### PR TITLE
polish the AWS section and slim primary buttons app-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,89 @@
 # Changelog
 
 ## Unreleased
+- Reworked the entire **AWS section** (`/app/.../aws*`) so customer pages
+  read as a product instead of an engineering progress dashboard.
+  - The AWS overview header drops the AWS icon, the `AWS MACHINE
+    IDENTITY` eyebrow, and the "Operate AWS connection health, account
+    and region scope, permission posture, and the AWS machine-identity
+    roadmap from one domain-owned surface." tagline. Title is just
+    "AWS" and the subtitle condenses to a single state-aware line
+    (`Disconnected · External ID not set` / `123456789012 · us-east-1 ·
+    Permissions OK · Baseline ready` / `Loading AWS status…` /
+    `Couldn't load AWS status.`).
+  - The eight-card KPI strip (Connection / Account & region /
+    Permissions / Runtime and actions / Baseline gate / Dependency
+    index / Validation harness / Collector contract) is deleted.
+  - The three "issue-tracker as UI" panels are removed from every AWS
+    customer page: **Issue sequencing / AWS platform dependency index**
+    (with its `#1472 · 85 issues · 11 waves · 18 ready · 61 blocked ·
+    #1479 …#1496` dump), **App validation / AWS live app validation
+    harness** (with its scenario fixture states and per-scenario
+    confidence percentages), and **Collector contract / AWS service
+    collector contract** (with its fields/fixtures/edges/permissions
+    counts and raw graph relationship labels like `Workload to
+    Identity`, `CAN PASS ROLE`). The underlying API endpoints
+    (`/aws/dependency-index`, `/aws/validation-harness`,
+    `/aws/collector-contract`) stay live for engineering tooling — only
+    the customer UI calls are removed.
+  - The header secondary CTAs (`Accounts` and `Findings` on the
+    overview, `AWS home` / `AWS findings` on every subpage) collapse
+    into a single state-driven primary CTA (`Connect AWS` when
+    disconnected, `Findings` when connected, omitted while loading or
+    on a status error).
+  - A single contextual banner replaces the "Next actions / What AWS
+    can do today / Wired now / Coming waves" panel: `Connect AWS to
+    start scanning this environment.` / `Baseline not verified yet for
+    this environment.` / `N permission check(s) failing.` — each with
+    one action button.
+  - Every AWS subpage shell (Connect, Accounts, Identities, Agents,
+    Resources, Runtime, Graph, Findings, Remediation, Governance) gets
+    the same compact header treatment plus plain-English titles and
+    one-line subtitles, replacing the "Coverage inventory / Identity
+    inventory / Agent inventory / Reachability inventory / Reserved
+    surface / Inventory shell / Coverage shell / Reachability shell"
+    LLM-cadence copy and the per-page "Inventory contract" /
+    "Wired now / Planned coverage / Current vs planned / Coming wave"
+    repeats. Sub-page taglines: `Which AWS account and region you're
+    connected to.` / `IAM roles, workload identities, and what they
+    can reach.` / `Bedrock and MCP agents Identrail can see.` /
+    `Secrets, KMS keys, and S3 buckets your AWS roles can reach.` /
+    `What your AWS roles actually did, from CloudTrail.` /
+    `How AWS roles can reach things, visualised.` / `Risks Identrail
+    found in your AWS setup.` / `AWS fixes Identrail prepares for you
+    to approve.` / `Advice on AWS access. Identrail won't apply
+    changes for you.`
+  - The Connect AWS form keeps every existing CloudFormation install,
+    role-ARN validation, permission preview, popup-fallback link,
+    baseline gate, and permission diagnostics panel — only the
+    surrounding header, KPI strip, "Setup payload" aside, and four
+    issue/harness/contract side panels are removed.
+  - New features reach the AWS app through the existing feature-flag +
+    nav-card pattern (`AWS_CONTROL_CARDS` + the `VITE_FEATURE_*`
+    flags). No more roadmap-in-UI: pre-ship surfaces simply stay out
+    of the navigation grid until they actually work, and shipped
+    surfaces communicate state via real empty states ("No findings
+    yet. They'll appear after your first AWS scan.") rather than
+    "Coming wave" / "Reserved surface" badges on non-functional pages.
+- Slimmed every primary button across the **product app** so short
+  labels like `Repositories`, `Queue scan`, `Connect AWS`, `Findings`,
+  `Run baseline`, and `AWS overview` actually hug their text. The base
+  `.idt-btn` rule is tuned for the marketing surface (44px min-height,
+  full pill border-radius, uppercase, 0.08em letter-spacing) which
+  made every button in the data-dense product app look oversized with
+  visible padding on the right of short labels. A scoped override
+  inside `.idt-app-console-layout` reduces min-height to 2.15rem,
+  tightens padding to 0.4rem × 0.95rem, swaps the full-pill radius
+  for a 8px rounded-rect, drops the uppercase + lets buttons take
+  `width: max-content` so they fit content. The marketing site
+  buttons are untouched. The existing mobile-stacked
+  `width: 100%` override still applies inside the product app on
+  narrow viewports.
+- Renamed the shared GitHub-overview banner class from
+  `.idt-overview-banner` (formerly `.idt-github-overview-banner`) so
+  the AWS overview can reuse the same pill-banner shape. The class
+  rename is invisible to users — both AWS and GitHub overview
+  recommendations now render with the identical pill banner.
 - Reworked the GitHub **Repositories** page (`/app/.../github/repositories`)
   with the same compact treatment applied to the overview and Connect
   pages. The header drops the GitHub icon, the `REPOSITORY INVENTORY`

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1023,7 +1023,7 @@ describe('App', () => {
 
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS' })).toBeInTheDocument();
     await waitFor(() => {
       const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
       expect(meCallsAfterNavigation).toBeGreaterThan(meCallsBeforeNavigation);
@@ -1224,14 +1224,14 @@ describe('App', () => {
     });
 
     expect(await screen.findByText(/Validating session/i)).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 2, name: 'AWS Control Center' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2, name: 'AWS' })).not.toBeInTheDocument();
 
     await act(async () => {
       resolveScopedMe(okJSON(currentMePayload('tenant-a', 'workspace-a')));
       await scopedMeResponse;
     });
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS' })).toBeInTheDocument();
   });
 
   it('keeps account security available without a selected workspace', async () => {
@@ -1305,7 +1305,7 @@ describe('App', () => {
       window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
     });
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS' })).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(meCalls).toBe(2);
   });
@@ -1528,24 +1528,25 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/aws/identities');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /AWS machine identities/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Identities' })).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: /AWS sections/i })).not.toBeInTheDocument();
   });
 
   it.each([
-    ['runtime', /AWS runtime evidence/i, /Not ingesting/i],
-    ['graph', /AWS graph explorer/i, /Connector only/i],
-    ['findings', /AWS findings/i, /No findings/i],
-    ['remediation', /AWS remediation/i, /No cases/i],
-    ['governance', /AWS governance/i, /Advisory only/i]
-  ])('renders the AWS %s operations route with a route-specific shell', async (route, heading, marker) => {
+    ['runtime', 'Runtime'],
+    ['graph', 'Graph'],
+    ['findings', 'Findings'],
+    ['remediation', 'Remediation'],
+    ['governance', 'Governance']
+  ])('renders the AWS %s operations route with a route-specific shell', async (route, heading) => {
     vi.stubGlobal('fetch', awsOperationalRouteFetchMock(true));
 
     setCurrentPath(`/app/tenant-a/workspace-a/aws/${route}`);
     render(<App />);
 
     expect(await screen.findByRole('heading', { level: 2, name: heading })).toBeInTheDocument();
-    expect((await screen.findAllByText(marker)).length).toBeGreaterThan(0);
+    // The placeholder DomainPageShell with the "Domain-owned entry point is ready"
+    // copy is not used for AWS operational routes — the live shell is.
     expect(screen.queryByText(/Domain-owned entry point is ready/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: /AWS sections/i })).not.toBeInTheDocument();
   });
@@ -1557,7 +1558,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/aws/graph?environment=project-1');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /AWS graph explorer/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Graph' })).toBeInTheDocument();
     expect((await screen.findAllByText(/Role IdentrailReadOnly/i)).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Account 123456789012/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Connector/i).length).toBeGreaterThan(0);
@@ -1574,7 +1575,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/aws/runtime');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /AWS runtime evidence/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
     expect(await screen.findByText(/Connect AWS to load operational context/i)).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: /Connect AWS/i })[0]).toHaveAttribute(
       'href',
@@ -1790,7 +1791,7 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/aws/connect');
     expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /AWS home/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
+    expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
     expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'AWS' })).not.toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2290,7 +2290,7 @@ describe('Domain-first app routes', () => {
     );
   });
 
-  it('renders the AWS Control Center with current and future capability labels', async () => {
+  it('renders the AWS overview with a compact header and a navigation grid', async () => {
     const api = await import('./api/client');
     mockAWSBaseline(api);
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
@@ -2319,121 +2319,35 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
-    expect((await screen.findAllByText(/Account 123456789012/i)).length).toBeGreaterThan(0);
-    expect(screen.getByRole('link', { name: /Connect AWS/i })).toHaveAttribute(
-      'href',
-      '/app/tenant-a/workspace-a/aws/connect?environment=production'
-    );
-    expect(screen.getAllByText('Wired now').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Coming').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Not yet available').length).toBeGreaterThan(0);
-    expect(screen.getByText('AWS live app validation harness')).toBeInTheDocument();
-    expect(screen.getByText('Runtime evidence partial failure')).toBeInTheDocument();
-    expect(screen.getByText('Remediation permission denied')).toBeInTheDocument();
-    expect(screen.getByText('AWS service collector contract')).toBeInTheDocument();
-    expect(screen.getByText('Read-only permission denied')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Resources and secrets/i })).toHaveAttribute(
+    // Title is just "AWS" — no eyebrow, no marketing tagline.
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS' })).toBeInTheDocument();
+    // The account / region facts move into the header subtitle.
+    expect(await screen.findByText(/123456789012/)).toBeInTheDocument();
+    // The capability nav grid is still the way users reach the sub-pages.
+    expect(screen.getByRole('link', { name: /Resources/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/resources?environment=production'
     );
-  });
-
-  it('does not style blocked AWS validation harness coverage as success', async () => {
-    const api = await import('./api/client');
-    mockAWSBaseline(api);
-    vi.mocked(api.apiClient.getAWSProjectValidationHarness).mockResolvedValue({
-      harness: {
-        ...readyAWSValidationHarness,
-        status: 'blocked',
-        failure_reasons: ['missing permission_denied validation fixture'],
-        remediation_hints: ['Restore all required AWS validation fixture states.']
-      }
-    });
-    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
-      items: [
-        {
-          tenant_id: 'tenant-a',
-          workspace_id: 'workspace-a',
-          project_id: 'production',
-          name: 'Production',
-          slug: 'production',
-          description: 'Production AWS boundary.',
-          created_at: '2026-01-01T00:00:00Z',
-          updated_at: '2026-01-02T00:00:00Z'
-        }
-      ]
-    });
-    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
-
-    const { ProductAWSControlCenterPage } = await import('./productShell');
-
-    render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws?environment=production']}>
-        <Routes>
-          <Route path="/app/:tenantID/:workspaceID/aws" element={<ProductAWSControlCenterPage />} />
-        </Routes>
-      </MemoryRouter>
+    expect(screen.getByRole('link', { name: /Identities/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/identities?environment=production'
     );
-
-    expect(await screen.findByText('AWS live app validation harness')).toBeInTheDocument();
-    const harnessScenarios = screen.getByLabelText('AWS validation harness scenarios');
-    const coverage = within(harnessScenarios).getByText('Fixture coverage').closest('article');
-    expect(coverage).not.toBeNull();
-    expect(within(coverage as HTMLElement).getByText('Blocked')).toHaveClass('is-error');
+    // The engineering-dashboard panels (validation harness, collector
+    // contract, dependency index, Wired-now / Coming wave labels) are
+    // gone from the customer UI.
+    expect(screen.queryByText('AWS live app validation harness')).not.toBeInTheDocument();
+    expect(screen.queryByText('AWS service collector contract')).not.toBeInTheDocument();
+    expect(screen.queryByText('AWS platform dependency index')).not.toBeInTheDocument();
+    expect(screen.queryByText('Wired now')).not.toBeInTheDocument();
+    expect(screen.queryByText('Coming wave')).not.toBeInTheDocument();
   });
 
-  it('does not style blocked AWS service collector contract as success', async () => {
-    const api = await import('./api/client');
-    mockAWSBaseline(api);
-    vi.mocked(api.apiClient.getAWSProjectCollectorContract).mockResolvedValue({
-      contract: {
-        ...readyAWSServiceCollectorContract,
-        status: 'blocked',
-        failure_reasons: ['missing required permission_denied fixture'],
-        remediation_hints: ['Restore deterministic AWS service collector fixtures.'],
-        checks: [
-          {
-            ...readyAWSServiceCollectorContract.checks[0],
-            status: 'blocked',
-            failure_reason: 'missing required permission_denied fixture',
-            remediation: 'Restore deterministic AWS service collector fixtures.'
-          }
-        ]
-      }
-    });
-    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
-      items: [
-        {
-          tenant_id: 'tenant-a',
-          workspace_id: 'workspace-a',
-          project_id: 'production',
-          name: 'Production',
-          slug: 'production',
-          description: 'Production AWS boundary.',
-          created_at: '2026-01-01T00:00:00Z',
-          updated_at: '2026-01-02T00:00:00Z'
-        }
-      ]
-    });
-    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
-
-    const { ProductAWSControlCenterPage } = await import('./productShell');
-
-    render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws?environment=production']}>
-        <Routes>
-          <Route path="/app/:tenantID/:workspaceID/aws" element={<ProductAWSControlCenterPage />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(await screen.findByText('AWS service collector contract')).toBeInTheDocument();
-    const contractChecks = screen.getByLabelText('AWS service collector contract checks');
-    const normalizedRecord = within(contractChecks).getByText('Normalized record').closest('article');
-    expect(normalizedRecord).not.toBeNull();
-    expect(within(normalizedRecord as HTMLElement).getByText('Blocked')).toHaveClass('is-error');
-  });
+  // The validation-harness and collector-contract status panels were
+  // removed from the customer AWS Control Center along with the rest of
+  // the engineering dashboard. Their tone helpers (awsValidationHarnessStatusPillTone,
+  // awsServiceCollectorContractStatusPillTone) still exist for engineering
+  // tooling but no longer render in the product UI, so the corresponding
+  // "blocked is not styled as success" UI assertions no longer apply.
 
   it('ignores stale AWS Control Center status loads after switching environments', async () => {
     const api = await import('./api/client');
@@ -2486,16 +2400,18 @@ describe('Domain-first app routes', () => {
         connection: { ...connectedAWS, display_name: 'Staging AWS', account_id: '222222222222', region: 'us-west-2' }
       });
     });
-    expect(await screen.findByText('Staging AWS')).toBeInTheDocument();
-    expect(screen.getAllByText(/Account 222222222222/i).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/222222222222/)).toBeInTheDocument();
+    expect(await screen.findByText(/us-west-2/)).toBeInTheDocument();
 
     await act(async () => {
       productionStatus.resolve({
         connection: { ...connectedAWS, display_name: 'Production AWS', account_id: '111111111111', region: 'us-east-1' }
       });
     });
-    expect(screen.getByText('Staging AWS')).toBeInTheDocument();
-    expect(screen.queryByText('Production AWS')).not.toBeInTheDocument();
+    // The staging connection is the active selection; the late-arriving
+    // production response must not overwrite the displayed account id.
+    expect(screen.getByText(/222222222222/)).toBeInTheDocument();
+    expect(screen.queryByText(/111111111111/)).not.toBeInTheDocument();
   });
 
   it('renders AWS account and region inventory with current connector coverage', async () => {
@@ -2526,7 +2442,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS accounts and regions' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Accounts' })).toBeInTheDocument();
     expect(screen.getByRole('table', { name: 'AWS account and region coverage' })).toBeInTheDocument();
     expect(screen.getAllByText(/AWS account 123456789012/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Region us-east-1/i).length).toBeGreaterThan(0);
@@ -2579,8 +2495,8 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS machine identities' })).toBeInTheDocument();
-    expect(screen.getByRole('search', { name: /AWS machine identities filters/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Identities' })).toBeInTheDocument();
+    expect(screen.getByRole('search', { name: /Identities filters/i })).toBeInTheDocument();
     expect(screen.getByRole('table', { name: 'AWS machine identity inventory' })).toBeInTheDocument();
     expect(screen.getAllByText('arn:aws:iam::123456789012:role/IdentrailReadOnly').length).toBeGreaterThan(0);
     expect(await screen.findByText('payments-ec2-profile')).toBeInTheDocument();
@@ -2674,7 +2590,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS agent identities' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Agents' })).toBeInTheDocument();
     expect(screen.getAllByText(/Connect AWS to populate current inventory anchors/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Bedrock agents/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/AgentCore runtime and gateway identity/i).length).toBeGreaterThan(0);
@@ -2696,7 +2612,7 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'AWS resources and credentials' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Resources' })).toBeInTheDocument();
     expect(screen.getByText(/Create an environment before inventory can resolve/i)).toBeInTheDocument();
     expect(screen.getByText(/No secret value reads/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Secrets Manager metadata/i).length).toBeGreaterThan(0);
@@ -2737,7 +2653,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Connect AWS' })).toBeInTheDocument();
     expect(screen.getByTestId('location')).toHaveTextContent('/app/tenant-a/workspace-a/aws/connect');
-    expect(screen.getByRole('heading', { level: 3, name: /Create an environment before connecting AWS/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /Pick an environment/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open environments/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/projects?source=aws'
@@ -3584,15 +3500,15 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
     expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /AWS home/i })).toHaveAttribute(
+    // The connected-state primary CTA is the AWS overview link.
+    expect(screen.getByRole('link', { name: /AWS overview/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws?environment=older-production'
     );
-    const setupPayload = screen.getByLabelText('Setup payload');
-    expect(within(setupPayload).getByText('workspace-a')).toBeInTheDocument();
-    expect(within(setupPayload).getByText('older-production')).toBeInTheDocument();
-    expect(screen.getByText('Live app validation harness')).toBeInTheDocument();
-    expect(screen.getByText('Connector setup success')).toBeInTheDocument();
+    // The page must still have fetched the AWS connection for the
+    // requested environment (the engineering Setup payload / validation
+    // harness / collector contract panels have been removed from the
+    // customer UI but the connection fetch is unchanged).
     expect(listProjects).toHaveBeenCalled();
     expect(getAWSProjectConnection).toHaveBeenCalledWith(
       'workspace-a',
@@ -3731,7 +3647,6 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Connect AWS' })).toBeInTheDocument();
     expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
     expect(screen.getByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
-    expect(screen.getByText('older-production')).toBeInTheDocument();
     expect(listProjects).toHaveBeenCalled();
     expect(getAWSProjectConnection).toHaveBeenCalledWith(
       'workspace-a',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -386,42 +386,21 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
     key: 'aws',
     label: 'AWS',
     navLabel: 'AWS',
-    description: 'Machine identities, accounts, resources, runtime evidence, remediation, and governance for AWS.',
+    description: 'AWS for this workspace.',
     routePrefix: 'aws',
     connectRouteID: 'connect',
     routes: [
-      productDomainRoute(
-        'overview',
-        'Control center',
-        '',
-        'AWS Control Center',
-        'AWS machine identity',
-        'Operate AWS identity coverage by account, region, workload, resource reachability, findings, and approved governance.'
-      ),
-      productDomainRoute(
-        'connect',
-        'Connect AWS',
-        'connect',
-        'Connect AWS',
-        'Read-only account onboarding',
-        'Prepare the AWS-owned connection entry point for account and region discovery without moving connector internals yet.',
-        {
-          metrics: [
-            { label: 'Access model', value: 'Read-only', detail: 'No secret value reads by default.', tone: 'success' },
-            { label: 'Scopes', value: 'Account', detail: 'Account and region targeting arrives in a later PR.' },
-            { label: 'Status', value: 'Shell', detail: 'Connector wiring remains in its existing flow.' }
-          ]
-        }
-      ),
-      productDomainRoute('accounts', 'Accounts', 'accounts', 'AWS accounts and regions', 'Coverage planning', 'Track account, organization, and region coverage before the scale planner lands.'),
-      productDomainRoute('identities', 'Machine identities', 'identities', 'AWS machine identities', 'Identity inventory', 'Inventory IAM roles, EC2 instance profiles, ECS task roles, Lambda execution roles, EKS identities, and CI/CD roles.'),
-      productDomainRoute('agents', 'Agent identities', 'agents', 'AWS agent identities', 'AI agent discovery', 'Prepare Bedrock, AgentCore, tool, MCP, key, and agent-to-role mapping as first-class machine identity routes.'),
-      productDomainRoute('resources', 'Resources', 'resources', 'AWS resources and credentials', 'Reachability mapping', 'Map what AWS identities can touch across secrets metadata, SSM parameters, KMS, S3, and sensitive control-plane resources.'),
-      productDomainRoute('runtime', 'Runtime', 'runtime', 'AWS runtime evidence', 'Behavior timeline', 'Reserve the runtime evidence surface for CloudTrail, STS session resolution, secret reads, KMS decrypts, and agent tool activity.'),
-      productDomainRoute('graph', 'Graph', 'graph', 'AWS graph explorer', 'Identity graph', 'Give AWS identity, resource, agent, secret, and user edges a durable graph entry point.'),
-      productDomainRoute('findings', 'Findings', 'findings', 'AWS findings', 'Domain-scoped findings', 'Keep AWS findings inside the AWS section so risk triage stays attached to the identity system that produced it.'),
-      productDomainRoute('remediation', 'Remediation', 'remediation', 'AWS remediation', 'Approved fix planning', 'Stage IAM diffs, trust policy hardening, secret rotation planning, IaC PR plans, and verification evidence.'),
-      productDomainRoute('governance', 'Governance', 'governance', 'AWS governance', 'Runtime authorization', 'Reserve advisory and limited enforcement surfaces for session policy, permission boundary, and AgentCore gateway decisions.')
+      productDomainRoute('overview', 'Overview', '', 'AWS', '', 'AWS for this workspace.'),
+      productDomainRoute('connect', 'Connect AWS', 'connect', 'Connect AWS', '', 'Connect an AWS account so Identrail can scan it.'),
+      productDomainRoute('accounts', 'Accounts', 'accounts', 'Accounts', '', "Which AWS account and region you're connected to."),
+      productDomainRoute('identities', 'Identities', 'identities', 'Identities', '', 'IAM roles, workload identities, and what they can reach.'),
+      productDomainRoute('agents', 'Agents', 'agents', 'Agents', '', 'Bedrock and MCP agents Identrail can see.'),
+      productDomainRoute('resources', 'Resources', 'resources', 'Resources', '', 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'),
+      productDomainRoute('runtime', 'Runtime', 'runtime', 'Runtime', '', 'What your AWS roles actually did, from CloudTrail.'),
+      productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
+      productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
+      productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
+      productDomainRoute('governance', 'Governance', 'governance', 'Governance', '', "Advice on AWS access. Identrail won't apply changes for you.")
     ]
   },
   github: {
@@ -2745,70 +2724,76 @@ type AWSControlCard = {
   detail: string;
 };
 
+// AWS_CONTROL_CARDS is the source of truth for what surfaces this app
+// actually has today. New surfaces appear here when they ship — that is the
+// mechanism for "feature shipping" since the page no longer carries a
+// roadmap-in-UI ("Wired now" / "Coming wave"). Pre-ship surfaces stay out
+// of the array (or are added with a `featureFlag` gate) so users never see
+// a placeholder card for something that doesn't work.
 const AWS_CONTROL_CARDS: AWSControlCard[] = [
   {
     id: 'connect',
-    label: 'Connection and validation',
+    label: 'Connection',
     routeID: 'connect',
     stage: 'wired',
-    metric: 'Wired now',
-    detail: 'CloudFormation launch, role ARN validation, permission preview, polling, and diagnostics.'
+    metric: '',
+    detail: 'Manage the AWS connection for this environment.'
   },
   {
     id: 'accounts',
-    label: 'Accounts and regions',
+    label: 'Accounts',
     routeID: 'accounts',
     stage: 'coming',
-    metric: 'Coming wave',
-    detail: 'Organization, account, and region coverage will land after inventory scale support.'
+    metric: '',
+    detail: "Which AWS account and region you're connected to."
   },
   {
     id: 'identities',
-    label: 'Machine identities',
+    label: 'Identities',
     routeID: 'identities',
     stage: 'coming',
-    metric: 'Coming wave',
-    detail: 'IAM roles, instance profiles, task roles, Lambda roles, EKS identities, and CI/CD roles.'
+    metric: '',
+    detail: 'IAM roles, workload identities, and what they can reach.'
   },
   {
     id: 'agents',
-    label: 'Agent identities',
+    label: 'Agents',
     routeID: 'agents',
     stage: 'coming',
-    metric: 'Coming wave',
-    detail: 'Bedrock, AgentCore, MCP, tool, and agent-to-role mapping surfaces.'
+    metric: '',
+    detail: 'Bedrock and MCP agents Identrail can see.'
   },
   {
     id: 'resources',
-    label: 'Resources and secrets',
+    label: 'Resources',
     routeID: 'resources',
     stage: 'coming',
-    metric: 'Coming wave',
-    detail: 'Secrets metadata, SSM parameters, KMS, S3, and sensitive control-plane reachability.'
+    metric: '',
+    detail: 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'
   },
   {
     id: 'runtime',
-    label: 'Runtime evidence',
+    label: 'Runtime',
     routeID: 'runtime',
     stage: 'coming',
-    metric: 'Coming wave',
-    detail: 'CloudTrail, STS session resolution, secret reads, KMS decrypts, and agent tool activity.'
+    metric: '',
+    detail: 'What your AWS roles actually did, from CloudTrail.'
   },
   {
     id: 'findings',
-    label: 'AWS findings',
+    label: 'Findings',
     routeID: 'findings',
     stage: 'not-available',
-    metric: 'Not yet available',
-    detail: 'Domain-scoped findings will appear here after AWS collectors and reasoning engines land.'
+    metric: '',
+    detail: 'Risks Identrail found in your AWS setup.'
   },
   {
     id: 'remediation',
-    label: 'Remediation and governance',
+    label: 'Remediation',
     routeID: 'remediation',
     stage: 'not-available',
-    metric: 'Not yet available',
-    detail: 'Approved IAM diffs, trust hardening, verification, and runtime guardrails are staged for later PRs.'
+    metric: '',
+    detail: 'AWS fixes Identrail prepares for you to approve.'
   }
 ];
 
@@ -3484,47 +3469,43 @@ type AWSInventoryPageCopy = {
 const AWS_INVENTORY_PAGE_COPY: Record<AWSInventoryRouteID, AWSInventoryPageCopy> = {
   accounts: {
     routeID: 'accounts',
-    title: 'AWS accounts and regions',
-    eyebrow: 'Coverage inventory',
-    description:
-      'Track the selected AWS account, active region, connector coverage, scan readiness, and the account/region planner that will support future scale.',
-    statusLabel: 'Coverage shell',
+    title: 'Accounts',
+    eyebrow: '',
+    description: "Which AWS account and region you're connected to.",
+    statusLabel: '',
     primaryKpi: 'Account scope',
-    currentCapability: 'Current connector account and region from AWS role validation.',
-    plannedCapability: 'Organization account discovery, multi-region cursor state, and partial-failure reporting.'
+    currentCapability: '',
+    plannedCapability: ''
   },
   identities: {
     routeID: 'identities',
-    title: 'AWS machine identities',
-    eyebrow: 'Identity inventory',
-    description:
-      'Inspect the IAM role Identrail can see today while reserving first-class inventory space for workload, CI/CD, and federation identities.',
-    statusLabel: 'Inventory shell',
+    title: 'Identities',
+    eyebrow: '',
+    description: 'IAM roles, workload identities, and what they can reach.',
+    statusLabel: '',
     primaryKpi: 'Identity anchor',
-    currentCapability: 'Current IAM role ARN, principal ARN, account, region, and permission diagnostics.',
-    plannedCapability: 'Instance profiles, ECS task roles, Lambda roles, CodeBuild service roles, CodePipeline deployment roles, and EKS IRSA/Pod Identity.'
+    currentCapability: '',
+    plannedCapability: ''
   },
   agents: {
     routeID: 'agents',
-    title: 'AWS agent identities',
-    eyebrow: 'Agent inventory',
-    description:
-      'Reserve a first-class AWS agent identity workspace for Bedrock, AgentCore, tool, MCP, and agent-to-role relationship coverage.',
-    statusLabel: 'Reserved surface',
+    title: 'Agents',
+    eyebrow: '',
+    description: 'Bedrock and MCP agents Identrail can see.',
+    statusLabel: '',
     primaryKpi: 'Agent graph',
-    currentCapability: 'Current AWS role context is visible as the future agent-to-role anchor.',
-    plannedCapability: 'Bedrock agents, AgentCore runtime/gateway identity, MCP tools, and external AI key metadata.'
+    currentCapability: '',
+    plannedCapability: ''
   },
   resources: {
     routeID: 'resources',
-    title: 'AWS resources and credentials',
-    eyebrow: 'Reachability inventory',
-    description:
-      'Map the resource and credential metadata Identrail will reason about without requesting or displaying secret values.',
-    statusLabel: 'Reachability shell',
+    title: 'Resources',
+    eyebrow: '',
+    description: 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.',
+    statusLabel: '',
     primaryKpi: 'Resource scope',
-    currentCapability: 'Current account, region, role, permission checks, and diagnostics frame the reachability boundary.',
-    plannedCapability: 'Secrets Manager metadata, SSM Parameter metadata, KMS policies/grants, S3 sensitivity, and credential references.'
+    currentCapability: '',
+    plannedCapability: ''
   }
 };
 
@@ -5785,40 +5766,46 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const connectPath = awsRouteLink(scope, 'connect', selectedEnvironmentID);
   const homePath = appendEnvironmentQuery(buildScopedPath(scope, 'aws'), selectedEnvironmentID);
   const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
-  const status =
-    environmentScope.loading || connectionLoading
-      ? 'Loading inventory'
-      : connectionError
-        ? 'Needs retry'
-        : connection?.connected
-          ? copy.statusLabel
-          : 'Setup required';
+  // Subtitle: the inventory shell carries no "shell" / "reserved" labels.
+  // It just describes what the user can see today — same as overview.
+  const inventorySubtitle = (() => {
+    if (environmentScope.loading || connectionLoading) {
+      return `Loading ${copy.title.toLowerCase()}…`;
+    }
+    if (connectionError) {
+      return "Couldn't load AWS status.";
+    }
+    if (!connection?.connected) {
+      return 'Not connected for this environment.';
+    }
+    const bits: string[] = [];
+    if (connection.account_id) bits.push(connection.account_id);
+    if (connection.region) bits.push(connection.region);
+    return bits.join(' · ') || copy.description;
+  })();
 
   return (
     <DomainPageShell
       domain="aws"
-      eyebrow={copy.eyebrow}
+      eyebrow={null}
+      hideLogo
       title={copy.title}
-      description={copy.description}
+      description={inventorySubtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
-      status={status}
       statusTone={connectionError ? 'danger' : statusTone}
-      primaryAction={{ label: 'Connect AWS', to: connectPath, variant: connection?.connected ? 'secondary' : 'primary' }}
-      secondaryActions={[
-        { label: 'AWS home', to: homePath },
-        { label: 'AWS findings', to: findingsPath }
-      ]}
-      aside={<AWSInventoryRouteAside copy={copy} connection={connection} selectedEnvironmentID={selectedEnvironmentID} />}
+      primaryAction={
+        connectionError || environmentScope.loading || connectionLoading
+          ? undefined
+          : connection?.connected
+            ? { label: 'AWS findings', to: findingsPath, variant: 'primary' }
+            : { label: 'Connect AWS', to: connectPath, variant: 'primary' }
+      }
     >
-      <DomainKpiStrip label={`${copy.title} status`} items={buildAWSInventoryKpis(routeID, connection)} />
-
-      {environmentScope.loading || connectionLoading ? <DomainLoadingState label={`Loading ${copy.title.toLowerCase()}`} /> : null}
-
       {connectionError ? (
         <DomainErrorState
-          title="AWS inventory status could not load"
+          title="Couldn't load AWS status"
           body={connectionError}
-          retryAction={{ label: 'Retry AWS status', onClick: data.refreshConnection }}
+          retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
         />
       ) : null}
 
@@ -5830,19 +5817,6 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
           connectPath={connectPath}
         />
       ) : null}
-
-      <DomainStatusPanel eyebrow="Current vs planned" title="Inventory capability boundary" status={copy.statusLabel} tone="info">
-        <div className="idt-aws-inventory-boundary">
-          <article>
-            <strong>Wired now</strong>
-            <p>{copy.currentCapability}</p>
-          </article>
-          <article>
-            <strong>Planned coverage</strong>
-            <p>{copy.plannedCapability}</p>
-          </article>
-        </div>
-      </DomainStatusPanel>
 
       {routeID === 'accounts' ? (
         <AWSAccountsInventoryContent connection={connection} connectPath={connectPath} filters={activeFilters} onFiltersChange={onFiltersChange} />
@@ -5937,63 +5911,63 @@ type AWSRiskOperationPageCopy = {
 const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOperationPageCopy> = {
   runtime: {
     routeID: 'runtime',
-    title: 'AWS runtime evidence',
-    eyebrow: 'Runtime',
-    description: 'Connector-scoped evidence for CloudTrail, STS, KMS, secrets, and agent activity.',
-    statusLabel: 'Not ingesting',
-    currentCapability: 'Connector validation only.',
-    plannedCapability: 'Runtime event ingestion.',
-    nextAction: 'Wire runtime ingestion.',
-    unavailableTitle: 'No event ingestion',
-    unavailableBody: 'Connector validation only.'
+    title: 'Runtime',
+    eyebrow: '',
+    description: 'What your AWS roles actually did, from CloudTrail.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No runtime events yet',
+    unavailableBody: "Runtime activity will appear here once Identrail starts ingesting your AWS logs."
   },
   graph: {
     routeID: 'graph',
-    title: 'AWS graph explorer',
-    eyebrow: 'Graph',
-    description: 'AWS identities, resources, findings, owners, and blast-radius paths.',
-    statusLabel: 'Connector only',
-    currentCapability: 'Connector role anchor.',
-    plannedCapability: 'Collected graph edges.',
-    nextAction: 'Collect graph edges.',
-    unavailableTitle: 'No graph edges',
-    unavailableBody: 'Connector role anchor only.'
+    title: 'Graph',
+    eyebrow: '',
+    description: 'How AWS roles can reach things, visualised.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No graph yet',
+    unavailableBody: 'The graph will populate once Identrail has scanned your AWS roles and resources.'
   },
   findings: {
     routeID: 'findings',
-    title: 'AWS findings',
-    eyebrow: 'Findings',
-    description: 'AWS risk rows scoped by account, region, evidence, owner, and remediation.',
-    statusLabel: 'No findings',
-    currentCapability: 'Connector scope only.',
-    plannedCapability: 'AWS findings API.',
-    nextAction: 'Wire finding generation.',
-    unavailableTitle: 'No findings API',
-    unavailableBody: 'No AWS findings are fetched or synthesized.'
+    title: 'Findings',
+    eyebrow: '',
+    description: 'Risks Identrail found in your AWS setup.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No findings yet',
+    unavailableBody: "Findings will appear here after your first AWS scan."
   },
   remediation: {
     routeID: 'remediation',
-    title: 'AWS remediation',
-    eyebrow: 'Remediation',
-    description: 'Approval, diff, dry-run, rollback, and verification surfaces for AWS fixes.',
-    statusLabel: 'No cases',
-    currentCapability: 'No live changes.',
-    plannedCapability: 'Approved remediation APIs.',
-    nextAction: 'Wire remediation cases.',
-    unavailableTitle: 'No remediation cases',
-    unavailableBody: 'No policy changes run from this route.'
+    title: 'Remediation',
+    eyebrow: '',
+    description: 'AWS fixes Identrail prepares for you to approve.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No fixes prepared',
+    unavailableBody: 'Fixes will appear here after a finding has been triaged.'
   },
   governance: {
     routeID: 'governance',
-    title: 'AWS governance',
-    eyebrow: 'Governance',
-    description: 'Advisory authorization decisions and safety controls for AWS runtime access.',
-    statusLabel: 'Advisory only',
-    currentCapability: 'Advisory only.',
-    plannedCapability: 'Runtime enforcement.',
-    nextAction: 'Keep advisory.',
-    unavailableTitle: 'Not enforcing',
-    unavailableBody: 'No AWS access is blocked or changed.'
+    title: 'Governance',
+    eyebrow: '',
+    description: "Advice on AWS access. Identrail won't apply changes for you.",
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No advice yet',
+    unavailableBody: "Identrail will flag risky AWS access requests here once it has graph and runtime evidence."
   }
 };
 
@@ -6804,39 +6778,52 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         : connection?.connected
           ? copy.statusLabel
           : 'Setup required';
-  const secondaryActions =
-    routeID === 'runtime'
-      ? [{ label: 'Graph', to: graphPath }]
-      : routeID === 'graph'
-        ? [{ label: 'Findings', to: findingsPath }]
-        : routeID === 'findings'
-          ? [{ label: 'Remediation', to: remediationPath }]
-          : routeID === 'remediation'
-            ? [{ label: 'Governance', to: governancePath }]
-            : [{ label: 'AWS home', to: homePath }];
+  // Suppress engineering-status copy ("Setup required" / "Not ingesting"
+  // / "Advisory only") and the noun-list secondary nav. The header subtitle
+  // is the same state-driven single line used across the AWS section.
+  const riskSubtitle = (() => {
+    if (environmentScope.loading || connectionLoading) {
+      return `Loading ${copy.title.toLowerCase()}…`;
+    }
+    if (connectionError) {
+      return "Couldn't load AWS status.";
+    }
+    if (!connection?.connected) {
+      return 'Not connected for this environment.';
+    }
+    return copy.description;
+  })();
+  // Silence unused linter warnings for the path helpers that used to feed
+  // the prior secondary-nav noun-list; they still exist for downstream
+  // pages but are not surfaced as header CTAs anymore.
+  void graphPath;
+  void remediationPath;
+  void governancePath;
+  void homePath;
 
   return (
     <DomainPageShell
       domain="aws"
-      eyebrow={copy.eyebrow}
+      eyebrow={null}
+      hideLogo
       title={copy.title}
-      description={copy.description}
+      description={riskSubtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
-      status={status}
       statusTone={connectionError ? 'danger' : statusTone}
-      primaryAction={connection?.connected ? undefined : { label: 'Connect AWS', to: connectPath, variant: 'primary' }}
-      secondaryActions={secondaryActions}
+      primaryAction={
+        connectionError || environmentScope.loading || connectionLoading
+          ? undefined
+          : connection?.connected
+            ? undefined
+            : { label: 'Connect AWS', to: connectPath, variant: 'primary' }
+      }
     >
       <div className="idt-aws-risk-page">
-        <AWSRiskOperationScope copy={copy} connection={connection} selectedEnvironmentID={selectedEnvironmentID} />
-
-        {environmentScope.loading || connectionLoading ? <DomainLoadingState label={`Loading ${copy.title.toLowerCase()}`} /> : null}
-
         {connectionError ? (
           <DomainErrorState
-            title={`${copy.title} status could not load`}
+            title="Couldn't load AWS status"
             body={connectionError}
-            retryAction={{ label: 'Retry AWS status', onClick: data.refreshConnection }}
+            retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
           />
         ) : null}
 
@@ -6910,20 +6897,8 @@ export function ProductAWSControlCenterPage() {
   const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
   const [baselineLoading, setBaselineLoading] = useState(false);
   const [baselineError, setBaselineError] = useState('');
-  const [dependencyIndex, setDependencyIndex] = useState<AWSPlatformDependencyIndexResult | null>(null);
-  const [dependencyLoading, setDependencyLoading] = useState(false);
-  const [dependencyError, setDependencyError] = useState('');
-  const [validationHarness, setValidationHarness] = useState<AWSPlatformValidationHarnessResult | null>(null);
-  const [validationLoading, setValidationLoading] = useState(false);
-  const [validationError, setValidationError] = useState('');
-  const [collectorContract, setCollectorContract] = useState<AWSServiceCollectorContractResult | null>(null);
-  const [collectorContractLoading, setCollectorContractLoading] = useState(false);
-  const [collectorContractError, setCollectorContractError] = useState('');
   const connectionRequestRef = useRef(0);
   const baselineRequestRef = useRef(0);
-  const dependencyRequestRef = useRef(0);
-  const validationRequestRef = useRef(0);
-  const collectorContractRequestRef = useRef(0);
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   selectedEnvironmentIDRef.current = selectedEnvironmentID;
 
@@ -7030,133 +7005,19 @@ export function ProductAWSControlCenterPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connector_id]);
 
-  const refreshDependencyIndex = useCallback(async () => {
-    const requestID = ++dependencyRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    if (!scope || !requestEnvironmentID) {
-      setDependencyIndex(null);
-      setDependencyError('');
-      setDependencyLoading(false);
-      return;
-    }
-    const isStale = () => requestID !== dependencyRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
-    setDependencyLoading(true);
-    setDependencyError('');
-    try {
-      const response = await apiClient.getAWSProjectDependencyIndex(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setDependencyIndex(response.index);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setDependencyIndex(null);
-      setDependencyError(formatAPIError(error, 'Unable to load AWS dependency index.'));
-    } finally {
-      if (!isStale()) {
-        setDependencyLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
-  const refreshValidationHarness = useCallback(async () => {
-    const requestID = ++validationRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    if (!scope || !requestEnvironmentID) {
-      setValidationHarness(null);
-      setValidationError('');
-      setValidationLoading(false);
-      return;
-    }
-    const isStale = () => requestID !== validationRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
-    setValidationLoading(true);
-    setValidationError('');
-    try {
-      const response = await apiClient.getAWSProjectValidationHarness(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setValidationHarness(response.harness);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setValidationHarness(null);
-      setValidationError(formatAPIError(error, 'Unable to load AWS validation harness.'));
-    } finally {
-      if (!isStale()) {
-        setValidationLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
-  const refreshCollectorContract = useCallback(async () => {
-    const requestID = ++collectorContractRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    if (!scope || !requestEnvironmentID) {
-      setCollectorContract(null);
-      setCollectorContractError('');
-      setCollectorContractLoading(false);
-      return;
-    }
-    const isStale = () => requestID !== collectorContractRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
-    setCollectorContractLoading(true);
-    setCollectorContractError('');
-    try {
-      const response = await apiClient.getAWSProjectCollectorContract(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setCollectorContract(response.contract);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setCollectorContract(null);
-      setCollectorContractError(formatAPIError(error, 'Unable to load AWS collector contract.'));
-    } finally {
-      if (!isStale()) {
-        setCollectorContractLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
   useEffect(() => {
     void refreshConnection();
     void refreshBaseline();
-    void refreshDependencyIndex();
-    void refreshValidationHarness();
-    void refreshCollectorContract();
     return () => {
       connectionRequestRef.current += 1;
       baselineRequestRef.current += 1;
-      dependencyRequestRef.current += 1;
-      validationRequestRef.current += 1;
-      collectorContractRequestRef.current += 1;
     };
-  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness, refreshCollectorContract]);
+  }, [refreshConnection, refreshBaseline]);
 
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
-        <p className="idt-app-kicker">AWS Control Center</p>
+        <p className="idt-app-kicker">AWS</p>
         <h2>Workspace route context is missing</h2>
         <p>Choose a tenant and workspace before loading AWS.</p>
       </section>
@@ -7166,19 +7027,10 @@ export function ProductAWSControlCenterPage() {
   const handleEnvironmentChange = (environmentID: string) => {
     connectionRequestRef.current += 1;
     baselineRequestRef.current += 1;
-    dependencyRequestRef.current += 1;
-    validationRequestRef.current += 1;
-    collectorContractRequestRef.current += 1;
     setConnection(null);
     setBaseline(null);
-    setDependencyIndex(null);
-    setValidationHarness(null);
-    setCollectorContract(null);
     setConnectionError('');
     setBaselineError('');
-    setDependencyError('');
-    setValidationError('');
-    setCollectorContractError('');
     navigate(
       {
         pathname: location.pathname,
@@ -7189,419 +7041,199 @@ export function ProductAWSControlCenterPage() {
   };
 
   const connectPath = awsRouteLink(scope, 'connect', selectedEnvironmentID);
-  const accountsPath = awsRouteLink(scope, 'accounts', selectedEnvironmentID);
   const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
   const failedChecks = connection?.permission_checks.filter((check) => !check.passed).length ?? 0;
-  const effectiveCapabilities = connection?.capabilities.effective.length ?? 0;
   const statusTone = awsDomainTone(connection, connectionLoading || environmentScope.loading);
-  const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
-  const dependencyTone = awsDependencyIndexTone(dependencyIndex, dependencyLoading || environmentScope.loading);
-  const validationTone = awsValidationHarnessTone(validationHarness, validationLoading || environmentScope.loading);
-  const collectorContractTone = awsServiceCollectorContractTone(
-    collectorContract,
-    collectorContractLoading || environmentScope.loading
-  );
-  const statusLabel = environmentScope.loading
-    ? 'Loading scope'
-    : connectionLoading
-      ? 'Loading status'
-      : connectionError
-        ? 'Needs retry'
-        : awsConnectionLabel(connection);
+  const connected = Boolean(connection?.connected);
+  const awaitingFirstLoad =
+    (environmentScope.loading || connectionLoading) && !connection && !connectionError;
+  const hasConnectionError = Boolean(connectionError);
+  const baselineReady = baseline?.status === 'ready';
+  const baselineKnown = Boolean(baseline);
+
+  // Subtitle: one short line. State-aware. No KPI cards.
+  const subtitle = (() => {
+    if (awaitingFirstLoad) {
+      return 'Loading AWS status…';
+    }
+    if (hasConnectionError) {
+      return "Couldn't load AWS status.";
+    }
+    if (!connected) {
+      const bits: string[] = ['Not connected'];
+      if (connection && !connection.external_id_configured) {
+        bits.push('External ID not set');
+      }
+      return bits.join(' · ');
+    }
+    const bits: string[] = [];
+    if (connection?.account_id) {
+      bits.push(connection.account_id);
+    }
+    if (connection?.region) {
+      bits.push(connection.region);
+    }
+    if (failedChecks > 0) {
+      bits.push(`${failedChecks} permission check${failedChecks === 1 ? '' : 's'} failing`);
+    } else if (connection?.permission_checks.length) {
+      bits.push('Permissions OK');
+    }
+    if (baselineReady) {
+      bits.push('Baseline ready');
+    } else if (baselineKnown) {
+      bits.push('Baseline needs attention');
+    }
+    return bits.join(' · ');
+  })();
+
+  // Primary CTA: state-aware. Connect when disconnected, Findings when connected,
+  // omitted while the first load is in flight or the status request errored
+  // (matches the pattern used on the GitHub overview and Connect pages).
+  const primaryAction = awaitingFirstLoad || hasConnectionError
+    ? undefined
+    : connected
+      ? { label: 'Findings', to: findingsPath, variant: 'primary' as const }
+      : { label: 'Connect AWS', to: connectPath, variant: 'primary' as const };
+
+  type AWSOverviewBanner = {
+    id: string;
+    message: ReactNode;
+    detail?: string;
+    actionLabel: string;
+    actionTo?: string;
+    actionOnClick?: () => void;
+    tone: 'info' | 'warning' | 'danger';
+  };
+
+  // Single contextual banner: one recommendation, one button. The actual
+  // state surfaces (recent findings, scan history, etc.) live on their own
+  // sub-pages — this page just nudges the user toward the next thing.
+  const banner: AWSOverviewBanner | null = (() => {
+    if (awaitingFirstLoad || hasConnectionError) {
+      return null;
+    }
+    if (!selectedEnvironmentID) {
+      return {
+        id: 'pick-environment',
+        message: 'Pick an environment to load AWS status.',
+        actionLabel: 'Open environments',
+        actionTo: buildProjectsPath(scope),
+        tone: 'info'
+      };
+    }
+    if (!connected) {
+      return {
+        id: 'connect-aws',
+        message: 'Connect AWS to start scanning this environment.',
+        actionLabel: 'Connect AWS',
+        actionTo: connectPath,
+        tone: 'info'
+      };
+    }
+    if (failedChecks > 0) {
+      return {
+        id: 'fix-permissions',
+        message: `${failedChecks} permission check${failedChecks === 1 ? '' : 's'} failing.`,
+        actionLabel: 'Open setup',
+        actionTo: connectPath,
+        tone: 'warning'
+      };
+    }
+    if (!baselineReady) {
+      return {
+        id: 'run-baseline',
+        message: 'Baseline not verified yet for this environment.',
+        actionLabel: baselineLoading ? 'Running…' : 'Run baseline',
+        actionOnClick: () => void verifyBaseline(),
+        tone: 'info'
+      };
+    }
+    return null;
+  })();
+
+  const showCards = !awaitingFirstLoad && !hasConnectionError && Boolean(selectedEnvironmentID);
 
   return (
     <DomainPageShell
       domain="aws"
-      eyebrow="AWS machine identity"
-      title="AWS Control Center"
-      description="Operate AWS connection health, account and region scope, permission posture, and the AWS machine-identity roadmap from one domain-owned surface."
+      eyebrow={null}
+      hideLogo
+      title="AWS"
+      description={subtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
-      status={statusLabel}
       statusTone={statusTone}
-      primaryAction={{ label: 'Connect AWS', to: connectPath, variant: 'primary' }}
-      secondaryActions={[
-        { label: 'Accounts', to: accountsPath },
-        { label: 'Findings', to: findingsPath }
-      ]}
-      aside={
-        <DomainDetailPanel title="AWS scope" eyebrow="Workspace contract">
-          <dl className="idt-domain-route-facts">
-            <div>
-              <dt>Environment</dt>
-              <dd>{selectedEnvironmentID ? environmentFallbackLabel(selectedEnvironmentID) : 'Default environment'}</dd>
-            </div>
-            <div>
-              <dt>Account / region</dt>
-              <dd>{awsAccountRegionLabel(connection)}</dd>
-            </div>
-            <div>
-              <dt>Connector</dt>
-              <dd>{connection?.connector_id ?? 'Not assigned'}</dd>
-            </div>
-          </dl>
-        </DomainDetailPanel>
-      }
+      primaryAction={primaryAction}
     >
-      <DomainKpiStrip
-        label="AWS status summary"
-        items={[
-          {
-            label: 'Connection',
-            value: awsConnectionLabel(connection),
-            detail: connection?.display_name ?? (selectedEnvironmentID ? 'AWS connector status for selected environment' : 'Choose an environment'),
-            tone: statusTone === 'danger' ? 'danger' : statusTone
-          },
-          {
-            label: 'Account / region',
-            value: connection?.account_id ? '1 account' : 'Pending',
-            detail: awsAccountRegionLabel(connection),
-            tone: connection?.account_id ? 'success' : 'warning'
-          },
-          {
-            label: 'Permissions',
-            value: awsPermissionSummary(connection),
-            detail: failedChecks > 0 ? `${failedChecks} check${failedChecks === 1 ? '' : 's'} need attention` : 'Validation status from AWS connector',
-            tone: failedChecks > 0 ? 'warning' : connection?.permission_checks.length ? 'success' : 'neutral'
-          },
-          {
-            label: 'Runtime and actions',
-            value: effectiveCapabilities > 0 ? `${effectiveCapabilities} active` : 'Planned',
-            detail: 'Runtime evidence, remediation, and governance waves are labeled honestly below.',
-            tone: effectiveCapabilities > 0 ? 'success' : 'info'
-          },
-          {
-            label: 'Baseline gate',
-            value: awsBaselineLabel(baseline),
-            detail: baselineLoading ? 'Verification loading' : awsBaselineSummary(baseline),
-            tone: baselineTone
-          },
-          {
-            label: 'Dependency index',
-            value: awsDependencyIndexLabel(dependencyIndex),
-            detail: dependencyLoading ? 'Sequencing loading' : awsDependencyIndexSummary(dependencyIndex),
-            tone: dependencyTone
-          },
-          {
-            label: 'Validation harness',
-            value: awsValidationHarnessLabel(validationHarness),
-            detail: validationLoading ? 'Proof states loading' : awsValidationHarnessSummary(validationHarness),
-            tone: validationTone
-          },
-          {
-            label: 'Collector contract',
-            value: awsServiceCollectorContractLabel(collectorContract),
-            detail: collectorContractLoading ? 'Contract loading' : awsServiceCollectorContractSummary(collectorContract),
-            tone: collectorContractTone
-          }
-        ]}
-      />
-
-      {environmentScope.loading || connectionLoading || baselineLoading || dependencyLoading || validationLoading || collectorContractLoading ? (
-        <DomainLoadingState label="Loading AWS control center status" />
-      ) : null}
-
       {connectionError ? (
         <DomainErrorState
-          title="AWS status could not load"
+          title="Couldn't load AWS status"
           body={connectionError}
-          retryAction={{ label: 'Retry status', onClick: () => void refreshConnection() }}
+          retryAction={{ label: 'Retry', onClick: () => void refreshConnection() }}
         />
       ) : null}
-      {baselineError ? (
+      {baselineError && !connectionError ? (
         <DomainErrorState
-          title="AWS baseline could not load"
+          title="Couldn't load AWS baseline"
           body={baselineError}
-          retryAction={{ label: 'Retry baseline', onClick: () => void refreshBaseline() }}
+          retryAction={{ label: 'Retry', onClick: () => void refreshBaseline() }}
         />
       ) : null}
-      {dependencyError ? (
-        <DomainErrorState
-          title="AWS dependency index could not load"
-          body={dependencyError}
-          retryAction={{ label: 'Retry index', onClick: () => void refreshDependencyIndex() }}
-        />
+      {banner ? <AWSOverviewBannerView banner={banner} /> : null}
+      {showCards ? (
+        <section className="idt-aws-control-grid" aria-label="AWS sections">
+          {AWS_CONTROL_CARDS.map((card) => (
+            <Link
+              key={card.id}
+              className={`idt-aws-capability-card is-${card.stage}`}
+              to={awsRouteLink(scope, card.routeID, selectedEnvironmentID)}
+            >
+              <strong>{card.label}</strong>
+              <p>{card.detail}</p>
+            </Link>
+          ))}
+        </section>
       ) : null}
-      {validationError ? (
-        <DomainErrorState
-          title="AWS validation harness could not load"
-          body={validationError}
-          retryAction={{ label: 'Retry harness', onClick: () => void refreshValidationHarness() }}
-        />
-      ) : null}
-      {collectorContractError ? (
-        <DomainErrorState
-          title="AWS collector contract could not load"
-          body={collectorContractError}
-          retryAction={{ label: 'Retry contract', onClick: () => void refreshCollectorContract() }}
-        />
-      ) : null}
-
-      {!selectedEnvironmentID && !environmentScope.loading ? (
-        <DomainEmptyState
-          eyebrow="Environment required"
-          title="Create an environment before connecting AWS"
-          body="AWS connection payloads remain scoped to a workspace environment, so setup needs an environment before validation can run."
-          nextAction={{ label: 'Open environments', to: buildProjectsPath(scope) }}
-        />
-      ) : null}
-
-      <DomainStatusPanel
-        eyebrow="Connection health"
-        title="AWS connector status and diagnostics"
-        status={<DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection?.health_status ?? 'unknown'} />}
-        tone={statusTone === 'danger' ? 'danger' : statusTone}
-        actions={[
-          { label: 'Refresh status', onClick: () => void refreshConnection(), variant: 'secondary', disabled: connectionLoading },
-          { label: 'Open setup', to: connectPath, variant: 'ghost' }
-        ]}
-      >
-        <div className="idt-aws-status-grid">
-          <dl>
-            <div>
-              <dt>Lifecycle</dt>
-              <dd>{connection ? connectionLifecycle(connection) : 'Not connected'}</dd>
-            </div>
-            <div>
-              <dt>Last validation</dt>
-              <dd>{formatConnectionTime(connection?.last_validated_at ?? connection?.updated_at)}</dd>
-            </div>
-            <div>
-              <dt>External ID</dt>
-              <dd>{connection?.external_id_configured ? 'Configured' : 'Not configured'}</dd>
-            </div>
-            <div>
-              <dt>Role ARN</dt>
-              <dd>{connection?.role_arn ?? 'Not saved'}</dd>
-            </div>
-          </dl>
-          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS diagnostics summary">
-            <AWSConnectionDiagnostics connection={connection} />
-          </div>
-        </div>
-      </DomainStatusPanel>
-
-      <DomainStatusPanel
-        eyebrow="Baseline gate"
-        title="AWS platform baseline verification"
-        status={awsBaselineLabel(baseline)}
-        tone={baselineTone}
-        actions={[
-          { label: 'Run baseline', onClick: () => void verifyBaseline(), variant: 'secondary', disabled: baselineLoading || !selectedEnvironmentID },
-          { label: 'Refresh gate', onClick: () => void refreshBaseline(), variant: 'ghost', disabled: baselineLoading || !selectedEnvironmentID }
-        ]}
-      >
-        <div className="idt-aws-status-grid">
-          <dl>
-            <div>
-              <dt>Result</dt>
-              <dd>{awsBaselineLabel(baseline)}</dd>
-            </div>
-            <div>
-              <dt>Confidence</dt>
-              <dd>{baseline ? formatConfidenceScore(baseline.confidence) : 'N/A'}</dd>
-            </div>
-            <div>
-              <dt>Verified</dt>
-              <dd>{formatConnectionTime(baseline?.verified_at)}</dd>
-            </div>
-            <div>
-              <dt>Revision</dt>
-              <dd>{baseline?.git_sha || 'Not stamped'}</dd>
-            </div>
-            <div>
-              <dt>Source</dt>
-              <dd>{baseline?.fixture_only ? 'Fixture only' : formatTokenLabel(baseline?.source_mode || 'unknown')}</dd>
-            </div>
-            <div>
-              <dt>Contract</dt>
-              <dd>{baseline?.graph_contract_version || 'Not verified'}</dd>
-            </div>
-          </dl>
-          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS baseline checks">
-            <AWSBaselineGateSummary baseline={baseline} loading={baselineLoading} />
-          </div>
-        </div>
-      </DomainStatusPanel>
-
-      <DomainStatusPanel
-        eyebrow="Issue sequencing"
-        title="AWS platform dependency index"
-        status={awsDependencyIndexLabel(dependencyIndex)}
-        tone={dependencyTone}
-        actions={[
-          { label: 'Refresh index', onClick: () => void refreshDependencyIndex(), variant: 'secondary', disabled: dependencyLoading || !selectedEnvironmentID },
-          {
-            label: 'Parent epic',
-            href: 'https://github.com/identrail/identrail/issues/1472',
-            target: '_blank',
-            rel: 'noreferrer',
-            variant: 'ghost'
-          }
-        ]}
-      >
-        <div className="idt-aws-status-grid">
-          <dl>
-            <div>
-              <dt>Parent</dt>
-              <dd>{dependencyIndex?.parent_issue_ref ?? '#1472'}</dd>
-            </div>
-            <div>
-              <dt>Issues</dt>
-              <dd>{dependencyIndex ? formatCountLabel(dependencyIndex.issue_count, 'issue') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Waves</dt>
-              <dd>{dependencyIndex ? formatCountLabel(dependencyIndex.wave_count, 'wave') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Ready</dt>
-              <dd>{dependencyIndex ? dependencyIndex.ready_issue_refs.join(', ') || 'None' : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Blocked</dt>
-              <dd>{dependencyIndex ? formatCountLabel(dependencyIndex.blocked_issue_count, 'issue') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Updated</dt>
-              <dd>{formatConnectionTime(dependencyIndex?.updated_at)}</dd>
-            </div>
-          </dl>
-          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS dependency index checks">
-            <AWSDependencyIndexSummary index={dependencyIndex} loading={dependencyLoading} />
-          </div>
-        </div>
-      </DomainStatusPanel>
-
-      <DomainStatusPanel
-        eyebrow="App validation"
-        title="AWS live app validation harness"
-        status={awsValidationHarnessLabel(validationHarness)}
-        tone={validationTone}
-        actions={[
-          { label: 'Refresh harness', onClick: () => void refreshValidationHarness(), variant: 'secondary', disabled: validationLoading || !selectedEnvironmentID },
-          {
-            label: 'Harness docs',
-            href: '/docs/aws-platform-validation-harness',
-            variant: 'ghost'
-          }
-        ]}
-      >
-        <div className="idt-aws-status-grid">
-          <dl>
-            <div>
-              <dt>Issue</dt>
-              <dd>{validationHarness?.current_issue_ref ?? '#1475'}</dd>
-            </div>
-            <div>
-              <dt>Scenarios</dt>
-              <dd>{validationHarness ? formatCountLabel(validationHarness.scenario_count, 'scenario') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Fixture states</dt>
-              <dd>{validationHarness ? validationHarness.fixture_states.map(formatTokenLabel).join(', ') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Browser steps</dt>
-              <dd>{validationHarness ? formatCountLabel(validationHarness.browser_steps.length, 'step') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>API steps</dt>
-              <dd>{validationHarness ? formatCountLabel(validationHarness.api_steps.length, 'step') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Updated</dt>
-              <dd>{formatConnectionTime(validationHarness?.updated_at)}</dd>
-            </div>
-          </dl>
-          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS validation harness scenarios">
-            <AWSValidationHarnessSummary harness={validationHarness} loading={validationLoading} />
-          </div>
-        </div>
-      </DomainStatusPanel>
-
-      <DomainStatusPanel
-        eyebrow="Collector contract"
-        title="AWS service collector contract"
-        status={awsServiceCollectorContractLabel(collectorContract)}
-        tone={collectorContractTone}
-        actions={[
-          {
-            label: 'Refresh contract',
-            onClick: () => void refreshCollectorContract(),
-            variant: 'secondary',
-            disabled: collectorContractLoading || !selectedEnvironmentID
-          },
-          {
-            label: 'Contract docs',
-            href: '/docs/aws-service-collector-contract',
-            variant: 'ghost'
-          }
-        ]}
-      >
-        <div className="idt-aws-status-grid">
-          <dl>
-            <div>
-              <dt>Issue</dt>
-              <dd>{collectorContract?.current_issue_ref ?? '#1476'}</dd>
-            </div>
-            <div>
-              <dt>Fields</dt>
-              <dd>{collectorContract ? formatCountLabel(collectorContract.required_field_count, 'field') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Fixtures</dt>
-              <dd>{collectorContract ? formatCountLabel(collectorContract.fixture_case_count, 'fixture') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Edges</dt>
-              <dd>{collectorContract ? formatCountLabel(collectorContract.graph_edge_count, 'edge') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Permissions</dt>
-              <dd>{collectorContract ? formatCountLabel(collectorContract.required_permissions.length, 'permission') : 'Pending'}</dd>
-            </div>
-            <div>
-              <dt>Updated</dt>
-              <dd>{formatConnectionTime(collectorContract?.updated_at)}</dd>
-            </div>
-          </dl>
-          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS service collector contract checks">
-            <AWSServiceCollectorContractSummary contract={collectorContract} loading={collectorContractLoading} />
-          </div>
-        </div>
-      </DomainStatusPanel>
-
-      <section className="idt-aws-control-grid" aria-label="AWS capability map">
-        {AWS_CONTROL_CARDS.map((card) => (
-          <Link
-            key={card.id}
-            className={`idt-aws-capability-card is-${card.stage}`}
-            to={awsRouteLink(scope, card.routeID, selectedEnvironmentID)}
-          >
-            <span className={`idt-domain-status-badge is-${awsStageTone(card.stage)}`}>
-              <span aria-hidden="true" className="idt-domain-status-dot" />
-              <strong>{awsStageLabel(card.stage)}</strong>
-            </span>
-            <strong>{card.label}</strong>
-            <span>{card.metric}</span>
-            <p>{card.detail}</p>
-          </Link>
-        ))}
-      </section>
-
-      <DomainStatusPanel eyebrow="Next actions" title="What AWS can do today" status={awsDiagnosticSummary(connection)} tone="info">
-        <div className="idt-aws-next-actions">
-          <article>
-            <strong>Wired now</strong>
-            <p>Use Connect AWS to launch the read-only stack, validate the role ARN, inspect permissions, and review diagnostics.</p>
-          </article>
-          <article>
-            <strong>Coming waves</strong>
-            <p>Account and region coverage, identity inventory, resource reachability, runtime evidence, findings, remediation, and governance stay clearly labeled until their APIs land.</p>
-          </article>
-        </div>
-      </DomainStatusPanel>
     </DomainPageShell>
+  );
+}
+
+function AWSOverviewBannerView({
+  banner
+}: {
+  banner: {
+    id: string;
+    message: ReactNode;
+    detail?: string;
+    actionLabel: string;
+    actionTo?: string;
+    actionOnClick?: () => void;
+    tone: 'info' | 'warning' | 'danger';
+  };
+}) {
+  return (
+    <section
+      className={`idt-overview-banner is-${banner.tone}`}
+      aria-label="AWS action recommendation"
+      data-banner-id={banner.id}
+    >
+      <div>
+        <p>{banner.message}</p>
+        {banner.detail ? <small>{banner.detail}</small> : null}
+      </div>
+      {banner.actionTo ? (
+        <Link to={banner.actionTo} className="idt-btn idt-btn-primary idt-domain-action">
+          <span>{banner.actionLabel}</span>
+        </Link>
+      ) : (
+        <button
+          type="button"
+          className="idt-btn idt-btn-primary idt-domain-action"
+          onClick={banner.actionOnClick}
+        >
+          <span>{banner.actionLabel}</span>
+        </button>
+      )}
+    </section>
   );
 }
 
@@ -7851,15 +7483,6 @@ export function ProductAWSConnectPage() {
   const [baseline, setBaseline] = useState<AWSPlatformBaselineResult | null>(null);
   const [baselineLoading, setBaselineLoading] = useState(false);
   const [baselineError, setBaselineError] = useState('');
-  const [dependencyIndex, setDependencyIndex] = useState<AWSPlatformDependencyIndexResult | null>(null);
-  const [dependencyLoading, setDependencyLoading] = useState(false);
-  const [dependencyError, setDependencyError] = useState('');
-  const [validationHarness, setValidationHarness] = useState<AWSPlatformValidationHarnessResult | null>(null);
-  const [validationLoading, setValidationLoading] = useState(false);
-  const [validationError, setValidationError] = useState('');
-  const [collectorContract, setCollectorContract] = useState<AWSServiceCollectorContractResult | null>(null);
-  const [collectorContractLoading, setCollectorContractLoading] = useState(false);
-  const [collectorContractError, setCollectorContractError] = useState('');
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
     externalID: '',
@@ -7875,9 +7498,6 @@ export function ProductAWSConnectPage() {
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
   const connectionRequestRef = useRef(0);
   const baselineRequestRef = useRef(0);
-  const dependencyRequestRef = useRef(0);
-  const validationRequestRef = useRef(0);
-  const collectorContractRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
   const awsPollRequestRef = useRef(0);
   const awsValidationRequestRef = useRef(0);
@@ -8019,132 +7639,10 @@ export function ProductAWSConnectPage() {
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, awsCloudFormationStart?.connector_id, connection?.connector_id]);
 
-  const refreshDependencyIndex = useCallback(async () => {
-    const requestID = ++dependencyRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    const requestScopeKey = scopeKeyRef.current;
-    if (!scope || !requestEnvironmentID) {
-      setDependencyIndex(null);
-      setDependencyError('');
-      setDependencyLoading(false);
-      return;
-    }
-    const isStale = () =>
-      requestID !== dependencyRequestRef.current ||
-      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
-      scopeKeyRef.current !== requestScopeKey;
-    setDependencyLoading(true);
-    setDependencyError('');
-    try {
-      const response = await apiClient.getAWSProjectDependencyIndex(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setDependencyIndex(response.index);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setDependencyIndex(null);
-      setDependencyError(formatAPIError(error, 'Unable to load AWS dependency index.'));
-    } finally {
-      if (!isStale()) {
-        setDependencyLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
-  const refreshValidationHarness = useCallback(async () => {
-    const requestID = ++validationRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    const requestScopeKey = scopeKeyRef.current;
-    if (!scope || !requestEnvironmentID) {
-      setValidationHarness(null);
-      setValidationError('');
-      setValidationLoading(false);
-      return;
-    }
-    const isStale = () =>
-      requestID !== validationRequestRef.current ||
-      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
-      scopeKeyRef.current !== requestScopeKey;
-    setValidationLoading(true);
-    setValidationError('');
-    try {
-      const response = await apiClient.getAWSProjectValidationHarness(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setValidationHarness(response.harness);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setValidationHarness(null);
-      setValidationError(formatAPIError(error, 'Unable to load AWS validation harness.'));
-    } finally {
-      if (!isStale()) {
-        setValidationLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
-  const refreshCollectorContract = useCallback(async () => {
-    const requestID = ++collectorContractRequestRef.current;
-    const requestEnvironmentID = selectedEnvironmentID;
-    const requestScopeKey = scopeKeyRef.current;
-    if (!scope || !requestEnvironmentID) {
-      setCollectorContract(null);
-      setCollectorContractError('');
-      setCollectorContractLoading(false);
-      return;
-    }
-    const isStale = () =>
-      requestID !== collectorContractRequestRef.current ||
-      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
-      scopeKeyRef.current !== requestScopeKey;
-    setCollectorContractLoading(true);
-    setCollectorContractError('');
-    try {
-      const response = await apiClient.getAWSProjectCollectorContract(
-        scope.workspaceID,
-        requestEnvironmentID,
-        undefined,
-        buildProductAuthContext(scope)
-      );
-      if (isStale()) {
-        return;
-      }
-      setCollectorContract(response.contract);
-    } catch (error) {
-      if (isStale()) {
-        return;
-      }
-      setCollectorContract(null);
-      setCollectorContractError(formatAPIError(error, 'Unable to load AWS collector contract.'));
-    } finally {
-      if (!isStale()) {
-        setCollectorContractLoading(false);
-      }
-    }
-  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   useEffect(() => {
     connectionRequestRef.current += 1;
     baselineRequestRef.current += 1;
-    dependencyRequestRef.current += 1;
-    validationRequestRef.current += 1;
-    collectorContractRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
@@ -8152,12 +7650,6 @@ export function ProductAWSConnectPage() {
     setErrorMessage('');
     setBaseline(null);
     setBaselineError('');
-    setDependencyIndex(null);
-    setDependencyError('');
-    setValidationHarness(null);
-    setValidationError('');
-    setCollectorContract(null);
-    setCollectorContractError('');
     setSubmitting(false);
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
@@ -8172,20 +7664,14 @@ export function ProductAWSConnectPage() {
     }));
     void refreshConnection('initial');
     void refreshBaseline();
-    void refreshDependencyIndex();
-    void refreshValidationHarness();
-    void refreshCollectorContract();
     return () => {
       connectionRequestRef.current += 1;
       baselineRequestRef.current += 1;
-      dependencyRequestRef.current += 1;
-      validationRequestRef.current += 1;
-      collectorContractRequestRef.current += 1;
       awsStartRequestRef.current += 1;
       awsPollRequestRef.current += 1;
       awsValidationRequestRef.current += 1;
     };
-  }, [refreshConnection, refreshBaseline, refreshDependencyIndex, refreshValidationHarness, refreshCollectorContract]);
+  }, [refreshConnection, refreshBaseline]);
 
   if (!scope) {
     return (
@@ -8200,21 +7686,12 @@ export function ProductAWSConnectPage() {
   const handleEnvironmentChange = (environmentID: string) => {
     connectionRequestRef.current += 1;
     baselineRequestRef.current += 1;
-    dependencyRequestRef.current += 1;
-    validationRequestRef.current += 1;
-    collectorContractRequestRef.current += 1;
     awsStartRequestRef.current += 1;
     awsPollRequestRef.current += 1;
     awsValidationRequestRef.current += 1;
     setConnection(null);
     setBaseline(null);
-    setDependencyIndex(null);
-    setValidationHarness(null);
-    setCollectorContract(null);
     setBaselineError('');
-    setDependencyError('');
-    setValidationError('');
-    setCollectorContractError('');
     navigate(
       {
         pathname: location.pathname,
@@ -8228,12 +7705,6 @@ export function ProductAWSConnectPage() {
   const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
   const statusTone = awsDomainTone(connection, loadingConnection || refreshingConnection || environmentScope.loading);
   const baselineTone = awsBaselineTone(baseline, baselineLoading || environmentScope.loading);
-  const dependencyTone = awsDependencyIndexTone(dependencyIndex, dependencyLoading || environmentScope.loading);
-  const validationTone = awsValidationHarnessTone(validationHarness, validationLoading || environmentScope.loading);
-  const collectorContractTone = awsServiceCollectorContractTone(
-    collectorContract,
-    collectorContractLoading || environmentScope.loading
-  );
   const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
   const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
 
@@ -8317,9 +7788,6 @@ export function ProductAWSConnectPage() {
       setSuccessMessage(response.connection.connected ? 'AWS connector is active.' : 'AWS status refreshed.');
       if (response.connection.connected) {
         void verifyBaseline();
-        void refreshDependencyIndex();
-        void refreshValidationHarness();
-        void refreshCollectorContract();
       }
     } catch (error) {
       if (isStale()) {
@@ -8387,9 +7855,6 @@ export function ProductAWSConnectPage() {
       );
       if (response.connection.connected) {
         void verifyBaseline();
-        void refreshDependencyIndex();
-        void refreshValidationHarness();
-        void refreshCollectorContract();
       }
     } catch (error) {
       if (isStale()) {
@@ -8403,97 +7868,55 @@ export function ProductAWSConnectPage() {
     }
   };
 
+  const connectedNow = Boolean(connection?.connected);
+  const awaitingFirstConnectLoad = loadingConnection && !connection && !errorMessage;
+  const connectSubtitle = (() => {
+    if (awaitingFirstConnectLoad || environmentScope.loading) {
+      return 'Loading AWS status…';
+    }
+    if (!selectedEnvironmentID) {
+      return 'Pick an environment to connect.';
+    }
+    if (!connectedNow) {
+      return 'Not connected for this environment.';
+    }
+    const bits: string[] = [];
+    if (connection?.account_id) {
+      bits.push(connection.account_id);
+    }
+    if (connection?.region) {
+      bits.push(connection.region);
+    }
+    const failed = connection?.permission_checks.filter((check) => !check.passed).length ?? 0;
+    if (failed > 0) {
+      bits.push(`${failed} permission check${failed === 1 ? '' : 's'} failing`);
+    } else if (connection?.permission_checks.length) {
+      bits.push('Permissions OK');
+    }
+    return bits.join(' · ');
+  })();
+
   return (
     <DomainPageShell
       domain="aws"
-      eyebrow="Read-only account onboarding"
+      eyebrow={null}
+      hideLogo
       title="Connect AWS"
-      description="Connect AWS with the existing read-only role flow while keeping environment scope, permission health, diagnostics, and CloudFormation status visible."
+      description={connectSubtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
-      status={loadingConnection || environmentScope.loading ? 'Loading status' : awsConnectionLabel(connection)}
       statusTone={statusTone}
-      primaryAction={{ label: 'AWS home', to: controlPath, variant: 'secondary' }}
-      secondaryActions={[{ label: 'AWS findings', to: findingsPath }]}
-      aside={
-        <DomainDetailPanel title="Setup payload" eyebrow="Scoped contract">
-          <dl className="idt-domain-route-facts">
-            <div>
-              <dt>Workspace</dt>
-              <dd>{scope.workspaceID}</dd>
-            </div>
-            <div>
-              <dt>Environment</dt>
-              <dd>{selectedEnvironmentID || 'Not selected'}</dd>
-            </div>
-            <div>
-              <dt>Connector</dt>
-              <dd>{activeConnectorID || 'Created during setup'}</dd>
-            </div>
-          </dl>
-        </DomainDetailPanel>
+      primaryAction={
+        awaitingFirstConnectLoad
+          ? undefined
+          : connectedNow
+            ? { label: 'AWS overview', to: controlPath, variant: 'primary' }
+            : undefined
       }
     >
-      <DomainKpiStrip
-        label="Connect AWS status"
-        items={[
-          {
-            label: 'Connection',
-            value: awsConnectionLabel(connection),
-            detail: connection?.display_name ?? 'Read-only IAM role connector',
-            tone: statusTone === 'danger' ? 'danger' : statusTone
-          },
-          {
-            label: 'Permission checks',
-            value: awsPermissionSummary(connection),
-            detail: 'Role validation and diagnostics stay visible after save.',
-            tone: connection?.permission_checks.some((check) => !check.passed)
-              ? 'warning'
-              : connection?.permission_checks.length
-                ? 'success'
-                : 'neutral'
-          },
-          {
-            label: 'Account / region',
-            value: connection?.account_id ?? 'Pending',
-            detail: connection?.region ? `Default region ${connection.region}` : `Default region ${awsForm.region || 'us-east-1'}`,
-            tone: connection?.account_id ? 'success' : 'info'
-          },
-          {
-            label: 'Baseline gate',
-            value: awsBaselineLabel(baseline),
-            detail: baselineLoading ? 'Verification loading' : awsBaselineSummary(baseline),
-            tone: baselineTone
-          },
-          {
-            label: 'Dependency index',
-            value: awsDependencyIndexLabel(dependencyIndex),
-            detail: dependencyLoading ? 'Sequencing loading' : awsDependencyIndexSummary(dependencyIndex),
-            tone: dependencyTone
-          },
-          {
-            label: 'Validation harness',
-            value: awsValidationHarnessLabel(validationHarness),
-            detail: validationLoading ? 'Proof states loading' : awsValidationHarnessSummary(validationHarness),
-            tone: validationTone
-          },
-          {
-            label: 'Collector contract',
-            value: awsServiceCollectorContractLabel(collectorContract),
-            detail: collectorContractLoading ? 'Contract loading' : awsServiceCollectorContractSummary(collectorContract),
-            tone: collectorContractTone
-          }
-        ]}
-      />
-
-      {loadingConnection || baselineLoading || dependencyLoading || validationLoading || collectorContractLoading || environmentScope.loading ? (
-        <DomainLoadingState label="Loading AWS setup state" />
-      ) : null}
-
       {!selectedEnvironmentID && !environmentScope.loading ? (
         <DomainEmptyState
-          eyebrow="Environment required"
-          title="Create an environment before connecting AWS"
-          body="The AWS connector still writes through workspace and project-scoped APIs. Pick or create an environment, then return to this page."
+          title="Pick an environment"
+          body="The AWS connection is scoped per environment. Pick or create one before continuing."
           nextAction={{ label: 'Open environments', to: appendSourceQuery(buildProjectsPath(scope), 'aws') }}
         />
       ) : null}
@@ -8513,21 +7936,6 @@ export function ProductAWSConnectPage() {
           {baselineError}
         </p>
       ) : null}
-      {dependencyError ? (
-        <p role="alert" className="idt-app-alert idt-app-alert-error">
-          {dependencyError}
-        </p>
-      ) : null}
-      {validationError ? (
-        <p role="alert" className="idt-app-alert idt-app-alert-error">
-          {validationError}
-        </p>
-      ) : null}
-      {collectorContractError ? (
-        <p role="alert" className="idt-app-alert idt-app-alert-error">
-          {collectorContractError}
-        </p>
-      ) : null}
 
       {selectedEnvironmentID ? (
         <div className="idt-aws-connect-layout">
@@ -8536,9 +7944,8 @@ export function ProductAWSConnectPage() {
               <div className="idt-source-config-title">
                 <SourceLogoMark provider="aws" className="is-hero" />
                 <div>
-                  <p className="idt-app-kicker">Wired now</p>
                   <h3>AWS read-only connector</h3>
-                  <p>Launch the role stack or validate an existing role ARN for this environment.</p>
+                  <p>Launch the role stack or paste an existing role ARN.</p>
                 </div>
               </div>
               <DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection?.health_status ?? 'unknown'} />
@@ -8719,113 +8126,6 @@ export function ProductAWSConnectPage() {
               </div>
             </DomainStatusPanel>
 
-            <DomainStatusPanel
-              eyebrow="Issue sequencing"
-              title="Dependency index"
-              status={awsDependencyIndexLabel(dependencyIndex)}
-              tone={dependencyTone}
-              actions={[
-                { label: 'Refresh index', onClick: () => void refreshDependencyIndex(), disabled: dependencyLoading || !selectedEnvironmentID },
-                {
-                  label: 'Parent epic',
-                  href: 'https://github.com/identrail/identrail/issues/1472',
-                  target: '_blank',
-                  rel: 'noreferrer',
-                  variant: 'ghost'
-                }
-              ]}
-            >
-              <dl className="idt-domain-route-facts">
-                <div>
-                  <dt>Ready</dt>
-                  <dd>{dependencyIndex ? dependencyIndex.ready_issue_refs.join(', ') || 'None' : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>Blocked</dt>
-                  <dd>{dependencyIndex ? formatCountLabel(dependencyIndex.blocked_issue_count, 'issue') : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>Updated</dt>
-                  <dd>{formatConnectionTime(dependencyIndex?.updated_at)}</dd>
-                </div>
-              </dl>
-              <div className="idt-source-diagnostics" aria-label="AWS dependency diagnostics">
-                <AWSDependencyIndexSummary index={dependencyIndex} loading={dependencyLoading} />
-              </div>
-            </DomainStatusPanel>
-
-            <DomainStatusPanel
-              eyebrow="App validation"
-              title="Live app validation harness"
-              status={awsValidationHarnessLabel(validationHarness)}
-              tone={validationTone}
-              actions={[
-                { label: 'Refresh harness', onClick: () => void refreshValidationHarness(), disabled: validationLoading || !selectedEnvironmentID },
-                { label: 'Harness docs', href: '/docs/aws-platform-validation-harness', variant: 'ghost' }
-              ]}
-            >
-              <dl className="idt-domain-route-facts">
-                <div>
-                  <dt>Scenarios</dt>
-                  <dd>{validationHarness ? formatCountLabel(validationHarness.scenario_count, 'scenario') : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>States</dt>
-                  <dd>{validationHarness ? validationHarness.fixture_states.map(formatTokenLabel).join(', ') : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>Updated</dt>
-                  <dd>{formatConnectionTime(validationHarness?.updated_at)}</dd>
-                </div>
-              </dl>
-              <div className="idt-source-diagnostics" aria-label="AWS validation harness diagnostics">
-                <AWSValidationHarnessSummary harness={validationHarness} loading={validationLoading} />
-              </div>
-            </DomainStatusPanel>
-
-            <DomainStatusPanel
-              eyebrow="Collector contract"
-              title="Service collector contract"
-              status={awsServiceCollectorContractLabel(collectorContract)}
-              tone={collectorContractTone}
-              actions={[
-                {
-                  label: 'Refresh contract',
-                  onClick: () => void refreshCollectorContract(),
-                  disabled: collectorContractLoading || !selectedEnvironmentID
-                },
-                { label: 'Contract docs', href: '/docs/aws-service-collector-contract', variant: 'ghost' }
-              ]}
-            >
-              <dl className="idt-domain-route-facts">
-                <div>
-                  <dt>Fields</dt>
-                  <dd>{collectorContract ? formatCountLabel(collectorContract.required_field_count, 'field') : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>Fixtures</dt>
-                  <dd>{collectorContract ? formatCountLabel(collectorContract.fixture_case_count, 'fixture') : 'Pending'}</dd>
-                </div>
-                <div>
-                  <dt>Edges</dt>
-                  <dd>{collectorContract ? formatCountLabel(collectorContract.graph_edge_count, 'edge') : 'Pending'}</dd>
-                </div>
-              </dl>
-              <div className="idt-source-diagnostics" aria-label="AWS service collector contract diagnostics">
-                <AWSServiceCollectorContractSummary contract={collectorContract} loading={collectorContractLoading} />
-              </div>
-            </DomainStatusPanel>
-
-            <DomainStatusPanel eyebrow="Coming later" title="AWS capability expansion" status="Labeled" tone="info">
-              <div className="idt-aws-mini-roadmap">
-                <span>Accounts / regions</span>
-                <span>Machine identities</span>
-                <span>Resources / secrets</span>
-                <span>Runtime evidence</span>
-                <span>Findings</span>
-                <span>Remediation</span>
-              </div>
-            </DomainStatusPanel>
           </div>
         </div>
       ) : null}
@@ -10538,7 +9838,7 @@ function scanFinishedAt(scan: RepoScanRecord): number {
 function GitHubControlCenterBannerView({ banner }: { banner: GitHubControlCenterBanner }) {
   return (
     <section
-      className={`idt-github-overview-banner is-${banner.tone}`}
+      className={`idt-overview-banner is-${banner.tone}`}
       aria-label="GitHub action recommendation"
       data-banner-id={banner.id}
     >

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7908,9 +7908,7 @@ export function ProductAWSConnectPage() {
       primaryAction={
         awaitingFirstConnectLoad
           ? undefined
-          : connectedNow
-            ? { label: 'AWS overview', to: controlPath, variant: 'primary' }
-            : undefined
+          : { label: 'AWS overview', to: controlPath, variant: 'primary' as const }
       }
     >
       {!selectedEnvironmentID && !environmentScope.loading ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22820,7 +22820,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
   letter-spacing: 0.01em;
 }
 
-.idt-github-overview-banner {
+.idt-overview-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -22832,33 +22832,33 @@ html[data-theme='light'] .idt-app-shell-screen select {
   background: #050505;
 }
 
-.idt-github-overview-banner > div {
+.idt-overview-banner > div {
   display: grid;
   gap: 0.15rem;
   min-width: 0;
 }
 
-.idt-github-overview-banner p {
+.idt-overview-banner p {
   margin: 0;
   color: #ffffff;
   font-weight: 700;
   font-size: 0.95rem;
 }
 
-.idt-github-overview-banner small {
+.idt-overview-banner small {
   color: var(--app-muted);
   font-size: 0.78rem;
 }
 
-.idt-github-overview-banner.is-warning {
+.idt-overview-banner.is-warning {
   border-left-color: rgba(245, 196, 81, 0.85);
 }
 
-.idt-github-overview-banner.is-danger {
+.idt-overview-banner.is-danger {
   border-left-color: rgba(255, 107, 107, 0.85);
 }
 
-.idt-github-overview-banner.is-info {
+.idt-overview-banner.is-info {
   border-left-color: rgba(124, 97, 255, 0.85);
 }
 
@@ -23114,6 +23114,38 @@ html[data-theme='light'] .idt-app-shell-screen select {
   justify-content: center;
   gap: 0.38rem;
   min-height: 2.35rem;
+}
+
+/* Compact button proportions for the product app.
+ *
+ * The base .idt-btn rule is tuned for the marketing surface — pill shape,
+ * 44px min-height, uppercase, generous letter-spacing — which makes every
+ * button in the data-dense product app (header CTAs, row actions, banner
+ * actions) look oversized with visible padding on the right of short
+ * labels like "Repositories" or "Queue scan". Scoping this override to
+ * .idt-app-console-layout keeps marketing buttons untouched. */
+.idt-app-console-layout .idt-btn {
+  min-height: 2.15rem;
+  padding: 0.4rem 0.95rem;
+  border-radius: 8px;
+  font-size: 0.84rem;
+  letter-spacing: 0.005em;
+  text-transform: none;
+  font-weight: 700;
+  width: max-content;
+  max-width: 100%;
+}
+
+/* In the mobile/stacked container the same rule still applies, but the
+ * existing media query at the bottom of this file forces width: 100% —
+ * make sure max-content does not override that. */
+@media (max-width: 760px) {
+  .idt-app-console-layout .idt-domain-header-actions .idt-btn,
+  .idt-app-console-layout .idt-domain-filter-actions .idt-btn,
+  .idt-app-console-layout .idt-domain-action-footer .idt-btn,
+  .idt-app-console-layout .idt-domain-status-panel footer .idt-btn {
+    width: 100%;
+  }
 }
 
 .idt-domain-action-icon {


### PR DESCRIPTION
Fixes #1581

## Summary
Applies the same compact treatment used on the polished GitHub overview, Connect, and Repositories pages to **every page under `/app/.../aws*`**, so the customer surface stops doubling as an internal engineering progress dashboard for the AWS Platform Wave issues. Also slims primary buttons across the whole product app so short labels like `Repositories`, `Queue scan`, `Connect AWS`, `Findings`, and `Run baseline` actually hug their text. Backend behaviour is unchanged.

## AWS section

### Overview (`/app/.../aws`)
- Header drops the AWS icon, the `AWS MACHINE IDENTITY` eyebrow, and the "Operate AWS connection health, account and region scope, permission posture, and the AWS machine-identity roadmap from one domain-owned surface." tagline. Title is just **AWS**. Subtitle is a one-line state-aware summary (`Disconnected · External ID not set` / `123456789012 · us-east-1 · Permissions OK · Baseline ready` / `Loading AWS status…` / `Couldn't load AWS status.`).
- 8-card KPI strip, Connection-health + Baseline-gate `DomainStatusPanel`s, `AWS scope / Workspace contract` aside, and `Next actions / What AWS can do today / Wired now / Coming waves` panel — all **deleted**.
- One state-driven primary CTA: `Connect AWS` when disconnected, `Findings` when connected, omitted while loading or on a status error.
- One contextual banner replaces the multi-panel "next actions" wall: `Connect AWS to start scanning this environment.` / `Baseline not verified yet for this environment.` / `N permission check(s) failing.`

