### PR TITLE
Add AWS platform baseline gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@
   `DomainHeader` accepts `eyebrow: null` and a new `hideLogo` prop to opt
   into the compact layout; the AWS and Kubernetes control centers are
   unchanged.
+- Added the AWS platform baseline gate for #1473. The API now persists
+  scoped `aws_platform_baseline_results`, exposes
+  `GET/POST /v1/workspaces/:workspace_id/projects/:project_id/aws/baseline`,
+  and blocks project-scoped AWS scan enqueue/replay with a structured
+  `412 aws_platform_baseline_not_ready` payload when required checks fail.
+  The gate verifies AWS connector health, graph contract availability, worker
+  queue capacity, fixture availability in fixture mode, app route prerequisites,
+  source mode, profile/contract versions, timestamps, evidence links, and the
+  configured baseline git SHA. The AWS Control Center and Connect AWS surfaces
+  now show the gate result and per-check diagnostics.
 - Switched the `Enforce Branch Protection` workflow off the long-lived
   `REPO_ADMIN_TOKEN` PAT and onto a dedicated GitHub App that mints a
   short-lived installation token per run via `actions/create-github-app-token`.

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -42,6 +42,10 @@ The read-only policy and rationale live together under `deploy/connectors/aws/po
 
 AWS connector health answers whether Identrail can assume the configured connector role. The account and region coverage registry answers a separate product question: which AWS accounts and regions are currently in scope, covered, pending, or blocked.
 
+The [AWS platform baseline gate](../aws-platform-baseline.md) combines connector
+health with graph contract, queue, fixture, and app prerequisites before
+project-scoped AWS scans or remediation work can start.
+
 The registry is intentionally internal for now because the UI flow is not ready. Services can write coverage rows through the AWS service layer after discovering organization accounts, selected regions, or scan outcomes. Each row is scoped by tenant, workspace, project, connector, account ID, and region, and can store organization metadata, the connector role ARN, coverage status, the last successful scan time, the last scan error, a scan cursor, and account/region availability flags.
 
 Use the registry when a scanner, connector workflow, or future UI needs to distinguish these states:

--- a/docs/aws-platform-baseline.md
+++ b/docs/aws-platform-baseline.md
@@ -1,0 +1,62 @@
+# AWS Platform Baseline Gate
+
+The AWS platform baseline gate is the required readiness check before
+project-scoped AWS scans, remediation jobs, or governance actions start. It is
+scoped by tenant, workspace, project, and optional connector ID, and persists
+its latest result in `aws_platform_baseline_results`.
+
+## Checks
+
+The verifier runs these checks and records each check name, status, timestamp,
+confidence, failure reason, remediation hint, and evidence link:
+
+- `aws_connector_health`: required. Confirms the selected AWS connector is
+  active, healthy, and not failing permission diagnostics.
+- `graph_contract_version`: required. Confirms the graph relationship contract
+  registry is present and stamps the supported contract version.
+- `worker_queue_availability`: required. Confirms the AWS scan queue can accept
+  work under `IDENTRAIL_SCAN_QUEUE_MAX_PENDING`; the default single-slot gate
+  treats queued and running scans for the same source as capacity blockers.
+- `fixture_availability`: required only when `IDENTRAIL_AWS_SOURCE=fixture`.
+  Confirms at least one configured fixture JSON file is readable.
+- `app_validation_prerequisites`: required. Confirms the project scope and AWS
+  app routes are valid and the project is not archived.
+
+Fixture-only execution does not require live AWS credentials. Set
+`IDENTRAIL_AWS_SOURCE=fixture` and point `IDENTRAIL_AWS_FIXTURES` at readable
+JSON fixture files or directories.
+
+## API
+
+```text
+GET  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline
+POST /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline
+```
+
+`POST` accepts optional `connector_id` and `git_sha`, verifies the baseline,
+persists the result, and returns `{ "baseline": ... }`. When `git_sha` is not
+provided, the service uses `IDENTRAIL_BASELINE_GIT_SHA` and then
+`IDENTRAIL_GIT_SHA`.
+
+Project-scoped AWS scan enqueue and replay call the verifier before writing to
+the queue. If any required check fails, the API returns:
+
+```json
+{
+  "error_code": "aws_platform_baseline_not_ready",
+  "failure_reasons": ["aws connector is missing"],
+  "baseline": {
+    "status": "blocked",
+    "required_checks_passed": false
+  }
+}
+```
+
+This response uses HTTP `412 Precondition Failed` so clients can distinguish a
+readiness failure from queue contention, validation errors, or server failures.
+
+## UI
+
+The AWS Control Center shows the gate as a KPI and detailed baseline panel with
+per-check diagnostics. Connect AWS also shows the gate beside permission
+diagnostics and can run the baseline after connector validation.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -53,6 +53,7 @@ AWS:
 - `IDENTRAIL_AWS_REGION`
 - `IDENTRAIL_AWS_PROFILE`
 - `IDENTRAIL_AWS_FIXTURES`
+- `IDENTRAIL_BASELINE_GIT_SHA` (optional revision stamped onto AWS platform baseline results; falls back to `IDENTRAIL_GIT_SHA` when unset)
 - `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` (comma-separated connector capability tiers to permit beyond the read-only `discovery` default; unknown values are ignored. Write-capable tiers stay gated until listed here _and_ provisioned with a dedicated write role. See [connector-capabilities.md](connector-capabilities.md).)
 
 Kubernetes:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -468,6 +468,16 @@ x-identrail-route-authorizations:
     action: tenancy.read
     resource_type: project
     resource_id_param: project_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline
+    action: scans.run
+    resource_type: project
+    resource_id_param: project_id
   - method: POST
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start
     action: tenancy.write
@@ -3542,6 +3552,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS platform baseline gate status
+      operationId: getAWSProjectBaseline
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS platform baseline result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  baseline:
+                    $ref: "#/components/schemas/AWSPlatformBaselineResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [ProjectManagement]
+      summary: Verify AWS platform baseline gate
+      operationId: verifyAWSProjectBaseline
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AWSPlatformBaselineRequest"
+      responses:
+        "200":
+          description: AWS platform baseline result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  baseline:
+                    $ref: "#/components/schemas/AWSPlatformBaselineResult"
+        "400":
+          description: Invalid AWS baseline request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -4116,6 +4190,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "412":
+          description: AWS platform baseline gate is not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AWSPlatformBaselineNotReadyResponse"
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "503":
@@ -4155,6 +4235,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "412":
+          description: AWS platform baseline gate is not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AWSPlatformBaselineNotReadyResponse"
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":
@@ -6092,6 +6178,109 @@ components:
           type: string
           format: date-time
           nullable: true
+    AWSPlatformBaselineRequest:
+      type: object
+      properties:
+        connector_id:
+          type: string
+        git_sha:
+          type: string
+    AWSPlatformBaselineCheck:
+      type: object
+      properties:
+        name:
+          type: string
+        category:
+          type: string
+        required:
+          type: boolean
+        status:
+          type: string
+          enum: [passed, failed, degraded, permission_denied, unknown, skipped]
+        message:
+          type: string
+        failure_reason:
+          type: string
+        remediation:
+          type: string
+        evidence_url:
+          type: string
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        evidence:
+          type: object
+          additionalProperties: true
+        checked_at:
+          type: string
+          format: date-time
+    AWSPlatformBaselineResult:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+        workspace_id:
+          type: string
+        project_id:
+          type: string
+        connector_id:
+          type: string
+        git_sha:
+          type: string
+        source_mode:
+          type: string
+        fixture_only:
+          type: boolean
+        connector_profile_version:
+          type: string
+        graph_contract_version:
+          type: string
+        account_id:
+          type: string
+        region:
+          type: string
+        status:
+          type: string
+          enum: [not_run, ready, degraded, blocked]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        required_checks_passed:
+          type: boolean
+        failure_reasons:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPlatformBaselineCheck"
+        verified_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPlatformBaselineNotReadyResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        error_code:
+          type: string
+          enum: [aws_platform_baseline_not_ready]
+        failure_reasons:
+          type: array
+          items: { type: string }
+        baseline:
+          $ref: "#/components/schemas/AWSPlatformBaselineResult"
     GitHubConnectionStartRequest:
       type: object
       properties:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -737,6 +737,8 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPost, Path: "/v1/connectors/k8s/heartbeat", Action: policyActionTenancyWrite, ResourceType: "connector"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/connection", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/connection", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/complete", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connection", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_baseline.go
+++ b/internal/api/aws_baseline.go
@@ -1,0 +1,572 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	defaultAWSBaselineSourceMode              = "sdk"
+	defaultAWSBaselineConnectorProfileVersion = "aws-readonly-iam-v1"
+	defaultAWSBaselineGraphContractVersion    = "relationship-contract-v1"
+)
+
+// ErrAWSPlatformBaselineNotReady indicates the AWS platform gate blocked a scan.
+var ErrAWSPlatformBaselineNotReady = errors.New("aws platform baseline not ready")
+
+// AWSPlatformBaselineRequest optionally pins the connector and revision to verify.
+type AWSPlatformBaselineRequest struct {
+	ConnectorID string `json:"connector_id,omitempty"`
+	GitSHA      string `json:"git_sha,omitempty"`
+}
+
+// AWSPlatformBaselineNotReadyError carries the persisted readiness result that
+// explains why a project-scoped AWS scan was refused.
+type AWSPlatformBaselineNotReadyError struct {
+	Result db.AWSPlatformBaselineResult
+}
+
+func (e AWSPlatformBaselineNotReadyError) Error() string {
+	return ErrAWSPlatformBaselineNotReady.Error()
+}
+
+func (e AWSPlatformBaselineNotReadyError) Is(target error) bool {
+	return target == ErrAWSPlatformBaselineNotReady
+}
+
+// VerifyAWSPlatformBaseline evaluates, persists, and returns the AWS readiness gate.
+func (s *Service) VerifyAWSPlatformBaseline(ctx context.Context, workspaceID string, projectID string, request AWSPlatformBaselineRequest) (db.AWSPlatformBaselineResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return db.AWSPlatformBaselineResult{}, err
+	}
+	now := s.Now().UTC()
+	sourceMode := s.awsBaselineSourceMode()
+	fixtureOnly := sourceMode == "fixture"
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	if err != nil {
+		return db.AWSPlatformBaselineResult{}, err
+	}
+	scanSource := db.ScanSource{ProjectID: project.ProjectID, ConnectorID: strings.TrimSpace(request.ConnectorID)}
+
+	checks := []db.AWSPlatformBaselineCheck{
+		s.awsBaselineConnectorHealthCheck(sourceMode, connection, hasConnection, now),
+		s.awsBaselineGraphContractCheck(now),
+		s.awsBaselineWorkerQueueCheck(ctx, scanSource, now),
+		s.awsBaselineFixtureCheck(sourceMode, now),
+		s.awsBaselineAppValidationCheck(scope, project, now),
+	}
+	status, requiredPassed, confidence, failureReasons, evidenceLinks := summarizeAWSBaselineChecks(checks)
+	result := db.AWSPlatformBaselineResult{
+		TenantID:                scope.TenantID,
+		WorkspaceID:             project.WorkspaceID,
+		ProjectID:               project.ProjectID,
+		GitSHA:                  firstNonEmptyAWSValue(strings.TrimSpace(request.GitSHA), strings.TrimSpace(s.AWSBaselineGitSHA)),
+		SourceMode:              sourceMode,
+		FixtureOnly:             fixtureOnly,
+		ConnectorProfileVersion: s.awsBaselineConnectorProfileVersion(),
+		GraphContractVersion:    s.awsBaselineGraphContractVersion(),
+		Status:                  status,
+		Confidence:              confidence,
+		RequiredChecksPassed:    requiredPassed,
+		FailureReasons:          failureReasons,
+		EvidenceLinks:           evidenceLinks,
+		Checks:                  checks,
+		VerifiedAt:              now,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	if hasConnection {
+		result.ConnectorID = connection.ConnectorID
+		result.AccountID = connection.AccountID
+		result.Region = connection.Region
+	}
+	stored, err := s.Store.UpsertAWSPlatformBaselineResult(ctx, result)
+	if err != nil {
+		return db.AWSPlatformBaselineResult{}, fmt.Errorf("persist aws platform baseline: %w", err)
+	}
+	return stored, nil
+}
+
+// GetAWSPlatformBaseline returns the latest persisted result or a deterministic
+// not-run payload when no verification has occurred yet.
+func (s *Service) GetAWSPlatformBaseline(ctx context.Context, workspaceID string, projectID string, request AWSPlatformBaselineRequest) (db.AWSPlatformBaselineResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return db.AWSPlatformBaselineResult{}, err
+	}
+	connectorID := strings.TrimSpace(request.ConnectorID)
+	if connectorID == "" {
+		connection, hasConnection, connectionErr := s.awsBaselineConnection(ctx, project, "")
+		if connectionErr != nil {
+			return db.AWSPlatformBaselineResult{}, connectionErr
+		}
+		if hasConnection && strings.TrimSpace(connection.ConnectorID) != "" {
+			result, err := s.Store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{
+				WorkspaceID: project.WorkspaceID,
+				ProjectID:   project.ProjectID,
+				ConnectorID: connection.ConnectorID,
+			})
+			if err == nil {
+				return result, nil
+			}
+			if !errors.Is(err, db.ErrNotFound) {
+				return db.AWSPlatformBaselineResult{}, err
+			}
+		}
+	}
+	result, err := s.Store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{
+		WorkspaceID: project.WorkspaceID,
+		ProjectID:   project.ProjectID,
+		ConnectorID: connectorID,
+	})
+	if err == nil {
+		return result, nil
+	}
+	if !errors.Is(err, db.ErrNotFound) {
+		return db.AWSPlatformBaselineResult{}, err
+	}
+	now := s.Now().UTC()
+	check := db.AWSPlatformBaselineCheck{
+		Name:          "aws_platform_baseline",
+		Category:      "readiness",
+		Required:      true,
+		Status:        db.AWSPlatformBaselineCheckUnknown,
+		Message:       "AWS platform baseline has not been verified for this project.",
+		FailureReason: "aws platform baseline has not run",
+		Remediation:   "Run AWS baseline verification before starting AWS scans or remediation.",
+		EvidenceURL:   awsBaselineProjectEvidenceURL(scope, project),
+		Confidence:    0,
+		Evidence: map[string]any{
+			"project_id": project.ProjectID,
+		},
+		CheckedAt: now,
+	}
+	return db.AWSPlatformBaselineResult{
+		TenantID:                scope.TenantID,
+		WorkspaceID:             project.WorkspaceID,
+		ProjectID:               project.ProjectID,
+		ConnectorID:             connectorID,
+		GitSHA:                  strings.TrimSpace(s.AWSBaselineGitSHA),
+		SourceMode:              s.awsBaselineSourceMode(),
+		FixtureOnly:             s.awsBaselineSourceMode() == "fixture",
+		ConnectorProfileVersion: s.awsBaselineConnectorProfileVersion(),
+		GraphContractVersion:    s.awsBaselineGraphContractVersion(),
+		Status:                  db.AWSPlatformBaselineStatusNotRun,
+		Confidence:              0,
+		RequiredChecksPassed:    false,
+		FailureReasons:          []string{check.FailureReason},
+		EvidenceLinks:           []string{check.EvidenceURL},
+		Checks:                  []db.AWSPlatformBaselineCheck{check},
+		VerifiedAt:              now,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}, nil
+}
+
+func (s *Service) ensureAWSPlatformBaselineReadyForScan(ctx context.Context, provider string, source db.ScanSource) error {
+	if strings.ToLower(strings.TrimSpace(provider)) != string(domain.ConnectorTypeAWS) {
+		return nil
+	}
+	source = source.Normalize()
+	if source.ProjectID == "" {
+		return nil
+	}
+	result, err := s.VerifyAWSPlatformBaseline(ctx, "", source.ProjectID, AWSPlatformBaselineRequest{ConnectorID: source.ConnectorID})
+	if err != nil {
+		return err
+	}
+	if !result.RequiredChecksPassed {
+		return AWSPlatformBaselineNotReadyError{Result: result}
+	}
+	return nil
+}
+
+func (s *Service) awsBaselineConnection(ctx context.Context, project db.TenancyProject, connectorID string) (AWSConnectionStatus, bool, error) {
+	connectorID = strings.TrimSpace(connectorID)
+	if connectorID != "" {
+		stored, err := s.Store.GetTenancyConnector(ctx, project.WorkspaceID, project.ProjectID, connectorID)
+		if err != nil {
+			return AWSConnectionStatus{}, false, err
+		}
+		if stored.Connector.Type != domain.ConnectorTypeAWS {
+			return AWSConnectionStatus{}, false, ErrInvalidAWSConnectionRequest
+		}
+		return s.awsConnectionStatusFromStored(ctx, stored), true, nil
+	}
+	items, err := s.Store.ListTenancyConnectors(ctx, project.WorkspaceID, project.ProjectID, domain.ConnectorTypeAWS, 25)
+	if err != nil {
+		return AWSConnectionStatus{}, false, fmt.Errorf("list aws baseline connectors: %w", err)
+	}
+	if len(items) == 0 {
+		return AWSConnectionStatus{}, false, nil
+	}
+	for _, item := range items {
+		status := s.awsConnectionStatusFromStored(ctx, item)
+		if status.Connected {
+			return status, true, nil
+		}
+	}
+	return s.awsConnectionStatusFromStored(ctx, items[0]), true, nil
+}
+
+func (s *Service) awsBaselineConnectorHealthCheck(sourceMode string, connection AWSConnectionStatus, hasConnection bool, checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	fixtureMode := sourceMode == "fixture"
+	check := awsPlatformBaselineCheck("aws_connector_health", "connector", !fixtureMode, checkedAt)
+	check.EvidenceURL = "/docs/auth/aws-connector"
+	check.Evidence["source_mode"] = sourceMode
+	if fixtureMode {
+		check.Status = db.AWSPlatformBaselineCheckSkipped
+		check.Message = "Fixture AWS source mode does not require a live AWS connector."
+		check.Confidence = 0.9
+		if hasConnection {
+			check.Evidence["connector_id"] = connection.ConnectorID
+			check.Evidence["status"] = connection.Status
+			check.Evidence["health_status"] = connection.HealthStatus
+		}
+		return check
+	}
+	if !hasConnection {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "No AWS connector is configured for this project."
+		check.FailureReason = "aws connector is missing"
+		check.Remediation = "Connect an AWS account before running AWS scans or remediation."
+		check.Confidence = 0.2
+		return check
+	}
+	check.Evidence = map[string]any{
+		"source_mode":       sourceMode,
+		"connector_id":      connection.ConnectorID,
+		"status":            connection.Status,
+		"health_status":     connection.HealthStatus,
+		"account_id":        connection.AccountID,
+		"region":            connection.Region,
+		"permission_checks": len(connection.PermissionChecks),
+		"diagnostics":       len(connection.Diagnostics),
+	}
+	if connection.Connected {
+		check.Status = db.AWSPlatformBaselineCheckPassed
+		check.Message = "AWS connector is active and healthy."
+		check.Confidence = 0.96
+		return check
+	}
+	check.Status = db.AWSPlatformBaselineCheckFailed
+	if awsConnectionHasPermissionDenial(connection) {
+		check.Status = db.AWSPlatformBaselineCheckPermissionDenied
+	}
+	check.Message = "AWS connector is not ready."
+	check.FailureReason = firstAWSBaselineConnectionFailure(connection)
+	check.Remediation = firstNonEmptyAWSValue(
+		connection.RemediationMessage,
+		firstAWSRemediation(connection.Diagnostics, connection.PermissionChecks),
+		"Validate the AWS connector role and required read-only IAM permissions.",
+	)
+	check.Confidence = 0.35
+	return check
+}
+
+func (s *Service) awsBaselineGraphContractCheck(checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	check := awsPlatformBaselineCheck("graph_contract_version", "graph", true, checkedAt)
+	contracts := domain.RelationshipContracts()
+	check.Evidence = map[string]any{
+		"contract_version":   s.awsBaselineGraphContractVersion(),
+		"relationship_count": len(contracts),
+	}
+	check.EvidenceURL = "/docs/aws-normalizer-graph"
+	if len(contracts) == 0 {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "No graph relationship contracts are registered."
+		check.FailureReason = "graph contract registry is empty"
+		check.Remediation = "Restore the relationship contract registry before running AWS scans."
+		check.Confidence = 0.2
+		return check
+	}
+	check.Status = db.AWSPlatformBaselineCheckPassed
+	check.Message = "Graph relationship contract registry is available."
+	check.Confidence = 0.95
+	return check
+}
+
+func (s *Service) awsBaselineWorkerQueueCheck(ctx context.Context, source db.ScanSource, checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	check := awsPlatformBaselineCheck("worker_queue_availability", "queue", true, checkedAt)
+	maxPending := s.ScanQueueMaxPending
+	if maxPending <= 0 {
+		maxPending = 1
+	}
+	source = source.Normalize()
+	countMode := "queued"
+	var (
+		count int
+		err   error
+	)
+	if maxPending == 1 {
+		countMode = "queued_running"
+		count, err = s.Store.CountPendingScansWithSource(ctx, string(domain.ConnectorTypeAWS), source)
+	} else {
+		count, err = s.Store.CountQueuedScansWithSource(ctx, string(domain.ConnectorTypeAWS), source)
+	}
+	check.Evidence = map[string]any{
+		"queue_limit":      maxPending,
+		"queue_count_mode": countMode,
+		"project_id":       source.ProjectID,
+		"connector_id":     source.ConnectorID,
+	}
+	if err != nil {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "AWS scan queue depth could not be read."
+		check.FailureReason = "worker queue depth check failed"
+		check.Remediation = "Verify API and worker storage connectivity before starting AWS scans."
+		check.Confidence = 0.25
+		return check
+	}
+	check.Evidence["pending_queue_count"] = count
+	if count >= maxPending {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "AWS scan queue is at capacity for this scan source."
+		check.FailureReason = "worker queue is full"
+		check.Remediation = "Wait for matching queued AWS scans to drain or increase IDENTRAIL_SCAN_QUEUE_MAX_PENDING."
+		check.Confidence = 0.45
+		return check
+	}
+	check.Status = db.AWSPlatformBaselineCheckPassed
+	check.Message = "AWS scan queue can accept work for this scan source."
+	check.Confidence = 0.94
+	return check
+}
+
+func (s *Service) awsBaselineFixtureCheck(sourceMode string, checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	check := awsPlatformBaselineCheck("fixture_availability", "fixtures", sourceMode == "fixture", checkedAt)
+	check.EvidenceURL = "/docs/configuration-reference"
+	check.Evidence = map[string]any{
+		"source_mode": sourceMode,
+	}
+	if sourceMode != "fixture" {
+		check.Status = db.AWSPlatformBaselineCheckSkipped
+		check.Message = "Live AWS source mode does not require fixture files."
+		check.Confidence = 0.9
+		return check
+	}
+	paths := append([]string(nil), s.AWSBaselineFixturePaths...)
+	check.Evidence["fixture_paths"] = paths
+	count, missing, scanErrors := countAWSFixtureFiles(paths)
+	check.Evidence["fixture_count"] = count
+	if len(missing) > 0 {
+		check.Evidence["missing_paths"] = missing
+	}
+	if len(scanErrors) > 0 {
+		check.Evidence["scan_errors"] = scanErrors
+	}
+	if len(paths) == 0 || count == 0 || len(missing) > 0 || len(scanErrors) > 0 {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "AWS fixture source mode cannot find usable fixture files."
+		check.FailureReason = "aws fixtures are unavailable"
+		check.Remediation = "Set IDENTRAIL_AWS_FIXTURES to one or more readable JSON fixture files or directories."
+		check.Confidence = 0.3
+		return check
+	}
+	check.Status = db.AWSPlatformBaselineCheckPassed
+	check.Message = "AWS fixture files are available for fixture-only execution."
+	check.Confidence = 0.92
+	return check
+}
+
+func (s *Service) awsBaselineAppValidationCheck(scope db.Scope, project db.TenancyProject, checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	check := awsPlatformBaselineCheck("app_validation_prerequisites", "app", true, checkedAt)
+	check.EvidenceURL = awsBaselineProjectEvidenceURL(scope, project)
+	check.Evidence = map[string]any{
+		"tenant_id":    scope.TenantID,
+		"workspace_id": project.WorkspaceID,
+		"project_id":   project.ProjectID,
+		"aws_url":      check.EvidenceURL,
+		"setup_url":    awsBaselineSetupEvidenceURL(scope, project),
+	}
+	if project.ArchivedAt != nil {
+		check.Status = db.AWSPlatformBaselineCheckFailed
+		check.Message = "AWS app validation is blocked because the project is archived."
+		check.FailureReason = "project is archived"
+		check.Remediation = "Restore the project before running AWS scans or remediation."
+		check.Confidence = 0.5
+		return check
+	}
+	check.Status = db.AWSPlatformBaselineCheckPassed
+	check.Message = "AWS app routes and project scope are available."
+	check.Confidence = 0.95
+	return check
+}
+
+func awsPlatformBaselineCheck(name string, category string, required bool, checkedAt time.Time) db.AWSPlatformBaselineCheck {
+	return db.AWSPlatformBaselineCheck{
+		Name:       name,
+		Category:   category,
+		Required:   required,
+		Status:     db.AWSPlatformBaselineCheckUnknown,
+		Evidence:   map[string]any{},
+		Confidence: 0,
+		CheckedAt:  checkedAt.UTC(),
+	}
+}
+
+func summarizeAWSBaselineChecks(checks []db.AWSPlatformBaselineCheck) (string, bool, float64, []string, []string) {
+	requiredPassed := true
+	degraded := false
+	failureReasons := []string{}
+	evidenceLinks := []string{}
+	for _, check := range checks {
+		if strings.TrimSpace(check.EvidenceURL) != "" {
+			evidenceLinks = append(evidenceLinks, check.EvidenceURL)
+		}
+		passed := check.Status == db.AWSPlatformBaselineCheckPassed || (!check.Required && check.Status == db.AWSPlatformBaselineCheckSkipped)
+		if check.Required && !passed {
+			requiredPassed = false
+			failureReasons = append(failureReasons, firstNonEmptyAWSValue(check.FailureReason, check.Message, check.Name))
+		}
+		if !check.Required && check.Status != db.AWSPlatformBaselineCheckPassed && check.Status != db.AWSPlatformBaselineCheckSkipped {
+			degraded = true
+		}
+	}
+	status := db.AWSPlatformBaselineStatusReady
+	confidence := 0.95
+	if !requiredPassed {
+		status = db.AWSPlatformBaselineStatusBlocked
+		confidence = 0.35
+	} else if degraded {
+		status = db.AWSPlatformBaselineStatusDegraded
+		confidence = 0.72
+	}
+	return status, requiredPassed, confidence, failureReasons, dedupeStrings(evidenceLinks)
+}
+
+func awsConnectionHasPermissionDenial(connection AWSConnectionStatus) bool {
+	for _, check := range connection.PermissionChecks {
+		if !check.Passed {
+			return true
+		}
+	}
+	for _, diagnostic := range connection.Diagnostics {
+		code := strings.ToLower(diagnostic.Code)
+		message := strings.ToLower(diagnostic.Message)
+		if strings.Contains(code, "permission") || strings.Contains(code, "denied") ||
+			strings.Contains(message, "permission") || strings.Contains(message, "denied") {
+			return true
+		}
+	}
+	return false
+}
+
+func firstAWSBaselineConnectionFailure(connection AWSConnectionStatus) string {
+	for _, diagnostic := range connection.Diagnostics {
+		if strings.TrimSpace(diagnostic.Message) != "" {
+			return strings.TrimSpace(diagnostic.Message)
+		}
+	}
+	for _, check := range connection.PermissionChecks {
+		if !check.Passed && strings.TrimSpace(check.Message) != "" {
+			return strings.TrimSpace(check.Message)
+		}
+	}
+	return "aws connector is not healthy"
+}
+
+func countAWSFixtureFiles(paths []string) (int, []string, []string) {
+	count := 0
+	missing := []string{}
+	scanErrors := []string{}
+	for _, rawPath := range paths {
+		path := strings.TrimSpace(rawPath)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			missing = append(missing, path)
+			continue
+		}
+		if !info.IsDir() {
+			if strings.EqualFold(filepath.Ext(path), ".json") {
+				count++
+			}
+			continue
+		}
+		err = filepath.WalkDir(path, func(entryPath string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				scanErrors = append(scanErrors, fmt.Sprintf("%s: %v", entryPath, walkErr))
+				return nil
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			if strings.EqualFold(filepath.Ext(entryPath), ".json") {
+				count++
+			}
+			return nil
+		})
+		if err != nil {
+			scanErrors = append(scanErrors, fmt.Sprintf("%s: %v", path, err))
+		}
+	}
+	return count, missing, scanErrors
+}
+
+func dedupeStrings(items []string) []string {
+	if len(items) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	deduped := []string{}
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		deduped = append(deduped, item)
+	}
+	return deduped
+}
+
+func (s *Service) awsBaselineSourceMode() string {
+	sourceMode := strings.ToLower(strings.TrimSpace(s.AWSBaselineSourceMode))
+	if sourceMode == "" {
+		return defaultAWSBaselineSourceMode
+	}
+	return sourceMode
+}
+
+func (s *Service) awsBaselineConnectorProfileVersion() string {
+	return firstNonEmptyAWSValue(strings.TrimSpace(s.AWSBaselineConnectorProfileVersion), defaultAWSBaselineConnectorProfileVersion)
+}
+
+func (s *Service) awsBaselineGraphContractVersion() string {
+	return firstNonEmptyAWSValue(strings.TrimSpace(s.AWSBaselineGraphContractVersion), defaultAWSBaselineGraphContractVersion)
+}
+
+func awsBaselineProjectEvidenceURL(scope db.Scope, project db.TenancyProject) string {
+	return fmt.Sprintf(
+		"/app/%s/%s/aws?environment=%s",
+		url.PathEscape(scope.TenantID),
+		url.PathEscape(project.WorkspaceID),
+		url.QueryEscape(project.ProjectID),
+	)
+}
+
+func awsBaselineSetupEvidenceURL(scope db.Scope, project db.TenancyProject) string {
+	return fmt.Sprintf(
+		"/app/%s/%s/aws/connect?environment=%s",
+		url.PathEscape(scope.TenantID),
+		url.PathEscape(project.WorkspaceID),
+		url.QueryEscape(project.ProjectID),
+	)
+}

--- a/internal/api/aws_baseline_test.go
+++ b/internal/api/aws_baseline_test.go
@@ -1,0 +1,453 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/app"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestVerifyAWSPlatformBaselineReadyPersists(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{result: app.ScanResult{Assets: 1}}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSBaselineGitSHA = "6dd631b1"
+
+	result, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("verify baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusReady || !result.RequiredChecksPassed {
+		t.Fatalf("expected ready baseline, got %+v", result)
+	}
+	if result.GitSHA != "6dd631b1" || result.ConnectorID != "aws-prod" || result.GraphContractVersion == "" {
+		t.Fatalf("expected revision and connector metadata, got %+v", result)
+	}
+	if len(result.Checks) != 5 {
+		t.Fatalf("expected five baseline checks, got %+v", result.Checks)
+	}
+	reloaded, err := store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{
+		WorkspaceID: "default",
+		ProjectID:   "project-a",
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("reload persisted baseline: %v", err)
+	}
+	if reloaded.Status != db.AWSPlatformBaselineStatusReady || reloaded.Checks[0].Name != "aws_connector_health" {
+		t.Fatalf("unexpected persisted baseline: %+v", reloaded)
+	}
+}
+
+func TestGetAWSPlatformBaselineReturnsNotRunPayload(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSBaselineGitSHA = "6dd631b1"
+
+	result, err := svc.GetAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("get baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusNotRun || result.RequiredChecksPassed {
+		t.Fatalf("expected deterministic not-run payload, got %+v", result)
+	}
+	if result.GitSHA != "6dd631b1" || result.SourceMode != "sdk" || result.FixtureOnly {
+		t.Fatalf("expected default metadata in not-run payload, got %+v", result)
+	}
+	if len(result.Checks) != 1 || result.Checks[0].Name != "aws_platform_baseline" {
+		t.Fatalf("expected single not-run check, got %+v", result.Checks)
+	}
+	if result.Checks[0].EvidenceURL != "/app/default/default/aws?environment=project-a" {
+		t.Fatalf("unexpected evidence URL %q", result.Checks[0].EvidenceURL)
+	}
+	if len(result.FailureReasons) != 1 || result.FailureReasons[0] != "aws platform baseline has not run" {
+		t.Fatalf("unexpected failure reasons: %+v", result.FailureReasons)
+	}
+	if !result.VerifiedAt.Equal(now) {
+		t.Fatalf("expected verified_at %v, got %v", now, result.VerifiedAt)
+	}
+}
+
+func TestGetAWSPlatformBaselineFallsBackToActiveConnectorResult(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 20, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	if _, err := store.UpsertAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineResult{
+		WorkspaceID:          "default",
+		ProjectID:            "project-a",
+		Status:               db.AWSPlatformBaselineStatusBlocked,
+		RequiredChecksPassed: false,
+		FailureReasons:       []string{"aws connector is missing"},
+		Checks: []db.AWSPlatformBaselineCheck{{
+			Name:          "aws_connector_health",
+			Required:      true,
+			Status:        db.AWSPlatformBaselineCheckFailed,
+			FailureReason: "aws connector is missing",
+			CheckedAt:     now.Add(-time.Minute),
+		}},
+		VerifiedAt: now.Add(-time.Minute),
+		CreatedAt:  now.Add(-time.Minute),
+		UpdatedAt:  now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed stale project-level baseline: %v", err)
+	}
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	verified, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("verify connector baseline: %v", err)
+	}
+	if verified.ConnectorID != "aws-prod" {
+		t.Fatalf("expected connector-specific baseline, got %+v", verified)
+	}
+
+	result, err := svc.GetAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("get connector fallback baseline: %v", err)
+	}
+	if result.ConnectorID != "aws-prod" || result.Status != db.AWSPlatformBaselineStatusReady {
+		t.Fatalf("expected active connector fallback result, got %+v", result)
+	}
+	if result.FailureReasons != nil && len(result.FailureReasons) > 0 && result.FailureReasons[0] == "aws connector is missing" {
+		t.Fatalf("default read returned stale project-level baseline: %+v", result)
+	}
+}
+
+func TestVerifyAWSPlatformBaselineFixtureModeRequiresReadableFixtures(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+
+	svc := NewService(store, fakeScanner{result: app.ScanResult{Assets: 1}}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSBaselineSourceMode = "fixture"
+	svc.AWSBaselineFixturePaths = []string{filepath.Join(t.TempDir(), "missing.json")}
+
+	blocked, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("verify missing fixture baseline: %v", err)
+	}
+	if blocked.Status != db.AWSPlatformBaselineStatusBlocked || blocked.RequiredChecksPassed {
+		t.Fatalf("expected fixture baseline to block, got %+v", blocked)
+	}
+	if len(blocked.FailureReasons) == 0 || blocked.FailureReasons[0] != "aws fixtures are unavailable" {
+		t.Fatalf("expected fixture failure reason, got %+v", blocked.FailureReasons)
+	}
+	blockedConnectorCheck := requireAWSBaselineCheck(t, blocked.Checks, "aws_connector_health")
+	if blockedConnectorCheck.Required || blockedConnectorCheck.Status != db.AWSPlatformBaselineCheckSkipped {
+		t.Fatalf("expected fixture mode to skip connector health, got %+v", blockedConnectorCheck)
+	}
+
+	fixtureDir := t.TempDir()
+	fixturePath := filepath.Join(fixtureDir, "roles.json")
+	if err := os.WriteFile(fixturePath, []byte(`{"roles":[]}`), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	svc.AWSBaselineFixturePaths = []string{fixtureDir}
+	ready, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("verify readable fixture baseline: %v", err)
+	}
+	if ready.Status != db.AWSPlatformBaselineStatusReady || !ready.FixtureOnly {
+		t.Fatalf("expected readable fixture baseline to pass, got %+v", ready)
+	}
+	readyConnectorCheck := requireAWSBaselineCheck(t, ready.Checks, "aws_connector_health")
+	if readyConnectorCheck.Required || readyConnectorCheck.Status != db.AWSPlatformBaselineCheckSkipped {
+		t.Fatalf("expected readable fixture baseline to skip connector health, got %+v", readyConnectorCheck)
+	}
+}
+
+func TestVerifyAWSPlatformBaselineExplainsUnhealthyConnectorAndFullQueue(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	if err := store.UpsertTenancyConnector(ctx, db.TenancyConnector{
+		WorkspaceID: "default",
+		ProjectID:   "project-a",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "AWS production",
+		Status:      domain.ConnectorStatusPending,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, db.TenancyConnectorState{
+		WorkspaceID:  "default",
+		ProjectID:    "project-a",
+		ConnectorID:  "aws-prod",
+		HealthStatus: "error",
+		Metadata: map[string]any{
+			"account_id": "123456789012",
+			"region":     "us-east-1",
+			"permission_checks": []AWSConnectionPermissionCheck{{
+				Name:    "iam:GetRole",
+				Passed:  false,
+				Message: "iam:GetRole denied",
+			}},
+			"diagnostics": []AWSConnectionDiagnostic{{
+				Code:    "AccessDenied",
+				Message: "sts:AssumeRole denied",
+			}},
+		},
+		ObservedAt: now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("seed unhealthy aws connector: %v", err)
+	}
+	if _, err := store.CreateQueuedScanWithSource(ctx, "aws", db.ScanSource{ProjectID: "project-a", ConnectorID: "aws-prod"}, now); err != nil {
+		t.Fatalf("seed queued aws scan: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.ScanQueueMaxPending = 1
+
+	result, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("verify unhealthy baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusBlocked || result.RequiredChecksPassed {
+		t.Fatalf("expected blocked baseline, got %+v", result)
+	}
+	connectorCheck := requireAWSBaselineCheck(t, result.Checks, "aws_connector_health")
+	if connectorCheck.Status != db.AWSPlatformBaselineCheckPermissionDenied || connectorCheck.FailureReason != "sts:AssumeRole denied" {
+		t.Fatalf("expected permission-denied connector check, got %+v", connectorCheck)
+	}
+	queueCheck := requireAWSBaselineCheck(t, result.Checks, "worker_queue_availability")
+	if queueCheck.Status != db.AWSPlatformBaselineCheckFailed || queueCheck.FailureReason != "worker queue is full" {
+		t.Fatalf("expected full queue check, got %+v", queueCheck)
+	}
+}
+
+func TestVerifyAWSPlatformBaselineQueueCheckIsSourceScoped(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 50, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedDefaultProject(t, store, ctx, "project-b")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	if _, err := store.CreateQueuedScanWithSource(ctx, "aws", db.ScanSource{ProjectID: "project-b"}, now); err != nil {
+		t.Fatalf("seed unrelated queued aws scan: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.ScanQueueMaxPending = 1
+
+	result, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("verify source-scoped baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusReady || !result.RequiredChecksPassed {
+		t.Fatalf("expected unrelated project queue not to block baseline, got %+v", result)
+	}
+	queueCheck := requireAWSBaselineCheck(t, result.Checks, "worker_queue_availability")
+	if queueCheck.Status != db.AWSPlatformBaselineCheckPassed {
+		t.Fatalf("expected source-scoped queue check to pass, got %+v", queueCheck)
+	}
+	if queueCheck.Evidence["pending_queue_count"] != 0 {
+		t.Fatalf("expected project-a source queue count 0, got %+v", queueCheck.Evidence)
+	}
+	if queueCheck.Evidence["queue_count_mode"] != "queued_running" {
+		t.Fatalf("expected default queue check to use queued/running mode, got %+v", queueCheck.Evidence)
+	}
+}
+
+func TestVerifyAWSPlatformBaselineBlocksRunningScanForDefaultLimit(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 52, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	queued, err := store.CreateQueuedScanWithSource(ctx, "aws", db.ScanSource{ProjectID: "project-a"}, now)
+	if err != nil {
+		t.Fatalf("seed queued aws scan: %v", err)
+	}
+	running, err := store.ClaimNextQueuedScan(ctx, "aws")
+	if err != nil {
+		t.Fatalf("claim queued aws scan: %v", err)
+	}
+	if running.ID != queued.ID || running.Status != "running" {
+		t.Fatalf("expected seeded scan to be running, got %+v", running)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.ScanQueueMaxPending = 1
+
+	result, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{})
+	if err != nil {
+		t.Fatalf("verify running-scan baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusBlocked || result.RequiredChecksPassed {
+		t.Fatalf("expected running scan to block default baseline, got %+v", result)
+	}
+	queueCheck := requireAWSBaselineCheck(t, result.Checks, "worker_queue_availability")
+	if queueCheck.Status != db.AWSPlatformBaselineCheckFailed || queueCheck.Evidence["pending_queue_count"] != 1 || queueCheck.Evidence["queue_count_mode"] != "queued_running" {
+		t.Fatalf("expected running scan to count against default queue gate, got %+v", queueCheck)
+	}
+}
+
+func TestVerifyAWSPlatformBaselineBlocksArchivedProject(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 9, 55, 0, 0, time.UTC)
+	archivedAt := now.Add(-time.Hour)
+	seedDefaultProject(t, store, ctx, "project-a")
+	if err := store.UpsertProject(ctx, db.TenancyProject{
+		WorkspaceID: "default",
+		ProjectID:   "project-a",
+		Name:        "Project project-a",
+		Slug:        "project-a",
+		ArchivedAt:  &archivedAt,
+	}); err != nil {
+		t.Fatalf("archive project: %v", err)
+	}
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.VerifyAWSPlatformBaseline(ctx, "default", "project-a", AWSPlatformBaselineRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("verify archived project baseline: %v", err)
+	}
+	if result.Status != db.AWSPlatformBaselineStatusBlocked || result.RequiredChecksPassed {
+		t.Fatalf("expected archived project to block baseline, got %+v", result)
+	}
+	appCheck := requireAWSBaselineCheck(t, result.Checks, "app_validation_prerequisites")
+	if appCheck.Status != db.AWSPlatformBaselineCheckFailed || appCheck.FailureReason != "project is archived" {
+		t.Fatalf("expected archived app validation check, got %+v", appCheck)
+	}
+}
+
+func TestRouterAWSScanBlockedByBaselineReturnsPrecondition(t *testing.T) {
+	r := newAWSConnectionTestRouter(t, &fakeAWSConnectorValidator{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/scans", `{"project_id":"project-1"}`)
+	if resp.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected baseline precondition failure, got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body struct {
+		ErrorCode      string                       `json:"error_code"`
+		FailureReasons []string                     `json:"failure_reasons"`
+		Baseline       db.AWSPlatformBaselineResult `json:"baseline"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode baseline response: %v", err)
+	}
+	if body.ErrorCode != "aws_platform_baseline_not_ready" {
+		t.Fatalf("unexpected error code: %+v", body)
+	}
+	if body.Baseline.Status != db.AWSPlatformBaselineStatusBlocked || body.Baseline.ProjectID != "project-1" {
+		t.Fatalf("unexpected baseline payload: %+v", body.Baseline)
+	}
+	if len(body.FailureReasons) == 0 || body.FailureReasons[0] != "aws connector is missing" {
+		t.Fatalf("expected connector failure reason, got %+v", body.FailureReasons)
+	}
+}
+
+func TestEnsureAWSPlatformBaselineBlocksMissingConnector(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"})
+	var notReady AWSPlatformBaselineNotReadyError
+	if !errorsAsAWSBaseline(err, &notReady) {
+		t.Fatalf("expected baseline not ready error, got %v", err)
+	}
+	if notReady.Result.VerifiedAt != now || notReady.Result.Status != db.AWSPlatformBaselineStatusBlocked {
+		t.Fatalf("unexpected not ready result: %+v", notReady.Result)
+	}
+}
+
+func TestEnsureAWSPlatformBaselineAllowsFixtureModeWithoutConnector(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 10, 5, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	fixtureDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fixtureDir, "roles.json"), []byte(`{"roles":[]}`), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSBaselineSourceMode = "fixture"
+	svc.AWSBaselineFixturePaths = []string{fixtureDir}
+
+	if err := svc.ensureAWSPlatformBaselineReadyForScan(ctx, "aws", db.ScanSource{ProjectID: "project-a"}); err != nil {
+		t.Fatalf("expected fixture baseline to allow scan without connector: %v", err)
+	}
+	result, err := store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{
+		WorkspaceID: "default",
+		ProjectID:   "project-a",
+	})
+	if err != nil {
+		t.Fatalf("reload fixture baseline: %v", err)
+	}
+	connectorCheck := requireAWSBaselineCheck(t, result.Checks, "aws_connector_health")
+	if result.Status != db.AWSPlatformBaselineStatusReady || !result.RequiredChecksPassed || connectorCheck.Required || connectorCheck.Status != db.AWSPlatformBaselineCheckSkipped {
+		t.Fatalf("expected ready fixture baseline with skipped connector health, got result=%+v connector=%+v", result, connectorCheck)
+	}
+}
+
+func TestAWSPlatformBaselineNotReadyErrorMatchesSentinel(t *testing.T) {
+	err := AWSPlatformBaselineNotReadyError{}
+	if err.Error() != ErrAWSPlatformBaselineNotReady.Error() {
+		t.Fatalf("unexpected error text %q", err.Error())
+	}
+	if !errors.Is(err, ErrAWSPlatformBaselineNotReady) {
+		t.Fatalf("expected not-ready error to match sentinel")
+	}
+}
+
+func requireAWSBaselineCheck(t *testing.T, checks []db.AWSPlatformBaselineCheck, name string) db.AWSPlatformBaselineCheck {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("missing baseline check %q in %+v", name, checks)
+	return db.AWSPlatformBaselineCheck{}
+}
+
+func errorsAsAWSBaseline(err error, target *AWSPlatformBaselineNotReadyError) bool {
+	if err == nil {
+		return false
+	}
+	var notReady AWSPlatformBaselineNotReadyError
+	if !errors.As(err, &notReady) {
+		return false
+	}
+	*target = notReady
+	return true
+}

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -180,6 +180,7 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/scan-policies/{policy_id}:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/kubernetes/connection:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection:",
+		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/complete:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connection:",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1161,6 +1161,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		scan, err := svc.EnqueueScan(c.Request.Context(), request)
 		if err != nil {
 			metrics.ScanEnqueueFailureTotal.Inc()
+			if status, payload, ok := awsBaselineNotReadyResponse(err); ok {
+				c.JSON(status, payload)
+				return
+			}
 			if errors.Is(err, ErrInvalidScanRequest) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan request"})
 				return
@@ -1199,6 +1203,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		scan, err := svc.ReplayScan(c.Request.Context(), scanID)
 		if err != nil {
 			metrics.ScanEnqueueFailureTotal.Inc()
+			if status, payload, ok := awsBaselineNotReadyResponse(err); ok {
+				c.JSON(status, payload)
+				return
+			}
 			switch {
 			case errors.Is(err, db.ErrNotFound):
 				c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
@@ -2426,6 +2434,58 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"connection": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/baseline", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPlatformBaseline(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPlatformBaselineRequest{
+			ConnectorID: strings.TrimSpace(c.Query("connector_id")),
+		})
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "project not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("get aws platform baseline", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws platform baseline"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"baseline": record})
+	})
+
+	v1.POST("/workspaces/:workspace_id/projects/:project_id/aws/baseline", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		var request AWSPlatformBaselineRequest
+		if c.Request.Body != nil && c.Request.ContentLength != 0 {
+			if err := c.ShouldBindJSON(&request); err != nil && !errors.Is(err, io.EOF) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+				return
+			}
+		}
+		record, err := svc.VerifyAWSPlatformBaseline(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), request)
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws baseline request"})
+			default:
+				if logger != nil {
+					logger.Error("verify aws platform baseline", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify aws platform baseline"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"baseline": record})
+	})
+
 	v1.POST("/workspaces/:workspace_id/projects/:project_id/github/connect/complete", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)
