### PR TITLE
Add AWS service collector contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+- Added the AWS service collector contract for #1476. The API now exposes
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract`
+  as a read-only, project-scoped contract for normalized AWS collector records,
+  graph edge semantics, fixture conventions, metadata-only permissions, and
+  explicit failure states. The provider layer exports the reusable
+  `AWSServiceCollector` interface plus contract helpers for future collectors,
+  the AWS Control Center and Connect AWS pages surface contract readiness, and
+  the web client, OpenAPI contract, tests, and docs cover the new collector
+  foundation.
 - Added the AWS live app validation harness for #1475. The API now exposes
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/validation-harness`
   as a read-only, project-scoped proof path for AWS setup, scan state, graph

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -50,6 +50,11 @@ The [AWS platform validation harness](../aws-platform-validation-harness.md)
 provides deterministic browser and API proof states for AWS setup, scan, graph,
 runtime, remediation, and governance app surfaces as future AWS waves land.
 
+The [AWS service collector contract](../aws-service-collector-contract.md)
+defines the normalized record fields, graph edge semantics, fixture cases,
+read-only permission boundary, and failure states that future AWS service
+collectors must reuse.
+
 The registry is intentionally internal for now because the UI flow is not ready. Services can write coverage rows through the AWS service layer after discovering organization accounts, selected regions, or scan outcomes. Each row is scoped by tenant, workspace, project, connector, account ID, and region, and can store organization metadata, the connector role ARN, coverage status, the last successful scan time, the last scan error, a scan cursor, and account/region availability flags.
 
 Use the registry when a scanner, connector workflow, or future UI needs to distinguish these states:

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -37,14 +37,19 @@ Behavior:
 
 To add a new AWS service collector:
 
-1. Implement `awsServiceCollector` in `internal/providers/aws`:
+1. Implement `AWSServiceCollector` in `internal/providers/aws`:
    - `ServiceName() string`
    - `CollectWithDiagnostics(ctx, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error)`
-2. Append the service in `NewAWSCompositeCollector(...)`.
-3. Add unit tests proving:
+2. Validate the collector output against
+   [`ServiceCollectorRecord`](./aws-service-collector-contract.md), required
+   fixture states, and graph edge semantics.
+3. Append the service in `NewAWSCompositeCollector(...)`.
+4. Add unit tests proving:
    - success path and returned assets
    - non-fatal failure path
    - context-propagation (`account`, `region`) to the service.
+   - pagination, throttling, partial failure, unsupported region, permission
+     denied, empty, and degraded fixture states.
 
 No behavior rewrite is required inside the existing IAM collector.
 
@@ -64,6 +69,9 @@ No behavior rewrite is required inside the existing IAM collector.
 - `IAMAPI.ListRoles(ctx, nextToken, pageSize)`
 - `Collector.Collect(ctx) ([]providers.RawAsset, error)`
 - `providers.DiagnosticCollector` contract through `CollectWithDiagnostics(ctx)`
+- `AWSServiceCollector` contract through `CollectWithDiagnostics(ctx, scope)`
+- `awscontract.AWSServiceCollectorContract()` for record fields, graph edges,
+  fixture cases, permissions, and read-only boundaries
 
 `RawAsset` payloads from composite collection are deduplicated and deterministically
 ordered by `kind`, then `source_id`.
@@ -87,3 +95,6 @@ ordered by `kind`, then `source_id`.
 - IAM role collection remains implemented through the existing AWS SDK IAM adapter.
 - AWS SDK CLI and runtime paths now use `NewAWSScanner`, which wires the composite collector.
 - The composite layer is now the extension point for future AWS service collection in the CLI/runtime path.