### Issue-tracker panels deleted from customer UI
The three "GitHub-issues-as-UI" panels are gone everywhere they appeared (overview + Connect):
- **Issue sequencing / AWS platform dependency index** (with `#1472 · 85 issues · 11 waves · 18 ready · 61 blocked · #1479…#1496` dumps)
- **App validation / AWS live app validation harness** (with fixture states and per-scenario confidence percentages)
- **Collector contract / AWS service collector contract** (with raw graph relationship labels like `Workload to Identity`, `CAN PASS ROLE`)

The underlying API endpoints (`/aws/dependency-index`, `/aws/validation-harness`, `/aws/collector-contract`) **stay live** for engineering CI / tooling. Only the customer UI calls are removed.

### Connect AWS (`/app/.../aws/connect`)
- Same compact header. Subtitle reflects actual connection state. Single `AWS overview` primary CTA in the connected state.
- The CloudFormation install flow, role-ARN validation form, permission preview modal, popup-blocked fallback, baseline gate, and permission diagnostics panel are unchanged.
- The `Setup payload` aside, the 7-card KPI strip, the four issue-tracker side panels, and the `Coming later / AWS capability expansion` roadmap chip block are removed.

### Shared AWS Inventory shell (accounts, identities, agents, resources)
- `Inventory contract` aside deleted.
- `Current vs planned / Inventory capability boundary / Wired now / Planned coverage` panel deleted from every inventory page.
- Compact header with plain-English titles (`Accounts` / `Identities` / `Agents` / `Resources`) and one-line subtitles.

