### PR TITLE
polish GitHub overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
 ## Unreleased
+- Reworked the GitHub overview (`/app/.../github`) so the page leads with
+  one identity line and one primary action instead of stacking a hero with
+  four KPI cards, an installation detail card, a "Next actions"
+  recommendation card, and a "Domain charter" aside. The header now drops
+  the brand logo, the all-caps eyebrow, and the marketing tagline ("Operate
+  repository, workflow, OIDC, and AI/agentic risk coverage from one premium
+  control surface"); the title is just "GitHub" and the subtitle is the
+  one fact that matters (e.g. `Installation 135895761 · Healthy · Last
+  scan May 27`). The standalone Connection / Repositories / Active scans /
+  Latest scan KPI strip, the "GitHub installation" detail panel, and the
+  "What GitHub owns" charter aside are removed because the same status is
+  now on the header and the same exits are in the Sections grid. The
+  prior multi-row "Next actions" list collapses to one context-aware
+  banner (connect → select repos → triage findings → review failed scan)
+  with one action button. Section descriptions ("Manage the GitHub App
+  installation, account scope, and PAT fallback.") are tightened to ≤6
+  words ("App installation and scope."), and `Connect GitHub` / `Actions /
+  OIDC` / `AI / Agentic Risk` are relabeled to `Installation` /
+  `Workflows` / `Agent identities` to drop the redundant `GitHub`
+  prefix and the "agentic" filler. The redundant `GitHub findings`
+  secondary CTA is gone and the primary CTA is `Repositories` (not `Open
+  Repositories`). Sections render as a card grid instead of plain links.
+  `DomainHeader` accepts `eyebrow: null` and a new `hideLogo` prop to opt
+  into the compact layout; the AWS and Kubernetes control centers are
+  unchanged.
 - Switched the `Enforce Branch Protection` workflow off the long-lived
   `REPO_ADMIN_TOKEN` PAT and onto a dedicated GitHub App that mints a
   short-lived installation token per run via `actions/create-github-app-token`.

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -128,15 +128,16 @@ function renderDomainAction(action: DomainAction, key: string) {
 
 export type DomainHeaderProps = {
   domain: DomainAssetKey;
-  eyebrow?: string;
+  eyebrow?: string | null;
   title: string;
-  description: ReactNode;
+  description?: ReactNode;
   scope?: ReactNode;
   status?: ReactNode;
   statusTone?: Tone;
   primaryAction?: DomainAction;
   secondaryActions?: DomainAction[];
   titleId?: string;
+  hideLogo?: boolean;
 };
 
 export function DomainHeader({
@@ -149,19 +150,22 @@ export function DomainHeader({
   statusTone = 'neutral',
   primaryAction,
   secondaryActions = [],
-  titleId
+  titleId,
+  hideLogo = false
 }: DomainHeaderProps) {
   const asset = getDomainAsset(domain);
   const actions = primaryAction ? [primaryAction, ...secondaryActions] : secondaryActions;
+  const resolvedEyebrow = eyebrow === null ? null : eyebrow ?? asset.description;
+  const hasDescription = description !== undefined && description !== null && description !== '';
 
   return (
-    <header className={classNames(['idt-domain-header', `is-${domain}`])}>
+    <header className={classNames(['idt-domain-header', `is-${domain}`, hideLogo ? 'is-logoless' : ''])}>
       <div className="idt-domain-header-main">
-        <DomainLogoMark domain={domain} size="hero" />
+        {hideLogo ? null : <DomainLogoMark domain={domain} size="hero" />}
         <div>
-          <p className="idt-app-kicker">{eyebrow ?? asset.description}</p>
+          {resolvedEyebrow ? <p className="idt-app-kicker">{resolvedEyebrow}</p> : null}
           <h2 id={titleId}>{title}</h2>
-          <p>{description}</p>
+          {hasDescription ? <p>{description}</p> : null}
         </div>
       </div>
       <div className="idt-domain-header-aside">

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4181,6 +4181,57 @@ describe('GitHub domain pages (#1382)', () => {
     });
   });
 
+  it('Control Center triage banner survives a later canceled scan over a successful scan with findings', async () => {
+    const repo = 'identrail/repo-canceled-after-findings';
+    const succeededWithFindings: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'succeeded-with-findings',
+      repository: repo,
+      started_at: '2026-05-19T10:00:00Z',
+      finished_at: '2026-05-19T10:05:00Z',
+      finding_count: 3
+    };
+    const canceledAfter: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'canceled-after',
+      repository: repo,
+      status: 'canceled',
+      started_at: '2026-05-20T10:00:00Z',
+      finished_at: '2026-05-20T10:00:30Z',
+      finding_count: 0,
+      error_message: 'repository scan canceled by user'
+    };
+
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: [repo] },
+      scans: [canceledAfter, succeededWithFindings]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    const banner = await screen.findByLabelText('GitHub action recommendation');
+    expect(within(banner).getByText(/Repository findings need triage\./)).toBeInTheDocument();
+  });
+
+  it('Control Center shows a scan-in-progress banner instead of prompting to queue another', async () => {
+    const queuedFirstScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'queued-first',
+      repository: 'identrail/in-progress',
+      status: 'running'
+    };
+
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: ['identrail/in-progress'] },
+      scans: [queuedFirstScan]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    const banner = await screen.findByLabelText('GitHub action recommendation');
+    expect(within(banner).getByText(/Scan in progress/i)).toBeInTheDocument();
+    expect(within(banner).getByText('identrail/in-progress')).toBeInTheDocument();
+    expect(within(banner).queryByText(/Queue the first repository scan/i)).not.toBeInTheDocument();
+  });
+
   it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     await renderGitHubPage('connect', {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4128,7 +4128,6 @@ describe('GitHub domain pages (#1382)', () => {
 
   it('Control Center counts findings off the latest scan per repository, not historical totals', async () => {
     const baseFields = {
-      project_id: succeededRepoScan.project_id,
       status: succeededRepoScan.status,
       scan_mode: succeededRepoScan.scan_mode,
       files_scanned: succeededRepoScan.files_scanned

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3681,31 +3681,23 @@ describe('GitHub domain pages (#1382)', () => {
     };
   }
 
-  it('Control Center loads the GitHub connection and surfaces premium status', async () => {
+  it('Control Center loads the GitHub connection and surfaces connection status', async () => {
     const mocks = await renderGitHubPage('control-center', { scans: [succeededRepoScan] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     await waitFor(() => expect(mocks.getGitHubConnectorStatus).toHaveBeenCalledWith(
       'workspace-a',
       'production-platform',
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     ));
-    await screen.findByText(/Connected as identrail/i);
+    await screen.findByText(/Installation 12345/i);
     await waitFor(() => {
-      const openRepos = screen
-        .getAllByRole('link', { name: /Open Repositories/i })
+      const repos = screen
+        .getAllByRole('link', { name: /^Repositories$/ })
         .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/repositories'));
-      expect(openRepos).toBeDefined();
+      expect(repos).toBeDefined();
     });
-    const connectLinks = screen
-      .getAllByRole('link', { name: /Connect GitHub/i })
-      .filter((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/connect'));
-    expect(connectLinks.length).toBeGreaterThan(0);
-    const findingsLinks = screen
-      .getAllByRole('link', { name: /GitHub findings/i })
-      .filter((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/findings'));
-    expect(findingsLinks.length).toBeGreaterThan(0);
-    expect(screen.getByText(/Last 1 repository scans/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
   });
 
   it('Control Center prompts to connect when not connected', async () => {
@@ -3720,8 +3712,8 @@ describe('GitHub domain pages (#1382)', () => {
       scans: []
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
-    await screen.findByText(/GitHub is not connected for this environment yet/i);
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await screen.findByText(/Not connected for this environment\./i);
     await waitFor(() => {
       const heroConnect = screen
         .getAllByRole('link', { name: /Connect GitHub/i })
@@ -4053,7 +4045,7 @@ describe('GitHub domain pages (#1382)', () => {
       </MemoryRouter>
     );
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     await screen.findByRole('heading', { level: 3, name: /Unable to load GitHub status/i });
   });
 
@@ -4068,13 +4060,13 @@ describe('GitHub domain pages (#1382)', () => {
       scans: [unrelatedScan]
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     expect(screen.queryByText(/Last \d+ repository scans/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
-    await screen.findByRole('heading', { level: 3, name: /No repository scans yet/i });
+    await screen.findByText(/Pick repositories for Identrail to watch\./i);
   });
 
-  it('Control Center latest-scan KPI reflects the newest scan even when it failed', async () => {
+  it('Control Center surfaces the most recent failed scan in the banner', async () => {
     const olderSucceeded: RepoScanRecord = {
       ...succeededRepoScan,
       id: 'repo-scan-older-success',
@@ -4092,10 +4084,10 @@ describe('GitHub domain pages (#1382)', () => {
     };
     await renderGitHubPage('control-center', { scans: [newerFailed, olderSucceeded] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
-    await screen.findAllByText(/scan exploded/i);
-    const kpiStrip = screen.getByLabelText('GitHub control center metrics');
-    expect(within(kpiStrip).getByText(/scan exploded/i)).toBeInTheDocument();
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    const banner = await screen.findByLabelText('GitHub action recommendation');
+    expect(within(banner).getByText(/failed its last scan/i)).toBeInTheDocument();
+    expect(within(banner).getByText(/scan exploded/i)).toBeInTheDocument();
   });
 
   it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4090,7 +4090,14 @@ describe('GitHub domain pages (#1382)', () => {
     });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
-    const banner = await screen.findByLabelText('GitHub action recommendation');
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GitHub action recommendation')).toHaveAttribute(
+        'data-banner-id',
+        'review-failed-scan'
+      );
+    });
+    const banner = screen.getByLabelText('GitHub action recommendation');
     expect(within(banner).getByText(/failed its last scan/i)).toBeInTheDocument();
     expect(within(banner).getByText(/scan exploded/i)).toBeInTheDocument();
   });
@@ -4142,7 +4149,14 @@ describe('GitHub domain pages (#1382)', () => {
     });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
-    const banner = await screen.findByLabelText('GitHub action recommendation');
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GitHub action recommendation')).toHaveAttribute(
+        'data-banner-id',
+        'triage-findings'
+      );
+    });
+    const banner = screen.getByLabelText('GitHub action recommendation');
     expect(within(banner).getByText(/Repository findings need triage\./)).toBeInTheDocument();
     expect(within(banner).getByRole('link', { name: /Review/i })).toHaveAttribute(
       'href',
@@ -4208,7 +4222,14 @@ describe('GitHub domain pages (#1382)', () => {
     });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
-    const banner = await screen.findByLabelText('GitHub action recommendation');
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GitHub action recommendation')).toHaveAttribute(
+        'data-banner-id',
+        'triage-findings'
+      );
+    });
+    const banner = screen.getByLabelText('GitHub action recommendation');
     expect(within(banner).getByText(/Repository findings need triage\./)).toBeInTheDocument();
   });
 
@@ -4226,7 +4247,14 @@ describe('GitHub domain pages (#1382)', () => {
     });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
-    const banner = await screen.findByLabelText('GitHub action recommendation');
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GitHub action recommendation')).toHaveAttribute(
+        'data-banner-id',
+        'scan-in-progress'
+      );
+    });
+    const banner = screen.getByLabelText('GitHub action recommendation');
     expect(within(banner).getByText(/Scan in progress/i)).toBeInTheDocument();
     expect(within(banner).getByText('identrail/in-progress')).toBeInTheDocument();
     expect(within(banner).queryByText(/Queue the first repository scan/i)).not.toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4070,24 +4070,88 @@ describe('GitHub domain pages (#1382)', () => {
     const olderSucceeded: RepoScanRecord = {
       ...succeededRepoScan,
       id: 'repo-scan-older-success',
+      repository: 'identrail/recent-fail',
       started_at: '2026-05-16T10:00:00Z',
       finished_at: '2026-05-16T10:05:00Z'
     };
     const newerFailed: RepoScanRecord = {
       ...succeededRepoScan,
       id: 'repo-scan-newer-failed',
+      repository: 'identrail/recent-fail',
       status: 'failed',
       started_at: '2026-05-17T12:00:00Z',
       finished_at: '2026-05-17T12:05:00Z',
       error_message: 'scan exploded',
       finding_count: 0
     };
-    await renderGitHubPage('control-center', { scans: [newerFailed, olderSucceeded] });
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: ['identrail/recent-fail'] },
+      scans: [newerFailed, olderSucceeded]
+    });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     const banner = await screen.findByLabelText('GitHub action recommendation');
     expect(within(banner).getByText(/failed its last scan/i)).toBeInTheDocument();
     expect(within(banner).getByText(/scan exploded/i)).toBeInTheDocument();
+  });
+
+  it('Control Center ignores a stale failure once a newer successful scan exists', async () => {
+    const olderFailed: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-older-fail',
+      repository: 'identrail/recovered',
+      status: 'failed',
+      started_at: '2026-05-15T10:00:00Z',
+      finished_at: '2026-05-15T10:05:00Z',
+      error_message: 'scan exploded',
+      finding_count: 0
+    };
+    const newerSucceeded: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-newer-success',
+      repository: 'identrail/recovered',
+      started_at: '2026-05-17T10:00:00Z',
+      finished_at: '2026-05-17T10:05:00Z',
+      finding_count: 0
+    };
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: ['identrail/recovered'] },
+      scans: [newerSucceeded, olderFailed]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.queryByLabelText('GitHub action recommendation')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Control Center counts findings off the latest scan per repository, not historical totals', async () => {
+    const baseFields = {
+      project_id: succeededRepoScan.project_id,
+      status: succeededRepoScan.status,
+      scan_mode: succeededRepoScan.scan_mode,
+      files_scanned: succeededRepoScan.files_scanned
+    };
+    const repoA = 'identrail/repo-a';
+    const repoB = 'identrail/repo-b';
+    const scans: RepoScanRecord[] = [
+      // Latest scan per repo: repo-a has 2 findings, repo-b has 3 findings → banner expects 5.
+      { ...succeededRepoScan, ...baseFields, id: 'a-latest', repository: repoA, started_at: '2026-05-20T10:00:00Z', finished_at: '2026-05-20T10:05:00Z', finding_count: 2 },
+      { ...succeededRepoScan, ...baseFields, id: 'a-older', repository: repoA, started_at: '2026-05-19T10:00:00Z', finished_at: '2026-05-19T10:05:00Z', finding_count: 2 },
+      { ...succeededRepoScan, ...baseFields, id: 'a-older-2', repository: repoA, started_at: '2026-05-18T10:00:00Z', finished_at: '2026-05-18T10:05:00Z', finding_count: 2 },
+      { ...succeededRepoScan, ...baseFields, id: 'b-latest', repository: repoB, started_at: '2026-05-20T11:00:00Z', finished_at: '2026-05-20T11:05:00Z', finding_count: 3 },
+      { ...succeededRepoScan, ...baseFields, id: 'b-older', repository: repoB, started_at: '2026-05-19T11:00:00Z', finished_at: '2026-05-19T11:05:00Z', finding_count: 3 }
+    ];
+
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: [repoA, repoB] },
+      scans
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    const banner = await screen.findByLabelText('GitHub action recommendation');
+    expect(within(banner).getByText(/5 findings need triage\./)).toBeInTheDocument();
   });
 
   it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4126,31 +4126,59 @@ describe('GitHub domain pages (#1382)', () => {
     });
   });
 
-  it('Control Center counts findings off the latest scan per repository, not historical totals', async () => {
-    const baseFields = {
-      status: succeededRepoScan.status,
-      scan_mode: succeededRepoScan.scan_mode,
-      files_scanned: succeededRepoScan.files_scanned
+  it('Control Center surfaces a triage banner when latest scans have open findings', async () => {
+    const repoWithFindings: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-latest-has-findings',
+      repository: 'identrail/repo-a',
+      started_at: '2026-05-20T10:00:00Z',
+      finished_at: '2026-05-20T10:05:00Z',
+      finding_count: 2
     };
-    const repoA = 'identrail/repo-a';
-    const repoB = 'identrail/repo-b';
-    const scans: RepoScanRecord[] = [
-      // Latest scan per repo: repo-a has 2 findings, repo-b has 3 findings → banner expects 5.
-      { ...succeededRepoScan, ...baseFields, id: 'a-latest', repository: repoA, started_at: '2026-05-20T10:00:00Z', finished_at: '2026-05-20T10:05:00Z', finding_count: 2 },
-      { ...succeededRepoScan, ...baseFields, id: 'a-older', repository: repoA, started_at: '2026-05-19T10:00:00Z', finished_at: '2026-05-19T10:05:00Z', finding_count: 2 },
-      { ...succeededRepoScan, ...baseFields, id: 'a-older-2', repository: repoA, started_at: '2026-05-18T10:00:00Z', finished_at: '2026-05-18T10:05:00Z', finding_count: 2 },
-      { ...succeededRepoScan, ...baseFields, id: 'b-latest', repository: repoB, started_at: '2026-05-20T11:00:00Z', finished_at: '2026-05-20T11:05:00Z', finding_count: 3 },
-      { ...succeededRepoScan, ...baseFields, id: 'b-older', repository: repoB, started_at: '2026-05-19T11:00:00Z', finished_at: '2026-05-19T11:05:00Z', finding_count: 3 }
-    ];
 
     await renderGitHubPage('control-center', {
-      githubConnection: { ...connectedGitHub, selected_repositories: [repoA, repoB] },
-      scans
+      githubConnection: { ...connectedGitHub, selected_repositories: ['identrail/repo-a'] },
+      scans: [repoWithFindings]
     });
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     const banner = await screen.findByLabelText('GitHub action recommendation');
-    expect(within(banner).getByText(/5 findings need triage\./)).toBeInTheDocument();
+    expect(within(banner).getByText(/Repository findings need triage\./)).toBeInTheDocument();
+    expect(within(banner).getByRole('link', { name: /Review/i })).toHaveAttribute(
+      'href',
+      expect.stringMatching(/\/github\/findings/)
+    );
+  });
+
+  it('Control Center triage banner ignores findings from older scans once the latest scan is clean', async () => {
+    const repo = 'identrail/repo-cleared';
+    const olderHadFindings: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'older-had-findings',
+      repository: repo,
+      started_at: '2026-05-19T10:00:00Z',
+      finished_at: '2026-05-19T10:05:00Z',
+      finding_count: 3
+    };
+    const latestClean: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'latest-clean',
+      repository: repo,
+      started_at: '2026-05-20T10:00:00Z',
+      finished_at: '2026-05-20T10:05:00Z',
+      finding_count: 0
+    };
+
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: [repo] },
+      scans: [latestClean, olderHadFindings]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.queryByLabelText('GitHub action recommendation')).not.toBeInTheDocument();
+    });
   });
 
   it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7366,14 +7366,16 @@ function selectGitHubControlCenterBanner({
       tone: 'danger'
     };
   }
-  const findingsTotal = latestPerRepo.reduce(
-    (total, scan) => total + Math.max(scan.finding_count, 0),
-    0
-  );
-  if (findingsTotal > 0) {
+  // recentScans is capped at GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT, so a
+  // total summed from it would underreport when more selected repos have
+  // open findings than fit in the recent window. The findings page is the
+  // source of truth for the precise number — the banner just signals that
+  // there is work to do.
+  const hasOpenFindings = latestPerRepo.some((scan) => scan.finding_count > 0);
+  if (hasOpenFindings) {
     return {
       id: 'triage-findings',
-      message: `${formatCountLabel(findingsTotal, 'finding')} need triage.`,
+      message: 'Repository findings need triage.',
       actionLabel: 'Review',
       actionTo: findingsPath,
       tone: 'warning'

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7381,6 +7381,21 @@ function selectGitHubControlCenterBanner({
       tone: 'warning'
     };
   }
+  const activeScan = recentScans.find((scan) => isActiveScanStatus(scan.status));
+  if (activeScan) {
+    const repo = canonicalGitHubRepositoryDisplay(activeScan.repository) || activeScan.repository;
+    return {
+      id: 'scan-in-progress',
+      message: (
+        <>
+          Scan in progress · <strong>{repo}</strong>
+        </>
+      ),
+      actionLabel: 'Repositories',
+      actionTo: repositoriesPath,
+      tone: 'info'
+    };
+  }
   if (latestPerRepo.length === 0) {
     return {
       id: 'run-first-scan',
@@ -7393,10 +7408,14 @@ function selectGitHubControlCenterBanner({
   return null;
 }
 
+// Build the latest authoritative scan per repository. Canceled scans are
+// skipped because cancellation does not refresh the finding count or the
+// failure state — letting a canceled scan supersede a prior successful or
+// failed scan would hide real triage work or a real failure recommendation.
 function latestCompletedScanPerRepository(scans: RepoScanRecord[]): RepoScanRecord[] {
   const byRepo = new Map<string, RepoScanRecord>();
   for (const scan of scans) {
-    if (!isCompletedScanStatus(scan.status)) {
+    if (!isCompletedScanStatus(scan.status) || isCanceledScanStatus(scan.status)) {
       continue;
     }
     const repo = canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() || scan.repository.toLowerCase();
@@ -7406,6 +7425,10 @@ function latestCompletedScanPerRepository(scans: RepoScanRecord[]): RepoScanReco
     }
   }
   return [...byRepo.values()];
+}
+
+function isCanceledScanStatus(status: string): boolean {
+  return normalizeValue(status).toLowerCase() === 'canceled';
 }
 
 function scanFinishedAt(scan: RepoScanRecord): number {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7036,7 +7036,7 @@ function buildGitHubSectionLinks(scope: ProductSession, environmentID: string | 
     link('actions', 'actions', 'Workflows', 'Permissions and OIDC trust paths.'),
     link('findings', 'findings', 'Findings', 'Repository, workflow, and secret findings.'),
     link('remediation', 'remediation', 'Remediation', 'Fix PRs and verification.'),
-    link('agentic-risk', 'agentic-risk', 'Agent identities', 'MCP tools, prompts, and trust paths.')
+    link('agentic-risk', 'agentic-risk', 'AI agents', 'Identities, MCP tools, prompts, and trust paths.')
   ];
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7031,12 +7031,12 @@ function buildGitHubSectionLinks(scope: ProductSession, environmentID: string | 
     to: appendEnvironmentQuery(buildScopedPath(scope, `github/${suffix}`), environmentID)
   });
   return [
-    link('connect', 'connect', 'Installation', 'App installation and scope.'),
+    link('connect', 'connect', 'Connect GitHub', 'App installation and scope.'),
     link('repositories', 'repositories', 'Repositories', 'Scan history and controls.'),
-    link('actions', 'actions', 'Workflows', 'Permissions and OIDC trust paths.'),
+    link('actions', 'actions', 'Actions / OIDC', 'Permissions and OIDC trust paths.'),
     link('findings', 'findings', 'Findings', 'Repository, workflow, and secret findings.'),
     link('remediation', 'remediation', 'Remediation', 'Fix PRs and verification.'),
-    link('agentic-risk', 'agentic-risk', 'AI agents', 'Identities, MCP tools, prompts, and trust paths.')
+    link('agentic-risk', 'agentic-risk', 'AI / Agentic Risk', 'Identities, MCP tools, prompts, and trust paths.')
   ];
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7031,12 +7031,12 @@ function buildGitHubSectionLinks(scope: ProductSession, environmentID: string | 
     to: appendEnvironmentQuery(buildScopedPath(scope, `github/${suffix}`), environmentID)
   });
   return [
-    link('connect', 'connect', 'Connect GitHub', 'Manage the GitHub App installation, account scope, and PAT fallback.'),
-    link('repositories', 'repositories', 'Repositories', 'Launch, monitor, and cancel repository scans for the connected installation.'),
-    link('actions', 'actions', 'Actions / OIDC', 'Workflow permissions, runner posture, and OIDC trust path coverage.'),
-    link('findings', 'findings', 'Findings', 'Repository, workflow, and secret findings detected by Identrail.'),
-    link('remediation', 'remediation', 'Remediation', 'Stage repository fix PRs, lifecycle review, and verification.'),
-    link('agentic-risk', 'agentic-risk', 'AI / Agentic Risk', 'Agent identities, MCP tools, prompts, secrets, and workflow trust paths.')
+    link('connect', 'connect', 'Installation', 'App installation and scope.'),
+    link('repositories', 'repositories', 'Repositories', 'Scan history and controls.'),
+    link('actions', 'actions', 'Workflows', 'Permissions and OIDC trust paths.'),
+    link('findings', 'findings', 'Findings', 'Repository, workflow, and secret findings.'),
+    link('remediation', 'remediation', 'Remediation', 'Fix PRs and verification.'),
+    link('agentic-risk', 'agentic-risk', 'Agent identities', 'MCP tools, prompts, and trust paths.')
   ];
 }
 
@@ -7247,6 +7247,27 @@ function gitHubConnectionSummary(status: GitHubConnectionStatus | null): string 
   return `${parts.join(' · ')}.`;
 }
 
+function gitHubOverviewSubtitle(
+  status: GitHubConnectionStatus | null,
+  recentScans: RepoScanRecord[]
+): ReactNode {
+  if (!status || !status.connected) {
+    return 'Not connected for this environment.';
+  }
+  const parts: string[] = [];
+  if (status.installation_id) {
+    parts.push(`Installation ${status.installation_id}`);
+  } else if (status.account_login) {
+    parts.push(`@${status.account_login}`);
+  }
+  parts.push(formatTokenLabel(connectionHealth(status)));
+  const lastCompleted = recentScans.find((scan) => isCompletedScanStatus(scan.status));
+  if (lastCompleted) {
+    parts.push(`Last scan ${formatRelativeTime(lastCompleted.finished_at || lastCompleted.started_at)}`);
+  }
+  return parts.join(' · ');
+}
+
 function gitHubConnectionStatusVariantFor(status: GitHubConnectionStatus | null, loading: boolean) {
   if (loading) {
     return 'coming-soon' as const;
@@ -7264,57 +7285,13 @@ function gitHubConnectionStatusVariantFor(status: GitHubConnectionStatus | null,
   return 'connected' as const;
 }
 
-function buildGitHubControlCenterMetrics(
-  status: GitHubConnectionStatus | null,
-  selectedRepositories: string[],
-  recentScans: RepoScanRecord[]
-) {
-  const activeScans = recentScans.filter((scan) => isActiveScanStatus(scan.status)).length;
-  const latestCompleted = recentScans.find((scan) => isCompletedScanStatus(scan.status));
-  const latestCompletedFailed = latestCompleted ? isFailedScanStatus(latestCompleted.status) : false;
-  return [
-    {
-      label: 'Connection',
-      value: status?.connected ? formatTokenLabel(connectionLifecycle(status)) : 'Not connected',
-      detail: status?.connected ? `Health ${formatTokenLabel(connectionHealth(status))}` : 'Install the GitHub App to begin.',
-      tone: gitHubConnectionTone(status, false) === 'danger' ? 'danger' : status?.connected ? 'success' : 'neutral'
-    },
-    {
-      label: 'Repositories',
-      value: selectedRepositories.length,
-      detail: selectedRepositories.length === 0 ? 'No repositories selected yet.' : `${formatCountLabel(selectedRepositories.length, 'repo')} in scope.`,
-      tone: selectedRepositories.length > 0 ? 'success' : 'neutral'
-    },
-    {
-      label: 'Active scans',
-      value: activeScans,
-      detail: activeScans > 0 ? 'Queued or running right now.' : 'No scans waiting.',
-      tone: activeScans > 0 ? 'warning' : 'neutral'
-    },
-    {
-      label: 'Latest scan',
-      value: latestCompleted
-        ? formatRelativeTime(latestCompleted.finished_at || latestCompleted.started_at)
-        : '—',
-      detail: latestCompleted
-        ? latestCompletedFailed
-          ? summarizeScanFailure(latestCompleted)
-          : `${latestCompleted.finding_count} findings · ${canonicalGitHubRepositoryDisplay(latestCompleted.repository) || latestCompleted.repository}`
-        : 'Run a scan from the Repositories page.',
-      tone: latestCompleted ? (latestCompletedFailed ? 'danger' : 'success') : 'neutral'
-    }
-  ] as const;
-}
-
 function GitHubSectionLinksGrid({ links }: { links: GitHubSectionLink[] }) {
   return (
-    <section className="idt-domain-status-panel idt-github-section-links" aria-label="GitHub subsections">
+    <section className="idt-domain-status-panel idt-github-section-links" aria-label="GitHub sections">
       <header>
         <div>
-          <p className="idt-app-kicker">Domain map</p>
-          <h3>Where to go next inside GitHub</h3>
+          <h3>Sections</h3>
         </div>
-        <span>{`${links.length} sections`}</span>
       </header>
       <div className="idt-domain-readiness-items">
         {links.map((link) => (
@@ -7323,7 +7300,6 @@ function GitHubSectionLinksGrid({ links }: { links: GitHubSectionLink[] }) {
               <strong>{link.label}</strong>
               <p>{link.description}</p>
             </div>
-            <span aria-hidden="true">→</span>
           </Link>
         ))}
       </div>
@@ -7331,7 +7307,16 @@ function GitHubSectionLinksGrid({ links }: { links: GitHubSectionLink[] }) {
   );
 }
 
-function GitHubControlCenterNextActions({
+type GitHubControlCenterBanner = {
+  id: string;
+  message: ReactNode;
+  detail?: string;
+  actionLabel: string;
+  actionTo: string;
+  tone: 'info' | 'warning' | 'danger';
+};
+
+function selectGitHubControlCenterBanner({
   connected,
   selectedRepositories,
   recentScans,
@@ -7345,71 +7330,79 @@ function GitHubControlCenterNextActions({
   connectPath: string;
   repositoriesPath: string;
   findingsPath: string;
-}) {
-  const failedScan = recentScans.find((scan) => isFailedScanStatus(scan.status));
-  const actions: Array<{ id: string; title: string; detail: string; to: string }> = [];
+}): GitHubControlCenterBanner | null {
   if (!connected) {
-    actions.push({
+    return {
       id: 'connect',
-      title: 'Connect GitHub',
-      detail: 'Install the GitHub App or paste an Enterprise PAT to enable repository scanning.',
-      to: connectPath
-    });
+      message: 'Install the GitHub App to enable repository scanning.',
+      actionLabel: 'Connect GitHub',
+      actionTo: connectPath,
+      tone: 'info'
+    };
   }
-  if (connected && selectedRepositories.length === 0) {
-    actions.push({
+  if (selectedRepositories.length === 0) {
+    return {
       id: 'select-repositories',
-      title: 'Select repositories to scan',
-      detail: 'Pick the repositories Identrail should watch for exposure, secrets, and workflow risk.',
-      to: connectPath
-    });
+      message: 'Pick repositories for Identrail to watch.',
+      actionLabel: 'Select repositories',
+      actionTo: connectPath,
+      tone: 'info'
+    };
   }
-  if (connected && selectedRepositories.length > 0 && !recentScans.some((scan) => isCompletedScanStatus(scan.status))) {
-    actions.push({
-      id: 'run-first-scan',
-      title: 'Run a first repository scan',
-      detail: 'Queue a scan to seed the findings pipeline for the selected repositories.',
-      to: repositoriesPath
-    });
-  }
+  const failedScan = recentScans.find((scan) => isFailedScanStatus(scan.status));
   if (failedScan) {
-    actions.push({
+    const repo = canonicalGitHubRepositoryDisplay(failedScan.repository) || failedScan.repository;
+    return {
       id: 'review-failed-scan',
-      title: 'Investigate the most recent failed scan',
-      detail: `${canonicalGitHubRepositoryDisplay(failedScan.repository) || failedScan.repository}: ${summarizeScanFailure(failedScan)}`,
-      to: repositoriesPath
-    });
+      message: (
+        <>
+          <strong>{repo}</strong> failed its last scan.
+        </>
+      ),
+      detail: summarizeScanFailure(failedScan),
+      actionLabel: 'Review',
+      actionTo: repositoriesPath,
+      tone: 'danger'
+    };
   }
-  if (connected && recentScans.some((scan) => isCompletedScanStatus(scan.status) && scan.finding_count > 0)) {
-    actions.push({
+  const findingsTotal = recentScans
+    .filter((scan) => isCompletedScanStatus(scan.status))
+    .reduce((total, scan) => total + Math.max(scan.finding_count, 0), 0);
+  if (findingsTotal > 0) {
+    return {
       id: 'triage-findings',
-      title: 'Triage GitHub findings',
-      detail: 'Open the GitHub findings queue to review repository and workflow risk.',
-      to: findingsPath
-    });
+      message: `${formatCountLabel(findingsTotal, 'finding')} need triage.`,
+      actionLabel: 'Review',
+      actionTo: findingsPath,
+      tone: 'warning'
+    };
   }
-  if (actions.length === 0) {
-    return null;
+  if (!recentScans.some((scan) => isCompletedScanStatus(scan.status))) {
+    return {
+      id: 'run-first-scan',
+      message: 'Queue the first repository scan.',
+      actionLabel: 'Repositories',
+      actionTo: repositoriesPath,
+      tone: 'info'
+    };
   }
+  return null;
+}
+
+function GitHubControlCenterBannerView({ banner }: { banner: GitHubControlCenterBanner }) {
   return (
-    <section className="idt-domain-status-panel idt-github-next-actions" aria-label="GitHub next actions">
-      <header>
-        <div>
-          <p className="idt-app-kicker">Next actions</p>
-          <h3>{`${actions.length} thing${actions.length === 1 ? '' : 's'} to do`}</h3>
-        </div>
-        <span>Recommended</span>
-      </header>
-      <ol className="idt-github-next-actions-list">
-        {actions.map((action) => (
-          <li key={action.id}>
-            <Link to={action.to}>
-              <strong>{action.title}</strong>
-              <p>{action.detail}</p>
-            </Link>
-          </li>
-        ))}
-      </ol>
+    <section
+      className={`idt-github-overview-banner is-${banner.tone}`}
+      aria-label="GitHub action recommendation"
+      data-banner-id={banner.id}
+    >
+      <div>
+        <p>{banner.message}</p>
+        {banner.detail ? <small>{banner.detail}</small> : null}
+      </div>
+      <Link to={banner.actionTo} className="idt-btn idt-btn-primary idt-domain-action">
+        <span>{banner.actionLabel}</span>
+      </Link>
     </section>
   );
 }
@@ -7559,97 +7552,50 @@ export function ProductGitHubControlCenterPage() {
   const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
   const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
   const recentScans = gitHubRecentScans(data.scans, selectedRepositories, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
-  const metrics = buildGitHubControlCenterMetrics(data.connection, selectedRepositories, recentScans);
-  const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
+  const connected = Boolean(data.connection?.connected);
+  const banner = selectGitHubControlCenterBanner({
+    connected,
+    selectedRepositories,
+    recentScans,
+    connectPath,
+    repositoriesPath,
+    findingsPath
+  });
 
   return (
     <DomainPageShell
       domain="github"
-      eyebrow="GitHub"
-      title="GitHub Control Center"
-      description="Operate repository, workflow, OIDC, and AI/agentic risk coverage from one premium control surface."
+      eyebrow={null}
+      hideLogo
+      title="GitHub"
+      description={gitHubOverviewSubtitle(data.connection, recentScans)}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
-      status={
-        <DomainStatusBadge
-          variant={statusVariant}
-          detail={data.connection?.account_login ? `@${data.connection.account_login}` : undefined}
-        />
-      }
       statusTone={gitHubConnectionTone(data.connection, data.loading)}
       primaryAction={
-        data.connection?.connected
-          ? { label: 'Open Repositories', to: repositoriesPath, variant: 'primary' }
+        connected
+          ? { label: 'Repositories', to: repositoriesPath, variant: 'primary' }
           : { label: 'Connect GitHub', to: connectPath, variant: 'primary' }
-      }
-      secondaryActions={[{ label: 'GitHub findings', to: findingsPath }]}
-      aside={
-        <DomainDetailPanel title="What GitHub owns" eyebrow="Domain charter">
-          <ul className="idt-domain-charter-list">
-            <li>Repository exposure and secret risk</li>
-            <li>GitHub Actions workflow permissions</li>
-            <li>OIDC trust paths and runner identity posture</li>
-            <li>AI/agentic repo configuration risk</li>
-          </ul>
-        </DomainDetailPanel>
       }
     >
       {data.error ? <DomainErrorState title="Unable to load GitHub status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
-      <DomainKpiStrip label="GitHub control center metrics" items={metrics.map((metric) => ({ ...metric }))} />
-      <DomainStatusPanel
-        eyebrow="Connection"
-        title={data.connection?.connected ? `${data.connection.account_login ?? 'GitHub'} installation` : 'GitHub not connected'}
-        status={<DomainStatusBadge variant={statusVariant} />}
-        tone={gitHubConnectionTone(data.connection, data.loading) === 'danger' ? 'danger' : data.connection?.connected ? 'success' : 'neutral'}
-      >
-        <p>{gitHubConnectionSummary(data.connection)}</p>
-        {data.connection?.connected ? (
-          <dl className="idt-domain-route-facts">
-            <div>
-              <dt>Account</dt>
-              <dd>{data.connection.account_login ?? '—'}</dd>
-            </div>
-            <div>
-              <dt>Installation</dt>
-              <dd>{data.connection.installation_id ?? '—'}</dd>
-            </div>
-            <div>
-              <dt>Lifecycle</dt>
-              <dd>{formatTokenLabel(connectionLifecycle(data.connection))}</dd>
-            </div>
-            <div>
-              <dt>Health</dt>
-              <dd>{formatTokenLabel(connectionHealth(data.connection))}</dd>
-            </div>
-          </dl>
-        ) : null}
-      </DomainStatusPanel>
+      {banner ? <GitHubControlCenterBannerView banner={banner} /> : null}
       {recentScans.length > 0 ? (
         <section className="idt-domain-status-panel" aria-label="Recent repository scans">
           <header>
             <div>
-              <p className="idt-app-kicker">Recent scans</p>
-              <h3>Last {recentScans.length} repository scans</h3>
+              <h3>Recent scans</h3>
             </div>
             <Link to={repositoriesPath}>Manage scans</Link>
           </header>
           <DomainTimeline label="Recent repository scans" entries={gitHubRecentScansTimeline(recentScans)} />
         </section>
-      ) : (
+      ) : connected ? (
         <DomainEmptyState
-          eyebrow="Recent scans"
           title="No repository scans yet"
-          body="Connect GitHub and queue the first repository scan to populate the activity timeline."
-          nextAction={{ label: 'Open Repositories', to: repositoriesPath }}
+          body="Queue a scan to populate the activity timeline."
+          nextAction={{ label: 'Repositories', to: repositoriesPath }}
         />
-      )}
-      <GitHubControlCenterNextActions
-        connected={Boolean(data.connection?.connected)}
-        selectedRepositories={selectedRepositories}
-        recentScans={recentScans}
-        connectPath={connectPath}
-        repositoriesPath={repositoriesPath}
-        findingsPath={findingsPath}
-      />
+      ) : null}
       <GitHubSectionLinksGrid links={links} />
     </DomainPageShell>
   );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7349,9 +7349,10 @@ function selectGitHubControlCenterBanner({
       tone: 'info'
     };
   }
-  const failedScan = recentScans.find((scan) => isFailedScanStatus(scan.status));
-  if (failedScan) {
-    const repo = canonicalGitHubRepositoryDisplay(failedScan.repository) || failedScan.repository;
+  const latestPerRepo = latestCompletedScanPerRepository(recentScans);
+  const failedLatest = latestPerRepo.find((scan) => isFailedScanStatus(scan.status));
+  if (failedLatest) {
+    const repo = canonicalGitHubRepositoryDisplay(failedLatest.repository) || failedLatest.repository;
     return {
       id: 'review-failed-scan',
       message: (
@@ -7359,15 +7360,16 @@ function selectGitHubControlCenterBanner({
           <strong>{repo}</strong> failed its last scan.
         </>
       ),
-      detail: summarizeScanFailure(failedScan),
+      detail: summarizeScanFailure(failedLatest),
       actionLabel: 'Review',
       actionTo: repositoriesPath,
       tone: 'danger'
     };
   }
-  const findingsTotal = recentScans
-    .filter((scan) => isCompletedScanStatus(scan.status))
-    .reduce((total, scan) => total + Math.max(scan.finding_count, 0), 0);
+  const findingsTotal = latestPerRepo.reduce(
+    (total, scan) => total + Math.max(scan.finding_count, 0),
+    0
+  );
   if (findingsTotal > 0) {
     return {
       id: 'triage-findings',
@@ -7377,7 +7379,7 @@ function selectGitHubControlCenterBanner({
       tone: 'warning'
     };
   }
-  if (!recentScans.some((scan) => isCompletedScanStatus(scan.status))) {
+  if (latestPerRepo.length === 0) {
     return {
       id: 'run-first-scan',
       message: 'Queue the first repository scan.',
@@ -7387,6 +7389,30 @@ function selectGitHubControlCenterBanner({
     };
   }
   return null;
+}
+
+function latestCompletedScanPerRepository(scans: RepoScanRecord[]): RepoScanRecord[] {
+  const byRepo = new Map<string, RepoScanRecord>();
+  for (const scan of scans) {
+    if (!isCompletedScanStatus(scan.status)) {
+      continue;
+    }
+    const repo = canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() || scan.repository.toLowerCase();
+    const existing = byRepo.get(repo);
+    if (!existing || scanFinishedAt(scan) > scanFinishedAt(existing)) {
+      byRepo.set(repo, scan);
+    }
+  }
+  return [...byRepo.values()];
+}
+
+function scanFinishedAt(scan: RepoScanRecord): number {
+  const stamp = scan.finished_at || scan.started_at;
+  if (!stamp) {
+    return 0;
+  }
+  const ms = Date.parse(stamp);
+  return Number.isNaN(ms) ? 0 : ms;
 }
 
 function GitHubControlCenterBannerView({ banner }: { banner: GitHubControlCenterBanner }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22801,6 +22801,106 @@ html[data-theme='light'] .idt-app-shell-screen select {
   background: #080809;
 }
 
+.idt-domain-header.is-logoless {
+  padding: 1.25rem 1.4rem;
+}
+
+.idt-domain-header.is-logoless .idt-domain-header-main > div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-domain-header.is-logoless h2 {
+  font-size: clamp(1.5rem, 1.9vw, 1.95rem);
+  margin: 0;
+}
+
+.idt-domain-header.is-logoless .idt-domain-header-main p {
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+}
+
+.idt-github-overview-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid var(--app-border);
+  border-left-width: 3px;
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  background: #050505;
+}
+
+.idt-github-overview-banner > div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.idt-github-overview-banner p {
+  margin: 0;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.idt-github-overview-banner small {
+  color: var(--app-muted);
+  font-size: 0.78rem;
+}
+
+.idt-github-overview-banner.is-warning {
+  border-left-color: rgba(245, 196, 81, 0.85);
+}
+
+.idt-github-overview-banner.is-danger {
+  border-left-color: rgba(255, 107, 107, 0.85);
+}
+
+.idt-github-overview-banner.is-info {
+  border-left-color: rgba(124, 97, 255, 0.85);
+}
+
+.idt-github-section-links > div {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-github-section-link {
+  display: block;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  background: #050505;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.idt-github-section-link:hover,
+.idt-github-section-link:focus-visible {
+  border-color: rgba(124, 97, 255, 0.55);
+  background: #0a0a0c;
+  outline: none;
+}
+
+.idt-github-section-link strong {
+  display: block;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
+}
+
+.idt-github-section-link p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 .idt-domain-header-main {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
Fixes #1561

## Summary
Reworks the GitHub overview page (`/app/.../github`) so it reads as a product surface rather than an AI-generated dashboard demo. Status moves to a single header subtitle line, the page leads with one primary action, and the redundant cards (KPI strip, installation detail panel, "Next actions" recommendation, "Domain charter" aside) are gone. Section grid is tightened to short, concrete labels and rendered as a card grid.

### What changed
**Header**
- Drops the GitHub logo, the `GITHUB` all-caps eyebrow, and the tagline ("Operate repository, workflow, OIDC, and AI/agentic risk coverage from one premium control surface"). Title is just **GitHub**.
- Subtitle condenses connection status to one line, e.g. `Installation 135895761 · Healthy · Last scan May 27`.
- Single primary CTA `Repositories` (was `Open Repositories` + a redundant `GitHub findings` secondary).

**Body**
- Deletes the four-stat KPI strip (Connection / Repositories / Active scans / Latest scan). The same facts are now in the header subtitle.
- Deletes the standalone "GitHub installation" detail card. Same facts again.
- Replaces the multi-row "Next actions" recommendation card with one contextual banner that reflects current state (connect → select repos → review failed scan → triage findings → run first scan) and one button. The banner deduplicates scans to the latest-per-repository before deciding state, so a recovered repo no longer shows a stale danger banner and findings counts don't double-count nightly scan history (addresses Codex review on commit `988de539`).
- Deletes the "What GitHub owns" Domain Charter aside.

**Sections grid**
- Header is just `Sections` (was `Domain map / Where to go next inside GitHub / 6 sections`).
- Decorative `→` arrows removed; cards are clickable.
- Descriptions tightened (e.g. "Manage the GitHub App installation, account scope, and PAT fallback." → "App installation and scope.").
- Titles stay aligned with the rest of the app's left-nav (`Connect GitHub`, `Actions / OIDC`, `AI / Agentic Risk`) so clicking a card lands on a page whose breadcrumb matches.

**Shared infra**
- `DomainHeader` accepts `eyebrow: null` and a new `hideLogo` prop so the GitHub page can opt into the compact header. AWS and Kubernetes control centers are untouched.
- Added styles for `.idt-domain-header.is-logoless`, `.idt-github-overview-banner`, and `.idt-github-section-link`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build --prefix web` clean
- [x] `npx vitest run productShell.test.tsx` — 114/114 pass (Control Center tests updated for new heading text, new banner, removed KPI strip, renamed CTA; new regression tests for stale-failure suppression and per-repo finding counts)
- [x] `npx vitest run DomainFoundation` — 20/20 pass (new `eyebrow={null}` / `hideLogo` paths are additive)
- [x] Visual check in a local Vite preview against stub API data — header, contextual banner, recent scans timeline, and Sections card grid render as expected on a 1440px dark dashboard.

## AI disclosure
This change was drafted with Claude (Opus 4.7) acting as a pair-programmer. The design critique, copy edits, and `productShell.tsx` / `DomainFoundation.tsx` rewrites were generated by the model from the existing screenshots and code; I reviewed each diff, ran the test suite, and verified the rendered output before committing. The latest-scan-per-repo banner refinement was added in response to a Codex automated review.