### PR TITLE
Implement CodeBuild service role inventory

### DIFF
--- a/docs/aws-codebuild-service-roles.md
+++ b/docs/aws-codebuild-service-roles.md
@@ -1,0 +1,60 @@
+# AWS CodeBuild Service Roles
+
+## Purpose
+
+Issue #1481 adds metadata-only CodeBuild service role inventory to the AWS
+machine identity graph. It maps each CodeBuild project to the IAM role it runs
+as, then carries safe build metadata for later CI/CD identity, credential
+reference, and blast-radius analysis.
+
+## Endpoint
+
+```text
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/codebuild-service-roles
+```
+
+Optional query parameters:
+
+- `connector_id`: scopes account and region context to a configured AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for deterministic UI and contract validation.
+
+The response returns `inventory`, including records, `runs_as` relationships,
+diagnostics, status, confidence, count summaries, and issue evidence links.
+
+## Evidence Collected
+
+Each record includes:
+
+- CodeBuild project ARN, name, visibility, source provider, source location,
+  source auth type, source version, and secondary source identifiers.
+- Service role ARN and role name.
+- Environment type, compute type, image, image-pull credential mode, privileged
+  mode, KMS key ARN, cache metadata, log destinations, VPC, subnet, security
+  group, artifact type, and artifact location metadata.
+- Environment variable names only.
+- Parameter Store and Secrets Manager references only.
+- Tags.
+
+The collector does not read build logs, source contents, artifacts, environment
+values, secret values, customer data, prompts, completions, or database rows.
+
+## Diagnostics
+
+Permission denial blocks the inventory because `ListProjects` and
+`BatchGetProjects` are the entry points. Per-page or per-batch failures are
+reported as partial failures so successful project-role records remain visible.
+Public or privileged projects are surfaced as degraded metadata because they
+change the review priority without requiring data-plane reads.
+
+## Graph Shape
+
+CodeBuild project workloads emit:
+
+```text
+codebuild_project --runs_as--> iam_role
+```
+
+That keeps CI/CD build identity aligned with the AWS service collector contract
+and gives downstream engines a deterministic machine identity edge without
+collecting build payloads.

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -4,8 +4,8 @@
 
 The AWS collector family uses a composable service collection layer. IAM remains
 the default identity source, and EC2 instance profiles, ECS task/execution roles,
-and Lambda execution roles are collected as workload identity services without
-changing IAM collector behavior.
+Lambda execution roles, and CodeBuild service roles are collected as workload
+identity services without changing IAM collector behavior.
 
 ## Composite Architecture
 
@@ -24,6 +24,10 @@ The collection path is:
 - `LambdaExecutionRoleCollector` maps Lambda functions to execution roles, alias
   and version references, event-source mappings, KMS metadata, and secret
   references without collecting function code or environment values.
+- `CodeBuildServiceRoleCollector` maps CodeBuild projects to service roles,
+  source/provider metadata, environment key names, credential references, VPC
+  config, and artifact metadata without collecting build logs, source,
+  artifacts, environment values, or secret values.
 
 Behavior:
 
@@ -107,6 +111,12 @@ ordered by `kind`, then `source_id`.
 - Lambda records include environment key names, KMS key ARNs, and secret/source
   access references, but not function code, logs, environment values, invocation
   payloads, or secret values.
+- CodeBuild project batch failures are surfaced as partial-failure diagnostics
+  while successfully described project-to-role evidence remains visible.
+- CodeBuild records include source/provider metadata, build environment
+  metadata, VPC config, artifact metadata, environment key names, and
+  Parameter Store or Secrets Manager references, but not build logs, source,
+  artifacts, environment values, or secret values.
 
 ## Security Posture
 
@@ -128,9 +138,11 @@ ordered by `kind`, then `source_id`.
 - Lambda execution-role collection is implemented through AWS SDK Lambda
   adapters for `ListFunctions`, `ListAliases`, `ListVersionsByFunction`,
   `ListEventSourceMappings`, and `ListTags`.
+- CodeBuild service-role collection is implemented through AWS SDK CodeBuild
+  adapters for `ListProjects` and `BatchGetProjects`.
 - AWS SDK CLI and runtime paths now use `NewAWSScanner`, which wires the