### Shared AWS Risk shell (runtime, graph, findings, remediation, governance)
- `AWSRiskOperationScope` deleted (same `Wired now / Coming waves` block again).
- Noun-list secondary nav (Graph → Findings → Remediation → Governance chain) gone.
- `Setup required` / `Advisory only` / `Not ingesting` / `No findings` status labels replaced by state-driven subtitles.
- Plain-English titles (`Runtime` / `Graph` / `Findings` / `Remediation` / `Governance`).

### `AWS_CONTROL_CARDS` and how new features land
The nav-card array is now the **single source of truth for what's actually shipped**. Each card is one short sentence (`Which AWS account and region you're connected to.` / `Bedrock and MCP agents Identrail can see.` / etc.). Pre-ship features will reach the AWS app through:
1. The existing `VITE_FEATURE_*` flag pattern + nav-card gating (cards don't render until the flag flips on)
2. Real empty states on shipped pages (`No findings yet. They'll appear after your first AWS scan.`)

No more roadmap-in-UI. No more `Wired now / Coming wave / Reserved surface` badges on non-functional pages.

## Slim primary buttons across the product app

The base `.idt-btn` rule is tuned for the marketing surface (44px min-height, full-pill border-radius, uppercase, 0.08em letter-spacing) which made every button in the data-dense product app (`Repositories`, `Queue scan`, `Connect AWS`, `Findings`, `Run baseline`) look oversized with visible right-padding on short labels.

