### PR TITLE
Add AWS epic PR guard

### DIFF
--- a/.github/branch-protection/dev.json
+++ b/.github/branch-protection/dev.json
@@ -8,6 +8,7 @@
       "CLI Smoke",
       "Web Build",
       "Infra Validate",
+      "aws-epic-pr-guard",
       "Deploy Portability",
       "Analyze (go)",
       "Analyze (javascript-typescript)"
@@ -27,4 +28,3 @@
   "required_linear_history": true,
   "block_creations": false
 }
-

--- a/.github/workflows/aws-epic-pr-guard.yml
+++ b/.github/workflows/aws-epic-pr-guard.yml
@@ -1,0 +1,43 @@
+name: AWS Epic PR Guard
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  aws-epic-pr-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          path: base
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Collect changed files
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "${RUNNER_TEMP}/aws-epic-pr-files.txt"
+          cat "${RUNNER_TEMP}/aws-epic-pr-files.txt"
+
+      - name: Collect commit messages
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[].commit.message' > "${RUNNER_TEMP}/aws-epic-pr-commits.txt"
+
+      - name: Validate AWS epic PR discipline
+        run: node base/scripts/validate_aws_epic_pr.mjs "$GITHUB_EVENT_PATH" "${RUNNER_TEMP}/aws-epic-pr-files.txt" "${RUNNER_TEMP}/aws-epic-pr-commits.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+- Added an AWS epic PR guard for #1472. Pull requests that reference the AWS
+  Machine Identity Platform parent issue or child issues #1473 through #1557 now
+  get a dedicated workflow check that requires the PR to target `dev`, prevents
+  direct closure of the parent epic, and requires child implementation PRs to
+  close exactly one focused child issue in the PR body. Qualified issue
+  references only activate the guard for `identrail/identrail`, and bare same-repo
+  AWS issue mentions activate it as non-closing references. The guard also scans
+  PR commit messages so commit-level closing keywords cannot prematurely close
+  the parent epic. The workflow runs from trusted base-branch code, reads PR
+  metadata through the GitHub API instead of checking out PR code, and adds the
+  `aws-epic-pr-guard` status to the dev branch-protection policy. Parent-only
+  PRs are rejected unless the diff is limited to the guard workflow, dev
+  branch-protection config, validator, validator tests, dependency-index docs,
+  and changelog files. The guard is backed by a local Node validator with
+  regression tests and documented in the AWS dependency index handoff guide.
 - Added the AWS service collector contract for #1476. The API now exposes
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract`
   as a read-only, project-scoped contract for normalized AWS collector records,

--- a/docs/aws-platform-dependency-index.md
+++ b/docs/aws-platform-dependency-index.md
@@ -72,6 +72,38 @@ Each `issues[]` item includes `blocker_refs`, `downstream_refs`,
 This rule is intentionally mechanical: blocked AWS child issues must not receive
 PRs until every blocker listed in the index is closed.
 
+## PR Discipline
+
+The AWS platform parent epic (#1472) remains open while the 85 child issues move
+through the program. The `AWS Epic PR Guard` workflow enforces the parent epic's
+PR discipline on every pull request that references #1472 or one of the AWS
+child issues from #1473 through #1557:
+
+- The guard runs as the required `aws-epic-pr-guard` status check for PRs into
+  `dev`.
+- The workflow runs from trusted base-branch code and validates PR-head metadata
+  through the GitHub API without checking out or executing the PR's copy of the
+  validator.
+- AWS platform PRs must target `dev`, matching the `origin/dev` base expected by
+  the epic.
+- AWS child implementation PRs must reference exactly one child issue.
+- Bare same-repo AWS issue mentions such as `Related: #1477` activate the guard
+  as non-closing references.
+- The focused child issue must use a closing keyword in the PR body, such as
+  `Closes #1477` or `Closes: #1477`, while the parent epic may only be referenced
+  with `Refs #1472`. Commit-message closing keywords do not satisfy the
+  child-closure rule.
+- Parent-only AWS epic PRs fail unless they are limited to the guard workflow,
+  dev branch-protection config, validator, validator tests, dependency-index
+  docs, and changelog files. This narrow path exists only so the guardrail can be
+  introduced and maintained without pretending to close one of the 85
+  implementation issues.
+- Qualified issue references only count for `identrail/identrail`; references to
+  other repositories do not activate AWS epic policy.
+- PRs that try to close #1472 directly fail the guard because the parent epic is
+  only complete after the full issue program is complete. The guard checks PR
+  title, PR body, and PR commit messages for parent-closing keywords.
+
 ## Scriptable Handoff
 
 The response is sorted by issue number and stable enough for automation. A

