### PR TITLE
Add IAM PassRole static relationship mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Add **IAM PassRole static relationship mapper** (#1487). Parses every IAM
+  role's permission policies for `iam:PassRole` statements and emits one
+  normalized record per (source, target, condition, effect) tuple with
+  explicit confidence tiers for specific ARNs, path-scoped wildcards,
+  account-position wildcards, and `*`. Surfaces Deny statements,
+  `iam:PassedToService` conditions, and inverse (NotAction/NotResource)
+  forms rather than silently expanding them. Adds the
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships`
+  endpoint with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states, OpenAPI schema, web API client types,
+  runtime/CLI wiring, and operator docs. The collector reuses the existing
+  IAM read-only permissions and never makes write or decrypt calls.
 - Add **SageMaker workload identity collector** (#1486). Read-only inventory
   of notebook, training, processing, transform, model, endpoint, pipeline,
   and Studio domain execution roles, with S3 prefix, ECR image, and KMS key

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -241,3 +241,10 @@ ordered by `kind`, then `source_id`.
   records execution roles, S3 prefix references, ECR image URIs, and KMS key
   ARNs without reading notebook contents, training payloads, or model
   artifacts.
+- IAM PassRole static relationships are exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships`
+  and the AWS machine identities page. The collector parses already-collected
+  IAM role permission policies for `iam:PassRole` statements, classifies
+  targets as specific/path-wildcard/account-wildcard/all with explicit
+  confidence tiers, and surfaces Deny statements plus
+  `iam:PassedToService` conditions. No AWS write or mutation APIs are used.

--- a/docs/aws-iam-passrole-relationships.md
+++ b/docs/aws-iam-passrole-relationships.md
@@ -1,0 +1,127 @@
+# AWS IAM PassRole Static Relationship Mapper
+
+## Purpose
+
+Issue #1487 adds a read-only, static mapper for `iam:PassRole` grants in the
+AWS machine identity graph. It parses the permission policies already
+collected by the IAM role collector and emits one normalized record per
+PassRole grant, capturing source role, target resource (or wildcard),
+service condition, policy/statement evidence, and confidence tier.
+
+The collector is metadata-only and **static** — it never executes AWS
+mutations or makes additional AWS calls beyond `ListRoles` (and the
+existing IAM SDK adapter's policy reads). It also never reads any object
+contents, secret values, or session-token data.
+
+## Endpoint
+
+```text
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
+```
+
+Optional query parameters:
+
+- `connector_id`: scopes the account, region, and read-only inventory
+  evidence to a configured AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`,
+  or `permission_denied` for deterministic UI/contract validation.
+
+The response returns `inventory`, including records, `can_pass_role`
+relationships, diagnostics, coverage gaps, status, confidence, count
+summaries, and issue evidence links.
+
+## Evidence Collected
+
+For each PassRole grant, the collector records:
+
+- Source role ARN, name, and path.
+- Target resource (specific ARN or wildcard) and a wildcard classification:
+  - `specific` — exact role ARN.
+  - `path_wildcard` — `arn:aws:iam::account:role/team/*` style.
+  - `account_wildcard` — `arn:aws:iam::*:role/...` style.
+  - `all` — `*`.
+- Action expression that matched (`iam:PassRole`, `iam:*`, or `*`).
+- Effect (`Allow` or `Deny`).
+- `iam:PassedToService` condition value and the operator (e.g.
+  `StringEquals`, `StringLike`).
+- Any other condition keys present (recorded for context, not modelled as
+  graph semantics this wave).
+- `NotAction` and `NotResource` flags so inverse statements are visible
+  rather than silently inverted into massive fan-out.
+- Policy name and statement `Sid` for evidence trails.
+- Confidence tier:
+  - `0.95` for specific role ARNs.
+  - `0.78` for path-scoped wildcards.
+  - `0.70` for account-position wildcards.
+  - `0.55` for `*`.
+
+## Required AWS Permissions
+
+The collector uses the existing IAM read-only adapter — no new actions are
+required beyond what is already documented for the IAM role collector:
+
+- `iam:ListRoles`
+- `iam:ListRolePolicies`
+- `iam:GetRolePolicy`
+- `iam:ListAttachedRolePolicies`
+- `iam:GetPolicy`
+- `iam:GetPolicyVersion`
+
+These are read-only metadata calls. The connector policy in
+`internal/connectors/aws/iam_policy.go` already grants them.
+
+## What Is Intentionally Not Collected
+
+- Session-tag-bound PassRole conditions (`aws:RequestTag`,
+  `iam:TagSession`). The wave's mapper only surfaces
+  `iam:PassedToService`; other condition keys are noted under
+  `other_condition_keys` so operators can audit them but are not modelled
+  as graph semantics.
+- Service-linked roles (path `/aws-service-role/`). AWS provisions these
+  implicitly; they are not pass-able through customer policies and are
+  excluded as a documented coverage gap.
+- Resource-based policies, group/user-attached policies, and SCP-imposed
+  boundaries (separate waves).
+
+## Fixture States
+
+| State              | Purpose                                                                                              |
+|--------------------|------------------------------------------------------------------------------------------------------|
+| `success`          | Specific, path-wildcard, account-wildcard, `*`, and Deny grants — one of each class.                 |
+| `empty`            | No grants; coverage gaps still surfaced.                                                             |
+| `degraded`         | The wildcard grant is flipped to degraded confidence and emits a `iam_passrole_wildcard_target` diag. |
+| `partial_failure`  | Earlier records survive; an `iam_passrole_page_failed` diagnostic explains the gap.                  |
+| `permission_denied`| Inventory is blocked; a `permission_denied` diagnostic is returned.                                  |
+
+## Live Validation
+
+When running against a real AWS account:
+
+```bash
+export IDENTRAIL_AWS_SOURCE=sdk
+export IDENTRAIL_AWS_REGION="<region>"
+export IDENTRAIL_AWS_ACCOUNT_ID="<account_id>"
+
+state_file="/tmp/identrail-passrole-state.json"
+go run ./cmd/cli --state-file "${state_file}" scan --output table
+```
+
+Verify that:
+
+- Every emitted record has a non-empty `source_role_arn`.
+- Records with `target_wildcard_kind != "specific"` have `unresolved_target: true`.
+- Deny statements appear with `effect: "Deny"` and are visible in the
+  inventory alongside Allow grants.
+- No secret values or policy contents beyond standard IAM policy fields
+  appear in the output.
+
+## Troubleshooting
+
+| Diagnostic code                          | Likely cause                                  | Operator action                                                                                       |
+|------------------------------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `permission_denied`                      | Connector role missing IAM read APIs          | Grant the actions listed above; no write or decrypt APIs are needed.                                  |
+| `iam_passrole_page_failed`                | IAM ListRoles throttled or denied             | Retry; already-collected records remain visible.                                                       |
+| `iam_passrole_policy_parse_failed`        | Policy document is not valid JSON             | Audit the policy in the AWS console; the collector skips unparseable policies rather than guessing.    |
+| `iam_passrole_wildcard_target`            | A grant points at a path/account wildcard or `*` | Tighten the grant to a specific ARN and add `iam:PassedToService` where possible.                   |
+| `iam_passrole_page_limit_exceeded`        | ListRoles paginated beyond max-pages          | Increase the page cap or scope the connector to a smaller account before retrying.                     |
+| `malformed_iam_passrole_record`           | Record has no source or target after normalization | Inspect the source role's policy; the collector skips ambiguous records.                            |

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -534,6 +534,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities
     action: tenancy.read
     resource_type: project
@@ -4253,6 +4258,56 @@ paths:
                     $ref: "#/components/schemas/AWSSageMakerWorkloadRoleInventoryResult"
         "400":
           description: Invalid AWS SageMaker workload role inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS IAM PassRole static relationship inventory
+      operationId: getAWSProjectIAMPassRoleRelationships
+      description: Returns scoped IAM PassRole grants extracted from collected role permission policies, with explicit confidence tiers for wildcards, deny statements, and inverse (NotAction/NotResource) forms. Read-only and metadata-only — the collector consumes already-collected IAM policy documents and never reads policy values that are not part of the document text.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only IAM PassRole inventory evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+      responses:
+        "200":
+          description: AWS IAM PassRole relationship inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSIAMPassRoleRelationshipInventoryResult"
+        "400":
+          description: Invalid AWS IAM PassRole relationship inventory request
           content:
             application/json:
               schema:
@@ -9009,6 +9064,164 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSageMakerWorkloadRoleDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSIAMPassRoleCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status:
+          type: string
+          enum: [unsupported]
+        reason: { type: string }
+        remediation: { type: string }
+    AWSIAMPassRoleRelationshipRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service:
+          type: string
+          enum: [iam-passrole]
+        workload_id: { type: string }
+        workload_type:
+          type: string
+          enum: [iam_passrole_relationship]
+        workload_name: { type: string }
+        source_role_arn: { type: string }
+        source_role_name: { type: string }
+        source_role_path: { type: string }
+        target_resource: { type: string }
+        target_wildcard_kind:
+          type: string
+          enum: [specific, path_wildcard, account_wildcard, all]
+        policy_name: { type: string }
+        statement_sid: { type: string }
+        action_expression:
+          type: string
+          enum: ["iam:PassRole", "iam:*", "*"]
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        passed_to_service: { type: string }
+        condition_operator: { type: string }
+        not_action: { type: boolean }
+        not_resource: { type: boolean }
+        other_condition_keys:
+          type: array
+          items: { type: string }
+        unresolved_target: { type: boolean }
+        tags:
+          type: object
+          additionalProperties: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        relationship_type:
+          type: string
+          enum: [can_pass_role]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded, deny]
+    AWSIAMPassRoleRelationshipEdge:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [can_pass_role]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        passed_to_service: { type: string }
+    AWSIAMPassRoleRelationshipDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code:
+          type: string
+          enum:
+            - iam_passrole_page_failed
+            - iam_passrole_page_limit_exceeded
+            - iam_passrole_policy_parse_failed
+            - iam_passrole_wildcard_target
+            - malformed_iam_passrole_record
+            - permission_denied
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSIAMPassRoleRelationshipInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        record_count: { type: integer }
+        source_role_count: { type: integer }
+        target_role_count: { type: integer }
+        wildcard_target_count: { type: integer }
+        deny_statement_count: { type: integer }
+        service_scoped_count: { type: integer }
+        unscoped_count: { type: integer }
+        relationship_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPassRoleCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPassRoleRelationshipRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPassRoleRelationshipEdge"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPassRoleRelationshipDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -9098,7 +9098,7 @@ components:
         target_resource: { type: string }
         target_wildcard_kind:
           type: string
-          enum: [specific, path_wildcard, account_wildcard, all]
+          enum: [specific, path_wildcard, account_wildcard, all, malformed]
         policy_name: { type: string }
         statement_sid: { type: string }
         action_expression:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -750,6 +750,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/event-driven-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/managed-compute-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sagemaker-workload-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_iam_passrole_relationships.go
+++ b/internal/api/aws_iam_passrole_relationships.go
@@ -357,10 +357,24 @@ func awsIAMPassRoleFixtureRecord(accountID, region, sourceARN, sourceName, targe
 	return record
 }
 
+// awsIAMPassRoleRelationshipEdges projects records into graph edges. Only
+// concrete (target_wildcard_kind=specific), allow-effect grants with both
+// endpoints resolved are emitted. Wildcard targets stay as record metadata
+// because synthesizing edges to "*" or "arn:aws:iam::*:role/*" would create
+// non-actionable fan-out in downstream graph queries. Deny statements are
+// equally suppressed here — they are documented evidence, not capabilities
+// — and downstream net-effect computation reads them from the record list,
+// not the edge list.
 func awsIAMPassRoleRelationshipEdges(records []AWSIAMPassRoleRelationshipRecord) []AWSIAMPassRoleRelationshipEdge {
 	result := make([]AWSIAMPassRoleRelationshipEdge, 0, len(records))
 	for _, record := range records {
-		if strings.TrimSpace(record.FromNodeID) == "" {
+		if strings.TrimSpace(record.FromNodeID) == "" || strings.TrimSpace(record.ToNodeID) == "" {
+			continue
+		}
+		if record.UnresolvedTarget {
+			continue
+		}
+		if !strings.EqualFold(record.Effect, "Allow") {
 			continue
 		}
 		result = append(result, AWSIAMPassRoleRelationshipEdge{

--- a/internal/api/aws_iam_passrole_relationships.go
+++ b/internal/api/aws_iam_passrole_relationships.go
@@ -1,0 +1,541 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsIAMPassRoleRelationshipCurrentIssue = 1487
+	awsIAMPassRoleRelationshipVersion      = "aws-iam-passrole-relationship-inventory-v1"
+)
+
+// AWSIAMPassRoleRelationshipInventoryRequest is the operator-facing request.
+type AWSIAMPassRoleRelationshipInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+}
+
+// AWSIAMPassRoleCoverageGap names a PassRole shape Identrail intentionally
+// does not collect this wave, with the reason and remediation the operator
+// should rely on.
+type AWSIAMPassRoleCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSIAMPassRoleRelationshipInventoryResult is the deterministic envelope this
+// endpoint returns.
+type AWSIAMPassRoleRelationshipInventoryResult struct {
+	TenantID            string                                 `json:"tenant_id"`
+	WorkspaceID         string                                 `json:"workspace_id"`
+	ProjectID           string                                 `json:"project_id"`
+	ConnectorID         string                                 `json:"connector_id,omitempty"`
+	AccountID           string                                 `json:"account_id,omitempty"`
+	Region              string                                 `json:"region,omitempty"`
+	ParentIssueNumber   int                                    `json:"parent_issue_number"`
+	ParentIssueRef      string                                 `json:"parent_issue_ref"`
+	CurrentIssueNumber  int                                    `json:"current_issue_number"`
+	CurrentIssueRef     string                                 `json:"current_issue_ref"`
+	Version             string                                 `json:"version"`
+	Status              string                                 `json:"status"`
+	FixtureState        string                                 `json:"fixture_state"`
+	Confidence          float64                                `json:"confidence"`
+	RecordCount         int                                    `json:"record_count"`
+	SourceRoleCount     int                                    `json:"source_role_count"`
+	TargetRoleCount     int                                    `json:"target_role_count"`
+	WildcardTargetCount int                                    `json:"wildcard_target_count"`
+	DenyStatementCount  int                                    `json:"deny_statement_count"`
+	ServiceScopedCount  int                                    `json:"service_scoped_count"`
+	UnscopedCount       int                                    `json:"unscoped_count"`
+	RelationshipCount   int                                    `json:"relationship_count"`
+	FailureReasons      []string                               `json:"failure_reasons"`
+	RemediationHints    []string                               `json:"remediation_hints"`
+	EvidenceLinks       []string                               `json:"evidence_links"`
+	CoverageGaps        []AWSIAMPassRoleCoverageGap            `json:"coverage_gaps"`
+	Records             []AWSIAMPassRoleRelationshipRecord     `json:"records"`
+	Relationships       []AWSIAMPassRoleRelationshipEdge       `json:"relationships"`
+	Diagnostics         []AWSIAMPassRoleRelationshipDiagnostic `json:"diagnostics"`
+	GeneratedAt         time.Time                              `json:"generated_at"`
+	UpdatedAt           time.Time                              `json:"updated_at"`
+}
+
+// AWSIAMPassRoleRelationshipRecord is one extracted PassRole grant exposed by
+// the API.
+type AWSIAMPassRoleRelationshipRecord struct {
+	AccountID          string            `json:"account_id"`
+	Region             string            `json:"region,omitempty"`
+	Service            string            `json:"service"`
+	WorkloadID         string            `json:"workload_id"`
+	WorkloadType       string            `json:"workload_type"`
+	WorkloadName       string            `json:"workload_name"`
+	SourceRoleARN      string            `json:"source_role_arn"`
+	SourceRoleName     string            `json:"source_role_name,omitempty"`
+	SourceRolePath     string            `json:"source_role_path,omitempty"`
+	TargetResource     string            `json:"target_resource"`
+	TargetWildcardKind string            `json:"target_wildcard_kind"`
+	PolicyName         string            `json:"policy_name,omitempty"`
+	StatementSid       string            `json:"statement_sid,omitempty"`
+	ActionExpression   string            `json:"action_expression"`
+	Effect             string            `json:"effect"`
+	PassedToService    string            `json:"passed_to_service,omitempty"`
+	ConditionOperator  string            `json:"condition_operator,omitempty"`
+	NotAction          bool              `json:"not_action,omitempty"`
+	NotResource        bool              `json:"not_resource,omitempty"`
+	OtherConditionKeys []string          `json:"other_condition_keys,omitempty"`
+	UnresolvedTarget   bool              `json:"unresolved_target"`
+	Tags               map[string]string `json:"tags,omitempty"`
+	Source             string            `json:"source"`
+	EvidenceRef        string            `json:"evidence_ref"`
+	FromNodeID         string            `json:"from_node_id"`
+	ToNodeID           string            `json:"to_node_id,omitempty"`
+	RelationshipType   string            `json:"relationship_type"`
+	Confidence         float64           `json:"confidence"`
+	CollectedAt        time.Time         `json:"collected_at"`
+	Status             string            `json:"status"`
+}
+
+// AWSIAMPassRoleRelationshipEdge is a single graph edge produced by the
+// PassRole collector.
+type AWSIAMPassRoleRelationshipEdge struct {
+	Type            string `json:"type"`
+	FromNodeID      string `json:"from_node_id"`
+	ToNodeID        string `json:"to_node_id,omitempty"`
+	EvidenceRef     string `json:"evidence_ref"`
+	Effect          string `json:"effect"`
+	PassedToService string `json:"passed_to_service,omitempty"`
+}
+
+// AWSIAMPassRoleRelationshipDiagnostic is a structured collector diagnostic
+// with an operator-facing remediation hint.
+type AWSIAMPassRoleRelationshipDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// GetAWSIAMPassRoleRelationshipInventory returns the PassRole relationship
+// inventory for the supplied scope, honoring connector status and the
+// optional fixture_state override.
+func (s *Service) GetAWSIAMPassRoleRelationshipInventory(ctx context.Context, workspaceID string, projectID string, request AWSIAMPassRoleRelationshipInventoryRequest) (AWSIAMPassRoleRelationshipInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, err
+	}
+	var (
+		connection    AWSConnectionStatus
+		hasConnection bool
+	)
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, err
+	}
+	return buildAWSIAMPassRoleRelationshipInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSIAMPassRoleRelationshipInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSIAMPassRoleRelationshipInventoryRequest, checkedAt time.Time) (AWSIAMPassRoleRelationshipInventoryResult, error) {
+	fixtureState := normalizeAWSIAMPassRoleRelationshipFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, coverageGaps := awsIAMPassRoleRelationshipFixtureRecords(accountID, region, fixtureState, checkedAt)
+	for _, record := range records {
+		if strings.TrimSpace(record.SourceRoleARN) == "" {
+			continue
+		}
+		if _, err := awscontract.NormalizeServiceCollectorRecord(awscontract.ServiceCollectorRecord{
+			TenantID:      scope.TenantID,
+			WorkspaceID:   project.WorkspaceID,
+			ProjectID:     project.ProjectID,
+			ConnectorID:   connectorID,
+			AccountID:     record.AccountID,
+			Region:        record.Region,
+			Service:       record.Service,
+			WorkloadID:    record.WorkloadID,
+			WorkloadType:  record.WorkloadType,
+			WorkloadName:  record.WorkloadName,
+			RoleARN:       record.SourceRoleARN,
+			Source:        record.Source,
+			EvidenceRef:   record.EvidenceRef,
+			Confidence:    record.Confidence,
+			ScanID:        "aws-iam-passrole-relationship-fixture",
+			CollectorName: "iam_passrole_relationship",
+			CollectedAt:   checkedAt,
+		}); err != nil {
+			return AWSIAMPassRoleRelationshipInventoryResult{}, fmt.Errorf("validate iam passrole relationship contract record: %w", err)
+		}
+	}
+	status, confidence, failures, remediations := summarizeAWSIAMPassRoleRelationshipInventory(fixtureState, diagnostics, records)
+	relationships := awsIAMPassRoleRelationshipEdges(records)
+	return AWSIAMPassRoleRelationshipInventoryResult{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		AccountID:           accountID,
+		Region:              region,
+		ParentIssueNumber:   awsPlatformDependencyParentIssue,
+		ParentIssueRef:      awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:  awsIAMPassRoleRelationshipCurrentIssue,
+		CurrentIssueRef:     awsIssueRef(awsIAMPassRoleRelationshipCurrentIssue),
+		Version:             awsIAMPassRoleRelationshipVersion,
+		Status:              status,
+		FixtureState:        fixtureState,
+		Confidence:          confidence,
+		RecordCount:         len(records),
+		SourceRoleCount:     awsIAMPassRoleSourceRoleCount(records),
+		TargetRoleCount:     awsIAMPassRoleTargetRoleCount(records),
+		WildcardTargetCount: awsIAMPassRoleWildcardTargetCount(records),
+		DenyStatementCount:  awsIAMPassRoleDenyCount(records),
+		ServiceScopedCount:  awsIAMPassRoleServiceScopedCount(records),
+		UnscopedCount:       awsIAMPassRoleUnscopedCount(records),
+		RelationshipCount:   len(relationships),
+		FailureReasons:      failures,
+		RemediationHints:    remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsIAMPassRoleRelationshipCurrentIssue),
+			"/docs/aws-iam-passrole-relationships",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  coverageGaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsIAMPassRoleRelationshipDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSIAMPassRoleRelationshipFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsIAMPassRoleRelationshipFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSIAMPassRoleRelationshipRecord, []providers.SourceError, []AWSIAMPassRoleCoverageGap) {
+	gaps := []AWSIAMPassRoleCoverageGap{{
+		Capability:  "passrole_session_tagging",
+		Status:      "unsupported",
+		Reason:      "Session tagging on iam:PassRole grants (aws:RequestTag, iam:TagSession) is not modelled in this wave; only iam:PassedToService conditions are surfaced.",
+		Remediation: "Treat session-tag-bound PassRole grants as unscoped for blast-radius reasoning until the condition mapper ships.",
+	}, {
+		Capability:  "service_linked_roles",
+		Status:      "unsupported",
+		Reason:      "Service-linked roles (path /aws-service-role/) are excluded because AWS provisions them implicitly and they are not pass-able through customer policies.",
+		Remediation: "Filter service-linked roles from PassRole follow-ups; coverage gap is documented and not a collector failure.",
+	}}
+	partition := awsIAMPassRolePartitionForRegion(region)
+	deployRoleARN := fmt.Sprintf("arn:%s:iam::%s:role/platform-deploy", partition, accountID)
+	pipelineRoleARN := fmt.Sprintf("arn:%s:iam::%s:role/codepipeline-deploy", partition, accountID)
+	wildcardRoleARN := fmt.Sprintf("arn:%s:iam::%s:role/data-ops", partition, accountID)
+	starRoleARN := fmt.Sprintf("arn:%s:iam::%s:role/security-admin", partition, accountID)
+	denyRoleARN := fmt.Sprintf("arn:%s:iam::%s:role/audit-readonly", partition, accountID)
+	lambdaTargetARN := fmt.Sprintf("arn:%s:iam::%s:role/payments-lambda", partition, accountID)
+	ecsTargetARN := fmt.Sprintf("arn:%s:iam::%s:role/payments-ecs-task", partition, accountID)
+	wildcardTargetARN := fmt.Sprintf("arn:%s:iam::%s:role/data-ops-*", partition, accountID)
+	starTarget := "*"
+	denyTargetARN := fmt.Sprintf("arn:%s:iam::%s:role/break-glass", partition, accountID)
+
+	records := []AWSIAMPassRoleRelationshipRecord{
+		awsIAMPassRoleFixtureRecord(accountID, region, deployRoleARN, "platform-deploy", lambdaTargetARN, "PassPaymentsLambda", "iam:PassRole", "Allow", "lambda.amazonaws.com", "StringEquals", checkedAt, partition),
+		awsIAMPassRoleFixtureRecord(accountID, region, pipelineRoleARN, "codepipeline-deploy", ecsTargetARN, "PassPaymentsEcs", "iam:PassRole", "Allow", "ecs-tasks.amazonaws.com", "StringEquals", checkedAt, partition),
+		awsIAMPassRoleFixtureRecord(accountID, region, wildcardRoleARN, "data-ops", wildcardTargetARN, "PassDataOpsRoles", "iam:PassRole", "Allow", "", "", checkedAt, partition),
+		awsIAMPassRoleFixtureRecord(accountID, region, starRoleARN, "security-admin", starTarget, "PassAny", "iam:PassRole", "Allow", "", "", checkedAt, partition),
+		awsIAMPassRoleFixtureRecord(accountID, region, denyRoleARN, "audit-readonly", denyTargetARN, "DenyBreakGlassPass", "iam:PassRole", "Deny", "", "", checkedAt, partition),
+	}
+	switch fixtureState {
+	case "empty":
+		return nil, nil, gaps
+	case "degraded":
+		// Mark the wildcard grant as unresolved with low confidence to
+		// illustrate the degraded preview state. Match by source role name
+		// (not index) so future record reorders cannot silently flip the
+		// wrong record.
+		for i := range records {
+			if records[i].SourceRoleName != "data-ops" {
+				continue
+			}
+			records[i].Confidence = 0.6
+			records[i].Status = "degraded"
+			break
+		}
+		return records, []providers.SourceError{{
+			Collector: "aws_iam_passrole/iam_passrole_relationship",
+			SourceID:  wildcardRoleARN,
+			Code:      "iam_passrole_wildcard_target",
+			Message:   "One PassRole grant targets a path-scoped wildcard; downstream consumers should treat it as unresolved",
+			Retryable: false,
+		}}, gaps
+	case "partial_failure":
+		return records[:3], []providers.SourceError{{
+			Collector: "aws_iam_passrole/iam_passrole_relationship",
+			SourceID:  fmt.Sprintf("service=iam-passrole|account=%s|region=%s|source=listroles", accountID, region),
+			Code:      "iam_passrole_page_failed",
+			Message:   "One IAM ListRoles page failed; partial PassRole evidence remains visible",
+			Retryable: true,
+		}}, gaps
+	case "permission_denied":
+		return nil, []providers.SourceError{{
+			Collector: "aws_iam_passrole/iam_passrole_relationship",
+			SourceID:  fmt.Sprintf("service=iam-passrole|account=%s|region=%s|source=listroles", accountID, region),
+			Code:      "permission_denied",
+			Message:   "Read-only IAM ListRoles/ListRolePolicies/GetRolePolicy permission is missing",
+			Retryable: false,
+		}}, gaps
+	default:
+		return records, nil, gaps
+	}
+}
+
+func awsIAMPassRoleFixtureRecord(accountID, region, sourceARN, sourceName, target, sid, action, effect, service, conditionOp string, checkedAt time.Time, partition string) AWSIAMPassRoleRelationshipRecord {
+	wildcardKind := awsIAMPassRoleWildcardKind(target)
+	unresolved := wildcardKind != "specific"
+	confidence := awsIAMPassRoleConfidenceFor(wildcardKind)
+	record := AWSIAMPassRoleRelationshipRecord{
+		AccountID:          accountID,
+		Region:             region,
+		Service:            "iam-passrole",
+		WorkloadID:         strings.Join([]string{sourceARN, "policy=" + sid, target, effect, service}, "|"),
+		WorkloadType:       "iam_passrole_relationship",
+		WorkloadName:       sourceName,
+		SourceRoleARN:      sourceARN,
+		SourceRoleName:     sourceName,
+		SourceRolePath:     "/",
+		TargetResource:     target,
+		TargetWildcardKind: wildcardKind,
+		PolicyName:         sourceName + "-passrole-policy",
+		StatementSid:       sid,
+		ActionExpression:   action,
+		Effect:             effect,
+		PassedToService:    service,
+		ConditionOperator:  conditionOp,
+		UnresolvedTarget:   unresolved,
+		Tags:               map[string]string{"owner": "platform-iam"},
+		Source:             "iam_policy_document",
+		EvidenceRef:        sourceARN + "#policy=" + sourceName + "-passrole-policy#sid=" + sid,
+		FromNodeID:         awsIdentityNodeIDForAPI(sourceARN),
+		RelationshipType:   "can_pass_role",
+		Confidence:         confidence,
+		CollectedAt:        checkedAt,
+		Status:             "ready",
+	}
+	if !unresolved {
+		record.ToNodeID = awsIdentityNodeIDForAPI(target)
+	}
+	if effect == "Deny" {
+		record.Status = "deny"
+	}
+	_ = partition
+	return record
+}
+
+func awsIAMPassRoleRelationshipEdges(records []AWSIAMPassRoleRelationshipRecord) []AWSIAMPassRoleRelationshipEdge {
+	result := make([]AWSIAMPassRoleRelationshipEdge, 0, len(records))
+	for _, record := range records {
+		if strings.TrimSpace(record.FromNodeID) == "" {
+			continue
+		}
+		result = append(result, AWSIAMPassRoleRelationshipEdge{
+			Type:            record.RelationshipType,
+			FromNodeID:      record.FromNodeID,
+			ToNodeID:        record.ToNodeID,
+			EvidenceRef:     record.EvidenceRef,
+			Effect:          record.Effect,
+			PassedToService: record.PassedToService,
+		})
+	}
+	return result
+}
+
+func summarizeAWSIAMPassRoleRelationshipInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSIAMPassRoleRelationshipRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35,
+			[]string{"iam passrole collection is blocked by missing read-only IAM permission"},
+			[]string{"Grant iam:ListRoles, iam:ListRolePolicies, iam:GetRolePolicy, iam:ListAttachedRolePolicies, iam:GetPolicy, iam:GetPolicyVersion; do not enable write/decrypt APIs."}
+	case "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.7,
+			[]string{"one or more PassRole grants use wildcard or unscoped resources"},
+			[]string{"Tighten wildcard PassRole grants to specific role ARNs and add iam:PassedToService where possible before treating coverage as complete."}
+	case "partial_failure":
+		return awsPlatformDependencyStatusDegraded, 0.78,
+			[]string{"one ListRoles page failed while previously-collected PassRole grants remain visible"},
+			[]string{"Retry the failed IAM ListRoles page without discarding successful PassRole evidence."}
+	default:
+		if len(diagnostics) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.82,
+				[]string{"iam passrole collection returned diagnostics"},
+				[]string{"Review diagnostics before treating PassRole coverage as complete."}
+		}
+		if len(records) == 0 {
+			return awsPlatformDependencyStatusReady, 0.93, nil, nil
+		}
+		return awsPlatformDependencyStatusReady, 0.93, nil, nil
+	}
+}
+
+func awsIAMPassRoleSourceRoleCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if arn := strings.TrimSpace(record.SourceRoleARN); arn != "" {
+			seen[arn] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsIAMPassRoleTargetRoleCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if record.UnresolvedTarget {
+			continue
+		}
+		if arn := strings.TrimSpace(record.TargetResource); arn != "" {
+			seen[arn] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsIAMPassRoleWildcardTargetCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	count := 0
+	for _, record := range records {
+		if record.UnresolvedTarget {
+			count++
+		}
+	}
+	return count
+}
+
+func awsIAMPassRoleDenyCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	count := 0
+	for _, record := range records {
+		if strings.EqualFold(record.Effect, "Deny") {
+			count++
+		}
+	}
+	return count
+}
+
+func awsIAMPassRoleServiceScopedCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	count := 0
+	for _, record := range records {
+		if strings.TrimSpace(record.PassedToService) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func awsIAMPassRoleUnscopedCount(records []AWSIAMPassRoleRelationshipRecord) int {
+	count := 0
+	for _, record := range records {
+		if strings.TrimSpace(record.PassedToService) == "" {
+			count++
+		}
+	}
+	return count
+}
+
+func awsIAMPassRoleRelationshipDiagnostics(diagnostics []providers.SourceError) []AWSIAMPassRoleRelationshipDiagnostic {
+	result := make([]AWSIAMPassRoleRelationshipDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSIAMPassRoleRelationshipDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: awsIAMPassRoleRelationshipDiagnosticRemediation(diagnostic.Code),
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func awsIAMPassRoleRelationshipDiagnosticRemediation(code string) string {
+	switch code {
+	case "permission_denied":
+		return "Grant iam:ListRoles, iam:ListRolePolicies, iam:GetRolePolicy, iam:ListAttachedRolePolicies, iam:GetPolicy, iam:GetPolicyVersion; do not enable write/decrypt APIs."
+	case "iam_passrole_wildcard_target":
+		return "Tighten the PassRole grant to specific role ARNs and add iam:PassedToService where possible."
+	case "iam_passrole_page_failed", "iam_passrole_page_limit_exceeded":
+		return "Retry only the failed IAM ListRoles call and keep previously-collected PassRole evidence visible."
+	case "iam_passrole_policy_parse_failed":
+		return "Audit the policy document for invalid JSON; the collector skips unparseable policies rather than guessing."
+	case "malformed_iam_passrole_record":
+		return "Inspect the source role's policy and confirm a valid iam:PassRole statement."
+	default:
+		return "Review the IAM PassRole collector diagnostic and retry after the scoped IAM permission issue is corrected."
+	}
+}
+
+func awsIAMPassRoleWildcardKind(target string) string {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "*" {
+		return "all"
+	}
+	if !strings.HasPrefix(trimmed, "arn:") {
+		return "specific"
+	}
+	if !strings.Contains(trimmed, "*") {
+		return "specific"
+	}
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) >= 5 && parts[4] == "*" {
+		return "account_wildcard"
+	}
+	return "path_wildcard"
+}
+
+func awsIAMPassRoleConfidenceFor(wildcardKind string) float64 {
+	switch wildcardKind {
+	case "specific":
+		return 0.95
+	case "path_wildcard":
+		return 0.78
+	case "account_wildcard":
+		return 0.7
+	default:
+		return 0.55
+	}
+}
+
+func awsIAMPassRolePartitionForRegion(region string) string {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(normalized, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(normalized, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}

--- a/internal/api/aws_iam_passrole_relationships.go
+++ b/internal/api/aws_iam_passrole_relationships.go
@@ -511,13 +511,19 @@ func awsIAMPassRoleRelationshipDiagnosticRemediation(code string) string {
 	}
 }
 
+// awsIAMPassRoleWildcardKind classifies a PassRole target into one of
+// specific (a concrete role ARN), path_wildcard, account_wildcard, all (a
+// bare "*"), or malformed (anything else — e.g. a typo'd resource that is
+// neither an ARN nor "*"). Malformed targets are treated as unresolved by
+// the rest of the inventory so they never produce spurious graph edges to
+// fake role nodes.
 func awsIAMPassRoleWildcardKind(target string) string {
 	trimmed := strings.TrimSpace(target)
 	if trimmed == "*" {
 		return "all"
 	}
 	if !strings.HasPrefix(trimmed, "arn:") {
-		return "specific"
+		return "malformed"
 	}
 	if !strings.Contains(trimmed, "*") {
 		return "specific"
@@ -537,6 +543,8 @@ func awsIAMPassRoleConfidenceFor(wildcardKind string) float64 {
 		return 0.78
 	case "account_wildcard":
 		return 0.7
+	case "malformed":
+		return 0.3
 	default:
 		return 0.55
 	}

--- a/internal/api/aws_iam_passrole_relationships.go
+++ b/internal/api/aws_iam_passrole_relationships.go
@@ -512,11 +512,11 @@ func awsIAMPassRoleRelationshipDiagnosticRemediation(code string) string {
 }
 
 // awsIAMPassRoleWildcardKind classifies a PassRole target into one of
-// specific (a concrete role ARN), path_wildcard, account_wildcard, all (a
-// bare "*"), or malformed (anything else — e.g. a typo'd resource that is
-// neither an ARN nor "*"). Malformed targets are treated as unresolved by
-// the rest of the inventory so they never produce spurious graph edges to
-// fake role nodes.
+// specific (a concrete IAM role ARN), path_wildcard, account_wildcard, all (a
+// bare "*"), or malformed (anything else — e.g. a typo'd resource, a
+// non-IAM ARN such as an S3 bucket or Lambda function). Only IAM role ARNs
+// resolve as "specific" so the API never emits a graph edge to a non-role
+// resource that happens to be a valid ARN of another service.
 func awsIAMPassRoleWildcardKind(target string) string {
 	trimmed := strings.TrimSpace(target)
 	if trimmed == "*" {
@@ -525,11 +525,21 @@ func awsIAMPassRoleWildcardKind(target string) string {
 	if !strings.HasPrefix(trimmed, "arn:") {
 		return "malformed"
 	}
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) != 6 {
+		return "malformed"
+	}
+	if !strings.EqualFold(parts[2], "iam") {
+		return "malformed"
+	}
+	resource := parts[5]
+	if !strings.HasPrefix(resource, "role/") {
+		return "malformed"
+	}
 	if !strings.Contains(trimmed, "*") {
 		return "specific"
 	}
-	parts := strings.SplitN(trimmed, ":", 6)
-	if len(parts) >= 5 && parts[4] == "*" {
+	if parts[4] == "*" {
 		return "account_wildcard"
 	}
 	return "path_wildcard"

--- a/internal/api/aws_iam_passrole_relationships_test.go
+++ b/internal/api/aws_iam_passrole_relationships_test.go
@@ -45,7 +45,7 @@ func TestGetAWSIAMPassRoleRelationshipInventoryBuildsScopedRecords(t *testing.T)
 			t.Fatalf("expected metadata-only evidence, got %+v", record)
 		}
 		switch record.TargetWildcardKind {
-		case "specific", "path_wildcard", "account_wildcard", "all":
+		case "specific", "path_wildcard", "account_wildcard", "all", "malformed":
 		default:
 			t.Fatalf("unexpected wildcard kind %q on %+v", record.TargetWildcardKind, record)
 		}
@@ -222,5 +222,31 @@ func TestRouterAWSIAMPassRoleRelationshipNilLoggerDoesNotPanic(t *testing.T) {
 	// against logger.Error panicking when logger is nil.
 	if resp == nil {
 		t.Fatalf("expected a response, got nil")
+	}
+}
+
+func TestAWSIAMPassRoleWildcardKindClassifiesMalformedTargets(t *testing.T) {
+	cases := map[string]string{
+		"arn:aws:iam::123456789012:role/payments":   "specific",
+		"arn:aws:iam::123456789012:role/payments-*": "path_wildcard",
+		"arn:aws:iam::*:role/payments":              "account_wildcard",
+		"*":                                         "all",
+		"not-an-arn":                                "malformed",
+		"role/payments":                             "malformed",
+		"":                                          "malformed",
+	}
+	for input, want := range cases {
+		if got := awsIAMPassRoleWildcardKind(input); got != want {
+			t.Fatalf("awsIAMPassRoleWildcardKind(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestAWSIAMPassRoleConfidenceForMalformedIsLowest(t *testing.T) {
+	specific := awsIAMPassRoleConfidenceFor("specific")
+	malformed := awsIAMPassRoleConfidenceFor("malformed")
+	all := awsIAMPassRoleConfidenceFor("all")
+	if !(malformed < all && malformed < specific) {
+		t.Fatalf("expected malformed confidence < all < specific, got malformed=%v all=%v specific=%v", malformed, all, specific)
 	}
 }

--- a/internal/api/aws_iam_passrole_relationships_test.go
+++ b/internal/api/aws_iam_passrole_relationships_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSIAMPassRoleRelationshipInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 8, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSIAMPassRoleRelationshipInventory(ctx, "default", "project-a", AWSIAMPassRoleRelationshipInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get iam passrole inventory: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1487" || result.Version != awsIAMPassRoleRelationshipVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.SourceRoleCount == 0 || result.WildcardTargetCount == 0 || result.DenyStatementCount == 0 {
+		t.Fatalf("expected source/wildcard/deny counts populated, got %+v", result)
+	}
+	if result.ServiceScopedCount == 0 || result.UnscopedCount == 0 {
+		t.Fatalf("expected both service-scoped and unscoped grants in fixture, got %+v", result)
+	}
+	for _, record := range result.Records {
+		evidence := strings.ToLower(record.EvidenceRef + " " + record.Source)
+		if strings.Contains(evidence, "secret") || strings.Contains(evidence, "presigned") {
+			t.Fatalf("expected metadata-only evidence, got %+v", record)
+		}
+		switch record.TargetWildcardKind {
+		case "specific", "path_wildcard", "account_wildcard", "all":
+		default:
+			t.Fatalf("unexpected wildcard kind %q on %+v", record.TargetWildcardKind, record)
+		}
+		if record.Confidence <= 0 || record.Confidence > 1 {
+			t.Fatalf("confidence out of bounds: %v", record.Confidence)
+		}
+	}
+}
+
+func TestRouterAWSIAMPassRoleRelationshipInventoryPartialFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 8, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSIAMPassRoleRelationshipInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
+		t.Fatalf("expected degraded partial_failure, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
+	}
+	if body.Inventory.RecordCount == 0 {
+		t.Fatalf("expected partial failure to retain some records, got 0")
+	}
+	foundDiag := false
+	for _, diag := range body.Inventory.Diagnostics {
+		if diag.Code == "iam_passrole_page_failed" {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected iam_passrole_page_failed diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestRouterAWSIAMPassRoleRelationshipInventoryPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 8, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-2")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-2", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-2/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=permission_denied", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSIAMPassRoleRelationshipInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusBlocked {
+		t.Fatalf("expected blocked status, got %q", body.Inventory.Status)
+	}
+	if len(body.Inventory.Records) != 0 {
+		t.Fatalf("expected no records on permission_denied, got %d", len(body.Inventory.Records))
+	}
+}
+
+func TestRouterAWSIAMPassRoleRelationshipInventoryInvalidFixtureState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 8, 16, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-3")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-3", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-3/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=invalid", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid fixture state, got %d", resp.Code)
+	}
+}
+
+func TestAWSIAMPassRoleFixtureUsesGovCloudPartition(t *testing.T) {
+	records, _, _ := awsIAMPassRoleRelationshipFixtureRecords("123456789012", "us-gov-west-1", "success", time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC))
+	if len(records) == 0 {
+		t.Fatalf("expected fixture records, got 0")
+	}
+	for _, record := range records {
+		if record.TargetResource == "*" {
+			continue
+		}
+		if !strings.HasPrefix(record.SourceRoleARN, "arn:aws-us-gov:iam::") {
+			t.Fatalf("expected GovCloud source role ARN, got %q", record.SourceRoleARN)
+		}
+	}
+}
+
+func TestNormalizeAWSIAMPassRoleFixtureStateHonorsExplicitOverride(t *testing.T) {
+	disconnected := AWSConnectionStatus{Connected: false}
+	if got := normalizeAWSIAMPassRoleRelationshipFixtureState("success", disconnected, true); got != "success" {
+		t.Fatalf("explicit success must not downgrade, got %q", got)
+	}
+	if got := normalizeAWSIAMPassRoleRelationshipFixtureState("", disconnected, true); got != "permission_denied" {
+		t.Fatalf("blank with disconnected should be permission_denied, got %q", got)
+	}
+	if got := normalizeAWSIAMPassRoleRelationshipFixtureState("invalid", disconnected, true); got != "" {
+		t.Fatalf("invalid should return empty, got %q", got)
+	}
+}

--- a/internal/api/aws_iam_passrole_relationships_test.go
+++ b/internal/api/aws_iam_passrole_relationships_test.go
@@ -166,3 +166,61 @@ func TestNormalizeAWSIAMPassRoleFixtureStateHonorsExplicitOverride(t *testing.T)
 		t.Fatalf("invalid should return empty, got %q", got)
 	}
 }
+
+func TestAWSIAMPassRoleRelationshipEdgesExcludeUnresolvedAndDeny(t *testing.T) {
+	records := []AWSIAMPassRoleRelationshipRecord{
+		{
+			FromNodeID:         "aws:identity:arn:aws:iam::123:role/source",
+			ToNodeID:           "aws:identity:arn:aws:iam::123:role/target",
+			RelationshipType:   "can_pass_role",
+			Effect:             "Allow",
+			UnresolvedTarget:   false,
+			EvidenceRef:        "evidence-1",
+			TargetWildcardKind: "specific",
+		},
+		{
+			FromNodeID:         "aws:identity:arn:aws:iam::123:role/source",
+			ToNodeID:           "",
+			RelationshipType:   "can_pass_role",
+			Effect:             "Allow",
+			UnresolvedTarget:   true,
+			TargetWildcardKind: "all",
+		},
+		{
+			FromNodeID:         "aws:identity:arn:aws:iam::123:role/source",
+			ToNodeID:           "aws:identity:arn:aws:iam::123:role/break-glass",
+			RelationshipType:   "can_pass_role",
+			Effect:             "Deny",
+			UnresolvedTarget:   false,
+			TargetWildcardKind: "specific",
+		},
+	}
+	edges := awsIAMPassRoleRelationshipEdges(records)
+	if len(edges) != 1 {
+		t.Fatalf("expected only the Allow+resolved record to produce an edge, got %d (%+v)", len(edges), edges)
+	}
+	if edges[0].EvidenceRef != "evidence-1" {
+		t.Fatalf("unexpected edge: %+v", edges[0])
+	}
+}
+
+func TestRouterAWSIAMPassRoleRelationshipNilLoggerDoesNotPanic(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 8, 17, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-nil-logger")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-nil-logger", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	// Use a nil zap logger to prove the 500 path does not panic when logging
+	// is absent (matches the production code's defensive guard).
+	r := NewRouter(nil, telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-nil-logger/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=success", "")
+	// Any non-panicking response is fine for this test; we are guarding
+	// against logger.Error panicking when logger is nil.
+	if resp == nil {
+		t.Fatalf("expected a response, got nil")
+	}
+}

--- a/internal/api/aws_iam_passrole_relationships_test.go
+++ b/internal/api/aws_iam_passrole_relationships_test.go
@@ -204,36 +204,33 @@ func TestAWSIAMPassRoleRelationshipEdgesExcludeUnresolvedAndDeny(t *testing.T) {
 	}
 }
 
-func TestRouterAWSIAMPassRoleRelationshipNilLoggerDoesNotPanic(t *testing.T) {
-	store := db.NewMemoryStore()
-	ctx := defaultScopeContext()
-	now := time.Date(2026, 6, 8, 17, 0, 0, 0, time.UTC)
-	seedDefaultProject(t, store, ctx, "project-nil-logger")
-	seedAWSConnectorForScanTest(t, store, ctx, "project-nil-logger", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
-
-	svc := NewService(store, fakeScanner{}, "aws")
-	svc.Now = func() time.Time { return now }
-	// Use a nil zap logger to prove the 500 path does not panic when logging
-	// is absent (matches the production code's defensive guard).
-	r := NewRouter(nil, telemetry.NewMetrics(), svc, RouterOptions{})
-
-	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-nil-logger/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=success", "")
-	// Any non-panicking response is fine for this test; we are guarding
-	// against logger.Error panicking when logger is nil.
-	if resp == nil {
-		t.Fatalf("expected a response, got nil")
-	}
-}
+// Note: the route's nil-logger guard is small and obvious. Exercising the
+// default 500 branch with a nil logger requires forcing
+// GetAWSIAMPassRoleRelationshipInventory to return a non-ErrNotFound, non-
+// ErrInvalidAWSConnectionRequest error from inside the service. The Service
+// type is concrete and has no error-injection hooks, so the previous
+// "fixture_state=success" assertion never actually reached the logger.Error
+// call and was deleted rather than left as false coverage. The production
+// guard remains; reintroduce a real test once Service grows a seam for
+// mocking error returns.
 
 func TestAWSIAMPassRoleWildcardKindClassifiesMalformedTargets(t *testing.T) {
 	cases := map[string]string{
-		"arn:aws:iam::123456789012:role/payments":   "specific",
-		"arn:aws:iam::123456789012:role/payments-*": "path_wildcard",
-		"arn:aws:iam::*:role/payments":              "account_wildcard",
-		"*":                                         "all",
-		"not-an-arn":                                "malformed",
-		"role/payments":                             "malformed",
-		"":                                          "malformed",
+		// Valid IAM role ARNs.
+		"arn:aws:iam::123456789012:role/payments":        "specific",
+		"arn:aws-us-gov:iam::123456789012:role/payments": "specific",
+		"arn:aws:iam::123456789012:role/payments-*":      "path_wildcard",
+		"arn:aws:iam::*:role/payments":                   "account_wildcard",
+		"*":                                              "all",
+		// Non-IAM ARNs must reject — otherwise edges would point at non-role
+		// resources.
+		"arn:aws:s3:::bucket": "malformed",
+		"arn:aws:lambda:us-east-1:123456789012:function:payments": "malformed",
+		"arn:aws:iam::123456789012:user/dev":                      "malformed",
+		// Non-ARN inputs.
+		"not-an-arn":    "malformed",
+		"role/payments": "malformed",
+		"":              "malformed",
 	}
 	for input, want := range cases {
 		if got := awsIAMPassRoleWildcardKind(input); got != want {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2764,6 +2764,34 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSIAMPassRoleRelationshipInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSIAMPassRoleRelationshipInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws iam passrole relationship request"})
+			default:
+				logger.Error("get aws iam passrole relationship inventory",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws iam passrole relationship inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2780,11 +2780,13 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			case errors.Is(err, ErrInvalidAWSConnectionRequest):
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws iam passrole relationship request"})
 			default:
-				logger.Error("get aws iam passrole relationship inventory",
-					zap.String("workspace_id", c.Param("workspace_id")),
-					zap.String("project_id", c.Param("project_id")),
-					telemetry.ZapError(err),
-				)
+				if logger != nil {
+					logger.Error("get aws iam passrole relationship inventory",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws iam passrole relationship inventory"})
 			}
 			return

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -644,6 +644,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewEventDrivenRoleCollector(eventDrivenAPI),
 				awsprovider.NewManagedComputeRoleCollector(managedComputeAPI),
 				awsprovider.NewSageMakerWorkloadRoleCollector(sageMakerAPI),
+				awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			}, awsprovider.NewRuleSet(
 				awsprovider.WithStaleAfter(time.Duration(staleAfterDays)*24*time.Hour),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "eks"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -126,6 +126,16 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	// IAM PassRole relationships carry a distinctive workload type
+	// (iam_passrole_relationship) plus PassRole-specific fields that no other
+	// classifier emits, so this matcher is unambiguous and order-insensitive.
+	var passRoleRel IAMPassRoleRelationship
+	if err := json.Unmarshal(payload, &passRoleRel); err == nil {
+		if isIAMPassRoleRelationshipFixture(passRoleRel) {
+			return rawKindIAMPassRoleRelationship, iamPassRoleRecordSourceID(passRoleRel)
+		}
+	}
+
 	var managedComputeRole ManagedComputeRole
 	if err := json.Unmarshal(payload, &managedComputeRole); err == nil {
 		sourceID := managedComputeRoleSourceID(managedComputeRole)
@@ -355,6 +365,23 @@ func isSageMakerWorkloadRoleFixture(record SageMakerWorkloadRole) bool {
 	}
 	// DomainID and EndpointConfig are SageMaker-only operator-facing fields.
 	return strings.TrimSpace(record.DomainID) != "" || strings.TrimSpace(record.EndpointConfig) != ""
+}
+
+// isIAMPassRoleRelationshipFixture identifies records that look like PassRole
+// edges. The matcher is strict (service or collector name match, or the
+// dedicated workload type), so it never claims unrelated records that happen
+// to embed similar field names.
+func isIAMPassRoleRelationshipFixture(record IAMPassRoleRelationship) bool {
+	if strings.EqualFold(strings.TrimSpace(record.Service), iamPassRoleServiceName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.CollectorName), iamPassRoleRelationshipCollectorName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.WorkloadType), "iam_passrole_relationship") {
+		return true
+	}
+	return false
 }
 
 func isSageMakerARN(arn string) bool {

--- a/internal/providers/aws/iam_passrole_relationship_collector.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector.go
@@ -1,0 +1,340 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindIAMPassRoleRelationship       = "iam_passrole_relationship"
+	iamPassRoleRelationshipCollectorName = "iam_passrole_relationship"
+	iamPassRoleServiceName               = "iam-passrole"
+)
+
+// IAMPassRoleRelationship is the normalized envelope describing one PassRole
+// grant: a source identity (the role whose policy contains the grant) can pass
+// a target role to a downstream AWS service. Wildcards, deny statements, and
+// inverse (NotAction/NotResource) forms are surfaced explicitly so operators
+// can reason about them rather than having them silently expand into vast
+// fan-out edges.
+type IAMPassRoleRelationship struct {
+	awscontract.ServiceCollectorRecord
+	SourceRoleARN      string            `json:"source_role_arn,omitempty"`
+	SourceRoleName     string            `json:"source_role_name,omitempty"`
+	SourceRolePath     string            `json:"source_role_path,omitempty"`
+	TargetResource     string            `json:"target_resource,omitempty"`
+	TargetWildcardKind string            `json:"target_wildcard_kind,omitempty"`
+	PolicyName         string            `json:"policy_name,omitempty"`
+	StatementSid       string            `json:"statement_sid,omitempty"`
+	ActionExpression   string            `json:"action_expression,omitempty"`
+	Effect             string            `json:"effect,omitempty"`
+	PassedToService    string            `json:"passed_to_service,omitempty"`
+	ConditionOperator  string            `json:"condition_operator,omitempty"`
+	NotAction          bool              `json:"not_action,omitempty"`
+	NotResource        bool              `json:"not_resource,omitempty"`
+	OtherConditionKeys []string          `json:"other_condition_keys,omitempty"`
+	UnresolvedTarget   bool              `json:"unresolved_target,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
+}
+
+// IAMPassRoleRelationshipCollector consumes IAM role assets via the shared
+// IAMAPI and emits one normalized record per PassRole grant. It does not call
+// AWS itself beyond ListRoles — every other input (policy documents, inline +
+// managed) is already populated on the IAMRole record by the IAM SDK adapter.
+type IAMPassRoleRelationshipCollector struct {
+	client   IAMAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+// IAMPassRoleRelationshipOption tunes the collector.
+type IAMPassRoleRelationshipOption func(*IAMPassRoleRelationshipCollector)
+
+func WithIAMPassRoleRelationshipPageSize(pageSize int32) IAMPassRoleRelationshipOption {
+	return func(c *IAMPassRoleRelationshipCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+func WithIAMPassRoleRelationshipMaxPages(maxPages int) IAMPassRoleRelationshipOption {
+	return func(c *IAMPassRoleRelationshipCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+func WithIAMPassRoleRelationshipRetryPolicy(policy RetryPolicy) IAMPassRoleRelationshipOption {
+	return func(c *IAMPassRoleRelationshipCollector) {
+		if policy.MaxRetries >= 0 {
+			c.retry.MaxRetries = policy.MaxRetries
+		}
+		if policy.BaseDelay > 0 {
+			c.retry.BaseDelay = policy.BaseDelay
+		}
+		if policy.MaxDelay > 0 {
+			c.retry.MaxDelay = policy.MaxDelay
+		}
+	}
+}
+
+func WithIAMPassRoleRelationshipSleeper(s Sleeper) IAMPassRoleRelationshipOption {
+	return func(c *IAMPassRoleRelationshipCollector) {
+		if s != nil {
+			c.sleep = s
+		}
+	}
+}
+
+func WithIAMPassRoleRelationshipClock(now func() time.Time) IAMPassRoleRelationshipOption {
+	return func(c *IAMPassRoleRelationshipCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// NewIAMPassRoleRelationshipCollector returns a collector configured with the
+// same defaults as the other AWS service collectors.
+func NewIAMPassRoleRelationshipCollector(client IAMAPI, opts ...IAMPassRoleRelationshipOption) *IAMPassRoleRelationshipCollector {
+	c := &IAMPassRoleRelationshipCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ServiceName returns the canonical service name used by the composite
+// collector when stamping diagnostics and scopes.
+func (c *IAMPassRoleRelationshipCollector) ServiceName() string {
+	return iamPassRoleServiceName
+}
+
+// Collect satisfies providers.Collector for callers without a scope.
+func (c *IAMPassRoleRelationshipCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: iamPassRoleServiceName})
+	return assets, err
+}
+
+// CollectWithDiagnostics walks every IAM role's permission policies and emits
+// one normalized PassRole record per (source, target, condition, effect)
+// tuple. Per-call state is held in local variables so concurrent invocations
+// do not race on shared collector state.
+func (c *IAMPassRoleRelationshipCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("iam passrole relationship collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(providers.SourceError{
+				Collector: iamPassRoleRelationshipCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "iam_passrole_page_limit_exceeded",
+				Message:   fmt.Sprintf("iam passrole relationship collection exceeded max pages (%d)", c.maxPages),
+				Retryable: false,
+			})
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("iam passrole relationship collection exceeded max pages (%d)", c.maxPages)
+		}
+		page, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (ListRolesPage, error) {
+			return c.client.ListRoles(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list iam roles for passrole relationships: %w", err)
+			addIssue(providers.SourceError{
+				Collector: iamPassRoleRelationshipCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "iam_passrole_page_failed",
+				Message:   wrapped.Error(),
+				Retryable: isRetryable(err),
+			})
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, role := range page.Roles {
+			for _, policy := range role.PermissionPolicies {
+				doc, parseErr := parsePassRolePolicyDocument(policy.Document)
+				if parseErr != nil {
+					addIssue(providers.SourceError{
+						Collector: iamPassRoleRelationshipCollectorName,
+						SourceID:  iamPassRoleSourceID(role.ARN, policy.Name, "<unparseable>"),
+						Code:      "iam_passrole_policy_parse_failed",
+						Message:   fmt.Sprintf("policy %q on role %q could not be parsed: %v", policy.Name, role.ARN, parseErr),
+						Retryable: false,
+					})
+					continue
+				}
+				for _, grant := range extractPassRoleGrants(doc) {
+					record := normalizeIAMPassRoleRelationship(scope, role, policy.Name, grant, collectedAt)
+					if strings.TrimSpace(record.SourceRoleARN) == "" || strings.TrimSpace(record.TargetResource) == "" {
+						addIssue(providers.SourceError{
+							Collector: iamPassRoleRelationshipCollectorName,
+							Code:      "malformed_iam_passrole_record",
+							Message:   "skipped iam passrole record without source or target",
+							Retryable: false,
+						})
+						continue
+					}
+					sourceID := iamPassRoleRecordSourceID(record)
+					if _, exists := seen[sourceID]; exists {
+						continue
+					}
+					payload, err := json.Marshal(record)
+					if err != nil {
+						return nil, nil, fmt.Errorf("marshal iam passrole relationship %q: %w", sourceID, err)
+					}
+					assets = append(assets, providers.RawAsset{
+						Kind:      rawKindIAMPassRoleRelationship,
+						SourceID:  sourceID,
+						Payload:   payload,
+						Collected: collectedAt.Format(time.RFC3339Nano),
+					})
+					seen[sourceID] = struct{}{}
+				}
+			}
+		}
+		if strings.TrimSpace(page.NextToken) == "" {
+			break
+		}
+		nextToken = strings.TrimSpace(page.NextToken)
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+// normalizeIAMPassRoleRelationship folds a single extracted grant into the
+// normalized record shape used by the API and graph layers.
+func normalizeIAMPassRoleRelationship(scope AWSCollectorScope, role IAMRole, policyName string, grant passRoleGrant, collectedAt time.Time) IAMPassRoleRelationship {
+	workloadID := iamPassRoleWorkloadID(role.ARN, policyName, grant)
+	wildcardKind := passRoleGrantWildcardKind(grant.TargetResource)
+	unresolved := wildcardKind != "specific"
+	record := IAMPassRoleRelationship{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			TenantID:      firstNonEmptyAWSValue(scope.TenantID, "tenant"),
+			WorkspaceID:   firstNonEmptyAWSValue(scope.WorkspaceID, "workspace"),
+			ProjectID:     firstNonEmptyAWSValue(scope.ProjectID, "project"),
+			ConnectorID:   firstNonEmptyAWSValue(scope.ConnectorID, "aws-connector"),
+			AccountID:     firstNonEmptyAWSValue(scope.AccountID, accountIDFromARN(role.ARN)),
+			Region:        strings.TrimSpace(scope.Region),
+			Service:       iamPassRoleServiceName,
+			WorkloadID:    workloadID,
+			WorkloadType:  "iam_passrole_relationship",
+			WorkloadName:  firstNonEmptyAWSValue(role.Name, roleNameFromARN(role.ARN)),
+			RoleARN:       strings.TrimSpace(role.ARN),
+			Source:        "iam_policy_document",
+			EvidenceRef:   iamPassRoleEvidenceRef(role.ARN, policyName, grant.Sid),
+			Confidence:    passRoleGrantConfidence(grant),
+			ScanID:        firstNonEmptyAWSValue(scope.ScanID, "aws-iam-passrole-fixture"),
+			CollectorName: iamPassRoleRelationshipCollectorName,
+			CollectedAt:   collectedAt,
+		},
+		SourceRoleARN:      strings.TrimSpace(role.ARN),
+		SourceRoleName:     firstNonEmptyAWSValue(role.Name, roleNameFromARN(role.ARN)),
+		SourceRolePath:     strings.TrimSpace(role.Path),
+		TargetResource:     strings.TrimSpace(grant.TargetResource),
+		TargetWildcardKind: wildcardKind,
+		PolicyName:         strings.TrimSpace(policyName),
+		StatementSid:       grant.Sid,
+		ActionExpression:   grant.ActionExpression,
+		Effect:             grant.Effect,
+		PassedToService:    strings.TrimSpace(grant.ServiceCondition),
+		ConditionOperator:  strings.TrimSpace(grant.ConditionOp),
+		NotAction:          grant.NotAction,
+		NotResource:        grant.NotResource,
+		OtherConditionKeys: append([]string(nil), grant.OtherConditions...),
+		UnresolvedTarget:   unresolved,
+		Tags:               copyTags(role.Tags),
+	}
+	return record
+}
+
+// iamPassRoleWorkloadID identifies the (source, policy, target, condition,
+// effect) edge uniquely so the normalizer can dedupe across page boundaries.
+func iamPassRoleWorkloadID(roleARN, policyName string, grant passRoleGrant) string {
+	return strings.Join(normalizeStringList([]string{
+		strings.TrimSpace(roleARN),
+		strings.TrimSpace(policyName),
+		strings.TrimSpace(grant.Sid),
+		grant.ActionExpression,
+		grant.Effect,
+		grant.TargetResource,
+		grant.ServiceCondition,
+	}), "|")
+}
+
+func iamPassRoleSourceID(roleARN, policyName, suffix string) string {
+	return strings.Join(normalizeStringList([]string{
+		strings.TrimSpace(roleARN),
+		strings.TrimSpace(policyName),
+		strings.TrimSpace(suffix),
+	}), "|")
+}
+
+func iamPassRoleRecordSourceID(record IAMPassRoleRelationship) string {
+	return strings.Join(normalizeStringList([]string{
+		record.SourceRoleARN,
+		record.PolicyName,
+		record.StatementSid,
+		record.ActionExpression,
+		record.Effect,
+		record.TargetResource,
+		record.PassedToService,
+	}), "|")
+}
+
+func iamPassRoleEvidenceRef(roleARN, policyName, sid string) string {
+	parts := []string{strings.TrimSpace(roleARN)}
+	if policy := strings.TrimSpace(policyName); policy != "" {
+		parts = append(parts, "policy="+policy)
+	}
+	if s := strings.TrimSpace(sid); s != "" {
+		parts = append(parts, "sid="+s)
+	}
+	return strings.Join(parts, "#")
+}
+
+var _ AWSServiceCollector = (*IAMPassRoleRelationshipCollector)(nil)
+var _ providers.Collector = (*IAMPassRoleRelationshipCollector)(nil)

--- a/internal/providers/aws/iam_passrole_relationship_collector.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector.go
@@ -322,6 +322,9 @@ func iamPassRoleRecordSourceID(record IAMPassRoleRelationship) string {
 		record.Effect,
 		record.TargetResource,
 		record.PassedToService,
+		record.ConditionOperator,
+		fmt.Sprintf("not_action=%t", record.NotAction),
+		fmt.Sprintf("not_resource=%t", record.NotResource),
 	}), "|")
 }
 

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -534,3 +534,21 @@ func TestIAMPassRoleNormalizerRejectsNonRoleARNs(t *testing.T) {
 		t.Fatalf("expected source identity, got %+v", bundle.Identities[0])
 	}
 }
+
+func TestPassRoleGrantWildcardKindMalformedClassification(t *testing.T) {
+	cases := map[string]string{
+		"arn:aws:iam::123456789012:role/payments": "specific",
+		"*":             "all",
+		"not-an-arn":    "malformed",
+		"role/payments": "malformed",
+	}
+	for input, want := range cases {
+		if got := passRoleGrantWildcardKind(input); got != want {
+			t.Fatalf("passRoleGrantWildcardKind(%q) = %q, want %q", input, got, want)
+		}
+		conf := passRoleGrantConfidence(passRoleGrant{TargetResource: input})
+		if conf <= 0 || conf > 1 {
+			t.Fatalf("confidence for %q out of bounds: %v", input, conf)
+		}
+	}
+}

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -489,14 +489,27 @@ func TestIAMPassRoleCollectorPropagatesPageToken(t *testing.T) {
 
 func TestIsIAMRoleARN(t *testing.T) {
 	cases := map[string]bool{
-		"arn:aws:iam::123456789012:role/payments":                 true,
-		"arn:aws:iam::123456789012:role/path/payments":            true,
-		"arn:aws-us-gov:iam::123456789012:role/payments":          true,
-		"arn:aws-cn:iam::123456789012:role/payments":              true,
-		"arn:aws:iam::123456789012:user/dev":                      false,
-		"arn:aws:iam::123456789012:policy/Admin":                  false,
-		"arn:aws:s3:::bucket":                                     false,
+		// Valid IAM role ARNs in commercial, GovCloud, and China partitions.
+		"arn:aws:iam::123456789012:role/payments":        true,
+		"arn:aws:iam::123456789012:role/path/payments":   true,
+		"arn:aws-us-gov:iam::123456789012:role/payments": true,
+		"arn:aws-cn:iam::123456789012:role/payments":     true,
+		// Wrong IAM resource kinds.
+		"arn:aws:iam::123456789012:user/dev":     false,
+		"arn:aws:iam::123456789012:policy/Admin": false,
+		// Trailing "role/" with no name.
+		"arn:aws:iam::123456789012:role/": false,
+		// Region segment populated — IAM is global.
+		"arn:aws:iam:us-east-1:123456789012:role/payments": false,
+		// Account ID must be exactly 12 digits.
+		"arn:aws:iam::12345:role/payments":         false,
+		"arn:aws:iam::1234567890123:role/payments": false,
+		"arn:aws:iam::abc123456789:role/payments":  false,
+		"arn:aws:iam:::role/payments":              false,
+		// Non-IAM services.
+		"arn:aws:s3:::bucket": false,
 		"arn:aws:lambda:us-east-1:123456789012:function:payments": false,
+		// Non-ARN inputs.
 		"*":          false,
 		"":           false,
 		"not-an-arn": false,
@@ -537,8 +550,19 @@ func TestIAMPassRoleNormalizerRejectsNonRoleARNs(t *testing.T) {
 
 func TestPassRoleGrantWildcardKindMalformedClassification(t *testing.T) {
 	cases := map[string]string{
-		"arn:aws:iam::123456789012:role/payments": "specific",
-		"*":             "all",
+		// Valid IAM role ARNs.
+		"arn:aws:iam::123456789012:role/payments":        "specific",
+		"arn:aws-us-gov:iam::123456789012:role/payments": "specific",
+		"arn:aws:iam::123456789012:role/payments-*":      "path_wildcard",
+		"arn:aws:iam::*:role/payments":                   "account_wildcard",
+		"*":                                              "all",
+		// Non-IAM ARNs must classify as malformed so the API does not emit
+		// PassRole edges to non-role resources.
+		"arn:aws:s3:::bucket": "malformed",
+		"arn:aws:lambda:us-east-1:123456789012:function:payments": "malformed",
+		"arn:aws:iam::123456789012:user/dev":                      "malformed",
+		"arn:aws:iam::123456789012:policy/Admin":                  "malformed",
+		// Pure non-ARN inputs.
 		"not-an-arn":    "malformed",
 		"role/payments": "malformed",
 	}

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -12,13 +12,17 @@ import (
 )
 
 type fakeIAMRolesAPI struct {
-	pages []ListRolesPage
-	calls int
-	err   error
+	pages     []ListRolesPage
+	calls     int
+	err       error
+	tokens    []string
+	pageSizes []int32
 }
 
 func (f *fakeIAMRolesAPI) ListRoles(ctx context.Context, nextToken string, pageSize int32) (ListRolesPage, error) {
 	f.calls++
+	f.tokens = append(f.tokens, nextToken)
+	f.pageSizes = append(f.pageSizes, pageSize)
 	if f.err != nil {
 		return ListRolesPage{}, f.err
 	}
@@ -89,12 +93,34 @@ func TestExtractPassRoleGrants_ExpandsResourcesAndConditions(t *testing.T) {
 	}
 }
 
-func TestExtractPassRoleGrants_NotActionAndNotResource(t *testing.T) {
+func TestExtractPassRoleGrants_NotActionListingPassRoleSuppressesGrant(t *testing.T) {
+	// NotAction containing iam:PassRole means PassRole is excluded — no grant
+	// should be emitted.
 	doc, err := parsePassRolePolicyDocument(`{
 		"Version": "2012-10-17",
 		"Statement": {
 			"Effect": "Allow",
 			"NotAction": "iam:PassRole",
+			"Resource": "*"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if grants := extractPassRoleGrants(doc); len(grants) != 0 {
+		t.Fatalf("expected zero grants when NotAction lists iam:PassRole, got %+v", grants)
+	}
+}
+
+func TestExtractPassRoleGrants_NotActionOmittingPassRoleEmitsInverseGrant(t *testing.T) {
+	// NotAction containing only an unrelated action means PassRole IS in the
+	// implicit "everything else" set the statement applies to. The grant is
+	// emitted with NotAction=true so consumers can mark it as inverse.
+	doc, err := parsePassRolePolicyDocument(`{
+		"Version": "2012-10-17",
+		"Statement": {
+			"Effect": "Allow",
+			"NotAction": "s3:GetObject",
 			"NotResource": "arn:aws:iam::123456789012:role/break-glass"
 		}
 	}`)
@@ -103,10 +129,27 @@ func TestExtractPassRoleGrants_NotActionAndNotResource(t *testing.T) {
 	}
 	grants := extractPassRoleGrants(doc)
 	if len(grants) != 1 {
-		t.Fatalf("expected one grant, got %d", len(grants))
+		t.Fatalf("expected one inverse grant, got %d (%+v)", len(grants), grants)
 	}
 	if !grants[0].NotAction || !grants[0].NotResource {
 		t.Fatalf("expected NotAction + NotResource flags, got %+v", grants[0])
+	}
+}
+
+func TestExtractPassRoleGrants_NotActionWildcardExcludesPassRole(t *testing.T) {
+	// NotAction iam:Pass* also explicitly excludes iam:PassRole — no grant.
+	doc, err := parsePassRolePolicyDocument(`{
+		"Statement": {
+			"Effect": "Allow",
+			"NotAction": "iam:Pass*",
+			"Resource": "*"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if grants := extractPassRoleGrants(doc); len(grants) != 0 {
+		t.Fatalf("expected zero grants when NotAction wildcard matches iam:PassRole, got %+v", grants)
 	}
 }
 
@@ -418,5 +461,76 @@ func TestIAMActionPatternMatches(t *testing.T) {
 		if got := iamActionPatternMatches(tc.pattern, tc.target); got != tc.want {
 			t.Fatalf("pattern %q vs %q: got %v, want %v", tc.pattern, tc.target, got, tc.want)
 		}
+	}
+}
+
+func TestIAMPassRoleCollectorPropagatesPageToken(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	role := IAMRole{
+		ARN:  "arn:aws:iam::123456789012:role/source",
+		Name: "source",
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:     "passrole",
+			Document: `{"Statement":[{"Effect":"Allow","Action":"iam:PassRole","Resource":"arn:aws:iam::123456789012:role/target"}]}`,
+		}},
+	}
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{
+		{Roles: []IAMRole{role}, NextToken: "page-2"},
+		{Roles: []IAMRole{role}},
+	}}
+	collector := NewIAMPassRoleRelationshipCollector(api, WithIAMPassRoleRelationshipClock(func() time.Time { return collectedAt }))
+	if _, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{}); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if got, want := strings.Join(api.tokens, ","), ",page-2"; got != want {
+		t.Fatalf("expected tokens %q, got %q", want, got)
+	}
+}
+
+func TestIsIAMRoleARN(t *testing.T) {
+	cases := map[string]bool{
+		"arn:aws:iam::123456789012:role/payments":                 true,
+		"arn:aws:iam::123456789012:role/path/payments":            true,
+		"arn:aws-us-gov:iam::123456789012:role/payments":          true,
+		"arn:aws-cn:iam::123456789012:role/payments":              true,
+		"arn:aws:iam::123456789012:user/dev":                      false,
+		"arn:aws:iam::123456789012:policy/Admin":                  false,
+		"arn:aws:s3:::bucket":                                     false,
+		"arn:aws:lambda:us-east-1:123456789012:function:payments": false,
+		"*":          false,
+		"":           false,
+		"not-an-arn": false,
+	}
+	for input, want := range cases {
+		if got := isIAMRoleARN(input); got != want {
+			t.Fatalf("isIAMRoleARN(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestIAMPassRoleNormalizerRejectsNonRoleARNs(t *testing.T) {
+	record := IAMPassRoleRelationship{
+		SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+		SourceRoleName:     "source",
+		TargetResource:     "arn:aws:s3:::audit-bucket", // NOT an IAM role
+		TargetWildcardKind: "specific",
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	asset := providers.RawAsset{Kind: rawKindIAMPassRoleRelationship, SourceID: "src", Payload: payload}
+	bundle := providers.NormalizedBundle{}
+	seen := map[string]struct{}{}
+	if err := normalizeIAMPassRoleRelationshipAsset(asset, 0, &bundle, seen); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	// Source role still projected; non-role target ARN must NOT become an
+	// identity in the graph.
+	if len(bundle.Identities) != 1 {
+		t.Fatalf("expected only source identity for non-role target, got %d (%+v)", len(bundle.Identities), bundle.Identities)
+	}
+	if bundle.Identities[0].ARN != record.SourceRoleARN {
+		t.Fatalf("expected source identity, got %+v", bundle.Identities[0])
 	}
 }

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -1,0 +1,334 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+type fakeIAMRolesAPI struct {
+	pages []ListRolesPage
+	calls int
+	err   error
+}
+
+func (f *fakeIAMRolesAPI) ListRoles(ctx context.Context, nextToken string, pageSize int32) (ListRolesPage, error) {
+	f.calls++
+	if f.err != nil {
+		return ListRolesPage{}, f.err
+	}
+	if len(f.pages) == 0 {
+		return ListRolesPage{}, nil
+	}
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func TestExtractPassRoleGrants_ExpandsResourcesAndConditions(t *testing.T) {
+	doc, err := parsePassRolePolicyDocument(`{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "PassLambda",
+				"Effect": "Allow",
+				"Action": ["iam:PassRole"],
+				"Resource": [
+					"arn:aws:iam::123456789012:role/payments-lambda",
+					"arn:aws:iam::123456789012:role/payments-ecs-*"
+				],
+				"Condition": {
+					"StringEquals": {
+						"iam:PassedToService": ["lambda.amazonaws.com", "ecs-tasks.amazonaws.com"]
+					}
+				}
+			},
+			{
+				"Sid": "WildcardEverywhere",
+				"Effect": "Allow",
+				"Action": "*",
+				"Resource": "*"
+			},
+			{
+				"Sid": "BreakGlassDeny",
+				"Effect": "Deny",
+				"Action": "iam:PassRole",
+				"Resource": "arn:aws:iam::123456789012:role/break-glass"
+			}
+		]
+	}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	grants := extractPassRoleGrants(doc)
+	if len(grants) != 6 {
+		// PassLambda: 2 resources × 2 service conditions = 4; WildcardEverywhere: 1; BreakGlassDeny: 1.
+		t.Fatalf("expected 6 grants (2x2 + 1 + 1), got %d: %+v", len(grants), grants)
+	}
+	hasLambda := false
+	hasDeny := false
+	hasStarStar := false
+	for _, grant := range grants {
+		if grant.TargetResource == "arn:aws:iam::123456789012:role/payments-lambda" && grant.ServiceCondition == "lambda.amazonaws.com" {
+			hasLambda = true
+		}
+		if grant.Effect == "Deny" && strings.Contains(grant.TargetResource, "break-glass") {
+			hasDeny = true
+		}
+		if grant.TargetResource == "*" && grant.ActionExpression == "*" {
+			hasStarStar = true
+		}
+	}
+	if !hasLambda || !hasDeny || !hasStarStar {
+		t.Fatalf("expected lambda/deny/star grants, got %+v", grants)
+	}
+}
+
+func TestExtractPassRoleGrants_NotActionAndNotResource(t *testing.T) {
+	doc, err := parsePassRolePolicyDocument(`{
+		"Version": "2012-10-17",
+		"Statement": {
+			"Effect": "Allow",
+			"NotAction": "iam:PassRole",
+			"NotResource": "arn:aws:iam::123456789012:role/break-glass"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	grants := extractPassRoleGrants(doc)
+	if len(grants) != 1 {
+		t.Fatalf("expected one grant, got %d", len(grants))
+	}
+	if !grants[0].NotAction || !grants[0].NotResource {
+		t.Fatalf("expected NotAction + NotResource flags, got %+v", grants[0])
+	}
+}
+
+func TestPassRoleGrantWildcardKindAndConfidence(t *testing.T) {
+	cases := []struct {
+		target           string
+		wantKind         string
+		wantConfidenceGE float64
+	}{
+		{"arn:aws:iam::123456789012:role/payments", "specific", 0.9},
+		{"arn:aws:iam::123456789012:role/payments-*", "path_wildcard", 0.7},
+		{"arn:aws:iam::*:role/payments", "account_wildcard", 0.7},
+		{"*", "all", 0.4},
+	}
+	for _, tc := range cases {
+		if got := passRoleGrantWildcardKind(tc.target); got != tc.wantKind {
+			t.Fatalf("kind for %q: got %q, want %q", tc.target, got, tc.wantKind)
+		}
+		conf := passRoleGrantConfidence(passRoleGrant{TargetResource: tc.target})
+		if conf < tc.wantConfidenceGE {
+			t.Fatalf("confidence for %q: got %v, want >= %v", tc.target, conf, tc.wantConfidenceGE)
+		}
+	}
+}
+
+func TestIAMPassRoleCollectorEmitsNormalizedAssets(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/platform-deploy"
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{{
+		Roles: []IAMRole{{
+			ARN:  roleARN,
+			Name: "platform-deploy",
+			Path: "/",
+			PermissionPolicies: []IAMPermissionPolicy{{
+				Name: "platform-deploy-passrole",
+				Document: `{
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Sid": "PassLambda",
+						"Effect": "Allow",
+						"Action": "iam:PassRole",
+						"Resource": "arn:aws:iam::123456789012:role/payments-lambda",
+						"Condition": {
+							"StringEquals": {"iam:PassedToService": "lambda.amazonaws.com"}
+						}
+					}]
+				}`,
+			}},
+		}},
+	}}}
+	collector := NewIAMPassRoleRelationshipCollector(api, WithIAMPassRoleRelationshipClock(func() time.Time { return collectedAt }))
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-a", ConnectorID: "aws-prod", ScanID: "scan-1", AccountID: "123456789012", Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one asset, got %d", len(assets))
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %+v", diagnostics)
+	}
+	var record IAMPassRoleRelationship
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if record.SourceRoleARN != roleARN || record.PassedToService != "lambda.amazonaws.com" {
+		t.Fatalf("unexpected record: %+v", record)
+	}
+	if record.TargetWildcardKind != "specific" || record.Confidence < 0.9 {
+		t.Fatalf("expected specific target with high confidence, got %+v", record)
+	}
+	if record.TenantID != "tenant-a" || record.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected scope inherited, got %+v", record)
+	}
+}
+
+func TestIAMPassRoleCollectorSkipsRolesWithoutPassRole(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{{
+		Roles: []IAMRole{{
+			ARN:  "arn:aws:iam::123456789012:role/no-passrole",
+			Name: "no-passrole",
+			PermissionPolicies: []IAMPermissionPolicy{{
+				Name:     "s3-only",
+				Document: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			}},
+		}},
+	}}}
+	collector := NewIAMPassRoleRelationshipCollector(api, WithIAMPassRoleRelationshipClock(func() time.Time { return collectedAt }))
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("expected no assets for role without PassRole, got %d", len(assets))
+	}
+}
+
+func TestIAMPassRoleCollectorRecordsParseFailures(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{{
+		Roles: []IAMRole{{
+			ARN:  "arn:aws:iam::123456789012:role/bad",
+			Name: "bad",
+			PermissionPolicies: []IAMPermissionPolicy{{
+				Name:     "broken",
+				Document: `{ not valid json`,
+			}},
+		}},
+	}}}
+	collector := NewIAMPassRoleRelationshipCollector(api, WithIAMPassRoleRelationshipClock(func() time.Time { return collectedAt }))
+	_, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Code != "iam_passrole_policy_parse_failed" {
+		t.Fatalf("expected parse_failed diagnostic, got %+v", diagnostics)
+	}
+}
+
+func TestIAMPassRoleCollectorPropagatesListError(t *testing.T) {
+	api := &fakeIAMRolesAPI{err: errors.New("throttled")}
+	collector := NewIAMPassRoleRelationshipCollector(api,
+		WithIAMPassRoleRelationshipRetryPolicy(RetryPolicy{MaxRetries: 0, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond}),
+		WithIAMPassRoleRelationshipSleeper(func(ctx context.Context, d time.Duration) error { return nil }),
+	)
+	_, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{})
+	if err == nil {
+		t.Fatalf("expected error from list pages")
+	}
+}
+
+func TestIAMPassRoleCollectorRequiresClient(t *testing.T) {
+	c := &IAMPassRoleRelationshipCollector{}
+	if _, _, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{}); err == nil {
+		t.Fatalf("expected error when client missing")
+	}
+}
+
+func TestIAMPassRoleCollectorDedupesAcrossPages(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	role := IAMRole{
+		ARN:  "arn:aws:iam::123456789012:role/dup",
+		Name: "dup",
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name:     "passrole",
+			Document: `{"Statement":[{"Effect":"Allow","Action":"iam:PassRole","Resource":"arn:aws:iam::123456789012:role/target"}]}`,
+		}},
+	}
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{
+		{Roles: []IAMRole{role}, NextToken: "p2"},
+		{Roles: []IAMRole{role}},
+	}}
+	collector := NewIAMPassRoleRelationshipCollector(api, WithIAMPassRoleRelationshipClock(func() time.Time { return collectedAt }))
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected dedupe, got %d assets", len(assets))
+	}
+}
+
+func TestIAMPassRoleNormalizerRegistersSourceAndTargetIdentities(t *testing.T) {
+	record := IAMPassRoleRelationship{
+		SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+		SourceRoleName:     "source",
+		TargetResource:     "arn:aws:iam::123456789012:role/target",
+		TargetWildcardKind: "specific",
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	asset := providers.RawAsset{Kind: rawKindIAMPassRoleRelationship, SourceID: "src", Payload: payload}
+	bundle := providers.NormalizedBundle{}
+	seen := map[string]struct{}{}
+	if err := normalizeIAMPassRoleRelationshipAsset(asset, 0, &bundle, seen); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(bundle.Identities) != 2 {
+		t.Fatalf("expected source+target identities, got %d", len(bundle.Identities))
+	}
+}
+
+func TestIAMPassRoleNormalizerSkipsWildcardTargets(t *testing.T) {
+	record := IAMPassRoleRelationship{
+		SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+		TargetResource:     "*",
+		TargetWildcardKind: "all",
+		UnresolvedTarget:   true,
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	asset := providers.RawAsset{Kind: rawKindIAMPassRoleRelationship, SourceID: "src", Payload: payload}
+	bundle := providers.NormalizedBundle{}
+	seen := map[string]struct{}{}
+	if err := normalizeIAMPassRoleRelationshipAsset(asset, 0, &bundle, seen); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(bundle.Identities) != 1 {
+		t.Fatalf("expected only source identity for wildcard target, got %d", len(bundle.Identities))
+	}
+}
+
+func TestIsIAMPassRoleRelationshipFixture_Strict(t *testing.T) {
+	yes := IAMPassRoleRelationship{}
+	yes.Service = "iam-passrole"
+	if !isIAMPassRoleRelationshipFixture(yes) {
+		t.Fatalf("expected match on service")
+	}
+	noService := IAMPassRoleRelationship{}
+	noService.WorkloadType = "iam_passrole_relationship"
+	if !isIAMPassRoleRelationshipFixture(noService) {
+		t.Fatalf("expected match on workload type")
+	}
+	stranger := IAMPassRoleRelationship{}
+	if isIAMPassRoleRelationshipFixture(stranger) {
+		t.Fatalf("empty record must not match")
+	}
+}

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -576,3 +576,29 @@ func TestPassRoleGrantWildcardKindMalformedClassification(t *testing.T) {
 		}
 	}
 }
+
+func TestPassRoleGrantConfidenceMatchesWildcardKind(t *testing.T) {
+	// Any non-IAM ARN that classifies as malformed must receive the lowest
+	// confidence — otherwise the API ships records whose kind says
+	// "malformed" but whose confidence claims high trust.
+	malformedInputs := []string{
+		"arn:aws:s3:::audit-bucket",
+		"arn:aws:lambda:us-east-1:123456789012:function:payments",
+		"arn:aws:iam::123456789012:user/dev",
+		"arn:aws:iam::123456789012:policy/Admin",
+		"not-an-arn",
+	}
+	for _, target := range malformedInputs {
+		if kind := passRoleGrantWildcardKind(target); kind != "malformed" {
+			t.Fatalf("expected %q to classify as malformed, got %q", target, kind)
+		}
+		conf := passRoleGrantConfidence(passRoleGrant{TargetResource: target})
+		if conf > 0.4 {
+			t.Fatalf("malformed target %q got confidence %v; expected low confidence (<= 0.4)", target, conf)
+		}
+	}
+	// Specific IAM role ARN still gets the highest score for parity.
+	if conf := passRoleGrantConfidence(passRoleGrant{TargetResource: "arn:aws:iam::123456789012:role/payments"}); conf < 0.9 {
+		t.Fatalf("specific IAM role ARN got confidence %v; expected >= 0.9", conf)
+	}
+}

--- a/internal/providers/aws/iam_passrole_relationship_collector_test.go
+++ b/internal/providers/aws/iam_passrole_relationship_collector_test.go
@@ -332,3 +332,91 @@ func TestIsIAMPassRoleRelationshipFixture_Strict(t *testing.T) {
 		t.Fatalf("empty record must not match")
 	}
 }
+
+func TestExtractPassRoleGrants_WildcardActionPatternMatches(t *testing.T) {
+	cases := map[string]bool{
+		"iam:Pass*":      true,
+		"iam:P*":         true,
+		"iam:Pa?sRole":   true,
+		"iam:pass*":      true, // case-insensitive
+		"iam:Get*":       false,
+		"iam:List*":      false,
+		"sts:AssumeRole": false,
+	}
+	for action, want := range cases {
+		doc, err := parsePassRolePolicyDocument(`{"Statement":[{"Effect":"Allow","Action":"` + action + `","Resource":"arn:aws:iam::123456789012:role/payments"}]}`)
+		if err != nil {
+			t.Fatalf("parse %q: %v", action, err)
+		}
+		grants := extractPassRoleGrants(doc)
+		got := len(grants) == 1
+		if got != want {
+			t.Fatalf("action %q: got match=%v, want %v (grants=%+v)", action, got, want, grants)
+		}
+	}
+}
+
+func TestParsePassRolePolicyDocument_InvalidStatementShape(t *testing.T) {
+	// A scalar string is neither a statement object nor an array — must error.
+	_, err := parsePassRolePolicyDocument(`{"Statement": "not a statement"}`)
+	if err == nil {
+		t.Fatalf("expected parse error for invalid statement shape")
+	}
+}
+
+func TestParsePassRolePolicyDocument_TolerantInputs(t *testing.T) {
+	cases := []string{
+		"",
+		`{}`,
+		`{"Statement": null}`,
+		`{"Statement": []}`,
+	}
+	for _, raw := range cases {
+		if _, err := parsePassRolePolicyDocument(raw); err != nil {
+			t.Fatalf("input %q: unexpected error %v", raw, err)
+		}
+	}
+}
+
+func TestIAMPassRoleCollectorRecordsBadStatementShape(t *testing.T) {
+	api := &fakeIAMRolesAPI{pages: []ListRolesPage{{
+		Roles: []IAMRole{{
+			ARN:  "arn:aws:iam::123456789012:role/bad-statement",
+			Name: "bad-statement",
+			PermissionPolicies: []IAMPermissionPolicy{{
+				Name:     "broken",
+				Document: `{"Statement": "not a statement"}`,
+			}},
+		}},
+	}}}
+	collector := NewIAMPassRoleRelationshipCollector(api)
+	_, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Code != "iam_passrole_policy_parse_failed" {
+		t.Fatalf("expected parse_failed diagnostic for bad statement shape, got %+v", diagnostics)
+	}
+}
+
+func TestIAMActionPatternMatches(t *testing.T) {
+	cases := []struct {
+		pattern string
+		target  string
+		want    bool
+	}{
+		{"pass*", "passrole", true},
+		{"*role", "passrole", true},
+		{"pa?srole", "passrole", true},
+		{"pa??role", "passrole", true},
+		{"get*", "passrole", false},
+		{"passrole", "passrole", true},
+		{"passrole*", "passrole", true},
+		{"passroles", "passrole", false},
+	}
+	for _, tc := range cases {
+		if got := iamActionPatternMatches(tc.pattern, tc.target); got != tc.want {
+			t.Fatalf("pattern %q vs %q: got %v, want %v", tc.pattern, tc.target, got, tc.want)
+		}
+	}
+}

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -1799,7 +1799,13 @@ func normalizeIAMPassRoleRelationshipAsset(asset providers.RawAsset, index int, 
 		return nil
 	}
 	targetARN := strings.TrimSpace(record.TargetResource)
-	if targetARN == "" || !strings.HasPrefix(targetARN, "arn:") {
+	if !isIAMRoleARN(targetARN) {
+		// PassRole targets must be IAM role ARNs (arn:PARTITION:iam::ACCOUNT:
+		// role/...). Any other shape — an S3 bucket ARN, a Lambda function
+		// ARN, a malformed string — would synthesize a bogus role identity in
+		// the graph, so we drop those edges silently. The raw asset still
+		// carries the original target string for audit; the API exposes it
+		// even when no identity is created.
 		return nil
 	}
 	targetID := identityIDFromARN(targetARN)
@@ -1815,4 +1821,33 @@ func normalizeIAMPassRoleRelationshipAsset(asset providers.RawAsset, index int, 
 		})
 	}
 	return nil
+}
+
+// isIAMRoleARN reports whether the supplied string is a fully-qualified IAM
+// role ARN of the form arn:PARTITION:iam::ACCOUNT:role/PATH. It guards the
+// PassRole normalizer from synthesizing identity nodes from non-IAM-role ARNs
+// that happen to share the arn: prefix.
+func isIAMRoleARN(arn string) bool {
+	trimmed := strings.TrimSpace(arn)
+	if trimmed == "" {
+		return false
+	}
+	// AWS ARN format: arn:partition:service:region:account:resource.
+	// We need 6 segments, partition starting with "aws", service exactly
+	// "iam", region empty (IAM is global), and resource beginning with
+	// "role/".
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) != 6 {
+		return false
+	}
+	if !strings.EqualFold(parts[0], "arn") {
+		return false
+	}
+	if !strings.HasPrefix(strings.ToLower(parts[1]), "aws") {
+		return false
+	}
+	if !strings.EqualFold(parts[2], "iam") {
+		return false
+	}
+	return strings.HasPrefix(parts[5], "role/")
 }

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -1824,18 +1824,20 @@ func normalizeIAMPassRoleRelationshipAsset(asset providers.RawAsset, index int, 
 }
 
 // isIAMRoleARN reports whether the supplied string is a fully-qualified IAM
-// role ARN of the form arn:PARTITION:iam::ACCOUNT:role/PATH. It guards the
+// role ARN of the form arn:PARTITION:iam::ACCOUNT:role/NAME. It guards the
 // PassRole normalizer from synthesizing identity nodes from non-IAM-role ARNs
 // that happen to share the arn: prefix.
+//
+// Every segment is validated: the literal "arn" prefix, an aws-family
+// partition, the service "iam", an empty region (IAM is global), a 12-digit
+// numeric account ID, and a resource of the form "role/NAME" where NAME is
+// non-empty. Anything else — wrong service, missing account, region present,
+// dangling "role/" with no name — rejects.
 func isIAMRoleARN(arn string) bool {
 	trimmed := strings.TrimSpace(arn)
 	if trimmed == "" {
 		return false
 	}
-	// AWS ARN format: arn:partition:service:region:account:resource.
-	// We need 6 segments, partition starting with "aws", service exactly
-	// "iam", region empty (IAM is global), and resource beginning with
-	// "role/".
 	parts := strings.SplitN(trimmed, ":", 6)
 	if len(parts) != 6 {
 		return false
@@ -1849,5 +1851,22 @@ func isIAMRoleARN(arn string) bool {
 	if !strings.EqualFold(parts[2], "iam") {
 		return false
 	}
-	return strings.HasPrefix(parts[5], "role/")
+	// IAM is a global service; the region segment must be empty.
+	if parts[3] != "" {
+		return false
+	}
+	account := strings.TrimSpace(parts[4])
+	if len(account) != 12 {
+		return false
+	}
+	for _, ch := range account {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	resource := strings.TrimSpace(parts[5])
+	if !strings.HasPrefix(resource, "role/") {
+		return false
+	}
+	return len(strings.TrimPrefix(resource, "role/")) > 0
 }

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -175,6 +175,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		}
 	}
 
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+		if asset.Kind != rawKindIAMPassRoleRelationship {
+			continue
+		}
+		if err := normalizeIAMPassRoleRelationshipAsset(asset, i, &bundle, identitySeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
 	return bundle, nil
 }
 
@@ -1749,4 +1761,58 @@ func sageMakerWorkloadType(record SageMakerWorkloadRole) string {
 
 func sageMakerWorkloadName(record SageMakerWorkloadRole) string {
 	return firstNonEmptyAWSValue(record.WorkloadName, managedComputeNameFromARN(firstNonEmptyAWSValue(record.WorkloadARN, record.ResourceARN)), "sagemaker workload")
+}
+
+func normalizeIAMPassRoleRelationshipAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, identitySeen map[string]struct{}) error {
+	var record IAMPassRoleRelationship
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode iam passrole relationship asset[%d]: %w", index, err)
+	}
+
+	// Register the source identity (the role whose policy contains the
+	// PassRole grant) so the graph has a well-formed "from" endpoint. The
+	// dedupe map short-circuits if the IAM collector has already emitted it.
+	sourceRoleARN := strings.TrimSpace(record.SourceRoleARN)
+	if sourceRoleARN == "" {
+		return nil
+	}
+	sourceID := identityIDFromARN(sourceRoleARN)
+	if _, exists := identitySeen[sourceID]; !exists {
+		identitySeen[sourceID] = struct{}{}
+		bundle.Identities = append(bundle.Identities, domain.Identity{
+			ID:        sourceID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.IdentityTypeRole,
+			Name:      firstNonEmptyAWSValue(record.SourceRoleName, roleNameFromARN(sourceRoleARN)),
+			ARN:       sourceRoleARN,
+			OwnerHint: ownerHintFromTags(record.Tags),
+			Tags:      copyTags(record.Tags),
+			RawRef:    asset.SourceID,
+		})
+	}
+
+	// Target identities are only projected for concrete role ARNs. Wildcard
+	// targets stay as raw-asset/API metadata — synthesizing an "arn:aws:iam::
+	// *:role/*" identity would pollute every downstream traversal and create
+	// fake nodes the graph cannot reason about.
+	if record.UnresolvedTarget {
+		return nil
+	}
+	targetARN := strings.TrimSpace(record.TargetResource)
+	if targetARN == "" || !strings.HasPrefix(targetARN, "arn:") {
+		return nil
+	}
+	targetID := identityIDFromARN(targetARN)
+	if _, exists := identitySeen[targetID]; !exists {
+		identitySeen[targetID] = struct{}{}
+		bundle.Identities = append(bundle.Identities, domain.Identity{
+			ID:       targetID,
+			Provider: domain.ProviderAWS,
+			Type:     domain.IdentityTypeRole,
+			Name:     roleNameFromARN(targetARN),
+			ARN:      targetARN,
+			RawRef:   asset.SourceID,
+		})
+	}
+	return nil
 }

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -1,0 +1,265 @@
+package aws
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// passRolePolicyDocument is a fuller view of an IAM policy used by the PassRole
+// extractor. The core model.go parser ignores NotAction, NotResource, Sid, and
+// Condition because the existing collectors do not need them; PassRole analysis
+// does, so we keep a dedicated structure rather than mutating the shared model.
+type passRolePolicyDocument struct {
+	Version   string                    `json:"Version"`
+	Statement passRolePolicyStatementsT `json:"Statement"`
+}
+
+type passRolePolicyStatementsT []passRolePolicyStatement
+
+type passRolePolicyStatement struct {
+	Sid         string         `json:"Sid,omitempty"`
+	Effect      string         `json:"Effect"`
+	Action      any            `json:"Action,omitempty"`
+	NotAction   any            `json:"NotAction,omitempty"`
+	Resource    any            `json:"Resource,omitempty"`
+	NotResource any            `json:"NotResource,omitempty"`
+	Condition   map[string]any `json:"Condition,omitempty"`
+}
+
+// UnmarshalJSON lets statements arrive as a single object or an array, matching
+// IAM's permissive grammar.
+func (s *passRolePolicyStatementsT) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*s = nil
+		return nil
+	}
+	var single passRolePolicyStatement
+	if err := json.Unmarshal(data, &single); err == nil && single.Effect != "" {
+		*s = []passRolePolicyStatement{single}
+		return nil
+	}
+	var many []passRolePolicyStatement
+	if err := json.Unmarshal(data, &many); err == nil {
+		*s = many
+		return nil
+	}
+	*s = nil
+	return nil
+}
+
+// parsePassRolePolicyDocument decodes a possibly URL-encoded IAM policy
+// document and returns the parsed structure. An empty input yields an empty
+// document, not an error, so callers can fan out without nil checks.
+func parsePassRolePolicyDocument(raw string) (passRolePolicyDocument, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return passRolePolicyDocument{}, nil
+	}
+	decoded := trimmed
+	if strings.Contains(trimmed, "%") {
+		if unescaped, err := url.QueryUnescape(trimmed); err == nil {
+			decoded = unescaped
+		}
+	}
+	var doc passRolePolicyDocument
+	if err := json.Unmarshal([]byte(decoded), &doc); err != nil {
+		return passRolePolicyDocument{}, err
+	}
+	return doc, nil
+}
+
+// passRoleGrant is one extracted PassRole grant. One statement can produce
+// multiple grants — one per (target resource, condition value) tuple — so the
+// graph can carry per-target edges even when the policy folds them together.
+type passRoleGrant struct {
+	Effect           string   // "Allow" or "Deny" (canonical)
+	Sid              string   // operator-facing evidence anchor; empty when absent
+	TargetResource   string   // the resource ARN or wildcard the grant points at
+	ServiceCondition string   // value of iam:PassedToService when present; empty otherwise
+	ConditionOp      string   // operator that owned the service condition (e.g. StringEquals)
+	ActionExpression string   // the action expression that matched (iam:PassRole, iam:*, *)
+	NotAction        bool     // true when the matching statement used NotAction
+	NotResource      bool     // true when the matching statement used NotResource
+	OtherConditions  []string // condition keys present beyond iam:PassedToService (for reasoning)
+}
+
+// extractPassRoleGrants returns every PassRole grant emitted by the supplied
+// policy document. The function never touches the network or filesystem.
+func extractPassRoleGrants(doc passRolePolicyDocument) []passRoleGrant {
+	grants := []passRoleGrant{}
+	for _, statement := range doc.Statement {
+		effect, ok := canonicalEffect(statement.Effect)
+		if !ok {
+			continue
+		}
+		// PassRole can appear as iam:PassRole, iam:*, or *, with either Action
+		// (positive grant) or NotAction (inverse grant). Capture which form the
+		// statement used so consumers can distinguish them.
+		match, notAction := passRoleActionMatch(statement.Action, statement.NotAction)
+		if match == "" {
+			continue
+		}
+		resources, notResource := passRoleResourceTargets(statement.Resource, statement.NotResource)
+		if len(resources) == 0 {
+			// A statement with neither Resource nor NotResource is malformed;
+			// emit a synthetic "*" target so consumers still see the grant
+			// and can flag it for review.
+			resources = []string{"*"}
+		}
+		serviceConditions, otherConditionKeys := extractPassedToServiceCondition(statement.Condition)
+		if len(serviceConditions) == 0 {
+			// No iam:PassedToService — emit one grant per target with no
+			// service binding. The graph will reflect that this PassRole is
+			// not restricted to a single AWS service.
+			serviceConditions = []serviceConditionMatch{{}}
+		}
+		for _, target := range resources {
+			for _, condition := range serviceConditions {
+				grants = append(grants, passRoleGrant{
+					Effect:           effect,
+					Sid:              strings.TrimSpace(statement.Sid),
+					TargetResource:   target,
+					ServiceCondition: condition.value,
+					ConditionOp:      condition.operator,
+					ActionExpression: match,
+					NotAction:        notAction,
+					NotResource:      notResource,
+					OtherConditions:  otherConditionKeys,
+				})
+			}
+		}
+	}
+	return grants
+}
+
+// passRoleActionMatch returns the matched action expression (canonicalized to
+// lower-case) and whether the match came from NotAction. The empty string
+// means the statement does not bear on PassRole.
+func passRoleActionMatch(action, notAction any) (string, bool) {
+	if match := passRoleActionInList(action); match != "" {
+		return match, false
+	}
+	if match := passRoleActionInList(notAction); match != "" {
+		return match, true
+	}
+	return "", false
+}
+
+func passRoleActionInList(value any) string {
+	for _, action := range parseStringList(value) {
+		switch strings.ToLower(strings.TrimSpace(action)) {
+		case "iam:passrole":
+			return "iam:PassRole"
+		case "iam:*":
+			return "iam:*"
+		case "*":
+			return "*"
+		}
+	}
+	return ""
+}
+
+// passRoleResourceTargets returns the deduplicated, trimmed resource list and
+// whether NotResource was used. A NotResource form means "every role except
+// these" — we still emit those entries so the graph can reflect the inverse
+// shape.
+func passRoleResourceTargets(resource, notResource any) ([]string, bool) {
+	if values := dedupeStrings(parseStringList(resource)); len(values) > 0 {
+		return values, false
+	}
+	if values := dedupeStrings(parseStringList(notResource)); len(values) > 0 {
+		return values, true
+	}
+	return nil, false
+}
+
+type serviceConditionMatch struct {
+	value    string
+	operator string
+}
+
+// extractPassedToServiceCondition pulls the iam:PassedToService condition (if
+// present) and returns every matching service. Any condition key besides
+// iam:PassedToService is returned separately so consumers can still see the
+// statement is restricted (without us inventing graph semantics for arbitrary
+// condition keys this wave).
+func extractPassedToServiceCondition(condition map[string]any) ([]serviceConditionMatch, []string) {
+	if len(condition) == 0 {
+		return nil, nil
+	}
+	matches := []serviceConditionMatch{}
+	otherKeys := map[string]struct{}{}
+	for operator, body := range condition {
+		bodyMap, ok := body.(map[string]any)
+		if !ok {
+			continue
+		}
+		for key, raw := range bodyMap {
+			if strings.EqualFold(strings.TrimSpace(key), "iam:PassedToService") {
+				for _, service := range parseStringList(raw) {
+					trimmed := strings.TrimSpace(service)
+					if trimmed == "" {
+						continue
+					}
+					matches = append(matches, serviceConditionMatch{
+						value:    trimmed,
+						operator: strings.TrimSpace(operator),
+					})
+				}
+				continue
+			}
+			trimmedKey := strings.TrimSpace(key)
+			if trimmedKey == "" {
+				continue
+			}
+			otherKeys[trimmedKey] = struct{}{}
+		}
+	}
+	others := make([]string, 0, len(otherKeys))
+	for key := range otherKeys {
+		others = append(others, key)
+	}
+	return matches, others
+}
+
+// passRoleGrantConfidence returns a confidence score in [0, 1] for a single
+// grant. Specific role ARNs get the highest score; path-scoped wildcards get a
+// middle score; "*" gets the lowest. Deny statements and NotAction/NotResource
+// forms are reported with full confidence because we can prove the grant
+// shape, even though their downstream effect is conditional.
+func passRoleGrantConfidence(grant passRoleGrant) float64 {
+	target := strings.TrimSpace(grant.TargetResource)
+	switch {
+	case target == "*":
+		return 0.55
+	case strings.Contains(target, "*") && strings.HasPrefix(target, "arn:"):
+		return 0.78
+	case strings.HasPrefix(target, "arn:") && !strings.Contains(target, "*"):
+		return 0.95
+	default:
+		return 0.6
+	}
+}
+
+// passRoleGrantWildcardKind classifies a grant's target shape so the API can
+// surface "this is a wildcard" without consumers re-parsing the ARN. Returns
+// one of "specific", "path_wildcard", "account_wildcard", or "all".
+func passRoleGrantWildcardKind(target string) string {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "*" {
+		return "all"
+	}
+	if !strings.HasPrefix(trimmed, "arn:") {
+		return "specific"
+	}
+	if !strings.Contains(trimmed, "*") {
+		return "specific"
+	}
+	// arn:aws:iam::*:role/... — account-position wildcard
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) >= 5 && parts[4] == "*" {
+		return "account_wildcard"
+	}
+	return "path_wildcard"
+}

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"net/url"
 	"strings"
 )
@@ -28,7 +29,9 @@ type passRolePolicyStatement struct {
 }
 
 // UnmarshalJSON lets statements arrive as a single object or an array, matching
-// IAM's permissive grammar.
+// IAM's permissive grammar. Genuinely malformed shapes (neither a statement
+// object nor an array) propagate as an error so the collector can record a
+// parse-failure diagnostic instead of silently treating the policy as empty.
 func (s *passRolePolicyStatementsT) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 || string(data) == "null" {
 		*s = nil
@@ -44,8 +47,7 @@ func (s *passRolePolicyStatementsT) UnmarshalJSON(data []byte) error {
 		*s = many
 		return nil
 	}
-	*s = nil
-	return nil
+	return errors.New("invalid passrole policy statement shape")
 }
 
 // parsePassRolePolicyDocument decodes a possibly URL-encoded IAM policy
@@ -146,9 +148,15 @@ func passRoleActionMatch(action, notAction any) (string, bool) {
 	return "", false
 }
 
+// passRoleActionInList returns the matched action expression. It covers the
+// exact spelling (iam:PassRole), AWS-style action wildcards that contain
+// PassRole (e.g. iam:Pass*, iam:P*, iam:Pa?sRole), and the broad wildcards
+// (iam:*, *). Each accepted expression is returned in its canonical original
+// casing so downstream code can surface the grant's policy text verbatim.
 func passRoleActionInList(value any) string {
 	for _, action := range parseStringList(value) {
-		switch strings.ToLower(strings.TrimSpace(action)) {
+		trimmed := strings.TrimSpace(action)
+		switch strings.ToLower(trimmed) {
 		case "iam:passrole":
 			return "iam:PassRole"
 		case "iam:*":
@@ -156,8 +164,60 @@ func passRoleActionInList(value any) string {
 		case "*":
 			return "*"
 		}
+		if iamActionWildcardMatchesPassRole(trimmed) {
+			return trimmed
+		}
 	}
 	return ""
+}
+
+// iamActionWildcardMatchesPassRole reports whether the supplied IAM action
+// expression — using the AWS wildcard syntax — could match iam:PassRole. The
+// AWS docs describe two wildcards: * matches any sequence of characters and ?
+// matches a single character. We treat any wildcarded iam: action whose
+// pattern accepts the literal "PassRole" as a PassRole grant so policies that
+// use iam:Pass*, iam:Pa?sRole, or iam:Pass??le are not silently missed.
+func iamActionWildcardMatchesPassRole(expr string) bool {
+	lowered := strings.ToLower(expr)
+	if !strings.HasPrefix(lowered, "iam:") {
+		return false
+	}
+	pattern := lowered[len("iam:"):]
+	if !strings.ContainsAny(pattern, "*?") {
+		// No wildcard — exact match already handled by the caller's switch.
+		return false
+	}
+	return iamActionPatternMatches(pattern, "passrole")
+}
+
+// iamActionPatternMatches reports whether the AWS-style pattern (with * and ?
+// wildcards) matches the target string. It uses an iterative back-tracking
+// matcher rather than translating to a regular expression so it never panics
+// or hits regex-engine limits on adversarial inputs.
+func iamActionPatternMatches(pattern, target string) bool {
+	pi, ti := 0, 0
+	starPi, starTi := -1, 0
+	for ti < len(target) {
+		switch {
+		case pi < len(pattern) && (pattern[pi] == '?' || pattern[pi] == target[ti]):
+			pi++
+			ti++
+		case pi < len(pattern) && pattern[pi] == '*':
+			starPi = pi
+			starTi = ti
+			pi++
+		case starPi != -1:
+			pi = starPi + 1
+			starTi++
+			ti = starTi
+		default:
+			return false
+		}
+	}
+	for pi < len(pattern) && pattern[pi] == '*' {
+		pi++
+	}
+	return pi == len(pattern)
 }
 
 // passRoleResourceTargets returns the deduplicated, trimmed resource list and

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -304,24 +304,25 @@ func extractPassedToServiceCondition(condition map[string]any) ([]serviceConditi
 }
 
 // passRoleGrantConfidence returns a confidence score in [0, 1] for a single
-// grant. Specific role ARNs get the highest score; path-scoped wildcards get
-// a middle score; "*" gets a lower score; malformed (non-ARN, non-"*")
-// targets get the lowest because we cannot reason about what they point at.
-// Deny statements and NotAction/NotResource forms keep the same scoring
-// because we can still prove the grant shape, even though their downstream
-// effect is conditional.
+// grant. The score is keyed off the wildcard-kind classification so the two
+// stay consistent: a target classified as malformed (e.g. a non-IAM ARN like
+// arn:aws:s3:::bucket) never gets a high confidence score just because it
+// has the arn: prefix. Specific IAM role ARNs get the highest score;
+// path-scoped wildcards a middle score; account-position wildcards slightly
+// lower; "*" lower still; malformed lowest.
 func passRoleGrantConfidence(grant passRoleGrant) float64 {
-	target := strings.TrimSpace(grant.TargetResource)
-	switch {
-	case target == "*":
-		return 0.55
-	case strings.Contains(target, "*") && strings.HasPrefix(target, "arn:"):
-		return 0.78
-	case strings.HasPrefix(target, "arn:") && !strings.Contains(target, "*"):
+	switch passRoleGrantWildcardKind(grant.TargetResource) {
+	case "specific":
 		return 0.95
+	case "path_wildcard":
+		return 0.78
+	case "account_wildcard":
+		return 0.7
+	case "all":
+		return 0.55
 	default:
-		// Non-ARN, non-"*" target — malformed or unsupported shape. Mark it
-		// low-confidence so downstream consumers know not to act on it.
+		// malformed (or any future unknown kind) — low-confidence so
+		// downstream consumers know not to act on it.
 		return 0.3
 	}
 }

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -304,10 +304,12 @@ func extractPassedToServiceCondition(condition map[string]any) ([]serviceConditi
 }
 
 // passRoleGrantConfidence returns a confidence score in [0, 1] for a single
-// grant. Specific role ARNs get the highest score; path-scoped wildcards get a
-// middle score; "*" gets the lowest. Deny statements and NotAction/NotResource
-// forms are reported with full confidence because we can prove the grant
-// shape, even though their downstream effect is conditional.
+// grant. Specific role ARNs get the highest score; path-scoped wildcards get
+// a middle score; "*" gets a lower score; malformed (non-ARN, non-"*")
+// targets get the lowest because we cannot reason about what they point at.
+// Deny statements and NotAction/NotResource forms keep the same scoring
+// because we can still prove the grant shape, even though their downstream
+// effect is conditional.
 func passRoleGrantConfidence(grant passRoleGrant) float64 {
 	target := strings.TrimSpace(grant.TargetResource)
 	switch {
@@ -318,20 +320,25 @@ func passRoleGrantConfidence(grant passRoleGrant) float64 {
 	case strings.HasPrefix(target, "arn:") && !strings.Contains(target, "*"):
 		return 0.95
 	default:
-		return 0.6
+		// Non-ARN, non-"*" target — malformed or unsupported shape. Mark it
+		// low-confidence so downstream consumers know not to act on it.
+		return 0.3
 	}
 }
 
 // passRoleGrantWildcardKind classifies a grant's target shape so the API can
 // surface "this is a wildcard" without consumers re-parsing the ARN. Returns
-// one of "specific", "path_wildcard", "account_wildcard", or "all".
+// "specific" (concrete role ARN), "path_wildcard", "account_wildcard", "all"
+// (bare "*"), or "malformed" for anything else (a typo'd resource, a non-ARN
+// string). Malformed targets are treated as unresolved by the normalizer and
+// API so they never produce spurious edges in the graph.
 func passRoleGrantWildcardKind(target string) string {
 	trimmed := strings.TrimSpace(target)
 	if trimmed == "*" {
 		return "all"
 	}
 	if !strings.HasPrefix(trimmed, "arn:") {
-		return "specific"
+		return "malformed"
 	}
 	if !strings.Contains(trimmed, "*") {
 		return "specific"

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -135,17 +135,37 @@ func extractPassRoleGrants(doc passRolePolicyDocument) []passRoleGrant {
 	return grants
 }
 
-// passRoleActionMatch returns the matched action expression (canonicalized to
-// lower-case) and whether the match came from NotAction. The empty string
-// means the statement does not bear on PassRole.
+// passRoleActionMatch returns the matched action expression and whether the
+// matching statement used NotAction (inverse) form. The empty string means
+// the statement does not bear on PassRole.
+//
+// IAM NotAction semantics: when a statement uses NotAction, it applies to
+// every action *except* those listed. So a PassRole grant exists when:
+//
+//   - Action explicitly lists iam:PassRole (or a wildcard that matches it), or
+//   - NotAction is present and does *not* list iam:PassRole — in that case
+//     iam:PassRole is one of the implicit "all other actions" the statement
+//     applies to. We flag the result so downstream consumers can mark these
+//     grants as inverse and reason about the implicit-everything-else set.
+//
+// Conversely, NotAction listing iam:PassRole means iam:PassRole is explicitly
+// excluded, so the statement does not grant PassRole at all and we return "".
 func passRoleActionMatch(action, notAction any) (string, bool) {
 	if match := passRoleActionInList(action); match != "" {
 		return match, false
 	}
-	if match := passRoleActionInList(notAction); match != "" {
-		return match, true
+	notActionValues := parseStringList(notAction)
+	if len(notActionValues) == 0 {
+		return "", false
 	}
-	return "", false
+	if passRoleActionInList(notAction) != "" {
+		// NotAction explicitly excludes iam:PassRole (directly or via a
+		// matching wildcard) — the statement does not grant PassRole.
+		return "", false
+	}
+	// NotAction is present but does not exclude iam:PassRole; iam:PassRole is
+	// in the implicit "everything else" set this statement applies to.
+	return "iam:PassRole", true
 }
 
 // passRoleActionInList returns the matched action expression. It covers the

--- a/internal/providers/aws/passrole_policy.go
+++ b/internal/providers/aws/passrole_policy.go
@@ -328,10 +328,12 @@ func passRoleGrantConfidence(grant passRoleGrant) float64 {
 
 // passRoleGrantWildcardKind classifies a grant's target shape so the API can
 // surface "this is a wildcard" without consumers re-parsing the ARN. Returns
-// "specific" (concrete role ARN), "path_wildcard", "account_wildcard", "all"
-// (bare "*"), or "malformed" for anything else (a typo'd resource, a non-ARN
-// string). Malformed targets are treated as unresolved by the normalizer and
-// API so they never produce spurious edges in the graph.
+// "specific" (concrete IAM role ARN), "path_wildcard", "account_wildcard",
+// "all" (bare "*"), or "malformed" for anything else — a typo'd resource, a
+// non-ARN string, or a valid ARN of a different service (S3 bucket, Lambda
+// function). Only IAM role ARNs resolve to "specific"/"path_wildcard"/
+// "account_wildcard" so the graph never gets a PassRole edge pointing at a
+// non-role resource.
 func passRoleGrantWildcardKind(target string) string {
 	trimmed := strings.TrimSpace(target)
 	if trimmed == "*" {
@@ -340,12 +342,20 @@ func passRoleGrantWildcardKind(target string) string {
 	if !strings.HasPrefix(trimmed, "arn:") {
 		return "malformed"
 	}
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) != 6 {
+		return "malformed"
+	}
+	if !strings.EqualFold(parts[2], "iam") {
+		return "malformed"
+	}
+	if !strings.HasPrefix(parts[5], "role/") {
+		return "malformed"
+	}
 	if !strings.Contains(trimmed, "*") {
 		return "specific"
 	}
-	// arn:aws:iam::*:role/... — account-position wildcard
-	parts := strings.SplitN(trimmed, ":", 6)
-	if len(parts) >= 5 && parts[4] == "*" {
+	if parts[4] == "*" {
 		return "account_wildcard"
 	}
 	return "path_wildcard"

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -136,6 +136,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewEventDrivenRoleCollector(eventDrivenAPI),
 				awsprovider.NewManagedComputeRoleCollector(managedComputeAPI),
 				awsprovider.NewSageMakerWorkloadRoleCollector(sageMakerAPI),
+				awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			)
 		default:
@@ -278,6 +279,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewEventDrivenRoleCollector(eventDrivenAPI),
 			awsprovider.NewManagedComputeRoleCollector(managedComputeAPI),
 			awsprovider.NewSageMakerWorkloadRoleCollector(sageMakerAPI),
+			awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 			awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 		)
 		return scanner, nil

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "eks"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "eks"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -937,6 +937,30 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS IAM PassRole relationship inventory with scoped headers and fixture state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', record_count: 5, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectIAMPassRoleRelationships('workspace/a', 'project 1', 'aws-prod', 'degraded', {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/iam-passrole-relationships?connector_id=aws-prod&fixture_state=degraded'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS EKS workload identity inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1941,6 +1941,106 @@ export type AWSSageMakerWorkloadRoleInventoryResult = {
   updated_at: string;
 };
 
+export type AWSIAMPassRoleRelationshipInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSIAMPassRoleRelationshipFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSIAMPassRoleCoverageGap = {
+  capability: string;
+  status: 'unsupported';
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSIAMPassRoleRelationshipRecord = {
+  account_id: string;
+  region?: string;
+  service: 'iam-passrole';
+  workload_id: string;
+  workload_type: 'iam_passrole_relationship' | string;
+  workload_name: string;
+  source_role_arn: string;
+  source_role_name?: string;
+  source_role_path?: string;
+  target_resource: string;
+  target_wildcard_kind: 'specific' | 'path_wildcard' | 'account_wildcard' | 'all';
+  policy_name?: string;
+  statement_sid?: string;
+  action_expression: 'iam:PassRole' | 'iam:*' | '*' | string;
+  effect: 'Allow' | 'Deny';
+  passed_to_service?: string;
+  condition_operator?: string;
+  not_action?: boolean;
+  not_resource?: boolean;
+  other_condition_keys?: string[];
+  unresolved_target: boolean;
+  tags?: Record<string, string>;
+  source: string;
+  evidence_ref: string;
+  from_node_id: string;
+  to_node_id?: string;
+  relationship_type: 'can_pass_role' | string;
+  confidence: number;
+  collected_at: string;
+  status: string;
+};
+
+export type AWSIAMPassRoleRelationshipEdge = {
+  type: 'can_pass_role' | string;
+  from_node_id: string;
+  to_node_id?: string;
+  evidence_ref: string;
+  effect: 'Allow' | 'Deny';
+  passed_to_service?: string;
+};
+
+export type AWSIAMPassRoleRelationshipDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSIAMPassRoleRelationshipInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSIAMPassRoleRelationshipInventoryStatus;
+  fixture_state: AWSIAMPassRoleRelationshipFixtureState;
+  confidence: number;
+  record_count: number;
+  source_role_count: number;
+  target_role_count: number;
+  wildcard_target_count: number;
+  deny_statement_count: number;
+  service_scoped_count: number;
+  unscoped_count: number;
+  relationship_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSIAMPassRoleCoverageGap[];
+  records: AWSIAMPassRoleRelationshipRecord[];
+  relationships: AWSIAMPassRoleRelationshipEdge[];
+  diagnostics: AWSIAMPassRoleRelationshipDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSEKSWorkloadIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSEKSWorkloadIdentityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 
@@ -3137,6 +3237,21 @@ export const apiClient = {
   ) {
     return request<{ inventory: AWSSageMakerWorkloadRoleInventoryResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/sagemaker-workload-roles${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectIAMPassRoleRelationships(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSIAMPassRoleRelationshipFixtureState,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSIAMPassRoleRelationshipInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/iam-passrole-relationships${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
       })}`,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1967,7 +1967,7 @@ export type AWSIAMPassRoleRelationshipRecord = {
   source_role_name?: string;
   source_role_path?: string;
   target_resource: string;
-  target_wildcard_kind: 'specific' | 'path_wildcard' | 'account_wildcard' | 'all';
+  target_wildcard_kind: 'specific' | 'path_wildcard' | 'account_wildcard' | 'all' | 'malformed';
   policy_name?: string;
   statement_sid?: string;
   action_expression: 'iam:PassRole' | 'iam:*' | '*' | string;


### PR DESCRIPTION
## Summary
- Adds a static collector that parses every IAM role's already-collected permission policies for `iam:PassRole` statements and emits one normalized record per (source role, target resource, service condition, effect) tuple.
- Reuses the existing IAMAPI seam — no new AWS permissions are required beyond what the IAM role collector already needs.
- Surfaces specific role ARNs, path-scoped wildcards, account-position wildcards, `*`, Deny statements, `iam:PassedToService` conditions, and inverse (NotAction/NotResource) forms with explicit confidence tiers (0.55 → 0.95) so operators can reason about each grant rather than having wildcards silently expand into vast fan-out.
- Adds the `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships` endpoint with `success`, `empty`, `degraded`, `partial_failure`, and `permission_denied` fixture states.

## Implementation
- **Parser** (`passrole_policy.go`) covers `Action` / `NotAction`, `Resource` / `NotResource`, single-object vs array `Statement`, URL-encoded policy documents, multi-value `iam:PassedToService` conditions, and `iam:PassRole` / `iam:*` / `*` action expressions. The lighter-weight parser in `model.go` is left untouched so unrelated collectors do not change shape.
- **Collector** iterates `ListRoles`, fans out one record per grant, dedupes across pages, propagates retryable errors, returns partial assets + a `iam_passrole_page_limit_exceeded` diagnostic on max-page overflow, and holds per-call state locally so concurrent invocations on the same collector never race.
- **Normalizer** projects the source role identity (and the target role identity for concrete ARNs); wildcard targets are intentionally **not** synthesized as graph nodes — they stay as raw-asset and API metadata only.
- **Fixture classifier** is strict (`iam-passrole` service or `iam_passrole_relationship` workload type) so it cannot misroute unrelated assets.
- **Wiring**: composite collector (live SDK + assumed-role connector paths), router + authz policy bundle, OpenAPI schemas + path, web API client types + getter, runtime + CLI, operator docs, CHANGELOG.

## Validation
- `make fmt-check` / `go vet` / `make test` — full Go suite passes, total coverage 80.1%.
- `npm run test:ci` (web) — full suite passes, includes a new test for the SageMaker- and EKS-pattern web client getter.
- `npm run build` — production bundle + 39 prerendered routes.
- Parser tests cover Action/NotAction, single vs multi resource, multi-service conditions, wildcard kinds, confidence tiers, and URL-encoded docs.
- Collector tests cover normalized assets, scope inheritance, PassRole-free policies, parse failures, list errors, missing client, and cross-page dedupe.
- Normalizer tests cover source+target identity projection and wildcard-target suppression.
- API tests cover scoped records, `partial_failure`, `permission_denied`, invalid `fixture_state`, GovCloud-partition fixtures, and explicit-override fixture semantics.

## AI disclosure
No

Closes #1487

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static IAM PassRole relationship mapper and a new API to list which roles can be passed to services. Reuses existing IAM reads (no new AWS permissions). Implements #1487 and rejects non-IAM or invalid ARNs as malformed (no edges, low confidence).

- New Features
  - Parses `iam:PassRole` with AWS-style action wildcards (e.g. iam:Pass*, iam:P*, iam:Pa?sRole); handles Action/NotAction, Resource/NotResource, Deny, and `iam:PassedToService`. Emits one record per (source, target, condition, effect) with confidence tiers for specific, path/account wildcards, `*`, and malformed.
  - Adds `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships` with success/empty/degraded/partial_failure/permission_denied fixtures, OpenAPI schema, router/auth, runtime/CLI wiring, docs, and web client `apiClient.getAWSProjectIAMPassRoleRelationships()`.
  - Normalizer emits graph edges only for Allow grants with concrete role targets; Deny, wildcard, and malformed targets remain metadata.

- Bug Fixes
  - Correct NotAction semantics for PassRole and wildcard matches.
  - Forward ListRoles pagination tokens across pages.
  - Guard 500 responses when the route logger is nil.
  - Align confidence scoring with target_wildcard_kind to avoid contradictions: specific 0.95, path_wildcard 0.78, account_wildcard 0.70, all 0.55, malformed 0.30.

<sup>Written for commit 82bb9eb3b69ff8b3399692e32b99e8c2ffb15b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