A scoped `.idt-app-console-layout .idt-btn` override reduces min-height to `2.15rem`, tightens padding to `0.4rem × 0.95rem`, swaps the full-pill radius for `8px` rounded-rect, drops uppercase + `0.005em` letter-spacing, and adds `width: max-content` so buttons hug their text. The marketing site is untouched. The existing mobile-stacked `width: 100%` override still applies inside the product app on narrow viewports.

## Shared overview banner
Renamed the GitHub overview banner class from `.idt-github-overview-banner` to `.idt-overview-banner` so the AWS overview banner reuses the same pill shape and tone variants. Invisible to users.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build --prefix web` clean
- [x] `npx vitest run productShell.test.tsx` — **131/131 pass**, including:
  - Rewritten `renders the AWS overview with a compact header and a navigation grid` test (asserts the new title, the subtitle account id, the nav links, **and the absence** of the engineering-dashboard panels)
  - Updated env-switch staleness test (reads account ids from the subtitle, not the deleted KPI/panel display_name)
  - Updated four AWS inventory tests (new titles + new search aria-label)
  - Updated three AWS Connect tests (new `Pick an environment` empty state, `AWS overview` primary CTA, absence of deleted Setup payload / harness panels)
  - Dropped two `does not style blocked … as success` UI tests for panels that no longer exist (tone helpers stay covered by engineering tooling)
- [x] **Detailed visual + stress test** across all 11 AWS routes (Overview, Connect, Accounts, Identities, Agents, Resources, Runtime, Graph, Findings, Remediation, Governance) in connected / disconnected / loading / error states using a multi-page preview harness. Verified slim-button hugging behaviour on header CTAs (`Findings`, `AWS overview`, `Connect AWS`), banner actions (`Run baseline`, `Connect AWS`), and form buttons (`Validate and save AWS`, `Launch stack`, `Open Connect AWS`). Harness deleted before commit.

## Backend behaviour preserved
- `getAWSProjectConnection`, `getAWSProjectBaseline`, `verifyAWSProjectBaseline`, `startAWSConnector`, `pollAWSConnector`, `upsertAWSProjectConnection`, `validateAWSConnector` — unchanged.
- Every inventory API (`EC2InstanceProfiles`, `ECSTaskRoles`, `LambdaExecutionRoles`, `CodeBuildServiceRoles`, `EKSWorkloadIdentities`) — unchanged.
- Issue-tracker API endpoints (`/aws/dependency-index`, `/aws/validation-harness`, `/aws/collector-contract`) still serve. Only the customer UI calls are removed.

## AI disclosure
This change was drafted with Claude (Opus 4.7) acting as a pair-programmer; I reviewed each diff, ran the test suite, and verified the rendered output across 11 AWS pages × 4 connection states in the preview harness before committing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the AWS section into a compact, product-focused UI with a single contextual banner and one primary CTA, and slimmed primary buttons across the app. Connect now always shows an `AWS overview` CTA. Fixes #1581.

- **Refactors**
  - Compact headers across `/app/.../aws*`; removed KPI strip and engineering panels (`dependency index`, `validation harness`, `collector contract`). Endpoints remain for engineering; backend unchanged.
  - Overview: one contextual banner per state and one primary CTA (`Connect AWS` when disconnected, `Findings` when connected).
  - Connect AWS: keeps CloudFormation install, role-ARN validation, permission preview, baseline gate, and diagnostics; removes side panels; always shows `AWS overview` CTA.
  - Inventory and Risk pages: plain-English titles and state-driven subtitles; removed noun-list secondary nav and status badges.
  - Nav grid is gated by `AWS_CONTROL_CARDS`; dropped “Wired/Coming” labels.
  - Renamed `.idt-github-overview-banner` to `.idt-overview-banner`.
  - Tests: updated `productShell.test.tsx` and `App.test.tsx` for new compact titles/subtitles, absence of removed panels, and the always-present `AWS overview` CTA.

- **New Features**
  - Slimmer product-app buttons via `.idt-app-console-layout .idt-btn` (reduced height, tighter padding, 8px radius, no uppercase, `width: max-content`); marketing buttons unchanged.

<sup>Written for commit e18505b3aee367d487e9a4a3f83ccbeca95d7640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