--- a/scripts/validate_aws_epic_pr.mjs
+++ b/scripts/validate_aws_epic_pr.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const AWS_EPIC_PARENT_ISSUE = 1472;
+export const AWS_EPIC_FIRST_CHILD_ISSUE = 1473;
+export const AWS_EPIC_LAST_CHILD_ISSUE = 1557;
+export const AWS_EPIC_REPOSITORY = 'identrail/identrail';
+export const AWS_EPIC_GUARDRAIL_MAINTENANCE_FILES = new Set([
+  '.github/branch-protection/dev.json',
+  '.github/workflows/aws-epic-pr-guard.yml',
+  'CHANGELOG.md',
+  'docs/aws-platform-dependency-index.md',
+  'scripts/validate_aws_epic_pr.mjs',
+  'scripts/validate_aws_epic_pr.test.mjs',
+]);
+
+const AWS_EPIC_GUARDRAIL_CORE_FILES = new Set([
+  '.github/workflows/aws-epic-pr-guard.yml',
+  'scripts/validate_aws_epic_pr.mjs',
+  'scripts/validate_aws_epic_pr.test.mjs',
+]);
+
+const closingKeywords = new Set([
+  'close',
+  'closed',
+  'closes',
+  'fix',
+  'fixed',
+  'fixes',
+  'resolve',
+  'resolved',
+  'resolves',
+]);
+
+const issueRefPattern =
+  /(?:#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/gi;
+const issueReferenceGroupPattern =
+  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\s*:?\s+((?:(?:#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)(?:\s*(?:,|and|&)\s*)?)+)/gi;
+
+export function sanitizeMarkdown(text = '') {
+  return text
+    .replace(
+      /<!--\s*This is an auto-generated description by cubic\.\s*-->[\s\S]*?(?:<!--\s*End of auto-generated description by cubic\.\s*-->|$)/gi,
+      ' '
+    )
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ');
+}
+
+export function issueNumberFromReference(reference, repository = AWS_EPIC_REPOSITORY) {
+  const normalizedRepository = repository.toLowerCase();
+  const value = String(reference);
+  const unqualifiedMatch = value.match(/^#(\d+)$/);
+  if (unqualifiedMatch) {
+    return Number.parseInt(unqualifiedMatch[1], 10);
+  }
+
+  const qualifiedMatch = value.match(/^([\w.-]+\/[\w.-]+)#(\d+)$/i);
+  if (qualifiedMatch) {
+    return qualifiedMatch[1].toLowerCase() === normalizedRepository
+      ? Number.parseInt(qualifiedMatch[2], 10)
+      : null;
+  }
+
+  const urlMatch = value.match(/^https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)$/i);
+  if (urlMatch) {
+    return urlMatch[1].toLowerCase() === normalizedRepository
+      ? Number.parseInt(urlMatch[2], 10)
+      : null;
+  }
+
+  return null;
+}
+
+export function extractIssueReferences(text = '') {
+  const sanitized = sanitizeMarkdown(text);
+  const references = [];
+  const keywordReferenceRanges = new Set();
+
+  for (const match of sanitized.matchAll(issueReferenceGroupPattern)) {
+    const keyword = match[1].toLowerCase();
+    const issueRefsText = match[2];
+    const issueRefsOffset = match.index + match[0].indexOf(issueRefsText);
+
+    for (const issueRefMatch of issueRefsText.matchAll(issueRefPattern)) {
+      const issueRef = issueRefMatch[0];
+      const issueNumber = issueNumberFromReference(issueRef);
+      if (!Number.isInteger(issueNumber)) {
+        continue;
+      }
+      const start = issueRefsOffset + issueRefMatch.index;
+      keywordReferenceRanges.add(`${start}:${start + issueRef.length}`);
+      references.push({
+        keyword,
+        issueNumber,
+        closing: closingKeywords.has(keyword),
+      });
+    }
+  }
+
+  for (const match of sanitized.matchAll(issueRefPattern)) {
+    const issueRef = match[0];
+    const issueNumber = issueNumberFromReference(issueRef);
+    if (!Number.isInteger(issueNumber)) {
+      continue;
+    }
+
+    const rangeKey = `${match.index}:${match.index + issueRef.length}`;
+    if (keywordReferenceRanges.has(rangeKey)) {
+      continue;
+    }
+
+    references.push({
+      keyword: 'mention',
+      issueNumber,
+      closing: false,
+    });
+  }
+
+  return references;
+}
+
+function uniqueNumbers(references) {
+  return [...new Set(references.map((reference) => reference.issueNumber))].sort((a, b) => a - b);
+}
+
+function formatIssueList(issueNumbers) {
+  return issueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ');
+}
+
+function normalizeChangedFiles(changedFiles = []) {
+  if (!Array.isArray(changedFiles)) {
+    return [];
+  }
+
+  return changedFiles.map((changedFile) => String(changedFile).trim()).filter(Boolean);
+}
+
+function normalizeText(value = '') {
+  if (Array.isArray(value)) {
+    return value.join('\n');
+  }
+
+  return String(value || '');
+}
+
+export function isGuardrailMaintenanceChange(changedFiles = []) {
+  const normalizedFiles = normalizeChangedFiles(changedFiles);
+  return (
+    normalizedFiles.length > 0 &&
+    normalizedFiles.every((changedFile) => AWS_EPIC_GUARDRAIL_MAINTENANCE_FILES.has(changedFile)) &&
+    normalizedFiles.some((changedFile) => AWS_EPIC_GUARDRAIL_CORE_FILES.has(changedFile))
+  );
+}
+
+export function validateAWSEpicPullRequest(event, options = {}) {
+  const pullRequest = event?.pull_request ?? event?.pullRequest ?? {};
+  const title = pullRequest.title || '';
+  const body = pullRequest.body || '';
+  const baseRef = pullRequest.base?.ref || pullRequest.baseRefName || event?.base_ref || '';
+  const changedFiles = normalizeChangedFiles(options.changedFiles);
+  const commitMessages = normalizeText(options.commitMessages);
+  const bodyReferences = extractIssueReferences(body);
+  const titleReferences = extractIssueReferences(title);
+  const commitReferences = extractIssueReferences(commitMessages);
+  const allReferences = [...bodyReferences, ...titleReferences, ...commitReferences];
+  const parentReferences = allReferences.filter(
+    (reference) => reference.issueNumber === AWS_EPIC_PARENT_ISSUE
+  );
+  const childReferences = allReferences.filter(
+    (reference) =>
+      reference.issueNumber >= AWS_EPIC_FIRST_CHILD_ISSUE &&
+      reference.issueNumber <= AWS_EPIC_LAST_CHILD_ISSUE
+  );
+  const bodyChildReferences = bodyReferences.filter(
+    (reference) =>
+      reference.issueNumber >= AWS_EPIC_FIRST_CHILD_ISSUE &&
+      reference.issueNumber <= AWS_EPIC_LAST_CHILD_ISSUE
+  );
+  const uniqueChildIssues = uniqueNumbers(childReferences);
+  const closingChildIssues = uniqueNumbers(bodyChildReferences.filter((reference) => reference.closing));
+  const parentOnlyGuardrailMaintenance =
+    parentReferences.length > 0 &&
+    uniqueChildIssues.length === 0 &&
+    isGuardrailMaintenanceChange(changedFiles);
+
+  const failures = [];
+  const awsEpicReferenced = parentReferences.length > 0 || childReferences.length > 0;
+  if (!awsEpicReferenced) {
+    return {
+      valid: true,
+      applicable: false,
+      failures,
+      summary: 'No AWS platform parent or child issue references were found.',
+    };
+  }
+
+  if (baseRef !== 'dev') {
+    failures.push(
+      `AWS platform PRs must target dev because #1472 requires future PRs to start from origin/dev; found base ${baseRef || '<unknown>'}.`
+    );
+  }
+
+  if (parentReferences.some((reference) => reference.closing)) {
+    failures.push(
+      'Do not close #1472 from a child or guardrail PR. The AWS platform parent epic should be referenced with "Refs #1472" until the full program is complete.'
+    );
+  }
+
+  if (!parentOnlyGuardrailMaintenance) {
+    if (uniqueChildIssues.length !== 1) {
+      failures.push(
+        `AWS platform PRs must reference exactly one focused child issue; found ${formatIssueList(uniqueChildIssues) || 'none'}. Parent-only PRs are allowed only when the change is limited to AWS epic guardrail maintenance files.`
+      );
+    }
+
+    if (closingChildIssues.length !== 1) {
+      failures.push(
+        `AWS platform PRs must close exactly one child issue in the PR body with Closes/Fixes/Resolves; found ${formatIssueList(closingChildIssues) || 'none'}.`
+      );
+    } else if (uniqueChildIssues.length === 1 && closingChildIssues[0] !== uniqueChildIssues[0]) {
+      failures.push(
+        `The closing child issue ${formatIssueList(closingChildIssues)} must match the only referenced AWS child issue ${formatIssueList(uniqueChildIssues)}.`
+      );
+    }
+  }
+
+  return {
+    valid: failures.length === 0,
+    applicable: true,
+    failures,
+    summary:
+      uniqueChildIssues.length > 0
+        ? `AWS platform child refs: ${formatIssueList(uniqueChildIssues)}.`
+        : parentOnlyGuardrailMaintenance
+          ? 'AWS platform parent guardrail maintenance ref only.'
+          : 'AWS platform parent ref only.',
+  };
+}
+
+function readChangedFiles(path) {
+  if (!path) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(path, 'utf8')
+    .split(/\r?\n/)
+    .map((changedFile) => changedFile.trim())
+    .filter(Boolean);
+}
+
+function readOptionalText(path) {
+  if (!path) {
+    return '';
+  }
+
+  return fs.readFileSync(path, 'utf8');
+}
+
+function readEvent(path) {
+  if (!path) {
+    throw new Error('Missing event JSON path. Pass a path or set GITHUB_EVENT_PATH.');
+  }
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+export function main(argv = process.argv) {
+  const eventPath = argv[2] || process.env.GITHUB_EVENT_PATH;
+  const changedFilesPath = argv[3] || process.env.AWS_EPIC_CHANGED_FILES_PATH;
+  const commitMessagesPath = argv[4] || process.env.AWS_EPIC_COMMIT_MESSAGES_PATH;
+  const result = validateAWSEpicPullRequest(readEvent(eventPath), {
+    changedFiles: readChangedFiles(changedFilesPath),
+    commitMessages: readOptionalText(commitMessagesPath),
+  });
+
+  console.log(result.summary);
+  if (!result.valid) {
+    for (const failure of result.failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    result.applicable
+      ? 'AWS platform PR discipline is satisfied.'
+      : 'AWS platform PR discipline is not applicable.'
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate_aws_epic_pr.test.mjs
+++ b/scripts/validate_aws_epic_pr.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  extractIssueReferences,
+  sanitizeMarkdown,
+  validateAWSEpicPullRequest,
+} from './validate_aws_epic_pr.mjs';
+
+function event({ base = 'dev', body = '', title = 'Test PR' } = {}) {
+  return {
+    pull_request: {
+      title,
+      body,
+      base: { ref: base },
+    },
+  };
+}
+
+const guardrailMaintenanceFiles = [
+  '.github/branch-protection/dev.json',
+  '.github/workflows/aws-epic-pr-guard.yml',
+  'CHANGELOG.md',
+  'docs/aws-platform-dependency-index.md',
+  'scripts/validate_aws_epic_pr.mjs',
+  'scripts/validate_aws_epic_pr.test.mjs',
+];
+
+test('ignores unrelated pull requests', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Closes #901',
+    })
+  );
+
+  assert.equal(result.valid, true);
+  assert.equal(result.applicable, false);
+});
+
+test('allows a parent guardrail maintenance PR that references the epic without closing it', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Refs #1472',
+    }),
+    { changedFiles: guardrailMaintenanceFiles }
+  );
+
+  assert.equal(result.valid, true);
+  assert.equal(result.applicable, true);
+});
+
+test('rejects parent-only AWS epic PRs when changed files are unavailable', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Refs #1472',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /reference exactly one focused child issue; found none/);
+});
+
+test('rejects parent-only AWS epic PRs that change implementation files', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Refs #1472',
+    }),
+    {
+      changedFiles: [
+        '.github/workflows/aws-epic-pr-guard.yml',
+        'internal/aws/collector.go',
+      ],
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /limited to AWS epic guardrail maintenance files/);
+});
+
+test('allows one AWS child issue to close from dev while referencing the parent epic', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: ['Closes: #1477', 'Refs #1472'].join('\n'),
+    })
+  );
+
+  assert.equal(result.valid, true);
+});
+
+test('rejects closing the parent epic', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Closes #1472',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /Do not close #1472/);
+});
+
+test('rejects closing the parent epic from a commit message', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: ['Closes #1477', 'Refs #1472'].join('\n'),
+    }),
+    {
+      commitMessages: 'add collector\n\nCloses: #1472',
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /Do not close #1472/);
+});
+
+test('rejects AWS platform PRs that do not target dev', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      base: 'main',
+      body: 'Closes #1477',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /must target dev/);
+});
+
+test('rejects multiple AWS child issues in one PR', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Closes #1477 and #1478',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /exactly one focused child issue/);
+});
+
+test('rejects child references that do not close the focused child issue', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Refs #1477',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /must close exactly one child issue/);
+});
+
+test('does not accept a child-closing keyword from commit messages only', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: 'Refs #1472',
+    }),
+    {
+      commitMessages: 'add collector\n\nCloses #1477',
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /in the PR body/);
+});
+
+test('detects bare AWS issue mentions as non-closing references', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      base: 'main',
+      body: 'Related: #1477',
+    })
+  );
+
+  assert.equal(result.applicable, true);
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /must target dev/);
+  assert.match(result.failures.join('\n'), /must close exactly one child issue/);
+});
+
+test('does not accept a child-closing keyword from the title only', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      title: 'Closes #1477',
+      body: 'Refs #1472',
+    })
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /in the PR body/);
+});
+
+test('extracts qualified and URL issue references outside code examples', () => {
+  const references = extractIssueReferences(
+    [
+      'Closes identrail/identrail#1477',
+      'Refs https://github.com/identrail/identrail/issues/1472',
+      'Related: #1480',
+      'Closes some-org/some-repo#1478',
+      'Refs https://github.com/some-org/some-repo/issues/1479',
+      '`Closes #1478`',
+      '```',
+      'Closes #1479',
+      '```',
+    ].join('\n')
+  );
+
+  assert.deepEqual(
+    references.map((reference) => [reference.keyword, reference.issueNumber, reference.closing]),
+    [
+      ['closes', 1477, true],
+      ['refs', 1472, false],
+      ['mention', 1480, false],
+    ]
+  );
+});
+
+test('sanitizes comments and code before policy extraction', () => {
+  assert.equal(
+    sanitizeMarkdown('Refs #1472 <!-- Closes #1477 --> `Closes #1478`').trim(),
+    'Refs #1472'
+  );
+});
+
+test('ignores Cubic generated summaries appended to the PR body', () => {
+  const result = validateAWSEpicPullRequest(
+    event({
+      body: [
+        'Refs #1472',
+        '<!-- This is an auto-generated description by cubic. -->',
+        'Validator rules: PRs must not close #1472.',
+        '<!-- End of auto-generated description by cubic. -->',
+      ].join('\n'),
+    }),
+    { changedFiles: guardrailMaintenanceFiles }
+  );
+
+  assert.equal(result.valid, true);
+});


### PR DESCRIPTION
## Summary

Adds a dedicated AWS Epic PR Guard workflow plus a testable Node validator for the #1472 AWS Machine Identity Platform program. The guard activates when a PR references #1472 or an AWS child issue in the 1473-1557 range.

## Why

The remaining parent-epic acceptance criterion says future PRs should start from origin/dev and close exactly one focused child issue. This makes that rule enforceable without prematurely closing #1472, which should remain open until the full child-issue program is complete.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
node --test scripts/validate_aws_epic_pr.test.mjs
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/aws-epic-pr-guard.yml
go test ./...
git diff --check
```

All checks passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

No

## Related Issues

Refs #1472

Note: this intentionally uses `Refs` rather than `Closes` because #1472 is the parent epic and should remain open until the AWS Machine Identity Platform child issue program is complete.