@@ -2634,6 +2694,19 @@ func repoScanEnqueueErrorResponse(err error) (int, gin.H) {
 			"error_detail": detail,
 		}
 	}
+}
+
+func awsBaselineNotReadyResponse(err error) (int, gin.H, bool) {
+	var notReady AWSPlatformBaselineNotReadyError
+	if !errors.As(err, &notReady) {
+		return 0, nil, false
+	}
+	return http.StatusPreconditionFailed, gin.H{
+		"error":           "aws platform baseline is not ready",
+		"error_code":      "aws_platform_baseline_not_ready",
+		"failure_reasons": notReady.Result.FailureReasons,
+		"baseline":        notReady.Result,
+	}, true
 }
 
 func repoScanListErrorResponse(err error) gin.H {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -168,6 +168,11 @@ type Service struct {
 	AWSScannerFactory                  AWSScannerFactory
 	AWSCloudFormationTemplateURL       string
 	AWSAccountID                       string
+	AWSBaselineGitSHA                  string
+	AWSBaselineSourceMode              string
+	AWSBaselineFixturePaths            []string
+	AWSBaselineConnectorProfileVersion string
+	AWSBaselineGraphContractVersion    string
 	AWSConnectorCapabilityPolicy       awsconnector.CapabilityPolicy
 	WorkflowRouter                     *workflow.Router
 	GitHubAppID                        int64
@@ -612,6 +617,9 @@ func (s *Service) EnqueueScan(ctx context.Context, requests ...ScanRequest) (db.
 	if err != nil {
 		return db.ScanRecord{}, err
 	}
+	if err := s.ensureAWSPlatformBaselineReadyForScan(ctx, s.Provider, source); err != nil {
+		return db.ScanRecord{}, err
+	}
 	maxPending := s.ScanQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = 1
@@ -712,6 +720,9 @@ func (s *Service) ReplayScan(ctx context.Context, scanID string) (db.ScanRecord,
 	sourceContext := db.ScanSource{
 		ProjectID:   source.ProjectID,
 		ConnectorID: source.ConnectorID,
+	}
+	if err := s.ensureAWSPlatformBaselineReadyForScan(ctx, source.Provider, sourceContext); err != nil {
+		return db.ScanRecord{}, err
 	}
 	if maxPending == 1 {
 		replay, err = s.Store.CreateQueuedScanIfNoPendingWithSource(ctx, source.Provider, sourceContext, s.Now().UTC())

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -5573,15 +5573,18 @@ func TestServiceProjectScopedAWSScanWithoutConnectorDoesNotUseOtherProjectConnec
 		return fakeScanner{err: fmt.Errorf("unexpected connector %s", connection.ConnectorID)}, nil
 	}
 
-	if _, err := svc.EnqueueScan(ctx, ScanRequest{ProjectID: "project-a"}); err != nil {
-		t.Fatalf("enqueue project without connector: %v", err)
+	var notReady AWSPlatformBaselineNotReadyError
+	if _, err := svc.EnqueueScan(ctx, ScanRequest{ProjectID: "project-a"}); !errors.As(err, &notReady) {
+		t.Fatalf("expected aws baseline not ready error, got %v", err)
 	}
-	processed, err := svc.ProcessNextQueuedScan(ctx)
-	if err != nil {
-		t.Fatalf("process project without connector: %v", err)
+	if notReady.Result.Status != db.AWSPlatformBaselineStatusBlocked || notReady.Result.RequiredChecksPassed {
+		t.Fatalf("expected blocked baseline result, got %+v", notReady.Result)
 	}
-	if !processed {
-		t.Fatal("expected queued scan to be processed")
+	if len(notReady.Result.FailureReasons) == 0 || !strings.Contains(notReady.Result.FailureReasons[0], "connector") {
+		t.Fatalf("expected connector failure reason, got %+v", notReady.Result.FailureReasons)
+	}
+	if _, err := store.GetAWSPlatformBaselineResult(ctx, db.AWSPlatformBaselineFilter{WorkspaceID: "default", ProjectID: "project-a"}); err != nil {
+		t.Fatalf("expected persisted baseline failure: %v", err)
 	}
 	if factoryCalled {
 		t.Fatal("expected project-a scan not to hydrate project-b connector")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	LogLevel                      string
 	Provider                      string
 	ServiceName                   string
+	BaselineGitSHA                string
 	TrustedProxies                []string
 	CORSAllowedOrigins            []string
 	DatabaseURL                   string
@@ -267,6 +268,7 @@ func Load() Config {
 		LogLevel:                      strings.ToLower(getEnv("IDENTRAIL_LOG_LEVEL", defaultLogLevel)),
 		Provider:                      strings.ToLower(getEnv("IDENTRAIL_PROVIDER", defaultProvider)),
 		ServiceName:                   getEnv("IDENTRAIL_SERVICE_NAME", defaultServiceName),
+		BaselineGitSHA:                getEnv("IDENTRAIL_BASELINE_GIT_SHA", getEnv("IDENTRAIL_GIT_SHA", "")),
 		TrustedProxies:                parseCommaSeparated(getEnv("IDENTRAIL_TRUSTED_PROXIES", "")),
 		CORSAllowedOrigins:            parseCommaSeparated(getEnv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")),
 		DatabaseURL:                   getEnv("IDENTRAIL_DATABASE_URL", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_LOG_LEVEL", "")
 	t.Setenv("IDENTRAIL_PROVIDER", "")
 	t.Setenv("IDENTRAIL_SERVICE_NAME", "")
+	t.Setenv("IDENTRAIL_BASELINE_GIT_SHA", "")
+	t.Setenv("IDENTRAIL_GIT_SHA", "")
 	t.Setenv("IDENTRAIL_TRUSTED_PROXIES", "")
 	t.Setenv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")
 	t.Setenv("IDENTRAIL_DATABASE_URL", "")
@@ -379,6 +381,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_LOG_LEVEL", "DEBUG")
 	t.Setenv("IDENTRAIL_PROVIDER", "AWS")
 	t.Setenv("IDENTRAIL_SERVICE_NAME", "identrail-dev")
+	t.Setenv("IDENTRAIL_BASELINE_GIT_SHA", "6dd631b1")
 	t.Setenv("IDENTRAIL_TRUSTED_PROXIES", "10.0.0.0/8,127.0.0.1")
 	t.Setenv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "https://app.identrail.io,https://console.identrail.io")
 	t.Setenv("IDENTRAIL_DATABASE_URL", "postgres://example")
@@ -479,6 +482,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.ServiceName != "identrail-dev" {
 		t.Fatalf("unexpected service name: %q", cfg.ServiceName)
+	}
+	if cfg.BaselineGitSHA != "6dd631b1" {
+		t.Fatalf("unexpected baseline git sha: %q", cfg.BaselineGitSHA)
 	}
 	if len(cfg.TrustedProxies) != 2 || cfg.TrustedProxies[0] != "10.0.0.0/8" || cfg.TrustedProxies[1] != "127.0.0.1" {
 		t.Fatalf("unexpected trusted proxies: %+v", cfg.TrustedProxies)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -46,6 +46,7 @@ type MemoryStore struct {
 	connStates                    map[string]TenancyConnectorState
 	connSecrets                   map[string]TenancyConnectorSecretEnvelope
 	awsCoverages                  map[string]AWSAccountRegionCoverage
+	awsBaselines                  map[string]AWSPlatformBaselineResult
 	users                         map[string]User
 	userIdentityByID              map[string]UserIdentity
 	userIdentityByProviderSubject map[string]string
@@ -98,6 +99,7 @@ func NewMemoryStore() *MemoryStore {
 		connStates:                    map[string]TenancyConnectorState{},
 		connSecrets:                   map[string]TenancyConnectorSecretEnvelope{},
 		awsCoverages:                  map[string]AWSAccountRegionCoverage{},
+		awsBaselines:                  map[string]AWSPlatformBaselineResult{},
 		users:                         map[string]User{},
 		userIdentityByID:              map[string]UserIdentity{},
 		userIdentityByProviderSubject: map[string]string{},
@@ -382,6 +384,11 @@ func (m *MemoryStore) claimNextQueuedScanLocked(scope *Scope, provider string) (
 
 // CountQueuedScans returns the queued scan count for one provider.
 func (m *MemoryStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
+	return m.CountQueuedScansWithSource(ctx, provider, ScanSource{})
+}
+
+// CountQueuedScansWithSource returns the queued scan count for one provider and scan source.
+func (m *MemoryStore) CountQueuedScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -390,6 +397,7 @@ func (m *MemoryStore) CountQueuedScans(ctx context.Context, provider string) (in
 		return 0, err
 	}
 	normalizedProvider := strings.TrimSpace(provider)
+	normalizedSource := source.Normalize()
 	count := 0
 	for _, record := range m.scans {
 		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
@@ -399,6 +407,39 @@ func (m *MemoryStore) CountQueuedScans(ctx context.Context, provider string) (in
 			continue
 		}
 		if normalizedProvider != "" && strings.TrimSpace(record.Provider) != normalizedProvider {
+			continue
+		}
+		if !scanSourceMatches(record, normalizedSource) {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
+// CountPendingScansWithSource returns queued or running scan count for one provider and scan source.
+func (m *MemoryStore) CountPendingScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
+	normalizedProvider := strings.TrimSpace(provider)
+	normalizedSource := source.Normalize()
+	count := 0
+	for _, record := range m.scans {
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		if record.DeadLettered || (record.Status != "queued" && record.Status != "running") {
+			continue
+		}
+		if normalizedProvider != "" && strings.TrimSpace(record.Provider) != normalizedProvider {
+			continue
+		}
+		if !scanSourceMatches(record, normalizedSource) {
 			continue
 		}
 		count++

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -106,6 +106,7 @@ func (m *MemoryStore) DeleteOrganization(ctx context.Context) error {
 			delete(m.awsCoverages, coverageKey)
 		}
 	}
+	m.deleteAWSPlatformBaselineResultsLocked(scope.TenantID, "", "")
 	m.mu.Unlock()
 
 	audit.WriteAction(ctx, audit.AuditEvent{
@@ -496,6 +497,7 @@ func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) e
 			delete(m.awsCoverages, coverageKey)
 		}
 	}
+	m.deleteAWSPlatformBaselineResultsLocked(scope.TenantID, normalizedWorkspaceID, "")
 	m.mu.Unlock()
 
 	audit.WriteAction(ctx, audit.AuditEvent{
@@ -604,6 +606,7 @@ func (m *MemoryStore) HardDeleteWorkspace(ctx context.Context, tenantID, workspa
 			delete(m.awsCoverages, coverageKey)
 		}
 	}
+	m.deleteAWSPlatformBaselineResultsLocked(tenant, id, "")
 	// Collect scan + repo-scan IDs first so the second pass can drain
 	// their child artifact maps. The postgres backend gets this "for
 	// free" via FK ON DELETE CASCADE on scans/repo_scans; the memory
@@ -1196,6 +1199,7 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 			delete(m.awsCoverages, coverageKey)
 		}
 	}
+	m.deleteAWSPlatformBaselineResultsLocked(scope.TenantID, resolvedWorkspaceID, projectID)
 	m.mu.Unlock()
 
 	audit.WriteAction(ctx, audit.AuditEvent{
@@ -1488,6 +1492,10 @@ func awsAccountRegionCoverageKey(tenantID string, workspaceID string, projectID 
 	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID), strings.TrimSpace(connectorID), strings.TrimSpace(accountID), strings.ToLower(strings.TrimSpace(region)))
 }
 
+func awsPlatformBaselineKey(tenantID string, workspaceID string, projectID string, connectorID string) string {
+	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID), strings.TrimSpace(connectorID))
+}
+
 // UpsertTenancyConnector persists one connector and its latest state atomically.
 func (m *MemoryStore) UpsertTenancyConnector(ctx context.Context, connector TenancyConnector, state TenancyConnectorState) error {
 	m.mu.Lock()
@@ -1776,6 +1784,94 @@ func cloneAWSAccountRegionCoverage(coverage AWSAccountRegionCoverage) AWSAccount
 	if coverage.LastSuccessfulScanAt != nil {
 		scanned := coverage.LastSuccessfulScanAt.UTC()
 		cloned.LastSuccessfulScanAt = &scanned
+	}
+	return cloned
+}
+
+// UpsertAWSPlatformBaselineResult persists one project-scoped AWS baseline gate result.
+func (m *MemoryStore) UpsertAWSPlatformBaselineResult(ctx context.Context, result AWSPlatformBaselineResult) (AWSPlatformBaselineResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	result.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, result.WorkspaceID)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	result.WorkspaceID = resolvedWorkspaceID
+	normalized, err := NormalizeAWSPlatformBaselineResultForWrite(result)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	if _, exists := m.projects[tenancyProjectKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID)]; !exists {
+		return AWSPlatformBaselineResult{}, ErrNotFound
+	}
+	if normalized.ConnectorID != "" {
+		connectorKey := tenancyConnectorKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID)
+		if connector, exists := m.connectors[connectorKey]; !exists || connector.Type != domain.ConnectorTypeAWS {
+			return AWSPlatformBaselineResult{}, ErrNotFound
+		}
+	}
+	key := awsPlatformBaselineKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID)
+	if existing, exists := m.awsBaselines[key]; exists {
+		normalized.CreatedAt = existing.CreatedAt
+	}
+	m.awsBaselines[key] = normalized
+	return cloneAWSPlatformBaselineResult(normalized), nil
+}
+
+// GetAWSPlatformBaselineResult returns the latest scoped AWS baseline gate result.
+func (m *MemoryStore) GetAWSPlatformBaselineResult(ctx context.Context, filter AWSPlatformBaselineFilter) (AWSPlatformBaselineResult, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, filter.WorkspaceID)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	projectID := strings.TrimSpace(filter.ProjectID)
+	if projectID == "" {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("project id is required")
+	}
+	key := awsPlatformBaselineKey(scope.TenantID, resolvedWorkspaceID, projectID, filter.ConnectorID)
+	result, exists := m.awsBaselines[key]
+	if !exists {
+		return AWSPlatformBaselineResult{}, ErrNotFound
+	}
+	return cloneAWSPlatformBaselineResult(result), nil
+}
+
+func (m *MemoryStore) deleteAWSPlatformBaselineResultsLocked(tenantID string, workspaceID string, projectID string) {
+	for key, baseline := range m.awsBaselines {
+		if tenantID != "" && baseline.TenantID != tenantID {
+			continue
+		}
+		if workspaceID != "" && baseline.WorkspaceID != workspaceID {
+			continue
+		}
+		if projectID != "" && baseline.ProjectID != projectID {
+			continue
+		}
+		delete(m.awsBaselines, key)
+	}
+}
+
+func cloneAWSPlatformBaselineResult(result AWSPlatformBaselineResult) AWSPlatformBaselineResult {
+	cloned := result
+	cloned.FailureReasons = append([]string(nil), result.FailureReasons...)
+	cloned.EvidenceLinks = append([]string(nil), result.EvidenceLinks...)
+	cloned.Checks = make([]AWSPlatformBaselineCheck, len(result.Checks))
+	for idx, check := range result.Checks {
+		cloned.Checks[idx] = check
+		cloned.Checks[idx].Evidence = cloneMetadataMap(check.Evidence)
 	}
 	return cloned
 }

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -548,6 +548,95 @@ func TestMemoryStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreAWSPlatformBaselineResult(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "workspace-a", ProjectID: "project-1", Name: "Project 1", Slug: "project-1"}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	if err := store.UpsertTenancyConnector(ctx, TenancyConnector{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Production AWS",
+		Status:      domain.ConnectorStatusActive,
+	}, TenancyConnectorState{WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws-prod", HealthStatus: "healthy"}); err != nil {
+		t.Fatalf("upsert connector: %v", err)
+	}
+	if err := store.UpsertOrganization(tenantB, TenancyOrganization{DisplayName: "Tenant B", Slug: "tenant-b"}); err != nil {
+		t.Fatalf("upsert tenant-b organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantB, TenancyWorkspace{WorkspaceID: "workspace-b", DisplayName: "Workspace B", Slug: "workspace-b"}); err != nil {
+		t.Fatalf("upsert tenant-b workspace: %v", err)
+	}
+	if err := store.UpsertProject(tenantB, TenancyProject{WorkspaceID: "workspace-b", ProjectID: "project-1", Name: "Project B", Slug: "project-b"}); err != nil {
+		t.Fatalf("upsert tenant-b project: %v", err)
+	}
+
+	result, err := store.UpsertAWSPlatformBaselineResult(ctx, AWSPlatformBaselineResult{
+		WorkspaceID:          "workspace-a",
+		ProjectID:            "project-1",
+		ConnectorID:          "aws-prod",
+		GitSHA:               "6dd631b1",
+		SourceMode:           "fixture",
+		FixtureOnly:          true,
+		AccountID:            "123456789012",
+		Region:               "US-WEST-2",
+		Status:               AWSPlatformBaselineStatusReady,
+		Confidence:           1.2,
+		RequiredChecksPassed: true,
+		EvidenceLinks:        []string{"/app/tenant-a/workspace-a/aws"},
+		Checks: []AWSPlatformBaselineCheck{{
+			Name:       "aws_connector_health",
+			Required:   true,
+			Status:     AWSPlatformBaselineCheckPassed,
+			Message:    "ok",
+			Confidence: 0.9,
+			Evidence:   map[string]any{"connector_id": "aws-prod"},
+			CheckedAt:  now,
+		}},
+		VerifiedAt: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("upsert baseline: %v", err)
+	}
+	if result.Region != "us-west-2" || result.Confidence != 1 {
+		t.Fatalf("expected normalized baseline, got %+v", result)
+	}
+	result.Checks[0].Evidence["connector_id"] = "mutated"
+	reloaded, err := store.GetAWSPlatformBaselineResult(ctx, AWSPlatformBaselineFilter{WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("reload baseline: %v", err)
+	}
+	if reloaded.Checks[0].Evidence["connector_id"] == "mutated" {
+		t.Fatalf("expected baseline evidence to be copied defensively")
+	}
+	if _, err := store.GetAWSPlatformBaselineResult(tenantB, AWSPlatformBaselineFilter{WorkspaceID: "workspace-b", ProjectID: "project-1", ConnectorID: "aws-prod"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant isolation, got %v", err)
+	}
+	if _, err := store.UpsertAWSPlatformBaselineResult(ctx, AWSPlatformBaselineResult{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "missing",
+		Status:      AWSPlatformBaselineStatusBlocked,
+		VerifiedAt:  now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing connector to be rejected, got %v", err)
+	}
+}
+
 func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
@@ -1976,6 +2065,128 @@ func TestMemoryStoreHardDeleteWorkspacePurgesChildRows(t *testing.T) {
 	}
 	if _, err := store.GetProject(ctx, "ws-1", "project-a"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected project purged with workspace, got %v", err)
+	}
+}
+
+func TestMemoryStoreDeleteCascadesPurgeAWSPlatformBaselines(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+	t.Run("project", func(t *testing.T) {
+		store, ctx := setupMemoryBaselineCascadeStore(t)
+		seedMemoryAWSPlatformBaseline(t, store, ctx, now)
+
+		if err := store.DeleteProject(ctx, "ws-1", "project-a"); err != nil {
+			t.Fatalf("delete project: %v", err)
+		}
+		if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "ws-1", ProjectID: "project-a", Name: "Project A", Slug: "project-a"}); err != nil {
+			t.Fatalf("recreate project: %v", err)
+		}
+		assertMemoryAWSPlatformBaselinePurged(t, store, ctx)
+	})
+
+	t.Run("workspace", func(t *testing.T) {
+		store, ctx := setupMemoryBaselineCascadeStore(t)
+		seedMemoryAWSPlatformBaseline(t, store, ctx, now)
+
+		if err := store.DeleteWorkspace(ctx, "ws-1"); err != nil {
+			t.Fatalf("delete workspace: %v", err)
+		}
+		if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "ws-1", DisplayName: "Workspace 1", Slug: "ws-1"}); err != nil {
+			t.Fatalf("recreate workspace: %v", err)
+		}
+		if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "ws-1", ProjectID: "project-a", Name: "Project A", Slug: "project-a"}); err != nil {
+			t.Fatalf("recreate project: %v", err)
+		}
+		assertMemoryAWSPlatformBaselinePurged(t, store, ctx)
+	})
+
+	t.Run("organization", func(t *testing.T) {
+		store, ctx := setupMemoryBaselineCascadeStore(t)
+		seedMemoryAWSPlatformBaseline(t, store, ctx, now)
+
+		if err := store.DeleteOrganization(ctx); err != nil {
+			t.Fatalf("delete organization: %v", err)
+		}
+		if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+			t.Fatalf("recreate organization: %v", err)
+		}
+		if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "ws-1", DisplayName: "Workspace 1", Slug: "ws-1"}); err != nil {
+			t.Fatalf("recreate workspace: %v", err)
+		}
+		if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "ws-1", ProjectID: "project-a", Name: "Project A", Slug: "project-a"}); err != nil {
+			t.Fatalf("recreate project: %v", err)
+		}
+		assertMemoryAWSPlatformBaselinePurged(t, store, ctx)
+	})
+
+	t.Run("hard delete workspace", func(t *testing.T) {
+		store, ctx := setupMemoryBaselineCascadeStore(t)
+		seedMemoryAWSPlatformBaseline(t, store, ctx, now)
+		past := now.Add(-(WorkspaceDeletionGracePeriod + time.Hour))
+		saved, err := store.SoftDeleteWorkspace(ctx, "ws-1", past)
+		if err != nil {
+			t.Fatalf("soft delete workspace: %v", err)
+		}
+		if _, err := store.HardDeleteWorkspace(context.Background(), "tenant-a", "ws-1", *saved.DeletedAt, now); err != nil {
+			t.Fatalf("hard delete workspace: %v", err)
+		}
+		if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "ws-1", DisplayName: "Workspace 1", Slug: "ws-1"}); err != nil {
+			t.Fatalf("recreate workspace: %v", err)
+		}
+		if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "ws-1", ProjectID: "project-a", Name: "Project A", Slug: "project-a"}); err != nil {
+			t.Fatalf("recreate project: %v", err)
+		}
+		assertMemoryAWSPlatformBaselinePurged(t, store, ctx)
+	})
+}
+
+func setupMemoryBaselineCascadeStore(t *testing.T) (*MemoryStore, context.Context) {
+	t.Helper()
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-1"})
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "ws-1", DisplayName: "Workspace 1", Slug: "ws-1"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "ws-1", ProjectID: "project-a", Name: "Project A", Slug: "project-a"}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	return store, ctx
+}
+
+func seedMemoryAWSPlatformBaseline(t *testing.T, store *MemoryStore, ctx context.Context, now time.Time) {
+	t.Helper()
+	if _, err := store.UpsertAWSPlatformBaselineResult(ctx, AWSPlatformBaselineResult{
+		WorkspaceID:          "ws-1",
+		ProjectID:            "project-a",
+		Status:               AWSPlatformBaselineStatusReady,
+		Confidence:           0.95,
+		RequiredChecksPassed: true,
+		Checks: []AWSPlatformBaselineCheck{{
+			Name:       "aws_connector_health",
+			Required:   true,
+			Status:     AWSPlatformBaselineCheckPassed,
+			Confidence: 0.96,
+			CheckedAt:  now,
+		}},
+		VerifiedAt: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("seed aws baseline: %v", err)
+	}
+}
+
+func assertMemoryAWSPlatformBaselinePurged(t *testing.T, store *MemoryStore, ctx context.Context) {
+	t.Helper()
+	_, err := store.GetAWSPlatformBaselineResult(ctx, AWSPlatformBaselineFilter{
+		WorkspaceID: "ws-1",
+		ProjectID:   "project-a",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected AWS baseline purged, got %v", err)
 	}
 }
 

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -1145,6 +1145,98 @@ func TestMemoryStoreCountQueuedScansBlankProviderIsWildcard(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreCountQueuedScansWithSource(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
+	if _, err := store.CreateQueuedScanWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: "project-a", ConnectorID: "aws-a"}, now); err != nil {
+		t.Fatalf("create project-a queued scan: %v", err)
+	}
+	if _, err := store.CreateQueuedScanWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: "project-b", ConnectorID: "aws-b"}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("create project-b queued scan: %v", err)
+	}
+	if _, err := store.CreateQueuedScanWithSource(defaultScopeContext(), "gcp", ScanSource{ProjectID: "project-a"}, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("create gcp queued scan: %v", err)
+	}
+
+	count, err := store.CountQueuedScansWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: "project-a"})
+	if err != nil {
+		t.Fatalf("count project-a queued scans: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected source-scoped queued count 1, got %d", count)
+	}
+	count, err = store.CountQueuedScansWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: "project-a", ConnectorID: "missing"})
+	if err != nil {
+		t.Fatalf("count missing connector queued scans: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected missing connector queued count 0, got %d", count)
+	}
+	count, err = store.CountQueuedScansWithSource(defaultScopeContext(), "aws", ScanSource{})
+	if err != nil {
+		t.Fatalf("count unscoped aws queued scans: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected unscoped aws queued count 2, got %d", count)
+	}
+}
+
+func TestMemoryStoreCountPendingScansWithSource(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
+	source := ScanSource{ProjectID: "project-a", ConnectorID: "aws-a"}
+	queued, err := store.CreateQueuedScanWithSource(ctx, "aws", source, now)
+	if err != nil {
+		t.Fatalf("create project-a queued scan: %v", err)
+	}
+	running, err := store.ClaimNextQueuedScan(ctx, "aws")
+	if err != nil {
+		t.Fatalf("claim project-a scan: %v", err)
+	}
+	if running.ID != queued.ID || running.Status != "running" {
+		t.Fatalf("expected seeded scan to be running, got %+v", running)
+	}
+	if _, err := store.CreateQueuedScanWithSource(ctx, "aws", source, now.Add(time.Minute)); err != nil {
+		t.Fatalf("create second project-a queued scan: %v", err)
+	}
+	if _, err := store.CreateQueuedScanWithSource(ctx, "aws", ScanSource{ProjectID: "project-b"}, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("create project-b queued scan: %v", err)
+	}
+	if _, err := store.CreateQueuedScanWithSource(ctx, "gcp", source, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("create gcp queued scan: %v", err)
+	}
+
+	count, err := store.CountPendingScansWithSource(ctx, "aws", source)
+	if err != nil {
+		t.Fatalf("count project-a pending scans: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected source-scoped pending count 2, got %d", count)
+	}
+	count, err = store.CountQueuedScansWithSource(ctx, "aws", source)
+	if err != nil {
+		t.Fatalf("count project-a queued scans: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected queued-only count 1, got %d", count)
+	}
+	count, err = store.CountPendingScansWithSource(ctx, "aws", ScanSource{ProjectID: "project-a", ConnectorID: "missing"})
+	if err != nil {
+		t.Fatalf("count missing connector pending scans: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected missing connector pending count 0, got %d", count)
+	}
+	count, err = store.CountPendingScansWithSource(ctx, "aws", ScanSource{})
+	if err != nil {
+		t.Fatalf("count unscoped aws pending scans: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected unscoped aws pending count 3, got %d", count)
+	}
+}
+
 func TestMemoryStoreCountQueuedScansAnyScope(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -577,10 +577,16 @@ func (p *PostgresStore) claimNextQueuedScan(ctx context.Context, provider string
 
 // CountQueuedScans returns queued scan requests count for one provider.
 func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
+	return p.CountQueuedScansWithSource(ctx, provider, ScanSource{})
+}
+
+// CountQueuedScansWithSource returns queued scan requests count for one provider and scan source.
+func (p *PostgresStore) CountQueuedScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return 0, err
 	}