-  composite collector with IAM, EC2 instance profile, ECS task role, and Lambda
-  execution role services.
+  composite collector with IAM, EC2 instance profile, ECS task role, Lambda
+  execution role, CodeBuild service role, and EKS workload identity services.
 - The composite layer is now the extension point for future AWS service collection in the CLI/runtime path.
 - The service collector contract is exposed through
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/collector-contract`
@@ -143,4 +155,7 @@ ordered by `kind`, then `source_id`.
   and the AWS machine identities page.
 - Lambda execution role inventory is exposed through
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/lambda-execution-roles`
+  and the AWS machine identities page.
+- CodeBuild service role inventory is exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/codebuild-service-roles`
   and the AWS machine identities page.

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -78,6 +78,8 @@ The response envelope is:
       "lambda:ListVersionsByFunction",
       "lambda:ListEventSourceMappings",
       "lambda:ListTags",
+      "codebuild:ListProjects",
+      "codebuild:BatchGetProjects",
       "eks:ListClusters",
       "eks:DescribeCluster",
       "eks:ListPodIdentityAssociations",
@@ -158,8 +160,9 @@ ECS workload collector adds metadata-only reads: `ecs:ListClusters`,
 `ecs:DescribeTaskDefinition`. The Lambda workload collector adds metadata-only
 reads: `lambda:ListFunctions`, `lambda:ListAliases`,
 `lambda:ListVersionsByFunction`, `lambda:ListEventSourceMappings`, and
-`lambda:ListTags`. The EKS workload identity collector adds metadata-only
-reads: `eks:ListClusters`, `eks:DescribeCluster`,
+`lambda:ListTags`. The CodeBuild service-role collector adds metadata-only
+reads: `codebuild:ListProjects` and `codebuild:BatchGetProjects`. The EKS
+workload identity collector adds metadata-only reads: `eks:ListClusters`, `eks:DescribeCluster`,
 `eks:ListPodIdentityAssociations`, `eks:DescribePodIdentityAssociation`,
 `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:ListFargateProfiles`, and
 `eks:DescribeFargateProfile`.
@@ -172,6 +175,11 @@ customer payloads by default.
 For ECS, `secret_refs` are only secret or parameter names/source references and
 `environment_keys` are only variable names. Plaintext environment values and
 secret values are intentionally outside the collector contract.
+
+For CodeBuild, `secret_refs` are only Parameter Store or Secrets Manager source
+references and `environment_keys` are only variable names. Build logs, source
+contents, artifact contents, plaintext environment values, and secret values are
+intentionally outside the collector contract.
 
 For EKS, AWS-side metadata proves clusters, OIDC issuer relationships, Pod
 Identity associations, managed node roles, and Fargate pod execution roles.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -7716,6 +7716,8 @@ components:
           type: string
         project_name:
           type: string
+        project_description:
+          type: string
         project_visibility:
           type: string
         source_type:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -504,6 +504,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/codebuild-service-roles
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities
     action: tenancy.read
     resource_type: project
@@ -3923,6 +3928,56 @@ paths:
                     $ref: "#/components/schemas/AWSLambdaExecutionRoleInventoryResult"
         "400":
           description: Invalid AWS Lambda execution role inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/codebuild-service-roles:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS CodeBuild service role machine identities
+      operationId: getAWSProjectCodeBuildServiceRoles
+      description: Returns scoped CodeBuild project, service role, source/provider, artifact, VPC, environment-key, secret-reference, graph relationship, and collector diagnostic evidence for the selected AWS connector without reading source contents, build logs, artifacts, environment values, or secret values.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only CodeBuild inventory evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+      responses:
+        "200":
+          description: AWS CodeBuild service role inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSCodeBuildServiceRoleInventoryResult"
+        "400":
+          description: Invalid AWS CodeBuild service role inventory request
           content:
             application/json:
               schema:
@@ -7630,6 +7685,218 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLambdaExecutionRoleDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSCodeBuildServiceRoleRecord:
+      type: object
+      properties:
+        account_id:
+          type: string
+        region:
+          type: string
+        service:
+          type: string
+          enum: [codebuild]
+        workload_id:
+          type: string
+        workload_type:
+          type: string
+          enum: [codebuild_project]
+        workload_name:
+          type: string
+        role_arn:
+          type: string
+        role_name:
+          type: string
+        project_arn:
+          type: string
+        project_name:
+          type: string
+        project_visibility:
+          type: string
+        source_type:
+          type: string
+        source_location:
+          type: string
+        source_auth_type:
+          type: string
+        source_version:
+          type: string
+        source_identifiers:
+          type: array
+          items: { type: string }
+        artifact_types:
+          type: array
+          items: { type: string }
+        artifact_locations:
+          type: array
+          items: { type: string }
+        environment_type:
+          type: string
+        compute_type:
+          type: string
+        image:
+          type: string
+        image_pull_credentials_type:
+          type: string
+        privileged_mode:
+          type: boolean
+        kms_key_arn:
+          type: string
+        cache_type:
+          type: string
+        cache_location:
+          type: string
+        log_types:
+          type: array
+          items: { type: string }
+        vpc_id:
+          type: string
+        subnet_ids:
+          type: array
+          items: { type: string }
+        security_group_ids:
+          type: array
+          items: { type: string }
+        environment_keys:
+          type: array
+          description: Environment variable names only; values are intentionally not collected.
+          items: { type: string }
+        secret_refs:
+          type: array
+          description: Parameter Store and Secrets Manager references only; never secret values.
+          items: { type: string }
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        source:
+          type: string
+        evidence_ref:
+          type: string
+        from_node_id:
+          type: string
+        to_node_id:
+          type: string
+        relationship_type:
+          type: string
+          enum: [runs_as]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+    AWSCodeBuildServiceRoleRelationship:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [runs_as]
+        from_node_id:
+          type: string
+        to_node_id:
+          type: string
+        evidence_ref:
+          type: string
+    AWSCodeBuildServiceRoleDiagnostic:
+      type: object
+      properties:
+        collector:
+          type: string
+        source_id:
+          type: string
+        code:
+          type: string
+          enum: [missing_codebuild_service_role, missing_project_arn, permission_denied, privileged_or_public_project, project_batch_get_failed, project_not_found]
+        message:
+          type: string
+        remediation:
+          type: string
+        retryable:
+          type: boolean
+    AWSCodeBuildServiceRoleInventoryResult:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+        workspace_id:
+          type: string
+        project_id:
+          type: string
+        connector_id:
+          type: string
+        account_id:
+          type: string
+        region:
+          type: string
+        parent_issue_number:
+          type: integer
+        parent_issue_ref:
+          type: string
+        current_issue_number:
+          type: integer
+        current_issue_ref:
+          type: string
+        version:
+          type: string
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        record_count:
+          type: integer
+        project_count:
+          type: integer
+        identity_count:
+          type: integer
+        resource_count:
+          type: integer
+        relationship_count:
+          type: integer
+        secret_ref_count:
+          type: integer
+        vpc_project_count:
+          type: integer
+        public_project_count:
+          type: integer
+        privileged_project_count:
+          type: integer
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCodeBuildServiceRoleRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCodeBuildServiceRoleRelationship"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCodeBuildServiceRoleDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.27 // indirect
+	github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNp
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28/go.mod h1:uxtQiKvLtNS4iXVsH2McVD/ls8FKN/uUhe1hGxPjrw0=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.27 h1:i49S7g2smFWmlconi97Nn8dxb7jSQ0TeOFD20NX3M+o=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.27/go.mod h1:qiLes3uVQAK+cpb837HUEhypYKGBz2ZCDcDl5BYQtpM=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3 h1:bdJcqPbvkHSyG7N+5PDsBB6cWnWXHWkZ80SaY09R8qQ=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3/go.mod h1:1j2vP0fJjVysTByZ5MSp0/iMlej8Oqa8TWYtcX3HTRQ=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.305.2 h1:xcHUdx4FNgUZmLuI6vqB5QDsVnWx1MVbPSoaXtLxUB8=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.305.2/go.mod h1:SUtka5kgdr5Wx2BdRrH/IGkCKHW63IVQoyBkP0P1gdo=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.82.3 h1:0h+khLoWaCU9JE6ZeQrQ9xZS+EnrjISQlnt/xtxEL/I=

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -744,6 +744,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ec2-instance-profiles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ecs-task-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/lambda-execution-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/codebuild-service-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_codebuild_service_roles.go
+++ b/internal/api/aws_codebuild_service_roles.go
@@ -1,0 +1,493 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsCodeBuildServiceRoleCurrentIssue = 1481
+	awsCodeBuildServiceRoleVersion      = "aws-codebuild-service-role-inventory-v1"
+)
+
+// AWSCodeBuildServiceRoleInventoryRequest controls the deterministic inventory state.
+type AWSCodeBuildServiceRoleInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+}
+
+// AWSCodeBuildServiceRoleInventoryResult exposes scoped CodeBuild service-role evidence.
+type AWSCodeBuildServiceRoleInventoryResult struct {
+	TenantID               string                                `json:"tenant_id"`
+	WorkspaceID            string                                `json:"workspace_id"`
+	ProjectID              string                                `json:"project_id"`
+	ConnectorID            string                                `json:"connector_id,omitempty"`
+	AccountID              string                                `json:"account_id,omitempty"`
+	Region                 string                                `json:"region,omitempty"`
+	ParentIssueNumber      int                                   `json:"parent_issue_number"`
+	ParentIssueRef         string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber     int                                   `json:"current_issue_number"`
+	CurrentIssueRef        string                                `json:"current_issue_ref"`
+	Version                string                                `json:"version"`
+	Status                 string                                `json:"status"`
+	FixtureState           string                                `json:"fixture_state"`
+	Confidence             float64                               `json:"confidence"`
+	RecordCount            int                                   `json:"record_count"`
+	ProjectCount           int                                   `json:"project_count"`
+	IdentityCount          int                                   `json:"identity_count"`
+	ResourceCount          int                                   `json:"resource_count"`
+	RelationshipCount      int                                   `json:"relationship_count"`
+	SecretRefCount         int                                   `json:"secret_ref_count"`
+	VPCProjectCount        int                                   `json:"vpc_project_count"`
+	PublicProjectCount     int                                   `json:"public_project_count"`
+	PrivilegedProjectCount int                                   `json:"privileged_project_count"`
+	FailureReasons         []string                              `json:"failure_reasons"`
+	RemediationHints       []string                              `json:"remediation_hints"`
+	EvidenceLinks          []string                              `json:"evidence_links"`
+	Records                []AWSCodeBuildServiceRoleRecord       `json:"records"`
+	Relationships          []AWSCodeBuildServiceRoleRelationship `json:"relationships"`
+	Diagnostics            []AWSCodeBuildServiceRoleDiagnostic   `json:"diagnostics"`
+	GeneratedAt            time.Time                             `json:"generated_at"`
+	UpdatedAt              time.Time                             `json:"updated_at"`
+}
+
+// AWSCodeBuildServiceRoleRecord is the operator-facing row for one CodeBuild project/role link.
+type AWSCodeBuildServiceRoleRecord struct {
+	AccountID                string            `json:"account_id"`
+	Region                   string            `json:"region"`
+	Service                  string            `json:"service"`
+	WorkloadID               string            `json:"workload_id"`
+	WorkloadType             string            `json:"workload_type"`
+	WorkloadName             string            `json:"workload_name"`
+	RoleARN                  string            `json:"role_arn,omitempty"`
+	RoleName                 string            `json:"role_name,omitempty"`
+	ProjectARN               string            `json:"project_arn,omitempty"`
+	ProjectName              string            `json:"project_name,omitempty"`
+	ProjectDescription       string            `json:"project_description,omitempty"`
+	ProjectVisibility        string            `json:"project_visibility,omitempty"`
+	SourceType               string            `json:"source_type,omitempty"`
+	SourceLocation           string            `json:"source_location,omitempty"`
+	SourceAuthType           string            `json:"source_auth_type,omitempty"`
+	SourceVersion            string            `json:"source_version,omitempty"`
+	SourceIdentifiers        []string          `json:"source_identifiers,omitempty"`
+	ArtifactTypes            []string          `json:"artifact_types,omitempty"`
+	ArtifactLocations        []string          `json:"artifact_locations,omitempty"`
+	EnvironmentType          string            `json:"environment_type,omitempty"`
+	ComputeType              string            `json:"compute_type,omitempty"`
+	Image                    string            `json:"image,omitempty"`
+	ImagePullCredentialsType string            `json:"image_pull_credentials_type,omitempty"`
+	PrivilegedMode           bool              `json:"privileged_mode,omitempty"`
+	KMSKeyARN                string            `json:"kms_key_arn,omitempty"`
+	CacheType                string            `json:"cache_type,omitempty"`
+	CacheLocation            string            `json:"cache_location,omitempty"`
+	LogTypes                 []string          `json:"log_types,omitempty"`
+	VPCID                    string            `json:"vpc_id,omitempty"`
+	SubnetIDs                []string          `json:"subnet_ids,omitempty"`
+	SecurityGroupIDs         []string          `json:"security_group_ids,omitempty"`
+	EnvironmentKeys          []string          `json:"environment_keys,omitempty"`
+	SecretRefs               []string          `json:"secret_refs,omitempty"`
+	Tags                     map[string]string `json:"tags,omitempty"`
+	Source                   string            `json:"source"`
+	EvidenceRef              string            `json:"evidence_ref"`
+	FromNodeID               string            `json:"from_node_id"`
+	ToNodeID                 string            `json:"to_node_id,omitempty"`
+	RelationshipType         string            `json:"relationship_type"`
+	Confidence               float64           `json:"confidence"`
+	CollectedAt              time.Time         `json:"collected_at"`
+	Status                   string            `json:"status"`
+}
+
+// AWSCodeBuildServiceRoleRelationship is the graph evidence exposed by the API.
+type AWSCodeBuildServiceRoleRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSCodeBuildServiceRoleDiagnostic is one explicit non-success state.
+type AWSCodeBuildServiceRoleDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// GetAWSCodeBuildServiceRoleInventory returns scoped deterministic CodeBuild service-role inventory.
+func (s *Service) GetAWSCodeBuildServiceRoleInventory(ctx context.Context, workspaceID string, projectID string, request AWSCodeBuildServiceRoleInventoryRequest) (AWSCodeBuildServiceRoleInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSCodeBuildServiceRoleInventoryResult{}, err
+	}
+	var connection AWSConnectionStatus
+	hasConnection := false
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSCodeBuildServiceRoleInventoryResult{}, err
+	}
+	return buildAWSCodeBuildServiceRoleInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSCodeBuildServiceRoleInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSCodeBuildServiceRoleInventoryRequest, checkedAt time.Time) (AWSCodeBuildServiceRoleInventoryResult, error) {
+	fixtureState := normalizeAWSCodeBuildServiceRoleFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSCodeBuildServiceRoleInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics := awsCodeBuildServiceRoleFixtureRecords(scope, project, connectorID, accountID, region, fixtureState, checkedAt)
+
+	for _, record := range records {
+		if strings.TrimSpace(record.RoleARN) == "" {
+			continue
+		}
+		if _, err := awscontract.NormalizeServiceCollectorRecord(awscontract.ServiceCollectorRecord{
+			TenantID:      scope.TenantID,
+			WorkspaceID:   project.WorkspaceID,
+			ProjectID:     project.ProjectID,
+			ConnectorID:   connectorID,
+			AccountID:     record.AccountID,
+			Region:        record.Region,
+			Service:       record.Service,
+			WorkloadID:    record.WorkloadID,
+			WorkloadType:  record.WorkloadType,
+			WorkloadName:  record.WorkloadName,
+			RoleARN:       record.RoleARN,
+			Source:        record.Source,
+			EvidenceRef:   record.EvidenceRef,
+			Confidence:    record.Confidence,
+			ScanID:        "aws-codebuild-service-role-fixture",
+			CollectorName: "codebuild_service_role",
+			CollectedAt:   checkedAt,
+		}); err != nil {
+			return AWSCodeBuildServiceRoleInventoryResult{}, fmt.Errorf("validate codebuild service role contract record: %w", err)
+		}
+	}
+
+	status, confidence, failures, remediations := summarizeAWSCodeBuildServiceRoleInventory(fixtureState, diagnostics)
+	relationships := awsCodeBuildServiceRoleRelationships(records)
+	result := AWSCodeBuildServiceRoleInventoryResult{
+		TenantID:               scope.TenantID,
+		WorkspaceID:            project.WorkspaceID,
+		ProjectID:              project.ProjectID,
+		ConnectorID:            connectorID,
+		AccountID:              accountID,
+		Region:                 region,
+		ParentIssueNumber:      awsPlatformDependencyParentIssue,
+		ParentIssueRef:         awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:     awsCodeBuildServiceRoleCurrentIssue,
+		CurrentIssueRef:        awsIssueRef(awsCodeBuildServiceRoleCurrentIssue),
+		Version:                awsCodeBuildServiceRoleVersion,
+		Status:                 status,
+		FixtureState:           fixtureState,
+		Confidence:             confidence,
+		RecordCount:            len(records),
+		ProjectCount:           awsCodeBuildServiceRoleProjectCount(records),
+		IdentityCount:          awsCodeBuildServiceRoleIdentityCount(records),
+		ResourceCount:          awsCodeBuildServiceRoleResourceCount(records),
+		RelationshipCount:      len(relationships),
+		SecretRefCount:         awsCodeBuildServiceRoleSecretRefCount(records),
+		VPCProjectCount:        awsCodeBuildServiceRoleVPCProjectCount(records),
+		PublicProjectCount:     awsCodeBuildServiceRolePublicProjectCount(records),
+		PrivilegedProjectCount: awsCodeBuildServiceRolePrivilegedProjectCount(records),
+		FailureReasons:         failures,
+		RemediationHints:       remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsCodeBuildServiceRoleCurrentIssue),
+			"/docs/aws-codebuild-service-roles",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsCodeBuildServiceRoleDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}
+	return result, nil
+}
+
+func normalizeAWSCodeBuildServiceRoleFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsCodeBuildServiceRoleFixtureRecords(_ db.Scope, _ db.TenancyProject, _ string, accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSCodeBuildServiceRoleRecord, []providers.SourceError) {
+	baseRecord := func(projectName string, roleARN string) AWSCodeBuildServiceRoleRecord {
+		projectARN := fmt.Sprintf("arn:aws:codebuild:%s:%s:project/%s", region, accountID, projectName)
+		status := "ready"
+		if strings.TrimSpace(roleARN) == "" {
+			status = "degraded"
+		}
+		return AWSCodeBuildServiceRoleRecord{
+			AccountID:         accountID,
+			Region:            region,
+			Service:           "codebuild",
+			WorkloadID:        projectARN,
+			WorkloadType:      "codebuild_project",
+			WorkloadName:      projectName,
+			RoleARN:           roleARN,
+			RoleName:          roleNameFromARNForAPI(roleARN),
+			ProjectARN:        projectARN,
+			ProjectName:       projectName,
+			ProjectVisibility: "PRIVATE",
+			Source:            "batchgetprojects",
+			EvidenceRef:       projectARN,
+			FromNodeID:        awsCodeBuildProjectNodeID(accountID, region, projectARN),
+			ToNodeID:          awsIdentityNodeIDForAPI(roleARN),
+			RelationshipType:  "runs_as",
+			Confidence:        0.96,
+			CollectedAt:       checkedAt,
+			Status:            status,
+		}
+	}
+
+	buildRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/payments-codebuild-service", accountID)
+	build := baseRecord("payments-build", buildRoleARN)
+	build.ProjectDescription = "Builds the payments service"
+	build.SourceType = "GITHUB"
+	build.SourceLocation = "https://github.com/example/payments"
+	build.SourceAuthType = "CODECONNECTIONS"
+	build.SourceVersion = "main"
+	build.SourceIdentifiers = []string{"GITHUB=https://github.com/example/payments"}
+	build.ArtifactTypes = []string{"S3"}
+	build.ArtifactLocations = []string{"payments-build-artifacts"}
+	build.EnvironmentType = "LINUX_CONTAINER"
+	build.ComputeType = "BUILD_GENERAL1_SMALL"
+	build.Image = "aws/codebuild/standard:7.0"
+	build.ImagePullCredentialsType = "CODEBUILD"
+	build.KMSKeyARN = fmt.Sprintf("arn:aws:kms:%s:%s:key/codebuild-artifacts", region, accountID)
+	build.CacheType = "LOCAL"
+	build.LogTypes = []string{"cloudwatch"}
+	build.VPCID = "vpc-prod"
+	build.SubnetIDs = []string{"subnet-a", "subnet-b"}
+	build.SecurityGroupIDs = []string{"sg-codebuild-payments"}
+	build.EnvironmentKeys = []string{"APP_ENV", "DATABASE_PASSWORD", "NPM_TOKEN"}
+	build.SecretRefs = []string{
+		fmt.Sprintf("DATABASE_PASSWORD=SECRETS_MANAGER:arn:aws:secretsmanager:%s:%s:secret:codebuild/payments-db", region, accountID),
+		"NPM_TOKEN=PARAMETER_STORE:/ci/npm/token",
+	}
+	build.Tags = map[string]string{"owner": "platform", "service": "payments"}
+	build.Confidence = 0.94
+
+	lintRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/frontend-codebuild-service", accountID)
+	lint := baseRecord("frontend-lint", lintRoleARN)
+	lint.SourceType = "CODEPIPELINE"
+	lint.ArtifactTypes = []string{"CODEPIPELINE"}
+	lint.EnvironmentType = "LINUX_CONTAINER"
+	lint.ComputeType = "BUILD_GENERAL1_SMALL"
+	lint.Image = "aws/codebuild/amazonlinux-x86_64-standard:5.0"
+	lint.EnvironmentKeys = []string{"APP_ENV"}
+	lint.LogTypes = []string{"cloudwatch"}
+	lint.Tags = map[string]string{"owner": "web", "service": "frontend"}
+
+	degraded := build
+	degraded.ProjectVisibility = "PUBLIC_READ"
+	degraded.PrivilegedMode = true
+	degraded.Status = "degraded"
+	degraded.Confidence = 0.88
+
+	switch fixtureState {
+	case "empty":
+		return nil, nil
+	case "degraded":
+		return []AWSCodeBuildServiceRoleRecord{degraded}, []providers.SourceError{{
+			Collector: "aws_codebuild/codebuild_service_role",
+			SourceID:  degraded.ProjectARN,
+			Code:      "privileged_or_public_project",
+			Message:   "CodeBuild service-role evidence is visible, but the project is public or uses privileged builds",
+			Retryable: false,
+		}}
+	case "partial_failure":
+		return []AWSCodeBuildServiceRoleRecord{build}, []providers.SourceError{{
+			Collector: "aws_codebuild/codebuild_service_role",
+			SourceID:  fmt.Sprintf("service=codebuild|account=%s|region=%s|source=batchgetprojects", accountID, region),
+			Code:      "project_batch_get_failed",
+			Message:   "One CodeBuild project metadata batch could not be listed; successful service-role evidence remains visible",
+			Retryable: true,
+		}}
+	case "permission_denied":
+		return nil, []providers.SourceError{{
+			Collector: "aws_codebuild/codebuild_service_role",
+			SourceID:  fmt.Sprintf("service=codebuild|account=%s|region=%s|source=listprojects", accountID, region),
+			Code:      "permission_denied",
+			Message:   "Read-only CodeBuild ListProjects or BatchGetProjects permission is missing",
+			Retryable: false,
+		}}
+	default:
+		return []AWSCodeBuildServiceRoleRecord{build, lint}, nil
+	}
+}
+
+func summarizeAWSCodeBuildServiceRoleInventory(fixtureState string, diagnostics []providers.SourceError) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35, []string{"codebuild service role collection is blocked by missing read-only permission"}, []string{"Grant codebuild:ListProjects and codebuild:BatchGetProjects for metadata-only collection."}
+	case "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.68, []string{"one or more CodeBuild projects are public or use privileged builds"}, []string{"Keep service-role evidence visible and review public/privileged project settings before treating blast radius as low."}
+	case "partial_failure":
+		return awsPlatformDependencyStatusDegraded, 0.76, []string{"one CodeBuild metadata partition failed while successful project-role records remain visible"}, []string{"Retry the failed CodeBuild metadata call without discarding successful service-role evidence."}
+	default:
+		if len(diagnostics) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.8, []string{"codebuild service role collection returned diagnostics"}, []string{"Review diagnostics before treating CodeBuild coverage as complete."}
+		}
+		return awsPlatformDependencyStatusReady, 0.97, nil, nil
+	}
+}
+
+func awsCodeBuildServiceRoleRelationships(records []AWSCodeBuildServiceRoleRecord) []AWSCodeBuildServiceRoleRelationship {
+	result := make([]AWSCodeBuildServiceRoleRelationship, 0, len(records))
+	for _, record := range records {
+		if strings.TrimSpace(record.FromNodeID) == "" || strings.TrimSpace(record.ToNodeID) == "" {
+			continue
+		}
+		result = append(result, AWSCodeBuildServiceRoleRelationship{
+			Type:        "runs_as",
+			FromNodeID:  record.FromNodeID,
+			ToNodeID:    record.ToNodeID,
+			EvidenceRef: record.EvidenceRef,
+		})
+	}
+	return result
+}
+
+func awsCodeBuildServiceRoleProjectCount(records []AWSCodeBuildServiceRoleRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if strings.TrimSpace(record.FromNodeID) != "" {
+			seen[record.FromNodeID] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsCodeBuildServiceRoleIdentityCount(records []AWSCodeBuildServiceRoleRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if strings.TrimSpace(record.ToNodeID) != "" {
+			seen[record.ToNodeID] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsCodeBuildServiceRoleResourceCount(records []AWSCodeBuildServiceRoleRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if strings.TrimSpace(record.ProjectARN) != "" {
+			seen[record.ProjectARN] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsCodeBuildServiceRoleSecretRefCount(records []AWSCodeBuildServiceRoleRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		for _, ref := range record.SecretRefs {
+			if strings.TrimSpace(ref) != "" {
+				seen[ref] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
+}
+
+func awsCodeBuildServiceRoleVPCProjectCount(records []AWSCodeBuildServiceRoleRecord) int {
+	count := 0
+	for _, record := range records {
+		if strings.TrimSpace(record.VPCID) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func awsCodeBuildServiceRolePublicProjectCount(records []AWSCodeBuildServiceRoleRecord) int {
+	count := 0
+	for _, record := range records {
+		if strings.EqualFold(record.ProjectVisibility, "PUBLIC_READ") {
+			count++
+		}
+	}
+	return count
+}
+
+func awsCodeBuildServiceRolePrivilegedProjectCount(records []AWSCodeBuildServiceRoleRecord) int {
+	count := 0
+	for _, record := range records {
+		if record.PrivilegedMode {
+			count++
+		}
+	}
+	return count
+}
+
+func awsCodeBuildServiceRoleDiagnostics(diagnostics []providers.SourceError) []AWSCodeBuildServiceRoleDiagnostic {
+	result := make([]AWSCodeBuildServiceRoleDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSCodeBuildServiceRoleDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: awsCodeBuildServiceRoleDiagnosticRemediation(diagnostic.Code),
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func awsCodeBuildServiceRoleDiagnosticRemediation(code string) string {
+	switch code {
+	case "permission_denied":
+		return "Grant metadata-only CodeBuild read permissions; do not add build log, source, artifact, or secret-value reads."
+	case "privileged_or_public_project":
+		return "Review public visibility and privileged build settings before using the service role in least-privilege reasoning."
+	case "project_batch_get_failed", "project_not_found":
+		return "Retry only the failed CodeBuild metadata call and keep successful project-role records visible."
+	case "missing_codebuild_service_role":
+		return "Inspect the CodeBuild project service role configuration before using it for least-privilege reasoning."
+	default:
+		return "Review the CodeBuild collector diagnostic and retry after the scoped AWS metadata issue is corrected."
+	}
+}
+
+func awsCodeBuildProjectNodeID(accountID string, region string, projectARN string) string {
+	account := strings.TrimSpace(accountID)
+	if account == "" {
+		account = "account"
+	}
+	trimmedRegion := strings.TrimSpace(region)
+	if trimmedRegion == "" {
+		trimmedRegion = "region"
+	}
+	normalizedProjectARN := strings.TrimSpace(projectARN)
+	if normalizedProjectARN == "" {
+		normalizedProjectARN = "project"
+	}
+	return fmt.Sprintf("aws:workload:codebuild:%s:%s:project/%s", account, trimmedRegion, normalizedProjectARN)
+}

--- a/internal/api/aws_codebuild_service_roles_test.go
+++ b/internal/api/aws_codebuild_service_roles_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSCodeBuildServiceRoleInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 6, 9, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCodeBuildServiceRoleInventory(ctx, "default", "project-a", AWSCodeBuildServiceRoleInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get codebuild service role inventory: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1481" || result.Version != awsCodeBuildServiceRoleVersion {
+		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
+	}
+	if result.ConnectorID != "aws-prod" || result.AccountID != "123456789012" || result.Region != "us-east-1" {
+		t.Fatalf("expected connector account/region context, got %+v", result)
+	}
+	if result.RecordCount != 2 || result.ProjectCount != 2 || result.IdentityCount != 2 || result.ResourceCount != 2 || result.RelationshipCount != 2 {
+		t.Fatalf("unexpected inventory counts: %+v", result)
+	}
+	if result.SecretRefCount != 2 || result.VPCProjectCount != 1 || result.PublicProjectCount != 0 || result.PrivilegedProjectCount != 0 {
+		t.Fatalf("unexpected CodeBuild metadata counts: %+v", result)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("did not expect diagnostics for success fixture: %+v", result.Diagnostics)
+	}
+	if result.Records[0].RelationshipType != "runs_as" || result.Records[0].ProjectARN == "" || result.Records[0].RoleARN == "" {
+		t.Fatalf("expected CodeBuild runs_as evidence, got %+v", result.Records[0])
+	}
+	if len(result.Records[0].EnvironmentKeys) != 3 || strings.Contains(strings.Join(result.Records[0].EnvironmentKeys, ","), "must-not-appear") {
+		t.Fatalf("expected environment keys without values, got %+v", result.Records[0])
+	}
+	if result.GeneratedAt != now || result.UpdatedAt != now {
+		t.Fatalf("expected deterministic timestamps %v, got %v/%v", now, result.GeneratedAt, result.UpdatedAt)
+	}
+}
+
+func TestGetAWSCodeBuildServiceRoleInventorySurfacesPrivilegedPublicProject(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 6, 9, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCodeBuildServiceRoleInventory(ctx, "default", "project-a", AWSCodeBuildServiceRoleInventoryRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "degraded",
+	})
+	if err != nil {
+		t.Fatalf("get degraded codebuild service role inventory: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded || len(result.FailureReasons) == 0 {
+		t.Fatalf("expected degraded result with failure reason, got %+v", result)
+	}
+	if result.RecordCount != 1 || len(result.Diagnostics) != 1 || result.PublicProjectCount != 1 || result.PrivilegedProjectCount != 1 {
+		t.Fatalf("expected retained record, public/privileged counts, and diagnostic, got %+v", result)
+	}
+	if result.Diagnostics[0].Code != "privileged_or_public_project" || result.Records[0].Status != "degraded" || !result.Records[0].PrivilegedMode {
+		t.Fatalf("expected explicit public/privileged state, got record=%+v diagnostics=%+v", result.Records[0], result.Diagnostics)
+	}
+}
+
+func TestRouterAWSCodeBuildServiceRoleInventory(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 6, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/codebuild-service-roles?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSCodeBuildServiceRoleInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
+		t.Fatalf("expected partial failure fixture, got %+v", body.Inventory)
+	}
+	if body.Inventory.RecordCount != 1 || len(body.Inventory.Diagnostics) != 1 || !body.Inventory.Diagnostics[0].Retryable {
+		t.Fatalf("expected retained record and retryable diagnostic, got %+v", body.Inventory)
+	}
+}
+
+func TestAWSCodeBuildServiceRoleInventoryHelperBranches(t *testing.T) {
+	disconnected := AWSConnectionStatus{Connected: false}
+	if got := normalizeAWSCodeBuildServiceRoleFixtureState("", disconnected, true); got != "permission_denied" {
+		t.Fatalf("expected disconnected connector to map to permission_denied, got %q", got)
+	}
+	if got := normalizeAWSCodeBuildServiceRoleFixtureState("bogus", AWSConnectionStatus{}, false); got != "" {
+		t.Fatalf("expected unknown fixture state to be rejected, got %q", got)
+	}
+	if got := normalizeAWSCodeBuildServiceRoleFixtureState("EMPTY", AWSConnectionStatus{}, false); got != "empty" {
+		t.Fatalf("expected explicit fixture state normalization, got %q", got)
+	}
+
+	status, confidence, failures, remediations := summarizeAWSCodeBuildServiceRoleInventory("success", []providers.SourceError{{
+		Code:      "project_not_found",
+		Message:   "project unavailable",
+		Retryable: true,
+	}})
+	if status != awsPlatformDependencyStatusDegraded || confidence != 0.8 || len(failures) != 1 || len(remediations) != 1 {
+		t.Fatalf("expected diagnostics to degrade successful state, got status=%s confidence=%f failures=%+v remediations=%+v", status, confidence, failures, remediations)
+	}
+
+	for _, code := range []string{"permission_denied", "privileged_or_public_project", "project_not_found", "missing_codebuild_service_role", "unknown"} {
+		if remediation := awsCodeBuildServiceRoleDiagnosticRemediation(code); strings.TrimSpace(remediation) == "" {
+			t.Fatalf("expected remediation for %q", code)
+		}
+	}
+
+	relationships := awsCodeBuildServiceRoleRelationships([]AWSCodeBuildServiceRoleRecord{
+		{FromNodeID: "codebuild-project", ToNodeID: "codebuild-role", EvidenceRef: "evidence"},
+		{FromNodeID: "", ToNodeID: "skipped", EvidenceRef: "missing-from"},
+	})
+	if len(relationships) != 1 || relationships[0].Type != "runs_as" {
+		t.Fatalf("expected one valid relationship, got %+v", relationships)
+	}
+	if got := awsCodeBuildProjectNodeID("", "", ""); !strings.Contains(got, "account") || !strings.Contains(got, "project/project") {
+		t.Fatalf("expected fallback codebuild project node id, got %q", got)
+	}
+}

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -205,6 +205,7 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 		"AWSPlatformDependencyIndexResult:",
 		"AWSPlatformValidationHarnessResult:",
 		"AWSLambdaExecutionRoleInventoryResult:",
+		"AWSCodeBuildServiceRoleInventoryResult:",
 		"GitHubConnectionStartRequest:",
 		"GitHubConnectionCompleteRequest:",
 		"GitHubConnectionRepositorySelectionRequest:",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2609,6 +2609,32 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/codebuild-service-roles", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSCodeBuildServiceRoleInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSCodeBuildServiceRoleInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws codebuild service role request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws codebuild service role inventory", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws codebuild service role inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -606,6 +606,10 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws lambda execution role collector: %w", err)
 			}
+			codeBuildAPI, err := awsprovider.NewSDKCodeBuildServiceRoleAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if err != nil {
+				return app.Scanner{}, fmt.Errorf("initialize aws codebuild service role collector: %w", err)
+			}
 			eksAPI, err := awsprovider.NewSDKEKSWorkloadIdentityAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws eks workload identity collector: %w", err)
@@ -614,6 +618,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewEC2InstanceProfileCollector(ec2API),
 				awsprovider.NewECSTaskRoleCollector(ecsAPI),
 				awsprovider.NewLambdaExecutionRoleCollector(lambdaAPI),
+				awsprovider.NewCodeBuildServiceRoleCollector(codeBuildAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			}, awsprovider.NewRuleSet(
 				awsprovider.WithStaleAfter(time.Duration(staleAfterDays)*24*time.Hour),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "eks"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "eks"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/connectors/aws/cfn_test.go
+++ b/internal/connectors/aws/cfn_test.go
@@ -93,6 +93,9 @@ func TestReadOnlyPolicyDocument(t *testing.T) {
 	if !strings.Contains(string(policy), "eks:ListClusters") || !strings.Contains(string(policy), "eks:DescribePodIdentityAssociation") {
 		t.Fatalf("expected EKS workload identity read actions in policy")
 	}
+	if !strings.Contains(string(policy), "codebuild:ListProjects") || !strings.Contains(string(policy), "codebuild:BatchGetProjects") {
+		t.Fatalf("expected CodeBuild service role read actions in policy")
+	}
 	hash, err := ReadOnlyPolicyHash()
 	if err != nil {
 		t.Fatalf("hash policy: %v", err)
@@ -105,6 +108,9 @@ func TestReadOnlyPolicyDocument(t *testing.T) {
 	}
 	if !permissionPreviewContainsService(PermissionPreview(), "EKS") {
 		t.Fatalf("expected EKS permission preview entry")
+	}
+	if !permissionPreviewContainsService(PermissionPreview(), "CodeBuild") {
+		t.Fatalf("expected CodeBuild permission preview entry")
 	}
 }
 

--- a/internal/connectors/aws/iam_policy.go
+++ b/internal/connectors/aws/iam_policy.go
@@ -53,6 +53,15 @@ const readOnlyPolicyJSON = `{
       "Resource": "*"
     },
     {
+      "Sid": "IdentityTrustGraphReadOnlyCodeBuild",
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetProjects",
+        "codebuild:ListProjects"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "IdentityTrustGraphReadOnlyEKS",
       "Effect": "Allow",
       "Action": [
@@ -175,6 +184,15 @@ func PermissionPreview() []PermissionPreviewItem {
 			},
 			Resources: []string{"*"},
 			Reason:    "Maps ECS services and task definitions back to task roles, execution roles, container images, and metadata-only secret references.",
+		},
+		{
+			Service: "CodeBuild",
+			Actions: []string{
+				"codebuild:ListProjects",
+				"codebuild:BatchGetProjects",
+			},
+			Resources: []string{"*"},
+			Reason:    "Maps CodeBuild projects back to service roles, project sources, artifacts, VPC metadata, and metadata-only secret references.",
 		},
 		{
 			Service: "EKS",

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -68,6 +68,7 @@ const (
 	ResourceTypeECSTask            ResourceType = "ecs_task"
 	ResourceTypeEKSCluster         ResourceType = "eks_cluster"
 	ResourceTypeEKSWorkload        ResourceType = "eks_workload"
+	ResourceTypeCodeBuildProject   ResourceType = "codebuild_project"
 	ResourceTypeBedrockAgentCore   ResourceType = "bedrock_agentcore"
 	ResourceTypeTool               ResourceType = "tool"
 	ResourceTypeAccessNode         ResourceType = "access_node"

--- a/internal/providers/aws/codebuild_service_role_collector.go
+++ b/internal/providers/aws/codebuild_service_role_collector.go
@@ -208,7 +208,19 @@ func (c *CodeBuildServiceRoleCollector) CollectWithDiagnostics(ctx context.Conte
 			return c.client.ListServiceRoles(callCtx, nextToken, c.pageSize)
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list codebuild service roles page %d: %w", page, err)
+			wrapped := fmt.Errorf("list codebuild service roles page %d: %w", page, err)
+			c.addIssue(providers.SourceError{
+				Collector: codeBuildServiceRoleCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "codebuild_service_role_page_failed",
+				Message:   wrapped.Error(),
+				Retryable: isRetryable(err),
+			})
+			issues := append([]providers.SourceError(nil), c.issues...)
+			if len(assets) > 0 {
+				return assets, issues, wrapped
+			}
+			return nil, issues, wrapped
 		}
 		for _, diagnostic := range response.Diagnostics {
 			c.addIssue(diagnostic)

--- a/internal/providers/aws/codebuild_service_role_collector.go
+++ b/internal/providers/aws/codebuild_service_role_collector.go
@@ -1,0 +1,366 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindCodeBuildServiceRole       = "codebuild_service_role"
+	codeBuildServiceRoleCollectorName = "codebuild_service_role"
+	codeBuildServiceName              = "codebuild"
+)
+
+// CodeBuildServiceRole captures CodeBuild project-to-service-role evidence. It
+// stores metadata only: environment values, source contents, logs, and artifacts
+// are never collected.
+type CodeBuildServiceRole struct {
+	awscontract.ServiceCollectorRecord
+	RoleName                 string            `json:"role_name,omitempty"`
+	ProjectARN               string            `json:"project_arn,omitempty"`
+	ProjectName              string            `json:"project_name,omitempty"`
+	ProjectDescription       string            `json:"project_description,omitempty"`
+	ProjectVisibility        string            `json:"project_visibility,omitempty"`
+	SourceType               string            `json:"source_type,omitempty"`
+	SourceLocation           string            `json:"source_location,omitempty"`
+	SourceAuthType           string            `json:"source_auth_type,omitempty"`
+	SourceVersion            string            `json:"source_version,omitempty"`
+	SourceIdentifiers        []string          `json:"source_identifiers,omitempty"`
+	ArtifactTypes            []string          `json:"artifact_types,omitempty"`
+	ArtifactLocations        []string          `json:"artifact_locations,omitempty"`
+	EnvironmentType          string            `json:"environment_type,omitempty"`
+	ComputeType              string            `json:"compute_type,omitempty"`
+	Image                    string            `json:"image,omitempty"`
+	ImagePullCredentialsType string            `json:"image_pull_credentials_type,omitempty"`
+	PrivilegedMode           bool              `json:"privileged_mode,omitempty"`
+	KMSKeyARN                string            `json:"kms_key_arn,omitempty"`
+	CacheType                string            `json:"cache_type,omitempty"`
+	CacheLocation            string            `json:"cache_location,omitempty"`
+	LogTypes                 []string          `json:"log_types,omitempty"`
+	VPCID                    string            `json:"vpc_id,omitempty"`
+	SubnetIDs                []string          `json:"subnet_ids,omitempty"`
+	SecurityGroupIDs         []string          `json:"security_group_ids,omitempty"`
+	EnvironmentKeys          []string          `json:"environment_keys,omitempty"`
+	SecretRefs               []string          `json:"secret_refs,omitempty"`
+	Tags                     map[string]string `json:"tags,omitempty"`
+}
+
+// CodeBuildServiceRolePage is one page of CodeBuild service-role inventory.
+type CodeBuildServiceRolePage struct {
+	Records     []CodeBuildServiceRole
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+// CodeBuildServiceRoleAPI defines the metadata-only CodeBuild operations used by the collector.
+type CodeBuildServiceRoleAPI interface {
+	ListServiceRoles(ctx context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error)
+}
+
+// CodeBuildServiceRoleCollector collects CodeBuild service-role machine identities.
+type CodeBuildServiceRoleCollector struct {
+	client   CodeBuildServiceRoleAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+	issues   []providers.SourceError
+}
+
+// CodeBuildServiceRoleOption customizes CodeBuildServiceRoleCollector behavior.
+type CodeBuildServiceRoleOption func(*CodeBuildServiceRoleCollector)
+
+// WithCodeBuildServiceRolePageSize configures CodeBuild batch size.
+func WithCodeBuildServiceRolePageSize(pageSize int32) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+// WithCodeBuildServiceRoleMaxPages limits list pagination to guard against runaways.
+func WithCodeBuildServiceRoleMaxPages(maxPages int) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+// WithCodeBuildServiceRoleRetryPolicy customizes retry strategy for transient CodeBuild errors.
+func WithCodeBuildServiceRoleRetryPolicy(policy RetryPolicy) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if policy.MaxRetries >= 0 {
+			c.retry.MaxRetries = policy.MaxRetries
+		}
+		if policy.BaseDelay > 0 {
+			c.retry.BaseDelay = policy.BaseDelay
+		}
+		if policy.MaxDelay > 0 {
+			c.retry.MaxDelay = policy.MaxDelay
+		}
+	}
+}
+
+// WithCodeBuildServiceRoleRetryJitterRatio configures bounded random jitter around retry backoff.
+func WithCodeBuildServiceRoleRetryJitterRatio(ratio float64) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if ratio < 0 {
+			ratio = 0
+		}
+		c.jitter = ratio
+	}
+}
+
+// WithCodeBuildServiceRoleRetryRandFunc injects deterministic randomness for retry jitter tests.
+func WithCodeBuildServiceRoleRetryRandFunc(randFn func() float64) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if randFn != nil {
+			c.randFn = randFn
+		}
+	}
+}
+
+// WithCodeBuildServiceRoleSleeper injects a testable sleep function.
+func WithCodeBuildServiceRoleSleeper(s Sleeper) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if s != nil {
+			c.sleep = s
+		}
+	}
+}
+
+// WithCodeBuildServiceRoleClock injects a deterministic clock.
+func WithCodeBuildServiceRoleClock(now func() time.Time) CodeBuildServiceRoleOption {
+	return func(c *CodeBuildServiceRoleCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// NewCodeBuildServiceRoleCollector creates a read-only CodeBuild service-role collector.
+func NewCodeBuildServiceRoleCollector(client CodeBuildServiceRoleAPI, opts ...CodeBuildServiceRoleOption) *CodeBuildServiceRoleCollector {
+	c := &CodeBuildServiceRoleCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *CodeBuildServiceRoleCollector) ServiceName() string {
+	return codeBuildServiceName
+}
+
+// Collect pulls CodeBuild service-role assets using an empty scope.
+func (c *CodeBuildServiceRoleCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: codeBuildServiceName})
+	return assets, err
+}
+
+// CollectWithDiagnostics pulls CodeBuild service-role assets and includes non-fatal source errors.
+func (c *CodeBuildServiceRoleCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("codebuild service role collector requires client")
+	}
+	c.issues = c.issues[:0]
+
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+
+	assets := make([]providers.RawAsset, 0, c.pageSize)
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			return nil, nil, fmt.Errorf("codebuild service role collection exceeded max pages (%d)", c.maxPages)
+		}
+
+		response, err := c.withRetry(ctx, func(callCtx context.Context) (CodeBuildServiceRolePage, error) {
+			return c.client.ListServiceRoles(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("list codebuild service roles page %d: %w", page, err)
+		}
+		for _, diagnostic := range response.Diagnostics {
+			c.addIssue(diagnostic)
+		}
+
+		for _, record := range response.Records {
+			normalized := normalizeCodeBuildServiceRoleScope(scope, record, collectedAt)
+			if strings.TrimSpace(normalized.WorkloadID) == "" || strings.TrimSpace(normalized.ProjectARN) == "" {
+				c.addIssue(providers.SourceError{
+					Collector: codeBuildServiceRoleCollectorName,
+					Code:      "malformed_source_record",
+					Message:   "skipped CodeBuild service role record without project identity",
+					Retryable: false,
+				})
+				continue
+			}
+			if strings.TrimSpace(normalized.RoleARN) == "" {
+				c.addIssue(providers.SourceError{
+					Collector: codeBuildServiceRoleCollectorName,
+					SourceID:  firstNonEmptyAWSValue(normalized.ProjectARN, normalized.ProjectName, normalized.WorkloadID),
+					Code:      "missing_codebuild_service_role",
+					Message:   "CodeBuild project did not include a service role ARN",
+					Retryable: false,
+				})
+				continue
+			}
+
+			sourceID := codeBuildServiceRoleSourceID(normalized)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, err := json.Marshal(normalized)
+			if err != nil {
+				return nil, nil, fmt.Errorf("marshal codebuild service role %q: %w", sourceID, err)
+			}
+
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindCodeBuildServiceRole,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+
+		if response.NextToken == "" {
+			break
+		}
+		nextToken = response.NextToken
+	}
+
+	issues := append([]providers.SourceError(nil), c.issues...)
+	return assets, issues, nil
+}
+
+func (c *CodeBuildServiceRoleCollector) withRetry(ctx context.Context, fn func(context.Context) (CodeBuildServiceRolePage, error)) (CodeBuildServiceRolePage, error) {
+	return retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, fn)
+}
+
+func (c *CodeBuildServiceRoleCollector) backoff(attempt int) time.Duration {
+	return awsRetryBackoff(c.retry, c.jitter, c.randFn, attempt)
+}
+
+func (c *CodeBuildServiceRoleCollector) addIssue(issue providers.SourceError) {
+	if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+		return
+	}
+	c.issues = append(c.issues, issue)
+}
+
+func normalizeCodeBuildServiceRoleScope(scope AWSCollectorScope, record CodeBuildServiceRole, collectedAt time.Time) CodeBuildServiceRole {
+	normalized := record
+	normalized.AccountID = firstNonEmptyAWSValue(record.AccountID, scope.AccountID)
+	normalized.Region = firstNonEmptyAWSValue(record.Region, scope.Region)
+	normalized.Service = firstNonEmptyAWSValue(record.Service, codeBuildServiceName)
+	normalized.RoleARN = strings.TrimSpace(record.RoleARN)
+	normalized.RoleName = firstNonEmptyAWSValue(record.RoleName, roleNameFromARN(record.RoleARN))
+	normalized.ProjectARN = strings.TrimSpace(record.ProjectARN)
+	normalized.ProjectName = firstNonEmptyAWSValue(record.ProjectName, codeBuildProjectNameFromARN(record.ProjectARN))
+	normalized.ProjectDescription = strings.TrimSpace(record.ProjectDescription)
+	normalized.ProjectVisibility = strings.TrimSpace(record.ProjectVisibility)
+	normalized.SourceType = strings.TrimSpace(record.SourceType)
+	normalized.SourceLocation = strings.TrimSpace(record.SourceLocation)
+	normalized.SourceAuthType = strings.TrimSpace(record.SourceAuthType)
+	normalized.SourceVersion = strings.TrimSpace(record.SourceVersion)
+	normalized.SourceIdentifiers = normalizeStringList(record.SourceIdentifiers)
+	normalized.ArtifactTypes = normalizeStringList(record.ArtifactTypes)
+	normalized.ArtifactLocations = normalizeStringList(record.ArtifactLocations)
+	normalized.EnvironmentType = strings.TrimSpace(record.EnvironmentType)
+	normalized.ComputeType = strings.TrimSpace(record.ComputeType)
+	normalized.Image = strings.TrimSpace(record.Image)
+	normalized.ImagePullCredentialsType = strings.TrimSpace(record.ImagePullCredentialsType)
+	normalized.KMSKeyARN = strings.TrimSpace(record.KMSKeyARN)
+	normalized.CacheType = strings.TrimSpace(record.CacheType)
+	normalized.CacheLocation = strings.TrimSpace(record.CacheLocation)
+	normalized.LogTypes = normalizeStringList(record.LogTypes)
+	normalized.VPCID = strings.TrimSpace(record.VPCID)
+	normalized.SubnetIDs = normalizeStringList(record.SubnetIDs)
+	normalized.SecurityGroupIDs = normalizeStringList(record.SecurityGroupIDs)
+	normalized.EnvironmentKeys = normalizeStringList(record.EnvironmentKeys)
+	normalized.SecretRefs = normalizeStringList(record.SecretRefs)
+	normalized.Tags = copyTags(record.Tags)
+	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, "codebuild_project")
+	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.ProjectARN, normalized.ProjectName)
+	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.ProjectName, codeBuildProjectNameFromARN(normalized.ProjectARN), normalized.ProjectARN)
+	normalized.Source = firstNonEmptyAWSValue(record.Source, "batchgetprojects")
+	normalized.EvidenceRef = firstNonEmptyAWSValue(record.EvidenceRef, normalized.ProjectARN, normalized.RoleARN)
+	normalized.CollectorName = firstNonEmptyAWSValue(record.CollectorName, codeBuildServiceRoleCollectorName)
+	normalized.ScanID = firstNonEmptyAWSValue(record.ScanID, scope.ScanID, "aws-codebuild-service-role-fixture")
+	normalized.ConnectorID = firstNonEmptyAWSValue(record.ConnectorID, scope.ConnectorID, "aws-connector")
+	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
+	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
+	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
+	normalized.CollectedAt = collectedAt
+	if normalized.Confidence <= 0 {
+		normalized.Confidence = codeBuildServiceRoleConfidence(normalized)
+	}
+	return normalized
+}
+
+func codeBuildServiceRoleConfidence(record CodeBuildServiceRole) float64 {
+	if record.PrivilegedMode || strings.EqualFold(record.ProjectVisibility, "PUBLIC_READ") {
+		return 0.88
+	}
+	if len(record.SecretRefs) > 0 {
+		return 0.94
+	}
+	return 0.96
+}
+
+func codeBuildServiceRoleSourceID(record CodeBuildServiceRole) string {
+	return strings.Join([]string{
+		firstNonEmptyAWSValue(record.AccountID, "account"),
+		firstNonEmptyAWSValue(record.Region, "region"),
+		firstNonEmptyAWSValue(record.ProjectARN, record.WorkloadID, record.ProjectName, "project"),
+		firstNonEmptyAWSValue(record.RoleARN, "no-role"),
+	}, "|")
+}
+
+func codeBuildProjectNameFromARN(arn string) string {
+	trimmed := strings.TrimSpace(arn)
+	if trimmed == "" {
+		return ""
+	}
+	marker := ":project/"
+	idx := strings.Index(trimmed, marker)
+	if idx < 0 {
+		return roleNameFromARN(trimmed)
+	}
+	rest := trimmed[idx+len(marker):]
+	return strings.TrimSpace(rest)
+}
+
+var _ AWSServiceCollector = (*CodeBuildServiceRoleCollector)(nil)
+var _ providers.Collector = (*CodeBuildServiceRoleCollector)(nil)

