### PR TITLE
fix GitHub overview flashing Not connected during load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 ## Unreleased
+- Stopped the GitHub overview (`/app/.../github`) from briefly showing a
+  "Not connected for this environment" subtitle, an "Install the GitHub
+  App" banner, and a Connect GitHub primary CTA on every load before the
+  connector-status API actually responded. The page now shows a neutral
+  "Loading GitHub status…" subtitle and suppresses the banner and primary
+  CTA until either the connection or an error has been observed, so on
+  slow networks the app no longer looks like it is denying a real
+  installation. The underlying `useGitHubDomainData` hook now starts in
+  the loading state when a fetch is going to happen and stays loading
+  while the project ID is still being resolved, instead of taking a
+  no-op resolved-null code path that left `loading=false` plus
+  `connection=null` — the exact state callers treated as "confirmed
+  disconnected".
 - Added the AWS platform issue dependency index for #1474. The API now exposes
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/dependency-index`
   as a read-only, project-scoped ledger for the #1472 AWS child issue graph,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3846,6 +3846,55 @@ describe('GitHub domain pages (#1382)', () => {
     });
   });
 
+  it('Control Center does not flash a disconnected state while the connection is still loading', async () => {
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    let resolveStatus: ((value: { connection: GitHubConnectionStatus }) => void) | undefined;
+    const pendingStatus = new Promise<{ connection: GitHubConnectionStatus }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    vi.spyOn(api.apiClient, 'getGitHubConnectorStatus').mockReturnValue(pendingStatus);
+    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [] });
+
+    const productShell = await import('./productShell');
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github" element={<productShell.ProductGitHubControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    // While loading, the page must not claim the user is disconnected.
+    expect(screen.queryByText(/Not connected for this environment\./i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('GitHub action recommendation')).not.toBeInTheDocument();
+    // The primary CTA in the header is omitted during the initial load —
+    // the Sections grid still renders its own "Connect GitHub" navigation
+    // card, which is fine.
+    expect(document.querySelector('.idt-domain-header-actions')).toBeNull();
+    expect(screen.getByText(/Loading GitHub status/i)).toBeInTheDocument();
+
+    // Resolve as disconnected; the page should now show the real disconnected UI.
+    resolveStatus?.({
+      connection: {
+        ...connectedGitHub,
+        connected: false,
+        account_login: undefined,
+        installation_id: undefined,
+        selected_repositories: []
+      }
+    });
+    await screen.findByText(/Not connected for this environment\./i);
+    await waitFor(() => {
+      const banner = screen.getByLabelText('GitHub action recommendation');
+      expect(banner).toHaveAttribute('data-banner-id', 'connect');
+    });
+  });
+
   it('Control Center shows the unavailable shell when the GitHub connector is gated off', async () => {
     await renderGitHubPage('control-center', { githubFeatureFlag: false, githubBackend: false });
 
@@ -4382,6 +4431,43 @@ describe('GitHub domain pages (#1382)', () => {
     expect(within(banner).getByText(/Scan in progress/i)).toBeInTheDocument();
     expect(within(banner).getByText('identrail/in-progress')).toBeInTheDocument();
     expect(within(banner).queryByText(/Queue the first repository scan/i)).not.toBeInTheDocument();
+  });
+
+  it('Control Center shows an active scan banner when a failed scan is being retried', async () => {
+    const failedScan: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'failed-retry',
+      repository: 'identrail/retrying-repo',
+      status: 'failed',
+      started_at: '2026-05-16T10:00:00Z',
+      finished_at: '2026-05-16T10:05:00Z',
+      finding_count: 0,
+      error_message: 'scan exploded'
+    };
+    const retryScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'retry-in-progress',
+      repository: 'identrail/retrying-repo',
+      status: 'running'
+    };
+
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: ['identrail/retrying-repo'] },
+      scans: [retryScan, failedScan]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GitHub action recommendation')).toHaveAttribute(
+        'data-banner-id',
+        'scan-in-progress'
+      );
+    });
+    const banner = screen.getByLabelText('GitHub action recommendation');
+    expect(within(banner).queryByText(/failed its last scan/i)).not.toBeInTheDocument();
+    expect(within(banner).getByText(/Scan in progress/i)).toBeInTheDocument();
+    expect(within(banner).getByText('identrail/retrying-repo')).toBeInTheDocument();
   });
 
   it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8089,13 +8089,10 @@ function selectGitHubControlCenterBanner({
   }
   const latestPerRepo = latestCompletedScanPerRepository(recentScans);
   const activeScanRepos = new Set(
-    recentScans.filter((scan) => isActiveScanStatus(scan.status)).map((scan) => {
-      const repo = canonicalGitHubRepositoryDisplay(scan.repository);
-      return repo.toLowerCase() || scan.repository.toLowerCase();
-    })
+    recentScans.filter((scan) => isActiveScanStatus(scan.status)).map((scan) => repoLookupKey(scan.repository))
   );
   const failedLatest = latestPerRepo.find(
-    (scan) => !activeScanRepos.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase()) && isFailedScanStatus(scan.status)
+    (scan) => !activeScanRepos.has(repoLookupKey(scan.repository)) && isFailedScanStatus(scan.status)
   );
   if (failedLatest) {
     const repo = canonicalGitHubRepositoryDisplay(failedLatest.repository) || failedLatest.repository;
@@ -8164,13 +8161,22 @@ function latestCompletedScanPerRepository(scans: RepoScanRecord[]): RepoScanReco
     if (!isCompletedScanStatus(scan.status) || isCanceledScanStatus(scan.status)) {
       continue;
     }
-    const repo = canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() || scan.repository.toLowerCase();
+    const repo = repoLookupKey(scan.repository);
     const existing = byRepo.get(repo);
     if (!existing || scanFinishedAt(scan) > scanFinishedAt(existing)) {
       byRepo.set(repo, scan);
     }
   }
   return [...byRepo.values()];
+}
+
+// Single source of truth for the repository key used by the GitHub overview
+// banner selector. Building the key in two places (e.g. once when seeding a
+// Set and again when querying it) is the bug class this helper exists to
+// prevent — when canonicalGitHubRepositoryDisplay can't canonicalize a
+// value, the bare-string fallback must match on both sides.
+function repoLookupKey(repository: string): string {
+  return canonicalGitHubRepositoryDisplay(repository).toLowerCase() || repository.toLowerCase();
 }
 
 function isCanceledScanStatus(status: string): boolean {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7837,7 +7837,10 @@ function useGitHubDomainData(
 ): GitHubDomainDataState {
   const [connection, setConnection] = useState<GitHubConnectionStatus | null>(null);
   const [scans, setScans] = useState<RepoScanRecord[]>([]);
-  const [loading, setLoading] = useState(false);
+  // Start in the loading state when a fetch is going to happen so the very
+  // first render does not falsely advertise the user as disconnected before
+  // the API has even been called.
+  const [loading, setLoading] = useState<boolean>(Boolean(scope) && available);
   const [error, setError] = useState('');
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -7851,16 +7854,25 @@ function useGitHubDomainData(
       setLoading(false);
       return undefined;
     }
+    const trimmedProject = normalizeValue(projectID);
+    if (!trimmedProject) {
+      // The environment scope has not finished resolving yet. Stay in the
+      // loading state so the caller does not interpret connection=null as
+      // "confirmed disconnected" while we are still waiting for the
+      // project ID to settle.
+      setLoading(true);
+      setConnection(null);
+      setScans([]);
+      setError('');
+      return undefined;
+    }
     let active = true;
     setLoading(true);
     setError('');
     setConnection(null);
     setScans([]);
     const auth = buildProductAuthContext(scope);
-    const trimmedProject = normalizeValue(projectID);
-    const statusRequest = trimmedProject
-      ? apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth)
-      : Promise.resolve<{ connection: GitHubConnectionStatus | null }>({ connection: null });
+    const statusRequest = apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth);
 
     statusRequest
       .then((statusResult) => statusResult.connection ?? null)
@@ -8076,7 +8088,15 @@ function selectGitHubControlCenterBanner({
     };
   }
   const latestPerRepo = latestCompletedScanPerRepository(recentScans);
-  const failedLatest = latestPerRepo.find((scan) => isFailedScanStatus(scan.status));
+  const activeScanRepos = new Set(
+    recentScans.filter((scan) => isActiveScanStatus(scan.status)).map((scan) => {
+      const repo = canonicalGitHubRepositoryDisplay(scan.repository);
+      return repo.toLowerCase() || scan.repository.toLowerCase();
+    })
+  );
+  const failedLatest = latestPerRepo.find(
+    (scan) => !activeScanRepos.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase()) && isFailedScanStatus(scan.status)
+  );
   if (failedLatest) {
     const repo = canonicalGitHubRepositoryDisplay(failedLatest.repository) || failedLatest.repository;
     return {
@@ -8330,14 +8350,31 @@ export function ProductGitHubControlCenterPage() {
   const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
   const recentScans = gitHubRecentScans(data.scans, selectedRepositories, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
   const connected = Boolean(data.connection?.connected);
-  const banner = selectGitHubControlCenterBanner({
-    connected,
-    selectedRepositories,
-    recentScans,
-    connectPath,
-    repositoriesPath,
-    findingsPath
-  });
+  // Suppress every connection-dependent surface (subtitle copy, banner,
+  // primary CTA, empty state) while the very first connection fetch is
+  // still in flight. Without this guard the page renders "Not connected"
+  // + "Install the GitHub App" + a Connect CTA during the API round-trip,
+  // then flips to the connected state once the response lands — a
+  // misleading flash that, on slower networks, can last several seconds.
+  const awaitingFirstLoad = data.loading && data.connection === null && !data.error;
+  const banner = awaitingFirstLoad
+    ? null
+    : selectGitHubControlCenterBanner({
+        connected,
+        selectedRepositories,
+        recentScans,
+        connectPath,
+        repositoriesPath,
+        findingsPath
+      });
+  const primaryAction = awaitingFirstLoad
+    ? undefined
+    : connected
+      ? { label: 'Repositories', to: repositoriesPath, variant: 'primary' as const }
+      : { label: 'Connect GitHub', to: connectPath, variant: 'primary' as const };
+  const subtitle = awaitingFirstLoad
+    ? 'Loading GitHub status…'
+    : gitHubOverviewSubtitle(data.connection, recentScans);
 
   return (
     <DomainPageShell
@@ -8345,14 +8382,10 @@ export function ProductGitHubControlCenterPage() {
       eyebrow={null}
       hideLogo
       title="GitHub"
-      description={gitHubOverviewSubtitle(data.connection, recentScans)}
+      description={subtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
       statusTone={gitHubConnectionTone(data.connection, data.loading)}
-      primaryAction={
-        connected
-          ? { label: 'Repositories', to: repositoriesPath, variant: 'primary' }
-          : { label: 'Connect GitHub', to: connectPath, variant: 'primary' }
-      }
+      primaryAction={primaryAction}
     >
       {data.error ? <DomainErrorState title="Unable to load GitHub status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
       {banner ? <GitHubControlCenterBannerView banner={banner} /> : null}
@@ -8366,7 +8399,7 @@ export function ProductGitHubControlCenterPage() {
           </header>
           <DomainTimeline label="Recent repository scans" entries={gitHubRecentScansTimeline(recentScans)} />
         </section>
-      ) : connected ? (
+      ) : !awaitingFirstLoad && connected ? (
         <DomainEmptyState
           title="No repository scans yet"
           body="Queue a scan to populate the activity timeline."


### PR DESCRIPTION
Fixes #1564

## Summary
The GitHub overview page mounted with \`data.connection = null\` and \`loading = false\`, so the very first render — before the connector-status API was even called — claimed the user was disconnected:

- Subtitle: "Not connected for this environment."
- Banner: "Install the GitHub App to enable repository scanning."
- Header primary CTA: "Connect GitHub"

When the API resolved (seconds to minutes on slow networks) the page flipped to the real connected state (\`Installation 135895761 · Healthy · Last scan May 27\`, the triage banner, and a Repositories CTA). For a security tool this misleading flash is the worst false-negative the surface can produce.

## Changes
**\`useGitHubDomainData\`**
- Initialises \`loading\` to \`Boolean(scope) && available\` so the first render already advertises a pending fetch.
- When the project ID is empty (because the env-scope load has not finished resolving), the hook now stays in the loading state instead of taking a \`Promise.resolve({connection: null})\` no-op path that left \`loading=false\` + \`connection=null\` — the exact "confirmed disconnected" pattern the page rendered.

**\`ProductGitHubControlCenterPage\`**
- Computes \`awaitingFirstLoad = data.loading && data.connection === null && !data.error\`.
- While \`awaitingFirstLoad\`, the subtitle reads "Loading GitHub status…", the recommendation banner is suppressed, the primary CTA is omitted, and the "No repository scans yet" empty state is skipped. The Sections grid keeps rendering as plain navigation.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run productShell.test.tsx\` — 119/119 pass, including a new regression test that holds the connector-status promise pending and asserts: no "Not connected" subtitle, no recommendation banner, no header primary CTA, and a visible "Loading GitHub status…" subtitle; then resolves the promise as disconnected and asserts the real "Not connected" UI appears.

## AI disclosure
This change was drafted with Claude (Opus 4.7) acting as a pair-programmer; I reviewed each diff, ran the test suite, and verified the rendered output before committing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the GitHub overview from flashing a false “Not connected” state during initial load. The page now shows “Loading GitHub status…” and hides banners and CTAs until the real status is known.

- **Bug Fixes**
  - `useGitHubDomainData`: start `loading` when a fetch will occur and keep it true until the project ID resolves; remove the resolved‑null path that produced `loading=false` + `connection=null`.
  - `ProductGitHubControlCenterPage`: gate subtitle, banner, primary CTA, and empty state behind `awaitingFirstLoad`; show “Loading GitHub status…” during the first fetch.
  - Banner logic: use a shared `repoLookupKey` for active‑scan suppression and dedupe so a running retry always suppresses the “failed last scan” banner.
  - Tests: added a regression test for no “Not connected” flash and a test ensuring “Scan in progress” shows instead of a failed‑scan banner when a retry is running.

<sup>Written for commit cb791db32f263b2344c9673c06696e43cf4685fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