+- The service collector contract is exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract`
+  and the AWS app surfaces.

--- a/docs/aws-platform-dependency-index.md
+++ b/docs/aws-platform-dependency-index.md
@@ -4,9 +4,9 @@ The AWS platform dependency index is the canonical, scriptable issue-ordering
 ledger for the AWS machine identity program under parent issue #1472. It exists
 so implementation PRs only open when their declared blockers are closed.
 
-Issue #1474 is the index itself and is now completed. Issue #1475, the AWS live
-app validation harness, is the next Wave 0 item allowed to proceed because issue
-#1473, the AWS platform baseline verification gate, is closed.
+Issue #1474 is the index itself and is now completed. Issue #1476, the AWS
+service collector contract, is completed too, so issues #1477 through #1496 are
+the next ready collector and resource-mapping items.
 
 ## API
 
@@ -24,9 +24,9 @@ The endpoint returns:
     "status": "ready",
     "issue_count": 85,
     "wave_count": 11,
-    "ready_issue_refs": ["#1475"],
-    "blocked_issue_refs": ["#1476"],
-    "completed_issue_refs": ["#1473", "#1474"],
+    "ready_issue_refs": ["#1477", "#1478", "#1479", "#1480", "#1481", "#1482", "#1483", "#1484", "#1485", "#1486", "#1487", "#1488", "#1489", "#1490", "#1491", "#1492", "#1493", "#1494", "#1495", "#1496"],
+    "blocked_issue_refs": ["#1497"],
+    "completed_issue_refs": ["#1473", "#1474", "#1475", "#1476"],
     "checks": [],
     "issues": []
   }
@@ -50,7 +50,7 @@ The index validates these required checks on every read:
 - `parent_sequence_ordering`: every blocker appears earlier than the issue it
   blocks.
 - `current_issue_readiness`: #1474 remains satisfied because it is completed,
-  and #1475 is the next allowed implementation issue.
+  and #1477 through #1496 are the next allowed implementation issues.
 
 If any required check fails, `status` becomes `blocked`, `confidence` drops, and
 `failure_reasons` plus `remediation_hints` explain what to fix before opening a

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -1,0 +1,149 @@
+# AWS service collector contract
+
+The AWS service collector contract is the shared language future AWS service
+collectors must use before their output can feed the graph, runtime evidence,
+intelligence, remediation, or governance engines. It is issue #1476 in the AWS
+machine identity program under parent issue #1472.
+
+The contract is deterministic and read-only. It does not call AWS, mutate live
+accounts, or collect customer payloads. It gives operators and implementers one
+API surface for the required record fields, graph edge semantics, fixture
+states, permission boundaries, and failure behavior every downstream collector
+PR must satisfy.
+
+## API
+
+```text
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/collector-contract
+```
+
+`connector_id` is optional. When supplied, the service uses it only to add AWS
+account and region context to the response. The contract itself stays stable
+across connectors.
+
+The response envelope is:
+
+```json
+{
+  "contract": {
+    "tenant_id": "tenant-a",
+    "workspace_id": "workspace-a",
+    "project_id": "production",
+    "connector_id": "aws-prod",
+    "account_id": "123456789012",
+    "region": "us-east-1",
+    "parent_issue_ref": "#1472",
+    "current_issue_ref": "#1476",
+    "version": "aws-service-collector-contract-v1",
+    "status": "ready",
+    "confidence": 0.97,
+    "required_field_count": 17,
+    "graph_edge_count": 7,
+    "fixture_case_count": 8,
+    "required_fixture_case_count": 8,
+    "normalized_record_fields": [
+      "tenant_id",
+      "workspace_id",
+      "project_id",
+      "connector_id",
+      "account_id",
+      "region",
+      "service",
+      "workload_id",
+      "workload_type",
+      "workload_name",
+      "role_arn",
+      "source",
+      "evidence_ref",
+      "confidence",
+      "scan_id",
+      "collector_name",
+      "collected_at"
+    ],
+    "required_permissions": [
+      "sts:GetCallerIdentity",
+      "iam:ListRoles",
+      "iam:GetRole"
+    ],
+    "read_only_boundaries": [
+      "collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows"
+    ],
+    "checks": [],
+    "graph_edges": [],
+    "fixture_cases": [],
+    "failure_reasons": [],
+    "remediation_hints": [],
+    "evidence_links": [],
+    "generated_at": "2026-06-04T16:45:00Z",
+    "updated_at": "2026-06-04T16:45:00Z"
+  }
+}
+```
+
+## Normalized Record Contract
+
+Every AWS service collector must emit records with tenant, workspace, project,
+connector, account, region, service, workload, role ARN, source, evidence
+reference, confidence, scan metadata, collector name, and collection time.
+
+The helper in `internal/providers/awscontract/contract.go` normalizes and
+validates one `ServiceCollectorRecord`. Future collectors should use it in unit
+or fixture tests before converting collected data into graph entities.
+
+## Graph Edge Contract
+
+Collectors should emit the precise graph edge they can prove:
+
+| AWS edge name | Identrail relationship |
+| --- | --- |
+| `runs-on` | `runs_as` |
+| `assumes` | `can_assume` |
+| `passes-role` | `can_pass_role` |
+| `can-access` | `can_access` |
+| `references-secret` | `uses_secret` |
+| `invokes` | `invokes` |
+| `observed-runtime-action` | `observed_action` |
+
+Do not overload `can_access` when a more precise relationship applies.
+
+## Fixture Conventions
+
+Each service collector must cover these deterministic fixture states:
+
+- `success`: authorized collection with scoped metadata evidence.
+- `empty`: authorized account, region, and service with zero records.
+- `pagination`: multiple pages with stable cursor/page evidence.
+- `throttling`: bounded retries end in a retryable degraded diagnostic.
+- `partial_failure`: one service, account, region, or partition fails while
+  successful partitions remain visible.
+- `unsupported_region`: unsupported service/region is explicit and blocked.
+- `permission_denied`: missing read-only permission is explicit and blocked.
+- `degraded`: malformed or incomplete source record is explicit and degraded.
+
+Negative fixture states are expected evidence, not successful findings.
+
+## Permissions and Boundaries
+
+The foundation contract currently requires metadata-only IAM reads such as
+`sts:GetCallerIdentity`, `iam:ListRoles`, `iam:GetRole`,
+`iam:ListRolePolicies`, `iam:GetRolePolicy`,
+`iam:ListAttachedRolePolicies`, `iam:GetPolicy`, and
+`iam:GetPolicyVersion`.
+
+Future service collectors may add service-specific read-only metadata
+permissions, but must not add actions that read secret values, object contents,
+prompts, completions, browser pages, code-interpreter output, database rows, or
+customer payloads by default.
+
+## Validation
+
+Use these checks before opening a downstream AWS collector PR:
+
+```bash
+go test ./internal/providers/aws ./internal/api
+npm test -- --run src/api/client.test.ts src/productShell.test.tsx
+```
+
+PR notes should include the collector contract status, covered fixture states,
+graph edge types, and any permission-denied, unsupported-region, partial-failure,
+or degraded evidence.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -483,6 +483,11 @@ x-identrail-route-authorizations:
     action: tenancy.read
     resource_type: project
     resource_id_param: project_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/collector-contract
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
   - method: POST
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline
     action: scans.run
@@ -3714,6 +3719,50 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/collector-contract:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS service collector contract
+      operationId: getAWSProjectCollectorContract
+      description: Returns the deterministic AWS service collector record, fixture, graph edge, permission, and read-only boundary contract required by future EC2, ECS, Lambda, EKS, Bedrock, and runtime collector PRs. The response is scoped to the tenant, workspace, project, and optional connector without calling AWS or reading customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used only to add account and region context to the returned evidence.
+      responses:
+        "200":
+          description: AWS service collector contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contract:
+                    $ref: "#/components/schemas/AWSServiceCollectorContractResult"
+        "400":
+          description: Invalid AWS collector contract request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -6637,6 +6686,150 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPlatformValidationScenario"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSServiceCollectorContractCheck:
+      type: object
+      properties:
+        name:
+          type: string
+        category:
+          type: string
+        required:
+          type: boolean
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        message:
+          type: string
+        failure_reason:
+          type: string
+        remediation:
+          type: string
+        evidence_url:
+          type: string
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        evidence:
+          type: object
+          additionalProperties: true
+        checked_at:
+          type: string
+          format: date-time
+    AWSServiceCollectorGraphEdge:
+      type: object
+      properties:
+        name:
+          type: string
+          enum: [runs-on, assumes, passes-role, can-access, references-secret, invokes, observed-runtime-action]
+        relationship_type:
+          type: string
+          enum: [runs_as, can_assume, can_pass_role, can_access, uses_secret, invokes, observed_action]
+        from_endpoint:
+          type: string
+        to_endpoint:
+          type: string
+        evidence:
+          type: string
+        required:
+          type: boolean
+    AWSServiceCollectorFixtureCase:
+      type: object
+      properties:
+        id:
+          type: string
+        state:
+          type: string
+          enum: [success, empty, pagination, throttling, partial_failure, unsupported_region, permission_denied, degraded]
+        label:
+          type: string
+        expected_status:
+          type: string
+          enum: [ready, degraded, blocked]
+        source_error_code:
+          type: string
+        retryable:
+          type: boolean
+        required:
+          type: boolean
+        evidence_boundary:
+          type: string
+    AWSServiceCollectorContractResult:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+        workspace_id:
+          type: string
+        project_id:
+          type: string
+        connector_id:
+          type: string
+        account_id:
+          type: string
+        region:
+          type: string
+        parent_issue_number:
+          type: integer
+        parent_issue_ref:
+          type: string
+        current_issue_number:
+          type: integer
+        current_issue_ref:
+          type: string
+        version:
+          type: string
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        required_field_count:
+          type: integer
+        graph_edge_count:
+          type: integer
+        fixture_case_count:
+          type: integer
+        required_fixture_case_count:
+          type: integer
+        normalized_record_fields:
+          type: array
+          items: { type: string }
+        required_permissions:
+          type: array
+          items: { type: string }
+        read_only_boundaries:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSServiceCollectorContractCheck"
+        graph_edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSServiceCollectorGraphEdge"
+        fixture_cases:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSServiceCollectorFixtureCase"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -740,6 +740,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dependency-index", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/validation-harness", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/complete", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_dependency_index.go
+++ b/internal/api/aws_dependency_index.go
@@ -34,6 +34,8 @@ var (
 	awsPlatformCompletedIssueRefs = map[string]struct{}{
 		"#1473": {},
 		"#1474": {},
+		"#1475": {},
+		"#1476": {},
 	}
 )
 

--- a/internal/api/aws_dependency_index_test.go
+++ b/internal/api/aws_dependency_index_test.go
@@ -34,13 +34,14 @@ func TestGetAWSPlatformDependencyIndexBuildsCanonicalLedger(t *testing.T) {
 	if result.IssueCount != 85 || result.WaveCount != 11 {
 		t.Fatalf("unexpected ledger shape: issues=%d waves=%d", result.IssueCount, result.WaveCount)
 	}
-	if got, want := strings.Join(result.CompletedIssueRefs, ","), "#1473,#1474"; got != want {
+	if got, want := strings.Join(result.CompletedIssueRefs, ","), "#1473,#1474,#1475,#1476"; got != want {
 		t.Fatalf("completed refs = %q, want %q", got, want)
 	}
-	if got, want := strings.Join(result.ReadyIssueRefs, ","), "#1475"; got != want {
-		t.Fatalf("ready refs = %q, want %q", got, want)
+	wantReadyRefs := "#1477,#1478,#1479,#1480,#1481,#1482,#1483,#1484,#1485,#1486,#1487,#1488,#1489,#1490,#1491,#1492,#1493,#1494,#1495,#1496"
+	if got := strings.Join(result.ReadyIssueRefs, ","); got != wantReadyRefs {
+		t.Fatalf("ready refs = %q, want %q", got, wantReadyRefs)
 	}
-	if result.BlockedIssueCount != 82 || !containsString(result.BlockedIssueRefs, "#1476") {
+	if result.BlockedIssueCount != 61 || !containsString(result.BlockedIssueRefs, "#1497") {
 		t.Fatalf("expected downstream issues blocked by incomplete blockers, got count=%d refs=%v", result.BlockedIssueCount, result.BlockedIssueRefs)
 	}
 	for _, check := range result.Checks {
@@ -52,9 +53,17 @@ func TestGetAWSPlatformDependencyIndexBuildsCanonicalLedger(t *testing.T) {
 	if current.ReadyForPR || current.DependencyStatus != awsPlatformIssueStateCompleted {
 		t.Fatalf("expected current issue completed after merge, got %+v", current)
 	}
-	blocked := requireAWSPlatformDependencyIssue(t, result.Issues, "#1476")
-	if blocked.ReadyForPR || blocked.DependencyStatus != awsPlatformIssueStateBlocked || !containsString(blocked.FailureReasons, "waiting on #1475") {
-		t.Fatalf("expected #1476 to wait on #1475, got %+v", blocked)
+	completed := requireAWSPlatformDependencyIssue(t, result.Issues, "#1476")
+	if completed.ReadyForPR || completed.DependencyStatus != awsPlatformIssueStateCompleted {
+		t.Fatalf("expected #1476 to be completed after this PR, got %+v", completed)
+	}
+	ready := requireAWSPlatformDependencyIssue(t, result.Issues, "#1477")
+	if !ready.ReadyForPR || ready.DependencyStatus != awsPlatformIssueStateReady || len(ready.FailureReasons) != 0 {
+		t.Fatalf("expected #1477 to be ready after #1476 completed, got %+v", ready)
+	}
+	blocked := requireAWSPlatformDependencyIssue(t, result.Issues, "#1497")
+	if blocked.ReadyForPR || blocked.DependencyStatus != awsPlatformIssueStateBlocked || !containsString(blocked.FailureReasons, "waiting on #1496") {
+		t.Fatalf("expected #1497 to wait on #1496, got %+v", blocked)
 	}
 	for _, issue := range result.Issues {
 		for _, blockerRef := range issue.BlockerRefs {
@@ -130,7 +139,7 @@ func TestRouterAWSPlatformDependencyIndex(t *testing.T) {
 	if body.Index.IssueCount != 85 || body.Index.ParentIssueRef != "#1472" || body.Index.CurrentIssueRef != "#1474" {
 		t.Fatalf("unexpected dependency index payload: %+v", body.Index)
 	}
-	if !containsString(body.Index.CompletedIssueRefs, "#1474") || !containsString(body.Index.ReadyIssueRefs, "#1475") || body.Index.Status != awsPlatformDependencyStatusReady {
+	if !containsString(body.Index.CompletedIssueRefs, "#1476") || !containsString(body.Index.ReadyIssueRefs, "#1477") || body.Index.Status != awsPlatformDependencyStatusReady {
 		t.Fatalf("expected merged issue and next ready issue in router payload, got %+v", body.Index)
 	}
 }

--- a/internal/api/aws_service_collector_contract.go
+++ b/internal/api/aws_service_collector_contract.go
@@ -1,0 +1,421 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsServiceCollectorContractCurrentIssue = 1476
+	awsServiceCollectorContractVersion      = awscontract.AWSServiceCollectorContractVersion
+
+	awsServiceCollectorContractStatusReady    = string(awscontract.ServiceCollectorStatusReady)
+	awsServiceCollectorContractStatusDegraded = string(awscontract.ServiceCollectorStatusDegraded)
+	awsServiceCollectorContractStatusBlocked  = string(awscontract.ServiceCollectorStatusBlocked)
+)
+
+// AWSServiceCollectorContractRequest optionally pins connector context used for
+// account and region evidence in the collector contract response.
+type AWSServiceCollectorContractRequest struct {
+	ConnectorID string `json:"connector_id,omitempty"`
+}
+
+// AWSServiceCollectorContractResult exposes the reusable AWS service collector
+// contract future collector PRs must satisfy.
+type AWSServiceCollectorContractResult struct {
+	TenantID                 string                             `json:"tenant_id"`
+	WorkspaceID              string                             `json:"workspace_id"`
+	ProjectID                string                             `json:"project_id"`
+	ConnectorID              string                             `json:"connector_id,omitempty"`
+	AccountID                string                             `json:"account_id,omitempty"`
+	Region                   string                             `json:"region,omitempty"`
+	ParentIssueNumber        int                                `json:"parent_issue_number"`
+	ParentIssueRef           string                             `json:"parent_issue_ref"`
+	CurrentIssueNumber       int                                `json:"current_issue_number"`
+	CurrentIssueRef          string                             `json:"current_issue_ref"`
+	Version                  string                             `json:"version"`
+	Status                   string                             `json:"status"`
+	Confidence               float64                            `json:"confidence"`
+	RequiredFieldCount       int                                `json:"required_field_count"`
+	GraphEdgeCount           int                                `json:"graph_edge_count"`
+	FixtureCaseCount         int                                `json:"fixture_case_count"`
+	RequiredFixtureCaseCount int                                `json:"required_fixture_case_count"`
+	NormalizedRecordFields   []string                           `json:"normalized_record_fields"`
+	RequiredPermissions      []string                           `json:"required_permissions"`
+	ReadOnlyBoundaries       []string                           `json:"read_only_boundaries"`
+	FailureReasons           []string                           `json:"failure_reasons"`
+	RemediationHints         []string                           `json:"remediation_hints"`
+	EvidenceLinks            []string                           `json:"evidence_links"`
+	Checks                   []AWSServiceCollectorContractCheck `json:"checks"`
+	GraphEdges               []AWSServiceCollectorGraphEdge     `json:"graph_edges"`
+	FixtureCases             []AWSServiceCollectorFixtureCase   `json:"fixture_cases"`
+	GeneratedAt              time.Time                          `json:"generated_at"`
+	UpdatedAt                time.Time                          `json:"updated_at"`
+}
+
+// AWSServiceCollectorContractCheck records one deterministic validation check
+// over the shared collector contract.
+type AWSServiceCollectorContractCheck struct {
+	Name          string         `json:"name"`
+	Category      string         `json:"category"`
+	Required      bool           `json:"required"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	FailureReason string         `json:"failure_reason,omitempty"`
+	Remediation   string         `json:"remediation,omitempty"`
+	EvidenceURL   string         `json:"evidence_url,omitempty"`
+	Confidence    float64        `json:"confidence"`
+	Evidence      map[string]any `json:"evidence,omitempty"`
+	CheckedAt     time.Time      `json:"checked_at"`
+}
+
+// AWSServiceCollectorGraphEdge is one required AWS graph relationship semantic.
+type AWSServiceCollectorGraphEdge struct {
+	Name             string `json:"name"`
+	RelationshipType string `json:"relationship_type"`
+	FromEndpoint     string `json:"from_endpoint"`
+	ToEndpoint       string `json:"to_endpoint"`
+	Evidence         string `json:"evidence"`
+	Required         bool   `json:"required"`
+}
+
+// AWSServiceCollectorFixtureCase is one required deterministic fixture state.
+type AWSServiceCollectorFixtureCase struct {
+	ID               string `json:"id"`
+	State            string `json:"state"`
+	Label            string `json:"label"`
+	ExpectedStatus   string `json:"expected_status"`
+	SourceErrorCode  string `json:"source_error_code,omitempty"`
+	Retryable        bool   `json:"retryable"`
+	Required         bool   `json:"required"`
+	EvidenceBoundary string `json:"evidence_boundary"`
+}
+
+// GetAWSServiceCollectorContract returns the deterministic AWS service
+// collector contract scoped to one workspace project. It does not call AWS.
+func (s *Service) GetAWSServiceCollectorContract(ctx context.Context, workspaceID string, projectID string, request AWSServiceCollectorContractRequest) (AWSServiceCollectorContractResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSServiceCollectorContractResult{}, err
+	}
+	var connection AWSConnectionStatus
+	hasConnection := false
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSServiceCollectorContractResult{}, err
+	}
+	return buildAWSServiceCollectorContract(scope, project, connection, hasConnection, s.Now().UTC()), nil
+}
+
+func buildAWSServiceCollectorContract(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, checkedAt time.Time) AWSServiceCollectorContractResult {
+	contract := awscontract.AWSServiceCollectorContract()
+	checks := awsServiceCollectorContractChecks(scope, project, contract, checkedAt)
+	status, confidence, failureReasons, remediationHints := summarizeAWSServiceCollectorContractChecks(checks)
+
+	result := AWSServiceCollectorContractResult{
+		TenantID:                 scope.TenantID,
+		WorkspaceID:              project.WorkspaceID,
+		ProjectID:                project.ProjectID,
+		ParentIssueNumber:        awsPlatformDependencyParentIssue,
+		ParentIssueRef:           awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:       awsServiceCollectorContractCurrentIssue,
+		CurrentIssueRef:          awsIssueRef(awsServiceCollectorContractCurrentIssue),
+		Version:                  contract.Version,
+		Status:                   status,
+		Confidence:               confidence,
+		RequiredFieldCount:       len(contract.NormalizedRecordFields),
+		GraphEdgeCount:           len(contract.GraphEdges),
+		FixtureCaseCount:         len(contract.FixtureCases),
+		RequiredFixtureCaseCount: awsRequiredFixtureCaseCount(contract.FixtureCases),
+		NormalizedRecordFields:   append([]string(nil), contract.NormalizedRecordFields...),
+		RequiredPermissions:      append([]string(nil), contract.RequiredPermissions...),
+		ReadOnlyBoundaries:       append([]string(nil), contract.ReadOnlyBoundaries...),
+		FailureReasons:           failureReasons,
+		RemediationHints:         remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsServiceCollectorContractCurrentIssue),
+			"/docs/aws-service-collector-contract",
+			"/docs/aws-platform-validation-harness",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		Checks:       checks,
+		GraphEdges:   awsServiceCollectorGraphEdges(contract.GraphEdges),
+		FixtureCases: awsServiceCollectorFixtureCases(contract.FixtureCases),
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}
+	if hasConnection {
+		result.ConnectorID = connection.ConnectorID
+		result.AccountID = connection.AccountID
+		result.Region = connection.Region
+	}
+	return result
+}
+
+func awsServiceCollectorContractChecks(scope db.Scope, project db.TenancyProject, contract awscontract.ServiceCollectorContract, checkedAt time.Time) []AWSServiceCollectorContractCheck {
+	return []AWSServiceCollectorContractCheck{
+		awsServiceCollectorContractRecordSchemaCheck(contract, checkedAt),
+		awsServiceCollectorContractGraphCheck(contract, checkedAt),
+		awsServiceCollectorContractFixtureCheck(contract, checkedAt),
+		awsServiceCollectorContractReadOnlyCheck(contract, checkedAt),
+		awsServiceCollectorContractScopeCheck(scope, project, checkedAt),
+	}
+}
+
+func awsServiceCollectorContractRecordSchemaCheck(contract awscontract.ServiceCollectorContract, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	check := awsServiceCollectorContractCheck("normalized_record_schema", "record", true, checkedAt)
+	check.EvidenceURL = "/docs/aws-service-collector-contract"
+	check.Evidence = map[string]any{
+		"version":        contract.Version,
+		"required_count": len(contract.NormalizedRecordFields),
+		"fields":         append([]string(nil), contract.NormalizedRecordFields...),
+	}
+	if strings.TrimSpace(contract.Version) != awsServiceCollectorContractVersion {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "AWS service collector contract version is not current."
+		check.FailureReason = "collector contract version mismatch"
+		check.Remediation = "Restore the canonical AWS service collector contract version before adding collectors."
+		check.Confidence = 0.25
+		return check
+	}
+	if !sameServiceCollectorStringSet(contract.NormalizedRecordFields, awscontract.RequiredServiceCollectorRecordFields()) {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "Normalized AWS service collector record fields do not match the shared contract."
+		check.FailureReason = "normalized record fields are incomplete"
+		check.Remediation = "Include connector, account, region, service, workload, role ARN, source, evidence, confidence, and scan metadata fields."
+		check.Confidence = 0.3
+		return check
+	}
+	check.Status = awsServiceCollectorContractStatusReady
+	check.Message = "Normalized AWS service collector record fields are deterministic."
+	check.Confidence = 0.98
+	return check
+}
+
+func awsServiceCollectorContractGraphCheck(contract awscontract.ServiceCollectorContract, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	check := awsServiceCollectorContractCheck("graph_edge_contract", "graph", true, checkedAt)
+	check.EvidenceURL = "/docs/graph-relationship-contract"
+	check.Evidence = map[string]any{
+		"edge_count": len(contract.GraphEdges),
+		"edges":      awsServiceCollectorGraphEdges(contract.GraphEdges),
+	}
+	if err := awscontract.ValidateServiceCollectorGraphEdges(contract.GraphEdges); err != nil {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "AWS service collector graph edge contract is incomplete."
+		check.FailureReason = err.Error()
+		check.Remediation = "Restore required runs-on, assumes, passes-role, can-access, references-secret, invokes, and observed-runtime-action mappings."
+		check.Confidence = 0.35
+		return check
+	}
+	check.Status = awsServiceCollectorContractStatusReady
+	check.Message = "AWS graph edge types map to supported relationship contracts."
+	check.Confidence = 0.97
+	return check
+}
+
+func awsServiceCollectorContractFixtureCheck(contract awscontract.ServiceCollectorContract, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	check := awsServiceCollectorContractCheck("fixture_conventions", "fixtures", true, checkedAt)
+	check.EvidenceURL = "/docs/aws-service-collector-contract"
+	check.Evidence = map[string]any{
+		"fixture_count": len(contract.FixtureCases),
+		"states":        awsServiceCollectorFixtureStates(contract.FixtureCases),
+	}
+	if err := awscontract.ValidateServiceCollectorFixtures(contract.FixtureCases); err != nil {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "AWS service collector fixture conventions are incomplete."
+		check.FailureReason = err.Error()
+		check.Remediation = "Restore deterministic pagination, throttling, partial-failure, unsupported-region, permission-denied, empty, degraded, and success fixtures."
+		check.Confidence = 0.35
+		return check
+	}
+	check.Status = awsServiceCollectorContractStatusReady
+	check.Message = "AWS service collector fixture states cover success and required failure modes."
+	check.Confidence = 0.98
+	return check
+}
+
+func awsServiceCollectorContractReadOnlyCheck(contract awscontract.ServiceCollectorContract, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	check := awsServiceCollectorContractCheck("read_only_boundaries", "safety", true, checkedAt)
+	check.EvidenceURL = "/docs/auth/aws-connector"
+	check.Evidence = map[string]any{
+		"permissions": append([]string(nil), contract.RequiredPermissions...),
+		"boundaries":  append([]string(nil), contract.ReadOnlyBoundaries...),
+	}
+	for _, permission := range contract.RequiredPermissions {
+		if awscontract.ServiceCollectorPermissionReadsPayload(permission) {
+			check.Status = awsServiceCollectorContractStatusBlocked
+			check.Message = "AWS service collector permissions include a payload-reading action."
+			check.FailureReason = fmt.Sprintf("%s is outside the read-only metadata boundary", permission)
+			check.Remediation = "Remove secret-value, object-content, prompt, completion, browser-output, database-row, and customer-payload reads from the collector contract."
+			check.Confidence = 0.2
+			return check
+		}
+	}
+	if len(contract.RequiredPermissions) == 0 || len(contract.ReadOnlyBoundaries) == 0 {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "AWS service collector read-only contract is missing permission or boundary evidence."
+		check.FailureReason = "read-only boundary is incomplete"
+		check.Remediation = "Document required metadata permissions and explicit non-collection boundaries."
+		check.Confidence = 0.3
+		return check
+	}
+	check.Status = awsServiceCollectorContractStatusReady
+	check.Message = "AWS service collector permissions stay inside read-only metadata boundaries."
+	check.Confidence = 0.96
+	return check
+}
+
+func awsServiceCollectorContractScopeCheck(scope db.Scope, project db.TenancyProject, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	check := awsServiceCollectorContractCheck("tenant_workspace_project_scope", "scope", true, checkedAt)
+	check.EvidenceURL = awsBaselineProjectEvidenceURL(scope, project)
+	check.Evidence = map[string]any{
+		"tenant_id":    scope.TenantID,
+		"workspace_id": project.WorkspaceID,
+		"project_id":   project.ProjectID,
+		"read_only":    true,
+	}
+	if strings.TrimSpace(scope.TenantID) == "" || strings.TrimSpace(project.WorkspaceID) == "" || strings.TrimSpace(project.ProjectID) == "" {
+		check.Status = awsServiceCollectorContractStatusBlocked
+		check.Message = "AWS service collector contract scope metadata is incomplete."
+		check.FailureReason = "tenant, workspace, or project scope is missing"
+		check.Remediation = "Resolve scoped project context before returning collector contract evidence."
+		check.Confidence = 0.25
+		return check
+	}
+	check.Status = awsServiceCollectorContractStatusReady
+	check.Message = "AWS service collector contract response is tenant, workspace, and project scoped."
+	check.Confidence = 0.97
+	return check
+}
+
+func awsServiceCollectorContractCheck(name string, category string, required bool, checkedAt time.Time) AWSServiceCollectorContractCheck {
+	return AWSServiceCollectorContractCheck{
+		Name:       name,
+		Category:   category,
+		Required:   required,
+		Status:     awsServiceCollectorContractStatusBlocked,
+		Confidence: 0,
+		Evidence:   map[string]any{},
+		CheckedAt:  checkedAt,
+	}
+}
+
+func summarizeAWSServiceCollectorContractChecks(checks []AWSServiceCollectorContractCheck) (string, float64, []string, []string) {
+	blockedFailures := []string{}
+	blockedRemediations := []string{}
+	degradedFailures := []string{}
+	degradedRemediations := []string{}
+	degraded := false
+	confidenceTotal := 0.0
+	for _, check := range checks {
+		confidenceTotal += check.Confidence
+		if check.Status == awsServiceCollectorContractStatusBlocked && check.Required {
+			blockedFailures = append(blockedFailures, firstNonEmptyAWSValue(check.FailureReason, fmt.Sprintf("%s is blocked", check.Name)))
+			blockedRemediations = append(blockedRemediations, firstNonEmptyAWSValue(check.Remediation, "Restore the required AWS service collector contract check."))
+		}
+		if check.Status == awsServiceCollectorContractStatusDegraded {
+			degraded = true
+			if check.FailureReason != "" {
+				degradedFailures = append(degradedFailures, check.FailureReason)
+			}
+			if check.Remediation != "" {
+				degradedRemediations = append(degradedRemediations, check.Remediation)
+			}
+		}
+	}
+	if len(checks) == 0 {
+		return awsServiceCollectorContractStatusBlocked, 0.25, []string{"service collector contract checks are missing"}, []string{"Restore service collector contract checks."}
+	}
+	averageConfidence := confidenceTotal / float64(len(checks))
+	if len(blockedFailures) > 0 {
+		return awsServiceCollectorContractStatusBlocked, lowerAWSServiceCollectorConfidence(averageConfidence, 0.45), dedupeStrings(blockedFailures), dedupeStrings(blockedRemediations)
+	}
+	if degraded {
+		return awsServiceCollectorContractStatusDegraded, lowerAWSServiceCollectorConfidence(averageConfidence, 0.75), dedupeStrings(degradedFailures), dedupeStrings(degradedRemediations)
+	}
+	return awsServiceCollectorContractStatusReady, averageConfidence, []string{}, []string{}
+}
+
+func awsRequiredFixtureCaseCount(fixtures []awscontract.ServiceCollectorFixtureCase) int {
+	count := 0
+	for _, fixture := range fixtures {
+		if fixture.Required {
+			count++
+		}
+	}
+	return count
+}
+
+func awsServiceCollectorGraphEdges(edges []awscontract.ServiceCollectorGraphEdgeContract) []AWSServiceCollectorGraphEdge {
+	result := make([]AWSServiceCollectorGraphEdge, 0, len(edges))
+	for _, edge := range edges {
+		result = append(result, AWSServiceCollectorGraphEdge{
+			Name:             edge.Name,
+			RelationshipType: string(edge.RelationshipType),
+			FromEndpoint:     string(edge.FromEndpoint),
+			ToEndpoint:       string(edge.ToEndpoint),
+			Evidence:         edge.Evidence,
+			Required:         edge.Required,
+		})
+	}
+	return result
+}
+
+func awsServiceCollectorFixtureCases(fixtures []awscontract.ServiceCollectorFixtureCase) []AWSServiceCollectorFixtureCase {
+	result := make([]AWSServiceCollectorFixtureCase, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		result = append(result, AWSServiceCollectorFixtureCase{
+			ID:               fixture.ID,
+			State:            string(fixture.State),
+			Label:            fixture.Label,
+			ExpectedStatus:   string(fixture.ExpectedStatus),
+			SourceErrorCode:  fixture.SourceErrorCode,
+			Retryable:        fixture.Retryable,
+			Required:         fixture.Required,
+			EvidenceBoundary: fixture.EvidenceBoundary,
+		})
+	}
+	return result
+}
+
+func awsServiceCollectorFixtureStates(fixtures []awscontract.ServiceCollectorFixtureCase) []string {
+	states := make([]string, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		states = append(states, string(fixture.State))
+	}
+	return dedupeStrings(states)
+}
+
+func sameServiceCollectorStringSet(left []string, right []string) bool {
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	if len(leftCopy) != len(rightCopy) {
+		return false
+	}
+	for i := range leftCopy {
+		if leftCopy[i] != rightCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func lowerAWSServiceCollectorConfidence(confidence float64, maximum float64) float64 {
+	if confidence < maximum {
+		return confidence
+	}
+	return maximum
+}

--- a/internal/api/aws_service_collector_contract_test.go
+++ b/internal/api/aws_service_collector_contract_test.go
@@ -1,0 +1,287 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+func TestGetAWSServiceCollectorContractBuildsCanonicalContract(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 4, 16, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSServiceCollectorContract(ctx, "default", "project-a", AWSServiceCollectorContractRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get service collector contract: %v", err)
+	}
+	if result.Status != awsServiceCollectorContractStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready contract, got %+v", result)
+	}
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1476" || result.Version != awsServiceCollectorContractVersion {
+		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
+	}
+	if result.ConnectorID != "aws-prod" || result.Region != "us-east-1" {
+		t.Fatalf("expected connector context, got %+v", result)
+	}
+	if result.RequiredFieldCount != 17 || result.GraphEdgeCount != 7 || result.FixtureCaseCount != 8 || result.RequiredFixtureCaseCount != 8 {
+		t.Fatalf("unexpected contract counts: %+v", result)
+	}
+	for _, field := range []string{"connector_id", "account_id", "region", "service", "workload_id", "role_arn", "evidence_ref", "confidence", "scan_id"} {
+		if !containsString(result.NormalizedRecordFields, field) {
+			t.Fatalf("missing normalized field %q in %+v", field, result.NormalizedRecordFields)
+		}
+	}
+	for _, state := range []string{"pagination", "throttling", "partial_failure", "unsupported_region", "permission_denied", "degraded"} {
+		if !containsAWSServiceCollectorFixtureState(result.FixtureCases, state) {
+			t.Fatalf("missing fixture state %q in %+v", state, result.FixtureCases)
+		}
+	}
+	for _, edge := range []string{"runs-on", "assumes", "passes-role", "can-access", "references-secret", "invokes", "observed-runtime-action"} {
+		if !containsAWSServiceCollectorGraphEdge(result.GraphEdges, edge) {
+			t.Fatalf("missing graph edge %q in %+v", edge, result.GraphEdges)
+		}
+	}
+	for _, check := range result.Checks {
+		if check.Status != awsServiceCollectorContractStatusReady {
+			t.Fatalf("expected contract check %s ready, got %+v", check.Name, check)
+		}
+	}
+	if !containsString(result.RequiredPermissions, "iam:GetRole") || len(result.ReadOnlyBoundaries) == 0 {
+		t.Fatalf("expected permissions and read-only boundaries, got permissions=%+v boundaries=%+v", result.RequiredPermissions, result.ReadOnlyBoundaries)
+	}
+	if result.GeneratedAt != now || result.UpdatedAt != now {
+		t.Fatalf("expected deterministic timestamps %v, got %v/%v", now, result.GeneratedAt, result.UpdatedAt)
+	}
+}
+
+func TestSummarizeAWSServiceCollectorContractBlocksMissingFixtures(t *testing.T) {
+	now := time.Date(2026, 6, 4, 17, 0, 0, 0, time.UTC)
+	checks := []AWSServiceCollectorContractCheck{
+		{
+			Name:          "fixture_conventions",
+			Category:      "fixtures",
+			Required:      true,
+			Status:        awsServiceCollectorContractStatusBlocked,
+			Message:       "missing fixtures",
+			FailureReason: "missing required permission_denied fixture",
+			Remediation:   "Restore deterministic fixture states.",
+			Confidence:    0.3,
+			CheckedAt:     now,
+		},
+	}
+	status, confidence, failures, remediations := summarizeAWSServiceCollectorContractChecks(checks)
+	if status != awsServiceCollectorContractStatusBlocked || confidence >= 0.5 {
+		t.Fatalf("expected blocked contract summary, got status=%s confidence=%f", status, confidence)
+	}
+	if !containsString(failures, "missing required permission_denied fixture") || len(remediations) == 0 {
+		t.Fatalf("expected fixture failure and remediation, got failures=%+v remediations=%+v", failures, remediations)
+	}
+}
+
+func TestAWSServiceCollectorContractChecksBlockInvalidInputs(t *testing.T) {
+	now := time.Date(2026, 6, 4, 17, 15, 0, 0, time.UTC)
+	canonical := awscontract.AWSServiceCollectorContract()
+	tests := []struct {
+		name        string
+		check       AWSServiceCollectorContractCheck
+		wantFailure string
+	}{
+		{
+			name: "version mismatch",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.Version = "aws-service-collector-contract-v0"
+				return awsServiceCollectorContractRecordSchemaCheck(contract, now)
+			}(),
+			wantFailure: "version mismatch",
+		},
+		{
+			name: "missing record field",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.NormalizedRecordFields = contract.NormalizedRecordFields[:len(contract.NormalizedRecordFields)-1]
+				return awsServiceCollectorContractRecordSchemaCheck(contract, now)
+			}(),
+			wantFailure: "normalized record fields are incomplete",
+		},
+		{
+			name: "missing graph edge",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.GraphEdges = contract.GraphEdges[:len(contract.GraphEdges)-1]
+				return awsServiceCollectorContractGraphCheck(contract, now)
+			}(),
+			wantFailure: "observed-runtime-action",
+		},
+		{
+			name: "missing fixture state",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.FixtureCases = contract.FixtureCases[:len(contract.FixtureCases)-1]
+				return awsServiceCollectorContractFixtureCheck(contract, now)
+			}(),
+			wantFailure: "degraded",
+		},
+		{
+			name: "payload-reading permission",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.RequiredPermissions = append(contract.RequiredPermissions, "secretsmanager:GetSecretValue")
+				return awsServiceCollectorContractReadOnlyCheck(contract, now)
+			}(),
+			wantFailure: "secretsmanager:GetSecretValue is outside the read-only metadata boundary",
+		},
+		{
+			name: "missing read-only evidence",
+			check: func() AWSServiceCollectorContractCheck {
+				contract := canonical
+				contract.RequiredPermissions = nil
+				return awsServiceCollectorContractReadOnlyCheck(contract, now)
+			}(),
+			wantFailure: "read-only boundary is incomplete",
+		},
+		{
+			name: "missing scope",
+			check: awsServiceCollectorContractScopeCheck(db.Scope{}, db.TenancyProject{
+				ProjectID: "project-a",
+			}, now),
+			wantFailure: "tenant, workspace, or project scope is missing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.check.Status != awsServiceCollectorContractStatusBlocked {
+				t.Fatalf("expected blocked check, got %+v", tt.check)
+			}
+			if !strings.Contains(tt.check.FailureReason, tt.wantFailure) {
+				t.Fatalf("expected failure to contain %q, got %q", tt.wantFailure, tt.check.FailureReason)
+			}
+			if tt.check.Remediation == "" || tt.check.Confidence <= 0 || tt.check.Confidence >= 0.5 {
+				t.Fatalf("expected actionable low-confidence blocked check, got %+v", tt.check)
+			}
+		})
+	}
+}
+
+func TestSummarizeAWSServiceCollectorContractHandlesEmptyAndDegraded(t *testing.T) {
+	status, confidence, failures, remediations := summarizeAWSServiceCollectorContractChecks(nil)
+	if status != awsServiceCollectorContractStatusBlocked || confidence != 0.25 {
+		t.Fatalf("expected empty checks to block at default confidence, got status=%s confidence=%f", status, confidence)
+	}
+	if !containsString(failures, "service collector contract checks are missing") || len(remediations) == 0 {
+		t.Fatalf("expected empty check failure/remediation, got failures=%+v remediations=%+v", failures, remediations)
+	}
+
+	now := time.Date(2026, 6, 4, 17, 20, 0, 0, time.UTC)
+	checks := []AWSServiceCollectorContractCheck{
+		{
+			Name:       "normalized_record_schema",
+			Required:   true,
+			Status:     awsServiceCollectorContractStatusReady,
+			Confidence: 0.98,
+			CheckedAt:  now,
+		},
+		{
+			Name:          "fixture_conventions",
+			Required:      true,
+			Status:        awsServiceCollectorContractStatusDegraded,
+			FailureReason: "throttling fixture is retrying",
+			Remediation:   "Keep degraded status visible until retry evidence completes.",
+			Confidence:    0.7,
+			CheckedAt:     now,
+		},
+	}
+	status, confidence, failures, remediations = summarizeAWSServiceCollectorContractChecks(checks)
+	if status != awsServiceCollectorContractStatusDegraded || confidence > 0.75 {
+		t.Fatalf("expected degraded summary with capped confidence, got status=%s confidence=%f", status, confidence)
+	}
+	if !containsString(failures, "throttling fixture is retrying") || len(remediations) != 1 {
+		t.Fatalf("expected degraded failure/remediation, got failures=%+v remediations=%+v", failures, remediations)
+	}
+}
+
+func TestAWSServiceCollectorPermissionReadsPayload(t *testing.T) {
+	for _, permission := range []string{
+		" secretsmanager:GetSecretValue ",
+		"secretsmanager:BatchGetSecretValue",
+		"secretsmanager:*",
+		"secretsmanager:Get*",
+		"ssm:GetParameter",
+		"ssm:GetParametersByPath",
+		"ssm:Get*",
+		"s3:GetObject*",
+		"s3:Get*",
+		"s3:*",
+		"bedrock:Converse",
+		"bedrock:ConverseStream",
+		"bedrock:Converse*",
+		"bedrock:Invoke",
+		"bedrock:InvokeModel",
+		"bedrock:Inv*",
+		"bedrock:*",
+		"rds-data:Execute",
+		"rds-data:*",
+	} {
+		if !awscontract.ServiceCollectorPermissionReadsPayload(permission) {
+			t.Fatalf("expected %q to be treated as a payload-reading permission", permission)
+		}
+	}
+	if awscontract.ServiceCollectorPermissionReadsPayload("iam:GetRolePolicy") {
+		t.Fatal("expected IAM policy metadata read to stay inside collector boundary")
+	}
+	if awscontract.ServiceCollectorPermissionReadsPayload("iam:Get*") {
+		t.Fatal("expected IAM wildcard metadata reads to stay inside collector boundary")
+	}
+}
+
+func TestRouterAWSServiceCollectorContract(t *testing.T) {
+	r := newAWSConnectionTestRouter(t, &fakeAWSConnectorValidator{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/workspace-a/projects/project-1/aws/collector-contract", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected collector contract 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body struct {
+		Contract AWSServiceCollectorContractResult `json:"contract"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode collector contract response: %v", err)
+	}
+	if body.Contract.Status != awsServiceCollectorContractStatusReady || body.Contract.CurrentIssueRef != "#1476" {
+		t.Fatalf("unexpected collector contract payload: %+v", body.Contract)
+	}
+	if body.Contract.RequiredFieldCount != 17 || !containsAWSServiceCollectorFixtureState(body.Contract.FixtureCases, "permission_denied") {
+		t.Fatalf("expected record fields and permission denied fixture, got %+v", body.Contract)
+	}
+}
+
+func containsAWSServiceCollectorFixtureState(fixtures []AWSServiceCollectorFixtureCase, state string) bool {
+	for _, fixture := range fixtures {
+		if fixture.State == state {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAWSServiceCollectorGraphEdge(edges []AWSServiceCollectorGraphEdge, name string) bool {
+	for _, edge := range edges {
+		if edge.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -183,6 +183,7 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/baseline:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/dependency-index:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/validation-harness:",
+		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/collector-contract:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/complete:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connection:",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2506,6 +2506,31 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"harness": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/collector-contract", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSServiceCollectorContract(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSServiceCollectorContractRequest{
+			ConnectorID: strings.TrimSpace(c.Query("connector_id")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws collector contract request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws service collector contract", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws service collector contract"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"contract": record})
+	})
+
 	v1.POST("/workspaces/:workspace_id/projects/:project_id/aws/baseline", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/aws/composite_collector.go
+++ b/internal/providers/aws/composite_collector.go
@@ -20,8 +20,11 @@ type AWSCollectorScope struct {
 	Service   string
 }
 
-// awsServiceCollector defines the internal contract for collectable AWS service modules.
-type awsServiceCollector interface {
+// AWSServiceCollector defines the reusable contract for collectable AWS service
+// modules. Future EC2, ECS, Lambda, EKS, Bedrock, and runtime collectors should
+// implement this interface so the composite collector can preserve partial
+// failure diagnostics across account, region, and service boundaries.
+type AWSServiceCollector interface {
 	ServiceName() string
 	CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error)
 }
@@ -30,7 +33,7 @@ type awsServiceCollector interface {
 type AWSCompositeCollector struct {
 	accountID string
 	region    string
-	services  []awsServiceCollector
+	services  []AWSServiceCollector
 }
 
 func (c *AWSCompositeCollector) AccountID() string {
@@ -49,8 +52,8 @@ func (c *AWSCompositeCollector) Region() string {
 
 // NewAWSCompositeCollector creates a composite AWS collector that runs IAM first by default
 // and accepts optional additional service collectors for future extension.
-func NewAWSCompositeCollector(iamAPI IAMAPI, accountID string, region string, additionalServices ...awsServiceCollector) *AWSCompositeCollector {
-	services := make([]awsServiceCollector, 0, 1+len(additionalServices))
+func NewAWSCompositeCollector(iamAPI IAMAPI, accountID string, region string, additionalServices ...AWSServiceCollector) *AWSCompositeCollector {
+	services := make([]AWSServiceCollector, 0, 1+len(additionalServices))
 	services = append(services, &iamCollectorAdapter{collector: NewCollector(iamAPI)})
 	for _, service := range additionalServices {
 		if service == nil {
@@ -245,4 +248,4 @@ func (a *iamCollectorAdapter) CollectWithDiagnostics(ctx context.Context, _ AWSC
 	return a.collector.CollectWithDiagnostics(ctx)
 }
 
-var _ awsServiceCollector = (*iamCollectorAdapter)(nil)
+var _ AWSServiceCollector = (*iamCollectorAdapter)(nil)

--- a/internal/providers/awscontract/contract.go
+++ b/internal/providers/awscontract/contract.go
@@ -1,0 +1,610 @@
+package awscontract
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	// AWSServiceCollectorContractVersion is the stable contract future AWS
+	// service collectors must cite when adding service-specific inventory.
+	AWSServiceCollectorContractVersion = "aws-service-collector-contract-v1"
+
+	ServiceCollectorStatusReady    ServiceCollectorStatus = "ready"
+	ServiceCollectorStatusDegraded ServiceCollectorStatus = "degraded"
+	ServiceCollectorStatusBlocked  ServiceCollectorStatus = "blocked"
+
+	ServiceCollectorFixtureSuccess           ServiceCollectorFixtureState = "success"
+	ServiceCollectorFixtureEmpty             ServiceCollectorFixtureState = "empty"
+	ServiceCollectorFixturePagination        ServiceCollectorFixtureState = "pagination"
+	ServiceCollectorFixtureThrottling        ServiceCollectorFixtureState = "throttling"
+	ServiceCollectorFixturePartialFailure    ServiceCollectorFixtureState = "partial_failure"
+	ServiceCollectorFixtureUnsupportedRegion ServiceCollectorFixtureState = "unsupported_region"
+	ServiceCollectorFixturePermissionDenied  ServiceCollectorFixtureState = "permission_denied"
+	ServiceCollectorFixtureDegraded          ServiceCollectorFixtureState = "degraded"
+)
+
+// ServiceCollectorStatus describes deterministic collector readiness states.
+type ServiceCollectorStatus string
+
+// ServiceCollectorFixtureState names fixture states every AWS service collector
+// must prove without reading customer payloads or mutating AWS.
+type ServiceCollectorFixtureState string
+
+// ServiceCollectorRecord is the normalized evidence envelope every AWS service
+// collector must emit before downstream graph and intelligence engines consume it.
+type ServiceCollectorRecord struct {
+	TenantID      string            `json:"tenant_id"`
+	WorkspaceID   string            `json:"workspace_id"`
+	ProjectID     string            `json:"project_id"`
+	ConnectorID   string            `json:"connector_id"`
+	AccountID     string            `json:"account_id"`
+	Region        string            `json:"region"`
+	Service       string            `json:"service"`
+	WorkloadID    string            `json:"workload_id"`
+	WorkloadType  string            `json:"workload_type"`
+	WorkloadName  string            `json:"workload_name"`
+	RoleARN       string            `json:"role_arn"`
+	Source        string            `json:"source"`
+	EvidenceRef   string            `json:"evidence_ref"`
+	Confidence    float64           `json:"confidence"`
+	ScanID        string            `json:"scan_id"`
+	CollectorName string            `json:"collector_name"`
+	CollectedAt   time.Time         `json:"collected_at"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+// ServiceCollectorGraphEdgeContract maps operator-facing AWS edge names to the
+// canonical graph relationship semantics used by Identrail.
+type ServiceCollectorGraphEdgeContract struct {
+	Name             string                          `json:"name"`
+	RelationshipType domain.RelationshipType         `json:"relationship_type"`
+	FromEndpoint     domain.RelationshipEndpointKind `json:"from_endpoint"`
+	ToEndpoint       domain.RelationshipEndpointKind `json:"to_endpoint"`
+	Evidence         string                          `json:"evidence"`
+	Required         bool                            `json:"required"`
+}
+
+// ServiceCollectorFixtureCase records one required fixture convention and the
+// expected collector status when the fixture is exercised.
+type ServiceCollectorFixtureCase struct {
+	ID               string                       `json:"id"`
+	State            ServiceCollectorFixtureState `json:"state"`
+	Label            string                       `json:"label"`
+	ExpectedStatus   ServiceCollectorStatus       `json:"expected_status"`
+	SourceErrorCode  string                       `json:"source_error_code,omitempty"`
+	Retryable        bool                         `json:"retryable"`
+	Required         bool                         `json:"required"`
+	EvidenceBoundary string                       `json:"evidence_boundary"`
+}
+
+// ServiceCollectorContract is the canonical AWS service collector contract.
+type ServiceCollectorContract struct {
+	Version                string                              `json:"version"`
+	NormalizedRecordFields []string                            `json:"normalized_record_fields"`
+	GraphEdges             []ServiceCollectorGraphEdgeContract `json:"graph_edges"`
+	FixtureCases           []ServiceCollectorFixtureCase       `json:"fixture_cases"`
+	RequiredPermissions    []string                            `json:"required_permissions"`
+	ReadOnlyBoundaries     []string                            `json:"read_only_boundaries"`
+}
+
+// AWSServiceCollectorContract returns a defensive copy of the canonical
+// contract for future AWS service collector implementations and tests.
+func AWSServiceCollectorContract() ServiceCollectorContract {
+	return ServiceCollectorContract{
+		Version:                AWSServiceCollectorContractVersion,
+		NormalizedRecordFields: RequiredServiceCollectorRecordFields(),
+		GraphEdges:             RequiredServiceCollectorGraphEdges(),
+		FixtureCases:           RequiredServiceCollectorFixtureCases(),
+		RequiredPermissions: []string{
+			"sts:GetCallerIdentity",
+			"iam:ListRoles",
+			"iam:GetRole",
+			"iam:ListRolePolicies",
+			"iam:GetRolePolicy",
+			"iam:ListAttachedRolePolicies",
+			"iam:GetPolicy",
+			"iam:GetPolicyVersion",
+		},
+		ReadOnlyBoundaries: []string{
+			"collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows",
+			"emit explicit permission_denied, unsupported_region, partial_failure, and degraded states instead of reporting false success",
+			"preserve tenant, workspace, project, connector, account, region, service, and scan scope on every record and diagnostic",
+			"require approved remediation or governance executors before any live AWS mutation",
+		},
+	}
+}
+
+// RequiredServiceCollectorRecordFields returns the stable field order future
+// collectors should assert against in fixture tests.
+func RequiredServiceCollectorRecordFields() []string {
+	return []string{
+		"tenant_id",
+		"workspace_id",
+		"project_id",
+		"connector_id",
+		"account_id",
+		"region",
+		"service",
+		"workload_id",
+		"workload_type",
+		"workload_name",
+		"role_arn",
+		"source",
+		"evidence_ref",
+		"confidence",
+		"scan_id",
+		"collector_name",
+		"collected_at",
+	}
+}
+
+// RequiredServiceCollectorGraphEdges returns the graph edge semantics every AWS
+// service collector should use when it can prove the relationship.
+func RequiredServiceCollectorGraphEdges() []ServiceCollectorGraphEdgeContract {
+	edges := []struct {
+		name string
+		rel  domain.RelationshipType
+	}{
+		{"runs-on", domain.RelationshipRunsAs},
+		{"assumes", domain.RelationshipCanAssume},
+		{"passes-role", domain.RelationshipCanPassRole},
+		{"can-access", domain.RelationshipCanAccess},
+		{"references-secret", domain.RelationshipUsesSecret},
+		{"invokes", domain.RelationshipInvokes},
+		{"observed-runtime-action", domain.RelationshipObservedAction},
+	}
+	result := make([]ServiceCollectorGraphEdgeContract, 0, len(edges))
+	for _, edge := range edges {
+		contract, ok := domain.RelationshipContractFor(edge.rel)
+		if !ok {
+			continue
+		}
+		result = append(result, ServiceCollectorGraphEdgeContract{
+			Name:             edge.name,
+			RelationshipType: contract.Type,
+			FromEndpoint:     contract.From,
+			ToEndpoint:       contract.To,
+			Evidence:         contract.Evidence,
+			Required:         true,
+		})
+	}
+	return result
+}
+
+// RequiredServiceCollectorFixtureCases returns deterministic fixture states that
+// future service collectors must cover in tests.
+func RequiredServiceCollectorFixtureCases() []ServiceCollectorFixtureCase {
+	return []ServiceCollectorFixtureCase{
+		{
+			ID:               "success_single_page",
+			State:            ServiceCollectorFixtureSuccess,
+			Label:            "Successful authorized collection",
+			ExpectedStatus:   ServiceCollectorStatusReady,
+			Required:         true,
+			EvidenceBoundary: "metadata, role ARN, workload identifiers, and scoped evidence references only",
+		},
+		{
+			ID:               "empty_authorized_region",
+			State:            ServiceCollectorFixtureEmpty,
+			Label:            "Authorized empty result",
+			ExpectedStatus:   ServiceCollectorStatusReady,
+			Required:         true,
+			EvidenceBoundary: "explicit zero-count evidence with account, region, and service context",
+		},
+		{
+			ID:               "pagination_multiple_pages",
+			State:            ServiceCollectorFixturePagination,
+			Label:            "Multi-page pagination",
+			ExpectedStatus:   ServiceCollectorStatusReady,
+			Required:         true,
+			EvidenceBoundary: "cursor/page counts only; no raw customer payloads",
+		},
+		{
+			ID:               "throttling_retryable",
+			State:            ServiceCollectorFixtureThrottling,
+			Label:            "AWS throttling after bounded retries",
+			ExpectedStatus:   ServiceCollectorStatusDegraded,
+			SourceErrorCode:  "aws_throttled",
+			Retryable:        true,
+			Required:         true,
+			EvidenceBoundary: "retry count, service, account, and region without request payloads",
+		},
+		{
+			ID:               "partial_failure_one_service",
+			State:            ServiceCollectorFixturePartialFailure,
+			Label:            "One service partition fails",
+			ExpectedStatus:   ServiceCollectorStatusDegraded,
+			SourceErrorCode:  "service_collection_failed",
+			Retryable:        true,
+			Required:         true,
+			EvidenceBoundary: "successful and failed partitions separated by service/account/region",
+		},
+		{
+			ID:               "unsupported_region",
+			State:            ServiceCollectorFixtureUnsupportedRegion,
+			Label:            "Unsupported AWS region",
+			ExpectedStatus:   ServiceCollectorStatusBlocked,
+			SourceErrorCode:  "unsupported_region",
+			Required:         true,
+			EvidenceBoundary: "region identifier and service capability only",
+		},
+		{
+			ID:               "permission_denied",
+			State:            ServiceCollectorFixturePermissionDenied,
+			Label:            "Read-only permission denied",
+			ExpectedStatus:   ServiceCollectorStatusBlocked,
+			SourceErrorCode:  "permission_denied",
+			Required:         true,
+			EvidenceBoundary: "denied action name and remediation hint, never credentials",
+		},
+		{
+			ID:               "degraded_source_record",
+			State:            ServiceCollectorFixtureDegraded,
+			Label:            "Malformed or incomplete source record",
+			ExpectedStatus:   ServiceCollectorStatusDegraded,
+			SourceErrorCode:  "malformed_source_record",
+			Required:         true,
+			EvidenceBoundary: "record identifier, validation error code, and collector name only",
+		},
+	}
+}
+
+// NormalizeServiceCollectorRecord trims and validates one normalized service
+// collector record before graph or API consumers use it.
+func NormalizeServiceCollectorRecord(record ServiceCollectorRecord) (ServiceCollectorRecord, error) {
+	normalized := record
+	normalized.TenantID = strings.TrimSpace(record.TenantID)
+	normalized.WorkspaceID = strings.TrimSpace(record.WorkspaceID)
+	normalized.ProjectID = strings.TrimSpace(record.ProjectID)
+	normalized.ConnectorID = strings.TrimSpace(record.ConnectorID)
+	normalized.AccountID = strings.TrimSpace(record.AccountID)
+	normalized.Region = strings.TrimSpace(record.Region)
+	normalized.Service = strings.ToLower(strings.TrimSpace(record.Service))
+	normalized.WorkloadID = strings.TrimSpace(record.WorkloadID)
+	normalized.WorkloadType = strings.ToLower(strings.TrimSpace(record.WorkloadType))
+	normalized.WorkloadName = strings.TrimSpace(record.WorkloadName)
+	normalized.RoleARN = strings.TrimSpace(record.RoleARN)
+	normalized.Source = strings.ToLower(strings.TrimSpace(record.Source))
+	normalized.EvidenceRef = strings.TrimSpace(record.EvidenceRef)
+	normalized.ScanID = strings.TrimSpace(record.ScanID)
+	normalized.CollectorName = strings.TrimSpace(record.CollectorName)
+	if record.Metadata != nil {
+		normalized.Metadata = make(map[string]string, len(record.Metadata))
+		for key, value := range record.Metadata {
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if key == "" || value == "" {
+				continue
+			}
+			normalized.Metadata[key] = value
+		}
+	}
+	if err := ValidateServiceCollectorRecord(normalized); err != nil {
+		return ServiceCollectorRecord{}, err
+	}
+	return normalized, nil
+}
+
+// ValidateServiceCollectorRecord enforces the normalized record contract.
+func ValidateServiceCollectorRecord(record ServiceCollectorRecord) error {
+	required := map[string]string{
+		"tenant_id":      record.TenantID,
+		"workspace_id":   record.WorkspaceID,
+		"project_id":     record.ProjectID,
+		"connector_id":   record.ConnectorID,
+		"account_id":     record.AccountID,
+		"region":         record.Region,
+		"service":        record.Service,
+		"workload_id":    record.WorkloadID,
+		"workload_type":  record.WorkloadType,
+		"workload_name":  record.WorkloadName,
+		"role_arn":       record.RoleARN,
+		"source":         record.Source,
+		"evidence_ref":   record.EvidenceRef,
+		"scan_id":        record.ScanID,
+		"collector_name": record.CollectorName,
+	}
+	for _, field := range RequiredServiceCollectorRecordFields() {
+		if field == "confidence" || field == "collected_at" {
+			continue
+		}
+		if strings.TrimSpace(required[field]) == "" {
+			return fmt.Errorf("%s is required", field)
+		}
+	}
+	if !isTwelveDigitAWSAccountID(record.AccountID) {
+		return fmt.Errorf("account_id must be 12 digits")
+	}
+	roleAccountID, ok := accountIDFromIAMRoleARN(record.RoleARN)
+	if !ok {
+		return fmt.Errorf("role_arn must be an AWS IAM role ARN")
+	}
+	if roleAccountID != record.AccountID {
+		return fmt.Errorf("role_arn account id must match account_id")
+	}
+	if record.Confidence <= 0 || record.Confidence > 1 {
+		return fmt.Errorf("confidence must be greater than 0 and at most 1")
+	}
+	if record.CollectedAt.IsZero() {
+		return fmt.Errorf("collected_at is required")
+	}
+	return nil
+}
+
+// ValidateAWSServiceCollectorContract enforces the whole reusable contract.
+func ValidateAWSServiceCollectorContract(contract ServiceCollectorContract) error {
+	if strings.TrimSpace(contract.Version) != AWSServiceCollectorContractVersion {
+		return fmt.Errorf("unexpected aws service collector contract version")
+	}
+	if !sameStringSet(contract.NormalizedRecordFields, RequiredServiceCollectorRecordFields()) {
+		return fmt.Errorf("normalized record fields do not match required contract")
+	}
+	if err := ValidateServiceCollectorGraphEdges(contract.GraphEdges); err != nil {
+		return err
+	}
+	if err := ValidateServiceCollectorFixtures(contract.FixtureCases); err != nil {
+		return err
+	}
+	if err := ValidateServiceCollectorReadOnlyBoundaries(contract.RequiredPermissions, contract.ReadOnlyBoundaries); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateServiceCollectorReadOnlyBoundaries verifies collectors stay inside
+// metadata-only IAM permissions and document their non-collection boundary.
+func ValidateServiceCollectorReadOnlyBoundaries(requiredPermissions []string, readOnlyBoundaries []string) error {
+	if len(requiredPermissions) == 0 {
+		return fmt.Errorf("required permissions are missing")
+	}
+	if len(readOnlyBoundaries) == 0 {
+		return fmt.Errorf("read-only boundaries are missing")
+	}
+	for _, permission := range requiredPermissions {
+		if strings.TrimSpace(permission) == "" {
+			return fmt.Errorf("required permissions include a blank action")
+		}
+		if ServiceCollectorPermissionReadsPayload(permission) {
+			return fmt.Errorf("%s is outside the read-only metadata boundary", permission)
+		}
+	}
+	return nil
+}
+
+// ValidateServiceCollectorFixtures verifies required fixture states are present.
+func ValidateServiceCollectorFixtures(fixtures []ServiceCollectorFixtureCase) error {
+	requiredStates := RequiredServiceCollectorFixtureStates()
+	requiredCases := requiredServiceCollectorFixtureCasesByState()
+	seen := map[ServiceCollectorFixtureState]struct{}{}
+	for _, fixture := range fixtures {
+		if strings.TrimSpace(fixture.ID) == "" {
+			return fmt.Errorf("fixture id is required")
+		}
+		if strings.TrimSpace(string(fixture.State)) == "" {
+			return fmt.Errorf("fixture %s state is required", fixture.ID)
+		}
+		if strings.TrimSpace(fixture.Label) == "" {
+			return fmt.Errorf("fixture %s label is required", fixture.ID)
+		}
+		switch fixture.ExpectedStatus {
+		case ServiceCollectorStatusReady, ServiceCollectorStatusDegraded, ServiceCollectorStatusBlocked:
+		default:
+			return fmt.Errorf("fixture %s has invalid expected status", fixture.ID)
+		}
+		if !fixture.Required {
+			continue
+		}
+		requiredFixture, ok := requiredCases[fixture.State]
+		if !ok {
+			continue
+		}
+		if fixture.ExpectedStatus != requiredFixture.ExpectedStatus {
+			return fmt.Errorf("fixture %s expected status must remain %s", fixture.State, requiredFixture.ExpectedStatus)
+		}
+		if fixture.Retryable != requiredFixture.Retryable {
+			return fmt.Errorf("fixture %s retryable must remain %t", fixture.State, requiredFixture.Retryable)
+		}
+		if strings.TrimSpace(fixture.SourceErrorCode) != requiredFixture.SourceErrorCode {
+			return fmt.Errorf("fixture %s source error code must remain %q", fixture.State, requiredFixture.SourceErrorCode)
+		}
+		seen[fixture.State] = struct{}{}
+	}
+	for _, state := range requiredStates {
+		if _, ok := seen[state]; !ok {
+			return fmt.Errorf("missing required %s fixture", state)
+		}
+	}
+	return nil
+}
+
+func requiredServiceCollectorFixtureCasesByState() map[ServiceCollectorFixtureState]ServiceCollectorFixtureCase {
+	cases := RequiredServiceCollectorFixtureCases()
+	result := make(map[ServiceCollectorFixtureState]ServiceCollectorFixtureCase, len(cases))
+	for _, fixture := range cases {
+		if fixture.Required {
+			result[fixture.State] = fixture
+		}
+	}
+	return result
+}
+
+// RequiredServiceCollectorFixtureStates returns all fixture states future
+// collectors must keep deterministic.
+func RequiredServiceCollectorFixtureStates() []ServiceCollectorFixtureState {
+	return []ServiceCollectorFixtureState{
+		ServiceCollectorFixtureSuccess,
+		ServiceCollectorFixtureEmpty,
+		ServiceCollectorFixturePagination,
+		ServiceCollectorFixtureThrottling,
+		ServiceCollectorFixturePartialFailure,
+		ServiceCollectorFixtureUnsupportedRegion,
+		ServiceCollectorFixturePermissionDenied,
+		ServiceCollectorFixtureDegraded,
+	}
+}
+
+// ValidateServiceCollectorGraphEdges verifies the AWS names map to supported
+// graph relationship contracts.
+func ValidateServiceCollectorGraphEdges(edges []ServiceCollectorGraphEdgeContract) error {
+	requiredNames := map[string]domain.RelationshipType{
+		"runs-on":                 domain.RelationshipRunsAs,
+		"assumes":                 domain.RelationshipCanAssume,
+		"passes-role":             domain.RelationshipCanPassRole,
+		"can-access":              domain.RelationshipCanAccess,
+		"references-secret":       domain.RelationshipUsesSecret,
+		"invokes":                 domain.RelationshipInvokes,
+		"observed-runtime-action": domain.RelationshipObservedAction,
+	}
+	seen := map[string]struct{}{}
+	for _, edge := range edges {
+		name := strings.TrimSpace(edge.Name)
+		expected, required := requiredNames[name]
+		if !required {
+			continue
+		}
+		if edge.RelationshipType != expected {
+			return fmt.Errorf("graph edge %s uses %s, want %s", name, edge.RelationshipType, expected)
+		}
+		contract, ok := domain.RelationshipContractFor(edge.RelationshipType)
+		if !ok {
+			return fmt.Errorf("graph edge %s uses unsupported relationship type %s", name, edge.RelationshipType)
+		}
+		if edge.FromEndpoint != contract.From || edge.ToEndpoint != contract.To {
+			return fmt.Errorf("graph edge %s endpoint contract does not match canonical relationship contract", name)
+		}
+		if strings.TrimSpace(edge.Evidence) == "" {
+			return fmt.Errorf("graph edge %s evidence is required", name)
+		}
+		if !edge.Required {
+			return fmt.Errorf("graph edge %s must remain required", name)
+		}
+		seen[name] = struct{}{}
+	}
+	for name := range requiredNames {
+		if _, ok := seen[name]; !ok {
+			return fmt.Errorf("missing required %s graph edge", name)
+		}
+	}
+	return nil
+}
+
+func isTwelveDigitAWSAccountID(accountID string) bool {
+	if len(accountID) != 12 {
+		return false
+	}
+	for _, ch := range accountID {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ServiceCollectorPermissionReadsPayload reports whether an IAM action pattern
+// can read customer payloads that AWS service collectors must never collect.
+func ServiceCollectorPermissionReadsPayload(permission string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(permission))
+	parts := strings.SplitN(normalized, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	forbiddenActions := map[string][]string{
+		"secretsmanager": {"getsecretvalue", "batchgetsecretvalue"},
+		"ssm":            {"getparameter", "getparameters"},
+		"s3":             {"getobject"},
+		"bedrock":        {"getprompt", "invoke", "converse"},
+		"rds-data":       {"execute"},
+	}
+	for service, actions := range forbiddenActions {
+		if !iamServicePatternIncludes(parts[0], service) {
+			continue
+		}
+		if parts[1] == "*" {
+			return true
+		}
+		for _, action := range actions {
+			if iamActionPatternIncludes(parts[1], action) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func iamServicePatternIncludes(requestedPattern string, forbiddenService string) bool {
+	if requestedPattern == forbiddenService {
+		return true
+	}
+	if !strings.ContainsAny(requestedPattern, "*?") {
+		return false
+	}
+	matched, err := path.Match(requestedPattern, forbiddenService)
+	return err == nil && matched
+}
+
+func iamActionPatternIncludes(requestedPattern string, forbiddenAction string) bool {
+	if requestedPattern == forbiddenAction || strings.HasPrefix(requestedPattern, forbiddenAction) {
+		return true
+	}
+	if !strings.ContainsAny(requestedPattern, "*?") {
+		return false
+	}
+	matched, err := path.Match(requestedPattern, forbiddenAction)
+	return err == nil && matched
+}
+
+func accountIDFromIAMRoleARN(roleARN string) (string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(roleARN), ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "iam" || parts[3] != "" {
+		return "", false
+	}
+	switch parts[1] {
+	case "aws", "aws-us-gov", "aws-cn":
+	default:
+		return "", false
+	}
+	if !isTwelveDigitAWSAccountID(parts[4]) || !isIAMRoleResource(parts[5]) {
+		return "", false
+	}
+	return parts[4], true
+}
+
+func isIAMRoleResource(resource string) bool {
+	rolePath := strings.TrimPrefix(resource, "role/")
+	if rolePath == resource || rolePath == "" || len(rolePath) > 512 {
+		return false
+	}
+	for _, ch := range rolePath {
+		switch {
+		case ch >= 'A' && ch <= 'Z':
+		case ch >= 'a' && ch <= 'z':
+		case ch >= '0' && ch <= '9':
+		case strings.ContainsRune("+=,.@_/-", ch):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func sameStringSet(left []string, right []string) bool {
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	if len(leftCopy) != len(rightCopy) {
+		return false
+	}
+	for i := range leftCopy {
+		if leftCopy[i] != rightCopy[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providers/awscontract/contract_test.go
+++ b/internal/providers/awscontract/contract_test.go
@@ -1,0 +1,490 @@
+package awscontract
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestAWSServiceCollectorContractIsComplete(t *testing.T) {
+	contract := AWSServiceCollectorContract()
+	if err := ValidateAWSServiceCollectorContract(contract); err != nil {
+		t.Fatalf("expected valid service collector contract: %v", err)
+	}
+	if contract.Version != AWSServiceCollectorContractVersion {
+		t.Fatalf("unexpected contract version %q", contract.Version)
+	}
+	for _, field := range []string{"connector_id", "account_id", "region", "service", "workload_id", "role_arn", "evidence_ref", "confidence", "scan_id"} {
+		if !containsString(contract.NormalizedRecordFields, field) {
+			t.Fatalf("missing normalized field %q in %+v", field, contract.NormalizedRecordFields)
+		}
+	}
+	for _, state := range []ServiceCollectorFixtureState{
+		ServiceCollectorFixturePagination,
+		ServiceCollectorFixtureThrottling,
+		ServiceCollectorFixturePartialFailure,
+		ServiceCollectorFixtureUnsupportedRegion,
+		ServiceCollectorFixturePermissionDenied,
+	} {
+		if !containsFixtureState(contract.FixtureCases, state) {
+			t.Fatalf("missing fixture state %q in %+v", state, contract.FixtureCases)
+		}
+	}
+	for _, edge := range []struct {
+		name string
+		rel  domain.RelationshipType
+	}{
+		{"runs-on", domain.RelationshipRunsAs},
+		{"assumes", domain.RelationshipCanAssume},
+		{"passes-role", domain.RelationshipCanPassRole},
+		{"can-access", domain.RelationshipCanAccess},
+		{"references-secret", domain.RelationshipUsesSecret},
+		{"invokes", domain.RelationshipInvokes},
+		{"observed-runtime-action", domain.RelationshipObservedAction},
+	} {
+		if !containsGraphEdge(contract.GraphEdges, edge.name, edge.rel) {
+			t.Fatalf("missing graph edge %s/%s in %+v", edge.name, edge.rel, contract.GraphEdges)
+		}
+	}
+}
+
+func TestNormalizeServiceCollectorRecord(t *testing.T) {
+	now := time.Date(2026, 6, 4, 16, 30, 0, 0, time.UTC)
+	normalized, err := NormalizeServiceCollectorRecord(ServiceCollectorRecord{
+		TenantID:      " tenant-a ",
+		WorkspaceID:   " workspace-a ",
+		ProjectID:     " project-a ",
+		ConnectorID:   " aws-prod ",
+		AccountID:     "123456789012",
+		Region:        " us-east-1 ",
+		Service:       " EC2 ",
+		WorkloadID:    " i-123 ",
+		WorkloadType:  " Instance ",
+		WorkloadName:  " web-1 ",
+		RoleARN:       " arn:aws:iam::123456789012:role/AppServer ",
+		Source:        " DescribeInstances ",
+		EvidenceRef:   " aws://ec2/us-east-1/i-123 ",
+		Confidence:    0.96,
+		ScanID:        " scan-a ",
+		CollectorName: " aws_ec2 ",
+		CollectedAt:   now,
+		Metadata: map[string]string{
+			" page ": " 1 ",
+			"empty":  "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalize record: %v", err)
+	}
+	if normalized.Service != "ec2" || normalized.Source != "describeinstances" || normalized.WorkloadType != "instance" {
+		t.Fatalf("expected normalized service/source/workload type, got %+v", normalized)
+	}
+	if normalized.Metadata["page"] != "1" || normalized.Metadata["empty"] != "" {
+		t.Fatalf("expected trimmed metadata without empty value, got %+v", normalized.Metadata)
+	}
+}
+
+func TestNormalizeServiceCollectorRecordRejectsUnsafeShape(t *testing.T) {
+	_, err := NormalizeServiceCollectorRecord(ServiceCollectorRecord{
+		TenantID:      "tenant-a",
+		WorkspaceID:   "workspace-a",
+		ProjectID:     "project-a",
+		ConnectorID:   "aws-prod",
+		AccountID:     "123",
+		Region:        "us-east-1",
+		Service:       "lambda",
+		WorkloadID:    "function-a",
+		WorkloadType:  "lambda_function",
+		WorkloadName:  "function-a",
+		RoleARN:       "not-an-arn",
+		Source:        "ListFunctions",
+		EvidenceRef:   "aws://lambda/us-east-1/function-a",
+		Confidence:    1.2,
+		ScanID:        "scan-a",
+		CollectorName: "aws_lambda",
+		CollectedAt:   time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected invalid account, ARN, or confidence error")
+	}
+	if !strings.Contains(err.Error(), "account_id") {
+		t.Fatalf("expected account id validation to fail first, got %v", err)
+	}
+}
+
+func TestValidateServiceCollectorRecordRejectsInvalidFields(t *testing.T) {
+	valid := validServiceCollectorRecord()
+	tests := []struct {
+		name    string
+		mutate  func(*ServiceCollectorRecord)
+		wantErr string
+	}{
+		{
+			name:    "missing required string field",
+			mutate:  func(record *ServiceCollectorRecord) { record.WorkloadName = "" },
+			wantErr: "workload_name is required",
+		},
+		{
+			name:    "invalid role arn",
+			mutate:  func(record *ServiceCollectorRecord) { record.RoleARN = "arn:aws:iam::123456789012:user/AppServer" },
+			wantErr: "role_arn must be an AWS IAM role ARN",
+		},
+		{
+			name:    "role arn account mismatch",
+			mutate:  func(record *ServiceCollectorRecord) { record.RoleARN = "arn:aws:iam::210987654321:role/AppServer" },
+			wantErr: "role_arn account id must match account_id",
+		},
+		{
+			name:    "zero confidence",
+			mutate:  func(record *ServiceCollectorRecord) { record.Confidence = 0 },
+			wantErr: "confidence must be greater than 0 and at most 1",
+		},
+		{
+			name:    "missing collected timestamp",
+			mutate:  func(record *ServiceCollectorRecord) { record.CollectedAt = time.Time{} },
+			wantErr: "collected_at is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := valid
+			tt.mutate(&record)
+			err := ValidateServiceCollectorRecord(record)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateServiceCollectorRecordAcceptsSupportedAWSPartitions(t *testing.T) {
+	for _, roleARN := range []string{
+		"arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		"arn:aws-us-gov:iam::123456789012:role/IdentrailReadOnly",
+		"arn:aws-cn:iam::123456789012:role/path/IdentrailReadOnly",
+	} {
+		record := validServiceCollectorRecord()
+		record.RoleARN = roleARN
+		if err := ValidateServiceCollectorRecord(record); err != nil {
+			t.Fatalf("expected supported role ARN partition %q to validate: %v", roleARN, err)
+		}
+	}
+}
+
+func TestValidateAWSServiceCollectorContractRejectsMalformedContract(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ServiceCollectorContract)
+		wantErr string
+	}{
+		{
+			name:    "version mismatch",
+			mutate:  func(contract *ServiceCollectorContract) { contract.Version = "aws-service-collector-contract-v0" },
+			wantErr: "unexpected aws service collector contract version",
+		},
+		{
+			name: "missing record field",
+			mutate: func(contract *ServiceCollectorContract) {
+				contract.NormalizedRecordFields = contract.NormalizedRecordFields[:len(contract.NormalizedRecordFields)-1]
+			},
+			wantErr: "normalized record fields do not match required contract",
+		},
+		{
+			name: "bad graph mapping",
+			mutate: func(contract *ServiceCollectorContract) {
+				contract.GraphEdges[0].RelationshipType = domain.RelationshipCanAccess
+			},
+			wantErr: "graph edge runs-on uses can_access",
+		},
+		{
+			name:    "missing permissions",
+			mutate:  func(contract *ServiceCollectorContract) { contract.RequiredPermissions = nil },
+			wantErr: "required permissions are missing",
+		},
+		{
+			name: "payload-reading permission",
+			mutate: func(contract *ServiceCollectorContract) {
+				contract.RequiredPermissions = append(contract.RequiredPermissions, "secretsmanager:GetSecretValue")
+			},
+			wantErr: "secretsmanager:GetSecretValue is outside the read-only metadata boundary",
+		},
+		{
+			name: "batch payload-reading permission",
+			mutate: func(contract *ServiceCollectorContract) {
+				contract.RequiredPermissions = append(contract.RequiredPermissions, "secretsmanager:BatchGetSecretValue")
+			},
+			wantErr: "secretsmanager:BatchGetSecretValue is outside the read-only metadata boundary",
+		},
+		{
+			name: "bedrock converse payload-reading permission",
+			mutate: func(contract *ServiceCollectorContract) {
+				contract.RequiredPermissions = append(contract.RequiredPermissions, "bedrock:ConverseStream")
+			},
+			wantErr: "bedrock:ConverseStream is outside the read-only metadata boundary",
+		},
+		{
+			name:    "missing read only boundaries",
+			mutate:  func(contract *ServiceCollectorContract) { contract.ReadOnlyBoundaries = nil },
+			wantErr: "read-only boundaries are missing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contract := AWSServiceCollectorContract()
+			tt.mutate(&contract)
+			err := ValidateAWSServiceCollectorContract(contract)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestAccountIDFromIAMRoleARN(t *testing.T) {
+	accountID, ok := accountIDFromIAMRoleARN("arn:aws-us-gov:iam::123456789012:role/path/IdentrailReadOnly")
+	if !ok || accountID != "123456789012" {
+		t.Fatalf("expected gov partition role ARN account, got accountID=%q ok=%v", accountID, ok)
+	}
+	for _, roleARN := range []string{
+		"arn:aws-iso:iam::123456789012:role/IdentrailReadOnly",
+		"arn:aws:iam::123456789012:user/IdentrailReadOnly",
+		"arn:aws:iam::123456789012:role/",
+		"arn:aws:iam::123456789012:role/Bad Space",
+		"arn:aws:ec2::123456789012:role/IdentrailReadOnly",
+	} {
+		if accountID, ok := accountIDFromIAMRoleARN(roleARN); ok {
+			t.Fatalf("expected invalid role ARN %q to fail, got account id %q", roleARN, accountID)
+		}
+	}
+}
+
+func TestValidateServiceCollectorFixturesRequiresNegativeStates(t *testing.T) {
+	fixtures := []ServiceCollectorFixtureCase{}
+	for _, fixture := range RequiredServiceCollectorFixtureCases() {
+		if fixture.State == ServiceCollectorFixturePermissionDenied {
+			continue
+		}
+		fixtures = append(fixtures, fixture)
+	}
+	err := ValidateServiceCollectorFixtures(fixtures)
+	if err == nil {
+		t.Fatal("expected missing fixture validation error")
+	}
+	if !strings.Contains(err.Error(), "permission_denied") {
+		t.Fatalf("expected missing permission_denied fixture, got %v", err)
+	}
+}
+
+func TestValidateServiceCollectorFixturesRejectsMalformedFixtures(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ServiceCollectorFixtureCase)
+		wantErr string
+	}{
+		{
+			name:    "missing id",
+			mutate:  func(fixture *ServiceCollectorFixtureCase) { fixture.ID = "" },
+			wantErr: "fixture id is required",
+		},
+		{
+			name:    "missing state",
+			mutate:  func(fixture *ServiceCollectorFixtureCase) { fixture.State = "" },
+			wantErr: "state is required",
+		},
+		{
+			name:    "missing label",
+			mutate:  func(fixture *ServiceCollectorFixtureCase) { fixture.Label = "" },
+			wantErr: "label is required",
+		},
+		{
+			name:    "invalid status",
+			mutate:  func(fixture *ServiceCollectorFixtureCase) { fixture.ExpectedStatus = "unknown" },
+			wantErr: "invalid expected status",
+		},
+		{
+			name: "required failure fixture marked ready",
+			mutate: func(fixture *ServiceCollectorFixtureCase) {
+				*fixture = fixtureCaseByState(t, RequiredServiceCollectorFixtureCases(), ServiceCollectorFixturePermissionDenied)
+				fixture.ExpectedStatus = ServiceCollectorStatusReady
+			},
+			wantErr: "fixture permission_denied expected status must remain blocked",
+		},
+		{
+			name: "required retryable fixture marked nonretryable",
+			mutate: func(fixture *ServiceCollectorFixtureCase) {
+				*fixture = fixtureCaseByState(t, RequiredServiceCollectorFixtureCases(), ServiceCollectorFixtureThrottling)
+				fixture.Retryable = false
+			},
+			wantErr: "fixture throttling retryable must remain true",
+		},
+		{
+			name: "required failure fixture missing source error code",
+			mutate: func(fixture *ServiceCollectorFixtureCase) {
+				*fixture = fixtureCaseByState(t, RequiredServiceCollectorFixtureCases(), ServiceCollectorFixtureUnsupportedRegion)
+				fixture.SourceErrorCode = ""
+			},
+			wantErr: `fixture unsupported_region source error code must remain "unsupported_region"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtures := RequiredServiceCollectorFixtureCases()
+			tt.mutate(&fixtures[0])
+			err := ValidateServiceCollectorFixtures(fixtures)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateServiceCollectorGraphEdgesRejectsMalformedEdges(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func([]ServiceCollectorGraphEdgeContract) []ServiceCollectorGraphEdgeContract
+		wantErr string
+	}{
+		{
+			name: "missing required edge",
+			mutate: func(edges []ServiceCollectorGraphEdgeContract) []ServiceCollectorGraphEdgeContract {
+				return edges[:len(edges)-1]
+			},
+			wantErr: "missing required observed-runtime-action graph edge",
+		},
+		{
+			name: "wrong endpoint contract",
+			mutate: func(edges []ServiceCollectorGraphEdgeContract) []ServiceCollectorGraphEdgeContract {
+				edges[0].FromEndpoint = domain.RelationshipEndpointPolicy
+				return edges
+			},
+			wantErr: "endpoint contract does not match canonical relationship contract",
+		},
+		{
+			name: "missing evidence",
+			mutate: func(edges []ServiceCollectorGraphEdgeContract) []ServiceCollectorGraphEdgeContract {
+				edges[0].Evidence = ""
+				return edges
+			},
+			wantErr: "graph edge runs-on evidence is required",
+		},
+		{
+			name: "required edge marked optional",
+			mutate: func(edges []ServiceCollectorGraphEdgeContract) []ServiceCollectorGraphEdgeContract {
+				edges[0].Required = false
+				return edges
+			},
+			wantErr: "graph edge runs-on must remain required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			edges := RequiredServiceCollectorGraphEdges()
+			err := ValidateServiceCollectorGraphEdges(tt.mutate(edges))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestServiceCollectorPermissionReadsPayload(t *testing.T) {
+	for _, permission := range []string{
+		" secretsmanager:GetSecretValue ",
+		"secretsmanager:BatchGetSecretValue",
+		"secretsmanager:*",
+		"secretsmanager:Get*",
+		"ssm:GetParameter",
+		"ssm:GetParametersByPath",
+		"ssm:Get*",
+		"s3:GetObject*",
+		"s3:Get*",
+		"s3:*",
+		"bedrock:GetPrompt",
+		"bedrock:Converse",
+		"bedrock:ConverseStream",
+		"bedrock:Converse*",
+		"bedrock:Invoke",
+		"bedrock:InvokeModel",
+		"bedrock:Inv*",
+		"bedrock:*",
+		"rds-data:Execute",
+		"rds-data:*",
+		"*:*",
+		"*:Get*",
+	} {
+		if !ServiceCollectorPermissionReadsPayload(permission) {
+			t.Fatalf("expected %q to be treated as a payload-reading permission", permission)
+		}
+	}
+	if ServiceCollectorPermissionReadsPayload("iam:GetRolePolicy") {
+		t.Fatal("expected IAM policy metadata read to stay inside collector boundary")
+	}
+	if ServiceCollectorPermissionReadsPayload("iam:Get*") {
+		t.Fatal("expected IAM wildcard metadata reads to stay inside collector boundary")
+	}
+	if ServiceCollectorPermissionReadsPayload("s3-control:GetAccessPoint") {
+		t.Fatal("expected adjacent service metadata reads to stay inside collector boundary")
+	}
+}
+
+func validServiceCollectorRecord() ServiceCollectorRecord {
+	return ServiceCollectorRecord{
+		TenantID:      "tenant-a",
+		WorkspaceID:   "workspace-a",
+		ProjectID:     "project-a",
+		ConnectorID:   "aws-prod",
+		AccountID:     "123456789012",
+		Region:        "us-east-1",
+		Service:       "ec2",
+		WorkloadID:    "i-123",
+		WorkloadType:  "instance",
+		WorkloadName:  "web-1",
+		RoleARN:       "arn:aws:iam::123456789012:role/AppServer",
+		Source:        "describeinstances",
+		EvidenceRef:   "aws://ec2/us-east-1/i-123",
+		Confidence:    0.96,
+		ScanID:        "scan-a",
+		CollectorName: "aws_ec2",
+		CollectedAt:   time.Date(2026, 6, 4, 17, 30, 0, 0, time.UTC),
+	}
+}
+
+func fixtureCaseByState(t *testing.T, fixtures []ServiceCollectorFixtureCase, state ServiceCollectorFixtureState) ServiceCollectorFixtureCase {
+	t.Helper()
+	for _, fixture := range fixtures {
+		if fixture.State == state {
+			return fixture
+		}
+	}
+	t.Fatalf("missing fixture state %s", state)
+	return ServiceCollectorFixtureCase{}
+}
+
+func containsFixtureState(fixtures []ServiceCollectorFixtureCase, state ServiceCollectorFixtureState) bool {
+	for _, fixture := range fixtures {
+		if fixture.State == state {
+			return true
+		}
+	}
+	return false
+}
+
+func containsGraphEdge(edges []ServiceCollectorGraphEdgeContract, name string, rel domain.RelationshipType) bool {
+	for _, edge := range edges {
+		if edge.Name == name && edge.RelationshipType == rel {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -746,4 +746,26 @@ describe('apiClient', () => {
     expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
+
+  it('gets AWS project collector contract with scoped headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ contract: { status: 'ready', required_field_count: 17, fixture_cases: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectCollectorContract('workspace/a', 'project 1', 'aws-prod', {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/collector-contract?connector_id=aws-prod');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -992,6 +992,82 @@ export type AWSPlatformValidationHarnessResult = {
   updated_at: string;
 };
 
+export type AWSServiceCollectorContractStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSServiceCollectorFixtureState =
+  | 'success'
+  | 'empty'
+  | 'pagination'
+  | 'throttling'
+  | 'partial_failure'
+  | 'unsupported_region'
+  | 'permission_denied'
+  | 'degraded';
+
+export type AWSServiceCollectorContractCheck = {
+  name: string;
+  category: string;
+  required: boolean;
+  status: AWSServiceCollectorContractStatus;
+  message: string;
+  failure_reason?: string;
+  remediation?: string;
+  evidence_url?: string;
+  confidence: number;
+  evidence?: Record<string, unknown>;
+  checked_at: string;
+};
+
+export type AWSServiceCollectorGraphEdge = {
+  name: string;
+  relationship_type: string;
+  from_endpoint: string;
+  to_endpoint: string;
+  evidence: string;
+  required: boolean;
+};
+
+export type AWSServiceCollectorFixtureCase = {
+  id: string;
+  state: AWSServiceCollectorFixtureState;
+  label: string;
+  expected_status: AWSServiceCollectorContractStatus;
+  source_error_code?: string;
+  retryable: boolean;
+  required: boolean;
+  evidence_boundary: string;
+};
+
+export type AWSServiceCollectorContractResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSServiceCollectorContractStatus;
+  confidence: number;
+  required_field_count: number;
+  graph_edge_count: number;
+  fixture_case_count: number;
+  required_fixture_case_count: number;
+  normalized_record_fields: string[];
+  required_permissions: string[];
+  read_only_boundaries: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  checks: AWSServiceCollectorContractCheck[];
+  graph_edges: AWSServiceCollectorGraphEdge[];
+  fixture_cases: AWSServiceCollectorFixtureCase[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSConnectorStartRequest = {
   workspace_id?: string;
   project_id?: string;
@@ -1942,6 +2018,14 @@ export const apiClient = {
   getAWSProjectValidationHarness(workspaceID: string, projectID: string, connectorID?: string, auth?: RequestAuthContext) {
     return request<{ harness: AWSPlatformValidationHarnessResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/validation-harness${buildQuery({
+        connector_id: connectorID
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectCollectorContract(workspaceID: string, projectID: string, connectorID?: string, auth?: RequestAuthContext) {
+    return request<{ contract: AWSServiceCollectorContractResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/collector-contract${buildQuery({
         connector_id: connectorID
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8,6 +8,7 @@ import type {
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
+  AWSServiceCollectorContractResult,
   CurrentUserContext,
   Finding,
   GitHubConnectionStatus,
@@ -190,11 +191,32 @@ const readyAWSDependencyIndex: AWSPlatformDependencyIndexResult = {
   confidence: 0.97,
   issue_count: 85,
   wave_count: 11,
-  ready_issue_count: 1,
-  blocked_issue_count: 82,
-  completed_issue_refs: ['#1473', '#1474'],
-  ready_issue_refs: ['#1475'],
-  blocked_issue_refs: ['#1476'],
+  ready_issue_count: 20,
+  blocked_issue_count: 61,
+  completed_issue_refs: ['#1473', '#1474', '#1475', '#1476'],
+  ready_issue_refs: [
+    '#1477',
+    '#1478',
+    '#1479',
+    '#1480',
+    '#1481',
+    '#1482',
+    '#1483',
+    '#1484',
+    '#1485',
+    '#1486',
+    '#1487',
+    '#1488',
+    '#1489',
+    '#1490',
+    '#1491',
+    '#1492',
+    '#1493',
+    '#1494',
+    '#1495',
+    '#1496'
+  ],
+  blocked_issue_refs: ['#1497'],
   failure_reasons: [],
   remediation_hints: [],
   evidence_links: [
@@ -376,6 +398,115 @@ function mockAWSValidationHarness(
   });
 }
 
+const readyAWSServiceCollectorContract: AWSServiceCollectorContractResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1472,
+  parent_issue_ref: '#1472',
+  current_issue_number: 1476,
+  current_issue_ref: '#1476',
+  version: 'aws-service-collector-contract-v1',
+  status: 'ready',
+  confidence: 0.97,
+  required_field_count: 17,
+  graph_edge_count: 7,
+  fixture_case_count: 8,
+  required_fixture_case_count: 8,
+  normalized_record_fields: [
+    'tenant_id',
+    'workspace_id',
+    'project_id',
+    'connector_id',
+    'account_id',
+    'region',
+    'service',
+    'workload_id',
+    'workload_type',
+    'workload_name',
+    'role_arn',
+    'source',
+    'evidence_ref',
+    'confidence',
+    'scan_id',
+    'collector_name',
+    'collected_at'
+  ],
+  required_permissions: ['sts:GetCallerIdentity', 'iam:ListRoles', 'iam:GetRole'],
+  read_only_boundaries: ['collect metadata and policy documents only'],
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: [
+    'https://github.com/identrail/identrail/issues/1472',
+    'https://github.com/identrail/identrail/issues/1476',
+    '/docs/aws-service-collector-contract'
+  ],
+  checks: [
+    {
+      name: 'normalized_record_schema',
+      category: 'record',
+      required: true,
+      status: 'ready',
+      message: 'Normalized AWS service collector record fields are deterministic.',
+      confidence: 0.98,
+      checked_at: '2026-05-17T10:00:00Z'
+    }
+  ],
+  graph_edges: [
+    {
+      name: 'runs-on',
+      relationship_type: 'runs_as',
+      from_endpoint: 'workload',
+      to_endpoint: 'identity',
+      evidence: 'runtime or workload configuration proving the identity used at execution time',
+      required: true
+    },
+    {
+      name: 'observed-runtime-action',
+      relationship_type: 'observed_action',
+      from_endpoint: 'identity_workload_agent_or_runtime_session',
+      to_endpoint: 'observed_action_target',
+      evidence: 'audit log, trace span, runtime event, or provider activity record',
+      required: true
+    }
+  ],
+  fixture_cases: [
+    {
+      id: 'pagination_multiple_pages',
+      state: 'pagination',
+      label: 'Multi-page pagination',
+      expected_status: 'ready',
+      retryable: false,
+      required: true,
+      evidence_boundary: 'cursor/page counts only; no raw customer payloads'
+    },
+    {
+      id: 'permission_denied',
+      state: 'permission_denied',
+      label: 'Read-only permission denied',
+      expected_status: 'blocked',
+      source_error_code: 'permission_denied',
+      retryable: false,
+      required: true,
+      evidence_boundary: 'denied action name and remediation hint, never credentials'
+    }
+  ],
+  generated_at: '2026-05-17T10:00:00Z',
+  updated_at: '2026-05-17T10:00:00Z'
+};
+
+function mockAWSServiceCollectorContract(
+  api: typeof import('./api/client'),
+  contract: AWSServiceCollectorContractResult = readyAWSServiceCollectorContract
+) {
+  vi.spyOn(api.apiClient, 'getAWSProjectCollectorContract').mockResolvedValue({
+    contract
+  });
+}
+
 function mockAWSBaseline(api: typeof import('./api/client'), baseline: AWSPlatformBaselineResult = readyAWSBaseline) {
   vi.spyOn(api.apiClient, 'getAWSProjectBaseline').mockResolvedValue({
     baseline
@@ -385,6 +516,7 @@ function mockAWSBaseline(api: typeof import('./api/client'), baseline: AWSPlatfo
   });
   mockAWSDependencyIndex(api);
   mockAWSValidationHarness(api);
+  mockAWSServiceCollectorContract(api);
 }
 
 const disconnectedKubernetes: KubernetesConnectionStatus = {
@@ -1699,6 +1831,8 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText('AWS live app validation harness')).toBeInTheDocument();
     expect(screen.getByText('Runtime evidence partial failure')).toBeInTheDocument();
     expect(screen.getByText('Remediation permission denied')).toBeInTheDocument();
+    expect(screen.getByText('AWS service collector contract')).toBeInTheDocument();
+    expect(screen.getByText('Read-only permission denied')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Resources and secrets/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/resources?environment=production'
@@ -1747,6 +1881,58 @@ describe('Domain-first app routes', () => {
     const coverage = within(harnessScenarios).getByText('Fixture coverage').closest('article');
     expect(coverage).not.toBeNull();
     expect(within(coverage as HTMLElement).getByText('Blocked')).toHaveClass('is-error');
+  });
+
+  it('does not style blocked AWS service collector contract as success', async () => {
+    const api = await import('./api/client');
+    mockAWSBaseline(api);
+    vi.mocked(api.apiClient.getAWSProjectCollectorContract).mockResolvedValue({
+      contract: {
+        ...readyAWSServiceCollectorContract,
+        status: 'blocked',
+        failure_reasons: ['missing required permission_denied fixture'],
+        remediation_hints: ['Restore deterministic AWS service collector fixtures.'],
+        checks: [
+          {
+            ...readyAWSServiceCollectorContract.checks[0],
+            status: 'blocked',
+            failure_reason: 'missing required permission_denied fixture',
+            remediation: 'Restore deterministic AWS service collector fixtures.'
+          }
+        ]
+      }
+    });
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+
+    const { ProductAWSControlCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws" element={<ProductAWSControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('AWS service collector contract')).toBeInTheDocument();
+    const contractChecks = screen.getByLabelText('AWS service collector contract checks');
+    const normalizedRecord = within(contractChecks).getByText('Normalized record').closest('article');
+    expect(normalizedRecord).not.toBeNull();
+    expect(within(normalizedRecord as HTMLElement).getByText('Blocked')).toHaveClass('is-error');
   });
 
   it('ignores stale AWS Control Center status loads after switching environments', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -32,6 +32,7 @@ import {
   type AWSPlatformBaselineResult,
   type AWSPlatformDependencyIndexResult,
   type AWSPlatformValidationHarnessResult,
+  type AWSServiceCollectorContractResult,
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
   type ExecutiveReport,
@@ -3199,6 +3200,155 @@ function AWSValidationHarnessSummary({
   );
 }
 
+function awsServiceCollectorContractLabel(contract: AWSServiceCollectorContractResult | null): string {
+  if (!contract) {
+    return 'Not loaded';
+  }
+  if (contract.status === 'ready') {
+    return 'Ready';
+  }
+  if (contract.status === 'degraded') {
+    return 'Degraded';
+  }
+  return 'Blocked';
+}
+
+function awsServiceCollectorContractTone(
+  contract: AWSServiceCollectorContractResult | null,
+  loading = false
+): 'success' | 'warning' | 'danger' | 'neutral' | 'info' {
+  if (loading) {
+    return 'info';
+  }
+  if (!contract) {
+    return 'neutral';
+  }
+  if (contract.status === 'ready') {
+    return 'success';
+  }
+  if (contract.status === 'degraded') {
+    return 'warning';
+  }
+  return 'danger';
+}
+
+function awsServiceCollectorContractSummary(contract: AWSServiceCollectorContractResult | null): string {
+  if (!contract) {
+    return 'No collector contract loaded';
+  }
+  return `${formatCountLabel(contract.required_field_count, 'field')} · ${formatCountLabel(
+    contract.fixture_case_count,
+    'fixture'
+  )} · ${formatCountLabel(contract.graph_edge_count, 'edge')}`;
+}
+
+function awsServiceCollectorCheckTone(status: AWSServiceCollectorContractResult['checks'][number]['status']): 'success' | 'warning' | 'error' | 'neutral' {
+  if (status === 'ready') {
+    return 'success';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  if (status === 'blocked') {
+    return 'error';
+  }
+  return 'neutral';
+}
+
+function awsServiceCollectorFixtureTone(
+  status: AWSServiceCollectorContractResult['fixture_cases'][number]['expected_status']
+): 'success' | 'warning' | 'error' | 'neutral' {
+  if (status === 'ready') {
+    return 'success';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  if (status === 'blocked') {
+    return 'error';
+  }
+  return 'neutral';
+}
+
+function AWSServiceCollectorContractSummary({
+  contract,
+  loading = false,
+  emptyLabel = 'Collector contract has not loaded for this environment.'
+}: {
+  contract: AWSServiceCollectorContractResult | null;
+  loading?: boolean;
+  emptyLabel?: string;
+}) {
+  if (loading) {
+    return (
+      <article>
+        <strong>AWS collector contract</strong>
+        <span className="idt-source-status-pill is-neutral">Loading</span>
+        <p>Loading collector contract checks.</p>
+      </article>
+    );
+  }
+  if (!contract) {
+    return (
+      <article>
+        <strong>AWS collector contract</strong>
+        <span className="idt-source-status-pill is-neutral">Not loaded</span>
+        <p>{emptyLabel}</p>
+      </article>
+    );
+  }
+  return (
+    <>
+      <article>
+        <strong>Normalized record</strong>
+        <span className={`idt-source-status-pill is-${awsServiceCollectorCheckTone(contract.status)}`}>
+          {formatTokenLabel(contract.status)}
+        </span>
+        <p>{contract.normalized_record_fields.slice(0, 8).map(formatTokenLabel).join(', ')}</p>
+        <small>{awsServiceCollectorContractSummary(contract)}</small>
+      </article>
+      {contract.checks.map((check) => (
+        <article key={check.name}>
+          <strong>{formatTokenLabel(check.name)}</strong>
+          <span className={`idt-source-status-pill is-${awsServiceCollectorCheckTone(check.status)}`}>{formatTokenLabel(check.status)}</span>
+          <p>{check.message}</p>
+          <small>
+            {check.required ? 'Required' : 'Optional'} · confidence {formatConfidenceScore(check.confidence)} ·{' '}
+            {formatConnectionTime(check.checked_at)}
+          </small>
+          {check.failure_reason ? <small>{formatTokenLabel(check.failure_reason)}</small> : null}
+          {check.remediation ? <small>{check.remediation}</small> : null}
+          {check.evidence_url ? (
+            <a href={check.evidence_url} target={check.evidence_url.startsWith('http') ? '_blank' : undefined} rel="noreferrer">
+              Evidence
+            </a>
+          ) : null}
+        </article>
+      ))}
+      {contract.fixture_cases.map((fixture) => (
+        <article key={fixture.id}>
+          <strong>{fixture.label}</strong>
+          <span className={`idt-source-status-pill is-${awsServiceCollectorFixtureTone(fixture.expected_status)}`}>
+            {formatTokenLabel(fixture.state)}
+          </span>
+          <p>{fixture.evidence_boundary}</p>
+          <small>{fixture.source_error_code ? formatTokenLabel(fixture.source_error_code) : 'No source error expected'}</small>
+        </article>
+      ))}
+      {contract.graph_edges.map((edge) => (
+        <article key={edge.name}>
+          <strong>{edge.name}</strong>
+          <span className="idt-source-status-pill is-neutral">{formatTokenLabel(edge.relationship_type)}</span>
+          <p>{edge.evidence}</p>
+          <small>
+            {formatTokenLabel(edge.from_endpoint)} to {formatTokenLabel(edge.to_endpoint)}
+          </small>
+        </article>
+      ))}
+    </>
+  );
+}
+
 type AWSInventoryRouteID = Extract<ProductDomainRouteID, 'accounts' | 'identities' | 'agents' | 'resources'>;
 
 type AWSInventoryPageCopy = {
@@ -5328,10 +5478,14 @@ export function ProductAWSControlCenterPage() {
   const [validationHarness, setValidationHarness] = useState<AWSPlatformValidationHarnessResult | null>(null);
   const [validationLoading, setValidationLoading] = useState(false);
   const [validationError, setValidationError] = useState('');
+  const [collectorContract, setCollectorContract] = useState<AWSServiceCollectorContractResult | null>(null);
+  const [collectorContractLoading, setCollectorContractLoading] = useState(false);
+  const [collectorContractError, setCollectorContractError] = useState('');
   const connectionRequestRef = useRef(0);
   const baselineRequestRef = useRef(0);
   const dependencyRequestRef = useRef(0);
   const validationRequestRef = useRef(0);
+  const collectorContractRequestRef = useRef(0);
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   selectedEnvironmentIDRef.current = selectedEnvironmentID;
 
@@ -5510,18 +5664,56 @@ export function ProductAWSControlCenterPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
+  const refreshCollectorContract = useCallback(async () => {
+    const requestID = ++collectorContractRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!scope || !requestEnvironmentID) {
+      setCollectorContract(null);
+      setCollectorContractError('');
+      setCollectorContractLoading(false);
+      return;
+    }
+    const isStale = () => requestID !== collectorContractRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
+    setCollectorContractLoading(true);
+    setCollectorContractError('');
+    try {
+      const response = await apiClient.getAWSProjectCollectorContract(
+        scope.workspaceID,
+        requestEnvironmentID,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setCollectorContract(response.contract);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setCollectorContract(null);
+      setCollectorContractError(formatAPIError(error, 'Unable to load AWS collector contract.'));
+    } finally {
+      if (!isStale()) {
+        setCollectorContractLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
   useEffect(() => {
     void refreshConnection();
     void refreshBaseline();
     void refreshDependencyIndex();
     void refreshValidationHarness();
+    void refreshCollectorContract();
     return () => {
       connectionRequestRef.current += 1;
       baselineRequestRef.current += 1;
       dependencyRequestRef.current += 1;
       validationRequestRef.current += 1;
+      collectorContractRequestRef.current += 1;
     };
-  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness]);
+  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness, refreshCollectorContract]);
 
   if (!scope) {
     return (
@@ -5538,14 +5730,17 @@ export function ProductAWSControlCenterPage() {
     baselineRequestRef.current += 1;
     dependencyRequestRef.current += 1;
     validationRequestRef.current += 1;
+    collectorContractRequestRef.current += 1;
     setConnection(null);
     setBaseline(null);
     setDependencyIndex(null);
     setValidationHarness(null);
+    setCollectorContract(null);
     setConnectionError('');
     setBaselineError('');
     setDependencyError('');
     setValidationError('');
+    setCollectorContractError('');
     navigate(
       {
         pathname: location.pathname,
@@ -5564,6 +5759,10 @@ export function ProductAWSControlCenterPage() {
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const dependencyTone = awsDependencyIndexTone(dependencyIndex, dependencyLoading || environmentScope.loading);
   const validationTone = awsValidationHarnessTone(validationHarness, validationLoading || environmentScope.loading);
+  const collectorContractTone = awsServiceCollectorContractTone(
+    collectorContract,
+    collectorContractLoading || environmentScope.loading
+  );
   const statusLabel = environmentScope.loading
     ? 'Loading scope'
     : connectionLoading
@@ -5649,11 +5848,17 @@ export function ProductAWSControlCenterPage() {
             value: awsValidationHarnessLabel(validationHarness),
             detail: validationLoading ? 'Proof states loading' : awsValidationHarnessSummary(validationHarness),
             tone: validationTone
+          },
+          {
+            label: 'Collector contract',
+            value: awsServiceCollectorContractLabel(collectorContract),
+            detail: collectorContractLoading ? 'Contract loading' : awsServiceCollectorContractSummary(collectorContract),
+            tone: collectorContractTone
           }
         ]}
       />
 
-      {environmentScope.loading || connectionLoading || baselineLoading || dependencyLoading || validationLoading ? (
+      {environmentScope.loading || connectionLoading || baselineLoading || dependencyLoading || validationLoading || collectorContractLoading ? (
         <DomainLoadingState label="Loading AWS control center status" />
       ) : null}
 
@@ -5683,6 +5888,13 @@ export function ProductAWSControlCenterPage() {
           title="AWS validation harness could not load"
           body={validationError}
           retryAction={{ label: 'Retry harness', onClick: () => void refreshValidationHarness() }}
+        />
+      ) : null}
+      {collectorContractError ? (
+        <DomainErrorState
+          title="AWS collector contract could not load"
+          body={collectorContractError}
+          retryAction={{ label: 'Retry contract', onClick: () => void refreshCollectorContract() }}
         />
       ) : null}
 
@@ -5865,6 +6077,58 @@ export function ProductAWSControlCenterPage() {
           </dl>
           <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS validation harness scenarios">
             <AWSValidationHarnessSummary harness={validationHarness} loading={validationLoading} />
+          </div>
+        </div>
+      </DomainStatusPanel>
+
+      <DomainStatusPanel
+        eyebrow="Collector contract"
+        title="AWS service collector contract"
+        status={awsServiceCollectorContractLabel(collectorContract)}
+        tone={collectorContractTone}
+        actions={[
+          {
+            label: 'Refresh contract',
+            onClick: () => void refreshCollectorContract(),
+            variant: 'secondary',
+            disabled: collectorContractLoading || !selectedEnvironmentID
+          },
+          {
+            label: 'Contract docs',
+            href: '/docs/aws-service-collector-contract',
+            variant: 'ghost'
+          }
+        ]}
+      >
+        <div className="idt-aws-status-grid">
+          <dl>
+            <div>
+              <dt>Issue</dt>
+              <dd>{collectorContract?.current_issue_ref ?? '#1476'}</dd>
+            </div>
+            <div>
+              <dt>Fields</dt>
+              <dd>{collectorContract ? formatCountLabel(collectorContract.required_field_count, 'field') : 'Pending'}</dd>
+            </div>
+            <div>
+              <dt>Fixtures</dt>
+              <dd>{collectorContract ? formatCountLabel(collectorContract.fixture_case_count, 'fixture') : 'Pending'}</dd>
+            </div>
+            <div>
+              <dt>Edges</dt>
+              <dd>{collectorContract ? formatCountLabel(collectorContract.graph_edge_count, 'edge') : 'Pending'}</dd>
+            </div>
+            <div>
+              <dt>Permissions</dt>
+              <dd>{collectorContract ? formatCountLabel(collectorContract.required_permissions.length, 'permission') : 'Pending'}</dd>
+            </div>
+            <div>
+              <dt>Updated</dt>
+              <dd>{formatConnectionTime(collectorContract?.updated_at)}</dd>
+            </div>
+          </dl>
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS service collector contract checks">
+            <AWSServiceCollectorContractSummary contract={collectorContract} loading={collectorContractLoading} />
           </div>
         </div>
       </DomainStatusPanel>
@@ -6155,6 +6419,9 @@ export function ProductAWSConnectPage() {
   const [validationHarness, setValidationHarness] = useState<AWSPlatformValidationHarnessResult | null>(null);
   const [validationLoading, setValidationLoading] = useState(false);
   const [validationError, setValidationError] = useState('');
+  const [collectorContract, setCollectorContract] = useState<AWSServiceCollectorContractResult | null>(null);
+  const [collectorContractLoading, setCollectorContractLoading] = useState(false);
+  const [collectorContractError, setCollectorContractError] = useState('');
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
     externalID: '',
@@ -6172,6 +6439,7 @@ export function ProductAWSConnectPage() {
   const baselineRequestRef = useRef(0);
   const dependencyRequestRef = useRef(0);
   const validationRequestRef = useRef(0);
+  const collectorContractRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
@@ -6393,11 +6661,52 @@ export function ProductAWSConnectPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
+  const refreshCollectorContract = useCallback(async () => {
+    const requestID = ++collectorContractRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    if (!scope || !requestEnvironmentID) {
+      setCollectorContract(null);
+      setCollectorContractError('');
+      setCollectorContractLoading(false);
+      return;
+    }
+    const isStale = () =>
+      requestID !== collectorContractRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    setCollectorContractLoading(true);
+    setCollectorContractError('');
+    try {
+      const response = await apiClient.getAWSProjectCollectorContract(
+        scope.workspaceID,
+        requestEnvironmentID,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setCollectorContract(response.contract);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setCollectorContract(null);
+      setCollectorContractError(formatAPIError(error, 'Unable to load AWS collector contract.'));
+    } finally {
+      if (!isStale()) {
+        setCollectorContractLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
   useEffect(() => {
     connectionRequestRef.current += 1;
     baselineRequestRef.current += 1;
     dependencyRequestRef.current += 1;
     validationRequestRef.current += 1;
+    collectorContractRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
@@ -6409,6 +6718,8 @@ export function ProductAWSConnectPage() {
     setDependencyError('');
     setValidationHarness(null);
     setValidationError('');
+    setCollectorContract(null);
+    setCollectorContractError('');
     setSubmitting(false);
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
@@ -6425,16 +6736,18 @@ export function ProductAWSConnectPage() {
     void refreshBaseline();
     void refreshDependencyIndex();
     void refreshValidationHarness();
+    void refreshCollectorContract();
     return () => {
       connectionRequestRef.current += 1;
       baselineRequestRef.current += 1;
       dependencyRequestRef.current += 1;
       validationRequestRef.current += 1;
+      collectorContractRequestRef.current += 1;
       awsStartRequestRef.current += 1;
       awsPollRequestRef.current += 1;
       awsValidationRequestRef.current += 1;
     };
-  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness]);
+  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness, refreshCollectorContract]);
 
   if (!scope) {
     return (
@@ -6451,6 +6764,7 @@ export function ProductAWSConnectPage() {
     baselineRequestRef.current += 1;
     dependencyRequestRef.current += 1;
     validationRequestRef.current += 1;
+    collectorContractRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
@@ -6458,9 +6772,11 @@ export function ProductAWSConnectPage() {
     setBaseline(null);
     setDependencyIndex(null);
     setValidationHarness(null);
+    setCollectorContract(null);
     setBaselineError('');
     setDependencyError('');
     setValidationError('');
+    setCollectorContractError('');
     navigate(
       {
         pathname: location.pathname,
@@ -6476,6 +6792,10 @@ export function ProductAWSConnectPage() {
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
   const dependencyTone = awsDependencyIndexTone(dependencyIndex, dependencyLoading || environmentScope.loading);
   const validationTone = awsValidationHarnessTone(validationHarness, validationLoading || environmentScope.loading);
+  const collectorContractTone = awsServiceCollectorContractTone(
+    collectorContract,
+    collectorContractLoading || environmentScope.loading
+  );
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
 
@@ -6561,6 +6881,7 @@ export function ProductAWSConnectPage() {
         void verifyBaseline();
         void refreshDependencyIndex();
         void refreshValidationHarness();
+        void refreshCollectorContract();
       }
     } catch (error) {
       if (isStale()) {
@@ -6630,6 +6951,7 @@ export function ProductAWSConnectPage() {
         void verifyBaseline();
         void refreshDependencyIndex();
         void refreshValidationHarness();
+        void refreshCollectorContract();
       }
     } catch (error) {
       if (isStale()) {
@@ -6715,11 +7037,17 @@ export function ProductAWSConnectPage() {
             value: awsValidationHarnessLabel(validationHarness),
             detail: validationLoading ? 'Proof states loading' : awsValidationHarnessSummary(validationHarness),
             tone: validationTone
+          },
+          {
+            label: 'Collector contract',
+            value: awsServiceCollectorContractLabel(collectorContract),
+            detail: collectorContractLoading ? 'Contract loading' : awsServiceCollectorContractSummary(collectorContract),
+            tone: collectorContractTone
           }
         ]}
       />
 
-      {loadingConnection || baselineLoading || dependencyLoading || validationLoading || environmentScope.loading ? (
+      {loadingConnection || baselineLoading || dependencyLoading || validationLoading || collectorContractLoading || environmentScope.loading ? (
         <DomainLoadingState label="Loading AWS setup state" />
       ) : null}
 
@@ -6755,6 +7083,11 @@ export function ProductAWSConnectPage() {
       {validationError ? (
         <p role="alert" className="idt-app-alert idt-app-alert-error">
           {validationError}
+        </p>
+      ) : null}
+      {collectorContractError ? (
+        <p role="alert" className="idt-app-alert idt-app-alert-error">
+          {collectorContractError}
         </p>
       ) : null}
 
@@ -7009,6 +7342,39 @@ export function ProductAWSConnectPage() {
               </dl>
               <div className="idt-source-diagnostics" aria-label="AWS validation harness diagnostics">
                 <AWSValidationHarnessSummary harness={validationHarness} loading={validationLoading} />
+              </div>
+            </DomainStatusPanel>
+
+            <DomainStatusPanel
+              eyebrow="Collector contract"
+              title="Service collector contract"
+              status={awsServiceCollectorContractLabel(collectorContract)}
+              tone={collectorContractTone}
+              actions={[
+                {
+                  label: 'Refresh contract',
+                  onClick: () => void refreshCollectorContract(),
+                  disabled: collectorContractLoading || !selectedEnvironmentID
+                },
+                { label: 'Contract docs', href: '/docs/aws-service-collector-contract', variant: 'ghost' }
+              ]}
+            >
+              <dl className="idt-domain-route-facts">
+                <div>
+                  <dt>Fields</dt>
+                  <dd>{collectorContract ? formatCountLabel(collectorContract.required_field_count, 'field') : 'Pending'}</dd>
+                </div>
+                <div>
+                  <dt>Fixtures</dt>
+                  <dd>{collectorContract ? formatCountLabel(collectorContract.fixture_case_count, 'fixture') : 'Pending'}</dd>
+                </div>
+                <div>
+                  <dt>Edges</dt>
+                  <dd>{collectorContract ? formatCountLabel(collectorContract.graph_edge_count, 'edge') : 'Pending'}</dd>
+                </div>
+              </dl>
+              <div className="idt-source-diagnostics" aria-label="AWS service collector contract diagnostics">
+                <AWSServiceCollectorContractSummary contract={collectorContract} loading={collectorContractLoading} />
               </div>
             </DomainStatusPanel>
 


### PR DESCRIPTION
## Summary
- Add the reusable AWS service collector contract package with normalized record validation, required fixture states, graph edge mappings, read-only boundaries, and provider tests.
- Expose `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract` with scoped backend, authz, OpenAPI, and web client support.
- Surface collector contract readiness in AWS Control Center and Connect AWS, and update the dependency index so #1475 is completed and #1476 is the ready Wave 1 issue.
- Document required permissions, fixture conventions, graph semantics, and validation steps.

## Validation
- `go test ./...`
- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `npm test -- --run src/productShell.test.tsx`
- `npm run build`
- `git diff --check`

## AI disclosure
No

Closes #1476

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable, versioned AWS service collector contract and a read‑only API to publish it, with client and UI support. Completes #1476 and updates the dependency index so `#1475` and `#1476` are completed and `#1477–#1496` are ready.

- **New Features**
  - Added `internal/providers/awscontract` (`aws-service-collector-contract-v1`) with normalized fields, graph edge semantics, required fixture states, statuses, and helpers.
  - Exposed GET `/v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract` with authz and OpenAPI; optional `connector_id` adds account/region context.
  - Added docs (`docs/aws-service-collector-contract.md`) and linked from `docs/auth/aws-connector.md` and `docs/aws-collector.md`; web client `getAWSProjectCollectorContract`; surfaced contract readiness in AWS Control Center and Connect AWS; tests cover provider, API, OpenAPI, client, and UI.
  - Updated dependency index API and docs to mark `#1475` and `#1476` complete and list `#1477–#1496` as ready.

- **Refactors**
  - Exported `AWSServiceCollector` in `internal/providers/aws` and updated the composite to use it; tests validate against contract fixtures.

<sup>Written for commit c15984a6e9d24804a850d98046c0aa4c79e2b0ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