--- a/internal/providers/aws/codebuild_service_role_collector_test.go
+++ b/internal/providers/aws/codebuild_service_role_collector_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -249,6 +250,72 @@ func TestCodeBuildServiceRoleCollectorRetriesThenCollects(t *testing.T) {
 	}
 	if delays[0] <= 100*time.Millisecond || delays[0] > 125*time.Millisecond {
 		t.Fatalf("expected bounded jittered delay, got %s", delays[0])
+	}
+}
+
+func TestCodeBuildServiceRoleCollectorPreservesAssetsWhenLaterPageFails(t *testing.T) {
+	calls := 0
+	api := codeBuildServiceRoleAPIFunc(func(_ context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error) {
+		calls++
+		if pageSize != 2 {
+			t.Fatalf("expected page size 2, got %d", pageSize)
+		}
+		switch calls {
+		case 1:
+			if nextToken != "" {
+				t.Fatalf("expected first request without token, got %q", nextToken)
+			}
+			return CodeBuildServiceRolePage{
+				Records: []CodeBuildServiceRole{{
+					ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+						WorkloadID:   "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+						WorkloadType: "codebuild_project",
+						WorkloadName: "payments-build",
+						RoleARN:      "arn:aws:iam::123456789012:role/payments-codebuild-service",
+						Source:       "batchgetprojects",
+						EvidenceRef:  "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+					},
+					RoleName:    "payments-codebuild-service",
+					ProjectARN:  "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+					ProjectName: "payments-build",
+				}},
+				NextToken: "page-2",
+			}, nil
+		case 2:
+			if nextToken != "page-2" {
+				t.Fatalf("expected second request with page-2 token, got %q", nextToken)
+			}
+			return CodeBuildServiceRolePage{}, errors.New("batch failed")
+		default:
+			t.Fatalf("unexpected extra page request %d", calls)
+			return CodeBuildServiceRolePage{}, nil
+		}
+	})
+	collector := NewCodeBuildServiceRoleCollector(api, WithCodeBuildServiceRolePageSize(2))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "list codebuild service roles page 2") {
+		t.Fatalf("expected page 2 failure, got %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected earlier page asset to be preserved, got %d assets: %+v", len(assets), assets)
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one page-failure diagnostic, got %+v", diagnostics)
+	}
+	if diagnostics[0].Code != "codebuild_service_role_page_failed" || diagnostics[0].SourceID != "page-2" {
+		t.Fatalf("expected page-failure diagnostic for page-2, got %+v", diagnostics[0])
+	}
+
+	var payload CodeBuildServiceRole
+	if err := json.Unmarshal(assets[0].Payload, &payload); err != nil {
+		t.Fatalf("decode preserved payload: %v", err)
+	}
+	if payload.ProjectName != "payments-build" || payload.RoleARN != "arn:aws:iam::123456789012:role/payments-codebuild-service" {
+		t.Fatalf("expected first-page project evidence, got %+v", payload)
 	}
 }
 