+	normalizedSource := source.Normalize()
 	var count int
 	if err := p.queryRowContext(
 		ctx,
@@ -589,13 +595,47 @@ func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND ($3 = '' OR provider = $3)
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
 		   AND status = 'queued'
 		   AND dead_lettered = FALSE`,
 		scope.TenantID,
 		scope.WorkspaceID,
 		strings.TrimSpace(provider),
+		normalizedSource.ProjectID,
+		normalizedSource.ConnectorID,
 	).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count queued scans: %w", err)
+	}
+	return count, nil
+}
+
+// CountPendingScansWithSource returns queued or running scan count for one provider and scan source.
+func (p *PostgresStore) CountPendingScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
+	normalizedSource := source.Normalize()
+	var count int
+	if err := p.queryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND ($3 = '' OR provider = $3)
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
+		   AND status IN ('queued', 'running')
+		   AND dead_lettered = FALSE`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		strings.TrimSpace(provider),
+		normalizedSource.ProjectID,
+		normalizedSource.ConnectorID,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count pending scans: %w", err)
 	}
 	return count, nil
 }

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -2305,6 +2305,222 @@ func scanAWSAccountRegionCoverageRows(rows rowsScanner) ([]AWSAccountRegionCover
 	return results, rows.Err()
 }
 
