### PR TITLE
polish the GitHub Repositories page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 # Changelog
 
 ## Unreleased
+- Reworked the GitHub **Repositories** page (`/app/.../github/repositories`)
+  with the same compact treatment applied to the overview and Connect
+  pages. The header drops the GitHub icon, the `REPOSITORY INVENTORY`
+  eyebrow, the "Launch, monitor, and cancel repository scans for the
+  selected installation." tagline, the standalone Connected pill, and
+  two of the three header CTAs (`Manage connection` and `GitHub home`).
+  The title is just `Repositories` and the subtitle is a single
+  state-aware line — `15 repositories · 8 recent scans · 2 failed`
+  when there is recent activity, just `15 repositories` for a clean
+  inventory, `Not connected for this environment.` when disconnected,
+  `Loading repositories…` during the first fetch, and `Unable to load
+  repositories.` when the status fetch fails. One primary CTA per
+  state: `Connect GitHub` (disconnected) or `GitHub findings`
+  (connected); the CTA is omitted while loading or in an error state
+  so the error panel stays the single source of truth.
+  The repository list is rebuilt as a compact table-like grid: each
+  row is a single card with the bold repo name and a clean status
+  line (`May 27 · 8 findings`, `May 24 · failed · Scan timed out`,
+  `full in flight`, or `Not scanned`), and the `Queue scan` / `Cancel
+  scan` buttons sit trailing on the same row. The previous bullet-list
+  rendering (`<ul>`/`<li>`) with browser default disc markers and the
+  inconsistent row heights are gone.
+  The `Selected repositories / X repositories in scope` sub-header,
+  the floating `Environment t` chrome chip, the `Activity / Recent
+  repository scan activity` framing with the `X scans loaded` counter,
+  and the `Reference / Scan operations` documentation aside (which
+  exposed three meta-bullets including the implementation rule
+  "Cancel is only available while a scan is queued or running.") are
+  all removed. The activity section header is now just `Recent
+  activity`. While loading or in an error state the install/manage
+  body, the recent activity section, and the speculative empty states
+  are suppressed so the page does not contradict the error panel or
+  prompt a user to "Connect GitHub" off an unknown status.
+  Backend behaviour is unchanged: `runRepoScan` is still posted with
+  `repository`, `project_id`, and `connector_id` (for github_app
+  installations) against the same auth context; `cancelRepoScan` is
+  still posted with the scan id; `data.reload()` is still called after
+  every successful mutation; and the four early-return shells (no
+  scope, availability loading, unavailable, missing environment) are
+  unchanged.
 - Reworked the GitHub **Connect** page (`/app/.../github/connect`) so it
   reads as a product surface rather than an AI-generated onboarding demo.
   The header drops the GitHub icon, the `GITHUB APP ONBOARDING` eyebrow,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4816,7 +4816,7 @@ describe('GitHub domain pages (#1382)', () => {
   it('Repositories page launches a scan via the existing API', async () => {
     const mocks = await renderGitHubPage('repositories', { scans: [] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
     fireEvent.click(queueButton);
 
@@ -4836,7 +4836,7 @@ describe('GitHub domain pages (#1382)', () => {
   it('Repositories page bypasses in-flight refreshes after queueing a scan', async () => {
     const initialMocks = await renderGitHubPage('repositories', { scans: [] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     await waitFor(() => expect(initialMocks.listRepoScans).toHaveBeenCalledTimes(1));
     cleanup();
     vi.restoreAllMocks();
@@ -4857,7 +4857,7 @@ describe('GitHub domain pages (#1382)', () => {
       }
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(1));
     const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
     await waitFor(() => expect(queueButton).not.toBeDisabled());
@@ -4887,7 +4887,7 @@ describe('GitHub domain pages (#1382)', () => {
   it('Repositories page cancels an active scan via the existing API', async () => {
     const mocks = await renderGitHubPage('repositories', { scans: [queuedRepoScan] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     const cancelButton = await screen.findByRole('button', { name: 'Cancel scan for identrail/identrail' });
     fireEvent.click(cancelButton);
 
@@ -4905,7 +4905,7 @@ describe('GitHub domain pages (#1382)', () => {
       githubConnection: { ...connectedGitHub, selected_repositories: [] }
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     await screen.findByRole('heading', { level: 3, name: /Select repositories for Identrail to watch/i });
     await waitFor(() => {
       const selectLink = screen
@@ -4921,15 +4921,38 @@ describe('GitHub domain pages (#1382)', () => {
       runRepoScanError: { message: 'rate limited', status: 429 }
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
     fireEvent.click(queueButton);
 
     await screen.findByRole('heading', { level: 3, name: /Repository scan error/i });
-    const homeLink = screen
-      .getAllByRole('link', { name: /GitHub home/i })
-      .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github'));
-    expect(homeLink).toBeDefined();
+    // Navigation must still work after a scan error — the primary CTA in
+    // the page header (GitHub findings link) stays reachable.
+    const findingsLink = screen
+      .getAllByRole('link', { name: /GitHub findings/i })
+      .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/findings'));
+    expect(findingsLink).toBeDefined();
+  });
+
+  it('Repositories page renders a compact subtitle and drops the Scan operations reference', async () => {
+    await renderGitHubPage('repositories', { scans: [succeededRepoScan] });
+
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
+    // Subtitle reflects the live repo count and scan totals — replaces
+    // the long "Launch, monitor, and cancel repository scans..." tagline.
+    await screen.findByText(/1 repository · 1 recent scan/i);
+    // The "Selected repositories / 1 repository in scope" sub-header is
+    // dropped — the section heading is just "Repositories".
+    expect(screen.queryByText(/1 repository in scope/i)).not.toBeInTheDocument();
+    // The "Reference / Scan operations" aside (with three meta-docs
+    // bullets) is removed entirely.
+    expect(screen.queryByRole('heading', { level: 3, name: 'Scan operations' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Scans use the existing repository scan APIs\./i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cancel is only available while a scan is queued or running\./i)).not.toBeInTheDocument();
+    // The Activity section header is the tighter "Recent activity"
+    // instead of "Activity / Recent repository scan activity".
+    expect(screen.queryByRole('heading', { level: 3, name: /Recent repository scan activity/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Recent activity' })).toBeInTheDocument();
   });
 
   it('Actions page renders the premium waiting-for-coverage shell', async () => {
@@ -5780,9 +5803,10 @@ describe('GitHub domain pages (#1382)', () => {
     };
     await renderGitHubPage('repositories', { scans: [unrelatedScan] });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
-    await screen.findByRole('heading', { level: 3, name: /Recent repository scan activity/i });
-    expect(screen.getByText(/0 scans loaded/i)).toBeInTheDocument();
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
+    await screen.findByRole('heading', { level: 3, name: 'Recent activity' });
+    const activity = screen.getByRole('region', { name: 'Recent repository scan activity' });
+    expect(within(activity).getByRole('heading', { level: 3, name: /No repository scans recorded yet/i })).toBeInTheDocument();
     expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
   });
 
@@ -5819,10 +5843,13 @@ describe('GitHub domain pages (#1382)', () => {
       }
     });
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(screen.getByText(/1 scan loaded/i)).toBeInTheDocument());
-    expect(screen.getAllByText(/identrail\/identrail/i)).toHaveLength(2);
+    await waitFor(() => {
+      const activity = screen.getByRole('region', { name: 'Recent repository scan activity' });
+      expect(within(activity).getAllByText(/identrail\/identrail/i).length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText(/identrail\/identrail/i).length).toBeGreaterThan(1);
   });
 
   it('Repositories page clears stale GitHub connection data when a reloading environment status fails', async () => {
@@ -5864,7 +5891,7 @@ describe('GitHub domain pages (#1382)', () => {
       </MemoryRouter>
     );
 
-    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     await waitFor(() => expect(screen.getByRole('combobox', { name: 'Environment' })).toHaveValue('production-platform'));
     expect(await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' })).toBeInTheDocument();
 
@@ -5875,8 +5902,15 @@ describe('GitHub domain pages (#1382)', () => {
     });
 
     await screen.findByRole('heading', { level: 3, name: /Unable to load repository status/i });
+    // After the reloading status request fails the stale Queue scan
+    // affordance is dropped and the body is suppressed so the error
+    // panel stays the single source of truth — the page must not also
+    // render a speculative "Connect GitHub to manage repositories"
+    // empty state off an errored status.
     expect(screen.queryByRole('button', { name: 'Queue scan for identrail/identrail' })).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: /Connect GitHub to manage repositories/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: /Connect GitHub to manage repositories/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Selected repositories' })).not.toBeInTheDocument();
+    await screen.findByText(/Unable to load repositories\./i);
 
     expect(getGitHubConnectorStatus).toHaveBeenCalledTimes(2);
   });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -10416,7 +10416,6 @@ export function ProductGitHubRepositoriesPage() {
   }
 
   const connectPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/connect'), selectedEnvironmentID);
-  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
   const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
   const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
   const rows = buildGitHubRepositoryRows(selectedRepositories, data.scans);
@@ -10471,35 +10470,55 @@ export function ProductGitHubRepositoriesPage() {
     }
   };
 
+  // Suppress every connection-dependent surface (subtitle, repo list,
+  // recent activity) while the first connection fetch is in flight or
+  // has failed. The header subtitle and any error panel below speak for
+  // the page in those states — the body is silenced so we do not
+  // contradict the error panel by, e.g., rendering "Connect GitHub to
+  // manage repositories" when the connection request itself failed.
+  const awaitingFirstLoad = data.loading && data.connection === null && !data.error;
+  const hasError = Boolean(data.error);
+  const showBody = !awaitingFirstLoad && !hasError;
+  const recentScanCount = selectedRepositoryScans.length;
+  const failedRecentScanCount = selectedRepositoryScans.filter((scan) => isFailedScanStatus(scan.status)).length;
+  const subtitle = (() => {
+    if (awaitingFirstLoad) {
+      return 'Loading repositories…';
+    }
+    if (hasError) {
+      return 'Unable to load repositories.';
+    }
+    if (!connected) {
+      return 'Not connected for this environment.';
+    }
+    const parts: string[] = [];
+    parts.push(
+      `${selectedRepositories.length} ${selectedRepositories.length === 1 ? 'repository' : 'repositories'}`
+    );
+    if (recentScanCount > 0) {
+      parts.push(`${recentScanCount} recent ${recentScanCount === 1 ? 'scan' : 'scans'}`);
+    }
+    if (failedRecentScanCount > 0) {
+      parts.push(`${failedRecentScanCount} failed`);
+    }
+    return parts.join(' · ');
+  })();
+  const primaryAction = awaitingFirstLoad || hasError
+    ? undefined
+    : connected
+      ? { label: 'GitHub findings', to: findingsPath, variant: 'primary' as const }
+      : { label: 'Connect GitHub', to: connectPath, variant: 'primary' as const };
+
   return (
     <DomainPageShell
       domain="github"
-      eyebrow="Repository inventory"
-      title="GitHub repositories"
-      description="Launch, monitor, and cancel repository scans for the selected installation."
+      eyebrow={null}
+      hideLogo
+      title="Repositories"
+      description={subtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
-      status={
-        <DomainStatusBadge
-          variant={statusVariant}
-          detail={data.connection?.account_login ? `@${data.connection.account_login}` : undefined}
-        />
-      }
       statusTone={gitHubConnectionTone(data.connection, data.loading)}
-      primaryAction={
-        connected
-          ? { label: 'Manage connection', to: connectPath, variant: 'secondary' }
-          : { label: 'Connect GitHub', to: connectPath, variant: 'primary' }
-      }
-      secondaryActions={[{ label: 'GitHub findings', to: findingsPath }, { label: 'GitHub home', to: basePath }]}
-      aside={
-        <DomainDetailPanel title="Scan operations" eyebrow="Reference">
-          <ul className="idt-domain-charter-list">
-            <li>Scans use the existing repository scan APIs.</li>
-            <li>Cancel is only available while a scan is queued or running.</li>
-            <li>Repository scope mirrors the GitHub App selection.</li>
-          </ul>
-        </DomainDetailPanel>
-      }
+      primaryAction={primaryAction}
     >
       {data.error ? <DomainErrorState title="Unable to load repository status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
       {scanError ? <DomainErrorState title="Repository scan error" body={scanError} /> : null}
@@ -10508,53 +10527,57 @@ export function ProductGitHubRepositoriesPage() {
           <p>{scanInfo}</p>
         </DomainStatusPanel>
       ) : null}
-      {!connected ? (
+      {showBody && !connected ? (
         <DomainEmptyState
-          eyebrow="Not connected"
           title="Connect GitHub to manage repositories"
           body="Install the GitHub App or paste an Enterprise PAT to populate the repository inventory."
           nextAction={{ label: 'Connect GitHub', to: connectPath }}
         />
-      ) : !hasRepositories ? (
+      ) : null}
+      {showBody && connected && !hasRepositories ? (
         <DomainEmptyState
-          eyebrow="No repositories selected"
           title="Select repositories for Identrail to watch"
           body="Pick repositories on the connection page so Identrail can queue scans and detect risk."
           nextAction={{ label: 'Select repositories', to: connectPath }}
         />
-      ) : (
-        <section className="idt-domain-status-panel" aria-label="Selected repositories">
+      ) : null}
+      {showBody && connected && hasRepositories ? (
+        <section className="idt-domain-status-panel idt-github-repository-panel" aria-label="Selected repositories">
           <header>
             <div>
-              <p className="idt-app-kicker">Selected repositories</p>
-              <h3>{`${rows.length} ${rows.length === 1 ? 'repository' : 'repositories'} in scope`}</h3>
+              <h3>Repositories</h3>
             </div>
-            <span>{`Environment ${selectedEnvironmentID}`}</span>
           </header>
-          <ul className="idt-github-repository-list">
+          <div className="idt-github-repository-table" role="list" aria-label="Repository scan controls">
             {rows.map((row) => {
               const submitting = submittingRepository === row.repository;
               const canCancel = Boolean(row.activeScan);
               const cancelingThis = canCancel && cancelingScanID === row.activeScan?.id;
+              const statusText = row.latest
+                ? isFailedScanStatus(row.latest.status)
+                  ? `${formatRelativeTime(row.latest.finished_at || row.latest.started_at)} · failed · ${summarizeScanFailure(row.latest)}`
+                  : isCompletedScanStatus(row.latest.status)
+                    ? `${formatRelativeTime(row.latest.finished_at || row.latest.started_at)} · ${row.latest.finding_count} ${row.latest.finding_count === 1 ? 'finding' : 'findings'}`
+                    : `${row.latest.scan_mode ?? 'scan'} in flight`
+                : 'Not scanned';
               return (
-                <li key={row.repository} className="idt-github-repository-row">
-                  <div>
+                <article key={row.repository} role="listitem" className="idt-github-repository-row">
+                  <div className="idt-github-repository-row-main">
                     <strong>{row.repository}</strong>
-                    {row.latest ? (
-                      <small>
-                        Last scan {formatRelativeTime(row.latest.finished_at || row.latest.started_at)} ·{' '}
-                        {formatTokenLabel(row.latest.status)} ·{' '}
-                        {isCompletedScanStatus(row.latest.status) && !isFailedScanStatus(row.latest.status)
-                          ? `${row.latest.finding_count} findings`
-                          : isFailedScanStatus(row.latest.status)
-                            ? summarizeScanFailure(row.latest)
-                            : `${row.latest.scan_mode ?? 'scan'} in flight`}
-                      </small>
-                    ) : (
-                      <small>No scans yet.</small>
-                    )}
+                    <span className="idt-github-repository-row-status">{statusText}</span>
                   </div>
-                  <div className="idt-inline-actions">
+                  <div className="idt-github-repository-row-actions">
+                    {canCancel && row.activeScan ? (
+                      <button
+                        type="button"
+                        className="idt-btn idt-btn-ghost"
+                        onClick={() => cancelScan(row.activeScan as RepoScanRecord)}
+                        disabled={cancelingThis || data.loading}
+                        aria-label={`Cancel scan for ${row.repository}`}
+                      >
+                        {cancelingThis ? 'Canceling...' : 'Cancel scan'}
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       className="idt-btn idt-btn-primary"
@@ -10570,36 +10593,22 @@ export function ProductGitHubRepositoriesPage() {
                             ? 'Scan in progress'
                             : 'Queue scan'}
                     </button>
-                    {canCancel && row.activeScan ? (
-                      <button
-                        type="button"
-                        className="idt-btn idt-btn-ghost"
-                        onClick={() => cancelScan(row.activeScan as RepoScanRecord)}
-                        disabled={cancelingThis || data.loading}
-                        aria-label={`Cancel scan for ${row.repository}`}
-                      >
-                        {cancelingThis ? 'Canceling...' : 'Cancel scan'}
-                      </button>
-                    ) : null}
                   </div>
-                </li>
+                </article>
               );
             })}
-          </ul>
+          </div>
         </section>
-      )}
-      {connected && hasRepositories ? (
+      ) : null}
+      {showBody && connected && hasRepositories ? (
         <section className="idt-domain-status-panel" aria-label="Recent repository scan activity">
           <header>
             <div>
-              <p className="idt-app-kicker">Activity</p>
-              <h3>Recent repository scan activity</h3>
+              <h3>Recent activity</h3>
             </div>
-            <span>{`${selectedRepositoryScans.length} scan${selectedRepositoryScans.length === 1 ? '' : 's'} loaded`}</span>
           </header>
           {selectedRepositoryScans.length === 0 ? (
             <DomainEmptyState
-              eyebrow="No activity"
               title="No repository scans recorded yet"
               body="Queue a scan for a selected repository to seed activity here."
             />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22880,6 +22880,63 @@ html[data-theme='light'] .idt-app-shell-screen select {
   line-height: 1.55;
 }
 
+.idt-github-repository-panel header {
+  margin-bottom: 0.35rem;
+}
+
+.idt-github-repository-table {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-github-repository-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.7rem 0.95rem;
+  background: #050505;
+}
+
+.idt-github-repository-row-main {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.idt-github-repository-row-main strong {
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 0.98rem;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.idt-github-repository-row-status {
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.idt-github-repository-row-actions {
+  display: flex;
+  gap: 0.45rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 760px) {
+  .idt-github-repository-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .idt-github-repository-row-actions {
+    justify-content: flex-start;
+  }
+}
+
 .idt-github-section-links > div {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));


### PR DESCRIPTION
Fixes #1576

## Summary
Applies the same compact treatment used on the overview and Connect pages so `/app/.../github/repositories` reads as a product surface rather than an AI-generated dashboard demo, and so the repository list renders as a scannable table instead of a bulleted prose list. Backend behaviour is unchanged.

## Header
- Drops the GitHub icon, the `REPOSITORY INVENTORY` eyebrow, the "Launch, monitor, and cancel repository scans for the selected installation." tagline, the standalone Connected pill, and two of the three header CTAs (`Manage connection`, `GitHub home`).
- Title is just **Repositories**.
- Subtitle is a single state-aware line:
  - Loading: `Loading repositories…`
  - Error: `Unable to load repositories.`
  - Disconnected: `Not connected for this environment.`
  - Connected: `15 repositories · 8 recent scans · 2 failed` — recent-scan and failed segments only appear when their counts are non-zero, so a clean inventory reads `15 repositories`.
- One primary CTA per state: `Connect GitHub` when disconnected, `GitHub findings` when connected, omitted while loading or in an error state.

## Body
- Repository list rebuilt as a CSS grid with **one card per repo** and three columns (repo + status + actions). The previous bulleted `<ul>`/`<li>` rendering with default browser disc markers and inconsistent row heights is gone.
- Status text condenses per row to one of:
  - `Not scanned`
  - `May 27 · 8 findings` (succeeded, relative time)
  - `May 24 · failed · Scan timed out` (failed)
  - `full in flight` (active)
- `Recent activity` is the new section header — the `ACTIVITY` eyebrow and the `X scans loaded` counter chip are gone.
- The `Selected repositories / X repositories in scope` sub-header and the floating `Environment t` chrome chip are removed.
- The `Reference / Scan operations` documentation aside (which exposed three implementation-rule bullets including "Cancel is only available while a scan is queued or running.") is removed entirely.
- While loading or in an error state the install/manage body, the recent activity section, and the speculative empty states are suppressed so the error panel stays the single source of truth.

## Backend behaviour preserved
- `runRepoScan` is still posted with `repository`, `project_id`, and `connector_id` (for `github_app` installations) against the same auth context.
- `cancelRepoScan` is still posted with the scan id.
- `data.reload()` is still called after every successful mutation.
- The four early-return shells (no scope, availability loading, unavailable, missing environment) are unchanged.
- The `aria-label`s on `Queue scan` and `Cancel scan` buttons are preserved exactly so existing tests against those buttons continue to work.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build --prefix web` clean
- [x] `npx vitest run productShell.test.tsx` — 133/133 pass, including the existing `Repositories page launches a scan via the existing API`, `Repositories page bypasses in-flight refreshes after queueing a scan`, `Repositories page cancels an active scan via the existing API`, `Repositories page shows the empty state when no repositories are selected`, and `Repositories page surfaces a scan error inline without breaking navigation` tests (updated to the new title / nav target only), plus a new `Repositories page renders a compact subtitle and drops the Scan operations reference` test that asserts the new subtitle copy is live, the Scan operations bullets are gone, and the activity heading is the tighter `Recent activity`. The `Repositories page clears stale GitHub connection data when a reloading environment status fails` test was also updated to assert the error-state body suppression (no speculative "Connect GitHub to manage repositories" empty state on a failed status fetch).
- [x] **Visual test** in a local Vite preview harness across five variants:
  - **mixed** (connected, 15 repos, 8 scans incl. a running scan + 2 failures + first-time rows): header reads `15 repositories · 8 recent scans · 2 failed`; rows show tight status lines with the `cloud-custodian` row exposing both `Cancel scan` and disabled `Scan in progress`; activity section header is just `Recent activity`.
  - **first-time** (connected, 15 repos, 0 scans): subtitle reads `15 repositories`; every row shows `Not scanned`; activity section shows the `No repository scans recorded yet` empty state.
  - **all-clean** (connected, 6 repos, 6 succeeded scans): subtitle reads `6 repositories · 6 recent scans`; rows show `May X · 0 findings`; activity section shows succeeded scans.
  - **disconnected**: subtitle reads `Not connected for this environment.`; primary CTA is `Connect GitHub`; body shows the connect empty state.
  - **loading** (status promise held pending): subtitle reads `Loading repositories…`; no primary CTA; no body.
  - **error** (status request rejects with rate limit): subtitle reads `Unable to load repositories.`; no primary CTA; only the error panel renders — no speculative row list or empty state.

## AI disclosure
This change was drafted with Claude (Opus 4.7) acting as a pair-programmer; I reviewed each diff, ran the test suite, and verified the rendered output across all five variants in the preview harness before committing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the GitHub Repositories page to match the compact product style and replaced the bulleted list with a scannable table-like grid. This makes repository status and actions clearer while keeping backend behavior unchanged.

- **New Features**
  - Simplified header: title is “Repositories,” with a state-aware subtitle (loading, error, disconnected, or “N repositories · X recent scans · Y failed”). One primary CTA per state: `Connect GitHub` or `GitHub findings`.
  - Rebuilt body: CSS grid with one row per repo (name · compact status · actions). Status shows “Not scanned,” “<date> · <findings>,” “<date> · failed · <reason>,” or “<mode> in flight.” `Queue scan`/`Cancel scan` ARIA labels stay the same.
  - Tighter activity: header is “Recent activity.” Removed eyebrows, counters, and the “Scan operations” reference block. Clean empty state when no scans.
  - Clear states: while loading or on error, the body is suppressed so the error panel is the single source of truth. Disconnected and no-selection empty states remain when applicable.
  - Behavior unchanged: same scan APIs, mutations, and early-return shells. Tests updated for the new title, headings, and error-state handling.

<sup>Written for commit 7ecf592f41c0eeaa099f53000010e394ce349285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