--- a/internal/providers/aws/codebuild_service_role_collector_test.go
+++ b/internal/providers/aws/codebuild_service_role_collector_test.go
@@ -1,0 +1,276 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+type fakeCodeBuildServiceRoleAPI struct {
+	pages []CodeBuildServiceRolePage
+	calls int
+}
+
+type codeBuildServiceRoleAPIFunc func(ctx context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error)
+
+func (f codeBuildServiceRoleAPIFunc) ListServiceRoles(ctx context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error) {
+	return f(ctx, nextToken, pageSize)
+}
+
+func (f *fakeCodeBuildServiceRoleAPI) ListServiceRoles(_ context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error) {
+	f.calls++
+	if pageSize != 2 {
+		return CodeBuildServiceRolePage{}, fakeRetryableError{message: "unexpected page size"}
+	}
+	switch f.calls {
+	case 1:
+		if nextToken != "" {
+			return CodeBuildServiceRolePage{}, fakeRetryableError{message: "unexpected first token"}
+		}
+	case 2:
+		if nextToken != "page-2" {
+			return CodeBuildServiceRolePage{}, fakeRetryableError{message: "unexpected second token"}
+		}
+	}
+	if f.calls > len(f.pages) {
+		return CodeBuildServiceRolePage{}, nil
+	}
+	return f.pages[f.calls-1], nil
+}
+
+func TestCodeBuildServiceRoleCollectorEmitsContractRecordsAndDiagnostics(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 6, 8, 0, 0, 0, time.UTC)
+	api := &fakeCodeBuildServiceRoleAPI{
+		pages: []CodeBuildServiceRolePage{
+			{
+				Records: []CodeBuildServiceRole{
+					{
+						ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+							WorkloadID:   "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+							WorkloadType: "codebuild_project",
+							WorkloadName: "payments-build",
+							RoleARN:      "arn:aws:iam::123456789012:role/payments-codebuild-service",
+							Source:       "batchgetprojects",
+							EvidenceRef:  "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+						},
+						RoleName:        "payments-codebuild-service",
+						ProjectARN:      "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+						ProjectName:     "payments-build",
+						SourceType:      "GITHUB",
+						EnvironmentType: "LINUX_CONTAINER",
+						ComputeType:     "BUILD_GENERAL1_SMALL",
+						Image:           "aws/codebuild/standard:7.0",
+						EnvironmentKeys: []string{"APP_ENV", "DATABASE_PASSWORD"},
+						SecretRefs:      []string{"DATABASE_PASSWORD=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:123456789012:secret:db"},
+						Tags:            map[string]string{"owner": "payments"},
+					},
+				},
+				Diagnostics: []providers.SourceError{{
+					Collector: codeBuildServiceRoleCollectorName,
+					SourceID:  "missing-project",
+					Code:      "project_not_found",
+					Message:   "project disappeared",
+					Retryable: true,
+				}},
+				NextToken: "page-2",
+			},
+			{
+				Records: []CodeBuildServiceRole{
+					{
+						ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+							WorkloadID:   "arn:aws:codebuild:us-east-1:123456789012:project/missing-role",
+							WorkloadType: "codebuild_project",
+							WorkloadName: "missing-role",
+							Source:       "batchgetprojects",
+							EvidenceRef:  "arn:aws:codebuild:us-east-1:123456789012:project/missing-role",
+						},
+						ProjectARN:  "arn:aws:codebuild:us-east-1:123456789012:project/missing-role",
+						ProjectName: "missing-role",
+					},
+				},
+			},
+		},
+	}
+	collector := NewCodeBuildServiceRoleCollector(api, WithCodeBuildServiceRolePageSize(2), WithCodeBuildServiceRoleClock(func() time.Time {
+		return fixedNow
+	}))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		ConnectorID: "aws-prod",
+		ScanID:      "scan-codebuild",
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one valid raw asset, got %d", len(assets))
+	}
+	if len(diagnostics) != 2 || diagnostics[0].Code != "project_not_found" || diagnostics[1].Code != "missing_codebuild_service_role" {
+		t.Fatalf("expected not-found and missing role diagnostics, got %+v", diagnostics)
+	}
+
+	var payload CodeBuildServiceRole
+	if err := json.Unmarshal(assets[0].Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload.Service != "codebuild" || payload.CollectorName != codeBuildServiceRoleCollectorName || payload.ProjectName != "payments-build" {
+		t.Fatalf("expected normalized CodeBuild metadata, got %+v", payload)
+	}
+	if strings.Contains(fmt.Sprint(payload.EnvironmentKeys), "must-not-appear") {
+		t.Fatalf("environment values must not be collected, got %+v", payload.EnvironmentKeys)
+	}
+	if _, err := awscontract.NormalizeServiceCollectorRecord(payload.ServiceCollectorRecord); err != nil {
+		t.Fatalf("expected payload to satisfy service collector contract: %v", err)
+	}
+}
+
+func TestRoleNormalizerAddsCodeBuildServiceRoleRunAsEdge(t *testing.T) {
+	record := CodeBuildServiceRole{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			Service:       "codebuild",
+			WorkloadID:    "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+			WorkloadType:  "codebuild_project",
+			WorkloadName:  "payments-build",
+			RoleARN:       "arn:aws:iam::123456789012:role/payments-codebuild-service",
+			Source:        "batchgetprojects",
+			EvidenceRef:   "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+			Confidence:    0.94,
+			ScanID:        "scan-codebuild",
+			CollectorName: codeBuildServiceRoleCollectorName,
+			CollectedAt:   time.Date(2026, 6, 6, 8, 0, 0, 0, time.UTC),
+		},
+		RoleName:        "payments-codebuild-service",
+		ProjectARN:      "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+		ProjectName:     "payments-build",
+		SourceType:      "GITHUB",
+		EnvironmentType: "LINUX_CONTAINER",
+		ComputeType:     "BUILD_GENERAL1_SMALL",
+		Image:           "aws/codebuild/standard:7.0",
+		EnvironmentKeys: []string{"APP_ENV", "DATABASE_PASSWORD"},
+		SecretRefs:      []string{"DATABASE_PASSWORD=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:123456789012:secret:db"},
+		Tags:            map[string]string{"owner": "payments"},
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{
+		{Kind: rawKindCodeBuildServiceRole, SourceID: "codebuild-role", Payload: payload},
+	})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if err := providers.ValidateNormalizedBundle(bundle); err != nil {
+		t.Fatalf("normalized bundle invalid: %v", err)
+	}
+	if len(bundle.Identities) != 1 || len(bundle.Workloads) != 1 || len(bundle.Resources) != 1 {
+		t.Fatalf("expected codebuild identity/workload/resource, got identities=%+v workloads=%+v resources=%+v", bundle.Identities, bundle.Workloads, bundle.Resources)
+	}
+	if bundle.Resources[0].Type != domain.ResourceTypeCodeBuildProject {
+		t.Fatalf("expected codebuild project resource, got %+v", bundle.Resources[0])
+	}
+	if strings.Contains(fmtAny(bundle.Resources[0].Metadata["environment_keys"]), "DATABASE_PASSWORD=value") {
+		t.Fatalf("environment values must not be normalized, got %+v", bundle.Resources[0].Metadata)
+	}
+
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("resolve relationships: %v", err)
+	}
+	if err := providers.ValidateGraphContract(bundle, relationships); err != nil {
+		t.Fatalf("graph contract invalid: %v", err)
+	}
+	if !hasRelationshipType(relationships, domain.RelationshipRunsAs) {
+		t.Fatalf("expected codebuild service role runs_as edge, got %+v", relationships)
+	}
+}
+
+func TestCodeBuildServiceRoleCollectorRetriesThenCollects(t *testing.T) {
+	attempt := 0
+	delays := []time.Duration{}
+	api := codeBuildServiceRoleAPIFunc(func(_ context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error) {
+		attempt++
+		if nextToken != "" {
+			t.Fatalf("expected single collector-facing page, got next token %q", nextToken)
+		}
+		if pageSize != 5 {
+			t.Fatalf("expected page size 5, got %d", pageSize)
+		}
+		if attempt == 1 {
+			return CodeBuildServiceRolePage{}, fakeRetryableError{message: "ThrottlingException"}
+		}
+		return CodeBuildServiceRolePage{Records: []CodeBuildServiceRole{{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+				WorkloadID:   "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+				WorkloadType: "codebuild_project",
+				WorkloadName: "payments-build",
+				RoleARN:      "arn:aws:iam::123456789012:role/payments-codebuild-service",
+				Source:       "batchgetprojects",
+				EvidenceRef:  "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+			},
+			ProjectARN:  "arn:aws:codebuild:us-east-1:123456789012:project/payments-build",
+			ProjectName: "payments-build",
+		}}}, nil
+	})
+
+	collector := NewCodeBuildServiceRoleCollector(
+		api,
+		WithCodeBuildServiceRolePageSize(5),
+		WithCodeBuildServiceRoleRetryPolicy(RetryPolicy{MaxRetries: 3, BaseDelay: 100 * time.Millisecond, MaxDelay: 500 * time.Millisecond}),
+		WithCodeBuildServiceRoleRetryJitterRatio(0.25),
+		WithCodeBuildServiceRoleRetryRandFunc(func() float64 { return 1 }),
+		WithCodeBuildServiceRoleSleeper(func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		}),
+	)
+
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("collect after retry: %v", err)
+	}
+	if len(assets) != 1 || attempt != 2 || len(delays) != 1 {
+		t.Fatalf("expected retry then one asset, attempts=%d delays=%+v assets=%+v", attempt, delays, assets)
+	}
+	if delays[0] <= 100*time.Millisecond || delays[0] > 125*time.Millisecond {
+		t.Fatalf("expected bounded jittered delay, got %s", delays[0])
+	}
+}
+
+func TestCodeBuildServiceRoleCollectorOptionsAndGuards(t *testing.T) {
+	collector := NewCodeBuildServiceRoleCollector(
+		codeBuildServiceRoleAPIFunc(func(context.Context, string, int32) (CodeBuildServiceRolePage, error) {
+			return CodeBuildServiceRolePage{NextToken: "again"}, nil
+		}),
+		WithCodeBuildServiceRoleMaxPages(1),
+		WithCodeBuildServiceRoleRetryPolicy(RetryPolicy{MaxRetries: 2, BaseDelay: time.Millisecond, MaxDelay: 3 * time.Millisecond}),
+		WithCodeBuildServiceRoleRetryJitterRatio(-1),
+	)
+	if collector.backoff(2) != 3*time.Millisecond {
+		t.Fatalf("expected capped no-jitter backoff, got %s", collector.backoff(2))
+	}
+	if _, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{}); err == nil || !strings.Contains(err.Error(), "exceeded max pages") {
+		t.Fatalf("expected max pages guard, got %v", err)
+	}
+	if _, _, err := NewCodeBuildServiceRoleCollector(nil).CollectWithDiagnostics(context.Background(), AWSCollectorScope{}); err == nil || !strings.Contains(err.Error(), "requires client") {
+		t.Fatalf("expected nil-client error, got %v", err)
+	}
+	if got := codeBuildProjectNameFromARN("arn:aws:codebuild:us-east-1:123456789012:project/payments-build"); got != "payments-build" {
+		t.Fatalf("expected project name from arn, got %q", got)
+	}
+}

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -125,6 +125,14 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	var codeBuildRole CodeBuildServiceRole
+	if err := json.Unmarshal(payload, &codeBuildRole); err == nil {
+		sourceID := codeBuildServiceRoleSourceID(codeBuildRole)
+		if isCodeBuildServiceRoleFixture(codeBuildRole) {
+			return rawKindCodeBuildServiceRole, sourceID
+		}
+	}
+
 	var profile EC2InstanceProfile
 	if err := json.Unmarshal(payload, &profile); err == nil {
 		sourceID := ec2InstanceProfileSourceID(profile)
@@ -171,6 +179,26 @@ func isLambdaExecutionRoleFixture(record LambdaExecutionRole) bool {
 		strings.TrimSpace(record.KMSKeyARN) != "" ||
 		len(record.EventSourceARNs) > 0 ||
 		len(record.DisabledEventSourceARNs) > 0
+}
+
+func isCodeBuildServiceRoleFixture(record CodeBuildServiceRole) bool {
+	if strings.EqualFold(strings.TrimSpace(record.Service), codeBuildServiceName) || strings.EqualFold(strings.TrimSpace(record.CollectorName), codeBuildServiceRoleCollectorName) {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(record.WorkloadType)) {
+	case "codebuild_project", "project":
+		return true
+	}
+	return strings.TrimSpace(record.ProjectARN) != "" ||
+		strings.TrimSpace(record.ProjectName) != "" ||
+		strings.TrimSpace(record.ProjectVisibility) != "" ||
+		strings.TrimSpace(record.SourceType) != "" ||
+		strings.TrimSpace(record.EnvironmentType) != "" ||
+		strings.TrimSpace(record.ComputeType) != "" ||
+		strings.TrimSpace(record.Image) != "" ||
+		strings.TrimSpace(record.CacheType) != "" ||
+		len(record.ArtifactTypes) > 0 ||
+		len(record.SourceIdentifiers) > 0
 }
 
 func isEKSWorkloadIdentityFixture(record EKSWorkloadIdentity) bool {

--- a/internal/providers/aws/ids.go
+++ b/internal/providers/aws/ids.go
@@ -65,6 +65,14 @@ func lambdaFunctionResourceID(functionARN string) string {
 	return "aws:resource:lambda-function:" + strings.TrimSpace(functionARN)
 }
 
+func codeBuildProjectWorkloadID(accountID, region, projectRef string) string {
+	return fmt.Sprintf("aws:workload:codebuild:%s:%s:project/%s", normalizeName(accountID), normalizeName(region), normalizeName(projectRef))
+}
+
+func codeBuildProjectResourceID(projectARN string) string {
+	return "aws:resource:codebuild-project:" + strings.TrimSpace(projectARN)
+}
+
 func eksWorkloadIdentityWorkloadID(accountID, region, workloadType, workloadID, roleKind string) string {
 	normalizedType := normalizeName(workloadType)
 	if normalizedType == "" {

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -95,6 +95,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		if err := ctx.Err(); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
+		if asset.Kind != rawKindCodeBuildServiceRole {
+			continue
+		}
+		if err := normalizeCodeBuildServiceRoleAsset(asset, i, &bundle, identitySeen, workloadSeen, resourceSeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
 		if asset.Kind != rawKindEKSWorkloadIdentity {
 			continue
 		}
@@ -477,6 +489,99 @@ func normalizeLambdaExecutionRoleAsset(asset providers.RawAsset, index int, bund
 	return nil
 }
 
+func normalizeCodeBuildServiceRoleAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, identitySeen map[string]struct{}, workloadSeen map[string]struct{}, resourceSeen map[string]struct{}) error {
+	var record CodeBuildServiceRole
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode codebuild service role asset[%d]: %w", index, err)
+	}
+
+	roleARN := strings.TrimSpace(record.RoleARN)
+	roleIdentityID := ""
+	if roleARN != "" {
+		roleIdentityID = identityIDFromARN(roleARN)
+		roleName := strings.TrimSpace(record.RoleName)
+		if roleName == "" {
+			roleName = roleNameFromARN(roleARN)
+		}
+		if _, exists := identitySeen[roleIdentityID]; !exists {
+			identitySeen[roleIdentityID] = struct{}{}
+			bundle.Identities = append(bundle.Identities, domain.Identity{
+				ID:        roleIdentityID,
+				Provider:  domain.ProviderAWS,
+				Type:      domain.IdentityTypeRole,
+				Name:      roleName,
+				ARN:       roleARN,
+				OwnerHint: ownerHintFromTags(record.Tags),
+				Tags:      copyTags(record.Tags),
+				RawRef:    asset.SourceID,
+			})
+		}
+	}
+
+	workloadID := codeBuildRoleWorkloadID(record)
+	if workloadID != "" {
+		if _, exists := workloadSeen[workloadID]; !exists {
+			workloadSeen[workloadID] = struct{}{}
+			bundle.Workloads = append(bundle.Workloads, domain.Workload{
+				ID:        workloadID,
+				Provider:  domain.ProviderAWS,
+				Type:      "codebuild_project",
+				Name:      codeBuildRoleWorkloadName(record),
+				AccountID: strings.TrimSpace(record.AccountID),
+				Region:    strings.TrimSpace(record.Region),
+				RawRef:    roleIdentityID,
+			})
+		}
+	}
+
+	if strings.TrimSpace(record.ProjectARN) != "" {
+		projectResourceID := codeBuildProjectResourceID(record.ProjectARN)
+		if _, exists := resourceSeen[projectResourceID]; !exists {
+			resourceSeen[projectResourceID] = struct{}{}
+			bundle.Resources = append(bundle.Resources, domain.Resource{
+				ID:        projectResourceID,
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeCodeBuildProject,
+				Name:      codeBuildRoleWorkloadName(record),
+				ARN:       strings.TrimSpace(record.ProjectARN),
+				Region:    strings.TrimSpace(record.Region),
+				AccountID: strings.TrimSpace(record.AccountID),
+				Labels:    copyTags(record.Tags),
+				Metadata: map[string]any{
+					"role_arn":                    roleARN,
+					"project_name":                strings.TrimSpace(record.ProjectName),
+					"project_visibility":          strings.TrimSpace(record.ProjectVisibility),
+					"source_type":                 strings.TrimSpace(record.SourceType),
+					"source_location":             strings.TrimSpace(record.SourceLocation),
+					"source_auth_type":            strings.TrimSpace(record.SourceAuthType),
+					"source_version":              strings.TrimSpace(record.SourceVersion),
+					"source_identifiers":          append([]string(nil), record.SourceIdentifiers...),
+					"artifact_types":              append([]string(nil), record.ArtifactTypes...),
+					"artifact_locations":          append([]string(nil), record.ArtifactLocations...),
+					"environment_type":            strings.TrimSpace(record.EnvironmentType),
+					"compute_type":                strings.TrimSpace(record.ComputeType),
+					"image":                       strings.TrimSpace(record.Image),
+					"image_pull_credentials_type": strings.TrimSpace(record.ImagePullCredentialsType),
+					"privileged_mode":             record.PrivilegedMode,
+					"kms_key_arn":                 strings.TrimSpace(record.KMSKeyARN),
+					"cache_type":                  strings.TrimSpace(record.CacheType),
+					"cache_location":              strings.TrimSpace(record.CacheLocation),
+					"log_types":                   append([]string(nil), record.LogTypes...),
+					"vpc_id":                      strings.TrimSpace(record.VPCID),
+					"subnet_ids":                  append([]string(nil), record.SubnetIDs...),
+					"security_group_ids":          append([]string(nil), record.SecurityGroupIDs...),
+					"environment_keys":            append([]string(nil), record.EnvironmentKeys...),
+					"secret_refs":                 append([]string(nil), record.SecretRefs...),
+				},
+				RawRef:         asset.SourceID,
+				SourceEntityID: workloadID,
+			})
+		}
+	}
+
+	return nil
+}
+
 func normalizeEKSWorkloadIdentityAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, identitySeen map[string]struct{}, workloadSeen map[string]struct{}, resourceSeen map[string]struct{}) error {
 	var record EKSWorkloadIdentity
 	if err := json.Unmarshal(asset.Payload, &record); err != nil {
@@ -738,6 +843,18 @@ func lambdaRoleWorkloadID(record LambdaExecutionRole) string {
 
 func lambdaRoleWorkloadName(record LambdaExecutionRole) string {
 	return firstNonEmptyAWSValue(record.WorkloadName, record.FunctionName, lambdaFunctionNameFromARN(record.FunctionARN), "lambda function")
+}
+
+func codeBuildRoleWorkloadID(record CodeBuildServiceRole) string {
+	return codeBuildProjectWorkloadID(
+		record.AccountID,
+		record.Region,
+		firstNonEmptyAWSValue(record.ProjectARN, record.WorkloadID, record.ProjectName),
+	)
+}
+
+func codeBuildRoleWorkloadName(record CodeBuildServiceRole) string {
+	return firstNonEmptyAWSValue(record.WorkloadName, record.ProjectName, codeBuildProjectNameFromARN(record.ProjectARN), "codebuild project")
 }
 
 func eksWorkloadIdentityNormalizedWorkloadID(record EKSWorkloadIdentity) string {

--- a/internal/providers/aws/sdk_codebuild_service_role.go
+++ b/internal/providers/aws/sdk_codebuild_service_role.go
@@ -98,9 +98,6 @@ func (a *SDKCodeBuildServiceRoleAPI) ListServiceRoles(ctx context.Context, nextT
 	}
 
 	names := normalizeStringList(output.Projects)
-	if pageSize > 0 && int(pageSize) < len(names) {
-		names = names[:pageSize]
-	}
 	records, diagnostics, err := a.batchGetProjectRecords(ctx, names)
 	if err != nil {
 		return CodeBuildServiceRolePage{}, err

--- a/internal/providers/aws/sdk_codebuild_service_role.go
+++ b/internal/providers/aws/sdk_codebuild_service_role.go
@@ -86,7 +86,7 @@ func (a *SDKCodeBuildServiceRoleAPI) ListServiceRoles(ctx context.Context, nextT
 	}
 
 	output, err := a.codeBuildClient.ListProjects(ctx, &codebuild.ListProjectsInput{
-		NextToken: awsv2.String(strings.TrimSpace(nextToken)),
+		NextToken: codeBuildListProjectsNextToken(nextToken),
 		SortBy:    codebuildtypes.ProjectSortByTypeName,
 		SortOrder: codebuildtypes.SortOrderTypeAscending,
 	})
@@ -109,6 +109,14 @@ func (a *SDKCodeBuildServiceRoleAPI) ListServiceRoles(ctx context.Context, nextT
 		return codeBuildServiceRoleSourceID(records[i]) < codeBuildServiceRoleSourceID(records[j])
 	})
 	return CodeBuildServiceRolePage{Records: records, NextToken: nextTokenFromCodeBuildListProjects(output), Diagnostics: diagnostics}, nil
+}
+
+func codeBuildListProjectsNextToken(nextToken string) *string {
+	trimmed := strings.TrimSpace(nextToken)
+	if trimmed == "" {
+		return nil
+	}
+	return awsv2.String(trimmed)
 }
 
 func (a *SDKCodeBuildServiceRoleAPI) batchGetProjectRecords(ctx context.Context, names []string) ([]CodeBuildServiceRole, []providers.SourceError, error) {

--- a/internal/providers/aws/sdk_codebuild_service_role.go
+++ b/internal/providers/aws/sdk_codebuild_service_role.go
@@ -1,0 +1,330 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	codebuildtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+// CodeBuildSDKClient defines the CodeBuild SDK calls required by the service-role adapter.
+type CodeBuildSDKClient interface {
+	ListProjects(ctx context.Context, params *codebuild.ListProjectsInput, optFns ...func(*codebuild.Options)) (*codebuild.ListProjectsOutput, error)
+	BatchGetProjects(ctx context.Context, params *codebuild.BatchGetProjectsInput, optFns ...func(*codebuild.Options)) (*codebuild.BatchGetProjectsOutput, error)
+}
+
+// SDKCodeBuildServiceRoleAPI adapts AWS SDK CodeBuild calls to CodeBuildServiceRoleAPI.
+type SDKCodeBuildServiceRoleAPI struct {
+	codeBuildClient CodeBuildSDKClient
+	accountID       string
+	region          string
+}
+
+var _ CodeBuildServiceRoleAPI = (*SDKCodeBuildServiceRoleAPI)(nil)
+
+// NewSDKCodeBuildServiceRoleAPI constructs a CodeBuild service-role API backed by the AWS SDK default credential chain.
+func NewSDKCodeBuildServiceRoleAPI(region string, profile string, accountID string) (CodeBuildServiceRoleAPI, error) {
+	return NewSDKCodeBuildServiceRoleAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+// NewSDKCodeBuildServiceRoleAPIWithContext constructs a CodeBuild service-role API using caller-provided context for config loading.
+func NewSDKCodeBuildServiceRoleAPIWithContext(ctx context.Context, region string, profile string, accountID string) (CodeBuildServiceRoleAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	return NewSDKCodeBuildServiceRoleAPIFromClient(codebuild.NewFromConfig(cfg), accountID, region), nil
+}
+
+// NewSDKCodeBuildServiceRoleAPIFromAssumeRole constructs a CodeBuild service-role API for an onboarded connector role.
+func NewSDKCodeBuildServiceRoleAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (CodeBuildServiceRoleAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	return NewSDKCodeBuildServiceRoleAPIFromClient(codebuild.NewFromConfig(cfg), accountID, region), nil
+}
+
+// NewSDKCodeBuildServiceRoleAPIFromClient creates a CodeBuildServiceRoleAPI from a provided CodeBuild client.
+func NewSDKCodeBuildServiceRoleAPIFromClient(codeBuildClient CodeBuildSDKClient, accountID string, region string) CodeBuildServiceRoleAPI {
+	return &SDKCodeBuildServiceRoleAPI{
+		codeBuildClient: codeBuildClient,
+		accountID:       strings.TrimSpace(accountID),
+		region:          strings.TrimSpace(region),
+	}
+}
+
+// ListServiceRoles returns one CodeBuild project-name page resolved to project metadata.
+func (a *SDKCodeBuildServiceRoleAPI) ListServiceRoles(ctx context.Context, nextToken string, pageSize int32) (CodeBuildServiceRolePage, error) {
+	if a.codeBuildClient == nil {
+		return CodeBuildServiceRolePage{}, fmt.Errorf("codebuild sdk client is required")
+	}
+
+	output, err := a.codeBuildClient.ListProjects(ctx, &codebuild.ListProjectsInput{
+		NextToken: awsv2.String(strings.TrimSpace(nextToken)),
+		SortBy:    codebuildtypes.ProjectSortByTypeName,
+		SortOrder: codebuildtypes.SortOrderTypeAscending,
+	})
+	if err != nil {
+		return CodeBuildServiceRolePage{}, err
+	}
+	if output == nil || len(output.Projects) == 0 {
+		return CodeBuildServiceRolePage{NextToken: nextTokenFromCodeBuildListProjects(output)}, nil
+	}
+
+	names := normalizeStringList(output.Projects)
+	if pageSize > 0 && int(pageSize) < len(names) {
+		names = names[:pageSize]
+	}
+	records, diagnostics, err := a.batchGetProjectRecords(ctx, names)
+	if err != nil {
+		return CodeBuildServiceRolePage{}, err
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		return codeBuildServiceRoleSourceID(records[i]) < codeBuildServiceRoleSourceID(records[j])
+	})
+	return CodeBuildServiceRolePage{Records: records, NextToken: nextTokenFromCodeBuildListProjects(output), Diagnostics: diagnostics}, nil
+}
+
+func (a *SDKCodeBuildServiceRoleAPI) batchGetProjectRecords(ctx context.Context, names []string) ([]CodeBuildServiceRole, []providers.SourceError, error) {
+	records := []CodeBuildServiceRole{}
+	diagnostics := []providers.SourceError{}
+	const batchSize = 100
+	for start := 0; start < len(names); start += batchSize {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		end := start + batchSize
+		if end > len(names) {
+			end = len(names)
+		}
+		batch := names[start:end]
+		output, err := a.codeBuildClient.BatchGetProjects(ctx, &codebuild.BatchGetProjectsInput{Names: batch})
+		if err != nil {
+			return nil, nil, err
+		}
+		if output == nil {
+			continue
+		}
+		for _, missing := range output.ProjectsNotFound {
+			diagnostics = append(diagnostics, codeBuildSourceDiagnostic("project_not_found", missing, "CodeBuild project listed by ListProjects was not returned by BatchGetProjects", true))
+		}
+		for _, project := range output.Projects {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
+			record := a.recordFromProject(project)
+			if strings.TrimSpace(record.ProjectARN) == "" {
+				diagnostics = append(diagnostics, codeBuildSourceDiagnostic("missing_project_arn", record.ProjectName, "CodeBuild project did not report a project ARN", false))
+				continue
+			}
+			records = append(records, record)
+		}
+	}
+	return records, diagnostics, nil
+}
+
+func (a *SDKCodeBuildServiceRoleAPI) recordFromProject(project codebuildtypes.Project) CodeBuildServiceRole {
+	projectARN := strings.TrimSpace(awsv2.ToString(project.Arn))
+	projectName := firstNonEmptyAWSValue(awsv2.ToString(project.Name), codeBuildProjectNameFromARN(projectARN))
+	roleARN := strings.TrimSpace(awsv2.ToString(project.ServiceRole))
+	record := CodeBuildServiceRole{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID:     a.accountID,
+			Region:        a.region,
+			Service:       codeBuildServiceName,
+			WorkloadID:    firstNonEmptyAWSValue(projectARN, projectName),
+			WorkloadType:  "codebuild_project",
+			WorkloadName:  firstNonEmptyAWSValue(projectName, codeBuildProjectNameFromARN(projectARN)),
+			RoleARN:       roleARN,
+			Source:        "batchgetprojects",
+			EvidenceRef:   firstNonEmptyAWSValue(projectARN, roleARN),
+			Confidence:    0.96,
+			CollectorName: codeBuildServiceRoleCollectorName,
+		},
+		RoleName:           roleNameFromARN(roleARN),
+		ProjectARN:         projectARN,
+		ProjectName:        projectName,
+		ProjectDescription: strings.TrimSpace(awsv2.ToString(project.Description)),
+		ProjectVisibility:  string(project.ProjectVisibility),
+		SourceVersion:      strings.TrimSpace(awsv2.ToString(project.SourceVersion)),
+		KMSKeyARN:          strings.TrimSpace(awsv2.ToString(project.EncryptionKey)),
+		Tags:               codeBuildTags(project.Tags),
+	}
+	if project.Source != nil {
+		record.SourceType = string(project.Source.Type)
+		record.SourceLocation = strings.TrimSpace(awsv2.ToString(project.Source.Location))
+		if project.Source.Auth != nil {
+			record.SourceAuthType = string(project.Source.Auth.Type)
+		}
+	}
+	record.SourceIdentifiers = codeBuildSourceIdentifiers(project)
+	record.ArtifactTypes, record.ArtifactLocations = codeBuildArtifacts(project)
+	if project.Environment != nil {
+		record.EnvironmentType = string(project.Environment.Type)
+		record.ComputeType = string(project.Environment.ComputeType)
+		record.Image = strings.TrimSpace(awsv2.ToString(project.Environment.Image))
+		record.ImagePullCredentialsType = string(project.Environment.ImagePullCredentialsType)
+		record.PrivilegedMode = awsv2.ToBool(project.Environment.PrivilegedMode)
+		record.EnvironmentKeys, record.SecretRefs = codeBuildEnvironmentMetadata(project.Environment.EnvironmentVariables)
+	}
+	if project.VpcConfig != nil {
+		record.VPCID = strings.TrimSpace(awsv2.ToString(project.VpcConfig.VpcId))
+		record.SubnetIDs = normalizeStringList(project.VpcConfig.Subnets)
+		record.SecurityGroupIDs = normalizeStringList(project.VpcConfig.SecurityGroupIds)
+	}
+	if project.Cache != nil {
+		record.CacheType = string(project.Cache.Type)
+		record.CacheLocation = strings.TrimSpace(awsv2.ToString(project.Cache.Location))
+	}
+	record.LogTypes = codeBuildLogTypes(project.LogsConfig)
+	record.Confidence = codeBuildServiceRoleConfidence(record)
+	return record
+}
+
+func nextTokenFromCodeBuildListProjects(output *codebuild.ListProjectsOutput) string {
+	if output == nil {
+		return ""
+	}
+	return strings.TrimSpace(awsv2.ToString(output.NextToken))
+}
+
+func codeBuildSourceDiagnostic(code string, sourceID string, message string, retryable bool) providers.SourceError {
+	return providers.SourceError{
+		Collector: codeBuildServiceRoleCollectorName,
+		SourceID:  strings.TrimSpace(sourceID),
+		Code:      code,
+		Message:   strings.TrimSpace(message),
+		Retryable: retryable,
+	}
+}
+
+func codeBuildTags(tags []codebuildtypes.Tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	result := map[string]string{}
+	for _, tag := range tags {
+		key := strings.TrimSpace(awsv2.ToString(tag.Key))
+		value := strings.TrimSpace(awsv2.ToString(tag.Value))
+		if key != "" {
+			result[key] = value
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func codeBuildSourceIdentifiers(project codebuildtypes.Project) []string {
+	result := []string{}
+	if project.Source != nil {
+		result = append(result, codeBuildSourceIdentifier(*project.Source))
+	}
+	for _, source := range project.SecondarySources {
+		result = append(result, codeBuildSourceIdentifier(source))
+	}
+	return normalizeStringList(result)
+}
+
+func codeBuildSourceIdentifier(source codebuildtypes.ProjectSource) string {
+	sourceType := strings.TrimSpace(string(source.Type))
+	identifier := strings.TrimSpace(awsv2.ToString(source.SourceIdentifier))
+	location := strings.TrimSpace(awsv2.ToString(source.Location))
+	switch {
+	case sourceType != "" && identifier != "":
+		return sourceType + "=" + identifier
+	case sourceType != "" && location != "":
+		return sourceType + "=" + location
+	case sourceType != "":
+		return sourceType
+	default:
+		return location
+	}
+}
+
+func codeBuildArtifacts(project codebuildtypes.Project) ([]string, []string) {
+	types := []string{}
+	locations := []string{}
+	addArtifact := func(artifact codebuildtypes.ProjectArtifacts) {
+		if artifact.Type != "" {
+			types = append(types, string(artifact.Type))
+		}
+		location := strings.TrimSpace(awsv2.ToString(artifact.Location))
+		if location != "" {
+			locations = append(locations, location)
+		}
+	}
+	if project.Artifacts != nil {
+		addArtifact(*project.Artifacts)
+	}
+	for _, artifact := range project.SecondaryArtifacts {
+		addArtifact(artifact)
+	}
+	return normalizeStringList(types), normalizeStringList(locations)
+}
+
+func codeBuildEnvironmentMetadata(vars []codebuildtypes.EnvironmentVariable) ([]string, []string) {
+	keys := []string{}
+	secretRefs := []string{}
+	for _, variable := range vars {
+		name := strings.TrimSpace(awsv2.ToString(variable.Name))
+		if name != "" {
+			keys = append(keys, name)
+		}
+		valueRef := strings.TrimSpace(awsv2.ToString(variable.Value))
+		varType := strings.TrimSpace(string(variable.Type))
+		if valueRef == "" {
+			continue
+		}
+		switch variable.Type {
+		case codebuildtypes.EnvironmentVariableTypeParameterStore, codebuildtypes.EnvironmentVariableTypeSecretsManager:
+			if name != "" && varType != "" {
+				secretRefs = append(secretRefs, name+"="+varType+":"+valueRef)
+			} else if varType != "" {
+				secretRefs = append(secretRefs, varType+":"+valueRef)
+			}
+		}
+	}
+	return normalizeStringList(keys), normalizeStringList(secretRefs)
+}
+
+func codeBuildLogTypes(config *codebuildtypes.LogsConfig) []string {
+	if config == nil {
+		return nil
+	}
+	result := []string{}
+	if config.CloudWatchLogs != nil {
+		result = append(result, "cloudwatch")
+	}
+	if config.S3Logs != nil {
+		result = append(result, "s3")
+	}
+	return normalizeStringList(result)
+}

--- a/internal/providers/aws/sdk_codebuild_service_role_test.go
+++ b/internal/providers/aws/sdk_codebuild_service_role_test.go
@@ -114,7 +114,7 @@ func TestSDKCodeBuildServiceRoleAPIMapsProjectRoleAndMetadata(t *testing.T) {
 	if len(page.Records) != 1 {
 		t.Fatalf("expected one codebuild role record, got %+v", page.Records)
 	}
-	if len(client.listProjectsInputs) != 1 || awsv2.ToString(client.listProjectsInputs[0].NextToken) != "" {
+	if len(client.listProjectsInputs) != 1 || client.listProjectsInputs[0].NextToken != nil {
 		t.Fatalf("expected one ListProjects call, got %+v", client.listProjectsInputs)
 	}
 	if len(client.batchGetProjectsInput) != 1 || len(client.batchGetProjectsInput[0].Names) != 1 || client.batchGetProjectsInput[0].Names[0] != "payments-build" {

--- a/internal/providers/aws/sdk_codebuild_service_role_test.go
+++ b/internal/providers/aws/sdk_codebuild_service_role_test.go
@@ -171,6 +171,32 @@ func TestSDKCodeBuildServiceRoleAPIEmitsProjectNotFoundDiagnostic(t *testing.T) 
 	}
 }
 
+func TestSDKCodeBuildServiceRoleAPIBatchesFullListProjectsPage(t *testing.T) {
+	client := &fakeCodeBuildSDKClient{
+		listProjectsOutputs: []*codebuild.ListProjectsOutput{{Projects: []string{"project-a", "project-b", "project-c"}, NextToken: awsv2.String("page-2")}},
+		projectsByName: map[string]codebuildtypes.Project{
+			"project-a": codeBuildSDKTestProject("project-a"),
+			"project-b": codeBuildSDKTestProject("project-b"),
+			"project-c": codeBuildSDKTestProject("project-c"),
+		},
+	}
+	api := NewSDKCodeBuildServiceRoleAPIFromClient(client, "123456789012", "us-east-1")
+
+	page, err := api.ListServiceRoles(context.Background(), "", 1)
+	if err != nil {
+		t.Fatalf("list service roles: %v", err)
+	}
+	if len(page.Records) != 3 {
+		t.Fatalf("expected every listed project to be resolved despite smaller public page size, got %+v", page.Records)
+	}
+	if page.NextToken != "page-2" {
+		t.Fatalf("expected AWS next token to be preserved, got %q", page.NextToken)
+	}
+	if len(client.batchGetProjectsInput) != 1 || len(client.batchGetProjectsInput[0].Names) != 3 {
+		t.Fatalf("expected full ListProjects page to be batched, got %+v", client.batchGetProjectsInput)
+	}
+}
+
 func TestSDKCodeBuildServiceRoleAPIHandlesNextTokenAndBatchErrors(t *testing.T) {
 	client := &fakeCodeBuildSDKClient{
 		listProjectsOutputs: []*codebuild.ListProjectsOutput{{Projects: []string{"payments-build"}, NextToken: awsv2.String("page-2")}},
@@ -184,5 +210,13 @@ func TestSDKCodeBuildServiceRoleAPIHandlesNextTokenAndBatchErrors(t *testing.T) 
 	}
 	if got := awsv2.ToString(client.listProjectsInputs[0].NextToken); got != "page-1" {
 		t.Fatalf("expected forwarded next token, got %q", got)
+	}
+}
+
+func codeBuildSDKTestProject(name string) codebuildtypes.Project {
+	return codebuildtypes.Project{
+		Arn:         awsv2.String("arn:aws:codebuild:us-east-1:123456789012:project/" + name),
+		Name:        awsv2.String(name),
+		ServiceRole: awsv2.String("arn:aws:iam::123456789012:role/" + name + "-service"),
 	}
 }

--- a/internal/providers/aws/sdk_codebuild_service_role_test.go
+++ b/internal/providers/aws/sdk_codebuild_service_role_test.go
@@ -1,0 +1,188 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	codebuildtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+)
+
+type fakeCodeBuildSDKClient struct {
+	listProjectsInputs    []*codebuild.ListProjectsInput
+	batchGetProjectsInput []*codebuild.BatchGetProjectsInput
+
+	listProjectsOutputs []*codebuild.ListProjectsOutput
+	projectsByName      map[string]codebuildtypes.Project
+
+	listProjectsErr     error
+	batchGetProjectsErr error
+	projectsNotFound    []string
+}
+
+func (f *fakeCodeBuildSDKClient) ListProjects(_ context.Context, params *codebuild.ListProjectsInput, _ ...func(*codebuild.Options)) (*codebuild.ListProjectsOutput, error) {
+	f.listProjectsInputs = append(f.listProjectsInputs, params)
+	if f.listProjectsErr != nil {
+		return nil, f.listProjectsErr
+	}
+	idx := len(f.listProjectsInputs) - 1
+	if idx >= len(f.listProjectsOutputs) {
+		return &codebuild.ListProjectsOutput{}, nil
+	}
+	return f.listProjectsOutputs[idx], nil
+}
+
+func (f *fakeCodeBuildSDKClient) BatchGetProjects(_ context.Context, params *codebuild.BatchGetProjectsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetProjectsOutput, error) {
+	f.batchGetProjectsInput = append(f.batchGetProjectsInput, params)
+	if f.batchGetProjectsErr != nil {
+		return nil, f.batchGetProjectsErr
+	}
+	output := &codebuild.BatchGetProjectsOutput{ProjectsNotFound: append([]string(nil), f.projectsNotFound...)}
+	for _, name := range params.Names {
+		if project, ok := f.projectsByName[name]; ok {
+			output.Projects = append(output.Projects, project)
+		}
+	}
+	return output, nil
+}
+
+func TestSDKCodeBuildServiceRoleAPIMapsProjectRoleAndMetadata(t *testing.T) {
+	projectARN := "arn:aws:codebuild:us-east-1:123456789012:project/payments-build"
+	roleARN := "arn:aws:iam::123456789012:role/payments-codebuild-service"
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:codebuild/payments-db"
+	client := &fakeCodeBuildSDKClient{
+		listProjectsOutputs: []*codebuild.ListProjectsOutput{
+			{Projects: []string{"payments-build"}},
+		},
+		projectsByName: map[string]codebuildtypes.Project{
+			"payments-build": {
+				Arn:               awsv2.String(projectARN),
+				Name:              awsv2.String("payments-build"),
+				ServiceRole:       awsv2.String(roleARN),
+				Description:       awsv2.String("payments ci"),
+				ProjectVisibility: codebuildtypes.ProjectVisibilityTypePrivate,
+				SourceVersion:     awsv2.String("main"),
+				EncryptionKey:     awsv2.String("arn:aws:kms:us-east-1:123456789012:key/codebuild"),
+				Source: &codebuildtypes.ProjectSource{
+					Type:             codebuildtypes.SourceTypeGithub,
+					Location:         awsv2.String("https://github.com/example/payments"),
+					SourceIdentifier: awsv2.String("primary"),
+					Auth:             &codebuildtypes.SourceAuth{Type: codebuildtypes.SourceAuthTypeCodeconnections},
+				},
+				Artifacts: &codebuildtypes.ProjectArtifacts{
+					Type:     codebuildtypes.ArtifactsTypeS3,
+					Location: awsv2.String("payments-artifacts"),
+				},
+				Environment: &codebuildtypes.ProjectEnvironment{
+					Type:                     codebuildtypes.EnvironmentTypeLinuxContainer,
+					ComputeType:              codebuildtypes.ComputeTypeBuildGeneral1Small,
+					Image:                    awsv2.String("aws/codebuild/standard:7.0"),
+					ImagePullCredentialsType: codebuildtypes.ImagePullCredentialsTypeCodebuild,
+					PrivilegedMode:           awsv2.Bool(true),
+					EnvironmentVariables: []codebuildtypes.EnvironmentVariable{
+						{Name: awsv2.String("APP_ENV"), Value: awsv2.String("prod"), Type: codebuildtypes.EnvironmentVariableTypePlaintext},
+						{Name: awsv2.String("DATABASE_PASSWORD"), Value: awsv2.String(secretARN), Type: codebuildtypes.EnvironmentVariableTypeSecretsManager},
+						{Name: awsv2.String("NPM_TOKEN"), Value: awsv2.String("/ci/npm/token"), Type: codebuildtypes.EnvironmentVariableTypeParameterStore},
+					},
+				},
+				VpcConfig: &codebuildtypes.VpcConfig{
+					VpcId:            awsv2.String("vpc-123"),
+					Subnets:          []string{"subnet-a", "subnet-b"},
+					SecurityGroupIds: []string{"sg-123"},
+				},
+				Cache: &codebuildtypes.ProjectCache{
+					Type:     codebuildtypes.CacheTypeLocal,
+					Location: awsv2.String("local-cache"),
+				},
+				LogsConfig: &codebuildtypes.LogsConfig{
+					CloudWatchLogs: &codebuildtypes.CloudWatchLogsConfig{},
+					S3Logs:         &codebuildtypes.S3LogsConfig{},
+				},
+				Tags: []codebuildtypes.Tag{{Key: awsv2.String("owner"), Value: awsv2.String("payments")}},
+			},
+		},
+	}
+	api := NewSDKCodeBuildServiceRoleAPIFromClient(client, "123456789012", "us-east-1")
+
+	page, err := api.ListServiceRoles(context.Background(), "", 25)
+	if err != nil {
+		t.Fatalf("list service roles: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected one codebuild role record, got %+v", page.Records)
+	}
+	if len(client.listProjectsInputs) != 1 || awsv2.ToString(client.listProjectsInputs[0].NextToken) != "" {
+		t.Fatalf("expected one ListProjects call, got %+v", client.listProjectsInputs)
+	}
+	if len(client.batchGetProjectsInput) != 1 || len(client.batchGetProjectsInput[0].Names) != 1 || client.batchGetProjectsInput[0].Names[0] != "payments-build" {
+		t.Fatalf("expected BatchGetProjects by project name, got %+v", client.batchGetProjectsInput)
+	}
+
+	record := page.Records[0]
+	if record.RoleARN != roleARN || record.RoleName != "payments-codebuild-service" || record.ProjectName != "payments-build" {
+		t.Fatalf("expected project service role metadata, got %+v", record)
+	}
+	if record.SourceType != "GITHUB" || record.SourceAuthType != "CODECONNECTIONS" || record.SourceLocation == "" {
+		t.Fatalf("expected source metadata, got %+v", record)
+	}
+	if record.EnvironmentType != "LINUX_CONTAINER" || record.ComputeType != "BUILD_GENERAL1_SMALL" || !record.PrivilegedMode {
+		t.Fatalf("expected environment metadata, got %+v", record)
+	}
+	if record.VPCID != "vpc-123" || len(record.SubnetIDs) != 2 || len(record.SecurityGroupIDs) != 1 {
+		t.Fatalf("expected vpc metadata, got %+v", record)
+	}
+	if len(record.SecretRefs) != 2 || !strings.Contains(record.SecretRefs[0]+record.SecretRefs[1], secretARN) {
+		t.Fatalf("expected secret reference metadata, got %+v", record.SecretRefs)
+	}
+	if strings.Contains(strings.Join(record.EnvironmentKeys, ","), "prod") || strings.Contains(strings.Join(record.SecretRefs, ","), "must-not-appear") {
+		t.Fatalf("environment values must not be collected, got record=%+v", record)
+	}
+	if len(record.LogTypes) != 2 || record.CacheType != "LOCAL" {
+		t.Fatalf("expected log/cache metadata, got %+v", record)
+	}
+}
+
+func TestSDKCodeBuildServiceRoleAPIFailsWhenProjectListingFails(t *testing.T) {
+	client := &fakeCodeBuildSDKClient{listProjectsErr: errors.New("codebuild unavailable")}
+	api := NewSDKCodeBuildServiceRoleAPIFromClient(client, "123456789012", "us-east-1")
+
+	if _, err := api.ListServiceRoles(context.Background(), "", 10); err == nil {
+		t.Fatal("expected list projects failure")
+	}
+}
+
+func TestSDKCodeBuildServiceRoleAPIEmitsProjectNotFoundDiagnostic(t *testing.T) {
+	client := &fakeCodeBuildSDKClient{
+		listProjectsOutputs: []*codebuild.ListProjectsOutput{{Projects: []string{"missing-project"}}},
+		projectsByName:      map[string]codebuildtypes.Project{},
+		projectsNotFound:    []string{"missing-project"},
+	}
+	api := NewSDKCodeBuildServiceRoleAPIFromClient(client, "123456789012", "us-east-1")
+
+	page, err := api.ListServiceRoles(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("list service roles: %v", err)
+	}
+	if len(page.Records) != 0 || len(page.Diagnostics) != 1 || page.Diagnostics[0].Code != "project_not_found" || !page.Diagnostics[0].Retryable {
+		t.Fatalf("expected project_not_found diagnostic, got page=%+v", page)
+	}
+}
+
+func TestSDKCodeBuildServiceRoleAPIHandlesNextTokenAndBatchErrors(t *testing.T) {
+	client := &fakeCodeBuildSDKClient{
+		listProjectsOutputs: []*codebuild.ListProjectsOutput{{Projects: []string{"payments-build"}, NextToken: awsv2.String("page-2")}},
+		projectsByName:      map[string]codebuildtypes.Project{},
+		batchGetProjectsErr: errors.New("batch failed"),
+	}
+	api := NewSDKCodeBuildServiceRoleAPIFromClient(client, "123456789012", "us-east-1")
+
+	if _, err := api.ListServiceRoles(context.Background(), "page-1", 10); err == nil || !strings.Contains(err.Error(), "batch failed") {
+		t.Fatalf("expected batch failure, got %v", err)
+	}
+	if got := awsv2.ToString(client.listProjectsInputs[0].NextToken); got != "page-1" {
+		t.Fatalf("expected forwarded next token, got %q", got)
+	}
+}

--- a/internal/providers/awscontract/contract.go
+++ b/internal/providers/awscontract/contract.go
@@ -124,6 +124,8 @@ func AWSServiceCollectorContract() ServiceCollectorContract {
 			"lambda:ListVersionsByFunction",
 			"lambda:ListEventSourceMappings",
 			"lambda:ListTags",
+			"codebuild:ListProjects",
+			"codebuild:BatchGetProjects",
 			"eks:ListClusters",
 			"eks:DescribeCluster",
 			"eks:ListPodIdentityAssociations",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -88,6 +88,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws lambda execution role collector: %w", lambdaErr)
 			}
+			codeBuildAPI, codeBuildErr := awsprovider.NewSDKCodeBuildServiceRoleAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if codeBuildErr != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("initialize aws codebuild service role collector: %w", codeBuildErr)
+			}
 			eksAPI, eksErr := awsprovider.NewSDKEKSWorkloadIdentityAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if eksErr != nil {
 				_ = store.Close()
@@ -100,6 +105,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewEC2InstanceProfileCollector(ec2API),
 				awsprovider.NewECSTaskRoleCollector(ecsAPI),
 				awsprovider.NewLambdaExecutionRoleCollector(lambdaAPI),
+				awsprovider.NewCodeBuildServiceRoleCollector(codeBuildAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			)
 		default:
@@ -201,6 +207,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if lambdaErr != nil {
 			return nil, lambdaErr
 		}
+		codeBuildAPI, codeBuildErr := awsprovider.NewSDKCodeBuildServiceRoleAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		if codeBuildErr != nil {
+			return nil, codeBuildErr
+		}
 		eksAPI, eksErr := awsprovider.NewSDKEKSWorkloadIdentityAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
 		if eksErr != nil {
 			return nil, eksErr
@@ -212,6 +222,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewEC2InstanceProfileCollector(ec2API),
 			awsprovider.NewECSTaskRoleCollector(ecsAPI),
 			awsprovider.NewLambdaExecutionRoleCollector(lambdaAPI),
+			awsprovider.NewCodeBuildServiceRoleCollector(codeBuildAPI),
 			awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 		)
 		return scanner, nil

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "eks"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "eks"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "eks"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "eks"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -841,6 +841,30 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS CodeBuild service role inventory with scoped headers and fixture state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', record_count: 2, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectCodeBuildServiceRoles('workspace/a', 'project 1', 'aws-prod', 'partial_failure', {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/codebuild-service-roles?connector_id=aws-prod&fixture_state=partial_failure'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS EKS workload identity inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1336,6 +1336,103 @@ export type AWSLambdaExecutionRoleInventoryResult = {
   updated_at: string;
 };
 
+export type AWSCodeBuildServiceRoleInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSCodeBuildServiceRoleFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+
+export type AWSCodeBuildServiceRoleRecord = {
+  account_id: string;
+  region: string;
+  service: string;
+  workload_id: string;
+  workload_type: string;
+  workload_name: string;
+  role_arn?: string;
+  role_name?: string;
+  project_arn?: string;
+  project_name?: string;
+  project_visibility?: string;
+  source_type?: string;
+  source_location?: string;
+  source_auth_type?: string;
+  source_version?: string;
+  source_identifiers?: string[];
+  artifact_types?: string[];
+  artifact_locations?: string[];
+  environment_type?: string;
+  compute_type?: string;
+  image?: string;
+  image_pull_credentials_type?: string;
+  privileged_mode?: boolean;
+  kms_key_arn?: string;
+  cache_type?: string;
+  cache_location?: string;
+  log_types?: string[];
+  vpc_id?: string;
+  subnet_ids?: string[];
+  security_group_ids?: string[];
+  environment_keys?: string[];
+  secret_refs?: string[];
+  tags?: Record<string, string>;
+  source: string;
+  evidence_ref: string;
+  from_node_id: string;
+  to_node_id?: string;
+  relationship_type: 'runs_as' | string;
+  confidence: number;
+  collected_at: string;
+  status: string;
+};
+
+export type AWSCodeBuildServiceRoleRelationship = {
+  type: 'runs_as' | string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSCodeBuildServiceRoleDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSCodeBuildServiceRoleInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCodeBuildServiceRoleInventoryStatus;
+  fixture_state: AWSCodeBuildServiceRoleFixtureState;
+  confidence: number;
+  record_count: number;
+  project_count: number;
+  identity_count: number;
+  resource_count: number;
+  relationship_count: number;
+  secret_ref_count: number;
+  vpc_project_count: number;
+  public_project_count: number;
+  privileged_project_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  records: AWSCodeBuildServiceRoleRecord[];
+  relationships: AWSCodeBuildServiceRoleRelationship[];
+  diagnostics: AWSCodeBuildServiceRoleDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSEKSWorkloadIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSEKSWorkloadIdentityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 
@@ -2442,6 +2539,21 @@ export const apiClient = {
   ) {
     return request<{ inventory: AWSLambdaExecutionRoleInventoryResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/lambda-execution-roles${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectCodeBuildServiceRoles(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSCodeBuildServiceRoleFixtureState,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSCodeBuildServiceRoleInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/codebuild-service-roles${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
       })}`,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1350,6 +1350,7 @@ export type AWSCodeBuildServiceRoleRecord = {
   role_name?: string;
   project_arn?: string;
   project_name?: string;
+  project_description?: string;
   project_visibility?: string;
   source_type?: string;
   source_location?: string;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   AuthConfigResponse,
   AWSConnectorStartResponse,
+  AWSCodeBuildServiceRoleInventoryResult,
   AWSConnectionStatus,
   AWSEC2InstanceProfileInventoryResult,
   AWSEKSWorkloadIdentityInventoryResult,
@@ -436,6 +437,91 @@ const readyAWSLambdaExecutionRoleInventory: AWSLambdaExecutionRoleInventoryResul
       from_node_id: 'aws:workload:lambda:123456789012:us-east-1:function/payments-worker',
       to_node_id: 'aws:identity:arn:aws:iam::123456789012:role/payments-lambda-execution',
       evidence_ref: 'arn:aws:lambda:us-east-1:123456789012:function:payments-worker'
+    }
+  ],
+  diagnostics: [],
+  generated_at: '2026-05-17T10:00:00Z',
+  updated_at: '2026-05-17T10:00:00Z'
+};
+
+const readyAWSCodeBuildServiceRoleInventory: AWSCodeBuildServiceRoleInventoryResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1472,
+  parent_issue_ref: '#1472',
+  current_issue_number: 1481,
+  current_issue_ref: '#1481',
+  version: 'aws-codebuild-service-role-inventory-v1',
+  status: 'ready',
+  fixture_state: 'success',
+  confidence: 0.96,
+  record_count: 1,
+  project_count: 1,
+  identity_count: 1,
+  resource_count: 1,
+  relationship_count: 1,
+  secret_ref_count: 1,
+  vpc_project_count: 1,
+  public_project_count: 0,
+  privileged_project_count: 0,
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: ['/docs/aws-codebuild-service-roles'],
+  records: [
+    {
+      account_id: '123456789012',
+      region: 'us-east-1',
+      service: 'codebuild',
+      workload_id: 'arn:aws:codebuild:us-east-1:123456789012:project/payments-build',
+      workload_type: 'codebuild_project',
+      workload_name: 'payments-build',
+      role_arn: 'arn:aws:iam::123456789012:role/payments-codebuild-service',
+      role_name: 'payments-codebuild-service',
+      project_arn: 'arn:aws:codebuild:us-east-1:123456789012:project/payments-build',
+      project_name: 'payments-build',
+      project_visibility: 'PRIVATE',
+      source_type: 'GITHUB',
+      source_location: 'https://github.com/identrail/payments',
+      source_auth_type: 'CODECONNECTIONS',
+      source_version: 'main',
+      source_identifiers: ['payments/main'],
+      artifact_types: ['S3'],
+      artifact_locations: ['identrail-build-artifacts/payments'],
+      environment_type: 'LINUX_CONTAINER',
+      compute_type: 'BUILD_GENERAL1_MEDIUM',
+      image: 'aws/codebuild/standard:7.0',
+      image_pull_credentials_type: 'CODEBUILD',
+      privileged_mode: false,
+      kms_key_arn: 'arn:aws:kms:us-east-1:123456789012:key/codebuild-artifacts',
+      cache_type: 'S3',
+      cache_location: 'identrail-codebuild-cache/payments',
+      log_types: ['cloudwatch'],
+      vpc_id: 'vpc-prod',
+      subnet_ids: ['subnet-a', 'subnet-b'],
+      security_group_ids: ['sg-codebuild-payments'],
+      environment_keys: ['APP_ENV', 'NPM_TOKEN'],
+      secret_refs: ['NPM_TOKEN=arn:aws:secretsmanager:us-east-1:123456789012:secret:codebuild/npm'],
+      tags: { owner: 'platform', service: 'payments' },
+      source: 'batchgetprojects',
+      evidence_ref: 'arn:aws:codebuild:us-east-1:123456789012:project/payments-build',
+      from_node_id: 'aws:workload:codebuild:123456789012:us-east-1:project/payments-build',
+      to_node_id: 'aws:identity:arn:aws:iam::123456789012:role/payments-codebuild-service',
+      relationship_type: 'runs_as',
+      confidence: 0.96,
+      collected_at: '2026-05-17T10:00:00Z',
+      status: 'ready'
+    }
+  ],
+  relationships: [
+    {
+      type: 'runs_as',
+      from_node_id: 'aws:workload:codebuild:123456789012:us-east-1:project/payments-build',
+      to_node_id: 'aws:identity:arn:aws:iam::123456789012:role/payments-codebuild-service',
+      evidence_ref: 'arn:aws:codebuild:us-east-1:123456789012:project/payments-build'
     }
   ],
   diagnostics: [],
@@ -2450,7 +2536,7 @@ describe('Domain-first app routes', () => {
     );
   });
 
-  it('renders AWS machine identity inventory with current IAM, EC2, ECS, Lambda, and EKS role rows', async () => {
+  it('renders AWS machine identity inventory with current IAM, EC2, ECS, Lambda, CodeBuild, and EKS role rows', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
       items: [
@@ -2476,6 +2562,9 @@ describe('Domain-first app routes', () => {
     const getLambdaExecutionRoles = vi
       .spyOn(api.apiClient, 'getAWSProjectLambdaExecutionRoles')
       .mockResolvedValue({ inventory: readyAWSLambdaExecutionRoleInventory });
+    const getCodeBuildServiceRoles = vi
+      .spyOn(api.apiClient, 'getAWSProjectCodeBuildServiceRoles')
+      .mockResolvedValue({ inventory: readyAWSCodeBuildServiceRoleInventory });
     const getEKSWorkloadIdentities = vi
       .spyOn(api.apiClient, 'getAWSProjectEKSWorkloadIdentities')
       .mockResolvedValue({ inventory: readyAWSEKSWorkloadIdentityInventory });
@@ -2499,17 +2588,21 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('payments-ecs-task')).toBeInTheDocument();
     expect(screen.getByText('payments-ecs-execution')).toBeInTheDocument();
     expect(await screen.findByText('payments-lambda-execution')).toBeInTheDocument();
+    expect(await screen.findByText('payments-codebuild-service')).toBeInTheDocument();
     expect(await screen.findByText('payments-irsa')).toBeInTheDocument();
     expect(screen.getByText('batch-pod-identity')).toBeInTheDocument();
     expect(screen.getByText(/payments-api runs as payments-ec2-instance-profile; IMDS Required/i)).toBeInTheDocument();
     expect(screen.getByText(/payments-api runs as payments-ecs-task; FARGATE; 0\/3 running/i)).toBeInTheDocument();
     expect(screen.getByText(/payments-api attaches execution support to payments-ecs-execution; FARGATE; 0\/3 running/i)).toBeInTheDocument();
     expect(screen.getByText(/payments-worker runs as payments-lambda-execution; nodejs20\.x \/ index\.handler; 1 event source; 3 env keys, values hidden; 1 secret refs, values hidden/i)).toBeInTheDocument();
+    expect(screen.getByText(/payments-build runs as payments-codebuild-service; Github source; LINUX_CONTAINER \/ BUILD_GENERAL1_MEDIUM; S3 artifacts; VPC vpc-prod; 1 secret refs, values hidden/i)).toBeInTheDocument();
     expect(screen.getByText(/payments\/payments-api runs as payments-irsa; prod-cluster; Irsa; OIDC provider linked; ACTIVE; Kubernetes annotations proven/i)).toBeInTheDocument();
     expect(screen.getByText(/jobs\/batch-worker runs as batch-pod-identity; prod-cluster; Pod Identity; OIDC provider linked; association a-123; AWS-side evidence/i)).toBeInTheDocument();
     expect(screen.getAllByText(/2 workloads \/ 2 relationships/i).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText(/1 functions \/ 1 relationships/i)).toBeInTheDocument();
     expect(screen.getByText(/1 mapped \/ 0 disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 projects \/ 1 relationships/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 secret refs \/ 1 VPC projects/i)).toBeInTheDocument();
     expect(screen.getByText(/1 task \/ 1 execution/i)).toBeInTheDocument();
     expect(screen.getByText(/2 service accounts \/ 2 relationships/i)).toBeInTheDocument();
     expect(screen.getByText(/1 IRSA \/ 1 Pod Identity \/ 0 node/i)).toBeInTheDocument();
@@ -2529,6 +2622,13 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getLambdaExecutionRoles).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getCodeBuildServiceRoles).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       'aws-connector-1',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4927,7 +4927,7 @@ function awsCodeBuildServiceRoleRow(record: AWSCodeBuildServiceRoleRecord): AWSI
     category: 'CodeBuild service role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
-    stage: status === 'wired now' ? 'wired' : 'coming',
+    stage,
     detail: `${projectLabel} runs as ${roleLabel}; ${sourceLabel}; ${environmentLabel}; ${artifactLabel}; ${vpcLabel}; ${secretLabel}.`,
     filters: {
       identityType: 'codebuild-role',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -29,6 +29,8 @@ import {
   type AWSCapabilityPermissionTier,
   type AWSConnectorStartResponse,
   type AWSConnectionStatus,
+  type AWSCodeBuildServiceRoleInventoryResult,
+  type AWSCodeBuildServiceRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
   type AWSEC2InstanceProfileRecord,
   type AWSEKSWorkloadIdentityInventoryResult,
@@ -3498,7 +3500,7 @@ const AWS_INVENTORY_PAGE_COPY: Record<AWSInventoryRouteID, AWSInventoryPageCopy>
     statusLabel: 'Inventory shell',
     primaryKpi: 'Identity anchor',
     currentCapability: 'Current IAM role ARN, principal ARN, account, region, and permission diagnostics.',
-    plannedCapability: 'Instance profiles, ECS task roles, Lambda roles, EKS IRSA/Pod Identity, and deploy roles.'
+    plannedCapability: 'Instance profiles, ECS task roles, Lambda roles, CodeBuild service roles, EKS IRSA/Pod Identity, and deploy roles.'
   },
   agents: {
     routeID: 'agents',
@@ -3586,6 +3588,13 @@ type AWSInventoryLambdaState = {
   onRetry: () => void;
 };
 
+type AWSInventoryCodeBuildState = {
+  inventory: AWSCodeBuildServiceRoleInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryEKSState = {
   inventory: AWSEKSWorkloadIdentityInventoryResult | null;
   loading: boolean;
@@ -3635,11 +3644,12 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'Instance profile', value: 'instance-profile' },
         { label: 'ECS task role', value: 'ecs-task-role' },
         { label: 'Lambda role', value: 'lambda-role' },
+        { label: 'CodeBuild role', value: 'codebuild-role' },
         { label: 'EKS identity', value: 'eks-identity' },
         { label: 'CI/CD role', value: 'cicd-role' }
       ]
     },
-    { id: 'service', label: 'Service', options: [{ label: 'All services', value: 'all' }, { label: 'IAM', value: 'iam' }, { label: 'EC2', value: 'ec2' }, { label: 'ECS', value: 'ecs' }, { label: 'Lambda', value: 'lambda' }, { label: 'EKS', value: 'eks' }, { label: 'OIDC', value: 'oidc' }] },
+    { id: 'service', label: 'Service', options: [{ label: 'All services', value: 'all' }, { label: 'IAM', value: 'iam' }, { label: 'EC2', value: 'ec2' }, { label: 'ECS', value: 'ecs' }, { label: 'Lambda', value: 'lambda' }, { label: 'CodeBuild', value: 'codebuild' }, { label: 'EKS', value: 'eks' }, { label: 'OIDC', value: 'oidc' }] },
     {
       id: 'risk',
       label: 'Risk',
@@ -4187,6 +4197,7 @@ function AWSMachineIdentitiesContent({
   ec2State,
   ecsState,
   lambdaState,
+  codeBuildState,
   eksState,
   filters,
   onFiltersChange
@@ -4195,6 +4206,7 @@ function AWSMachineIdentitiesContent({
   ec2State: AWSInventoryEC2State;
   ecsState: AWSInventoryECSState;
   lambdaState: AWSInventoryLambdaState;
+  codeBuildState: AWSInventoryCodeBuildState;
   eksState: AWSInventoryEKSState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
@@ -4202,10 +4214,12 @@ function AWSMachineIdentitiesContent({
   const ec2Inventory = ec2State.inventory;
   const ecsInventory = ecsState.inventory;
   const lambdaInventory = lambdaState.inventory;
+  const codeBuildInventory = codeBuildState.inventory;
   const eksInventory = eksState.inventory;
   const ec2Rows = buildAWSEC2InstanceProfileRows(ec2Inventory, ec2State.loading, connection);
   const ecsRows = buildAWSECSTaskRoleRows(ecsInventory, ecsState.loading, connection);
   const lambdaRows = buildAWSLambdaExecutionRoleRows(lambdaInventory, lambdaState.loading, connection);
+  const codeBuildRows = buildAWSCodeBuildServiceRoleRows(codeBuildInventory, codeBuildState.loading, connection);
   const eksRows = buildAWSEKSWorkloadIdentityRows(eksInventory, eksState.loading, connection);
   const rows: AWSInventoryTableRow[] = [
     ...(connection?.role_arn
@@ -4232,6 +4246,7 @@ function AWSMachineIdentitiesContent({
     ...ec2Rows,
     ...ecsRows,
     ...lambdaRows,
+    ...codeBuildRows,
     ...eksRows,
     {
       id: 'cicd-oidc',
@@ -4253,6 +4268,7 @@ function AWSMachineIdentitiesContent({
       {ec2State.loading ? <DomainLoadingState label="Loading EC2 instance profiles" /> : null}
       {ecsState.loading ? <DomainLoadingState label="Loading ECS task roles" /> : null}
       {lambdaState.loading ? <DomainLoadingState label="Loading Lambda execution roles" /> : null}
+      {codeBuildState.loading ? <DomainLoadingState label="Loading CodeBuild service roles" /> : null}
       {eksState.loading ? <DomainLoadingState label="Loading EKS workload identities" /> : null}
       {ec2State.error ? (
         <DomainErrorState
@@ -4273,6 +4289,13 @@ function AWSMachineIdentitiesContent({
           title="Lambda execution roles could not load"
           body={lambdaState.error}
           retryAction={{ label: 'Retry Lambda inventory', onClick: lambdaState.onRetry }}
+        />
+      ) : null}
+      {codeBuildState.error ? (
+        <DomainErrorState
+          title="CodeBuild service roles could not load"
+          body={codeBuildState.error}
+          retryAction={{ label: 'Retry CodeBuild inventory', onClick: codeBuildState.onRetry }}
         />
       ) : null}
       {eksState.error ? (
@@ -4327,6 +4350,24 @@ function AWSMachineIdentitiesContent({
         >
           <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="Lambda execution role diagnostics">
             {lambdaInventory.diagnostics.map((diagnostic) => (
+              <article key={`${diagnostic.code}-${diagnostic.source_id ?? diagnostic.collector}`}>
+                <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                <p>{diagnostic.message}</p>
+                {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+      {codeBuildInventory?.diagnostics.length ? (
+        <DomainStatusPanel
+          eyebrow="CodeBuild collector diagnostics"
+          title="Partial CodeBuild service-role evidence"
+          status={formatTokenLabel(codeBuildInventory.status)}
+          tone={codeBuildInventory.status === 'blocked' ? 'danger' : 'warning'}
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="CodeBuild service role diagnostics">
+            {codeBuildInventory.diagnostics.map((diagnostic) => (
               <article key={`${diagnostic.code}-${diagnostic.source_id ?? diagnostic.collector}`}>
                 <strong>{formatTokenLabel(diagnostic.code)}</strong>
                 <p>{diagnostic.message}</p>
@@ -4428,6 +4469,18 @@ function AWSMachineIdentitiesContent({
             <div>
               <dt>Lambda diagnostics</dt>
               <dd>{lambdaInventory?.diagnostics.length ? `${lambdaInventory.diagnostics.length} active` : lambdaInventory ? 'Clear' : 'Not loaded'}</dd>
+            </div>
+            <div>
+              <dt>CodeBuild workload links</dt>
+              <dd>{codeBuildInventory ? `${codeBuildInventory.project_count} projects / ${codeBuildInventory.relationship_count} relationships` : codeBuildState.loading ? 'Loading' : 'Not loaded'}</dd>
+            </div>
+            <div>
+              <dt>CodeBuild credential refs</dt>
+              <dd>{codeBuildInventory ? `${codeBuildInventory.secret_ref_count} secret refs / ${codeBuildInventory.vpc_project_count} VPC projects` : 'Not loaded'}</dd>
+            </div>
+            <div>
+              <dt>CodeBuild diagnostics</dt>
+              <dd>{codeBuildInventory?.diagnostics.length ? `${codeBuildInventory.diagnostics.length} active` : codeBuildInventory ? 'Clear' : 'Not loaded'}</dd>
             </div>
             <div>
               <dt>EKS workload links</dt>
@@ -4785,6 +4838,129 @@ function awsLambdaExecutionRoleRow(record: AWSLambdaExecutionRoleRecord): AWSInv
       record.account_id,
       record.region,
       'lambda execution role'
+    ])
+  };
+}
+
+function buildAWSCodeBuildServiceRoleRows(
+  inventory: AWSCodeBuildServiceRoleInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsCodeBuildServiceRoleRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'codebuild-service-roles-blocked',
+        name: 'CodeBuild service roles unavailable',
+        category: 'CodeBuild service role',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'CodeBuild service-role collection is blocked.',
+        filters: { identityType: 'codebuild-role', service: 'codebuild', risk: 'unscored', status: 'not-yet-available', search: '' },
+        searchText: inventorySearchText(['codebuild', 'service role', inventory.account_id, inventory.region, 'blocked'])
+      }
+    ];
+  }
+  if (inventory) {
+    return [
+      {
+        id: 'codebuild-service-roles-empty',
+        name: 'No CodeBuild service roles found',
+        category: 'CodeBuild service role',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'wired now',
+        stage: 'wired',
+        detail: 'The collector completed for this account and region without CodeBuild projects that reference service roles.',
+        filters: { identityType: 'codebuild-role', service: 'codebuild', risk: 'low', status: 'wired-now', search: '' },
+        searchText: inventorySearchText(['codebuild', 'service role', inventory.account_id, inventory.region, 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'codebuild-service-roles-loading',
+        name: 'CodeBuild service roles',
+        category: 'CodeBuild service role',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading CodeBuild project service-role evidence for the selected environment.',
+        filters: { identityType: 'codebuild-role', service: 'codebuild', risk: 'unscored', status: 'coming', search: '' },
+        searchText: inventorySearchText(['codebuild', 'service role', 'loading'])
+      }
+    ];
+  }
+  return [
+    {
+      id: 'codebuild-service-roles',
+      name: 'CodeBuild service roles',
+      category: 'CodeBuild service role',
+      scope: 'Account and region expansion',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Service-role inventory maps CodeBuild projects back to IAM roles after AWS is connected.',
+      filters: { identityType: 'codebuild-role', service: 'codebuild', risk: 'unscored', status: 'coming', search: '' },
+      searchText: inventorySearchText(['codebuild', 'service role', 'ci', 'cd', 'inventory'])
+    }
+  ];
+}
+
+function awsCodeBuildServiceRoleRow(record: AWSCodeBuildServiceRoleRecord): AWSInventoryTableRow {
+  const stage: AWSCapabilityStage = record.status === 'ready' && record.role_arn ? 'wired' : 'coming';
+  const status = stage === 'wired' ? (record.privileged_mode || record.project_visibility === 'PUBLIC_READ' ? 'degraded' : 'wired now') : 'degraded';
+  const roleLabel = record.role_name || record.role_arn || 'role unresolved';
+  const projectLabel = record.project_name || record.workload_name || record.project_arn || record.workload_id;
+  const sourceLabel = record.source_type ? `${formatTokenLabel(record.source_type)} source` : 'source not reported';
+  const environmentLabel = record.environment_type || record.compute_type ? `${record.environment_type || 'environment not reported'} / ${record.compute_type || 'compute not reported'}` : 'environment not reported';
+  const artifactLabel = record.artifact_types?.length ? `${record.artifact_types.join(', ')} artifacts` : 'artifacts not reported';
+  const secretLabel = record.secret_refs?.length ? `${record.secret_refs.length} secret refs, values hidden` : 'no secret refs reported';
+  const vpcLabel = record.vpc_id ? `VPC ${record.vpc_id}` : 'no VPC config reported';
+  const risk = record.privileged_mode || record.project_visibility === 'PUBLIC_READ' ? 'high' : record.secret_refs?.length ? 'medium' : 'low';
+  return {
+    id: `codebuild-service-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.project_arn}`,
+    name: roleLabel,
+    category: 'CodeBuild service role',
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage: status === 'wired now' ? 'wired' : 'coming',
+    detail: `${projectLabel} runs as ${roleLabel}; ${sourceLabel}; ${environmentLabel}; ${artifactLabel}; ${vpcLabel}; ${secretLabel}.`,
+    filters: {
+      identityType: 'codebuild-role',
+      service: 'codebuild',
+      risk,
+      status: status === 'wired now' ? 'wired-now' : 'degraded',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.role_arn,
+      record.role_name,
+      record.project_arn,
+      record.project_name,
+      record.source_type,
+      record.source_location,
+      record.source_auth_type,
+      record.source_version,
+      record.environment_type,
+      record.compute_type,
+      record.image,
+      record.kms_key_arn,
+      record.vpc_id,
+      ...(record.source_identifiers ?? []),
+      ...(record.artifact_types ?? []),
+      ...(record.artifact_locations ?? []),
+      ...(record.log_types ?? []),
+      ...(record.subnet_ids ?? []),
+      ...(record.security_group_ids ?? []),
+      ...(record.secret_refs ?? []),
+      ...(record.environment_keys ?? []),
+      record.account_id,
+      record.region,
+      'codebuild service role ci cd build project'
     ])
   };
 }
@@ -5161,6 +5337,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [lambdaInventoryLoading, setLambdaInventoryLoading] = useState(false);
   const [lambdaInventoryError, setLambdaInventoryError] = useState('');
   const lambdaInventoryRequestRef = useRef(0);
+  const [codeBuildInventory, setCodeBuildInventory] = useState<AWSCodeBuildServiceRoleInventoryResult | null>(null);
+  const [codeBuildInventoryLoading, setCodeBuildInventoryLoading] = useState(false);
+  const [codeBuildInventoryError, setCodeBuildInventoryError] = useState('');
+  const codeBuildInventoryRequestRef = useRef(0);
   const [eksInventory, setEKSInventory] = useState<AWSEKSWorkloadIdentityInventoryResult | null>(null);
   const [eksInventoryLoading, setEKSInventoryLoading] = useState(false);
   const [eksInventoryError, setEKSInventoryError] = useState('');
@@ -5293,6 +5473,46 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       lambdaInventoryRequestRef.current += 1;
     };
   }, [loadLambdaInventory]);
+
+  const loadCodeBuildInventory = useCallback(async () => {
+    const requestID = ++codeBuildInventoryRequestRef.current;
+    setCodeBuildInventory(null);
+    setCodeBuildInventoryError('');
+    if (routeID !== 'identities' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setCodeBuildInventoryLoading(false);
+      return;
+    }
+    setCodeBuildInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectCodeBuildServiceRoles(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== codeBuildInventoryRequestRef.current) {
+        return;
+      }
+      setCodeBuildInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== codeBuildInventoryRequestRef.current) {
+        return;
+      }
+      setCodeBuildInventoryError(formatAPIError(error, 'Unable to load CodeBuild service role inventory.'));
+    } finally {
+      if (requestID === codeBuildInventoryRequestRef.current) {
+        setCodeBuildInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadCodeBuildInventory();
+    return () => {
+      codeBuildInventoryRequestRef.current += 1;
+    };
+  }, [loadCodeBuildInventory]);
 
   const loadEKSInventory = useCallback(async () => {
     const requestID = ++eksInventoryRequestRef.current;
@@ -5430,6 +5650,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: lambdaInventoryLoading,
             error: lambdaInventoryError,
             onRetry: () => void loadLambdaInventory()
+          }}
+          codeBuildState={{
+            inventory: codeBuildInventory,
+            loading: codeBuildInventoryLoading,
+            error: codeBuildInventoryError,
+            onRetry: () => void loadCodeBuildInventory()
           }}
           eksState={{
             inventory: eksInventory,


### PR DESCRIPTION
## Summary
- adds the AWS CodeBuild service-role collector, SDK adapter, normalizer, fixture support, and graph/resource typing
- exposes CodeBuild service-role inventory through the API, OpenAPI contract, authz policy, frontend client, and AWS machine identities page
- updates connector permissions and docs while keeping CodeBuild evidence metadata-only with no secret values, source contents, build logs, or artifacts collected

## Validation
- blocker confirmed closed: #1476
- go test ./internal/providers/aws ./internal/api ./internal/runtime ./internal/cli
- npm test -- --run src/api/client.test.ts src/productShell.test.tsx
- go test ./... -coverprofile=coverage.out
- go tool cover -func=coverage.out => total 80.4%
- npm run build
- git diff --check

## AI Assistance Disclosure
No

Closes #1481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS CodeBuild service-role inventory to map projects to IAM roles and expose them via API and UI. Also fixes project page batching in the CodeBuild adapter and preserves partial-page evidence on batch errors, satisfying #1481 with metadata-only collection.

- **New Features**
  - Added CodeBuild service-role collector, SDK adapter using `github.com/aws/aws-sdk-go-v2/service/codebuild`, normalizer, graph/resource types, and fixture support.
  - Added API GET `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/codebuild-service-roles` with `connector_id` and `fixture_state`; updated OpenAPI, router, authz policy, tests, and docs.
  - Updated web client and AWS machine identities page to display CodeBuild service roles.
  - Included CodeBuild in the AWS composite scanner; updated CLI and runtime builders.

- **Migration**
  - Update AWS connector IAM policy to include `codebuild:ListProjects` and `codebuild:BatchGetProjects` so collection can run.

<sup>Written for commit 57c695c608bbc8dbfbd7c4140a217ac3f9208b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