+// UpsertAWSPlatformBaselineResult persists one project-scoped AWS platform readiness result.
+func (p *PostgresStore) UpsertAWSPlatformBaselineResult(ctx context.Context, result AWSPlatformBaselineResult) (AWSPlatformBaselineResult, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	result.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, result.WorkspaceID)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	result.WorkspaceID = resolvedWorkspaceID
+	normalized, err := NormalizeAWSPlatformBaselineResultForWrite(result)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	failureReasonsPayload, err := json.Marshal(normalized.FailureReasons)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("marshal aws baseline failure reasons: %w", err)
+	}
+	evidenceLinksPayload, err := json.Marshal(normalized.EvidenceLinks)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("marshal aws baseline evidence links: %w", err)
+	}
+	checksPayload, err := json.Marshal(normalized.Checks)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("marshal aws baseline checks: %w", err)
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`INSERT INTO aws_platform_baseline_results (
+		     tenant_id, workspace_id, project_id, connector_id, git_sha, source_mode,
+		     fixture_only, connector_profile_version, graph_contract_version, account_id,
+		     region, status, confidence, required_checks_passed, failure_reasons,
+		     evidence_links, checks, verified_at, created_at, updated_at
+		 )
+		 SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb, $16::jsonb, $17::jsonb, $18, $19, $20
+		 FROM tenancy_projects p
+		 WHERE p.tenant_id = $1
+		   AND p.workspace_id = $2
+		   AND p.project_id = $3
+		   AND (
+		     $4 = ''
+		     OR EXISTS (
+		       SELECT 1
+		       FROM tenancy_connectors c
+		       WHERE c.tenant_id = $1
+		         AND c.workspace_id = $2
+		         AND c.project_id = $3
+		         AND c.connector_id = $4
+		         AND c.type = $21
+		     )
+		   )
+		 ON CONFLICT (tenant_id, workspace_id, project_id, connector_id) DO UPDATE
+		 SET git_sha = EXCLUDED.git_sha,
+		     source_mode = EXCLUDED.source_mode,
+		     fixture_only = EXCLUDED.fixture_only,
+		     connector_profile_version = EXCLUDED.connector_profile_version,
+		     graph_contract_version = EXCLUDED.graph_contract_version,
+		     account_id = EXCLUDED.account_id,
+		     region = EXCLUDED.region,
+		     status = EXCLUDED.status,
+		     confidence = EXCLUDED.confidence,
+		     required_checks_passed = EXCLUDED.required_checks_passed,
+		     failure_reasons = EXCLUDED.failure_reasons,
+		     evidence_links = EXCLUDED.evidence_links,
+		     checks = EXCLUDED.checks,
+		     verified_at = EXCLUDED.verified_at,
+		     updated_at = EXCLUDED.updated_at
+		 RETURNING tenant_id, workspace_id, project_id, connector_id, git_sha, source_mode,
+		           fixture_only, connector_profile_version, graph_contract_version, account_id,
+		           region, status, confidence, required_checks_passed, failure_reasons,
+		           evidence_links, checks, verified_at, created_at, updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+		normalized.GitSHA,
+		normalized.SourceMode,
+		normalized.FixtureOnly,
+		normalized.ConnectorProfileVersion,
+		normalized.GraphContractVersion,
+		normalized.AccountID,
+		normalized.Region,
+		normalized.Status,
+		normalized.Confidence,
+		normalized.RequiredChecksPassed,
+		failureReasonsPayload,
+		evidenceLinksPayload,
+		checksPayload,
+		normalized.VerifiedAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+		string(domain.ConnectorTypeAWS),
+	)
+	if isTenancyFKViolation(err) {
+		return AWSPlatformBaselineResult{}, ErrNotFound
+	}
+	if err != nil {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("upsert aws platform baseline result: %w", err)
+	}
+	defer rows.Close()
+	records, err := scanAWSPlatformBaselineRows(rows)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	if len(records) == 0 {
+		return AWSPlatformBaselineResult{}, ErrNotFound
+	}
+	return records[0], nil
+}
+
+// GetAWSPlatformBaselineResult returns one persisted project-scoped AWS platform readiness result.
+func (p *PostgresStore) GetAWSPlatformBaselineResult(ctx context.Context, filter AWSPlatformBaselineFilter) (AWSPlatformBaselineResult, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, filter.WorkspaceID)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	projectID := strings.TrimSpace(filter.ProjectID)
+	if projectID == "" {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("project id is required")
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, project_id, connector_id, git_sha, source_mode,
+		        fixture_only, connector_profile_version, graph_contract_version, account_id,
+		        region, status, confidence, required_checks_passed, failure_reasons,
+		        evidence_links, checks, verified_at, created_at, updated_at
+		 FROM aws_platform_baseline_results
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4`,
+		scope.TenantID,
+		resolvedWorkspaceID,
+		projectID,
+		strings.TrimSpace(filter.ConnectorID),
+	)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("query aws platform baseline result: %w", err)
+	}
+	defer rows.Close()
+	records, err := scanAWSPlatformBaselineRows(rows)
+	if err != nil {
+		return AWSPlatformBaselineResult{}, err
+	}
+	if len(records) == 0 {
+		return AWSPlatformBaselineResult{}, ErrNotFound
+	}
+	return records[0], nil
+}
+
+func scanAWSPlatformBaselineRows(rows rowsScanner) ([]AWSPlatformBaselineResult, error) {
+	results := []AWSPlatformBaselineResult{}
+	for rows.Next() {
+		var item AWSPlatformBaselineResult
+		var failureReasonsPayload []byte
+		var evidenceLinksPayload []byte
+		var checksPayload []byte
+		if err := rows.Scan(
+			&item.TenantID,
+			&item.WorkspaceID,
+			&item.ProjectID,
+			&item.ConnectorID,
+			&item.GitSHA,
+			&item.SourceMode,
+			&item.FixtureOnly,
+			&item.ConnectorProfileVersion,
+			&item.GraphContractVersion,
+			&item.AccountID,
+			&item.Region,
+			&item.Status,
+			&item.Confidence,
+			&item.RequiredChecksPassed,
+			&failureReasonsPayload,
+			&evidenceLinksPayload,
+			&checksPayload,
+			&item.VerifiedAt,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan aws platform baseline row: %w", err)
+		}
+		if len(failureReasonsPayload) > 0 {
+			if err := json.Unmarshal(failureReasonsPayload, &item.FailureReasons); err != nil {
+				return nil, fmt.Errorf("decode aws baseline failure reasons: %w", err)
+			}
+		}
+		if len(evidenceLinksPayload) > 0 {
+			if err := json.Unmarshal(evidenceLinksPayload, &item.EvidenceLinks); err != nil {
+				return nil, fmt.Errorf("decode aws baseline evidence links: %w", err)
+			}
+		}
+		if len(checksPayload) > 0 {
+			if err := json.Unmarshal(checksPayload, &item.Checks); err != nil {
+				return nil, fmt.Errorf("decode aws baseline checks: %w", err)
+			}
+		}
+		if item.FailureReasons == nil {
+			item.FailureReasons = []string{}
+		}
+		if item.EvidenceLinks == nil {
+			item.EvidenceLinks = []string{}
+		}
+		if item.Checks == nil {
+			item.Checks = []AWSPlatformBaselineCheck{}
+		}
+		results = append(results, item)
+	}
+	return results, rows.Err()
+}
+
 func (p *PostgresStore) listTenancyConnectorRows(ctx context.Context, tenantID string, workspaceID string, projectID string, connectorID string, connectorType string, limit int) ([]TenancyConnectorWithState, error) {
 	query := `SELECT
 		     c.tenant_id, c.workspace_id, c.project_id, c.connector_id, c.type, c.display_name, c.status,

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -305,6 +305,143 @@ func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreAWSPlatformBaselineResultRegistry(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	checks := []AWSPlatformBaselineCheck{{
+		Name:        "aws_connector_health",
+		Category:    "connector",
+		Required:    true,
+		Status:      AWSPlatformBaselineCheckPassed,
+		Message:     "AWS connector is active and healthy.",
+		EvidenceURL: "/docs/auth/aws-connector",
+		Confidence:  0.96,
+		Evidence:    map[string]any{"connector_id": "aws-prod"},
+		CheckedAt:   now,
+	}}
+	failureReasonsPayload, err := json.Marshal([]string{})
+	if err != nil {
+		t.Fatalf("marshal failure reasons: %v", err)
+	}
+	evidenceLinksPayload, err := json.Marshal([]string{"/docs/auth/aws-connector"})
+	if err != nil {
+		t.Fatalf("marshal evidence links: %v", err)
+	}
+	checksPayload, err := json.Marshal(checks)
+	if err != nil {
+		t.Fatalf("marshal checks: %v", err)
+	}
+	baselineColumns := []string{
+		"tenant_id", "workspace_id", "project_id", "connector_id", "git_sha", "source_mode",
+		"fixture_only", "connector_profile_version", "graph_contract_version", "account_id",
+		"region", "status", "confidence", "required_checks_passed", "failure_reasons",
+		"evidence_links", "checks", "verified_at", "created_at", "updated_at",
+	}
+	resultRows := sqlmock.NewRows(baselineColumns).AddRow(
+		"tenant-a", "workspace-a", "project-1", "aws-prod", "6dd631b1", "sdk",
+		false, "aws-readonly-iam-v1", "relationship-contract-v1", "123456789012",
+		"us-east-1", AWSPlatformBaselineStatusReady, 0.95, true, failureReasonsPayload,
+		evidenceLinksPayload, checksPayload, now, now, now,
+	)
+	mock.ExpectQuery(`(?s)INSERT INTO aws_platform_baseline_results.*FROM tenancy_projects p.*c\.type = \$21.*ON CONFLICT.*RETURNING`).
+		WithArgs(
+			"tenant-a",
+			"workspace-a",
+			"project-1",
+			"aws-prod",
+			"6dd631b1",
+			"sdk",
+			false,
+			"aws-readonly-iam-v1",
+			"relationship-contract-v1",
+			"123456789012",
+			"us-east-1",
+			AWSPlatformBaselineStatusReady,
+			0.95,
+			true,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			string(domain.ConnectorTypeAWS),
+		).
+		WillReturnRows(resultRows)
+
+	upserted, err := store.UpsertAWSPlatformBaselineResult(ctx, AWSPlatformBaselineResult{
+		WorkspaceID:             "workspace-a",
+		ProjectID:               "project-1",
+		ConnectorID:             "aws-prod",
+		GitSHA:                  "6dd631b1",
+		SourceMode:              "sdk",
+		ConnectorProfileVersion: "aws-readonly-iam-v1",
+		GraphContractVersion:    "relationship-contract-v1",
+		AccountID:               "123456789012",
+		Region:                  "us-east-1",
+		Status:                  AWSPlatformBaselineStatusReady,
+		Confidence:              0.95,
+		RequiredChecksPassed:    true,
+		EvidenceLinks:           []string{"/docs/auth/aws-connector"},
+		Checks:                  checks,
+		VerifiedAt:              now,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	})
+	if err != nil {
+		t.Fatalf("upsert aws baseline: %v", err)
+	}
+	if upserted.Status != AWSPlatformBaselineStatusReady || len(upserted.Checks) != 1 {
+		t.Fatalf("unexpected upserted baseline: %+v", upserted)
+	}
+
+	getRows := sqlmock.NewRows(baselineColumns).AddRow(
+		"tenant-a", "workspace-a", "project-1", "aws-prod", "6dd631b1", "sdk",
+		false, "aws-readonly-iam-v1", "relationship-contract-v1", "123456789012",
+		"us-east-1", AWSPlatformBaselineStatusReady, 0.95, true, failureReasonsPayload,
+		evidenceLinksPayload, checksPayload, now, now, now,
+	)
+	mock.ExpectQuery(`(?s)SELECT tenant_id, workspace_id, project_id, connector_id, git_sha, source_mode.*FROM aws_platform_baseline_results.*connector_id = \$4`).
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod").
+		WillReturnRows(getRows)
+
+	loaded, err := store.GetAWSPlatformBaselineResult(ctx, AWSPlatformBaselineFilter{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("get aws baseline: %v", err)
+	}
+	if loaded.ConnectorID != "aws-prod" || len(loaded.EvidenceLinks) != 1 || loaded.Checks[0].Name != "aws_connector_health" {
+		t.Fatalf("unexpected loaded baseline: %+v", loaded)
+	}
+
+	emptyRows := sqlmock.NewRows(baselineColumns)
+	mock.ExpectQuery(`(?s)SELECT tenant_id, workspace_id, project_id, connector_id, git_sha, source_mode.*FROM aws_platform_baseline_results.*connector_id = \$4`).
+		WithArgs("tenant-a", "workspace-a", "project-1", "missing").
+		WillReturnRows(emptyRows)
+
+	_, err = store.GetAWSPlatformBaselineResult(ctx, AWSPlatformBaselineFilter{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "missing",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing baseline to return ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreKubernetesEnrollmentTokenClaim(t *testing.T) {
 	rawDB, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1413,9 +1413,11 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND ($3 = '' OR provider = $3)
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
 		   AND status = 'queued'
 		   AND dead_lettered = FALSE`)).
