### PR TITLE
Fix GitHub Control Center direct dashboard

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1545,7 +1545,7 @@ describe('App', () => {
     render(<App />);
 
     expect(await screen.findByRole('heading', { level: 2, name: heading })).toBeInTheDocument();
-    expect(await screen.findByText(marker)).toBeInTheDocument();
+    expect((await screen.findAllByText(marker)).length).toBeGreaterThan(0);
     expect(screen.queryByText(/Domain-owned entry point is ready/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: /AWS sections/i })).not.toBeInTheDocument();
   });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4887,6 +4887,87 @@ describe('GitHub domain pages (#1382)', () => {
     );
   });
 
+  it('Overview skips dashboard cache warmups after the auth session resets', async () => {
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'getOnboardingState').mockResolvedValue({
+      state: {
+        user_id: 'user-1',
+        org_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: productionProject.project_id,
+        current_step: 'complete',
+        connector_skipped: false,
+        scan_skipped: false,
+        started_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }
+    });
+    const pendingProjects = deferred<{ items: typeof productionProject[] }>();
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockReturnValue(pendingProjects.promise);
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValue({ connection: connectedGitHub });
+    const listRepoScans = vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [succeededRepoScan] });
+    vi.spyOn(api.apiClient, 'listRepoFindings').mockResolvedValue({ items: [], summary: undefined });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getKubernetesProjectConnection').mockResolvedValue({ connection: connectedKubernetes });
+
+    const { ProductOverviewPage, ProductGitHubControlCenterPage, clearProductAuthSessionCacheForTests } = await import('./productShell');
+    const overviewRender = render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductOverviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(1));
+    overviewRender.unmount();
+    clearProductAuthSessionCacheForTests();
+
+    await act(async () => {
+      pendingProjects.resolve({ items: [productionProject] });
+      await pendingProjects.promise;
+      await Promise.resolve();
+    });
+
+    expect(getGitHubConnectorStatus).not.toHaveBeenCalled();
+    expect(listRepoScans).not.toHaveBeenCalled();
+    cleanup();
+    vi.restoreAllMocks();
+
+    const nextSessionStatus = deferred<{ connection: GitHubConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getGitHubConnectorStatus').mockReturnValue(nextSessionStatus.promise);
+    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [] });
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github" element={<ProductGitHubControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    expect(screen.queryByText(/Installation 12345/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading GitHub status/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      nextSessionStatus.resolve({
+        connection: {
+          ...connectedGitHub,
+          installation_id: 67890,
+          selected_repositories: []
+        }
+      });
+    });
+
+    expect(await screen.findByText(/Installation 67890/i)).toBeInTheDocument();
+  });
+
   it('Control Center hides recent scans when no repositories are selected', async () => {
     const unrelatedScan: RepoScanRecord = {
       ...succeededRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4730,6 +4730,64 @@ describe('GitHub domain pages (#1382)', () => {
     await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(2));
   });
 
+  it('Control Center reuses the overview environment cache before loading GitHub status', async () => {
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'getOnboardingState').mockResolvedValue({
+      state: {
+        user_id: 'user-1',
+        org_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: productionProject.project_id,
+        current_step: 'complete',
+        connector_skipped: false,
+        scan_skipped: false,
+        started_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }
+    });
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValue({ connection: connectedGitHub });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getKubernetesProjectConnection').mockResolvedValue({ connection: connectedKubernetes });
+    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [succeededRepoScan] });
+    vi.spyOn(api.apiClient, 'listRepoFindings').mockResolvedValue({ items: [], summary: undefined });
+
+    const { ProductOverviewPage, ProductGitHubControlCenterPage } = await import('./productShell');
+    const overviewRender = render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductOverviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('region', { name: 'Domain posture' });
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(1));
+    overviewRender.unmount();
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github" element={<ProductGitHubControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await waitFor(() =>
+      expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
+        'workspace-a',
+        'production-platform',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(listProjects).toHaveBeenCalledTimes(1);
+  });
+
   it('Control Center hides recent scans when no repositories are selected', async () => {
     const unrelatedScan: RepoScanRecord = {
       ...succeededRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4199,6 +4199,49 @@ describe('GitHub domain pages (#1382)', () => {
     );
   });
 
+  it('Control Center fetches additional scan pages until selected-repository activity is available', async () => {
+    const unrelatedRepoScans: RepoScanRecord[] = Array.from({ length: 3 }).map((_, index) => ({
+      ...succeededRepoScan,
+      id: `repo-scan-control-center-unrelated-${index}`,
+      repository: `team-${index + 1}/unrelated`
+    }));
+    const selectedRepoScan: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-control-center-selected',
+      repository: 'identrail/identrail',
+      started_at: '2026-05-18T10:00:00Z',
+      finished_at: '2026-05-18T10:05:00Z',
+      finding_count: 2,
+      files_scanned: 17
+    };
+
+    let pageCalls = 0;
+    const mocks = await renderGitHubPage('control-center', {
+      listRepoScans: () => {
+        pageCalls += 1;
+        if (pageCalls === 1) {
+          return Promise.resolve({
+            items: unrelatedRepoScans,
+            next_cursor: 'repo-page-2'
+          });
+        }
+        return Promise.resolve({
+          items: [selectedRepoScan]
+        });
+      }
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(2));
+    expect(mocks.listRepoScans).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: 'repo-page-2', limit: 50 }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(screen.getByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    expect(screen.getByText(/identrail\/identrail/i)).toBeInTheDocument();
+  });
+
   it('Control Center prompts to connect when not connected', async () => {
     await renderGitHubPage('control-center', {
       githubConnection: {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4691,6 +4691,45 @@ describe('GitHub domain pages (#1382)', () => {
     });
   });
 
+  it('Control Center keeps cached scans visible while surfacing same-environment refresh failures', async () => {
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValueOnce({ connection: connectedGitHub })
+      .mockResolvedValueOnce({ connection: connectedGitHub });
+    const listRepoScans = vi
+      .spyOn(api.apiClient, 'listRepoScans')
+      .mockResolvedValueOnce({ items: [succeededRepoScan] })
+      .mockRejectedValueOnce(new api.ApiError('rate limited', 429));
+
+    const productShell = await import('./productShell');
+    const renderControlCenter = () =>
+      render(
+        <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github?environment=production-platform']}>
+          <Routes>
+            <Route path="/app/:tenantID/:workspaceID/github" element={<productShell.ProductGitHubControlCenterPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+    const firstRender = renderControlCenter();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(1));
+    firstRender.unmount();
+
+    renderControlCenter();
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    await screen.findByRole('heading', { level: 3, name: /Unable to load GitHub status/i });
+    expect(screen.getByText(/rate limited/i)).toBeInTheDocument();
+    await waitFor(() => expect(getGitHubConnectorStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(2));
+  });
+
   it('Control Center hides recent scans when no repositories are selected', async () => {
     const unrelatedScan: RepoScanRecord = {
       ...succeededRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4191,6 +4191,12 @@ describe('GitHub domain pages (#1382)', () => {
       expect(repos).toBeDefined();
     });
     expect(screen.getByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listRepoScans).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, sort_by: 'started_at', sort_order: 'desc' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('Control Center prompts to connect when not connected', async () => {
@@ -4589,6 +4595,57 @@ describe('GitHub domain pages (#1382)', () => {
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
     await screen.findByRole('heading', { level: 3, name: /Unable to load GitHub status/i });
+    // The error panel is the single source of truth — the page must not
+    // also speculate a "run your first scan" recommendation or claim
+    // "no repository scans yet" off a failed fetch.
+    expect(screen.queryByLabelText('GitHub action recommendation')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: /No repository scans yet/i })).not.toBeInTheDocument();
+  });
+
+  it('Control Center reuses the last loaded dashboard while refreshing the same environment', async () => {
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValueOnce({ connection: connectedGitHub });
+    const listRepoScans = vi
+      .spyOn(api.apiClient, 'listRepoScans')
+      .mockResolvedValueOnce({ items: [succeededRepoScan] });
+
+    const productShell = await import('./productShell');
+    const renderControlCenter = () =>
+      render(
+        <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github?environment=production-platform']}>
+          <Routes>
+            <Route path="/app/:tenantID/:workspaceID/github" element={<productShell.ProductGitHubControlCenterPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+    const firstRender = renderControlCenter();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(1));
+    firstRender.unmount();
+
+    const pendingStatus = deferred<{ connection: GitHubConnectionStatus }>();
+    const pendingScans = deferred<{ items: RepoScanRecord[] }>();
+    getGitHubConnectorStatus.mockReturnValueOnce(pendingStatus.promise);
+    listRepoScans.mockReturnValueOnce(pendingScans.promise);
+
+    renderControlCenter();
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Recent scans' })).toBeInTheDocument();
+    expect(screen.getByText(/Installation 12345/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Loading GitHub status/i)).not.toBeInTheDocument();
+    await waitFor(() => expect(getGitHubConnectorStatus).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      pendingStatus.resolve({ connection: connectedGitHub });
+      pendingScans.resolve({ items: [succeededRepoScan] });
+    });
   });
 
   it('Control Center hides recent scans when no repositories are selected', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4294,7 +4294,7 @@ describe('GitHub domain pages (#1382)', () => {
     // the Sections grid still renders its own "Connect GitHub" navigation
     // card, which is fine.
     expect(document.querySelector('.idt-domain-header-actions')).toBeNull();
-    expect(screen.getByText(/Loading GitHub status/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Loading GitHub status/i)).not.toBeInTheDocument();
 
     // Resolve as disconnected; the page should now show the real disconnected UI.
     resolveStatus?.({
@@ -4730,7 +4730,7 @@ describe('GitHub domain pages (#1382)', () => {
     await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(2));
   });
 
-  it('Control Center reuses the overview environment cache before loading GitHub status', async () => {
+  it('Control Center reuses overview caches without showing a loading status', async () => {
     mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -4753,7 +4753,7 @@ describe('GitHub domain pages (#1382)', () => {
       .mockResolvedValue({ connection: connectedGitHub });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
     vi.spyOn(api.apiClient, 'getKubernetesProjectConnection').mockResolvedValue({ connection: connectedKubernetes });
-    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [succeededRepoScan] });
+    const listRepoScans = vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [succeededRepoScan] });
     vi.spyOn(api.apiClient, 'listRepoFindings').mockResolvedValue({ items: [], summary: undefined });
 
     const { ProductOverviewPage, ProductGitHubControlCenterPage } = await import('./productShell');
@@ -4767,6 +4767,8 @@ describe('GitHub domain pages (#1382)', () => {
 
     await screen.findByRole('region', { name: 'Domain posture' });
     await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getGitHubConnectorStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(2));
     overviewRender.unmount();
 
     render(
@@ -4778,6 +4780,9 @@ describe('GitHub domain pages (#1382)', () => {
     );
 
     await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    expect(screen.getByText(/Installation 12345/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Loading GitHub status/i)).not.toBeInTheDocument();
+    expect(listProjects).toHaveBeenCalledTimes(1);
     await waitFor(() =>
       expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
         'workspace-a',
@@ -4785,7 +4790,6 @@ describe('GitHub domain pages (#1382)', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
-    expect(listProjects).toHaveBeenCalledTimes(1);
   });
 
   it('Control Center hides recent scans when no repositories are selected', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4425,6 +4425,57 @@ describe('GitHub domain pages (#1382)', () => {
     await screen.findByText(/Repository scan queued for identrail\/identrail/i);
   });
 
+  it('Repositories page bypasses in-flight refreshes after queueing a scan', async () => {
+    const initialMocks = await renderGitHubPage('repositories', { scans: [] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await waitFor(() => expect(initialMocks.listRepoScans).toHaveBeenCalledTimes(1));
+    cleanup();
+    vi.restoreAllMocks();
+
+    const pendingRefresh = deferred<{ items: RepoScanRecord[]; next_cursor?: string }>();
+    const queuedAfterMutation: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-after-mutation'
+    };
+    let listCalls = 0;
+    const mocks = await renderGitHubPage('repositories', {
+      listRepoScans: () => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return pendingRefresh.promise;
+        }
+        return Promise.resolve({ items: [queuedAfterMutation] });
+      }
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(1));
+    const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
+    await waitFor(() => expect(queueButton).not.toBeDisabled());
+    fireEvent.click(queueButton);
+
+    await waitFor(() =>
+      expect(mocks.runRepoScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repository: 'identrail/identrail',
+          project_id: 'production-platform',
+          connector_id: 'github-app'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(2));
+    await screen.findByText(/Repository scan queued for identrail\/identrail/i);
+    await screen.findByText(/scan in flight/i);
+
+    await act(async () => {
+      pendingRefresh.resolve({ items: [] });
+    });
+
+    expect(screen.getByLabelText('Selected repositories')).toHaveTextContent('scan in flight');
+  });
+
   it('Repositories page cancels an active scan via the existing API', async () => {
     const mocks = await renderGitHubPage('repositories', { scans: [queuedRepoScan] });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
@@ -4197,6 +4197,50 @@ describe('GitHub domain pages (#1382)', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('Control Center clears cached dashboard data when the auth session resets', async () => {
+    const firstRender = await renderGitHubPage('control-center', { scans: [succeededRepoScan] });
+
+    await screen.findByText(/Installation 12345/i);
+    await waitFor(() => expect(firstRender.listRepoScans).toHaveBeenCalledTimes(1));
+    cleanup();
+    vi.restoreAllMocks();
+
+    const productShell = await import('./productShell');
+    productShell.clearProductAuthSessionCacheForTests();
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    const nextSessionStatus = deferred<{ connection: GitHubConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'getGitHubConnectorStatus').mockReturnValue(nextSessionStatus.promise);
+    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [] });
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github?environment=production-platform']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github" element={<productShell.ProductGitHubControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub' });
+    expect(screen.queryByText(/Installation 12345/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading GitHub status/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      nextSessionStatus.resolve({
+        connection: {
+          ...connectedGitHub,
+          installation_id: 67890,
+          selected_repositories: []
+        }
+      });
+    });
+
+    expect(await screen.findByText(/Installation 67890/i)).toBeInTheDocument();
   });
 
   it('Control Center fetches additional scan pages until selected-repository activity is available', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3063,6 +3063,65 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
   });
 
+  it('retries requested environment verification after transient getProject failures', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const recentProjects = Array.from({ length: 50 }, (_, index) => ({
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: `recent-environment-${index + 1}`,
+      name: `Recent Environment ${index + 1}`,
+      slug: `recent-environment-${index + 1}`,
+      description: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z'
+    }));
+    const olderProduction = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'older-production',
+      name: 'Older Production',
+      slug: 'older-production',
+      description: 'Long-lived production boundary.',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z'
+    };
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: recentProjects });
+    const getProject = vi
+      .spyOn(api.apiClient, 'getProject')
+      .mockRejectedValueOnce(new api.ApiError('temporary outage', 503))
+      .mockResolvedValueOnce({ project: olderProduction });
+
+    const { ProductDomainRoutePage } = await import('./productShell');
+    const renderRepositoriesPage = () =>
+      render(
+        <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/repositories?environment=older-production']}>
+          <Routes>
+            <Route
+              path="/app/:tenantID/:workspaceID/github/repositories"
+              element={<ProductDomainRoutePage domain="github" routeID="repositories" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+    const firstRender = renderRepositoriesPage();
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
+    expect(await screen.findByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
+    await waitFor(() => expect(getProject).toHaveBeenCalledTimes(1));
+    firstRender.unmount();
+
+    renderRepositoriesPage();
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getProject).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.queryByText(/Unable to verify selected environment older-production/i)).not.toBeInTheDocument()
+    );
+  });
+
   it('does not silently switch AWS connect to a fallback environment when getProject check fails transiently', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -4885,6 +4944,74 @@ describe('GitHub domain pages (#1382)', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('Overview warms GitHub caches when backend availability resolves after mount', async () => {
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    let githubBackend: BackendFeatureState = false;
+    vi.doMock('./hooks/useBackendFeatures', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./hooks/useBackendFeatures')>();
+      return {
+        ...actual,
+        useBackendFeatures: () => ({
+          features: {
+            onboardingWizard: undefined,
+            connectors: { github: githubBackend, aws: undefined, kubernetes: true },
+            configReachable: true
+          },
+          loading: false
+        })
+      };
+    });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'getOnboardingState').mockResolvedValue({
+      state: {
+        user_id: 'user-1',
+        org_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: productionProject.project_id,
+        current_step: 'complete',
+        connector_skipped: false,
+        scan_skipped: false,
+        started_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }
+    });
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValue({ connection: connectedGitHub });
+    const listRepoScans = vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [succeededRepoScan] });
+    vi.spyOn(api.apiClient, 'listRepoFindings').mockResolvedValue({ items: [], summary: undefined });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getKubernetesProjectConnection').mockResolvedValue({ connection: connectedKubernetes });
+
+    const { ProductOverviewPage } = await import('./productShell');
+    const renderOverviewRoute = () => (
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductOverviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const overviewRender = render(renderOverviewRoute());
+
+    await screen.findByRole('region', { name: 'Domain posture' });
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(1));
+    expect(getGitHubConnectorStatus).not.toHaveBeenCalled();
+
+    githubBackend = true;
+    overviewRender.rerender(renderOverviewRoute());
+
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
+        'workspace-a',
+        'production-platform',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(listRepoScans).toHaveBeenCalled();
   });
 
   it('Overview skips dashboard cache warmups after the auth session resets', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2459,11 +2459,129 @@ type EnvironmentScopeState = {
   error: string;
 };
 
+type EnvironmentScopeSnapshot = {
+  items: ProjectRecord[];
+  rejectedRequestedID: string;
+  error: string;
+};
+
+const ENVIRONMENT_SCOPE_CACHE_LIMIT = 24;
+const environmentScopeCache = new Map<string, EnvironmentScopeSnapshot>();
+const environmentScopeRequests = new Map<string, Promise<EnvironmentScopeSnapshot>>();
+
+function environmentScopeCacheKey(scope: ProductSession | null, requestedEnvironmentID: string): string {
+  if (!scope) {
+    return '';
+  }
+  return [scope.tenantID, scope.workspaceID, normalizeValue(requestedEnvironmentID)].join('::');
+}
+
+function writeEnvironmentScopeCache(key: string, snapshot: EnvironmentScopeSnapshot) {
+  if (!key) {
+    return;
+  }
+  environmentScopeCache.delete(key);
+  environmentScopeCache.set(key, {
+    items: snapshot.items,
+    rejectedRequestedID: snapshot.rejectedRequestedID,
+    error: snapshot.error
+  });
+  while (environmentScopeCache.size > ENVIRONMENT_SCOPE_CACHE_LIMIT) {
+    const oldestKey = environmentScopeCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    environmentScopeCache.delete(oldestKey);
+  }
+}
+
+function primeEnvironmentScopeCache(scope: ProductSession, projects: ProjectRecord[]) {
+  const key = environmentScopeCacheKey(scope, '');
+  writeEnvironmentScopeCache(key, {
+    items: projects
+      .slice()
+      .sort((left, right) => new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime())
+      .slice(0, ENVIRONMENT_SELECTOR_LIMIT),
+    rejectedRequestedID: '',
+    error: ''
+  });
+}
+
+function loadEnvironmentScopeSnapshot(
+  scope: ProductSession,
+  requestedEnvironmentID: string,
+  auth: RequestAuthContext
+): Promise<EnvironmentScopeSnapshot> {
+  const cacheKey = environmentScopeCacheKey(scope, requestedEnvironmentID);
+  const cached = environmentScopeCache.get(cacheKey);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+  const inFlight = environmentScopeRequests.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = (async () => {
+    const requestedID = normalizeValue(requestedEnvironmentID);
+    const response = await apiClient.listProjects(
+      scope.workspaceID,
+      {
+        limit: ENVIRONMENT_SELECTOR_LIMIT,
+        sort_by: 'updated_at',
+        sort_order: 'desc',
+        include_archived: false
+      },
+      auth
+    );
+    let nextItems = response.items ?? [];
+    let rejectedID = '';
+    let error = '';
+
+    if (requestedID && !nextItems.some((item) => item.project_id === requestedID)) {
+      try {
+        const requestedResponse = await apiClient.getProject(scope.workspaceID, requestedID, auth);
+        if (isProjectArchived(requestedResponse.project)) {
+          rejectedID = requestedID;
+        } else {
+          nextItems = [requestedResponse.project, ...nextItems];
+        }
+      } catch (requestError) {
+        if (isTransientProjectLookupError(requestError)) {
+          const requestedErrorMessage = normalizeValue(formatAPIError(requestError, ''));
+          const fallbackMessage = `Unable to verify selected environment ${requestedID}.`;
+          error = requestedErrorMessage ? `${fallbackMessage} ${requestedErrorMessage}` : fallbackMessage;
+        } else {
+          rejectedID = requestedID;
+        }
+      }
+    }
+
+    return {
+      items: nextItems,
+      rejectedRequestedID: rejectedID,
+      error
+    };
+  })();
+
+  environmentScopeRequests.set(cacheKey, request);
+  return request
+    .then((snapshot) => {
+      writeEnvironmentScopeCache(cacheKey, snapshot);
+      return snapshot;
+    })
+    .finally(() => {
+      environmentScopeRequests.delete(cacheKey);
+    });
+}
+
 function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentID: string): EnvironmentScopeState {
-  const [items, setItems] = useState<ProjectRecord[]>([]);
-  const [loading, setLoading] = useState(Boolean(scope));
-  const [error, setError] = useState('');
-  const [rejectedRequestedID, setRejectedRequestedID] = useState('');
+  const cacheKey = environmentScopeCacheKey(scope, requestedEnvironmentID);
+  const cachedSnapshot = cacheKey ? environmentScopeCache.get(cacheKey) : undefined;
+  const [items, setItems] = useState<ProjectRecord[]>(() => cachedSnapshot?.items ?? []);
+  const [loading, setLoading] = useState(Boolean(scope) && !cachedSnapshot);
+  const [error, setError] = useState(() => cachedSnapshot?.error ?? '');
+  const [rejectedRequestedID, setRejectedRequestedID] = useState(() => cachedSnapshot?.rejectedRequestedID ?? '');
 
   useEffect(() => {
     if (!scope) {
@@ -2475,73 +2593,34 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
     }
 
     let active = true;
-    setLoading(true);
-    setError('');
-    setRejectedRequestedID('');
+    const requestCacheKey = environmentScopeCacheKey(scope, requestedEnvironmentID);
+    const requestSnapshot = requestCacheKey ? environmentScopeCache.get(requestCacheKey) : undefined;
+    setLoading(!requestSnapshot);
+    setError(requestSnapshot?.error ?? '');
+    setRejectedRequestedID(requestSnapshot?.rejectedRequestedID ?? '');
+    setItems(requestSnapshot?.items ?? []);
 
-    const loadEnvironments = async () => {
-      try {
-        const requestedID = normalizeValue(requestedEnvironmentID);
-        const response = await apiClient.listProjects(
-          scope.workspaceID,
-          {
-            limit: ENVIRONMENT_SELECTOR_LIMIT,
-            sort_by: 'updated_at',
-            sort_order: 'desc',
-            include_archived: false
-          },
-          buildProductAuthContext(scope)
-        );
+    loadEnvironmentScopeSnapshot(scope, requestedEnvironmentID, buildProductAuthContext(scope))
+      .then((snapshot) => {
         if (!active) {
           return;
         }
-        let nextItems = response.items ?? [];
-        let rejectedID = '';
-        if (requestedID && !nextItems.some((item) => item.project_id === requestedID)) {
-          try {
-            const requestedResponse = await apiClient.getProject(
-              scope.workspaceID,
-              requestedID,
-              buildProductAuthContext(scope)
-            );
-            if (!active) {
-              return;
-            }
-            if (isProjectArchived(requestedResponse.project)) {
-              rejectedID = requestedID;
-            } else {
-              nextItems = [requestedResponse.project, ...nextItems];
-            }
-          } catch (requestError) {
-            if (!active) {
-              return;
-            }
-            if (isTransientProjectLookupError(requestError)) {
-              const requestedErrorMessage = normalizeValue(formatAPIError(requestError, ''));
-              const fallbackMessage = `Unable to verify selected environment ${requestedID}.`;
-              setError(requestedErrorMessage ? `${fallbackMessage} ${requestedErrorMessage}` : fallbackMessage);
-            } else {
-              rejectedID = requestedID;
-            }
-          }
+        setItems(snapshot.items);
+        setRejectedRequestedID(snapshot.rejectedRequestedID);
+        setError(snapshot.error);
+      })
+      .catch((loadError) => {
+        if (active) {
+          setItems([]);
+          setRejectedRequestedID('');
+          setError(loadError instanceof Error ? loadError.message : 'Unable to load environments.');
         }
-        setRejectedRequestedID(rejectedID);
-        setItems(nextItems);
-      } catch (loadError) {
-        if (!active) {
-          return;
-        }
-        setItems([]);
-        setRejectedRequestedID('');
-        setError(loadError instanceof Error ? loadError.message : 'Unable to load environments.');
-      } finally {
+      })
+      .finally(() => {
         if (active) {
           setLoading(false);
         }
-      }
-    };
-
-    void loadEnvironments();
+      });
 
     return () => {
       active = false;
@@ -11839,6 +11918,7 @@ export function ProductOverviewPage() {
       try {
         const auth = buildProductAuthContext(scope);
         const activeProjectItems = await listOverviewProjects(scope.workspaceID, { include_archived: false }, auth);
+        primeEnvironmentScopeCache(scope, activeProjectItems);
         const [scanResponse, findingResponse, connectionRollups] = await Promise.all([
           apiClient.listRepoScans({ limit: OVERVIEW_SCAN_LIMIT }, auth),
           apiClient.listRepoFindings(

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -515,6 +515,14 @@ function productScopedCacheKey(parts: string[]): string {
   return [String(productAuthSessionVersion), ...parts].join('::');
 }
 
+function currentProductAuthSessionVersion(): number {
+  return productAuthSessionVersion;
+}
+
+function isCurrentProductAuthSessionVersion(version: number): boolean {
+  return version === productAuthSessionVersion;
+}
+
 function isCurrentProductScopedCacheKey(key: string): boolean {
   return key.startsWith(`${productAuthSessionVersion}::`);
 }
@@ -12062,11 +12070,15 @@ export function ProductOverviewPage() {
 
     let mounted = true;
     const loadOverview = async () => {
+      const requestSessionVersion = currentProductAuthSessionVersion();
       setLoading(true);
       setError('');
       try {
         const auth = buildProductAuthContext(scope);
         const activeProjectItems = await listOverviewProjects(scope.workspaceID, { include_archived: false }, auth);
+        if (!mounted || !isCurrentProductAuthSessionVersion(requestSessionVersion)) {
+          return;
+        }
         primeEnvironmentScopeCache(scope, activeProjectItems);
         primeGitHubControlCenterDataCache(scope, activeProjectItems, sourceAvailability.github, auth);
         const [scanResponse, findingResponse, connectionRollups] = await Promise.all([
@@ -12082,7 +12094,7 @@ export function ProductOverviewPage() {
           ),
           loadOverviewConnectionRollups(scope, activeProjectItems, sourceAvailability, auth)
         ]);
-        if (!mounted) {
+        if (!mounted || !isCurrentProductAuthSessionVersion(requestSessionVersion)) {
           return;
         }
         setActiveProjects(
@@ -12098,13 +12110,13 @@ export function ProductOverviewPage() {
         );
         setSourceConnectionRollups(connectionRollups);
       } catch (err) {
-        if (!mounted) {
+        if (!mounted || !isCurrentProductAuthSessionVersion(requestSessionVersion)) {
           return;
         }
         setError(formatAPIError(err, 'Unable to load workspace overview'));
         setSourceConnectionRollups(emptyOverviewConnectionRollups());
       } finally {
-        if (mounted) {
+        if (mounted && isCurrentProductAuthSessionVersion(requestSessionVersion)) {
           setLoading(false);
         }
       }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8558,7 +8558,12 @@ type GitHubDomainDataSnapshot = {
   scans: RepoScanRecord[];
 };
 
+type GitHubDomainDataLoadResult = GitHubDomainDataSnapshot & {
+  error: string;
+};
+
 const gitHubDomainDataCache = new Map<string, GitHubDomainDataSnapshot>();
+const gitHubDomainDataRequests = new Map<string, Promise<GitHubDomainDataLoadResult>>();
 
 function gitHubDomainDataCacheKey(
   scope: ProductSession | null,
@@ -8648,6 +8653,90 @@ async function listRepoScansForSelectedRepositories(
   return matches.slice(0, scanLimit);
 }
 
+function gitHubDomainDataRequestKey(cacheKey: string, scanPageLimit: number, maxScanPages: number): string {
+  return [cacheKey, scanPageLimit, maxScanPages].join('::');
+}
+
+function fetchGitHubDomainDataSnapshot(
+  scope: ProductSession,
+  projectID: string,
+  scanLimit: number,
+  scanPageLimit: number,
+  maxScanPages: number,
+  auth: RequestAuthContext
+): Promise<GitHubDomainDataLoadResult> {
+  const cacheKey = gitHubDomainDataCacheKey(scope, projectID, scanLimit);
+  const requestKey = gitHubDomainDataRequestKey(cacheKey, scanPageLimit, maxScanPages);
+  const inFlight = gitHubDomainDataRequests.get(requestKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = (async () => {
+    const statusResult = await apiClient.getGitHubConnectorStatus(scope.workspaceID, projectID, auth);
+    const connection = statusResult.connection ?? null;
+    let scans: RepoScanRecord[] = [];
+    let error = '';
+
+    try {
+      scans = await listRepoScansForSelectedRepositories(connection?.selected_repositories ?? [], scanLimit, auth, {
+        pageLimit: scanPageLimit,
+        maxPages: maxScanPages
+      });
+    } catch (scanError) {
+      error = formatAPIError(scanError, 'Unable to load recent repository scans.');
+    }
+
+    return { connection, scans, error };
+  })();
+
+  gitHubDomainDataRequests.set(requestKey, request);
+  return request.finally(() => {
+    gitHubDomainDataRequests.delete(requestKey);
+  });
+}
+
+function primeGitHubControlCenterDataCache(
+  scope: ProductSession,
+  projects: ProjectRecord[],
+  availability: SourceAvailability,
+  auth: RequestAuthContext
+) {
+  if (!availability.available) {
+    return;
+  }
+  const defaultProject = projects.find((project) => !isProjectArchived(project));
+  if (!defaultProject) {
+    return;
+  }
+  const cacheKey = gitHubDomainDataCacheKey(
+    scope,
+    defaultProject.project_id,
+    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT
+  );
+  if (!cacheKey || gitHubDomainDataCache.has(cacheKey)) {
+    return;
+  }
+
+  void fetchGitHubDomainDataSnapshot(
+    scope,
+    defaultProject.project_id,
+    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT,
+    GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT,
+    GITHUB_MAX_SCAN_PAGE_FETCHES,
+    auth
+  )
+    .then((snapshot) => {
+      if (!snapshot.error) {
+        writeGitHubDomainDataCache(cacheKey, { connection: snapshot.connection, scans: snapshot.scans });
+      }
+    })
+    .catch(() => {
+      // This is a background warm-up only. The Control Center performs the
+      // authoritative load and surfaces any failure when the user opens it.
+    });
+}
+
 function useGitHubDomainData(
   scope: ProductSession | null,
   projectID: string | undefined,
@@ -8697,55 +8786,35 @@ function useGitHubDomainData(
     const requestSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
     const isSameRequestTarget = activeCacheKeyRef.current === requestCacheKey;
     activeCacheKeyRef.current = requestCacheKey;
-    setLoading(true);
+    setLoading(!requestSnapshot);
     setError('');
     if (!isSameRequestTarget) {
       setConnection(requestSnapshot?.connection ?? null);
       setScans(requestSnapshot?.scans ?? []);
     }
     const auth = buildProductAuthContext(scope);
-    const statusRequest = apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth);
 
-    statusRequest
-      .then((statusResult) => statusResult.connection ?? null)
-      .then(async (connectionResult) => {
+    fetchGitHubDomainDataSnapshot(scope, trimmedProject, scanLimit, scanPageLimit, maxScanPages, auth)
+      .then((snapshot) => {
         if (!active) {
           return;
         }
-        let nextError = '';
-        const nextConnection = connectionResult;
-
-        let nextScans: RepoScanRecord[] = [];
-        try {
-          nextScans = await listRepoScansForSelectedRepositories(
-            nextConnection?.selected_repositories ?? [],
-            scanLimit,
-            auth,
-            { pageLimit: scanPageLimit, maxPages: maxScanPages }
-          );
-        } catch (error) {
-          nextError = formatAPIError(error, 'Unable to load recent repository scans.');
-        }
-
-        if (!active) {
-          return;
-        }
-        if (nextError) {
+        if (snapshot.error) {
           const fallbackSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
           if (fallbackSnapshot) {
-            setConnection(nextConnection);
+            setConnection(snapshot.connection);
             setScans(fallbackSnapshot.scans);
-            writeGitHubDomainDataCache(requestCacheKey, { connection: nextConnection, scans: fallbackSnapshot.scans });
-            setError(nextError);
+            writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: fallbackSnapshot.scans });
+            setError(snapshot.error);
             return;
           }
         }
-        if (!nextError) {
-          writeGitHubDomainDataCache(requestCacheKey, { connection: nextConnection, scans: nextScans });
+        if (!snapshot.error) {
+          writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: snapshot.scans });
         }
-        setConnection(nextConnection);
-        setScans(nextScans);
-        setError(nextError);
+        setConnection(snapshot.connection);
+        setScans(snapshot.scans);
+        setError(snapshot.error);
       })
       .catch((error) => {
         if (!active) {
@@ -9241,7 +9310,7 @@ export function ProductGitHubControlCenterPage() {
       ? { label: 'Repositories', to: repositoriesPath, variant: 'primary' as const }
       : { label: 'Connect GitHub', to: connectPath, variant: 'primary' as const };
   const subtitle = awaitingFirstLoad
-    ? 'Loading GitHub status…'
+    ? undefined
     : gitHubOverviewSubtitle(data.connection, recentScans);
 
   return (
@@ -11919,6 +11988,7 @@ export function ProductOverviewPage() {
         const auth = buildProductAuthContext(scope);
         const activeProjectItems = await listOverviewProjects(scope.workspaceID, { include_archived: false }, auth);
         primeEnvironmentScopeCache(scope, activeProjectItems);
+        primeGitHubControlCenterDataCache(scope, activeProjectItems, sourceAvailability.github, auth);
         const [scanResponse, findingResponse, connectionRollups] = await Promise.all([
           apiClient.listRepoScans({ limit: OVERVIEW_SCAN_LIMIT }, auth),
           apiClient.listRepoFindings(

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8390,6 +8390,7 @@ const GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT = 50;
 const GITHUB_REPOSITORIES_SCANS_LIMIT = 50;
 const GITHUB_REMEDIATION_FINDINGS_LIMIT = 100;
 const GITHUB_MAX_SCAN_PAGE_FETCHES = 50;
+const GITHUB_DOMAIN_DATA_CACHE_LIMIT = 24;
 
 type GitHubAvailability = {
   loading: boolean;
@@ -8496,10 +8497,18 @@ function writeGitHubDomainDataCache(key: string, snapshot: GitHubDomainDataSnaps
   if (!key) {
     return;
   }
+  gitHubDomainDataCache.delete(key);
   gitHubDomainDataCache.set(key, {
     connection: snapshot.connection,
     scans: snapshot.scans
   });
+  while (gitHubDomainDataCache.size > GITHUB_DOMAIN_DATA_CACHE_LIMIT) {
+    const oldestKey = gitHubDomainDataCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    gitHubDomainDataCache.delete(oldestKey);
+  }
 }
 
 async function listRepoScansForSelectedRepositories(
@@ -9063,8 +9072,7 @@ export function ProductGitHubControlCenterPage() {
     selectedEnvironmentID,
     availability.available,
     GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT,
-    GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT,
-    1
+    GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT
   );
 
   if (!scope) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8386,6 +8386,7 @@ export function ProductKubernetesRemediationPage() {
 // =====================================================
 
 const GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT = 5;
+const GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT = 50;
 const GITHUB_REPOSITORIES_SCANS_LIMIT = 50;
 const GITHUB_REMEDIATION_FINDINGS_LIMIT = 100;
 const GITHUB_MAX_SCAN_PAGE_FETCHES = 50;
@@ -8472,15 +8473,47 @@ type GitHubDomainDataState = {
   reload: () => void;
 };
 
+type GitHubDomainDataSnapshot = {
+  connection: GitHubConnectionStatus | null;
+  scans: RepoScanRecord[];
+};
+
+const gitHubDomainDataCache = new Map<string, GitHubDomainDataSnapshot>();
+
+function gitHubDomainDataCacheKey(
+  scope: ProductSession | null,
+  projectID: string | undefined,
+  scanLimit: number
+): string {
+  const trimmedProject = normalizeValue(projectID);
+  if (!scope || !trimmedProject) {
+    return '';
+  }
+  return [scope.tenantID, scope.workspaceID, trimmedProject, scanLimit].join('::');
+}
+
+function writeGitHubDomainDataCache(key: string, snapshot: GitHubDomainDataSnapshot) {
+  if (!key) {
+    return;
+  }
+  gitHubDomainDataCache.set(key, {
+    connection: snapshot.connection,
+    scans: snapshot.scans
+  });
+}
+
 async function listRepoScansForSelectedRepositories(
   selectedRepositories: string[],
   scanLimit: number,
-  auth: RequestAuthContext
+  auth: RequestAuthContext,
+  options: { pageLimit?: number; maxPages?: number } = {}
 ): Promise<RepoScanRecord[]> {
   if (!selectedRepositories.length || scanLimit <= 0) {
     return [];
   }
 
+  const pageLimit = Math.max(scanLimit, options.pageLimit ?? scanLimit);
+  const maxPages = Math.max(1, options.maxPages ?? GITHUB_MAX_SCAN_PAGE_FETCHES);
   const allowed = new Set(selectedRepositories.map((repository) => canonicalGitHubRepositoryDisplay(repository).toLowerCase()));
   const matches: RepoScanRecord[] = [];
   const seenCursors = new Set<string>();
@@ -8488,14 +8521,14 @@ async function listRepoScansForSelectedRepositories(
   let pagesFetched = 0;
 
   do {
-    if (pagesFetched >= GITHUB_MAX_SCAN_PAGE_FETCHES) {
+    if (pagesFetched >= maxPages) {
       break;
     }
     pagesFetched += 1;
 
     const response = (await apiClient.listRepoScans(
       {
-        limit: scanLimit,
+        limit: pageLimit,
         cursor,
         sort_by: 'started_at',
         sort_order: 'desc'
@@ -8531,14 +8564,19 @@ function useGitHubDomainData(
   scope: ProductSession | null,
   projectID: string | undefined,
   available: boolean,
-  scanLimit: number
+  scanLimit: number,
+  scanPageLimit = scanLimit,
+  maxScanPages = GITHUB_MAX_SCAN_PAGE_FETCHES
 ): GitHubDomainDataState {
-  const [connection, setConnection] = useState<GitHubConnectionStatus | null>(null);
-  const [scans, setScans] = useState<RepoScanRecord[]>([]);
+  const cacheKey = gitHubDomainDataCacheKey(scope, projectID, scanLimit);
+  const cachedSnapshot = cacheKey ? gitHubDomainDataCache.get(cacheKey) : undefined;
+  const activeCacheKeyRef = useRef(cacheKey);
+  const [connection, setConnection] = useState<GitHubConnectionStatus | null>(() => cachedSnapshot?.connection ?? null);
+  const [scans, setScans] = useState<RepoScanRecord[]>(() => cachedSnapshot?.scans ?? []);
   // Start in the loading state when a fetch is going to happen so the very
   // first render does not falsely advertise the user as disconnected before
   // the API has even been called.
-  const [loading, setLoading] = useState<boolean>(Boolean(scope) && available);
+  const [loading, setLoading] = useState<boolean>(Boolean(scope) && available && !cachedSnapshot);
   const [error, setError] = useState('');
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -8546,6 +8584,7 @@ function useGitHubDomainData(
 
   useEffect(() => {
     if (!scope || !available) {
+      activeCacheKeyRef.current = '';
       setConnection(null);
       setScans([]);
       setError('');
@@ -8558,6 +8597,7 @@ function useGitHubDomainData(
       // loading state so the caller does not interpret connection=null as
       // "confirmed disconnected" while we are still waiting for the
       // project ID to settle.
+      activeCacheKeyRef.current = '';
       setLoading(true);
       setConnection(null);
       setScans([]);
@@ -8565,10 +8605,16 @@ function useGitHubDomainData(
       return undefined;
     }
     let active = true;
+    const requestCacheKey = gitHubDomainDataCacheKey(scope, trimmedProject, scanLimit);
+    const requestSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
+    const isSameRequestTarget = activeCacheKeyRef.current === requestCacheKey;
+    activeCacheKeyRef.current = requestCacheKey;
     setLoading(true);
     setError('');
-    setConnection(null);
-    setScans([]);
+    if (!isSameRequestTarget) {
+      setConnection(requestSnapshot?.connection ?? null);
+      setScans(requestSnapshot?.scans ?? []);
+    }
     const auth = buildProductAuthContext(scope);
     const statusRequest = apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth);
 
@@ -8586,7 +8632,8 @@ function useGitHubDomainData(
           nextScans = await listRepoScansForSelectedRepositories(
             nextConnection?.selected_repositories ?? [],
             scanLimit,
-            auth
+            auth,
+            { pageLimit: scanPageLimit, maxPages: maxScanPages }
           );
         } catch (error) {
           nextError = formatAPIError(error, 'Unable to load recent repository scans.');
@@ -8595,12 +8642,32 @@ function useGitHubDomainData(
         if (!active) {
           return;
         }
+        if (nextError) {
+          const fallbackSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
+          if (fallbackSnapshot) {
+            setConnection(nextConnection);
+            setScans(fallbackSnapshot.scans);
+            writeGitHubDomainDataCache(requestCacheKey, { connection: nextConnection, scans: fallbackSnapshot.scans });
+            setError('');
+            return;
+          }
+        }
+        if (!nextError) {
+          writeGitHubDomainDataCache(requestCacheKey, { connection: nextConnection, scans: nextScans });
+        }
         setConnection(nextConnection);
         setScans(nextScans);
         setError(nextError);
       })
       .catch((error) => {
         if (!active) {
+          return;
+        }
+        const fallbackSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
+        if (fallbackSnapshot) {
+          setConnection(fallbackSnapshot.connection);
+          setScans(fallbackSnapshot.scans);
+          setError('');
           return;
         }
         setError(formatAPIError(error, 'Unable to load GitHub connection status.'));
@@ -8614,7 +8681,7 @@ function useGitHubDomainData(
     return () => {
       active = false;
     };
-  }, [available, projectID, reloadToken, scanLimit, scope?.tenantID, scope?.workspaceID]);
+  }, [available, maxScanPages, projectID, reloadToken, scanLimit, scanPageLimit, scope?.tenantID, scope?.workspaceID]);
 
   return { loading, error, connection, scans, reload };
 }
@@ -8995,7 +9062,9 @@ export function ProductGitHubControlCenterPage() {
     scope,
     selectedEnvironmentID,
     availability.available,
-    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT
+    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT,
+    GITHUB_CONTROL_CENTER_SCAN_FETCH_LIMIT,
+    1
   );
 
   if (!scope) {
@@ -9061,7 +9130,15 @@ export function ProductGitHubControlCenterPage() {
   // then flips to the connected state once the response lands — a
   // misleading flash that, on slower networks, can last several seconds.
   const awaitingFirstLoad = data.loading && data.connection === null && !data.error;
-  const banner = awaitingFirstLoad
+  const hasError = Boolean(data.error);
+  // When the scan list errors out, we cannot truthfully recommend a next
+  // action or claim "no repository scans yet" — the fetch failed, the
+  // page does not know whether scans exist. The error panel becomes the
+  // single source of truth and the speculative banner / empty state are
+  // suppressed. The header subtitle and primary CTA can still reflect
+  // the connection result because that fetch did succeed.
+  const suppressDerivedSurfaces = awaitingFirstLoad || hasError;
+  const banner = suppressDerivedSurfaces
     ? null
     : selectGitHubControlCenterBanner({
         connected,
@@ -9103,7 +9180,7 @@ export function ProductGitHubControlCenterPage() {
           </header>
           <DomainTimeline label="Recent repository scans" entries={gitHubRecentScansTimeline(recentScans)} />
         </section>
-      ) : !awaitingFirstLoad && connected ? (
+      ) : !suppressDerivedSurfaces && connected ? (
         <DomainEmptyState
           title="No repository scans yet"
           body="Queue a scan to populate the activity timeline."
@@ -9118,7 +9195,7 @@ export function ProductGitHubControlCenterPage() {
 export function ProductGitHubConnectPage() {
   const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
   const availability = useGitHubAvailability();
-  const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
+  const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, 0);
   const [installError, setInstallError] = useState('');
   const [installing, setInstalling] = useState(false);
   const [pendingInstallURL, setPendingInstallURL] = useState('');
@@ -9792,7 +9869,7 @@ export function ProductGitHubRemediationPage() {
     scope,
     selectedEnvironmentID,
     availability.available,
-    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT
+    0
   );
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8657,7 +8657,7 @@ function useGitHubDomainData(
             setConnection(nextConnection);
             setScans(fallbackSnapshot.scans);
             writeGitHubDomainDataCache(requestCacheKey, { connection: nextConnection, scans: fallbackSnapshot.scans });
-            setError('');
+            setError(nextError);
             return;
           }
         }
@@ -8676,7 +8676,7 @@ function useGitHubDomainData(
         if (fallbackSnapshot) {
           setConnection(fallbackSnapshot.connection);
           setScans(fallbackSnapshot.scans);
-          setError('');
+          setError(formatAPIError(error, 'Unable to load GitHub connection status.'));
           return;
         }
         setError(formatAPIError(error, 'Unable to load GitHub connection status.'));

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2593,7 +2593,9 @@ function loadEnvironmentScopeSnapshot(
   environmentScopeRequests.set(cacheKey, request);
   return request
     .then((snapshot) => {
-      writeEnvironmentScopeCache(cacheKey, snapshot);
+      if (!snapshot.error) {
+        writeEnvironmentScopeCache(cacheKey, snapshot);
+      }
       return snapshot;
     })
     .finally(() => {
@@ -12132,6 +12134,7 @@ export function ProductOverviewPage() {
     scope?.workspaceID,
     scope?.projectID,
     sourceAvailability.aws.available,
+    sourceAvailability.github.available,
     sourceAvailability.kubernetes.available
   ]);
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -498,6 +498,7 @@ function setValidatedProductAuthScope(routeScopeKey: string) {
 
 function resetProductAuthSessionCache(options: { unauthenticated?: boolean } = {}) {
   productAuthSessionVersion += 1;
+  clearProductScopedDataCaches();
   validatedProductAuthSession = false;
   validatedProductAuthScopeKey = '';
   clearMeCache(options);
@@ -505,8 +506,24 @@ function resetProductAuthSessionCache(options: { unauthenticated?: boolean } = {
 
 export function clearProductAuthSessionCacheForTests() {
   productAuthSessionVersion += 1;
+  clearProductScopedDataCaches();
   validatedProductAuthSession = false;
   validatedProductAuthScopeKey = '';
+}
+
+function productScopedCacheKey(parts: string[]): string {
+  return [String(productAuthSessionVersion), ...parts].join('::');
+}
+
+function isCurrentProductScopedCacheKey(key: string): boolean {
+  return key.startsWith(`${productAuthSessionVersion}::`);
+}
+
+function clearProductScopedDataCaches() {
+  environmentScopeCache.clear();
+  environmentScopeRequests.clear();
+  gitHubDomainDataCache.clear();
+  gitHubDomainDataRequests.clear();
 }
 
 function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider | null {
@@ -2473,11 +2490,11 @@ function environmentScopeCacheKey(scope: ProductSession | null, requestedEnviron
   if (!scope) {
     return '';
   }
-  return [scope.tenantID, scope.workspaceID, normalizeValue(requestedEnvironmentID)].join('::');
+  return productScopedCacheKey([scope.tenantID, scope.workspaceID, normalizeValue(requestedEnvironmentID)]);
 }
 
 function writeEnvironmentScopeCache(key: string, snapshot: EnvironmentScopeSnapshot) {
-  if (!key) {
+  if (!key || !isCurrentProductScopedCacheKey(key)) {
     return;
   }
   environmentScopeCache.delete(key);
@@ -2602,7 +2619,7 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
 
     loadEnvironmentScopeSnapshot(scope, requestedEnvironmentID, buildProductAuthContext(scope))
       .then((snapshot) => {
-        if (!active) {
+        if (!active || !isCurrentProductScopedCacheKey(requestCacheKey)) {
           return;
         }
         setItems(snapshot.items);
@@ -2610,14 +2627,14 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
         setError(snapshot.error);
       })
       .catch((loadError) => {
-        if (active) {
+        if (active && isCurrentProductScopedCacheKey(requestCacheKey)) {
           setItems([]);
           setRejectedRequestedID('');
           setError(loadError instanceof Error ? loadError.message : 'Unable to load environments.');
         }
       })
       .finally(() => {
-        if (active) {
+        if (active && isCurrentProductScopedCacheKey(requestCacheKey)) {
           setLoading(false);
         }
       });
@@ -8574,11 +8591,11 @@ function gitHubDomainDataCacheKey(
   if (!scope || !trimmedProject) {
     return '';
   }
-  return [scope.tenantID, scope.workspaceID, trimmedProject, scanLimit].join('::');
+  return productScopedCacheKey([scope.tenantID, scope.workspaceID, trimmedProject, String(scanLimit)]);
 }
 
 function writeGitHubDomainDataCache(key: string, snapshot: GitHubDomainDataSnapshot) {
-  if (!key) {
+  if (!key || !isCurrentProductScopedCacheKey(key)) {
     return;
   }
   gitHubDomainDataCache.delete(key);
@@ -8796,7 +8813,7 @@ function useGitHubDomainData(
 
     fetchGitHubDomainDataSnapshot(scope, trimmedProject, scanLimit, scanPageLimit, maxScanPages, auth)
       .then((snapshot) => {
-        if (!active) {
+        if (!active || !isCurrentProductScopedCacheKey(requestCacheKey)) {
           return;
         }
         if (snapshot.error) {
@@ -8817,7 +8834,7 @@ function useGitHubDomainData(
         setError(snapshot.error);
       })
       .catch((error) => {
-        if (!active) {
+        if (!active || !isCurrentProductScopedCacheKey(requestCacheKey)) {
           return;
         }
         const fallbackSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
@@ -8830,7 +8847,7 @@ function useGitHubDomainData(
         setError(formatAPIError(error, 'Unable to load GitHub connection status.'));
       })
       .finally(() => {
-        if (active) {
+        if (active && isCurrentProductScopedCacheKey(requestCacheKey)) {
           setLoading(false);
         }
       });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -524,6 +524,7 @@ function clearProductScopedDataCaches() {
   environmentScopeRequests.clear();
   gitHubDomainDataCache.clear();
   gitHubDomainDataRequests.clear();
+  gitHubDomainDataCacheEpochs.clear();
 }
 
 function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider | null {
@@ -8579,8 +8580,17 @@ type GitHubDomainDataLoadResult = GitHubDomainDataSnapshot & {
   error: string;
 };
 
+type GitHubDomainDataCacheWriteOptions = {
+  expectedEpoch?: number;
+};
+
+type GitHubDomainDataFetchOptions = {
+  bypassInFlight?: boolean;
+};
+
 const gitHubDomainDataCache = new Map<string, GitHubDomainDataSnapshot>();
 const gitHubDomainDataRequests = new Map<string, Promise<GitHubDomainDataLoadResult>>();
+const gitHubDomainDataCacheEpochs = new Map<string, number>();
 
 function gitHubDomainDataCacheKey(
   scope: ProductSession | null,
@@ -8594,8 +8604,42 @@ function gitHubDomainDataCacheKey(
   return productScopedCacheKey([scope.tenantID, scope.workspaceID, trimmedProject, String(scanLimit)]);
 }
 
-function writeGitHubDomainDataCache(key: string, snapshot: GitHubDomainDataSnapshot) {
+function rememberGitHubDomainDataCacheEpoch(key: string, epoch: number) {
+  if (!key) {
+    return;
+  }
+  gitHubDomainDataCacheEpochs.delete(key);
+  gitHubDomainDataCacheEpochs.set(key, epoch);
+  while (gitHubDomainDataCacheEpochs.size > GITHUB_DOMAIN_DATA_CACHE_LIMIT * 2) {
+    const oldestKey = gitHubDomainDataCacheEpochs.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    gitHubDomainDataCacheEpochs.delete(oldestKey);
+  }
+}
+
+function gitHubDomainDataCacheEpoch(key: string): number {
+  const epoch = key ? (gitHubDomainDataCacheEpochs.get(key) ?? 0) : 0;
+  rememberGitHubDomainDataCacheEpoch(key, epoch);
+  return epoch;
+}
+
+function bumpGitHubDomainDataCacheEpoch(key: string): number {
+  const epoch = key ? (gitHubDomainDataCacheEpochs.get(key) ?? 0) + 1 : 0;
+  rememberGitHubDomainDataCacheEpoch(key, epoch);
+  return epoch;
+}
+
+function writeGitHubDomainDataCache(
+  key: string,
+  snapshot: GitHubDomainDataSnapshot,
+  options: GitHubDomainDataCacheWriteOptions = {}
+) {
   if (!key || !isCurrentProductScopedCacheKey(key)) {
+    return;
+  }
+  if (options.expectedEpoch !== undefined && gitHubDomainDataCacheEpochs.get(key) !== options.expectedEpoch) {
     return;
   }
   gitHubDomainDataCache.delete(key);
@@ -8609,6 +8653,7 @@ function writeGitHubDomainDataCache(key: string, snapshot: GitHubDomainDataSnaps
       break;
     }
     gitHubDomainDataCache.delete(oldestKey);
+    gitHubDomainDataCacheEpochs.delete(oldestKey);
   }
 }
 
@@ -8680,13 +8725,16 @@ function fetchGitHubDomainDataSnapshot(
   scanLimit: number,
   scanPageLimit: number,
   maxScanPages: number,
-  auth: RequestAuthContext
+  auth: RequestAuthContext,
+  options: GitHubDomainDataFetchOptions = {}
 ): Promise<GitHubDomainDataLoadResult> {
   const cacheKey = gitHubDomainDataCacheKey(scope, projectID, scanLimit);
   const requestKey = gitHubDomainDataRequestKey(cacheKey, scanPageLimit, maxScanPages);
-  const inFlight = gitHubDomainDataRequests.get(requestKey);
-  if (inFlight) {
-    return inFlight;
+  if (!options.bypassInFlight) {
+    const inFlight = gitHubDomainDataRequests.get(requestKey);
+    if (inFlight) {
+      return inFlight;
+    }
   }
 
   const request = (async () => {
@@ -8709,7 +8757,9 @@ function fetchGitHubDomainDataSnapshot(
 
   gitHubDomainDataRequests.set(requestKey, request);
   return request.finally(() => {
-    gitHubDomainDataRequests.delete(requestKey);
+    if (gitHubDomainDataRequests.get(requestKey) === request) {
+      gitHubDomainDataRequests.delete(requestKey);
+    }
   });
 }
 
@@ -8734,6 +8784,7 @@ function primeGitHubControlCenterDataCache(
   if (!cacheKey || gitHubDomainDataCache.has(cacheKey)) {
     return;
   }
+  const cacheEpoch = gitHubDomainDataCacheEpoch(cacheKey);
 
   void fetchGitHubDomainDataSnapshot(
     scope,
@@ -8745,7 +8796,9 @@ function primeGitHubControlCenterDataCache(
   )
     .then((snapshot) => {
       if (!snapshot.error) {
-        writeGitHubDomainDataCache(cacheKey, { connection: snapshot.connection, scans: snapshot.scans });
+        writeGitHubDomainDataCache(cacheKey, { connection: snapshot.connection, scans: snapshot.scans }, {
+          expectedEpoch: cacheEpoch
+        });
       }
     })
     .catch(() => {
@@ -8803,6 +8856,10 @@ function useGitHubDomainData(
     const requestSnapshot = requestCacheKey ? gitHubDomainDataCache.get(requestCacheKey) : undefined;
     const isSameRequestTarget = activeCacheKeyRef.current === requestCacheKey;
     activeCacheKeyRef.current = requestCacheKey;
+    const bypassInFlight = reloadToken > 0 && isSameRequestTarget;
+    const requestCacheEpoch = bypassInFlight
+      ? bumpGitHubDomainDataCacheEpoch(requestCacheKey)
+      : gitHubDomainDataCacheEpoch(requestCacheKey);
     setLoading(!requestSnapshot);
     setError('');
     if (!isSameRequestTarget) {
@@ -8811,7 +8868,9 @@ function useGitHubDomainData(
     }
     const auth = buildProductAuthContext(scope);
 
-    fetchGitHubDomainDataSnapshot(scope, trimmedProject, scanLimit, scanPageLimit, maxScanPages, auth)
+    fetchGitHubDomainDataSnapshot(scope, trimmedProject, scanLimit, scanPageLimit, maxScanPages, auth, {
+      bypassInFlight
+    })
       .then((snapshot) => {
         if (!active || !isCurrentProductScopedCacheKey(requestCacheKey)) {
           return;
@@ -8821,13 +8880,17 @@ function useGitHubDomainData(
           if (fallbackSnapshot) {
             setConnection(snapshot.connection);
             setScans(fallbackSnapshot.scans);
-            writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: fallbackSnapshot.scans });
+            writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: fallbackSnapshot.scans }, {
+              expectedEpoch: requestCacheEpoch
+            });
             setError(snapshot.error);
             return;
           }
         }
         if (!snapshot.error) {
-          writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: snapshot.scans });
+          writeGitHubDomainDataCache(requestCacheKey, { connection: snapshot.connection, scans: snapshot.scans }, {
+            expectedEpoch: requestCacheEpoch
+          });
         }
         setConnection(snapshot.connection);
         setScans(snapshot.scans);


### PR DESCRIPTION
No issue: Direct user-reported GitHub Control Center navigation regression, no tracker issue exists.

## What
- Keep the GitHub Control Center dashboard visible while the same environment refreshes instead of dropping back through transient loading, disconnected, or empty states.
- Reduce Control Center scan-history churn by fetching one broader dashboard page instead of repeatedly paging through small result windows.
- Avoid scan-history fetches on GitHub Connect and Remediation status calls when those pages only need connector status.
- Add regression coverage for the immediate dashboard reuse path and the broader Control Center scan fetch.

## Why
Clicking GitHub Control Center could force users through several intermediate phases before reaching the actual dashboard. The route cleared connection and scan state before every refresh, and small scan-history pages made the dashboard more likely to trip the app rate limiter before showing the intended recent-scan view.

## Impact and risk
Users should land on the populated GitHub dashboard directly when cached data is available, while background refresh still updates the connection and scan data. Risk is limited to the GitHub domain data hook and related GitHub pages; the change preserves existing API contracts.

## Validation
- `npm test -- productShell.test.tsx App.test.tsx --run` — 209 tests passed.
- `npm run build` — passed, including prerendering 39 routes.
- Push hooks passed: merge-conflict check, YAML check, end-of-file check, trailing whitespace, gofmt, go vet, local token hygiene, and Vercel artifact hygiene.

## AI Assistance Disclosure
- AI-assisted: No