-		WithArgs("default", "default", "aws").
+		WithArgs("default", "default", "aws", "", "").
 		WillReturnRows(countRows)
 
 	count, err := store.CountQueuedScans(defaultScopeContext(), "aws")
@@ -1588,8 +1590,11 @@ func TestPostgresStoreCountQueuedScansBlankProviderIsWildcard(t *testing.T) {
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND ($3 = '' OR provider = $3)
-		   AND status = 'queued'`)).
-		WithArgs("default", "default", "").
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
+		   AND status = 'queued'
+		   AND dead_lettered = FALSE`)).
+		WithArgs("default", "default", "", "", "").
 		WillReturnRows(countRows)
 
 	count, err := store.CountQueuedScans(defaultScopeContext(), "")
@@ -1598,6 +1603,74 @@ func TestPostgresStoreCountQueuedScansBlankProviderIsWildcard(t *testing.T) {
 	}
 	if count != 2 {
 		t.Fatalf("expected wildcard queued count 2, got %d", count)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCountQueuedScansWithSource(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	countRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND ($3 = '' OR provider = $3)
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
+		   AND status = 'queued'
+		   AND dead_lettered = FALSE`)).
+		WithArgs("default", "default", "aws", "project-a", "aws-prod").
+		WillReturnRows(countRows)
+
+	count, err := store.CountQueuedScansWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: " project-a ", ConnectorID: " aws-prod "})
+	if err != nil {
+		t.Fatalf("count queued scans with source: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected source-scoped queued count 1, got %d", count)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCountPendingScansWithSource(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	countRows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND ($3 = '' OR provider = $3)
+		   AND ($4 = '' OR source_project_id = $4)
+		   AND ($5 = '' OR source_connector_id = $5)
+		   AND status IN ('queued', 'running')
+		   AND dead_lettered = FALSE`)).
+		WithArgs("default", "default", "aws", "project-a", "aws-prod").
+		WillReturnRows(countRows)
+
+	count, err := store.CountPendingScansWithSource(defaultScopeContext(), "aws", ScanSource{ProjectID: " project-a ", ConnectorID: " aws-prod "})
+	if err != nil {
+		t.Fatalf("count pending scans with source: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected source-scoped pending count 2, got %d", count)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -984,6 +984,20 @@ const (
 	AWSAccountRegionCoverageUnreachable = "unreachable"
 )
 
+const (
+	AWSPlatformBaselineStatusNotRun   = "not_run"
+	AWSPlatformBaselineStatusReady    = "ready"
+	AWSPlatformBaselineStatusDegraded = "degraded"
+	AWSPlatformBaselineStatusBlocked  = "blocked"
+
+	AWSPlatformBaselineCheckPassed           = "passed"
+	AWSPlatformBaselineCheckFailed           = "failed"
+	AWSPlatformBaselineCheckDegraded         = "degraded"
+	AWSPlatformBaselineCheckPermissionDenied = "permission_denied"
+	AWSPlatformBaselineCheckUnknown          = "unknown"
+	AWSPlatformBaselineCheckSkipped          = "skipped"
+)
+
 // AWSAccountRegionCoverage stores account/region inventory and scan readiness
 // for one project-scoped AWS connector. Connector health describes whether
 // Identrail can use the connector role; coverage describes each target account
@@ -1021,6 +1035,56 @@ type AWSAccountRegionCoverageFilter struct {
 	AccountID   string
 	Region      string
 	Limit       int
+}
+
+// AWSPlatformBaselineCheck records one operator-visible readiness check for the
+// AWS baseline gate. Evidence must never contain secret values.
+type AWSPlatformBaselineCheck struct {
+	Name          string         `json:"name"`
+	Category      string         `json:"category"`
+	Required      bool           `json:"required"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	FailureReason string         `json:"failure_reason,omitempty"`
+	Remediation   string         `json:"remediation,omitempty"`
+	EvidenceURL   string         `json:"evidence_url,omitempty"`
+	Confidence    float64        `json:"confidence"`
+	Evidence      map[string]any `json:"evidence,omitempty"`
+	CheckedAt     time.Time      `json:"checked_at"`
+}
+
+// AWSPlatformBaselineResult is the persisted project-scoped readiness gate
+// result used before AWS scans or later remediation/governance jobs can start.
+type AWSPlatformBaselineResult struct {
+	TenantID                string                     `json:"tenant_id"`
+	WorkspaceID             string                     `json:"workspace_id"`
+	ProjectID               string                     `json:"project_id"`
+	ConnectorID             string                     `json:"connector_id,omitempty"`
+	GitSHA                  string                     `json:"git_sha"`
+	SourceMode              string                     `json:"source_mode"`
+	FixtureOnly             bool                       `json:"fixture_only"`
+	ConnectorProfileVersion string                     `json:"connector_profile_version"`
+	GraphContractVersion    string                     `json:"graph_contract_version"`
+	AccountID               string                     `json:"account_id,omitempty"`
+	Region                  string                     `json:"region,omitempty"`
+	Status                  string                     `json:"status"`
+	Confidence              float64                    `json:"confidence"`
+	RequiredChecksPassed    bool                       `json:"required_checks_passed"`
+	FailureReasons          []string                   `json:"failure_reasons"`
+	EvidenceLinks           []string                   `json:"evidence_links"`
+	Checks                  []AWSPlatformBaselineCheck `json:"checks"`
+	VerifiedAt              time.Time                  `json:"verified_at"`
+	CreatedAt               time.Time                  `json:"created_at"`
+	UpdatedAt               time.Time                  `json:"updated_at"`
+}
+
+// AWSPlatformBaselineFilter identifies one scoped AWS baseline result. An empty
+// connector id returns the project-level result when no specific connector was
+// requested.
+type AWSPlatformBaselineFilter struct {
+	WorkspaceID string
+	ProjectID   string
+	ConnectorID string
 }
 
 // TenancyConnectorSecretEnvelope stores one encrypted connector secret envelope.
@@ -2251,6 +2315,149 @@ func NormalizeAWSAccountRegionCoverageForWrite(coverage AWSAccountRegionCoverage
 	return normalized, nil
 }
 
+// NormalizeAWSPlatformBaselineResultForWrite validates and canonicalizes one AWS
+// platform baseline gate result before persistence.
+func NormalizeAWSPlatformBaselineResultForWrite(result AWSPlatformBaselineResult) (AWSPlatformBaselineResult, error) {
+	normalized := result
+	normalized.TenantID = strings.TrimSpace(result.TenantID)
+	if normalized.TenantID == "" {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(result.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.ProjectID = strings.TrimSpace(result.ProjectID)
+	if normalized.ProjectID == "" {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("project id is required")
+	}
+	normalized.ConnectorID = strings.TrimSpace(result.ConnectorID)
+	normalized.GitSHA = strings.TrimSpace(result.GitSHA)
+	normalized.SourceMode = strings.ToLower(strings.TrimSpace(result.SourceMode))
+	normalized.ConnectorProfileVersion = strings.TrimSpace(result.ConnectorProfileVersion)
+	normalized.GraphContractVersion = strings.TrimSpace(result.GraphContractVersion)
+	normalized.AccountID = strings.TrimSpace(result.AccountID)
+	if normalized.AccountID != "" && !validAWSAccountID(normalized.AccountID) {
+		return AWSPlatformBaselineResult{}, fmt.Errorf("aws account id must be 12 digits")
+	}
+	normalized.Region = strings.ToLower(strings.TrimSpace(result.Region))
+	normalized.Status = strings.ToLower(strings.TrimSpace(result.Status))
+	if normalized.Status == "" {
+		normalized.Status = AWSPlatformBaselineStatusNotRun
+	}
+	switch normalized.Status {
+	case AWSPlatformBaselineStatusNotRun,
+		AWSPlatformBaselineStatusReady,
+		AWSPlatformBaselineStatusDegraded,
+		AWSPlatformBaselineStatusBlocked:
+	default:
+		return AWSPlatformBaselineResult{}, fmt.Errorf("invalid aws platform baseline status")
+	}
+	normalized.Confidence = clampConfidence(result.Confidence)
+	normalized.FailureReasons = normalizeStringList(result.FailureReasons)
+	normalized.EvidenceLinks = normalizeStringList(result.EvidenceLinks)
+	normalized.Checks = normalizeAWSPlatformBaselineChecks(result.Checks)
+	if normalized.FailureReasons == nil {
+		normalized.FailureReasons = []string{}
+	}
+	if normalized.EvidenceLinks == nil {
+		normalized.EvidenceLinks = []string{}
+	}
+	if normalized.Checks == nil {
+		normalized.Checks = []AWSPlatformBaselineCheck{}
+	}
+	if normalized.VerifiedAt.IsZero() {
+		normalized.VerifiedAt = time.Now().UTC()
+	} else {
+		normalized.VerifiedAt = normalized.VerifiedAt.UTC()
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = normalized.VerifiedAt
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.VerifiedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+func normalizeAWSPlatformBaselineChecks(checks []AWSPlatformBaselineCheck) []AWSPlatformBaselineCheck {
+	if len(checks) == 0 {
+		return []AWSPlatformBaselineCheck{}
+	}
+	normalized := make([]AWSPlatformBaselineCheck, 0, len(checks))
+	for _, check := range checks {
+		item := check
+		item.Name = strings.TrimSpace(check.Name)
+		if item.Name == "" {
+			continue
+		}
+		item.Category = strings.TrimSpace(check.Category)
+		item.Status = strings.ToLower(strings.TrimSpace(check.Status))
+		switch item.Status {
+		case AWSPlatformBaselineCheckPassed,
+			AWSPlatformBaselineCheckFailed,
+			AWSPlatformBaselineCheckDegraded,
+			AWSPlatformBaselineCheckPermissionDenied,
+			AWSPlatformBaselineCheckUnknown,
+			AWSPlatformBaselineCheckSkipped:
+		default:
+			item.Status = AWSPlatformBaselineCheckUnknown
+		}
+		item.Message = strings.TrimSpace(check.Message)
+		item.FailureReason = strings.TrimSpace(check.FailureReason)
+		item.Remediation = strings.TrimSpace(check.Remediation)
+		item.EvidenceURL = strings.TrimSpace(check.EvidenceURL)
+		item.Confidence = clampConfidence(check.Confidence)
+		if item.Evidence == nil {
+			item.Evidence = map[string]any{}
+		} else {
+			item.Evidence = cloneMetadataMap(item.Evidence)
+		}
+		if item.CheckedAt.IsZero() {
+			item.CheckedAt = time.Now().UTC()
+		} else {
+			item.CheckedAt = item.CheckedAt.UTC()
+		}
+		normalized = append(normalized, item)
+	}
+	return normalized
+}
+
+func normalizeStringList(items []string) []string {
+	if len(items) == 0 {
+		return []string{}
+	}
+	normalized := make([]string, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		value := strings.TrimSpace(item)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func clampConfidence(confidence float64) float64 {
+	switch {
+	case confidence < 0:
+		return 0
+	case confidence > 1:
+		return 1
+	default:
+		return confidence
+	}
+}
+
 func validAWSAccountID(accountID string) bool {
 	if len(accountID) != 12 {
 		return false
@@ -2656,6 +2863,8 @@ type Store interface {
 	ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error)
 	ClaimNextQueuedScanAnyScope(ctx context.Context, provider string) (ScanRecord, error)
 	CountQueuedScans(ctx context.Context, provider string) (int, error)
+	CountQueuedScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error)
+	CountPendingScansWithSource(ctx context.Context, provider string, source ScanSource) (int, error)
 	GetScan(ctx context.Context, scanID string) (ScanRecord, error)
 	CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error
 	ScheduleScanRetry(ctx context.Context, scanID string, queuedAt time.Time, retryCount int, maxRetryCount int, failureCategory string, errorMessage string, nextRetryAt time.Time) error
@@ -2760,6 +2969,8 @@ type Store interface {
 	ListTenancyConnectorsUnscoped(ctx context.Context, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
 	UpsertAWSAccountRegionCoverage(ctx context.Context, coverage AWSAccountRegionCoverage) (AWSAccountRegionCoverage, error)
 	ListAWSAccountRegionCoverages(ctx context.Context, filter AWSAccountRegionCoverageFilter) ([]AWSAccountRegionCoverage, error)
+	UpsertAWSPlatformBaselineResult(ctx context.Context, result AWSPlatformBaselineResult) (AWSPlatformBaselineResult, error)
+	GetAWSPlatformBaselineResult(ctx context.Context, filter AWSPlatformBaselineFilter) (AWSPlatformBaselineResult, error)
 	ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, status domain.ConnectorStatus, health string, lastErrorCode string, lastErrorMessage string, observedAt time.Time, updatedAt time.Time) (bool, error)
 	UpsertTenancyScanPolicy(ctx context.Context, policy TenancyScanPolicy) error
 	GetTenancyScanPolicy(ctx context.Context, workspaceID string, projectID string, policyID string) (TenancyScanPolicy, error)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -285,6 +285,93 @@ func TestNormalizeAWSAccountRegionCoverageForWrite(t *testing.T) {
 	}
 }
 
+func TestNormalizeAWSPlatformBaselineResultForWrite(t *testing.T) {
+	verified := time.Date(2026, 6, 4, 12, 0, 0, 0, time.FixedZone("WAT", 60*60))
+	normalized, err := NormalizeAWSPlatformBaselineResultForWrite(AWSPlatformBaselineResult{
+		TenantID:                " tenant-a ",
+		WorkspaceID:             " workspace-a ",
+		ProjectID:               " project-1 ",
+		ConnectorID:             " aws-prod ",
+		GitSHA:                  " 6dd631b1 ",
+		SourceMode:              " SDK ",
+		ConnectorProfileVersion: " aws-readonly-iam-v1 ",
+		GraphContractVersion:    " relationship-contract-v1 ",
+		AccountID:               " 123456789012 ",
+		Region:                  " US-EAST-1 ",
+		Status:                  " READY ",
+		Confidence:              1.5,
+		FailureReasons:          []string{" ", "missing connector", "missing connector"},
+		EvidenceLinks:           []string{"/docs/auth/aws-connector", " ", "/docs/auth/aws-connector"},
+		Checks: []AWSPlatformBaselineCheck{
+			{
+				Name:          " aws_connector_health ",
+				Category:      " connector ",
+				Required:      true,
+				Status:        "PERMISSION_DENIED",
+				Message:       " denied ",
+				FailureReason: " iam denied ",
+				Remediation:   " reconnect ",
+				EvidenceURL:   " /docs/auth/aws-connector ",
+				Confidence:    -1,
+				Evidence:      map[string]any{"connector_id": "aws-prod"},
+				CheckedAt:     verified,
+			},
+			{Name: " ", Status: AWSPlatformBaselineCheckPassed},
+			{Name: "unknown_status", Status: "custom"},
+		},
+		VerifiedAt: verified,
+	})
+	if err != nil {
+		t.Fatalf("normalize aws baseline: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" || normalized.SourceMode != "sdk" || normalized.Region != "us-east-1" {
+		t.Fatalf("unexpected normalized identity fields: %+v", normalized)
+	}
+	if normalized.Status != AWSPlatformBaselineStatusReady || normalized.Confidence != 1 {
+		t.Fatalf("expected ready status and clamped confidence, got %+v", normalized)
+	}
+	if len(normalized.FailureReasons) != 1 || normalized.FailureReasons[0] != "missing connector" {
+		t.Fatalf("expected deduped failure reasons, got %+v", normalized.FailureReasons)
+	}
+	if len(normalized.EvidenceLinks) != 1 || len(normalized.Checks) != 2 {
+		t.Fatalf("expected deduped evidence and blank check removal, got links=%+v checks=%+v", normalized.EvidenceLinks, normalized.Checks)
+	}
+	if normalized.Checks[0].Status != AWSPlatformBaselineCheckPermissionDenied || normalized.Checks[0].Confidence != 0 {
+		t.Fatalf("expected normalized first check, got %+v", normalized.Checks[0])
+	}
+	if normalized.Checks[1].Status != AWSPlatformBaselineCheckUnknown {
+		t.Fatalf("expected unsupported check status to become unknown, got %+v", normalized.Checks[1])
+	}
+	if normalized.VerifiedAt.Location() != time.UTC || normalized.CreatedAt.Location() != time.UTC || normalized.UpdatedAt.Location() != time.UTC {
+		t.Fatalf("expected baseline timestamps in UTC, got %+v", normalized)
+	}
+
+	defaulted, err := NormalizeAWSPlatformBaselineResultForWrite(AWSPlatformBaselineResult{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+	})
+	if err != nil {
+		t.Fatalf("normalize default baseline: %v", err)
+	}
+	if defaulted.Status != AWSPlatformBaselineStatusNotRun || defaulted.FailureReasons == nil || defaulted.EvidenceLinks == nil || defaulted.Checks == nil {
+		t.Fatalf("expected default empty baseline fields, got %+v", defaulted)
+	}
+
+	invalids := []AWSPlatformBaselineResult{
+		{WorkspaceID: "workspace-a", ProjectID: "project-1"},
+		{TenantID: "tenant-a", ProjectID: "project-1"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", AccountID: "not-account"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", Status: "bad"},
+	}
+	for _, invalid := range invalids {
+		if _, err := NormalizeAWSPlatformBaselineResultForWrite(invalid); err == nil {
+			t.Fatalf("expected invalid aws baseline error for %+v", invalid)
+		}
+	}
+}
+
 func TestNormalizeAuthzEntityAttributesForWrite(t *testing.T) {
 	normalized, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
 		EntityKind:     "RESOURCE",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -131,6 +131,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 	svc.AWSConnectorValidator = awsprovider.NewConnectionValidator(cfg.AWSRegion, cfg.AWSProfile)
 	svc.AWSCloudFormationTemplateURL = cfg.AWSCloudFormationTemplateURL
 	svc.AWSAccountID = cfg.AWSAccountID
+	svc.AWSBaselineGitSHA = cfg.BaselineGitSHA
+	svc.AWSBaselineSourceMode = cfg.AWSSource
+	svc.AWSBaselineFixturePaths = append([]string(nil), cfg.AWSFixturePath...)
+	svc.AWSBaselineConnectorProfileVersion = "aws-readonly-iam-v1"
+	svc.AWSBaselineGraphContractVersion = "relationship-contract-v1"
 	svc.AWSConnectorCapabilityPolicy = awsconnector.NewCapabilityPolicyFromStrings(cfg.AWSConnectorCapabilities)
 	svc.GitHubAppID = parseInt64Config(cfg.GitHubAppID)
 	svc.GitHubAppName = cfg.GitHubAppName

--- a/migrations/000037_aws_platform_baseline_results.down.sql
+++ b/migrations/000037_aws_platform_baseline_results.down.sql
@@ -1,0 +1,6 @@
+DROP POLICY IF EXISTS aws_platform_baseline_results_scope_isolation ON aws_platform_baseline_results;
+ALTER TABLE aws_platform_baseline_results NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE aws_platform_baseline_results DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS idx_aws_platform_baseline_results_scope_status;
+DROP TABLE IF EXISTS aws_platform_baseline_results;

--- a/migrations/000037_aws_platform_baseline_results.up.sql
+++ b/migrations/000037_aws_platform_baseline_results.up.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS aws_platform_baseline_results (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    connector_id TEXT NOT NULL DEFAULT '',
+    git_sha TEXT NOT NULL DEFAULT '',
+    source_mode TEXT NOT NULL DEFAULT '',
+    fixture_only BOOLEAN NOT NULL DEFAULT FALSE,
+    connector_profile_version TEXT NOT NULL DEFAULT '',
+    graph_contract_version TEXT NOT NULL DEFAULT '',
+    account_id TEXT NOT NULL DEFAULT '',
+    region TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+    required_checks_passed BOOLEAN NOT NULL DEFAULT FALSE,
+    failure_reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence_links JSONB NOT NULL DEFAULT '[]'::jsonb,
+    checks JSONB NOT NULL DEFAULT '[]'::jsonb,
+    verified_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id, connector_id),
+    FOREIGN KEY (tenant_id, workspace_id, project_id)
+        REFERENCES tenancy_projects(tenant_id, workspace_id, project_id)
+        ON DELETE CASCADE,
+    CHECK (status IN ('not_run', 'ready', 'degraded', 'blocked')),
+    CHECK (confidence >= 0 AND confidence <= 1),
+    CHECK (account_id = '' OR account_id ~ '^[0-9]{12}$'),
+    CHECK (jsonb_typeof(failure_reasons) = 'array'),
+    CHECK (jsonb_typeof(evidence_links) = 'array'),
+    CHECK (jsonb_typeof(checks) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS idx_aws_platform_baseline_results_scope_status
+    ON aws_platform_baseline_results (tenant_id, workspace_id, project_id, connector_id, status, updated_at DESC);
+
+ALTER TABLE aws_platform_baseline_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE aws_platform_baseline_results FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS aws_platform_baseline_results_scope_isolation ON aws_platform_baseline_results;
+CREATE POLICY aws_platform_baseline_results_scope_isolation ON aws_platform_baseline_results
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -666,4 +666,40 @@ describe('apiClient', () => {
     expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
+
+  it('gets and verifies AWS project baseline gate with scoped headers', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ baseline: { status: 'not_run', checks: [] } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ baseline: { status: 'ready', checks: [] } })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const auth = {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    };
+
+    await apiClient.getAWSProjectBaseline('workspace/a', 'project 1', 'aws-prod', auth);
+    await apiClient.verifyAWSProjectBaseline('workspace/a', 'project 1', { connector_id: 'aws-prod' }, auth);
+
+    const [getURL, getOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(getURL).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/baseline?connector_id=aws-prod');
+    expect(getOptions.method ?? 'GET').toBe('GET');
+
+    const [postURL, postOptions] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(postURL).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/baseline');
+    expect(postOptions.method).toBe('POST');
+    expect(postOptions.body).toBe(JSON.stringify({ connector_id: 'aws-prod' }));
+    const headers = new Headers(postOptions.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -813,6 +813,51 @@ export type AWSConnectionUpsertRequest = {
   capabilities?: ConnectorCapability[];
 };
 
+export type AWSPlatformBaselineStatus = 'not_run' | 'ready' | 'degraded' | 'blocked';
+export type AWSPlatformBaselineCheckStatus = 'passed' | 'failed' | 'degraded' | 'permission_denied' | 'unknown' | 'skipped';
+
+export type AWSPlatformBaselineCheck = {
+  name: string;
+  category: string;
+  required: boolean;
+  status: AWSPlatformBaselineCheckStatus;
+  message: string;
+  failure_reason?: string;
+  remediation?: string;
+  evidence_url?: string;
+  confidence: number;
+  evidence?: Record<string, unknown>;
+  checked_at: string;
+};
+
+export type AWSPlatformBaselineResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  git_sha: string;
+  source_mode: string;
+  fixture_only: boolean;
+  connector_profile_version: string;
+  graph_contract_version: string;
+  account_id?: string;
+  region?: string;
+  status: AWSPlatformBaselineStatus;
+  confidence: number;
+  required_checks_passed: boolean;
+  failure_reasons: string[];
+  evidence_links: string[];
+  checks: AWSPlatformBaselineCheck[];
+  verified_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSPlatformBaselineRequest = {
+  connector_id?: string;
+  git_sha?: string;
+};
+
 export type AWSConnectorStartRequest = {
   workspace_id?: string;
   project_id?: string;
@@ -1742,6 +1787,24 @@ export const apiClient = {
     return request<{ connection: AWSConnectionStatus }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/connection`,
       auth
+    );
+  },
+  getAWSProjectBaseline(workspaceID: string, projectID: string, connectorID?: string, auth?: RequestAuthContext) {
+    return request<{ baseline: AWSPlatformBaselineResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/baseline${buildQuery({
+        connector_id: connectorID
+      })}`,
+      auth
+    );
+  },
+  verifyAWSProjectBaseline(workspaceID: string, projectID: string, payload: AWSPlatformBaselineRequest = {}, auth?: RequestAuthContext) {
+    return request<{ baseline: AWSPlatformBaselineResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/baseline`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
     );
   },
   startAWSConnector(payload: AWSConnectorStartRequest, auth?: RequestAuthContext) {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -5,6 +5,7 @@ import type {
   AuthConfigResponse,
   AWSConnectorStartResponse,
   AWSConnectionStatus,
+  AWSPlatformBaselineResult,
   CurrentUserContext,
   Finding,
   GitHubConnectionStatus,
@@ -137,6 +138,48 @@ const connectedAWS: AWSConnectionStatus = {
   updated_at: '2026-05-17T10:00:00Z',
   last_validated_at: '2026-05-17T10:00:00Z'
 };
+
+const readyAWSBaseline: AWSPlatformBaselineResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  git_sha: '6dd631b1',
+  source_mode: 'sdk',
+  fixture_only: false,
+  connector_profile_version: 'aws-readonly-iam-v1',
+  graph_contract_version: 'relationship-contract-v1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  status: 'ready',
+  confidence: 0.95,
+  required_checks_passed: true,
+  failure_reasons: [],
+  evidence_links: ['/app/tenant-a/workspace-a/aws?environment=production'],
+  checks: [
+    {
+      name: 'aws_connector_health',
+      category: 'connector',
+      required: true,
+      status: 'passed',
+      message: 'AWS connector is active and healthy.',
+      confidence: 0.96,
+      checked_at: '2026-05-17T10:00:00Z'
+    }
+  ],
+  verified_at: '2026-05-17T10:00:00Z',
+  created_at: '2026-05-17T10:00:00Z',
+  updated_at: '2026-05-17T10:00:00Z'
+};
+
+function mockAWSBaseline(api: typeof import('./api/client'), baseline: AWSPlatformBaselineResult = readyAWSBaseline) {
+  vi.spyOn(api.apiClient, 'getAWSProjectBaseline').mockResolvedValue({
+    baseline
+  });
+  vi.spyOn(api.apiClient, 'verifyAWSProjectBaseline').mockResolvedValue({
+    baseline
+  });
+}
 
 const disconnectedKubernetes: KubernetesConnectionStatus = {
   provider: 'kubernetes',
@@ -1411,6 +1454,7 @@ describe('Domain-first app routes', () => {
 
   it('renders the AWS Control Center with current and future capability labels', async () => {
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -1454,6 +1498,7 @@ describe('Domain-first app routes', () => {
 
   it('ignores stale AWS Control Center status loads after switching environments', async () => {
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -1653,6 +1698,7 @@ describe('Domain-first app routes', () => {
   it('keeps AWS connect on the domain page when no environment exists', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [] });
 
     const { ProductAWSConnectPage } = await import('./productShell');
@@ -2202,6 +2248,7 @@ describe('Domain-first app routes', () => {
   it('clears stale AWS connect form values when the selected environment changes', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -2271,6 +2318,7 @@ describe('Domain-first app routes', () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -2346,6 +2394,7 @@ describe('Domain-first app routes', () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -2416,6 +2465,7 @@ describe('Domain-first app routes', () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {
@@ -2481,6 +2531,7 @@ describe('Domain-first app routes', () => {
   it('loads AWS connect actions for the selected environment even when it is outside the first page', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: Array.from({ length: 50 }, (_, index) => ({
         tenant_id: 'tenant-a',
@@ -2574,6 +2625,7 @@ describe('Domain-first app routes', () => {
   it('does not silently switch AWS connect to a fallback environment when getProject check fails transiently', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
+    mockAWSBaseline(api);
     const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
         {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -29,6 +29,7 @@ import {
   type AWSCapabilityPermissionTier,
   type AWSConnectorStartResponse,
   type AWSConnectionStatus,
+  type AWSPlatformBaselineResult,
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
   type ExecutiveReport,
@@ -2752,6 +2753,73 @@ function awsDiagnosticSummary(connection: AWSConnectionStatus | null): string {
   return formatCountLabel(connection.diagnostics.length, 'item');
 }
 
+function awsBaselineLabel(baseline: AWSPlatformBaselineResult | null): string {
+  if (!baseline) {
+    return 'Not verified';
+  }
+  if (baseline.status === 'ready') {
+    return 'Ready';
+  }
+  if (baseline.status === 'degraded') {
+    return 'Degraded';
+  }
+  if (baseline.status === 'blocked') {
+    return 'Blocked';
+  }
+  return 'Not run';
+}
+
+function awsBaselineTone(
+  baseline: AWSPlatformBaselineResult | null,
+  loading = false
+): 'success' | 'warning' | 'danger' | 'neutral' | 'info' {
+  if (loading) {
+    return 'info';
+  }
+  if (!baseline) {
+    return 'neutral';
+  }
+  if (baseline.status === 'ready') {
+    return 'success';
+  }
+  if (baseline.status === 'degraded' || baseline.status === 'not_run') {
+    return 'warning';
+  }
+  return 'danger';
+}
+
+function awsBaselineCheckTone(status: AWSPlatformBaselineResult['checks'][number]['status']): 'success' | 'warning' | 'error' | 'neutral' {
+  if (status === 'passed') {
+    return 'success';
+  }
+  if (status === 'failed' || status === 'permission_denied') {
+    return 'error';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function awsBaselineSummary(baseline: AWSPlatformBaselineResult | null): string {
+  if (!baseline) {
+    return 'No verification';
+  }
+  if (baseline.status === 'ready') {
+    return `${formatConfidenceScore(baseline.confidence)} confidence`;
+  }
+  return baseline.failure_reasons[0] ? formatTokenLabel(baseline.failure_reasons[0]) : formatTokenLabel(baseline.status);
+}
+
+function awsBaselineAccountRegionLabel(baseline: AWSPlatformBaselineResult | null): string {
+  if (!baseline?.account_id && !baseline?.region) {
+    return 'Pending';
+  }
+  return [baseline.account_id ? `Account ${baseline.account_id}` : '', baseline.region ? `Region ${baseline.region}` : '']
+    .filter(Boolean)
+    .join(' · ');
+}
+
 function awsAccountRegionLabel(connection: AWSConnectionStatus | null): string {
   if (!connection?.account_id && !connection?.region) {
     return 'Pending';
@@ -2820,6 +2888,68 @@ function AWSConnectionDiagnostics({
           <span className="idt-source-status-pill is-warning">Diagnostic</span>
           <p>{diagnostic.message}</p>
           {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+        </article>
+      ))}
+    </>
+  );
+}
+
+function AWSBaselineGateSummary({
+  baseline,
+  loading = false,
+  emptyLabel = 'AWS baseline has not run for this environment.'
+}: {
+  baseline: AWSPlatformBaselineResult | null;
+  loading?: boolean;
+  emptyLabel?: string;
+}) {
+  if (loading) {
+    return (
+      <article>
+        <strong>AWS baseline gate</strong>
+        <span className="idt-source-status-pill is-neutral">Loading</span>
+        <p>Loading baseline checks.</p>
+      </article>
+    );
+  }
+  if (!baseline) {
+    return (
+      <article>
+        <strong>AWS baseline gate</strong>
+        <span className="idt-source-status-pill is-neutral">Not run</span>
+        <p>{emptyLabel}</p>
+      </article>
+    );
+  }
+  if (baseline.checks.length === 0) {
+    return (
+      <article>
+        <strong>AWS baseline gate</strong>
+        <span className={`idt-source-status-pill is-${baseline.status === 'ready' ? 'success' : 'warning'}`}>
+          {awsBaselineLabel(baseline)}
+        </span>
+        <p>{awsBaselineSummary(baseline)}</p>
+      </article>
+    );
+  }
+  return (
+    <>
+      {baseline.checks.map((check) => (
+        <article key={check.name}>
+          <strong>{formatTokenLabel(check.name)}</strong>
+          <span className={`idt-source-status-pill is-${awsBaselineCheckTone(check.status)}`}>{formatTokenLabel(check.status)}</span>
+          <p>{check.message}</p>
+          <small>
+            {check.required ? 'Required' : 'Optional'} · confidence {formatConfidenceScore(check.confidence)} ·{' '}
+            {formatConnectionTime(check.checked_at)}
+          </small>
+          {check.failure_reason ? <small>{formatTokenLabel(check.failure_reason)}</small> : null}
+          {check.remediation ? <small>{check.remediation}</small> : null}
+          {check.evidence_url ? (
+            <a href={check.evidence_url} target={check.evidence_url.startsWith('http') ? '_blank' : undefined} rel="noreferrer">
+              Evidence
+            </a>
+          ) : null}
         </article>
       ))}
     </>
@@ -4946,7 +5076,11 @@ export function ProductAWSControlCenterPage() {
   const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
   const [connectionLoading, setConnectionLoading] = useState(false);
   const [connectionError, setConnectionError] = useState('');
+  const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
+  const [baselineLoading, setBaselineLoading] = useState(false);
+  const [baselineError, setBaselineError] = useState('');
   const connectionRequestRef = useRef(0);
+  const baselineRequestRef = useRef(0);
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   selectedEnvironmentIDRef.current = selectedEnvironmentID;
 
@@ -4985,12 +5119,82 @@ export function ProductAWSControlCenterPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
+  const refreshBaseline = useCallback(async () => {
+    const requestID = ++baselineRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!scope || !requestEnvironmentID) {
+      setBaseline(null);
+      setBaselineError('');
+      setBaselineLoading(false);
+      return;
+    }
+    const isStale = () => requestID !== baselineRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
+    setBaselineLoading(true);
+    setBaselineError('');
+    try {
+      const response = await apiClient.getAWSProjectBaseline(
+        scope.workspaceID,
+        requestEnvironmentID,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setBaseline(response.baseline);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setBaseline(null);
+      setBaselineError(formatAPIError(error, 'Unable to load AWS baseline gate.'));
+    } finally {
+      if (!isStale()) {
+        setBaselineLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  const verifyBaseline = useCallback(async () => {
+    const requestID = ++baselineRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!scope || !requestEnvironmentID) {
+      return;
+    }
+    const isStale = () => requestID !== baselineRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
+    setBaselineLoading(true);
+    setBaselineError('');
+    try {
+      const response = await apiClient.verifyAWSProjectBaseline(
+        scope.workspaceID,
+        requestEnvironmentID,
+        { connector_id: connection?.connector_id },
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setBaseline(response.baseline);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setBaselineError(formatAPIError(error, 'Unable to verify AWS baseline gate.'));
+    } finally {
+      if (!isStale()) {
+        setBaselineLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connector_id]);
+
   useEffect(() => {
     void refreshConnection();
+    void refreshBaseline();
     return () => {
       connectionRequestRef.current += 1;
+      baselineRequestRef.current += 1;
     };
-  }, [refreshConnection]);
+  }, [refreshConnection, refreshBaseline]);
 
   if (!scope) {
     return (
@@ -5004,8 +5208,11 @@ export function ProductAWSControlCenterPage() {
 
   const handleEnvironmentChange = (environmentID: string) => {
     connectionRequestRef.current += 1;
+    baselineRequestRef.current += 1;
     setConnection(null);
+    setBaseline(null);
     setConnectionError('');
+    setBaselineError('');
     navigate(
       {
         pathname: location.pathname,
@@ -5021,6 +5228,7 @@ export function ProductAWSControlCenterPage() {
   const failedChecks = connection?.permission_checks.filter((check) => !check.passed).length ?? 0;
   const effectiveCapabilities = connection?.capabilities.effective.length ?? 0;
   const statusTone = awsDomainTone(connection, connectionLoading || environmentScope.loading);
+  const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const statusLabel = environmentScope.loading
     ? 'Loading scope'
     : connectionLoading
@@ -5088,17 +5296,30 @@ export function ProductAWSControlCenterPage() {
             value: effectiveCapabilities > 0 ? `${effectiveCapabilities} active` : 'Planned',
             detail: 'Runtime evidence, remediation, and governance waves are labeled honestly below.',
             tone: effectiveCapabilities > 0 ? 'success' : 'info'
+          },
+          {
+            label: 'Baseline gate',
+            value: awsBaselineLabel(baseline),
+            detail: baselineLoading ? 'Verification loading' : awsBaselineSummary(baseline),
+            tone: baselineTone
           }
         ]}
       />
 
-      {environmentScope.loading || connectionLoading ? <DomainLoadingState label="Loading AWS control center status" /> : null}
+      {environmentScope.loading || connectionLoading || baselineLoading ? <DomainLoadingState label="Loading AWS control center status" /> : null}
 
       {connectionError ? (
         <DomainErrorState
           title="AWS status could not load"
           body={connectionError}
           retryAction={{ label: 'Retry status', onClick: () => void refreshConnection() }}
+        />
+      ) : null}
+      {baselineError ? (
+        <DomainErrorState
+          title="AWS baseline could not load"
+          body={baselineError}
+          retryAction={{ label: 'Retry baseline', onClick: () => void refreshBaseline() }}
         />
       ) : null}
 
@@ -5142,6 +5363,49 @@ export function ProductAWSControlCenterPage() {
           </dl>
           <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS diagnostics summary">
             <AWSConnectionDiagnostics connection={connection} />
+          </div>
+        </div>
+      </DomainStatusPanel>
+
+      <DomainStatusPanel
+        eyebrow="Baseline gate"
+        title="AWS platform baseline verification"
+        status={awsBaselineLabel(baseline)}
+        tone={baselineTone}
+        actions={[
+          { label: 'Run baseline', onClick: () => void verifyBaseline(), variant: 'secondary', disabled: baselineLoading || !selectedEnvironmentID },
+          { label: 'Refresh gate', onClick: () => void refreshBaseline(), variant: 'ghost', disabled: baselineLoading || !selectedEnvironmentID }
+        ]}
+      >
+        <div className="idt-aws-status-grid">
+          <dl>
+            <div>
+              <dt>Result</dt>
+              <dd>{awsBaselineLabel(baseline)}</dd>
+            </div>
+            <div>
+              <dt>Confidence</dt>
+              <dd>{baseline ? formatConfidenceScore(baseline.confidence) : 'N/A'}</dd>
+            </div>
+            <div>
+              <dt>Verified</dt>
+              <dd>{formatConnectionTime(baseline?.verified_at)}</dd>
+            </div>
+            <div>
+              <dt>Revision</dt>
+              <dd>{baseline?.git_sha || 'Not stamped'}</dd>
+            </div>
+            <div>
+              <dt>Source</dt>
+              <dd>{baseline?.fixture_only ? 'Fixture only' : formatTokenLabel(baseline?.source_mode || 'unknown')}</dd>
+            </div>
+            <div>
+              <dt>Contract</dt>
+              <dd>{baseline?.graph_contract_version || 'Not verified'}</dd>
+            </div>
+          </dl>
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS baseline checks">
+            <AWSBaselineGateSummary baseline={baseline} loading={baselineLoading} />
           </div>
         </div>
       </DomainStatusPanel>
@@ -5423,6 +5687,9 @@ export function ProductAWSConnectPage() {
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
+  const [baselineLoading, setBaselineLoading] = useState(false);
+  const [baselineError, setBaselineError] = useState('');
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
     externalID: '',
@@ -5437,6 +5704,7 @@ export function ProductAWSConnectPage() {
   const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
   const connectionRequestRef = useRef(0);
+  const baselineRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
@@ -5500,13 +5768,94 @@ export function ProductAWSConnectPage() {
     [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]
   );
 
+  const refreshBaseline = useCallback(async () => {
+    const requestID = ++baselineRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    if (!scope || !requestEnvironmentID) {
+      setBaseline(null);
+      setBaselineError('');
+      setBaselineLoading(false);
+      return;
+    }
+    const isStale = () =>
+      requestID !== baselineRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    setBaselineLoading(true);
+    setBaselineError('');
+    try {
+      const response = await apiClient.getAWSProjectBaseline(
+        scope.workspaceID,
+        requestEnvironmentID,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setBaseline(response.baseline);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setBaseline(null);
+      setBaselineError(formatAPIError(error, 'Unable to load AWS baseline gate.'));
+    } finally {
+      if (!isStale()) {
+        setBaselineLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  const verifyBaseline = useCallback(async () => {
+    const requestID = ++baselineRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    if (!scope || !requestEnvironmentID) {
+      return;
+    }
+    const isStale = () =>
+      requestID !== baselineRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    setBaselineLoading(true);
+    setBaselineError('');
+    try {
+      const response = await apiClient.verifyAWSProjectBaseline(
+        scope.workspaceID,
+        requestEnvironmentID,
+        {
+          connector_id: awsCloudFormationStart?.connector_id ?? connection?.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setBaseline(response.baseline);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setBaselineError(formatAPIError(error, 'Unable to verify AWS baseline gate.'));
+    } finally {
+      if (!isStale()) {
+        setBaselineLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, awsCloudFormationStart?.connector_id, connection?.connector_id]);
+
   useEffect(() => {
     connectionRequestRef.current += 1;
+    baselineRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
     setSuccessMessage('');
     setErrorMessage('');
+    setBaseline(null);
+    setBaselineError('');
     setSubmitting(false);
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
@@ -5520,13 +5869,15 @@ export function ProductAWSConnectPage() {
       displayName: ''
     }));
     void refreshConnection('initial');
+    void refreshBaseline();
     return () => {
       connectionRequestRef.current += 1;
+      baselineRequestRef.current += 1;
       awsStartRequestRef.current += 1;
       awsPollRequestRef.current += 1;
       awsValidationRequestRef.current += 1;
     };
-  }, [refreshConnection]);
+  }, [refreshConnection, refreshBaseline]);
 
   if (!scope) {
     return (
@@ -5540,10 +5891,13 @@ export function ProductAWSConnectPage() {
 
   const handleEnvironmentChange = (environmentID: string) => {
     connectionRequestRef.current += 1;
+    baselineRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
     setConnection(null);
+    setBaseline(null);
+    setBaselineError('');
     navigate(
       {
         pathname: location.pathname,
@@ -5556,6 +5910,7 @@ export function ProductAWSConnectPage() {
   const controlPath = appendEnvironmentQuery(buildScopedPath(scope, 'aws'), selectedEnvironmentID);
   const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
   const statusTone = awsDomainTone(connection, loadingConnection || refreshingConnection || environmentScope.loading);
+  const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
 
@@ -5637,6 +5992,9 @@ export function ProductAWSConnectPage() {
       }
       setConnection(response.connection);
       setSuccessMessage(response.connection.connected ? 'AWS connector is active.' : 'AWS status refreshed.');
+      if (response.connection.connected) {
+        void verifyBaseline();
+      }
     } catch (error) {
       if (isStale()) {
         return;
@@ -5701,6 +6059,9 @@ export function ProductAWSConnectPage() {
       setSuccessMessage(
         response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
       );
+      if (response.connection.connected) {
+        void verifyBaseline();
+      }
     } catch (error) {
       if (isStale()) {
         return;
@@ -5767,11 +6128,17 @@ export function ProductAWSConnectPage() {
             value: connection?.account_id ?? 'Pending',
             detail: connection?.region ? `Default region ${connection.region}` : `Default region ${awsForm.region || 'us-east-1'}`,
             tone: connection?.account_id ? 'success' : 'info'
+          },
+          {
+            label: 'Baseline gate',
+            value: awsBaselineLabel(baseline),
+            detail: baselineLoading ? 'Verification loading' : awsBaselineSummary(baseline),
+            tone: baselineTone
           }
         ]}
       />
 
-      {loadingConnection || environmentScope.loading ? <DomainLoadingState label="Loading AWS setup state" /> : null}
+      {loadingConnection || baselineLoading || environmentScope.loading ? <DomainLoadingState label="Loading AWS setup state" /> : null}
 
       {!selectedEnvironmentID && !environmentScope.loading ? (
         <DomainEmptyState
@@ -5790,6 +6157,11 @@ export function ProductAWSConnectPage() {
       {errorMessage ? (
         <p role="alert" className="idt-app-alert idt-app-alert-error">
           {errorMessage}
+        </p>
+      ) : null}
+      {baselineError ? (
+        <p role="alert" className="idt-app-alert idt-app-alert-error">
+          {baselineError}
         </p>
       ) : null}
 
@@ -5951,6 +6323,35 @@ export function ProductAWSConnectPage() {
             >
               <div className="idt-source-diagnostics" aria-label="AWS permission diagnostics">
                 <AWSConnectionDiagnostics connection={connection} emptyLabel="Validate the role to populate permission checks." />
+              </div>
+            </DomainStatusPanel>
+
+            <DomainStatusPanel
+              eyebrow="Baseline gate"
+              title="Platform readiness"
+              status={awsBaselineLabel(baseline)}
+              tone={baselineTone}
+              actions={[
+                { label: 'Run baseline', onClick: () => void verifyBaseline(), disabled: baselineLoading || !selectedEnvironmentID },
+                { label: 'Refresh gate', onClick: () => void refreshBaseline(), variant: 'ghost', disabled: baselineLoading || !selectedEnvironmentID }
+              ]}
+            >
+              <dl className="idt-domain-route-facts">
+                <div>
+                  <dt>Verified</dt>
+                  <dd>{formatConnectionTime(baseline?.verified_at)}</dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{baseline ? formatConfidenceScore(baseline.confidence) : 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Account / region</dt>
+                  <dd>{awsBaselineAccountRegionLabel(baseline)}</dd>
+                </div>
+              </dl>
+              <div className="idt-source-diagnostics" aria-label="AWS baseline diagnostics">
+                <AWSBaselineGateSummary baseline={baseline} loading={baselineLoading} />
               </div>
             </DomainStatusPanel>
 


### PR DESCRIPTION
## Summary
- add a persisted AWS platform baseline gate with connector, graph contract, queue, fixture, and app prerequisite checks
- block project-scoped AWS scan enqueue/replay with HTTP 412 when required baseline checks fail
- expose baseline GET/POST APIs, OpenAPI docs, config docs, and AWS UI panels in Control Center and Connect AWS

## Validation
- go test ./internal/db ./internal/api ./internal/config ./internal/runtime -count=1
- go test ./... -count=1
- npm --prefix web test -- --run src/api/client.test.ts src/productShell.test.tsx
- npm --prefix web run build

Closes #1473

AI disclosure: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AWS platform baseline gate to block project-scoped AWS scans and replays until required checks pass. Persists scoped results, exposes GET/POST APIs, returns structured 412 errors, and shows per-check diagnostics in the UI. Implements #1473.

- **New Features**
  - Persists project/connector-scoped results in `aws_platform_baseline_results` with status (`not_run`, `ready`, `degraded`, `blocked`), `required_checks_passed`, `git_sha`, `source_mode`, `fixture_only`, profile/contract versions, optional `connector_id`, account/region, `confidence`, `failure_reasons`, `evidence_links`, and a `checks` array (name/category/required/status/message/failure_reason/remediation/evidence_url/evidence/checked_at).
  - Adds `GET/POST /v1/workspaces/:workspace_id/projects/:project_id/aws/baseline` (GET requires `tenancy.read`; POST requires `scans.run`).
  - Blocks AWS enqueue/replay with HTTP 412 `aws_platform_baseline_not_ready`, returning the persisted baseline result.
  - Verifies connector health, graph contract, worker queue availability (project/connector-scoped), fixture mode, app route prerequisites, source mode, profile/contract versions, timestamps/evidence, and the baseline Git SHA. Updates OpenAPI and docs; web client adds `getAWSProjectBaseline` and `verifyAWSProjectBaseline`; Control Center and Connect AWS show gate status with per-check diagnostics.

- **Migration**
  - Run `000037_aws_platform_baseline_results`.
  - Optionally set `IDENTRAIL_BASELINE_GIT_SHA` (falls back to `IDENTRAIL_GIT_SHA`). Update clients to handle HTTP 412 and call the new baseline APIs (supports `connector_id`).

<sup>Written for commit 1e1a1113fe6def298d5ac3876861e27bc73b5c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



