### PR TITLE
Add KMS key policy and decrypt reachability collector

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -4,6 +4,7 @@ fail-on-severity: high
 license-check: true
 allow-dependencies-licenses:
   - pkg:golang/github.com/apparentlymart/go-textseg/v15
+  - pkg:golang/github.com/aws/aws-sdk-go-v2/service/kms
   - pkg:golang/golang.org/x/mod
   - pkg:golang/golang.org/x/sync
   - pkg:golang/golang.org/x/text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ## Unreleased
+- Add **KMS key policy and decrypt reachability collector** (#1489).
+  Read-only, metadata-only inventory of every KMS key in scope, capturing
+  manager (customer vs AWS), state, spec, multi-region linkage, rotation
+  status, aliases, tags, the parsed key-policy grants, and the live KMS
+  grants from `ListGrants`. Classifies each key as `public`,
+  `cross_account`, `restricted`, `managed_by_iam`, `managed_by_aws`,
+  `private_with_grants`, or `private`, and emits `can_decrypt` graph
+  edges only for resolved Allow grants to IAM principal ARNs — tagged
+  with the source (`key_policy` vs `kms_grant`) and capability bucket
+  (`decrypt`, `encrypt`, `admin`, `grant`, `sign`). Adds the
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability`
+  endpoint with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states, OpenAPI schema, web API client
+  types, runtime/CLI wiring, and operator docs. The collector never
+  decrypts, encrypts, signs, verifies, or generates data keys; never
+  reads ciphertext or plaintext; and never surfaces encryption-context
+  values (only the constraint keys).
 - Add **S3 resource and bucket-policy reachability collector** (#1488).
   Read-only, metadata-only inventory of S3 buckets, public-access-block
   state, ownership controls, default encryption, access points, tags, and

--- a/deploy/connectors/aws/policies/identrail-readonly-policy.json
+++ b/deploy/connectors/aws/policies/identrail-readonly-policy.json
@@ -50,7 +50,11 @@
       "Action": [
         "kms:DescribeKey",
         "kms:GetKeyPolicy",
-        "kms:ListKeys"
+        "kms:GetKeyRotationStatus",
+        "kms:ListAliases",
+        "kms:ListGrants",
+        "kms:ListKeys",
+        "kms:ListResourceTags"
       ],
       "Resource": "*"
     },

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -257,3 +257,16 @@ ordered by `kind`, then `source_id`.
   Allow grants to IAM principal ARNs. The collector never reads object
   contents, never lists bucket objects, never issues presigned URLs, and
   never inspects per-object ACL grants.
+- KMS key policy and decrypt reachability is exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability`
+  and the AWS machine identities page. The collector records key metadata
+  (manager, state, spec, multi-region linkage, rotation status, aliases,
+  tags), the identity grants inferred from the key policy, and the live
+  KMS grants from `ListGrants`. It classifies each key's exposure
+  (public / cross-account / restricted / managed_by_iam / managed_by_aws
+  / private_with_grants / private) and emits `can_decrypt` edges only for
+  resolved Allow grants to IAM principal ARNs, tagging each edge with
+  its source (`key_policy` or `kms_grant`) and capability bucket. The
+  collector never decrypts, encrypts, signs, verifies, or generates data
+  keys; never reads ciphertext or plaintext; and never surfaces
+  encryption-context *values*.

--- a/docs/aws-kms-decrypt-reachability.md
+++ b/docs/aws-kms-decrypt-reachability.md
@@ -1,0 +1,179 @@
+# AWS KMS Key Policy and Decrypt Reachability Collector
+
+## Purpose
+
+Issue #1489 adds a read-only, metadata-only collector for AWS KMS keys and
+the identity reachability inferred from each key's policy *and* its live
+KMS grants. The collector emits one normalized record per key, capturing
+key manager (customer vs AWS), key state and spec, multi-region replica
+linkage, rotation status, aliases, the parsed key-policy grants, and the
+live KMS grants surfaced via `ListGrants`. Each key is classified into
+one of `public`, `cross_account`, `restricted`, `managed_by_iam`,
+`managed_by_aws`, `private_with_grants`, or `private`.
+
+The collector **never decrypts, encrypts, signs, verifies, or generates
+data keys**, never reads ciphertext or plaintext, never reads CloudTrail
+event bodies, and never reads encryption-context *values* (only the
+constraint *keys*, since the values can carry tenant-identifying data).
+
+## Endpoint
+
+```text
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability
+```
+
+Optional query parameters:
+
+- `connector_id`: scopes the account, region, and read-only inventory
+  evidence to a configured AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`,
+  or `permission_denied` for deterministic UI/contract validation.
+
+The response returns `inventory`, including records, `can_decrypt`
+relationships, diagnostics, coverage gaps, status, confidence, exposure
+counts, grant counts, and issue evidence links.
+
+## Evidence Collected
+
+Per key:
+
+- Key ARN, key id, region, account, key manager (`CUSTOMER` or `AWS`),
+  state, usage (`ENCRYPT_DECRYPT` / `SIGN_VERIFY` / ...), spec, origin,
+  description, and `enabled` flag.
+- Aliases attached to the key (names only; ARN form is deterministic and
+  derivable).
+- Rotation surface: whether rotation *can* be enabled for this key type
+  (symmetric customer-managed keys with `AWS_KMS` or `EXTERNAL` origin)
+  and whether it *is* enabled today.
+- Multi-region linkage: whether the key is multi-region, whether it is
+  the primary, and the ARNs of the primary and replica keys.
+- Key policy: presence, statement count, whether the canonical
+  `EnableIAMUserPermissions` IAM-delegation statement is present, plus
+  one inferred grant per `(principal, action, effect)` tuple. Each grant
+  carries the action list, a capability bucket
+  (`decrypt`, `encrypt`, `admin`, `grant`, `sign`), condition keys,
+  cross-account / public flags, and the statement Sid.
+- Live KMS grants (a separate AWS primitive from key policies):
+  grant id, grantee principal (or service principal), retiring
+  principal, issuing account, operation list, capability bucket, the
+  *keys* (not values) of any encryption-context constraint, and a
+  cross-account flag.
+- Tag map.
+- Exposure classification + reasons (e.g.
+  `kms_key_policy_allow_to_wildcard_principal`,
+  `kms_key_policy_explicit_deny_to_all`,
+  `kms_key_policy_delegates_to_iam`,
+  `kms_live_grant_to_cross_account_principal`,
+  `kms_managed_by_aws`).
+- Confidence tier:
+  - `0.95` for public exposure.
+  - `0.92` for cross-account exposure.
+  - `0.90` for explicit-deny restricted keys.
+  - `0.88` for IAM-delegation-only keys.
+  - `0.87` for private keys with specific grants.
+  - `0.85` for AWS-managed keys (not customer-actionable).
+  - `0.84` for fully private keys.
+  - `0.70` when classification is unknown.
+
+For each resolved IAM principal granted Allow access via either the key
+policy or a live KMS grant, a graph edge is emitted (`can_decrypt`, from
+the principal node to the key). Wildcard principals (`*`), service
+principals (e.g. `lambda.amazonaws.com`), federated principals, and Deny
+statements are surfaced in the record's grants but do not produce
+directed edges. Edges record both the source (`key_policy` vs
+`kms_grant`) and the capability bucket so downstream code can filter
+"who can decrypt this key" without re-parsing actions.
+
+## Required AWS Permissions
+
+The connector role (`internal/connectors/aws/iam_policy.go`) grants the
+following read-only KMS actions:
+
+- `kms:ListKeys`
+- `kms:DescribeKey`
+- `kms:GetKeyPolicy`
+- `kms:GetKeyRotationStatus`
+- `kms:ListAliases`
+- `kms:ListGrants`
+- `kms:ListResourceTags`
+
+These are metadata-only calls. The connector role is forbidden from
+holding `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey*`,
+`kms:ReEncrypt*`, `kms:Sign`, `kms:Verify`, `kms:CreateGrant`,
+`kms:PutKeyPolicy`, `kms:ScheduleKeyDeletion`, or any other cryptographic
+or mutating KMS action.
+
+## What Is Intentionally Not Collected
+
+- Plaintext, ciphertext, derived data keys, signatures, and verification
+  results.
+- CloudTrail KMS event bodies and per-call audit records.
+- Encryption-context *values* on live grants. The *keys* are recorded
+  because they describe the constraint shape; the values can encode
+  tenant or customer identifiers and are surfaced as a documented
+  coverage gap (`encryption_context_values`).
+- Subset-match grant constraint evaluation. The wave records the
+  constraint keys but does not yet evaluate whether a caller's
+  encryption context satisfies the subset relation
+  (`grant_constraint_subset_match`).
+- Resolution of `kms:ViaService` and `kms:CallerAccount` condition
+  values into specific identity nodes
+  (`via_service_condition_resolution`). The condition *keys* are
+  recorded; resolving them into specific service or account identities
+  is tracked separately.
+
+## Fixture States
+
+| State              | Purpose                                                                                          |
+|--------------------|--------------------------------------------------------------------------------------------------|
+| `success`          | Five keys: one private-with-grants CMK, one public CMK, one cross-account CMK, one AWS-managed key, one explicit-deny restricted CMK. |
+| `empty`            | No keys; coverage gaps still surfaced.                                                           |
+| `degraded`         | The public CMK loses rotation and reports degraded status + `kms_rotation_disabled` diagnostic.   |
+| `partial_failure`  | First three keys remain; a `kms_list_grants_failed` diagnostic explains the gap.                  |
+| `permission_denied`| Inventory is blocked; a `permission_denied` diagnostic is returned.                              |
+
+## Live Validation
+
+When running against a real AWS account:
+
+```bash
+export IDENTRAIL_AWS_SOURCE=sdk
+export IDENTRAIL_AWS_REGION="<region>"
+export IDENTRAIL_AWS_ACCOUNT_ID="<account_id>"
+
+state_file="/tmp/identrail-kms-state.json"
+go run ./cmd/cli --state-file "${state_file}" scan --output table
+```
+
+Verify that:
+
+- Every emitted record has a non-empty `key_arn` and `key_id`.
+- `exposure_classification` is one of `public`, `cross_account`,
+  `restricted`, `managed_by_iam`, `managed_by_aws`,
+  `private_with_grants`, or `private`.
+- AWS-managed keys (alias prefix `alias/aws/`) classify as
+  `managed_by_aws` and never trigger findings.
+- `EnableIAMUserPermissions`-only customer-managed keys classify as
+  `managed_by_iam`, not `private_with_grants` or `public`.
+- Encryption-context *values* never appear in the response — only the
+  *keys* on `grants[].encryption_context_keys`.
+- No call output references `Decrypt`, `Encrypt`, `GenerateDataKey`,
+  `Sign`, `Verify`, or any other cryptographic operation.
+
+## Troubleshooting
+
+| Diagnostic code                                | Likely cause                                                | Operator action                                                                              |
+|------------------------------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `permission_denied`                            | Connector role missing read-only KMS metadata permissions   | Grant the actions listed above; do not enable cryptographic APIs.                            |
+| `kms_decrypt_reachability_page_failed`         | `ListKeys` throttled or denied                              | Retry; already-collected records remain visible.                                              |
+| `kms_decrypt_reachability_page_limit_exceeded` | Key pagination exceeded max-pages cap                       | Increase the page cap or scope the connector to a smaller account before retrying.            |
+| `kms_describe_key_failed`                      | `DescribeKey` failed for one key                            | Retry only the failed call; preserve previously-collected evidence.                           |
+| `kms_key_policy_failed`                        | `GetKeyPolicy` failed for one key                           | Retry; an absent policy is not a diagnostic, a denied call is.                                |
+| `kms_key_policy_parse_failed`                  | Key policy is not valid JSON                                | Audit the policy in the AWS console; the collector skips unparseable policies.                |
+| `kms_key_rotation_failed`                      | `GetKeyRotationStatus` denied                               | Retry; rotation-unsupported key types are recognised separately and do not produce a diagnostic. |
+| `kms_rotation_disabled`                        | Rotation-capable customer-managed key has rotation disabled | Enable automatic rotation or document the exception.                                          |
+| `kms_list_grants_failed`                       | `ListGrants` failed for one key                             | Retry only the failed call; preserve previously-collected evidence.                           |
+| `kms_list_aliases_failed`                      | Account-level `ListAliases` denied or throttled             | Retry; without aliases the per-key alias list will be empty but classification is unaffected. |
+| `kms_list_tags_failed`                         | `ListResourceTags` denied or throttled                      | Retry; absence of tags is silent.                                                             |
+| `kms_key_id_missing`                           | A `ListKeys` summary did not include an id or ARN           | Confirm the response shape upstream; the collector skips ambiguous records.                   |
+| `malformed_kms_decrypt_reachability_record`    | Record has no key id after normalization                    | Confirm `ListKeys` returned keys with ids; the collector skips ambiguous records.             |

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -544,6 +544,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities
     action: tenancy.read
     resource_type: project
@@ -4363,6 +4368,56 @@ paths:
                     $ref: "#/components/schemas/AWSS3BucketReachabilityInventoryResult"
         "400":
           description: Invalid AWS S3 bucket reachability inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS KMS decrypt reachability inventory
+      operationId: getAWSProjectKMSDecryptReachability
+      description: Returns scoped KMS key metadata, key-policy grants, live KMS grants, rotation state, alias and multi-region context, and exposure classification. Metadata-only — never reads plaintext, ciphertext, or CloudTrail event bodies.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only KMS reachability evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+      responses:
+        "200":
+          description: AWS KMS decrypt reachability inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSKMSDecryptReachabilityInventoryResult"
+        "400":
+          description: Invalid AWS KMS decrypt reachability inventory request
           content:
             application/json:
               schema:
@@ -9119,6 +9174,249 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSageMakerWorkloadRoleDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSKMSCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status:
+          type: string
+          enum: [unsupported]
+        reason: { type: string }
+        remediation: { type: string }
+    AWSKMSIdentityGrant:
+      type: object
+      properties:
+        principal_arn: { type: string }
+        principal_type: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        actions:
+          type: array
+          items: { type: string }
+        not_action: { type: boolean }
+        capabilities:
+          type: array
+          items: { type: string }
+        condition_keys:
+          type: array
+          items: { type: string }
+        is_public: { type: boolean }
+        is_cross_account: { type: boolean }
+        has_condition: { type: boolean }
+        statement_sid: { type: string }
+        wildcard_principal: { type: boolean }
+    AWSKMSGrant:
+      type: object
+      properties:
+        grant_id: { type: string }
+        name: { type: string }
+        grantee_principal: { type: string }
+        grantee_principal_type: { type: string }
+        retiring_principal: { type: string }
+        issuing_account: { type: string }
+        operations:
+          type: array
+          items: { type: string }
+        capabilities:
+          type: array
+          items: { type: string }
+        encryption_context_keys:
+          type: array
+          items: { type: string }
+        encryption_context_subset_keys:
+          type: array
+          items: { type: string }
+        has_constraints: { type: boolean }
+        is_cross_account: { type: boolean }
+        created_at: { type: string }
+    AWSKMSDecryptReachabilityRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service:
+          type: string
+          enum: [kms]
+        key_arn: { type: string }
+        key_id: { type: string }
+        key_manager:
+          type: string
+          enum: [CUSTOMER, AWS, ""]
+        key_state: { type: string }
+        key_usage: { type: string }
+        key_spec: { type: string }
+        origin: { type: string }
+        description: { type: string }
+        enabled: { type: boolean }
+        created_at: { type: string }
+        deletion_date: { type: string }
+        multi_region: { type: boolean }
+        multi_region_primary: { type: boolean }
+        primary_key_arn: { type: string }
+        replica_key_arns:
+          type: array
+          items: { type: string }
+        rotation_enabled: { type: boolean }
+        rotation_supported: { type: boolean }
+        aliases:
+          type: array
+          items: { type: string }
+        has_key_policy: { type: boolean }
+        key_policy_statement_count: { type: integer }
+        iam_delegation_enabled: { type: boolean }
+        identity_grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSIdentityGrant"
+        grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSGrant"
+        exposure_classification:
+          type: string
+          enum: [public, cross_account, restricted, managed_by_iam, managed_by_aws, private_with_grants, private, unknown]
+        exposure_reasons:
+          type: array
+          items: { type: string }
+        tags:
+          type: object
+          additionalProperties: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        from_node_id: { type: string }
+        relationship_type:
+          type: string
+          enum: [can_decrypt]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+    AWSKMSDecryptReachabilityEdge:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [can_decrypt]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        effect:
+          type: string
+          enum: [Allow]
+        source:
+          type: string
+          enum: [key_policy, kms_grant]
+        principal_type: { type: string }
+        capabilities:
+          type: array
+          items: { type: string }
+        has_condition: { type: boolean }
+    AWSKMSDecryptReachabilityDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code:
+          type: string
+          enum:
+            - kms_decrypt_reachability_page_failed
+            - kms_decrypt_reachability_page_limit_exceeded
+            - kms_describe_key_failed
+            - kms_key_policy_failed
+            - kms_key_policy_parse_failed
+            - kms_key_rotation_failed
+            - kms_list_grants_failed
+            - kms_list_grants_page_limit_exceeded
+            - kms_list_aliases_failed
+            - kms_list_aliases_page_limit_exceeded
+            - kms_list_tags_failed
+            - kms_list_tags_page_limit_exceeded
+            - kms_rotation_disabled
+            - kms_key_id_missing
+            - permission_denied
+            - malformed_kms_decrypt_reachability_record
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSKMSDecryptReachabilityInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        key_count: { type: integer }
+        customer_managed_key_count: { type: integer }
+        aws_managed_key_count: { type: integer }
+        public_key_count: { type: integer }
+        cross_account_key_count: { type: integer }
+        restricted_key_count: { type: integer }
+        keys_with_rotation_count: { type: integer }
+        keys_missing_rotation_count: { type: integer }
+        keys_pending_deletion_count: { type: integer }
+        multi_region_key_count: { type: integer }
+        identity_grant_count: { type: integer }
+        public_grant_count: { type: integer }
+        cross_account_grant_count: { type: integer }
+        deny_grant_count: { type: integer }
+        live_grant_count: { type: integer }
+        cross_account_live_grant_count: { type: integer }
+        relationship_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSDecryptReachabilityRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSDecryptReachabilityEdge"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSKMSDecryptReachabilityDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.28 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.28 h1:li8rTZAAb22g4
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.28/go.mod h1:/brXioSGIMEdcBFoubpSdmighSVp6poP+mma/wB7iHA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 h1:hiME6pBzC7OTl9LMtlyTWBuEl1f4QBcUmFDKC7MLXtc=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29/go.mod h1:G7RP+uhagpKtKhd1BM9N6JQqjCcGEU47K5lBVZQyRQw=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 h1:PEgVSsWtR8NNxsDxFL2Ywisi7R+1EFQARGsT4q3mWwI=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4/go.mod h1:3EeKyDGPGSCEphG2OolwNGNF45RvQIfm27AYYpfEWrw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.92.2 h1:MeFQKmFAYIoXH9+oXgaOPeM7pQ5LATWJyJykj9lsHEo=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.92.2/go.mod h1:Clrn/3iAEhtDG9HJn1HYp+arjui7NU6jrcx0BEd+bk0=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.5 h1:zVrbhpCtXv5tdrMcD40KlrMIEB1Hqs7tt6Co506kJRc=

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -752,6 +752,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sagemaker-workload-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_kms_decrypt_reachability.go
+++ b/internal/api/aws_kms_decrypt_reachability.go
@@ -1,0 +1,757 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+const (
+	awsKMSDecryptReachabilityCurrentIssue = 1489
+	awsKMSDecryptReachabilityVersion      = "aws-kms-decrypt-reachability-inventory-v1"
+)
+
+// AWSKMSDecryptReachabilityInventoryRequest is the operator-facing request.
+type AWSKMSDecryptReachabilityInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+}
+
+// AWSKMSCoverageGap names a KMS capability this wave intentionally does not
+// model, with the reason and remediation an operator should rely on.
+type AWSKMSCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSKMSDecryptReachabilityInventoryResult is the deterministic envelope this
+// endpoint returns.
+type AWSKMSDecryptReachabilityInventoryResult struct {
+	TenantID                   string                                `json:"tenant_id"`
+	WorkspaceID                string                                `json:"workspace_id"`
+	ProjectID                  string                                `json:"project_id"`
+	ConnectorID                string                                `json:"connector_id,omitempty"`
+	AccountID                  string                                `json:"account_id,omitempty"`
+	Region                     string                                `json:"region,omitempty"`
+	ParentIssueNumber          int                                   `json:"parent_issue_number"`
+	ParentIssueRef             string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber         int                                   `json:"current_issue_number"`
+	CurrentIssueRef            string                                `json:"current_issue_ref"`
+	Version                    string                                `json:"version"`
+	Status                     string                                `json:"status"`
+	FixtureState               string                                `json:"fixture_state"`
+	Confidence                 float64                               `json:"confidence"`
+	KeyCount                   int                                   `json:"key_count"`
+	CustomerManagedKeyCount    int                                   `json:"customer_managed_key_count"`
+	AWSManagedKeyCount         int                                   `json:"aws_managed_key_count"`
+	PublicKeyCount             int                                   `json:"public_key_count"`
+	CrossAccountKeyCount       int                                   `json:"cross_account_key_count"`
+	RestrictedKeyCount         int                                   `json:"restricted_key_count"`
+	KeysWithRotationCount      int                                   `json:"keys_with_rotation_count"`
+	KeysMissingRotationCount   int                                   `json:"keys_missing_rotation_count"`
+	KeysPendingDeletionCount   int                                   `json:"keys_pending_deletion_count"`
+	MultiRegionKeyCount        int                                   `json:"multi_region_key_count"`
+	IdentityGrantCount         int                                   `json:"identity_grant_count"`
+	PublicGrantCount           int                                   `json:"public_grant_count"`
+	CrossAccountGrantCount     int                                   `json:"cross_account_grant_count"`
+	DenyGrantCount             int                                   `json:"deny_grant_count"`
+	LiveGrantCount             int                                   `json:"live_grant_count"`
+	CrossAccountLiveGrantCount int                                   `json:"cross_account_live_grant_count"`
+	RelationshipCount          int                                   `json:"relationship_count"`
+	FailureReasons             []string                              `json:"failure_reasons"`
+	RemediationHints           []string                              `json:"remediation_hints"`
+	EvidenceLinks              []string                              `json:"evidence_links"`
+	CoverageGaps               []AWSKMSCoverageGap                   `json:"coverage_gaps"`
+	Records                    []AWSKMSDecryptReachabilityRecord     `json:"records"`
+	Relationships              []AWSKMSDecryptReachabilityEdge       `json:"relationships"`
+	Diagnostics                []AWSKMSDecryptReachabilityDiagnostic `json:"diagnostics"`
+	GeneratedAt                time.Time                             `json:"generated_at"`
+	UpdatedAt                  time.Time                             `json:"updated_at"`
+}
+
+// AWSKMSDecryptReachabilityRecord is one KMS key's metadata, exposure
+// classification, and the identity grants inferred from its key policy +
+// live grants.
+type AWSKMSDecryptReachabilityRecord struct {
+	AccountID               string                `json:"account_id"`
+	Region                  string                `json:"region"`
+	Service                 string                `json:"service"`
+	KeyARN                  string                `json:"key_arn"`
+	KeyID                   string                `json:"key_id"`
+	KeyManager              string                `json:"key_manager,omitempty"`
+	KeyState                string                `json:"key_state,omitempty"`
+	KeyUsage                string                `json:"key_usage,omitempty"`
+	KeySpec                 string                `json:"key_spec,omitempty"`
+	Origin                  string                `json:"origin,omitempty"`
+	Description             string                `json:"description,omitempty"`
+	Enabled                 bool                  `json:"enabled"`
+	CreatedAt               string                `json:"created_at,omitempty"`
+	DeletionDate            string                `json:"deletion_date,omitempty"`
+	MultiRegion             bool                  `json:"multi_region,omitempty"`
+	MultiRegionPrimary      bool                  `json:"multi_region_primary,omitempty"`
+	PrimaryKeyARN           string                `json:"primary_key_arn,omitempty"`
+	ReplicaKeyARNs          []string              `json:"replica_key_arns,omitempty"`
+	RotationEnabled         bool                  `json:"rotation_enabled"`
+	RotationSupported       bool                  `json:"rotation_supported"`
+	Aliases                 []string              `json:"aliases,omitempty"`
+	HasKeyPolicy            bool                  `json:"has_key_policy"`
+	KeyPolicyStatementCount int                   `json:"key_policy_statement_count"`
+	IAMDelegationEnabled    bool                  `json:"iam_delegation_enabled"`
+	IdentityGrants          []AWSKMSIdentityGrant `json:"identity_grants,omitempty"`
+	Grants                  []AWSKMSGrant         `json:"grants,omitempty"`
+	ExposureClassification  string                `json:"exposure_classification"`
+	ExposureReasons         []string              `json:"exposure_reasons,omitempty"`
+	Tags                    map[string]string     `json:"tags,omitempty"`
+	Source                  string                `json:"source"`
+	EvidenceRef             string                `json:"evidence_ref"`
+	FromNodeID              string                `json:"from_node_id"`
+	RelationshipType        string                `json:"relationship_type"`
+	Confidence              float64               `json:"confidence"`
+	CollectedAt             time.Time             `json:"collected_at"`
+	Status                  string                `json:"status"`
+}
+
+// AWSKMSIdentityGrant mirrors the collector-side key-policy grant struct.
+type AWSKMSIdentityGrant struct {
+	PrincipalARN      string   `json:"principal_arn,omitempty"`
+	PrincipalType     string   `json:"principal_type,omitempty"`
+	Effect            string   `json:"effect"`
+	Actions           []string `json:"actions,omitempty"`
+	NotAction         bool     `json:"not_action,omitempty"`
+	Capabilities      []string `json:"capabilities,omitempty"`
+	ConditionKeys     []string `json:"condition_keys,omitempty"`
+	IsPublic          bool     `json:"is_public,omitempty"`
+	IsCrossAccount    bool     `json:"is_cross_account,omitempty"`
+	HasCondition      bool     `json:"has_condition,omitempty"`
+	StatementSid      string   `json:"statement_sid,omitempty"`
+	WildcardPrincipal bool     `json:"wildcard_principal,omitempty"`
+}
+
+// AWSKMSGrant mirrors a live KMS grant.
+type AWSKMSGrant struct {
+	GrantID                     string   `json:"grant_id,omitempty"`
+	Name                        string   `json:"name,omitempty"`
+	GranteePrincipal            string   `json:"grantee_principal,omitempty"`
+	GranteePrincipalType        string   `json:"grantee_principal_type,omitempty"`
+	RetiringPrincipal           string   `json:"retiring_principal,omitempty"`
+	IssuingAccount              string   `json:"issuing_account,omitempty"`
+	Operations                  []string `json:"operations,omitempty"`
+	Capabilities                []string `json:"capabilities,omitempty"`
+	EncryptionContextKeys       []string `json:"encryption_context_keys,omitempty"`
+	EncryptionContextSubsetKeys []string `json:"encryption_context_subset_keys,omitempty"`
+	HasConstraints              bool     `json:"has_constraints,omitempty"`
+	IsCrossAccount              bool     `json:"is_cross_account,omitempty"`
+	CreatedAt                   string   `json:"created_at,omitempty"`
+}
+
+// AWSKMSDecryptReachabilityEdge is one graph edge from a principal to a key.
+// Edges are only emitted for resolved, allow-effect, non-wildcard grants
+// pointing at IAM role/user ARNs.
+type AWSKMSDecryptReachabilityEdge struct {
+	Type          string   `json:"type"`
+	FromNodeID    string   `json:"from_node_id"`
+	ToNodeID      string   `json:"to_node_id"`
+	EvidenceRef   string   `json:"evidence_ref"`
+	Effect        string   `json:"effect"`
+	Source        string   `json:"source"` // "key_policy" or "kms_grant"
+	PrincipalType string   `json:"principal_type"`
+	Capabilities  []string `json:"capabilities,omitempty"`
+	HasCondition  bool     `json:"has_condition,omitempty"`
+}
+
+// AWSKMSDecryptReachabilityDiagnostic is a structured collector diagnostic.
+type AWSKMSDecryptReachabilityDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// GetAWSKMSDecryptReachabilityInventory returns the KMS decrypt reachability
+// inventory for the supplied scope.
+func (s *Service) GetAWSKMSDecryptReachabilityInventory(ctx context.Context, workspaceID string, projectID string, request AWSKMSDecryptReachabilityInventoryRequest) (AWSKMSDecryptReachabilityInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSKMSDecryptReachabilityInventoryResult{}, err
+	}
+	var (
+		connection    AWSConnectionStatus
+		hasConnection bool
+	)
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSKMSDecryptReachabilityInventoryResult{}, err
+	}
+	return buildAWSKMSDecryptReachabilityInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSKMSDecryptReachabilityInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSKMSDecryptReachabilityInventoryRequest, checkedAt time.Time) (AWSKMSDecryptReachabilityInventoryResult, error) {
+	fixtureState := normalizeAWSKMSDecryptReachabilityFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSKMSDecryptReachabilityInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, coverageGaps := awsKMSDecryptReachabilityFixtureRecords(accountID, region, fixtureState, checkedAt)
+	for _, record := range records {
+		if err := validateKMSDecryptReachabilityRecord(scope, project, connectorID, record); err != nil {
+			return AWSKMSDecryptReachabilityInventoryResult{}, fmt.Errorf("validate kms decrypt reachability record: %w", err)
+		}
+	}
+	status, confidence, failures, remediations := summarizeAWSKMSDecryptReachabilityInventory(fixtureState, diagnostics, records)
+	relationships := awsKMSDecryptReachabilityEdges(records)
+	return AWSKMSDecryptReachabilityInventoryResult{
+		TenantID:                   scope.TenantID,
+		WorkspaceID:                project.WorkspaceID,
+		ProjectID:                  project.ProjectID,
+		ConnectorID:                connectorID,
+		AccountID:                  accountID,
+		Region:                     region,
+		ParentIssueNumber:          awsPlatformDependencyParentIssue,
+		ParentIssueRef:             awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:         awsKMSDecryptReachabilityCurrentIssue,
+		CurrentIssueRef:            awsIssueRef(awsKMSDecryptReachabilityCurrentIssue),
+		Version:                    awsKMSDecryptReachabilityVersion,
+		Status:                     status,
+		FixtureState:               fixtureState,
+		Confidence:                 confidence,
+		KeyCount:                   len(records),
+		CustomerManagedKeyCount:    countKeysByManager(records, "CUSTOMER"),
+		AWSManagedKeyCount:         countKeysByManager(records, "AWS"),
+		PublicKeyCount:             countKeysByExposure(records, "public"),
+		CrossAccountKeyCount:       countKeysByExposure(records, "cross_account"),
+		RestrictedKeyCount:         countKeysByExposure(records, "restricted"),
+		KeysWithRotationCount:      countKeysWith(records, func(r AWSKMSDecryptReachabilityRecord) bool { return r.RotationEnabled }),
+		KeysMissingRotationCount:   countKeysWith(records, func(r AWSKMSDecryptReachabilityRecord) bool { return r.RotationSupported && !r.RotationEnabled }),
+		KeysPendingDeletionCount:   countKeysWith(records, func(r AWSKMSDecryptReachabilityRecord) bool { return strings.EqualFold(r.KeyState, "PendingDeletion") }),
+		MultiRegionKeyCount:        countKeysWith(records, func(r AWSKMSDecryptReachabilityRecord) bool { return r.MultiRegion }),
+		IdentityGrantCount:         countKMSPolicyGrants(records, func(g AWSKMSIdentityGrant) bool { return true }),
+		PublicGrantCount:           countKMSPolicyGrants(records, func(g AWSKMSIdentityGrant) bool { return g.IsPublic }),
+		CrossAccountGrantCount:     countKMSPolicyGrants(records, func(g AWSKMSIdentityGrant) bool { return g.IsCrossAccount }),
+		DenyGrantCount:             countKMSPolicyGrants(records, func(g AWSKMSIdentityGrant) bool { return strings.EqualFold(g.Effect, "Deny") }),
+		LiveGrantCount:             countKMSLiveGrants(records, func(g AWSKMSGrant) bool { return true }),
+		CrossAccountLiveGrantCount: countKMSLiveGrants(records, func(g AWSKMSGrant) bool { return g.IsCrossAccount }),
+		RelationshipCount:          len(relationships),
+		FailureReasons:             failures,
+		RemediationHints:           remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsKMSDecryptReachabilityCurrentIssue),
+			"/docs/aws-kms-decrypt-reachability",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  coverageGaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsKMSDecryptReachabilityDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSKMSDecryptReachabilityFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsKMSDecryptReachabilityFixtureRecords(accountID, region, fixtureState string, checkedAt time.Time) ([]AWSKMSDecryptReachabilityRecord, []providers.SourceError, []AWSKMSCoverageGap) {
+	gaps := []AWSKMSCoverageGap{{
+		Capability:  "encryption_context_values",
+		Status:      "unsupported",
+		Reason:      "Live KMS grant encryption-context *values* can carry tenant/customer-specific identifiers and are not surfaced; only the constraint *keys* are recorded.",
+		Remediation: "Audit encryption-context values directly in the AWS Console when investigating a specific grant.",
+	}, {
+		Capability:  "grant_constraint_subset_match",
+		Status:      "unsupported",
+		Reason:      "Subset-match grant constraints describe an unordered set; the wave records the keys but does not yet evaluate whether a caller satisfies the subset.",
+		Remediation: "Treat subset-constrained grants as scope-limited and audit the caller's encryption context before relying on reachability.",
+	}, {
+		Capability:  "via_service_condition_resolution",
+		Status:      "unsupported",
+		Reason:      "kms:ViaService and kms:CallerAccount conditions are recorded as condition keys but their service / account values are not resolved into specific identity nodes.",
+		Remediation: "Treat ViaService-conditioned grants as service-scoped until the dedicated condition resolver lands.",
+	}}
+	partition := awsKMSPartitionForRegion(region)
+	cmkARN := fmt.Sprintf("arn:%s:kms:%s:%s:key/aaaa1111-2222-3333-4444-555566667777", partition, region, accountID)
+	publicKeyARN := fmt.Sprintf("arn:%s:kms:%s:%s:key/bbbb1111-2222-3333-4444-555566667777", partition, region, accountID)
+	crossAccountARN := fmt.Sprintf("arn:%s:kms:%s:%s:key/cccc1111-2222-3333-4444-555566667777", partition, region, accountID)
+	awsManagedARN := fmt.Sprintf("arn:%s:kms:%s:%s:key/dddd1111-2222-3333-4444-555566667777", partition, region, accountID)
+	restrictedARN := fmt.Sprintf("arn:%s:kms:%s:%s:key/eeee1111-2222-3333-4444-555566667777", partition, region, accountID)
+
+	records := []AWSKMSDecryptReachabilityRecord{
+		// Private customer-managed key with IAM delegation + an app-role grant.
+		awsKMSDecryptReachabilityFixtureRecord(accountID, region, "aaaa1111-2222-3333-4444-555566667777", cmkARN, "private_with_grants", "CUSTOMER", checkedAt, partition, func(r *AWSKMSDecryptReachabilityRecord) {
+			r.HasKeyPolicy = true
+			r.KeyPolicyStatementCount = 2
+			r.IAMDelegationEnabled = true
+			r.RotationSupported = true
+			r.RotationEnabled = true
+			r.Aliases = []string{"alias/payments"}
+			r.IdentityGrants = []AWSKMSIdentityGrant{
+				{
+					PrincipalARN:  fmt.Sprintf("arn:%s:iam::%s:root", partition, accountID),
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt", "encrypt", "grant", "sign"},
+					StatementSid:  "EnableIAMUserPermissions",
+				},
+				{
+					PrincipalARN:  fmt.Sprintf("arn:%s:iam::%s:role/payments-app", partition, accountID),
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:Decrypt", "kms:GenerateDataKey"},
+					Capabilities:  []string{"decrypt", "encrypt"},
+					StatementSid:  "AppAccess",
+				},
+			}
+			r.Grants = []AWSKMSGrant{{
+				GrantID:               "grant-0001",
+				Name:                  "lambda-decrypt",
+				GranteePrincipal:      fmt.Sprintf("arn:%s:iam::%s:role/lambda-decrypt", partition, accountID),
+				GranteePrincipalType:  "aws",
+				Operations:            []string{"Decrypt"},
+				Capabilities:          []string{"decrypt"},
+				HasConstraints:        true,
+				EncryptionContextKeys: []string{"tenant_id"},
+			}}
+			r.ExposureReasons = []string{"kms_key_policy_allow_to_specific_principal"}
+		}),
+		// Public customer-managed key (wildcard principal, no condition).
+		awsKMSDecryptReachabilityFixtureRecord(accountID, region, "bbbb1111-2222-3333-4444-555566667777", publicKeyARN, "public", "CUSTOMER", checkedAt, partition, func(r *AWSKMSDecryptReachabilityRecord) {
+			r.HasKeyPolicy = true
+			r.KeyPolicyStatementCount = 1
+			r.RotationSupported = true
+			r.Aliases = []string{"alias/public-data"}
+			r.IdentityGrants = []AWSKMSIdentityGrant{{
+				PrincipalARN:      "*",
+				PrincipalType:     "*",
+				Effect:            "Allow",
+				Actions:           []string{"kms:Decrypt"},
+				Capabilities:      []string{"decrypt"},
+				IsPublic:          true,
+				WildcardPrincipal: true,
+				StatementSid:      "PublicDecrypt",
+			}}
+			r.ExposureReasons = []string{"kms_key_policy_allow_to_wildcard_principal"}
+		}),
+		// Cross-account customer-managed key (partner has Decrypt).
+		awsKMSDecryptReachabilityFixtureRecord(accountID, region, "cccc1111-2222-3333-4444-555566667777", crossAccountARN, "cross_account", "CUSTOMER", checkedAt, partition, func(r *AWSKMSDecryptReachabilityRecord) {
+			r.HasKeyPolicy = true
+			r.KeyPolicyStatementCount = 1
+			r.RotationSupported = true
+			r.RotationEnabled = true
+			r.Aliases = []string{"alias/partner-feed"}
+			r.IdentityGrants = []AWSKMSIdentityGrant{{
+				PrincipalARN:   fmt.Sprintf("arn:%s:iam::999999999999:role/partner-ingest", partition),
+				PrincipalType:  "aws",
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt", "kms:GenerateDataKey"},
+				Capabilities:   []string{"decrypt", "encrypt"},
+				IsCrossAccount: true,
+				StatementSid:   "PartnerDecrypt",
+			}}
+			r.ExposureReasons = []string{"kms_key_policy_allow_to_cross_account_principal"}
+		}),
+		// AWS-managed key (not actionable — surfaces as managed_by_aws).
+		awsKMSDecryptReachabilityFixtureRecord(accountID, region, "dddd1111-2222-3333-4444-555566667777", awsManagedARN, "managed_by_aws", "AWS", checkedAt, partition, func(r *AWSKMSDecryptReachabilityRecord) {
+			r.Aliases = []string{"alias/aws/s3"}
+			r.HasKeyPolicy = false
+			r.ExposureReasons = []string{"kms_managed_by_aws"}
+		}),
+		// Explicitly restricted key (deny-all to wildcard).
+		awsKMSDecryptReachabilityFixtureRecord(accountID, region, "eeee1111-2222-3333-4444-555566667777", restrictedARN, "restricted", "CUSTOMER", checkedAt, partition, func(r *AWSKMSDecryptReachabilityRecord) {
+			r.HasKeyPolicy = true
+			r.KeyPolicyStatementCount = 2
+			r.IAMDelegationEnabled = true
+			r.RotationSupported = true
+			r.RotationEnabled = true
+			r.IdentityGrants = []AWSKMSIdentityGrant{
+				{
+					PrincipalARN:  fmt.Sprintf("arn:%s:iam::%s:root", partition, accountID),
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt", "encrypt", "grant", "sign"},
+					StatementSid:  "EnableIAMUserPermissions",
+				},
+				{
+					PrincipalARN:      "*",
+					PrincipalType:     "*",
+					Effect:            "Deny",
+					Actions:           []string{"kms:*"},
+					Capabilities:      []string{"admin", "decrypt", "encrypt", "grant", "sign"},
+					WildcardPrincipal: true,
+					StatementSid:      "DenyBreakGlass",
+				},
+			}
+			r.ExposureReasons = []string{"kms_key_policy_explicit_deny_to_all"}
+		}),
+	}
+	switch fixtureState {
+	case "empty":
+		return nil, nil, gaps
+	case "degraded":
+		// Flag the rotation-capable but rotation-disabled CMK as degraded.
+		for i := range records {
+			if records[i].KeyID != "bbbb1111-2222-3333-4444-555566667777" {
+				continue
+			}
+			records[i].Status = "degraded"
+			records[i].Confidence = 0.7
+			records[i].ExposureReasons = append(records[i].ExposureReasons, "kms_rotation_disabled_on_rotation_capable_key")
+			break
+		}
+		return records, []providers.SourceError{{
+			Collector: kmsCollectorRefForAPI,
+			SourceID:  publicKeyARN,
+			Code:      "kms_rotation_disabled",
+			Message:   "Customer-managed key has automatic rotation disabled despite supporting it",
+			Retryable: false,
+		}}, gaps
+	case "partial_failure":
+		return records[:3], []providers.SourceError{{
+			Collector: kmsCollectorRefForAPI,
+			SourceID:  fmt.Sprintf("service=kms|account=%s|region=%s|source=listgrants", accountID, region),
+			Code:      "kms_list_grants_failed",
+			Message:   "ListGrants for one key was throttled; earlier records remain visible",
+			Retryable: true,
+		}}, gaps
+	case "permission_denied":
+		return nil, []providers.SourceError{{
+			Collector: kmsCollectorRefForAPI,
+			SourceID:  fmt.Sprintf("service=kms|account=%s|region=%s|source=listkeys", accountID, region),
+			Code:      "permission_denied",
+			Message:   "Read-only KMS metadata permission is missing",
+			Retryable: false,
+		}}, gaps
+	default:
+		return records, nil, gaps
+	}
+}
+
+const kmsCollectorRefForAPI = "aws_kms/kms_decrypt_reachability"
+
+func awsKMSDecryptReachabilityFixtureRecord(accountID, region, id, arn, exposure, manager string, checkedAt time.Time, partition string, mutate func(*AWSKMSDecryptReachabilityRecord)) AWSKMSDecryptReachabilityRecord {
+	confidence := 0.9
+	switch exposure {
+	case "public":
+		confidence = 0.95
+	case "cross_account":
+		confidence = 0.92
+	case "restricted":
+		confidence = 0.9
+	case "private_with_grants":
+		confidence = 0.87
+	case "managed_by_aws":
+		confidence = 0.85
+	case "private":
+		confidence = 0.84
+	}
+	record := AWSKMSDecryptReachabilityRecord{
+		AccountID:              accountID,
+		Region:                 region,
+		Service:                "kms",
+		KeyARN:                 arn,
+		KeyID:                  id,
+		KeyManager:             manager,
+		KeyState:               "Enabled",
+		KeyUsage:               "ENCRYPT_DECRYPT",
+		KeySpec:                "SYMMETRIC_DEFAULT",
+		Origin:                 "AWS_KMS",
+		Enabled:                true,
+		ExposureClassification: exposure,
+		Tags:                   map[string]string{"owner": "payments-platform"},
+		Source:                 "kms_key_metadata",
+		EvidenceRef:            arn,
+		FromNodeID:             "aws:resource:kms-key:" + arn,
+		RelationshipType:       "can_decrypt",
+		Confidence:             confidence,
+		CollectedAt:            checkedAt,
+		Status:                 "ready",
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	_ = partition
+	return record
+}
+
+func awsKMSDecryptReachabilityEdges(records []AWSKMSDecryptReachabilityRecord) []AWSKMSDecryptReachabilityEdge {
+	result := []AWSKMSDecryptReachabilityEdge{}
+	for _, record := range records {
+		toNode := "aws:resource:kms-key:" + record.KeyARN
+		for _, grant := range record.IdentityGrants {
+			if !strings.EqualFold(grant.Effect, "Allow") {
+				continue
+			}
+			if grant.WildcardPrincipal || grant.PrincipalARN == "*" || grant.PrincipalARN == "" {
+				continue
+			}
+			if !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
+				continue
+			}
+			result = append(result, AWSKMSDecryptReachabilityEdge{
+				Type:          "can_decrypt",
+				FromNodeID:    awsIdentityNodeIDForAPI(grant.PrincipalARN),
+				ToNodeID:      toNode,
+				EvidenceRef:   record.EvidenceRef,
+				Effect:        grant.Effect,
+				Source:        "key_policy",
+				PrincipalType: grant.PrincipalType,
+				Capabilities:  append([]string(nil), grant.Capabilities...),
+				HasCondition:  grant.HasCondition,
+			})
+		}
+		for _, grant := range record.Grants {
+			if grant.GranteePrincipal == "" {
+				continue
+			}
+			if !isIAMPrincipalARNForKMSEdge(grant.GranteePrincipal) {
+				continue
+			}
+			result = append(result, AWSKMSDecryptReachabilityEdge{
+				Type:          "can_decrypt",
+				FromNodeID:    awsIdentityNodeIDForAPI(grant.GranteePrincipal),
+				ToNodeID:      toNode,
+				EvidenceRef:   record.EvidenceRef,
+				Effect:        "Allow",
+				Source:        "kms_grant",
+				PrincipalType: grant.GranteePrincipalType,
+				Capabilities:  append([]string(nil), grant.Capabilities...),
+				HasCondition:  grant.HasConstraints,
+			})
+		}
+	}
+	return result
+}
+
+func summarizeAWSKMSDecryptReachabilityInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSKMSDecryptReachabilityRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35,
+			[]string{"kms decrypt reachability collection is blocked by missing read-only KMS permission"},
+			[]string{"Grant kms:ListKeys, kms:DescribeKey, kms:GetKeyPolicy, kms:GetKeyRotationStatus, kms:ListAliases, kms:ListGrants, and kms:ListResourceTags. Do not enable encrypt/decrypt/sign/verify APIs."}
+	case "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.7,
+			[]string{"one or more customer-managed KMS keys have rotation disabled"},
+			[]string{"Enable automatic rotation for symmetric customer-managed keys or document the exception."}
+	case "partial_failure":
+		return awsPlatformDependencyStatusDegraded, 0.78,
+			[]string{"one KMS sub-call failed while previously-collected key evidence remains visible"},
+			[]string{"Retry the failed KMS metadata call without discarding successful key evidence."}
+	default:
+		if len(diagnostics) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.82,
+				[]string{"kms decrypt reachability collection returned diagnostics"},
+				[]string{"Review diagnostics before treating KMS coverage as complete."}
+		}
+		return awsPlatformDependencyStatusReady, 0.93, nil, nil
+	}
+}
+
+func awsKMSDecryptReachabilityDiagnostics(diagnostics []providers.SourceError) []AWSKMSDecryptReachabilityDiagnostic {
+	result := make([]AWSKMSDecryptReachabilityDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSKMSDecryptReachabilityDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: awsKMSDecryptReachabilityDiagnosticRemediation(diagnostic.Code),
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func awsKMSDecryptReachabilityDiagnosticRemediation(code string) string {
+	switch code {
+	case "permission_denied":
+		return "Grant the read-only KMS actions listed in the docs; do not enable cryptographic APIs."
+	case "kms_rotation_disabled":
+		return "Enable automatic rotation on the affected customer-managed key or document the exception."
+	case "kms_describe_key_failed", "kms_key_policy_failed", "kms_key_rotation_failed",
+		"kms_list_grants_failed", "kms_list_aliases_failed", "kms_list_tags_failed":
+		return "Retry only the failed KMS metadata call and keep previously-collected key evidence visible."
+	case "kms_key_policy_parse_failed":
+		return "Audit the key policy document for invalid JSON; the collector skips unparseable policies rather than guessing."
+	case "malformed_kms_decrypt_reachability_record":
+		return "Confirm ListKeys returned a key with an id or ARN; the collector skips ambiguous records."
+	default:
+		return "Review the KMS collector diagnostic and retry after the scoped KMS permission issue is corrected."
+	}
+}
+
+func countKeysByExposure(records []AWSKMSDecryptReachabilityRecord, exposure string) int {
+	count := 0
+	for _, record := range records {
+		if record.ExposureClassification == exposure {
+			count++
+		}
+	}
+	return count
+}
+
+func countKeysByManager(records []AWSKMSDecryptReachabilityRecord, manager string) int {
+	count := 0
+	for _, record := range records {
+		if strings.EqualFold(record.KeyManager, manager) {
+			count++
+		}
+	}
+	return count
+}
+
+func countKeysWith(records []AWSKMSDecryptReachabilityRecord, pred func(AWSKMSDecryptReachabilityRecord) bool) int {
+	count := 0
+	for _, record := range records {
+		if pred(record) {
+			count++
+		}
+	}
+	return count
+}
+
+func countKMSPolicyGrants(records []AWSKMSDecryptReachabilityRecord, pred func(AWSKMSIdentityGrant) bool) int {
+	count := 0
+	for _, record := range records {
+		for _, grant := range record.IdentityGrants {
+			if pred(grant) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func countKMSLiveGrants(records []AWSKMSDecryptReachabilityRecord, pred func(AWSKMSGrant) bool) int {
+	count := 0
+	for _, record := range records {
+		for _, grant := range record.Grants {
+			if pred(grant) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// validateKMSDecryptReachabilityRecord enforces the scope-and-evidence
+// subset of the service collector contract that is meaningful for resource
+// records (KMS keys carry no role of their own). Required fields are
+// checked in a deterministic order so callers see the same error for the
+// same input.
+func validateKMSDecryptReachabilityRecord(scope db.Scope, project db.TenancyProject, connectorID string, record AWSKMSDecryptReachabilityRecord) error {
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"tenant_id", scope.TenantID},
+		{"workspace_id", project.WorkspaceID},
+		{"project_id", project.ProjectID},
+		{"connector_id", connectorID},
+		{"account_id", record.AccountID},
+		{"region", record.Region},
+		{"service", record.Service},
+		{"key_arn", record.KeyARN},
+		{"key_id", record.KeyID},
+		{"source", record.Source},
+		{"evidence_ref", record.EvidenceRef},
+		{"exposure_classification", record.ExposureClassification},
+	}
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+	if record.Confidence <= 0 || record.Confidence > 1 {
+		return fmt.Errorf("confidence must be greater than 0 and at most 1")
+	}
+	if record.CollectedAt.IsZero() {
+		return fmt.Errorf("collected_at is required")
+	}
+	return nil
+}
+
+// isIAMPrincipalARNForKMSEdge reports whether the supplied principal looks
+// like a real IAM role or user ARN. We only emit graph edges for principals
+// that have an identity node in the graph; service principals, federated
+// principals, and non-IAM ARNs would produce dangling references.
+func isIAMPrincipalARNForKMSEdge(principal string) bool {
+	trimmed := strings.TrimSpace(principal)
+	if trimmed == "" {
+		return false
+	}
+	parts := strings.SplitN(trimmed, ":", 6)
+	if len(parts) != 6 {
+		return false
+	}
+	if parts[0] != "arn" {
+		return false
+	}
+	switch parts[1] {
+	case "aws", "aws-us-gov", "aws-cn":
+	default:
+		return false
+	}
+	if parts[2] != "iam" {
+		return false
+	}
+	if parts[3] != "" {
+		return false
+	}
+	if len(parts[4]) != 12 {
+		return false
+	}
+	for _, r := range parts[4] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	resource := parts[5]
+	if strings.HasPrefix(resource, "role/") && len(resource) > len("role/") {
+		return true
+	}
+	if strings.HasPrefix(resource, "user/") && len(resource) > len("user/") {
+		return true
+	}
+	return false
+}
+
+// awsKMSPartitionForRegion is a local partition helper so the api package
+// does not import the providers/aws helpers directly.
+func awsKMSPartitionForRegion(region string) string {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(normalized, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(normalized, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}

--- a/internal/api/aws_kms_decrypt_reachability.go
+++ b/internal/api/aws_kms_decrypt_reachability.go
@@ -514,6 +514,9 @@ func awsKMSDecryptReachabilityEdges(records []AWSKMSDecryptReachabilityRecord) [
 			if !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
 				continue
 			}
+			if !kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
+				continue
+			}
 			result = append(result, AWSKMSDecryptReachabilityEdge{
 				Type:          "can_decrypt",
 				FromNodeID:    awsIdentityNodeIDForAPI(grant.PrincipalARN),
@@ -533,6 +536,9 @@ func awsKMSDecryptReachabilityEdges(records []AWSKMSDecryptReachabilityRecord) [
 			if !isIAMPrincipalARNForKMSEdge(grant.GranteePrincipal) {
 				continue
 			}
+			if !kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
+				continue
+			}
 			result = append(result, AWSKMSDecryptReachabilityEdge{
 				Type:          "can_decrypt",
 				FromNodeID:    awsIdentityNodeIDForAPI(grant.GranteePrincipal),
@@ -547,6 +553,15 @@ func awsKMSDecryptReachabilityEdges(records []AWSKMSDecryptReachabilityRecord) [
 		}
 	}
 	return result
+}
+
+func kmsCapabilitiesIncludeDecrypt(capabilities []string) bool {
+	for _, capability := range capabilities {
+		if strings.EqualFold(strings.TrimSpace(capability), "decrypt") {
+			return true
+		}
+	}
+	return false
 }
 
 func summarizeAWSKMSDecryptReachabilityInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSKMSDecryptReachabilityRecord) (string, float64, []string, []string) {

--- a/internal/api/aws_kms_decrypt_reachability_test.go
+++ b/internal/api/aws_kms_decrypt_reachability_test.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSKMSDecryptReachabilityInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSKMSDecryptReachabilityInventory(ctx, "default", "project-a", AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get kms inventory: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1489" || result.Version != awsKMSDecryptReachabilityVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.KeyCount != 5 {
+		t.Fatalf("expected 5 keys in fixture, got %d", result.KeyCount)
+	}
+	if result.PublicKeyCount == 0 || result.CrossAccountKeyCount == 0 || result.RestrictedKeyCount == 0 || result.AWSManagedKeyCount == 0 || result.CustomerManagedKeyCount == 0 {
+		t.Fatalf("expected mixed key counts populated, got %+v", result)
+	}
+	if result.PublicGrantCount == 0 || result.CrossAccountGrantCount == 0 || result.DenyGrantCount == 0 {
+		t.Fatalf("expected public/cross/deny grant counts populated, got %+v", result)
+	}
+	if result.LiveGrantCount == 0 {
+		t.Fatalf("expected at least one live KMS grant, got %d", result.LiveGrantCount)
+	}
+	for _, record := range result.Records {
+		evidence := strings.ToLower(record.EvidenceRef + " " + record.Source)
+		if strings.Contains(evidence, "ciphertext") || strings.Contains(evidence, "plaintext") || strings.Contains(evidence, "decrypted") {
+			t.Fatalf("expected metadata-only evidence, got %+v", record)
+		}
+		switch record.ExposureClassification {
+		case "public", "cross_account", "restricted", "managed_by_iam", "managed_by_aws", "private_with_grants", "private", "unknown":
+		default:
+			t.Fatalf("unexpected exposure %q on %+v", record.ExposureClassification, record)
+		}
+		// Encryption-context VALUES must never appear; only keys.
+		for _, g := range record.Grants {
+			for _, k := range g.EncryptionContextKeys {
+				if strings.Contains(k, "secret-value") {
+					t.Fatalf("encryption-context VALUES leaked into API response: %q", k)
+				}
+			}
+		}
+	}
+}
+
+func TestGetAWSKMSDecryptReachabilityInventoryDegradedFlagsRotation(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSKMSDecryptReachabilityInventory(ctx, "default", "project-a", AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get kms inventory degraded: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded || len(result.FailureReasons) == 0 {
+		t.Fatalf("expected degraded status with failure reasons, got %+v", result)
+	}
+	missingRotation := false
+	for _, record := range result.Records {
+		if record.KeyID == "bbbb1111-2222-3333-4444-555566667777" && record.Status == "degraded" {
+			missingRotation = true
+		}
+	}
+	if !missingRotation {
+		t.Fatalf("expected public CMK to be flagged as degraded with missing rotation")
+	}
+}
+
+func TestRouterAWSKMSDecryptReachabilityPartialFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/kms-decrypt-reachability?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSKMSDecryptReachabilityInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
+		t.Fatalf("expected degraded partial_failure, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
+	}
+	if body.Inventory.KeyCount == 0 {
+		t.Fatalf("expected partial failure to retain some records, got 0")
+	}
+	foundDiag := false
+	for _, diag := range body.Inventory.Diagnostics {
+		if diag.Code == "kms_list_grants_failed" {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected kms_list_grants_failed diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestRouterAWSKMSDecryptReachabilityPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 16, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-2")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-2", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-2/aws/kms-decrypt-reachability?connector_id=aws-prod&fixture_state=permission_denied", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSKMSDecryptReachabilityInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusBlocked || body.Inventory.FixtureState != "permission_denied" {
+		t.Fatalf("expected blocked permission_denied, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
+	}
+	if len(body.Inventory.Records) != 0 {
+		t.Fatalf("expected no records under permission_denied, got %d", len(body.Inventory.Records))
+	}
+}
+
+func TestRouterAWSKMSDecryptReachabilityInvalidFixtureState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 17, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-3")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-3", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-3/aws/kms-decrypt-reachability?connector_id=aws-prod&fixture_state=bogus", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestAWSKMSDecryptReachabilityEdgesExcludeWildcardsAndDenies(t *testing.T) {
+	records := []AWSKMSDecryptReachabilityRecord{{
+		KeyARN:      "arn:aws:kms:us-east-1:123456789012:key/k1",
+		EvidenceRef: "arn:aws:kms:us-east-1:123456789012:key/k1",
+		IdentityGrants: []AWSKMSIdentityGrant{
+			{Effect: "Allow", PrincipalARN: "*", WildcardPrincipal: true},
+			{Effect: "Deny", PrincipalARN: "arn:aws:iam::123456789012:role/blocked"},
+			{Effect: "Allow", PrincipalARN: "arn:aws:iam::123456789012:role/allowed", PrincipalType: "aws", Capabilities: []string{"decrypt"}},
+			{Effect: "Allow", PrincipalARN: "arn:aws:sns:us-east-1:123456789012:topic/x", PrincipalType: "aws"},
+			{Effect: "Allow", PrincipalARN: "lambda.amazonaws.com", PrincipalType: "service"},
+		},
+		Grants: []AWSKMSGrant{
+			{GranteePrincipal: "arn:aws:iam::123456789012:role/lambda-decrypt", GranteePrincipalType: "aws", Capabilities: []string{"decrypt"}},
+			{GranteePrincipal: "ec2.amazonaws.com", GranteePrincipalType: "service"},
+		},
+	}}
+	edges := awsKMSDecryptReachabilityEdges(records)
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 edges (one key-policy + one kms-grant, both IAM ARNs), got %d: %+v", len(edges), edges)
+	}
+	wantSources := map[string]bool{"key_policy": false, "kms_grant": false}
+	for _, e := range edges {
+		wantSources[e.Source] = true
+		if e.Type != "can_decrypt" {
+			t.Fatalf("expected can_decrypt type, got %q", e.Type)
+		}
+	}
+	for source, ok := range wantSources {
+		if !ok {
+			t.Fatalf("expected an edge from source %q", source)
+		}
+	}
+}
+
+func TestIsIAMPrincipalARNForKMSEdge(t *testing.T) {
+	cases := []struct {
+		arn  string
+		want bool
+	}{
+		{"arn:aws:iam::123456789012:role/payments", true},
+		{"arn:aws:iam::123456789012:user/alice", true},
+		{"arn:aws-us-gov:iam::123456789012:role/gov", true},
+		{"arn:aws-cn:iam::123456789012:role/cn", true},
+		{"arn:aws:sns:us-east-1:123456789012:topic/x", false},
+		{"arn:aws:iam::123456789012:group/devs", false},
+		{"arn:aws:iam:us-east-1:123456789012:role/r", false},
+		{"arn:aws:iam::abc:role/r", false},
+		{"arn:aws:iam::123456789012:role/", false},
+		{"lambda.amazonaws.com", false},
+		{"", false},
+		{"*", false},
+	}
+	for _, tc := range cases {
+		if got := isIAMPrincipalARNForKMSEdge(tc.arn); got != tc.want {
+			t.Fatalf("isIAMPrincipalARNForKMSEdge(%q) = %v, want %v", tc.arn, got, tc.want)
+		}
+	}
+}
+
+func TestAWSKMSPartitionForRegion(t *testing.T) {
+	cases := map[string]string{
+		"us-east-1":     "aws",
+		"us-gov-west-1": "aws-us-gov",
+		"cn-north-1":    "aws-cn",
+		"":              "aws",
+	}
+	for region, want := range cases {
+		if got := awsKMSPartitionForRegion(region); got != want {
+			t.Fatalf("awsKMSPartitionForRegion(%q)=%q want %q", region, got, want)
+		}
+	}
+}
+
+func TestGetAWSKMSDecryptReachabilityInventoryGovCloudPartition(t *testing.T) {
+	now := time.Date(2026, 6, 10, 18, 0, 0, 0, time.UTC)
+	connection := AWSConnectionStatus{
+		ConnectorID: "aws-gov",
+		AccountID:   "123456789012",
+		Region:      "us-gov-west-1",
+		Connected:   true,
+	}
+	project := db.TenancyProject{WorkspaceID: "default", ProjectID: "project-g"}
+	scope := db.Scope{TenantID: "default", WorkspaceID: "default"}
+	result, err := buildAWSKMSDecryptReachabilityInventory(scope, project, connection, true, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: "aws-gov"}, now)
+	if err != nil {
+		t.Fatalf("build gov inventory: %v", err)
+	}
+	for _, record := range result.Records {
+		if !strings.HasPrefix(record.KeyARN, "arn:aws-us-gov:kms:us-gov-west-1:") {
+			t.Fatalf("expected GovCloud partition ARN, got %q", record.KeyARN)
+		}
+	}
+}

--- a/internal/api/aws_kms_decrypt_reachability_test.go
+++ b/internal/api/aws_kms_decrypt_reachability_test.go
@@ -186,11 +186,13 @@ func TestAWSKMSDecryptReachabilityEdgesExcludeWildcardsAndDenies(t *testing.T) {
 			{Effect: "Allow", PrincipalARN: "*", WildcardPrincipal: true},
 			{Effect: "Deny", PrincipalARN: "arn:aws:iam::123456789012:role/blocked"},
 			{Effect: "Allow", PrincipalARN: "arn:aws:iam::123456789012:role/allowed", PrincipalType: "aws", Capabilities: []string{"decrypt"}},
+			{Effect: "Allow", PrincipalARN: "arn:aws:iam::123456789012:role/encrypt-only", PrincipalType: "aws", Capabilities: []string{"encrypt"}},
 			{Effect: "Allow", PrincipalARN: "arn:aws:sns:us-east-1:123456789012:topic/x", PrincipalType: "aws"},
 			{Effect: "Allow", PrincipalARN: "lambda.amazonaws.com", PrincipalType: "service"},
 		},
 		Grants: []AWSKMSGrant{
 			{GranteePrincipal: "arn:aws:iam::123456789012:role/lambda-decrypt", GranteePrincipalType: "aws", Capabilities: []string{"decrypt"}},
+			{GranteePrincipal: "arn:aws:iam::123456789012:role/lambda-encrypt", GranteePrincipalType: "aws", Capabilities: []string{"encrypt"}},
 			{GranteePrincipal: "ec2.amazonaws.com", GranteePrincipalType: "service"},
 		},
 	}}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2824,6 +2824,36 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSKMSDecryptReachabilityInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSKMSDecryptReachabilityInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws kms decrypt reachability request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws kms decrypt reachability inventory",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws kms decrypt reachability inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -638,6 +638,10 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws s3 bucket reachability collector: %w", err)
 			}
+			kmsAPI, err := awsprovider.NewSDKKMSDecryptReachabilityAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if err != nil {
+				return app.Scanner{}, fmt.Errorf("initialize aws kms decrypt reachability collector: %w", err)
+			}
 			return awsprovider.NewAWSScannerWithServices(iamAPI, cfg.AWSAccountID, cfg.AWSRegion, []awsprovider.AWSServiceCollector{
 				awsprovider.NewEC2InstanceProfileCollector(ec2API),
 				awsprovider.NewECSTaskRoleCollector(ecsAPI),
@@ -651,6 +655,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
+				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 			}, awsprovider.NewRuleSet(
 				awsprovider.WithStaleAfter(time.Duration(staleAfterDays)*24*time.Hour),
 			)), nil

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/connectors/aws/cfn_test.go
+++ b/internal/connectors/aws/cfn_test.go
@@ -154,6 +154,35 @@ func TestReadOnlyPolicyDocument(t *testing.T) {
 			t.Fatalf("connector policy must not include object-level S3 action %q", sensitive)
 		}
 	}
+	for _, action := range []string{
+		"kms:ListKeys",
+		"kms:DescribeKey",
+		"kms:GetKeyPolicy",
+		"kms:GetKeyRotationStatus",
+		"kms:ListAliases",
+		"kms:ListGrants",
+		"kms:ListResourceTags",
+	} {
+		if !strings.Contains(string(policy), "\""+action+"\"") {
+			t.Fatalf("expected KMS reachability read action %q in policy", action)
+		}
+	}
+	for _, sensitive := range []string{
+		"kms:Decrypt",
+		"kms:Encrypt",
+		"kms:GenerateDataKey",
+		"kms:ReEncryptFrom",
+		"kms:ReEncryptTo",
+		"kms:Sign",
+		"kms:Verify",
+		"kms:CreateGrant",
+		"kms:PutKeyPolicy",
+		"kms:ScheduleKeyDeletion",
+	} {
+		if strings.Contains(string(policy), "\""+sensitive+"\"") {
+			t.Fatalf("connector policy must not include cryptographic or mutating KMS action %q", sensitive)
+		}
+	}
 	hash, err := ReadOnlyPolicyHash()
 	if err != nil {
 		t.Fatalf("hash policy: %v", err)

--- a/internal/connectors/aws/iam_policy.go
+++ b/internal/connectors/aws/iam_policy.go
@@ -122,7 +122,11 @@ const readOnlyPolicyJSON = `{
       "Action": [
         "kms:DescribeKey",
         "kms:GetKeyPolicy",
-        "kms:ListKeys"
+        "kms:GetKeyRotationStatus",
+        "kms:ListAliases",
+        "kms:ListGrants",
+        "kms:ListKeys",
+        "kms:ListResourceTags"
       ],
       "Resource": "*"
     },
@@ -279,10 +283,18 @@ func PermissionPreview() []PermissionPreviewItem {
 			Reason:    "Reads bucket-level metadata (location, policy, public-access block, ownership controls, default encryption, tags) plus account-scoped access-point metadata to classify identity-to-bucket reachability. Never reads object contents, presigned URLs, or per-object ACLs.",
 		},
 		{
-			Service:   "KMS",
-			Actions:   []string{"kms:DescribeKey", "kms:GetKeyPolicy", "kms:ListKeys"},
+			Service: "KMS",
+			Actions: []string{
+				"kms:ListKeys",
+				"kms:DescribeKey",
+				"kms:GetKeyPolicy",
+				"kms:GetKeyRotationStatus",
+				"kms:ListAliases",
+				"kms:ListGrants",
+				"kms:ListResourceTags",
+			},
 			Resources: []string{"*"},
-			Reason:    "Reads key policies that can grant sensitive machine identities decrypt or administration paths.",
+			Reason:    "Reads key metadata, key policies, rotation status, aliases, live grants, and tags so Identrail can map which IAM principals can decrypt or administer customer-managed keys. Metadata-only — no Encrypt, Decrypt, Sign, Verify, GenerateDataKey, or grant-creation calls are made.",
 		},
 	}
 }

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -144,6 +144,14 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	// KMS reachability records carry kms service and kms_key workload type.
+	var kmsReach KMSDecryptReachability
+	if err := json.Unmarshal(payload, &kmsReach); err == nil {
+		if isKMSDecryptReachabilityFixture(kmsReach) {
+			return rawKindKMSDecryptReachability, kmsDecryptReachabilitySourceID(kmsReach)
+		}
+	}
+
 	var managedComputeRole ManagedComputeRole
 	if err := json.Unmarshal(payload, &managedComputeRole); err == nil {
 		sourceID := managedComputeRoleSourceID(managedComputeRole)
@@ -501,6 +509,22 @@ func isS3BucketReachabilityFixture(record S3BucketReachability) bool {
 		return true
 	}
 	if strings.EqualFold(strings.TrimSpace(record.WorkloadType), "s3_bucket") {
+		return true
+	}
+	return false
+}
+
+// isKMSDecryptReachabilityFixture identifies a record that looks like a KMS
+// decrypt reachability fixture. Strict match on service (kms), collector
+// name, or workload type (kms_key) so it never claims unrelated assets.
+func isKMSDecryptReachabilityFixture(record KMSDecryptReachability) bool {
+	if strings.EqualFold(strings.TrimSpace(record.Service), kmsServiceName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.CollectorName), kmsDecryptReachabilityCollectorName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.WorkloadType), "kms_key") {
 		return true
 	}
 	return false

--- a/internal/providers/aws/kms_decrypt_reachability_collector.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector.go
@@ -1,0 +1,642 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindKMSDecryptReachability       = "kms_decrypt_reachability"
+	kmsDecryptReachabilityCollectorName = "kms_decrypt_reachability"
+	kmsServiceName                      = "kms"
+)
+
+// KMSDecryptReachability is the normalized envelope describing one KMS key
+// (and the inferred identity reachability into it). The collector captures
+// metadata only — never plaintext material, never ciphertext, never
+// CloudTrail event bodies — so this struct holds key configuration,
+// rotation status, exposure signals, and inferred identity grants from the
+// key policy *and* live KMS grants.
+type KMSDecryptReachability struct {
+	awscontract.ServiceCollectorRecord
+
+	KeyARN       string `json:"key_arn,omitempty"`
+	KeyID        string `json:"key_id,omitempty"`
+	KeyManager   string `json:"key_manager,omitempty"` // AWS / CUSTOMER
+	KeyState     string `json:"key_state,omitempty"`   // Enabled / Disabled / PendingDeletion / ...
+	KeyUsage     string `json:"key_usage,omitempty"`   // ENCRYPT_DECRYPT / SIGN_VERIFY / ...
+	KeySpec      string `json:"key_spec,omitempty"`    // SYMMETRIC_DEFAULT / RSA_4096 / ...
+	Origin       string `json:"origin,omitempty"`      // AWS_KMS / EXTERNAL / AWS_CLOUDHSM
+	Description  string `json:"description,omitempty"`
+	Enabled      bool   `json:"enabled,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	DeletionDate string `json:"deletion_date,omitempty"`
+
+	// Multi-region replica metadata. Reachability is mostly governed by the
+	// per-region key policy, but multi-region keys propagate ciphertext across
+	// regions and operators should see the replica relationship explicitly.
+	MultiRegion        bool     `json:"multi_region,omitempty"`
+	MultiRegionPrimary bool     `json:"multi_region_primary,omitempty"`
+	PrimaryKeyARN      string   `json:"primary_key_arn,omitempty"`
+	ReplicaKeyARNs     []string `json:"replica_key_arns,omitempty"`
+
+	// Rotation surface. We surface whether rotation *is* enabled and whether
+	// the key *can* be rotated — symmetric customer-managed keys without an
+	// imported key material support automatic rotation; others do not.
+	RotationEnabled   bool   `json:"rotation_enabled,omitempty"`
+	RotationSupported bool   `json:"rotation_supported,omitempty"`
+	LastRotatedAt     string `json:"last_rotated_at,omitempty"`
+
+	// Aliases attached to the key. Aliases are how most callers reference KMS
+	// keys, so surfacing them avoids ARN-only output.
+	Aliases []string `json:"aliases,omitempty"`
+
+	// Key policy + parsed grants.
+	HasKeyPolicy            bool               `json:"has_key_policy,omitempty"`
+	KeyPolicyStatementCount int                `json:"key_policy_statement_count,omitempty"`
+	IAMDelegationEnabled    bool               `json:"iam_delegation_enabled,omitempty"`
+	IdentityGrants          []KMSIdentityGrant `json:"identity_grants,omitempty"`
+
+	// Live KMS grants (a separate AWS primitive from key policies).
+	Grants []KMSGrant `json:"grants,omitempty"`
+
+	// Exposure summary computed across policy, IAM delegation, and grant
+	// signals.
+	ExposureClassification string   `json:"exposure_classification,omitempty"`
+	ExposureReasons        []string `json:"exposure_reasons,omitempty"`
+
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// KMSIdentityGrant is one principal-to-key grant inferred from the key
+// policy. KMS specifies actions like kms:Decrypt, kms:Encrypt,
+// kms:GenerateDataKey*, kms:ReEncrypt*, kms:CreateGrant, etc. We bucket the
+// actions into capability classes so the API can render them without each
+// caller re-deriving the mapping.
+type KMSIdentityGrant struct {
+	PrincipalARN      string   `json:"principal_arn,omitempty"`
+	PrincipalType     string   `json:"principal_type,omitempty"` // aws / service / federated / canonical_user / *
+	Effect            string   `json:"effect"`                   // Allow / Deny
+	Actions           []string `json:"actions,omitempty"`
+	NotAction         bool     `json:"not_action,omitempty"`
+	Capabilities      []string `json:"capabilities,omitempty"` // decrypt / encrypt / admin / grant / sign / verify
+	ConditionKeys     []string `json:"condition_keys,omitempty"`
+	HasCondition      bool     `json:"has_condition,omitempty"`
+	StatementSid      string   `json:"statement_sid,omitempty"`
+	IsPublic          bool     `json:"is_public,omitempty"`
+	IsCrossAccount    bool     `json:"is_cross_account,omitempty"`
+	WildcardPrincipal bool     `json:"wildcard_principal,omitempty"`
+}
+
+// KMSGrant mirrors a single live KMS grant as returned by ListGrants. KMS
+// grants are an out-of-policy reachability primitive: they allow a principal
+// to use a key without editing the key policy, so missing them would leave a
+// reachability blind spot. We never include the encryption-context values
+// (those can be sensitive); only the constraint *keys* are surfaced.
+type KMSGrant struct {
+	GrantID                     string   `json:"grant_id,omitempty"`
+	Name                        string   `json:"name,omitempty"`
+	GranteePrincipal            string   `json:"grantee_principal,omitempty"`
+	GranteePrincipalType        string   `json:"grantee_principal_type,omitempty"` // aws / service
+	RetiringPrincipal           string   `json:"retiring_principal,omitempty"`
+	IssuingAccount              string   `json:"issuing_account,omitempty"`
+	Operations                  []string `json:"operations,omitempty"`
+	Capabilities                []string `json:"capabilities,omitempty"`
+	EncryptionContextKeys       []string `json:"encryption_context_keys,omitempty"`
+	EncryptionContextSubsetKeys []string `json:"encryption_context_subset_keys,omitempty"`
+	HasConstraints              bool     `json:"has_constraints,omitempty"`
+	IsCrossAccount              bool     `json:"is_cross_account,omitempty"`
+	CreatedAt                   string   `json:"created_at,omitempty"`
+}
+
+// KMSDecryptReachabilityPage is one page of normalized key records plus
+// per-page collector diagnostics.
+type KMSDecryptReachabilityPage struct {
+	Records     []KMSDecryptReachability
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+// KMSDecryptReachabilityAPI is the narrow seam between the collector and
+// the underlying SDK or fixture client.
+type KMSDecryptReachabilityAPI interface {
+	ListKMSKeyReachability(ctx context.Context, nextToken string, pageSize int32) (KMSDecryptReachabilityPage, error)
+}
+
+// KMSDecryptReachabilityCollector turns KMS key metadata into payload-safe
+// normalized records and exposure-classified identity reachability evidence.
+type KMSDecryptReachabilityCollector struct {
+	client   KMSDecryptReachabilityAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+// KMSDecryptReachabilityOption tunes the collector.
+type KMSDecryptReachabilityOption func(*KMSDecryptReachabilityCollector)
+
+func WithKMSDecryptReachabilityPageSize(pageSize int32) KMSDecryptReachabilityOption {
+	return func(c *KMSDecryptReachabilityCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+func WithKMSDecryptReachabilityMaxPages(maxPages int) KMSDecryptReachabilityOption {
+	return func(c *KMSDecryptReachabilityCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+func WithKMSDecryptReachabilityRetryPolicy(policy RetryPolicy) KMSDecryptReachabilityOption {
+	return func(c *KMSDecryptReachabilityCollector) {
+		if policy.MaxRetries >= 0 {
+			c.retry.MaxRetries = policy.MaxRetries
+		}
+		if policy.BaseDelay > 0 {
+			c.retry.BaseDelay = policy.BaseDelay
+		}
+		if policy.MaxDelay > 0 {
+			c.retry.MaxDelay = policy.MaxDelay
+		}
+	}
+}
+
+func WithKMSDecryptReachabilitySleeper(s Sleeper) KMSDecryptReachabilityOption {
+	return func(c *KMSDecryptReachabilityCollector) {
+		if s != nil {
+			c.sleep = s
+		}
+	}
+}
+
+func WithKMSDecryptReachabilityClock(now func() time.Time) KMSDecryptReachabilityOption {
+	return func(c *KMSDecryptReachabilityCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// NewKMSDecryptReachabilityCollector constructs the collector with the same
+// defaults as the rest of the AWS service collectors.
+func NewKMSDecryptReachabilityCollector(client KMSDecryptReachabilityAPI, opts ...KMSDecryptReachabilityOption) *KMSDecryptReachabilityCollector {
+	c := &KMSDecryptReachabilityCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ServiceName returns the canonical AWS service the collector covers.
+func (c *KMSDecryptReachabilityCollector) ServiceName() string {
+	return kmsServiceName
+}
+
+// Collect satisfies providers.Collector for callers without a scope.
+func (c *KMSDecryptReachabilityCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: kmsServiceName})
+	return assets, err
+}
+
+// CollectWithDiagnostics walks every KMS key in the account, normalizes the
+// metadata, and emits one raw asset per key. Per-call state lives in local
+// variables so concurrent invocations on the same collector instance do not
+// race.
+func (c *KMSDecryptReachabilityCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("kms decrypt reachability collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(providers.SourceError{
+				Collector: kmsDecryptReachabilityCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "kms_decrypt_reachability_page_limit_exceeded",
+				Message:   fmt.Sprintf("kms decrypt reachability collection exceeded max pages (%d)", c.maxPages),
+				Retryable: false,
+			})
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("kms decrypt reachability collection exceeded max pages (%d)", c.maxPages)
+		}
+		response, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (KMSDecryptReachabilityPage, error) {
+			return c.client.ListKMSKeyReachability(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list kms keys for reachability page %d: %w", page, err)
+			addIssue(providers.SourceError{
+				Collector: kmsDecryptReachabilityCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "kms_decrypt_reachability_page_failed",
+				Message:   wrapped.Error(),
+				Retryable: isRetryable(err),
+			})
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, diagnostic := range response.Diagnostics {
+			addIssue(diagnostic)
+		}
+		for _, record := range response.Records {
+			normalized := normalizeKMSDecryptReachabilityScope(scope, record, collectedAt)
+			if strings.TrimSpace(normalized.KeyARN) == "" && strings.TrimSpace(normalized.KeyID) == "" {
+				addIssue(providers.SourceError{
+					Collector: kmsDecryptReachabilityCollectorName,
+					Code:      "malformed_kms_decrypt_reachability_record",
+					Message:   "skipped kms key record without an ARN or key id",
+					Retryable: false,
+				})
+				continue
+			}
+			sourceID := kmsDecryptReachabilitySourceID(normalized)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, err := json.Marshal(normalized)
+			if err != nil {
+				return nil, nil, fmt.Errorf("marshal kms decrypt reachability %q: %w", sourceID, err)
+			}
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindKMSDecryptReachability,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+		if strings.TrimSpace(response.NextToken) == "" {
+			break
+		}
+		nextToken = strings.TrimSpace(response.NextToken)
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+// normalizeKMSDecryptReachabilityScope fills in scope/contract fields and
+// computes the exposure classification from the key's settings + grants.
+func normalizeKMSDecryptReachabilityScope(scope AWSCollectorScope, record KMSDecryptReachability, collectedAt time.Time) KMSDecryptReachability {
+	normalized := record
+	normalized.AccountID = firstNonEmptyAWSValue(record.AccountID, scope.AccountID, accountIDFromARN(record.KeyARN))
+	normalized.Region = firstNonEmptyAWSValue(record.Region, scope.Region)
+	normalized.Service = firstNonEmptyAWSValue(record.Service, kmsServiceName)
+	normalized.KeyID = strings.TrimSpace(record.KeyID)
+	normalized.KeyARN = strings.TrimSpace(record.KeyARN)
+	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, "kms_key")
+	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.KeyID, normalized.KeyARN)
+	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.KeyARN, normalized.KeyID)
+	normalized.RoleARN = strings.TrimSpace(record.RoleARN)
+	normalized.Source = firstNonEmptyAWSValue(record.Source, "kms_key_metadata")
+	normalized.EvidenceRef = firstNonEmptyAWSValue(record.EvidenceRef, normalized.KeyARN, normalized.KeyID)
+	normalized.CollectorName = firstNonEmptyAWSValue(record.CollectorName, kmsDecryptReachabilityCollectorName)
+	normalized.ScanID = firstNonEmptyAWSValue(record.ScanID, scope.ScanID, "aws-kms-decrypt-reachability-fixture")
+	normalized.ConnectorID = firstNonEmptyAWSValue(record.ConnectorID, scope.ConnectorID, "aws-connector")
+	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
+	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
+	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
+	normalized.KeyManager = strings.ToUpper(strings.TrimSpace(record.KeyManager))
+	normalized.KeyState = strings.TrimSpace(record.KeyState)
+	normalized.KeyUsage = strings.TrimSpace(record.KeyUsage)
+	normalized.KeySpec = strings.TrimSpace(record.KeySpec)
+	normalized.Origin = strings.TrimSpace(record.Origin)
+	normalized.Aliases = dedupeStrings(normalizeStringList(record.Aliases))
+	normalized.ReplicaKeyARNs = dedupeStrings(normalizeStringList(record.ReplicaKeyARNs))
+	normalized.PrimaryKeyARN = strings.TrimSpace(record.PrimaryKeyARN)
+	normalized.IdentityGrants = annotateKMSGrants(record.IdentityGrants, normalized.AccountID)
+	normalized.Grants = annotateKMSLiveGrants(record.Grants, normalized.AccountID)
+	normalized.ExposureClassification, normalized.ExposureReasons = classifyKMSKeyExposure(normalized)
+	normalized.Tags = copyTags(record.Tags)
+	normalized.CollectedAt = collectedAt
+	if normalized.Confidence <= 0 {
+		normalized.Confidence = kmsDecryptReachabilityConfidence(normalized)
+	}
+	return normalized
+}
+
+// annotateKMSGrants enriches each key-policy grant with cross-account /
+// public flags derived from the principal ARN and the key-owning account,
+// and computes capability classes from the action list.
+func annotateKMSGrants(grants []KMSIdentityGrant, accountID string) []KMSIdentityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]KMSIdentityGrant, 0, len(grants))
+	for _, grant := range grants {
+		grant.PrincipalARN = strings.TrimSpace(grant.PrincipalARN)
+		grant.PrincipalType = strings.ToLower(strings.TrimSpace(grant.PrincipalType))
+		grant.Effect = canonicalKMSGrantEffect(grant.Effect)
+		grant.Actions = normalizeStringList(grant.Actions)
+		grant.ConditionKeys = normalizeStringList(grant.ConditionKeys)
+		grant.WildcardPrincipal = grant.WildcardPrincipal || grant.PrincipalARN == "*"
+		grant.IsPublic = grant.IsPublic || grant.WildcardPrincipal
+		if !grant.IsCrossAccount && accountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
+			grantAccount := accountIDFromARN(grant.PrincipalARN)
+			if grantAccount != "" && grantAccount != accountID {
+				grant.IsCrossAccount = true
+			}
+		}
+		grant.HasCondition = grant.HasCondition || len(grant.ConditionKeys) > 0
+		grant.Capabilities = kmsCapabilitiesForActions(grant.Actions)
+		out = append(out, grant)
+	}
+	return out
+}
+
+// annotateKMSLiveGrants enriches each live KMS grant with cross-account
+// flags + capability classes.
+func annotateKMSLiveGrants(grants []KMSGrant, accountID string) []KMSGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]KMSGrant, 0, len(grants))
+	for _, grant := range grants {
+		grant.GranteePrincipal = strings.TrimSpace(grant.GranteePrincipal)
+		grant.GranteePrincipalType = strings.ToLower(strings.TrimSpace(grant.GranteePrincipalType))
+		grant.RetiringPrincipal = strings.TrimSpace(grant.RetiringPrincipal)
+		grant.IssuingAccount = strings.TrimSpace(grant.IssuingAccount)
+		grant.Operations = normalizeStringList(grant.Operations)
+		grant.EncryptionContextKeys = dedupeStrings(normalizeStringList(grant.EncryptionContextKeys))
+		grant.EncryptionContextSubsetKeys = dedupeStrings(normalizeStringList(grant.EncryptionContextSubsetKeys))
+		grant.HasConstraints = grant.HasConstraints || len(grant.EncryptionContextKeys) > 0 || len(grant.EncryptionContextSubsetKeys) > 0
+		grant.Capabilities = kmsCapabilitiesForActions(grant.Operations)
+		if !grant.IsCrossAccount && accountID != "" && grant.GranteePrincipal != "" {
+			granteeAccount := accountIDFromARN(grant.GranteePrincipal)
+			if granteeAccount != "" && granteeAccount != accountID {
+				grant.IsCrossAccount = true
+			}
+		}
+		out = append(out, grant)
+	}
+	return out
+}
+
+// kmsCapabilitiesForActions buckets KMS action strings into capability
+// classes. Returned values are sorted and deduped so output is deterministic.
+//
+// The mapping is deliberately strict — a KMS action that does not appear here
+// is *not* silently classed as "other"; instead it is omitted from the
+// capability list so a future KMS API addition does not get hidden inside an
+// opaque bucket.
+func kmsCapabilitiesForActions(actions []string) []string {
+	if len(actions) == 0 {
+		return nil
+	}
+	caps := map[string]struct{}{}
+	for _, action := range actions {
+		trimmed := strings.TrimSpace(action)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		switch {
+		case lower == "*", lower == "kms:*":
+			caps["decrypt"] = struct{}{}
+			caps["encrypt"] = struct{}{}
+			caps["admin"] = struct{}{}
+			caps["grant"] = struct{}{}
+			caps["sign"] = struct{}{}
+		case lower == "kms:decrypt", lower == "decrypt":
+			caps["decrypt"] = struct{}{}
+		case strings.HasPrefix(lower, "kms:reencrypt"), strings.HasPrefix(lower, "reencrypt"):
+			caps["decrypt"] = struct{}{}
+			caps["encrypt"] = struct{}{}
+		case strings.HasPrefix(lower, "kms:generatedatakey"), strings.HasPrefix(lower, "generatedatakey"):
+			caps["decrypt"] = struct{}{}
+			caps["encrypt"] = struct{}{}
+		case lower == "kms:encrypt", lower == "encrypt":
+			caps["encrypt"] = struct{}{}
+		case lower == "kms:sign", lower == "sign":
+			caps["sign"] = struct{}{}
+		case lower == "kms:verify", lower == "verify":
+			caps["sign"] = struct{}{}
+		case lower == "kms:creategrant", lower == "creategrant":
+			caps["grant"] = struct{}{}
+		case lower == "kms:retiregrant", lower == "retiregrant",
+			lower == "kms:revokegrant", lower == "revokegrant",
+			lower == "kms:listgrants", lower == "listgrants":
+			caps["grant"] = struct{}{}
+		case lower == "kms:putkeypolicy", lower == "putkeypolicy",
+			lower == "kms:schedulekeydeletion", lower == "schedulekeydeletion",
+			lower == "kms:disablekey", lower == "disablekey",
+			lower == "kms:enablekey", lower == "enablekey",
+			lower == "kms:cancelkeydeletion", lower == "cancelkeydeletion",
+			lower == "kms:updatekeydescription", lower == "updatekeydescription",
+			lower == "kms:enablekeyrotation", lower == "enablekeyrotation",
+			lower == "kms:disablekeyrotation", lower == "disablekeyrotation",
+			lower == "kms:tagresource", lower == "tagresource",
+			lower == "kms:untagresource", lower == "untagresource",
+			lower == "kms:replicatekey", lower == "replicatekey",
+			lower == "kms:updateprimaryregion", lower == "updateprimaryregion":
+			caps["admin"] = struct{}{}
+		}
+	}
+	if len(caps) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(caps))
+	for cap := range caps {
+		out = append(out, cap)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// classifyKMSKeyExposure folds policy, IAM delegation, and grant signals
+// into one of "public" / "cross_account" / "restricted" /
+// "managed_by_iam" / "private_with_grants" / "private". The reasons slice
+// explains the contributing signals so the API can render an audit-friendly
+// summary.
+//
+// Notes:
+//   - AWS-managed keys (KeyManager=AWS) cannot have their policy changed by
+//     the customer, so we always classify them as "managed_by_aws" — they
+//     are a documented coverage class rather than a finding.
+//   - "EnableIAMUserPermissions"-only key policies delegate access entirely
+//     to IAM. That is the AWS default and is not, on its own, an exposure
+//     finding, so it gets its own classification.
+func classifyKMSKeyExposure(record KMSDecryptReachability) (string, []string) {
+	reasons := []string{}
+	if strings.EqualFold(record.KeyManager, "AWS") {
+		reasons = append(reasons, "kms_managed_by_aws")
+		return "managed_by_aws", dedupeStrings(reasons)
+	}
+	public := false
+	crossAccount := false
+	denyAll := false
+	hasNonDelegationGrant := false
+	for _, grant := range record.IdentityGrants {
+		switch grant.Effect {
+		case "Allow":
+			if grant.IsPublic && !grant.HasCondition {
+				public = true
+				reasons = append(reasons, "kms_key_policy_allow_to_wildcard_principal")
+			}
+			if grant.IsCrossAccount && !grant.HasCondition {
+				crossAccount = true
+				reasons = append(reasons, "kms_key_policy_allow_to_cross_account_principal")
+			}
+			if !isIAMDelegationGrant(grant, record.AccountID) {
+				hasNonDelegationGrant = true
+			}
+		case "Deny":
+			if grant.WildcardPrincipal && !grant.HasCondition {
+				denyAll = true
+				reasons = append(reasons, "kms_key_policy_explicit_deny_to_all")
+			}
+		}
+	}
+	for _, g := range record.Grants {
+		if g.IsCrossAccount {
+			crossAccount = true
+			reasons = append(reasons, "kms_live_grant_to_cross_account_principal")
+			break
+		}
+	}
+	// IAM semantics: an explicit Deny to all principals with no conditions
+	// shadows any Allow regardless of the Allow's principals.
+	switch {
+	case denyAll:
+		return "restricted", dedupeStrings(reasons)
+	case public:
+		return "public", dedupeStrings(reasons)
+	case crossAccount:
+		return "cross_account", dedupeStrings(reasons)
+	case record.IAMDelegationEnabled && !hasNonDelegationGrant:
+		reasons = append(reasons, "kms_key_policy_delegates_to_iam")
+		return "managed_by_iam", dedupeStrings(reasons)
+	case record.HasKeyPolicy || len(record.Grants) > 0:
+		return "private_with_grants", dedupeStrings(reasons)
+	default:
+		return "private", dedupeStrings(reasons)
+	}
+}
+
+// isIAMDelegationGrant reports whether the supplied policy grant is the
+// canonical "EnableIAMUserPermissions" delegation: Allow kms:* to the
+// account root principal with no conditions. We treat this as the AWS
+// default delegation rather than a real exposure signal.
+func isIAMDelegationGrant(grant KMSIdentityGrant, accountID string) bool {
+	if !strings.EqualFold(grant.Effect, "Allow") {
+		return false
+	}
+	if grant.HasCondition {
+		return false
+	}
+	if grant.WildcardPrincipal {
+		return false
+	}
+	if grant.PrincipalARN == "" {
+		return false
+	}
+	expected := fmt.Sprintf(":iam::%s:root", strings.TrimSpace(accountID))
+	if accountID == "" || !strings.Contains(grant.PrincipalARN, expected) {
+		return false
+	}
+	for _, action := range grant.Actions {
+		lower := strings.ToLower(strings.TrimSpace(action))
+		if lower != "kms:*" && lower != "*" {
+			return false
+		}
+	}
+	return len(grant.Actions) > 0
+}
+
+func canonicalKMSGrantEffect(effect string) string {
+	switch strings.ToLower(strings.TrimSpace(effect)) {
+	case "allow":
+		return "Allow"
+	case "deny":
+		return "Deny"
+	default:
+		return strings.TrimSpace(effect)
+	}
+}
+
+func kmsDecryptReachabilityConfidence(record KMSDecryptReachability) float64 {
+	switch record.ExposureClassification {
+	case "public":
+		return 0.95
+	case "cross_account":
+		return 0.92
+	case "restricted":
+		return 0.9
+	case "managed_by_iam":
+		return 0.88
+	case "private_with_grants":
+		return 0.87
+	case "managed_by_aws":
+		return 0.85
+	case "private":
+		return 0.84
+	default:
+		return 0.7
+	}
+}
+
+func kmsDecryptReachabilitySourceID(record KMSDecryptReachability) string {
+	return strings.Join(normalizeStringList([]string{
+		record.Service,
+		record.KeyARN,
+		record.KeyID,
+		record.Region,
+	}), "|")
+}
+
+// kmsKeyARNFromID synthesizes a KMS key ARN from the supplied id, region,
+// and account. KMS key ARNs are partition + region + account scoped so we
+// must have all three.
+func kmsKeyARNFromID(keyID, accountID, region string) string {
+	trimmed := strings.TrimSpace(keyID)
+	if trimmed == "" || strings.TrimSpace(accountID) == "" || strings.TrimSpace(region) == "" {
+		return ""
+	}
+	partition := awsPartitionForRegion(region)
+	return fmt.Sprintf("arn:%s:kms:%s:%s:key/%s", partition, region, accountID, trimmed)
+}
+
+var _ AWSServiceCollector = (*KMSDecryptReachabilityCollector)(nil)
+var _ providers.Collector = (*KMSDecryptReachabilityCollector)(nil)

--- a/internal/providers/aws/kms_decrypt_reachability_collector_test.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector_test.go
@@ -104,6 +104,58 @@ func TestParseKMSKeyPolicyGrants_NotPrincipalIsSkipped(t *testing.T) {
 	}
 }
 
+func TestParseKMSKeyPolicyGrants_NotActionIsSkipped(t *testing.T) {
+	grants, _, _, err := parseKMSKeyPolicyGrants(`{
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": {"AWS": "arn:aws:iam::123456789012:role/app"},
+			"NotAction": "kms:Encrypt",
+			"Resource": "*"
+		}]
+	}`, "123456789012")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("expected NotAction to be skipped, got %+v", grants)
+	}
+}
+
+func TestParseKMSKeyPolicyGrants_PreservesAllPrincipalEntries(t *testing.T) {
+	grants, _, _, err := parseKMSKeyPolicyGrants(`{
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": {
+				"AWS": ["arn:aws:iam::123456789012:role/app", "arn:aws:iam::123456789012:user/alice"],
+				"Service": "lambda.amazonaws.com"
+			},
+			"Action": "kms:Decrypt",
+			"Resource": "*"
+		}]
+	}`, "123456789012")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(grants) != 3 {
+		t.Fatalf("expected all principal entries, got %+v", grants)
+	}
+	want := map[string]bool{
+		"arn:aws:iam::123456789012:role/app":   false,
+		"arn:aws:iam::123456789012:user/alice": false,
+		"lambda.amazonaws.com":                 false,
+	}
+	for _, grant := range grants {
+		if _, ok := want[grant.PrincipalARN]; ok {
+			want[grant.PrincipalARN] = true
+		}
+	}
+	for principal, found := range want {
+		if !found {
+			t.Fatalf("expected principal %q in %+v", principal, grants)
+		}
+	}
+}
+
 func TestParseKMSKeyPolicyGrants_MalformedShape(t *testing.T) {
 	if _, _, _, err := parseKMSKeyPolicyGrants(`{"Statement": 42}`, ""); err == nil {
 		t.Fatalf("expected error on malformed statement shape")

--- a/internal/providers/aws/kms_decrypt_reachability_collector_test.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector_test.go
@@ -139,20 +139,23 @@ func TestParseKMSKeyPolicyGrants_PreservesAllPrincipalEntries(t *testing.T) {
 	if len(grants) != 3 {
 		t.Fatalf("expected all principal entries, got %+v", grants)
 	}
-	want := map[string]bool{
-		"arn:aws:iam::123456789012:role/app":   false,
-		"arn:aws:iam::123456789012:user/alice": false,
-		"lambda.amazonaws.com":                 false,
+	want := map[string]string{
+		"arn:aws:iam::123456789012:role/app":   "aws",
+		"arn:aws:iam::123456789012:user/alice": "aws",
+		"lambda.amazonaws.com":                 "service",
 	}
 	for _, grant := range grants {
-		if _, ok := want[grant.PrincipalARN]; ok {
-			want[grant.PrincipalARN] = true
+		wantType, ok := want[grant.PrincipalARN]
+		if !ok {
+			t.Fatalf("unexpected principal %q in %+v", grant.PrincipalARN, grants)
 		}
+		if grant.PrincipalType != wantType {
+			t.Fatalf("expected principal %q type %q, got %q", grant.PrincipalARN, wantType, grant.PrincipalType)
+		}
+		delete(want, grant.PrincipalARN)
 	}
-	for principal, found := range want {
-		if !found {
-			t.Fatalf("expected principal %q in %+v", principal, grants)
-		}
+	for principal := range want {
+		t.Fatalf("expected principal %q in %+v", principal, grants)
 	}
 }
 

--- a/internal/providers/aws/kms_decrypt_reachability_collector_test.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector_test.go
@@ -1,0 +1,477 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+type fakeKMSDecryptReachabilityAPI struct {
+	pages []KMSDecryptReachabilityPage
+	calls int
+	err   error
+}
+
+func (f *fakeKMSDecryptReachabilityAPI) ListKMSKeyReachability(ctx context.Context, nextToken string, pageSize int32) (KMSDecryptReachabilityPage, error) {
+	f.calls++
+	if f.err != nil {
+		return KMSDecryptReachabilityPage{}, f.err
+	}
+	if len(f.pages) == 0 {
+		return KMSDecryptReachabilityPage{}, nil
+	}
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func TestParseKMSKeyPolicyGrants_DelegationAndAppGrant(t *testing.T) {
+	owner := "123456789012"
+	grants, count, iam, err := parseKMSKeyPolicyGrants(`{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "EnableIAMUserPermissions",
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+				"Action": "kms:*",
+				"Resource": "*"
+			},
+			{
+				"Sid": "AppDecrypt",
+				"Effect": "Allow",
+				"Principal": {"AWS": "arn:aws:iam::123456789012:role/payments-app"},
+				"Action": ["kms:Decrypt", "kms:GenerateDataKey"],
+				"Resource": "*"
+			}
+		]
+	}`, owner)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 statements, got %d", count)
+	}
+	if !iam {
+		t.Fatalf("expected EnableIAMUserPermissions to be detected")
+	}
+	if len(grants) != 2 {
+		t.Fatalf("expected 2 grants, got %d", len(grants))
+	}
+}
+
+func TestParseKMSKeyPolicyGrants_PublicWildcardWithoutCondition(t *testing.T) {
+	grants, _, iam, err := parseKMSKeyPolicyGrants(`{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "PublicDecrypt",
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "kms:Decrypt",
+			"Resource": "*"
+		}]
+	}`, "123456789012")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if iam {
+		t.Fatalf("wildcard principal must not be detected as IAM delegation")
+	}
+	if len(grants) != 1 || !grants[0].WildcardPrincipal || grants[0].PrincipalARN != "*" {
+		t.Fatalf("expected wildcard principal grant, got %+v", grants)
+	}
+}
+
+func TestParseKMSKeyPolicyGrants_NotPrincipalIsSkipped(t *testing.T) {
+	grants, _, _, err := parseKMSKeyPolicyGrants(`{
+		"Statement": [{
+			"Effect": "Allow",
+			"NotPrincipal": {"AWS": "arn:aws:iam::123456789012:role/admin"},
+			"Action": "kms:Decrypt",
+			"Resource": "*"
+		}]
+	}`, "123456789012")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("expected NotPrincipal to be skipped, got %+v", grants)
+	}
+}
+
+func TestParseKMSKeyPolicyGrants_MalformedShape(t *testing.T) {
+	if _, _, _, err := parseKMSKeyPolicyGrants(`{"Statement": 42}`, ""); err == nil {
+		t.Fatalf("expected error on malformed statement shape")
+	}
+}
+
+func TestParseKMSKeyPolicyGrants_BlankAndURLEncoded(t *testing.T) {
+	if grants, count, iam, err := parseKMSKeyPolicyGrants("  ", ""); err != nil || count != 0 || iam || len(grants) != 0 {
+		t.Fatalf("blank policy: grants=%v count=%d iam=%v err=%v", grants, count, iam, err)
+	}
+	encoded := "%7B%22Statement%22%3A%5B%5D%7D"
+	if _, count, _, err := parseKMSKeyPolicyGrants(encoded, ""); err != nil || count != 0 {
+		t.Fatalf("url-encoded empty policy: count=%d err=%v", count, err)
+	}
+}
+
+func TestKMSCapabilitiesForActions_BucketsByClass(t *testing.T) {
+	cases := []struct {
+		actions []string
+		want    []string
+	}{
+		{[]string{"kms:Decrypt"}, []string{"decrypt"}},
+		{[]string{"kms:GenerateDataKeyWithoutPlaintext"}, []string{"decrypt", "encrypt"}},
+		{[]string{"kms:ReEncryptFrom", "kms:ReEncryptTo"}, []string{"decrypt", "encrypt"}},
+		{[]string{"kms:Sign", "kms:Verify"}, []string{"sign"}},
+		{[]string{"kms:CreateGrant", "kms:ListGrants"}, []string{"grant"}},
+		{[]string{"kms:PutKeyPolicy", "kms:ScheduleKeyDeletion"}, []string{"admin"}},
+		{[]string{"kms:*"}, []string{"admin", "decrypt", "encrypt", "grant", "sign"}},
+		{nil, nil},
+		{[]string{"unknown:action"}, nil},
+	}
+	for _, tc := range cases {
+		got := kmsCapabilitiesForActions(tc.actions)
+		if !equalStringSlices(got, tc.want) {
+			t.Fatalf("kmsCapabilitiesForActions(%v) = %v, want %v", tc.actions, got, tc.want)
+		}
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestClassifyKMSKeyExposure_DenyAllShadowsPublic(t *testing.T) {
+	got, _ := classifyKMSKeyExposure(KMSDecryptReachability{
+		HasKeyPolicy: true,
+		KeyManager:   "CUSTOMER",
+		IdentityGrants: []KMSIdentityGrant{
+			{Effect: "Allow", IsPublic: true, WildcardPrincipal: true, PrincipalARN: "*"},
+			{Effect: "Deny", WildcardPrincipal: true, PrincipalARN: "*"},
+		},
+	})
+	if got != "restricted" {
+		t.Fatalf("expected restricted, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_Public(t *testing.T) {
+	got, _ := classifyKMSKeyExposure(KMSDecryptReachability{
+		HasKeyPolicy: true,
+		KeyManager:   "CUSTOMER",
+		IdentityGrants: []KMSIdentityGrant{
+			{Effect: "Allow", IsPublic: true, WildcardPrincipal: true, PrincipalARN: "*"},
+		},
+	})
+	if got != "public" {
+		t.Fatalf("expected public, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_CrossAccountFromLiveGrant(t *testing.T) {
+	got, _ := classifyKMSKeyExposure(KMSDecryptReachability{
+		HasKeyPolicy: true,
+		KeyManager:   "CUSTOMER",
+		Grants: []KMSGrant{{
+			GranteePrincipal: "arn:aws:iam::999999999999:role/partner",
+			IsCrossAccount:   true,
+		}},
+	})
+	if got != "cross_account" {
+		t.Fatalf("expected cross_account, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_ManagedByIAM(t *testing.T) {
+	rec := KMSDecryptReachability{
+		HasKeyPolicy:         true,
+		KeyManager:           "CUSTOMER",
+		IAMDelegationEnabled: true,
+		IdentityGrants: []KMSIdentityGrant{
+			{
+				Effect:       "Allow",
+				PrincipalARN: "arn:aws:iam::123456789012:root",
+				Actions:      []string{"kms:*"},
+			},
+		},
+	}
+	rec.AccountID = "123456789012"
+	got, _ := classifyKMSKeyExposure(rec)
+	if got != "managed_by_iam" {
+		t.Fatalf("expected managed_by_iam, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_ManagedByAWS(t *testing.T) {
+	got, _ := classifyKMSKeyExposure(KMSDecryptReachability{KeyManager: "AWS"})
+	if got != "managed_by_aws" {
+		t.Fatalf("expected managed_by_aws, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_PrivateWithGrants(t *testing.T) {
+	rec := KMSDecryptReachability{
+		HasKeyPolicy: true,
+		KeyManager:   "CUSTOMER",
+		IdentityGrants: []KMSIdentityGrant{{
+			Effect:       "Allow",
+			PrincipalARN: "arn:aws:iam::123456789012:role/payments",
+			Actions:      []string{"kms:Decrypt"},
+		}},
+	}
+	rec.AccountID = "123456789012"
+	got, _ := classifyKMSKeyExposure(rec)
+	if got != "private_with_grants" {
+		t.Fatalf("expected private_with_grants, got %q", got)
+	}
+}
+
+func TestClassifyKMSKeyExposure_PrivateDefault(t *testing.T) {
+	got, _ := classifyKMSKeyExposure(KMSDecryptReachability{KeyManager: "CUSTOMER"})
+	if got != "private" {
+		t.Fatalf("expected private, got %q", got)
+	}
+}
+
+func TestIsIAMDelegationGrant(t *testing.T) {
+	owner := "123456789012"
+	yes := KMSIdentityGrant{
+		Effect:       "Allow",
+		PrincipalARN: "arn:aws:iam::123456789012:root",
+		Actions:      []string{"kms:*"},
+	}
+	if !isIAMDelegationGrant(yes, owner) {
+		t.Fatalf("expected delegation grant to match")
+	}
+	wrongAccount := yes
+	wrongAccount.PrincipalARN = "arn:aws:iam::999999999999:root"
+	if isIAMDelegationGrant(wrongAccount, owner) {
+		t.Fatalf("delegation must be account-scoped")
+	}
+	conditioned := yes
+	conditioned.HasCondition = true
+	if isIAMDelegationGrant(conditioned, owner) {
+		t.Fatalf("conditional grants must not be delegation")
+	}
+	wildcard := yes
+	wildcard.WildcardPrincipal = true
+	if isIAMDelegationGrant(wildcard, owner) {
+		t.Fatalf("wildcard principal must not be delegation")
+	}
+	narrow := yes
+	narrow.Actions = []string{"kms:Decrypt"}
+	if isIAMDelegationGrant(narrow, owner) {
+		t.Fatalf("narrow actions must not be delegation")
+	}
+}
+
+func TestAnnotateKMSGrants_CrossAccountAndCapabilities(t *testing.T) {
+	out := annotateKMSGrants([]KMSIdentityGrant{{
+		PrincipalARN: "arn:aws:iam::999999999999:role/partner",
+		Effect:       "Allow",
+		Actions:      []string{"kms:Decrypt"},
+	}}, "123456789012")
+	if len(out) != 1 || !out[0].IsCrossAccount {
+		t.Fatalf("expected cross-account flag, got %+v", out)
+	}
+	if len(out[0].Capabilities) != 1 || out[0].Capabilities[0] != "decrypt" {
+		t.Fatalf("expected decrypt capability, got %+v", out[0].Capabilities)
+	}
+}
+
+func TestAnnotateKMSLiveGrants_CrossAccount(t *testing.T) {
+	out := annotateKMSLiveGrants([]KMSGrant{{
+		GranteePrincipal: "arn:aws:iam::999999999999:role/partner",
+		Operations:       []string{"Decrypt"},
+	}}, "123456789012")
+	if len(out) != 1 || !out[0].IsCrossAccount {
+		t.Fatalf("expected cross-account live grant, got %+v", out)
+	}
+	if len(out[0].Capabilities) != 1 || out[0].Capabilities[0] != "decrypt" {
+		t.Fatalf("expected decrypt capability, got %+v", out[0].Capabilities)
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_NormalizesAndDedupes(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	api := &fakeKMSDecryptReachabilityAPI{pages: []KMSDecryptReachabilityPage{
+		{Records: []KMSDecryptReachability{
+			{KeyID: "k1", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/k1"},
+			{KeyID: "k1", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/k1"}, // dup
+			{KeyID: "k2", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/k2"},
+		}, NextToken: "next"},
+		{Records: []KMSDecryptReachability{
+			{KeyID: "k3", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/k3"},
+		}},
+	}}
+	c := NewKMSDecryptReachabilityCollector(api, WithKMSDecryptReachabilityClock(func() time.Time { return now }))
+	assets, diags, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		Service:   "kms",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		TenantID:  "tenant-1",
+	})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 3 {
+		t.Fatalf("expected 3 deduped assets, got %d", len(assets))
+	}
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	var first KMSDecryptReachability
+	if err := json.Unmarshal(assets[0].Payload, &first); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if first.TenantID != "tenant-1" || first.AccountID != "123456789012" {
+		t.Fatalf("scope not propagated: %+v", first)
+	}
+	if assets[0].Kind != rawKindKMSDecryptReachability {
+		t.Fatalf("unexpected raw kind: %s", assets[0].Kind)
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_PageLimitDiagnostic(t *testing.T) {
+	api := &fakeKMSDecryptReachabilityAPI{pages: []KMSDecryptReachabilityPage{
+		{Records: []KMSDecryptReachability{{KeyID: "a", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/a"}}, NextToken: "p2"},
+		{Records: []KMSDecryptReachability{{KeyID: "b", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/b"}}, NextToken: "p3"},
+	}}
+	c := NewKMSDecryptReachabilityCollector(api, WithKMSDecryptReachabilityMaxPages(1))
+	_, diags, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{Service: "kms", AccountID: "123456789012", Region: "us-east-1"})
+	if err == nil {
+		t.Fatalf("expected page-limit error")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Code == "kms_decrypt_reachability_page_limit_exceeded" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected page-limit diagnostic, got %+v", diags)
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_ListErrorPropagates(t *testing.T) {
+	api := &fakeKMSDecryptReachabilityAPI{err: errors.New("boom")}
+	c := NewKMSDecryptReachabilityCollector(api,
+		WithKMSDecryptReachabilityRetryPolicy(RetryPolicy{MaxRetries: 0, BaseDelay: time.Microsecond, MaxDelay: time.Microsecond}),
+		WithKMSDecryptReachabilitySleeper(func(ctx context.Context, _ time.Duration) error { return nil }),
+	)
+	assets, diags, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{Service: "kms"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(assets) != 0 {
+		t.Fatalf("expected no assets, got %d", len(assets))
+	}
+	if len(diags) == 0 {
+		t.Fatalf("expected diagnostic on list failure")
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_SkipsMalformedRecord(t *testing.T) {
+	api := &fakeKMSDecryptReachabilityAPI{pages: []KMSDecryptReachabilityPage{{Records: []KMSDecryptReachability{{}}}}}
+	c := NewKMSDecryptReachabilityCollector(api)
+	assets, diags, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{Service: "kms"})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("expected no assets, got %d", len(assets))
+	}
+	found := false
+	for _, d := range diags {
+		if d.Code == "malformed_kms_decrypt_reachability_record" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected malformed diagnostic, got %+v", diags)
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_NilClient(t *testing.T) {
+	c := NewKMSDecryptReachabilityCollector(nil)
+	if _, _, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{Service: "kms"}); err == nil {
+		t.Fatalf("expected error when client nil")
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_ServiceName(t *testing.T) {
+	c := NewKMSDecryptReachabilityCollector(&fakeKMSDecryptReachabilityAPI{})
+	if c.ServiceName() != "kms" {
+		t.Fatalf("expected service name kms, got %q", c.ServiceName())
+	}
+}
+
+func TestKMSDecryptReachabilityCollector_AcceptsDiagnostics(t *testing.T) {
+	api := &fakeKMSDecryptReachabilityAPI{pages: []KMSDecryptReachabilityPage{{
+		Records: []KMSDecryptReachability{{KeyID: "k1", KeyARN: "arn:aws:kms:us-east-1:123456789012:key/k1"}},
+		Diagnostics: []providers.SourceError{{
+			Collector: kmsDecryptReachabilityCollectorName,
+			SourceID:  "k1",
+			Code:      "kms_list_grants_failed",
+			Message:   "denied",
+		}},
+	}}}
+	c := NewKMSDecryptReachabilityCollector(api)
+	_, diags, err := c.CollectWithDiagnostics(context.Background(), AWSCollectorScope{Service: "kms", AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(diags) != 1 || diags[0].Code != "kms_list_grants_failed" {
+		t.Fatalf("expected collector diagnostic, got %+v", diags)
+	}
+}
+
+func TestKMSKeyARNFromIDPartitionAware(t *testing.T) {
+	cases := []struct {
+		region, partition string
+	}{
+		{"us-east-1", "aws"},
+		{"us-gov-west-1", "aws-us-gov"},
+		{"cn-north-1", "aws-cn"},
+	}
+	for _, tc := range cases {
+		arn := kmsKeyARNFromID("key123", "123456789012", tc.region)
+		if !strings.HasPrefix(arn, "arn:"+tc.partition+":kms:"+tc.region+":") {
+			t.Fatalf("region %q: expected partition %q, got %q", tc.region, tc.partition, arn)
+		}
+	}
+	if got := kmsKeyARNFromID("", "123456789012", "us-east-1"); got != "" {
+		t.Fatalf("expected empty ARN for empty id, got %q", got)
+	}
+}
+
+func TestKMSDecryptReachabilityConfidenceFallback(t *testing.T) {
+	if got := kmsDecryptReachabilityConfidence(KMSDecryptReachability{ExposureClassification: ""}); got != 0.7 {
+		t.Fatalf("expected 0.7 for unknown classification, got %v", got)
+	}
+	if got := kmsDecryptReachabilityConfidence(KMSDecryptReachability{ExposureClassification: "public"}); got != 0.95 {
+		t.Fatalf("expected 0.95 for public, got %v", got)
+	}
+}
+
+func TestCanonicalKMSGrantEffect(t *testing.T) {
+	for in, want := range map[string]string{"allow": "Allow", "DENY": "Deny", "Other": "Other", "": ""} {
+		if got := canonicalKMSGrantEffect(in); got != want {
+			t.Fatalf("canonicalKMSGrantEffect(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/providers/aws/kms_key_policy_parser.go
+++ b/internal/providers/aws/kms_key_policy_parser.go
@@ -1,0 +1,191 @@
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// kmsKeyPolicyDocument is a focused projection of the KMS key-policy grammar
+// the reachability collector needs. KMS key policies share the IAM resource
+// policy grammar with S3 bucket policies, but the action namespace is
+// kms:*, so we keep a separate parser to keep classification rules close to
+// their service semantics.
+type kmsKeyPolicyDocument struct {
+	Version   string               `json:"Version"`
+	ID        string               `json:"Id,omitempty"`
+	Statement kmsKeyPolicyStmtList `json:"Statement"`
+}
+
+type kmsKeyPolicyStmtList []kmsKeyPolicyStatement
+
+type kmsKeyPolicyStatement struct {
+	Sid          string         `json:"Sid,omitempty"`
+	Effect       string         `json:"Effect"`
+	Principal    any            `json:"Principal,omitempty"`
+	NotPrincipal any            `json:"NotPrincipal,omitempty"`
+	Action       any            `json:"Action,omitempty"`
+	NotAction    any            `json:"NotAction,omitempty"`
+	Resource     any            `json:"Resource,omitempty"`
+	NotResource  any            `json:"NotResource,omitempty"`
+	Condition    map[string]any `json:"Condition,omitempty"`
+}
+
+// UnmarshalJSON tolerates both single-object and array Statement forms.
+func (s *kmsKeyPolicyStmtList) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*s = nil
+		return nil
+	}
+	var single kmsKeyPolicyStatement
+	if err := json.Unmarshal(data, &single); err == nil && single.Effect != "" {
+		*s = []kmsKeyPolicyStatement{single}
+		return nil
+	}
+	var many []kmsKeyPolicyStatement
+	if err := json.Unmarshal(data, &many); err == nil {
+		*s = many
+		return nil
+	}
+	return errors.New("invalid kms key policy statement shape")
+}
+
+// parseKMSKeyPolicyGrants returns the inferred identity reachability grants
+// from a key policy, the statement count, and whether the canonical
+// "EnableIAMUserPermissions" delegation statement is present. Empty or
+// absent policies return nil grants, no error.
+func parseKMSKeyPolicyGrants(raw string, ownerAccountID string) ([]KMSIdentityGrant, int, bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, 0, false, nil
+	}
+	decoded := trimmed
+	if strings.Contains(trimmed, "%") {
+		if unescaped, err := url.QueryUnescape(trimmed); err == nil {
+			decoded = unescaped
+		}
+	}
+	var doc kmsKeyPolicyDocument
+	if err := json.Unmarshal([]byte(decoded), &doc); err != nil {
+		return nil, 0, false, err
+	}
+	grants := []KMSIdentityGrant{}
+	iamDelegation := false
+	for _, statement := range doc.Statement {
+		effect := canonicalKMSGrantEffect(statement.Effect)
+		if effect == "" {
+			continue
+		}
+		// NotPrincipal has inverse semantics — listing the excluded principal
+		// as a regular grant would invert the meaning, so we skip the
+		// statement entirely.
+		if statement.Principal == nil && statement.NotPrincipal != nil {
+			continue
+		}
+		principals, principalType, wildcardPrincipal := kmsExtractPrincipals(statement.Principal)
+		if len(principals) == 0 {
+			continue
+		}
+		actions, notAction := kmsExtractActions(statement.Action, statement.NotAction)
+		conditionKeys := kmsCollectConditionKeys(statement.Condition)
+		hasCondition := len(conditionKeys) > 0
+		for _, principal := range principals {
+			grant := KMSIdentityGrant{
+				PrincipalARN:      principal,
+				PrincipalType:     principalType,
+				Effect:            effect,
+				Actions:           actions,
+				NotAction:         notAction,
+				ConditionKeys:     conditionKeys,
+				HasCondition:      hasCondition,
+				StatementSid:      strings.TrimSpace(statement.Sid),
+				WildcardPrincipal: wildcardPrincipal || principal == "*",
+			}
+			if isIAMDelegationGrant(grant, ownerAccountID) {
+				iamDelegation = true
+			}
+			grants = append(grants, grant)
+		}
+	}
+	return grants, len(doc.Statement), iamDelegation, nil
+}
+
+// kmsExtractPrincipals returns the principal ARN list along with the
+// principal type and whether a wildcard principal is present.
+func kmsExtractPrincipals(principal any) (principals []string, principalType string, wildcardPrincipal bool) {
+	if principal == nil {
+		return nil, "", false
+	}
+	return kmsPrincipalsFromAny(principal)
+}
+
+func kmsPrincipalsFromAny(value any) ([]string, string, bool) {
+	switch typed := value.(type) {
+	case string:
+		if typed == "*" {
+			return []string{"*"}, "*", true
+		}
+		return []string{typed}, "aws", false
+	case map[string]any:
+		// KMS key policies use {"AWS": ARN[]}, {"Service": "ec2.amazonaws.com"},
+		// {"Federated": "..."}, {"CanonicalUser": "..."}.
+		for _, key := range []string{"AWS", "Service", "Federated", "CanonicalUser"} {
+			if raw, ok := typed[key]; ok {
+				values := parseStringList(raw)
+				wildcard := false
+				for _, value := range values {
+					if value == "*" {
+						wildcard = true
+						break
+					}
+				}
+				return values, strings.ToLower(key), wildcard
+			}
+		}
+	}
+	return nil, "", false
+}
+
+func kmsExtractActions(action, notAction any) ([]string, bool) {
+	if list := parseStringList(action); len(list) > 0 {
+		return list, false
+	}
+	if list := parseStringList(notAction); len(list) > 0 {
+		return list, true
+	}
+	return nil, false
+}
+
+// kmsCollectConditionKeys returns every condition key found in the
+// statement. The keys are returned sorted so the API output is
+// deterministic.
+func kmsCollectConditionKeys(condition map[string]any) []string {
+	if len(condition) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, body := range condition {
+		bodyMap, ok := body.(map[string]any)
+		if !ok {
+			continue
+		}
+		for key := range bodyMap {
+			trimmed := strings.TrimSpace(key)
+			if trimmed == "" {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for key := range seen {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/providers/aws/kms_key_policy_parser.go
+++ b/internal/providers/aws/kms_key_policy_parser.go
@@ -84,7 +84,7 @@ func parseKMSKeyPolicyGrants(raw string, ownerAccountID string) ([]KMSIdentityGr
 		if statement.Principal == nil && statement.NotPrincipal != nil {
 			continue
 		}
-		principals, principalType, wildcardPrincipal := kmsExtractPrincipals(statement.Principal)
+		principals := kmsExtractPrincipals(statement.Principal)
 		if len(principals) == 0 {
 			continue
 		}
@@ -96,15 +96,15 @@ func parseKMSKeyPolicyGrants(raw string, ownerAccountID string) ([]KMSIdentityGr
 		hasCondition := len(conditionKeys) > 0
 		for _, principal := range principals {
 			grant := KMSIdentityGrant{
-				PrincipalARN:      principal,
-				PrincipalType:     principalType,
+				PrincipalARN:      principal.Value,
+				PrincipalType:     principal.Type,
 				Effect:            effect,
 				Actions:           actions,
 				NotAction:         notAction,
 				ConditionKeys:     conditionKeys,
 				HasCondition:      hasCondition,
 				StatementSid:      strings.TrimSpace(statement.Sid),
-				WildcardPrincipal: wildcardPrincipal || principal == "*",
+				WildcardPrincipal: principal.Wildcard,
 			}
 			if isIAMDelegationGrant(grant, ownerAccountID) {
 				iamDelegation = true
@@ -115,61 +115,62 @@ func parseKMSKeyPolicyGrants(raw string, ownerAccountID string) ([]KMSIdentityGr
 	return grants, len(doc.Statement), iamDelegation, nil
 }
 
-// kmsExtractPrincipals returns the principal ARN list along with the
-// principal type and whether a wildcard principal is present.
-func kmsExtractPrincipals(principal any) (principals []string, principalType string, wildcardPrincipal bool) {
+type kmsParsedPrincipal struct {
+	Value    string
+	Type     string
+	Wildcard bool
+}
+
+func kmsExtractPrincipals(principal any) []kmsParsedPrincipal {
 	if principal == nil {
-		return nil, "", false
+		return nil
 	}
 	return kmsPrincipalsFromAny(principal)
 }
 
-func kmsPrincipalsFromAny(value any) ([]string, string, bool) {
+func kmsPrincipalsFromAny(value any) []kmsParsedPrincipal {
 	switch typed := value.(type) {
 	case string:
 		if typed == "*" {
-			return []string{"*"}, "*", true
+			return []kmsParsedPrincipal{{Value: "*", Type: "*", Wildcard: true}}
 		}
-		return []string{typed}, "aws", false
+		return []kmsParsedPrincipal{{Value: typed, Type: "aws"}}
 	case map[string]any:
 		// KMS key policies use {"AWS": ARN[]}, {"Service": "ec2.amazonaws.com"},
 		// {"Federated": "..."}, {"CanonicalUser": "..."}.
-		out := []string{}
-		principalType := ""
-		wildcard := false
+		out := []kmsParsedPrincipal{}
 		for _, key := range []string{"AWS", "Service", "Federated", "CanonicalUser"} {
 			if raw, ok := typed[key]; ok {
+				principalType := strings.ToLower(key)
 				values := parseStringList(raw)
 				for _, value := range values {
-					if value == "*" {
-						wildcard = true
-					}
-				}
-				if len(values) > 0 {
-					out = append(out, values...)
-					keyType := strings.ToLower(key)
-					if principalType == "" {
-						principalType = keyType
-					} else if principalType != keyType {
-						principalType = "mixed"
-					}
+					out = append(out, kmsParsedPrincipal{
+						Value:    value,
+						Type:     principalType,
+						Wildcard: value == "*",
+					})
 				}
 			}
 		}
 		if len(out) > 0 {
-			sort.Strings(out)
-			return out, principalType, wildcard
+			sort.Slice(out, func(i, j int) bool {
+				if out[i].Value == out[j].Value {
+					return out[i].Type < out[j].Type
+				}
+				return out[i].Value < out[j].Value
+			})
+			return out
 		}
 		if raw, ok := typed["*"]; ok {
 			values := parseStringList(raw)
 			for _, value := range values {
 				if value == "*" {
-					return []string{"*"}, "*", true
+					return []kmsParsedPrincipal{{Value: "*", Type: "*", Wildcard: true}}
 				}
 			}
 		}
 	}
-	return nil, "", false
+	return nil
 }
 
 func kmsExtractActions(action, notAction any) ([]string, bool) {

--- a/internal/providers/aws/kms_key_policy_parser.go
+++ b/internal/providers/aws/kms_key_policy_parser.go
@@ -89,6 +89,9 @@ func parseKMSKeyPolicyGrants(raw string, ownerAccountID string) ([]KMSIdentityGr
 			continue
 		}
 		actions, notAction := kmsExtractActions(statement.Action, statement.NotAction)
+		if notAction {
+			continue
+		}
 		conditionKeys := kmsCollectConditionKeys(statement.Condition)
 		hasCondition := len(conditionKeys) > 0
 		for _, principal := range principals {
@@ -131,17 +134,38 @@ func kmsPrincipalsFromAny(value any) ([]string, string, bool) {
 	case map[string]any:
 		// KMS key policies use {"AWS": ARN[]}, {"Service": "ec2.amazonaws.com"},
 		// {"Federated": "..."}, {"CanonicalUser": "..."}.
+		out := []string{}
+		principalType := ""
+		wildcard := false
 		for _, key := range []string{"AWS", "Service", "Federated", "CanonicalUser"} {
 			if raw, ok := typed[key]; ok {
 				values := parseStringList(raw)
-				wildcard := false
 				for _, value := range values {
 					if value == "*" {
 						wildcard = true
-						break
 					}
 				}
-				return values, strings.ToLower(key), wildcard
+				if len(values) > 0 {
+					out = append(out, values...)
+					keyType := strings.ToLower(key)
+					if principalType == "" {
+						principalType = keyType
+					} else if principalType != keyType {
+						principalType = "mixed"
+					}
+				}
+			}
+		}
+		if len(out) > 0 {
+			sort.Strings(out)
+			return out, principalType, wildcard
+		}
+		if raw, ok := typed["*"]; ok {
+			values := parseStringList(raw)
+			for _, value := range values {
+				if value == "*" {
+					return []string{"*"}, "*", true
+				}
 			}
 		}
 	}

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -199,6 +199,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		}
 	}
 
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+		if asset.Kind != rawKindKMSDecryptReachability {
+			continue
+		}
+		if err := normalizeKMSDecryptReachabilityAsset(asset, i, &bundle, identitySeen, resourceSeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
 	return bundle, nil
 }
 
@@ -2031,6 +2043,144 @@ func s3DenyGrantCount(grants []S3IdentityGrant) int {
 	count := 0
 	for _, grant := range grants {
 		if strings.EqualFold(grant.Effect, "Deny") {
+			count++
+		}
+	}
+	return count
+}
+
+// normalizeKMSDecryptReachabilityAsset registers the KMS key as a Resource
+// (with exposure + rotation metadata) and projects concrete IAM-principal
+// grants — both key-policy and live KMS grants — as Identity nodes so the
+// graph can render principal→key reachability. Wildcard ("*"), service,
+// federated, and canonical-user principals stay as resource metadata only;
+// the graph does not synthesize a fake identity for "*" or a service-name
+// string.
+func normalizeKMSDecryptReachabilityAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, identitySeen map[string]struct{}, resourceSeen map[string]struct{}) error {
+	var record KMSDecryptReachability
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode kms decrypt reachability asset[%d]: %w", index, err)
+	}
+	keyARN := strings.TrimSpace(record.KeyARN)
+	if keyARN == "" {
+		return nil
+	}
+	resourceID := kmsKeyResourceID(keyARN)
+	if _, exists := resourceSeen[resourceID]; !exists {
+		resourceSeen[resourceID] = struct{}{}
+		bundle.Resources = append(bundle.Resources, domain.Resource{
+			ID:        resourceID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.ResourceTypeKMSKey,
+			Name:      firstNonEmptyAWSValue(record.KeyID, keyARN),
+			ARN:       keyARN,
+			Region:    strings.TrimSpace(record.Region),
+			AccountID: strings.TrimSpace(record.AccountID),
+			Labels:    copyTags(record.Tags),
+			Metadata: map[string]any{
+				"key_manager":                    record.KeyManager,
+				"key_state":                      record.KeyState,
+				"key_usage":                      record.KeyUsage,
+				"key_spec":                       record.KeySpec,
+				"origin":                         record.Origin,
+				"enabled":                        record.Enabled,
+				"multi_region":                   record.MultiRegion,
+				"multi_region_primary":           record.MultiRegionPrimary,
+				"replica_key_count":              len(record.ReplicaKeyARNs),
+				"primary_key_arn":                record.PrimaryKeyARN,
+				"rotation_supported":             record.RotationSupported,
+				"rotation_enabled":               record.RotationEnabled,
+				"aliases":                        append([]string(nil), record.Aliases...),
+				"has_key_policy":                 record.HasKeyPolicy,
+				"key_policy_statement_count":     record.KeyPolicyStatementCount,
+				"iam_delegation_enabled":         record.IAMDelegationEnabled,
+				"exposure_classification":        record.ExposureClassification,
+				"exposure_reasons":               append([]string(nil), record.ExposureReasons...),
+				"identity_grant_count":           len(record.IdentityGrants),
+				"public_grant_count":             kmsPublicGrantCount(record.IdentityGrants),
+				"cross_account_grant_count":      kmsCrossAccountGrantCount(record.IdentityGrants),
+				"deny_grant_count":               kmsDenyGrantCount(record.IdentityGrants),
+				"live_grant_count":               len(record.Grants),
+				"cross_account_live_grant_count": kmsCrossAccountLiveGrantCount(record.Grants),
+			},
+			RawRef: asset.SourceID,
+		})
+	}
+
+	// Project each concrete IAM principal as an Identity for the graph.
+	project := func(principal string) {
+		principal = strings.TrimSpace(principal)
+		if principal == "" || principal == "*" {
+			return
+		}
+		if !isIAMRoleARN(principal) && !isIAMUserARN(principal) {
+			return
+		}
+		identityID := identityIDFromARN(principal)
+		if _, exists := identitySeen[identityID]; exists {
+			return
+		}
+		identitySeen[identityID] = struct{}{}
+		identityType := domain.IdentityTypeRole
+		if isIAMUserARN(principal) {
+			identityType = domain.IdentityTypeUser
+		}
+		bundle.Identities = append(bundle.Identities, domain.Identity{
+			ID:       identityID,
+			Provider: domain.ProviderAWS,
+			Type:     identityType,
+			Name:     roleNameFromARN(principal),
+			ARN:      principal,
+			RawRef:   asset.SourceID,
+		})
+	}
+	for _, grant := range record.IdentityGrants {
+		project(grant.PrincipalARN)
+	}
+	for _, grant := range record.Grants {
+		project(grant.GranteePrincipal)
+	}
+	return nil
+}
+
+func kmsKeyResourceID(keyARN string) string {
+	return "aws:resource:kms-key:" + strings.TrimSpace(keyARN)
+}
+
+func kmsPublicGrantCount(grants []KMSIdentityGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if grant.IsPublic {
+			count++
+		}
+	}
+	return count
+}
+
+func kmsCrossAccountGrantCount(grants []KMSIdentityGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if grant.IsCrossAccount {
+			count++
+		}
+	}
+	return count
+}
+
+func kmsDenyGrantCount(grants []KMSIdentityGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			count++
+		}
+	}
+	return count
+}
+
+func kmsCrossAccountLiveGrantCount(grants []KMSGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if grant.IsCrossAccount {
 			count++
 		}
 	}

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -1948,30 +1948,7 @@ func normalizeS3BucketReachabilityAsset(asset providers.RawAsset, index int, bun
 	// Project each concrete IAM principal as an Identity so the graph
 	// surfaces principal→bucket reachability for downstream traversals.
 	for _, grant := range record.IdentityGrants {
-		principal := strings.TrimSpace(grant.PrincipalARN)
-		if principal == "" || principal == "*" {
-			continue
-		}
-		if !isIAMRoleARN(principal) && !isIAMUserARN(principal) {
-			continue
-		}
-		identityID := identityIDFromARN(principal)
-		if _, exists := identitySeen[identityID]; exists {
-			continue
-		}
-		identitySeen[identityID] = struct{}{}
-		identityType := domain.IdentityTypeRole
-		if isIAMUserARN(principal) {
-			identityType = domain.IdentityTypeUser
-		}
-		bundle.Identities = append(bundle.Identities, domain.Identity{
-			ID:       identityID,
-			Provider: domain.ProviderAWS,
-			Type:     identityType,
-			Name:     roleNameFromARN(principal),
-			ARN:      principal,
-			RawRef:   asset.SourceID,
-		})
+		projectAWSIAMPrincipalIdentity(bundle, identitySeen, grant.PrincipalARN, asset.SourceID)
 	}
 	return nil
 }
@@ -2108,39 +2085,40 @@ func normalizeKMSDecryptReachabilityAsset(asset providers.RawAsset, index int, b
 	}
 
 	// Project each concrete IAM principal as an Identity for the graph.
-	project := func(principal string) {
-		principal = strings.TrimSpace(principal)
-		if principal == "" || principal == "*" {
-			return
-		}
-		if !isIAMRoleARN(principal) && !isIAMUserARN(principal) {
-			return
-		}
-		identityID := identityIDFromARN(principal)
-		if _, exists := identitySeen[identityID]; exists {
-			return
-		}
-		identitySeen[identityID] = struct{}{}
-		identityType := domain.IdentityTypeRole
-		if isIAMUserARN(principal) {
-			identityType = domain.IdentityTypeUser
-		}
-		bundle.Identities = append(bundle.Identities, domain.Identity{
-			ID:       identityID,
-			Provider: domain.ProviderAWS,
-			Type:     identityType,
-			Name:     roleNameFromARN(principal),
-			ARN:      principal,
-			RawRef:   asset.SourceID,
-		})
-	}
 	for _, grant := range record.IdentityGrants {
-		project(grant.PrincipalARN)
+		projectAWSIAMPrincipalIdentity(bundle, identitySeen, grant.PrincipalARN, asset.SourceID)
 	}
 	for _, grant := range record.Grants {
-		project(grant.GranteePrincipal)
+		projectAWSIAMPrincipalIdentity(bundle, identitySeen, grant.GranteePrincipal, asset.SourceID)
 	}
 	return nil
+}
+
+func projectAWSIAMPrincipalIdentity(bundle *providers.NormalizedBundle, identitySeen map[string]struct{}, principal string, rawRef string) {
+	principal = strings.TrimSpace(principal)
+	if principal == "" || principal == "*" {
+		return
+	}
+	if !isIAMRoleARN(principal) && !isIAMUserARN(principal) {
+		return
+	}
+	identityID := identityIDFromARN(principal)
+	if _, exists := identitySeen[identityID]; exists {
+		return
+	}
+	identitySeen[identityID] = struct{}{}
+	identityType := domain.IdentityTypeRole
+	if isIAMUserARN(principal) {
+		identityType = domain.IdentityTypeUser
+	}
+	bundle.Identities = append(bundle.Identities, domain.Identity{
+		ID:       identityID,
+		Provider: domain.ProviderAWS,
+		Type:     identityType,
+		Name:     roleNameFromARN(principal),
+		ARN:      principal,
+		RawRef:   rawRef,
+	})
 }
 
 func kmsKeyResourceID(keyARN string) string {

--- a/internal/providers/aws/sdk_kms_decrypt_reachability.go
+++ b/internal/providers/aws/sdk_kms_decrypt_reachability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
@@ -203,11 +204,12 @@ func (a *SDKKMSDecryptReachabilityAPI) enrichDescribeKey(ctx context.Context, ke
 			}
 		}
 	}
-	// Symmetric customer-managed keys with AWS_KMS or EXTERNAL origin support
-	// rotation; everything else does not.
+	// Symmetric customer-managed keys with AWS_KMS origin support automatic
+	// rotation. Imported EXTERNAL-origin key material is not automatically
+	// rotation-capable.
 	if strings.EqualFold(string(meta.KeyManager), "CUSTOMER") &&
 		strings.EqualFold(string(meta.KeySpec), "SYMMETRIC_DEFAULT") &&
-		(strings.EqualFold(string(meta.Origin), "AWS_KMS") || strings.EqualFold(string(meta.Origin), "EXTERNAL")) {
+		strings.EqualFold(string(meta.Origin), "AWS_KMS") {
 		record.RotationSupported = true
 	}
 }
@@ -388,6 +390,8 @@ func kmsGrantFromSDK(entry kmstypes.GrantListEntry) KMSGrant {
 		for k := range entry.Constraints.EncryptionContextSubset {
 			g.EncryptionContextSubsetKeys = append(g.EncryptionContextSubsetKeys, k)
 		}
+		sort.Strings(g.EncryptionContextKeys)
+		sort.Strings(g.EncryptionContextSubsetKeys)
 	}
 	if entry.CreationDate != nil {
 		g.CreatedAt = entry.CreationDate.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/providers/aws/sdk_kms_decrypt_reachability.go
+++ b/internal/providers/aws/sdk_kms_decrypt_reachability.go
@@ -1,0 +1,436 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+// KMSSDKClient is the narrow seam between the AWS SDK KMS client and the
+// reachability collector. Only metadata-only and policy/grant inspection
+// calls are exposed; encrypt/decrypt/sign/verify APIs are deliberately
+// absent so the collector cannot accidentally invoke cryptographic
+// operations.
+type KMSSDKClient interface {
+	ListKeys(ctx context.Context, params *kms.ListKeysInput, optFns ...func(*kms.Options)) (*kms.ListKeysOutput, error)
+	DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+	GetKeyPolicy(ctx context.Context, params *kms.GetKeyPolicyInput, optFns ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error)
+	GetKeyRotationStatus(ctx context.Context, params *kms.GetKeyRotationStatusInput, optFns ...func(*kms.Options)) (*kms.GetKeyRotationStatusOutput, error)
+	ListAliases(ctx context.Context, params *kms.ListAliasesInput, optFns ...func(*kms.Options)) (*kms.ListAliasesOutput, error)
+	ListGrants(ctx context.Context, params *kms.ListGrantsInput, optFns ...func(*kms.Options)) (*kms.ListGrantsOutput, error)
+	ListResourceTags(ctx context.Context, params *kms.ListResourceTagsInput, optFns ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error)
+}
+
+// SDKKMSDecryptReachabilityAPI implements the collector seam against the
+// AWS SDK. Every read is metadata-only: ListKeys + per-key
+// Describe/GetKeyPolicy/ListGrants/ListAliases/ListResourceTags.
+type SDKKMSDecryptReachabilityAPI struct {
+	client    KMSSDKClient
+	accountID string
+	region    string
+}
+
+var _ KMSDecryptReachabilityAPI = (*SDKKMSDecryptReachabilityAPI)(nil)
+
+// NewSDKKMSDecryptReachabilityAPI constructs the SDK-backed API using
+// ambient AWS credentials.
+func NewSDKKMSDecryptReachabilityAPI(region string, profile string, accountID string) (KMSDecryptReachabilityAPI, error) {
+	return NewSDKKMSDecryptReachabilityAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+// NewSDKKMSDecryptReachabilityAPIWithContext constructs the SDK-backed API
+// using the supplied context for config loading.
+func NewSDKKMSDecryptReachabilityAPIWithContext(ctx context.Context, region string, profile string, accountID string) (KMSDecryptReachabilityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := kmsDecryptReachabilityAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKKMSDecryptReachabilityAPIFromClient(kms.NewFromConfig(cfg), resolved, resolvedRegion), nil
+}
+
+// NewSDKKMSDecryptReachabilityAPIFromAssumeRole constructs the SDK-backed
+// API after assuming the supplied connector role.
+func NewSDKKMSDecryptReachabilityAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (KMSDecryptReachabilityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolved, err := kmsDecryptReachabilityAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKKMSDecryptReachabilityAPIFromClient(kms.NewFromConfig(cfg), resolved, resolvedRegion), nil
+}
+
+// NewSDKKMSDecryptReachabilityAPIFromClient is the seam tests use to inject
+// a fake KMS client.
+func NewSDKKMSDecryptReachabilityAPIFromClient(client KMSSDKClient, accountID string, region string) KMSDecryptReachabilityAPI {
+	return &SDKKMSDecryptReachabilityAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+// ListKMSKeyReachability enumerates one page of KMS keys (using the SDK's
+// native pagination via Marker/NextMarker), describes each key, and folds
+// in policy + grant + alias + tag metadata. Aliases are pre-fetched once
+// per page-call to avoid an N+1 ListAliases-per-key.
+func (a *SDKKMSDecryptReachabilityAPI) ListKMSKeyReachability(ctx context.Context, nextToken string, pageSize int32) (KMSDecryptReachabilityPage, error) {
+	if a.client == nil {
+		return KMSDecryptReachabilityPage{}, errors.New("kms SDK client is required")
+	}
+	limit := pageSize
+	if limit <= 0 {
+		limit = defaultPageSize
+	}
+	listOutput, err := a.client.ListKeys(ctx, &kms.ListKeysInput{
+		Limit:  awsv2.Int32(limit),
+		Marker: stringPtrOrNil(nextToken),
+	})
+	if err != nil {
+		return KMSDecryptReachabilityPage{}, err
+	}
+	if listOutput == nil {
+		return KMSDecryptReachabilityPage{}, nil
+	}
+	diagnostics := []providers.SourceError{}
+	// Pre-fetch every alias in the account once per page. ListAliases is
+	// paginated separately, but the cost is paid once instead of once per
+	// key in the page.
+	aliasesByKey, aliasDiagnostics := a.fetchAliasesByKey(ctx)
+	diagnostics = append(diagnostics, aliasDiagnostics...)
+
+	records := []KMSDecryptReachability{}
+	for _, summary := range listOutput.Keys {
+		keyID := strings.TrimSpace(awsv2.ToString(summary.KeyId))
+		keyARN := strings.TrimSpace(awsv2.ToString(summary.KeyArn))
+		if keyID == "" && keyARN == "" {
+			diagnostics = append(diagnostics, kmsDecryptReachabilityDiagnostic("kms_key_id_missing", "listkeys", "KMS key summary did not include an id or arn", false))
+			continue
+		}
+		record := KMSDecryptReachability{KeyID: keyID, KeyARN: keyARN}
+		record.Region = a.region
+		a.enrichDescribeKey(ctx, keyID, keyARN, &record, &diagnostics)
+		// Use whichever id flavor DescribeKey produced for the rest of the
+		// per-key calls.
+		callID := firstNonEmptyAWSValue(record.KeyID, keyID, keyARN)
+		a.enrichKeyPolicy(ctx, callID, &record, &diagnostics)
+		a.enrichKeyRotation(ctx, callID, &record, &diagnostics)
+		a.enrichGrants(ctx, callID, &record, &diagnostics)
+		a.enrichTags(ctx, callID, &record, &diagnostics)
+		if list, ok := aliasesByKey[strings.TrimSpace(record.KeyID)]; ok {
+			record.Aliases = list
+		}
+		records = append(records, record)
+	}
+	return KMSDecryptReachabilityPage{
+		Records:     records,
+		NextToken:   strings.TrimSpace(awsv2.ToString(listOutput.NextMarker)),
+		Diagnostics: diagnostics,
+	}, nil
+}
+
+func (a *SDKKMSDecryptReachabilityAPI) enrichDescribeKey(ctx context.Context, keyID string, keyARN string, record *KMSDecryptReachability, diagnostics *[]providers.SourceError) {
+	id := firstNonEmptyAWSValue(keyARN, keyID)
+	output, err := a.client.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: awsv2.String(id)})
+	if err != nil {
+		*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_describe_key_failed", id, fmt.Sprintf("DescribeKey %q failed: %v", id, err), true))
+		return
+	}
+	if output == nil || output.KeyMetadata == nil {
+		return
+	}
+	meta := output.KeyMetadata
+	record.KeyID = strings.TrimSpace(awsv2.ToString(meta.KeyId))
+	record.KeyARN = strings.TrimSpace(awsv2.ToString(meta.Arn))
+	record.AccountID = strings.TrimSpace(awsv2.ToString(meta.AWSAccountId))
+	record.KeyManager = string(meta.KeyManager)
+	record.KeyState = string(meta.KeyState)
+	record.KeyUsage = string(meta.KeyUsage)
+	record.KeySpec = string(meta.KeySpec)
+	record.Origin = string(meta.Origin)
+	record.Description = strings.TrimSpace(awsv2.ToString(meta.Description))
+	record.Enabled = meta.Enabled
+	if meta.CreationDate != nil {
+		record.CreatedAt = meta.CreationDate.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if meta.DeletionDate != nil {
+		record.DeletionDate = meta.DeletionDate.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if meta.MultiRegion != nil && *meta.MultiRegion {
+		record.MultiRegion = true
+		if meta.MultiRegionConfiguration != nil {
+			record.MultiRegionPrimary = strings.EqualFold(string(meta.MultiRegionConfiguration.MultiRegionKeyType), "PRIMARY")
+			if meta.MultiRegionConfiguration.PrimaryKey != nil {
+				record.PrimaryKeyARN = strings.TrimSpace(awsv2.ToString(meta.MultiRegionConfiguration.PrimaryKey.Arn))
+			}
+			for _, replica := range meta.MultiRegionConfiguration.ReplicaKeys {
+				if arn := strings.TrimSpace(awsv2.ToString(replica.Arn)); arn != "" {
+					record.ReplicaKeyARNs = append(record.ReplicaKeyARNs, arn)
+				}
+			}
+		}
+	}
+	// Symmetric customer-managed keys with AWS_KMS or EXTERNAL origin support
+	// rotation; everything else does not.
+	if strings.EqualFold(string(meta.KeyManager), "CUSTOMER") &&
+		strings.EqualFold(string(meta.KeySpec), "SYMMETRIC_DEFAULT") &&
+		(strings.EqualFold(string(meta.Origin), "AWS_KMS") || strings.EqualFold(string(meta.Origin), "EXTERNAL")) {
+		record.RotationSupported = true
+	}
+}
+
+func (a *SDKKMSDecryptReachabilityAPI) enrichKeyPolicy(ctx context.Context, keyID string, record *KMSDecryptReachability, diagnostics *[]providers.SourceError) {
+	if keyID == "" {
+		return
+	}
+	output, err := a.client.GetKeyPolicy(ctx, &kms.GetKeyPolicyInput{KeyId: awsv2.String(keyID), PolicyName: awsv2.String("default")})
+	if err != nil {
+		*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_key_policy_failed", keyID, fmt.Sprintf("GetKeyPolicy %q failed: %v", keyID, err), true))
+		return
+	}
+	if output == nil || output.Policy == nil {
+		return
+	}
+	record.HasKeyPolicy = true
+	grants, statementCount, iamDelegation, parseErr := parseKMSKeyPolicyGrants(awsv2.ToString(output.Policy), strings.TrimSpace(record.AccountID))
+	if parseErr != nil {
+		*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_key_policy_parse_failed", keyID, fmt.Sprintf("parse key policy %q: %v", keyID, parseErr), false))
+		return
+	}
+	record.KeyPolicyStatementCount = statementCount
+	record.IdentityGrants = grants
+	record.IAMDelegationEnabled = iamDelegation
+}
+
+func (a *SDKKMSDecryptReachabilityAPI) enrichKeyRotation(ctx context.Context, keyID string, record *KMSDecryptReachability, diagnostics *[]providers.SourceError) {
+	if keyID == "" {
+		return
+	}
+	output, err := a.client.GetKeyRotationStatus(ctx, &kms.GetKeyRotationStatusInput{KeyId: awsv2.String(keyID)})
+	if err != nil {
+		if kmsIsRotationUnsupported(err) {
+			return
+		}
+		*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_key_rotation_failed", keyID, fmt.Sprintf("GetKeyRotationStatus %q failed: %v", keyID, err), true))
+		return
+	}
+	if output == nil {
+		return
+	}
+	record.RotationEnabled = output.KeyRotationEnabled
+}
+
+func (a *SDKKMSDecryptReachabilityAPI) enrichGrants(ctx context.Context, keyID string, record *KMSDecryptReachability, diagnostics *[]providers.SourceError) {
+	if keyID == "" {
+		return
+	}
+	nextToken := ""
+	for page := 1; ; page++ {
+		if page > defaultMaxPages {
+			*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_grants_page_limit_exceeded", keyID, fmt.Sprintf("ListGrants paginated beyond max pages for %q", keyID), false))
+			return
+		}
+		output, err := a.client.ListGrants(ctx, &kms.ListGrantsInput{
+			KeyId:  awsv2.String(keyID),
+			Marker: stringPtrOrNil(nextToken),
+		})
+		if err != nil {
+			*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_grants_failed", keyID, fmt.Sprintf("ListGrants %q failed: %v", keyID, err), true))
+			return
+		}
+		if output == nil {
+			return
+		}
+		for _, entry := range output.Grants {
+			record.Grants = append(record.Grants, kmsGrantFromSDK(entry))
+		}
+		nextToken = strings.TrimSpace(awsv2.ToString(output.NextMarker))
+		if nextToken == "" {
+			return
+		}
+	}
+}
+
+func (a *SDKKMSDecryptReachabilityAPI) enrichTags(ctx context.Context, keyID string, record *KMSDecryptReachability, diagnostics *[]providers.SourceError) {
+	if keyID == "" {
+		return
+	}
+	nextToken := ""
+	tags := map[string]string{}
+	for page := 1; ; page++ {
+		if page > defaultMaxPages {
+			*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_tags_page_limit_exceeded", keyID, fmt.Sprintf("ListResourceTags paginated beyond max pages for %q", keyID), false))
+			break
+		}
+		output, err := a.client.ListResourceTags(ctx, &kms.ListResourceTagsInput{
+			KeyId:  awsv2.String(keyID),
+			Marker: stringPtrOrNil(nextToken),
+		})
+		if err != nil {
+			*diagnostics = append(*diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_tags_failed", keyID, fmt.Sprintf("ListResourceTags %q failed: %v", keyID, err), true))
+			break
+		}
+		if output == nil {
+			break
+		}
+		for _, tag := range output.Tags {
+			key := strings.TrimSpace(awsv2.ToString(tag.TagKey))
+			if key == "" {
+				continue
+			}
+			tags[key] = strings.TrimSpace(awsv2.ToString(tag.TagValue))
+		}
+		nextToken = strings.TrimSpace(awsv2.ToString(output.NextMarker))
+		if nextToken == "" {
+			break
+		}
+	}
+	if len(tags) > 0 {
+		record.Tags = tags
+	}
+}
+
+// fetchAliasesByKey pulls every alias in the account once and indexes them
+// by TargetKeyId. We only surface alias *names*, never alias ARNs, since
+// the ARN is a deterministic projection of the name.
+func (a *SDKKMSDecryptReachabilityAPI) fetchAliasesByKey(ctx context.Context) (map[string][]string, []providers.SourceError) {
+	if a.client == nil {
+		return map[string][]string{}, nil
+	}
+	out := map[string][]string{}
+	diagnostics := []providers.SourceError{}
+	nextToken := ""
+	for page := 1; ; page++ {
+		if page > defaultMaxPages {
+			diagnostics = append(diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_aliases_page_limit_exceeded", "listaliases", "ListAliases paginated beyond max pages", false))
+			break
+		}
+		output, err := a.client.ListAliases(ctx, &kms.ListAliasesInput{Marker: stringPtrOrNil(nextToken)})
+		if err != nil {
+			diagnostics = append(diagnostics, kmsDecryptReachabilityDiagnostic("kms_list_aliases_failed", "listaliases", fmt.Sprintf("ListAliases failed: %v", err), true))
+			break
+		}
+		if output == nil {
+			break
+		}
+		for _, alias := range output.Aliases {
+			name := strings.TrimSpace(awsv2.ToString(alias.AliasName))
+			target := strings.TrimSpace(awsv2.ToString(alias.TargetKeyId))
+			if name == "" || target == "" {
+				continue
+			}
+			out[target] = append(out[target], name)
+		}
+		nextToken = strings.TrimSpace(awsv2.ToString(output.NextMarker))
+		if nextToken == "" {
+			break
+		}
+	}
+	return out, diagnostics
+}
+
+func kmsGrantFromSDK(entry kmstypes.GrantListEntry) KMSGrant {
+	g := KMSGrant{
+		GrantID:           strings.TrimSpace(awsv2.ToString(entry.GrantId)),
+		Name:              strings.TrimSpace(awsv2.ToString(entry.Name)),
+		GranteePrincipal:  strings.TrimSpace(awsv2.ToString(entry.GranteePrincipal)),
+		RetiringPrincipal: strings.TrimSpace(awsv2.ToString(entry.RetiringPrincipal)),
+		IssuingAccount:    strings.TrimSpace(awsv2.ToString(entry.IssuingAccount)),
+	}
+	if entry.GranteeServicePrincipal != nil && strings.TrimSpace(*entry.GranteeServicePrincipal) != "" {
+		g.GranteePrincipalType = "service"
+		if g.GranteePrincipal == "" {
+			g.GranteePrincipal = strings.TrimSpace(*entry.GranteeServicePrincipal)
+		}
+	} else if g.GranteePrincipal != "" {
+		g.GranteePrincipalType = "aws"
+	}
+	for _, op := range entry.Operations {
+		g.Operations = append(g.Operations, string(op))
+	}
+	if entry.Constraints != nil {
+		for k := range entry.Constraints.EncryptionContextEquals {
+			g.EncryptionContextKeys = append(g.EncryptionContextKeys, k)
+		}
+		for k := range entry.Constraints.EncryptionContextSubset {
+			g.EncryptionContextSubsetKeys = append(g.EncryptionContextSubsetKeys, k)
+		}
+	}
+	if entry.CreationDate != nil {
+		g.CreatedAt = entry.CreationDate.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return g
+}
+
+func kmsDecryptReachabilityDiagnostic(code string, sourceID string, message string, retryable bool) providers.SourceError {
+	return providers.SourceError{
+		Collector: kmsDecryptReachabilityCollectorName,
+		SourceID:  strings.TrimSpace(sourceID),
+		Code:      strings.TrimSpace(code),
+		Message:   strings.TrimSpace(message),
+		Retryable: retryable,
+	}
+}
+
+func kmsDecryptReachabilityAccountID(ctx context.Context, cfg awsv2.Config, accountID string) (string, error) {
+	trimmed := strings.TrimSpace(accountID)
+	if trimmed != "" {
+		return trimmed, nil
+	}
+	identity, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("read AWS caller identity for kms account id: %w", err)
+	}
+	resolved := strings.TrimSpace(awsv2.ToString(identity.Account))
+	if resolved == "" {
+		return "", fmt.Errorf("read AWS caller identity for kms account id: empty account id")
+	}
+	return resolved, nil
+}
+
+// kmsIsRotationUnsupported recognises the AWS error returned when
+// GetKeyRotationStatus is called on a key type that does not support
+// rotation (asymmetric, HMAC, multi-region replica, etc.). It is not a
+// diagnostic — the absence of rotation is expected for those key types.
+func kmsIsRotationUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unsupportedoperationexception") ||
+		strings.Contains(msg, "kms key with arn") && strings.Contains(msg, "does not support") ||
+		strings.Contains(msg, "is not supported for")
+}

--- a/internal/providers/aws/sdk_kms_decrypt_reachability_test.go
+++ b/internal/providers/aws/sdk_kms_decrypt_reachability_test.go
@@ -1,0 +1,345 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+type fakeKMSSDKClient struct {
+	listKeys     []*kms.ListKeysOutput
+	listKeysErr  error
+	listKeysCall int
+	describe     map[string]*kms.DescribeKeyOutput
+	describeErr  map[string]error
+	policy       map[string]*kms.GetKeyPolicyOutput
+	policyErr    map[string]error
+	rotation     map[string]*kms.GetKeyRotationStatusOutput
+	rotationErr  map[string]error
+	aliases      []*kms.ListAliasesOutput
+	aliasesErr   error
+	aliasesCall  int
+	grants       map[string]*kms.ListGrantsOutput
+	grantsErr    map[string]error
+	tags         map[string]*kms.ListResourceTagsOutput
+	tagsErr      map[string]error
+}
+
+func (f *fakeKMSSDKClient) ListKeys(ctx context.Context, _ *kms.ListKeysInput, _ ...func(*kms.Options)) (*kms.ListKeysOutput, error) {
+	f.listKeysCall++
+	if f.listKeysErr != nil {
+		return nil, f.listKeysErr
+	}
+	if f.listKeysCall > len(f.listKeys) {
+		return &kms.ListKeysOutput{}, nil
+	}
+	return f.listKeys[f.listKeysCall-1], nil
+}
+
+func (f *fakeKMSSDKClient) DescribeKey(ctx context.Context, in *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	id := awsv2.ToString(in.KeyId)
+	if err, ok := f.describeErr[id]; ok {
+		return nil, err
+	}
+	if out, ok := f.describe[id]; ok {
+		return out, nil
+	}
+	// DescribeKey accepts either a key id or an ARN; check both.
+	for k, out := range f.describe {
+		if out != nil && out.KeyMetadata != nil && awsv2.ToString(out.KeyMetadata.Arn) == id {
+			return f.describe[k], nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeKMSSDKClient) GetKeyPolicy(ctx context.Context, in *kms.GetKeyPolicyInput, _ ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error) {
+	id := awsv2.ToString(in.KeyId)
+	if err, ok := f.policyErr[id]; ok {
+		return nil, err
+	}
+	return f.policy[id], nil
+}
+
+func (f *fakeKMSSDKClient) GetKeyRotationStatus(ctx context.Context, in *kms.GetKeyRotationStatusInput, _ ...func(*kms.Options)) (*kms.GetKeyRotationStatusOutput, error) {
+	id := awsv2.ToString(in.KeyId)
+	if err, ok := f.rotationErr[id]; ok {
+		return nil, err
+	}
+	return f.rotation[id], nil
+}
+
+func (f *fakeKMSSDKClient) ListAliases(ctx context.Context, _ *kms.ListAliasesInput, _ ...func(*kms.Options)) (*kms.ListAliasesOutput, error) {
+	f.aliasesCall++
+	if f.aliasesErr != nil {
+		return nil, f.aliasesErr
+	}
+	if f.aliasesCall > len(f.aliases) {
+		return &kms.ListAliasesOutput{}, nil
+	}
+	return f.aliases[f.aliasesCall-1], nil
+}
+
+func (f *fakeKMSSDKClient) ListGrants(ctx context.Context, in *kms.ListGrantsInput, _ ...func(*kms.Options)) (*kms.ListGrantsOutput, error) {
+	id := awsv2.ToString(in.KeyId)
+	if err, ok := f.grantsErr[id]; ok {
+		return nil, err
+	}
+	if out, ok := f.grants[id]; ok {
+		return out, nil
+	}
+	return &kms.ListGrantsOutput{}, nil
+}
+
+func (f *fakeKMSSDKClient) ListResourceTags(ctx context.Context, in *kms.ListResourceTagsInput, _ ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error) {
+	id := awsv2.ToString(in.KeyId)
+	if err, ok := f.tagsErr[id]; ok {
+		return nil, err
+	}
+	if out, ok := f.tags[id]; ok {
+		return out, nil
+	}
+	return &kms.ListResourceTagsOutput{}, nil
+}
+
+func TestSDKKMSDecryptReachabilityAPI_NilClient(t *testing.T) {
+	api := &SDKKMSDecryptReachabilityAPI{}
+	if _, err := api.ListKMSKeyReachability(context.Background(), "", 0); err == nil {
+		t.Fatalf("expected error with nil client")
+	}
+}
+
+func TestSDKKMSDecryptReachabilityAPI_ListKeysError(t *testing.T) {
+	api := NewSDKKMSDecryptReachabilityAPIFromClient(&fakeKMSSDKClient{listKeysErr: errors.New("boom")}, "123456789012", "us-east-1")
+	if _, err := api.ListKMSKeyReachability(context.Background(), "", 0); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmkID := "aaaa1111-2222-3333-4444-555566667777"
+	awsManagedID := "bbbb1111-2222-3333-4444-555566667777"
+	asymmetricID := "cccc1111-2222-3333-4444-555566667777"
+	fake := &fakeKMSSDKClient{
+		listKeys: []*kms.ListKeysOutput{{
+			Keys: []kmstypes.KeyListEntry{
+				{KeyId: awsv2.String(cmkID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID)},
+				{KeyId: awsv2.String(awsManagedID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + awsManagedID)},
+				{KeyId: awsv2.String(asymmetricID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + asymmetricID)},
+				{KeyId: awsv2.String(""), KeyArn: awsv2.String("")},
+			},
+		}},
+		describe: map[string]*kms.DescribeKeyOutput{
+			cmkID: {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId:        awsv2.String(cmkID),
+				Arn:          awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID),
+				AWSAccountId: awsv2.String("123456789012"),
+				KeyManager:   kmstypes.KeyManagerTypeCustomer,
+				KeyState:     kmstypes.KeyStateEnabled,
+				KeyUsage:     kmstypes.KeyUsageTypeEncryptDecrypt,
+				KeySpec:      kmstypes.KeySpecSymmetricDefault,
+				Origin:       kmstypes.OriginTypeAwsKms,
+				CreationDate: &created,
+				Enabled:      true,
+				MultiRegion:  awsv2.Bool(true),
+				MultiRegionConfiguration: &kmstypes.MultiRegionConfiguration{
+					MultiRegionKeyType: kmstypes.MultiRegionKeyTypePrimary,
+					PrimaryKey:         &kmstypes.MultiRegionKey{Arn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID)},
+					ReplicaKeys:        []kmstypes.MultiRegionKey{{Arn: awsv2.String("arn:aws:kms:eu-west-1:123456789012:key/replica")}},
+				},
+			}},
+			awsManagedID: {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId:      awsv2.String(awsManagedID),
+				Arn:        awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + awsManagedID),
+				KeyManager: kmstypes.KeyManagerTypeAws,
+				KeyState:   kmstypes.KeyStateEnabled,
+			}},
+			asymmetricID: {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId:      awsv2.String(asymmetricID),
+				Arn:        awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + asymmetricID),
+				KeyManager: kmstypes.KeyManagerTypeCustomer,
+				KeyState:   kmstypes.KeyStateEnabled,
+				KeyUsage:   kmstypes.KeyUsageTypeSignVerify,
+				KeySpec:    kmstypes.KeySpec("RSA_4096"),
+				Origin:     kmstypes.OriginTypeAwsKms,
+			}},
+		},
+		policy: map[string]*kms.GetKeyPolicyOutput{
+			cmkID: {Policy: awsv2.String(`{"Statement":[{"Sid":"EnableIAMUserPermissions","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"kms:*","Resource":"*"}]}`)},
+		},
+		policyErr: map[string]error{
+			asymmetricID: errors.New("AccessDenied: policy"),
+		},
+		rotation: map[string]*kms.GetKeyRotationStatusOutput{
+			cmkID: {KeyRotationEnabled: true},
+		},
+		rotationErr: map[string]error{
+			asymmetricID: errors.New("UnsupportedOperationException: KMS key with arn does not support rotation"),
+		},
+		aliases: []*kms.ListAliasesOutput{{
+			Aliases: []kmstypes.AliasListEntry{
+				{AliasName: awsv2.String("alias/payments"), TargetKeyId: awsv2.String(cmkID)},
+				{AliasName: awsv2.String("alias/aws/s3"), TargetKeyId: awsv2.String(awsManagedID)},
+				{AliasName: awsv2.String(""), TargetKeyId: awsv2.String(cmkID)},
+			},
+		}},
+		grants: map[string]*kms.ListGrantsOutput{
+			cmkID: {Grants: []kmstypes.GrantListEntry{{
+				GrantId:          awsv2.String("grant-1"),
+				Name:             awsv2.String("lambda-decrypt"),
+				GranteePrincipal: awsv2.String("arn:aws:iam::123456789012:role/lambda-decrypt"),
+				Operations:       []kmstypes.GrantOperation{kmstypes.GrantOperationDecrypt},
+				Constraints: &kmstypes.GrantConstraints{
+					EncryptionContextEquals: map[string]string{"tenant_id": "secret-value-we-dont-keep"},
+				},
+				CreationDate: &created,
+			}}},
+		},
+		tags: map[string]*kms.ListResourceTagsOutput{
+			cmkID: {Tags: []kmstypes.Tag{{TagKey: awsv2.String("owner"), TagValue: awsv2.String("payments")}, {TagKey: awsv2.String(""), TagValue: awsv2.String("ignored")}}},
+		},
+	}
+	api := NewSDKKMSDecryptReachabilityAPIFromClient(fake, "123456789012", "us-east-1")
+	page, err := api.ListKMSKeyReachability(context.Background(), "", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	byID := map[string]KMSDecryptReachability{}
+	for _, r := range page.Records {
+		byID[r.KeyID] = r
+	}
+	if len(byID) != 3 {
+		t.Fatalf("expected 3 named records, got %d", len(byID))
+	}
+	cmk := byID[cmkID]
+	if cmk.KeyManager != string(kmstypes.KeyManagerTypeCustomer) {
+		t.Fatalf("expected customer manager, got %q", cmk.KeyManager)
+	}
+	if !cmk.HasKeyPolicy || !cmk.IAMDelegationEnabled {
+		t.Fatalf("expected policy + IAM delegation, got %+v", cmk)
+	}
+	if !cmk.RotationSupported || !cmk.RotationEnabled {
+		t.Fatalf("expected rotation supported + enabled, got %+v", cmk)
+	}
+	if !cmk.MultiRegion || !cmk.MultiRegionPrimary || len(cmk.ReplicaKeyARNs) != 1 {
+		t.Fatalf("expected multi-region primary with replica, got %+v", cmk)
+	}
+	if len(cmk.Aliases) != 1 || cmk.Aliases[0] != "alias/payments" {
+		t.Fatalf("expected single alias/payments, got %+v", cmk.Aliases)
+	}
+	if len(cmk.Grants) != 1 || cmk.Grants[0].GranteePrincipal == "" {
+		t.Fatalf("expected one live grant, got %+v", cmk.Grants)
+	}
+	// Encryption context VALUES must never reach the record.
+	if len(cmk.Grants[0].EncryptionContextKeys) != 1 || cmk.Grants[0].EncryptionContextKeys[0] != "tenant_id" {
+		t.Fatalf("expected only encryption-context key 'tenant_id', got %+v", cmk.Grants[0].EncryptionContextKeys)
+	}
+	for _, key := range cmk.Grants[0].EncryptionContextKeys {
+		if key == "secret-value-we-dont-keep" {
+			t.Fatalf("encryption context VALUES leaked into record")
+		}
+	}
+	if v, ok := cmk.Tags["owner"]; !ok || v != "payments" {
+		t.Fatalf("expected owner tag, got %+v", cmk.Tags)
+	}
+
+	awsManaged := byID[awsManagedID]
+	if awsManaged.KeyManager != string(kmstypes.KeyManagerTypeAws) {
+		t.Fatalf("expected AWS-managed, got %+v", awsManaged.KeyManager)
+	}
+
+	asym := byID[asymmetricID]
+	if asym.RotationSupported {
+		t.Fatalf("asymmetric keys must not be rotation-supported, got %+v", asym)
+	}
+	// UnsupportedOperationException must NOT produce a rotation diagnostic.
+	codes := map[string]int{}
+	for _, d := range page.Diagnostics {
+		codes[d.Code]++
+	}
+	if codes["kms_key_rotation_failed"] > 0 {
+		t.Fatalf("unsupported rotation must not produce a diagnostic, got codes=%+v", codes)
+	}
+	if codes["kms_key_policy_failed"] == 0 {
+		t.Fatalf("expected kms_key_policy_failed for asymmetric AccessDenied")
+	}
+	if codes["kms_key_id_missing"] == 0 {
+		t.Fatalf("expected kms_key_id_missing for empty key in summary")
+	}
+}
+
+func TestSDKKMSDecryptReachabilityAPI_AliasesError(t *testing.T) {
+	api := NewSDKKMSDecryptReachabilityAPIFromClient(&fakeKMSSDKClient{
+		listKeys:   []*kms.ListKeysOutput{{}},
+		aliasesErr: errors.New("AccessDenied: ListAliases"),
+	}, "123456789012", "us-east-1")
+	page, err := api.ListKMSKeyReachability(context.Background(), "", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, d := range page.Diagnostics {
+		if d.Code == "kms_list_aliases_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected aliases diagnostic")
+	}
+}
+
+func TestSDKKMSDecryptReachabilityAPI_GrantsError(t *testing.T) {
+	cmkID := "aaaa1111-2222-3333-4444-555566667777"
+	fake := &fakeKMSSDKClient{
+		listKeys: []*kms.ListKeysOutput{{
+			Keys: []kmstypes.KeyListEntry{{KeyId: awsv2.String(cmkID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID)}},
+		}},
+		describe: map[string]*kms.DescribeKeyOutput{
+			cmkID: {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId:      awsv2.String(cmkID),
+				Arn:        awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID),
+				KeyManager: kmstypes.KeyManagerTypeCustomer,
+			}},
+		},
+		grantsErr: map[string]error{cmkID: errors.New("AccessDenied: ListGrants")},
+	}
+	api := NewSDKKMSDecryptReachabilityAPIFromClient(fake, "123456789012", "us-east-1")
+	page, err := api.ListKMSKeyReachability(context.Background(), "", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, d := range page.Diagnostics {
+		if d.Code == "kms_list_grants_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected list_grants diagnostic")
+	}
+}
+
+func TestKMSIsRotationUnsupported(t *testing.T) {
+	cases := map[string]bool{
+		"UnsupportedOperationException: KMS key spec does not support rotation": true,
+		"KMS key with arn does not support rotation":                            true,
+		"GenerateDataKey is not supported for asymmetric keys":                  true,
+		"AccessDenied: rotation":                                                false,
+		"":                                                                      false,
+	}
+	for in, want := range cases {
+		var err error
+		if in != "" {
+			err = errors.New(in)
+		}
+		if got := kmsIsRotationUnsupported(err); got != want {
+			t.Fatalf("kmsIsRotationUnsupported(%q)=%v want %v", in, got, want)
+		}
+	}
+}

--- a/internal/providers/aws/sdk_kms_decrypt_reachability_test.go
+++ b/internal/providers/aws/sdk_kms_decrypt_reachability_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -126,12 +127,14 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 	cmkID := "aaaa1111-2222-3333-4444-555566667777"
 	awsManagedID := "bbbb1111-2222-3333-4444-555566667777"
 	asymmetricID := "cccc1111-2222-3333-4444-555566667777"
+	externalID := "dddd1111-2222-3333-4444-555566667777"
 	fake := &fakeKMSSDKClient{
 		listKeys: []*kms.ListKeysOutput{{
 			Keys: []kmstypes.KeyListEntry{
 				{KeyId: awsv2.String(cmkID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + cmkID)},
 				{KeyId: awsv2.String(awsManagedID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + awsManagedID)},
 				{KeyId: awsv2.String(asymmetricID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + asymmetricID)},
+				{KeyId: awsv2.String(externalID), KeyArn: awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + externalID)},
 				{KeyId: awsv2.String(""), KeyArn: awsv2.String("")},
 			},
 		}},
@@ -169,6 +172,15 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 				KeySpec:    kmstypes.KeySpec("RSA_4096"),
 				Origin:     kmstypes.OriginTypeAwsKms,
 			}},
+			externalID: {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId:      awsv2.String(externalID),
+				Arn:        awsv2.String("arn:aws:kms:us-east-1:123456789012:key/" + externalID),
+				KeyManager: kmstypes.KeyManagerTypeCustomer,
+				KeyState:   kmstypes.KeyStateEnabled,
+				KeyUsage:   kmstypes.KeyUsageTypeEncryptDecrypt,
+				KeySpec:    kmstypes.KeySpecSymmetricDefault,
+				Origin:     kmstypes.OriginTypeExternal,
+			}},
 		},
 		policy: map[string]*kms.GetKeyPolicyOutput{
 			cmkID: {Policy: awsv2.String(`{"Statement":[{"Sid":"EnableIAMUserPermissions","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"kms:*","Resource":"*"}]}`)},
@@ -196,7 +208,14 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 				GranteePrincipal: awsv2.String("arn:aws:iam::123456789012:role/lambda-decrypt"),
 				Operations:       []kmstypes.GrantOperation{kmstypes.GrantOperationDecrypt},
 				Constraints: &kmstypes.GrantConstraints{
-					EncryptionContextEquals: map[string]string{"tenant_id": "secret-value-we-dont-keep"},
+					EncryptionContextEquals: map[string]string{
+						"tenant_id": "secret-value-we-dont-keep",
+						"app":       "billing",
+					},
+					EncryptionContextSubset: map[string]string{
+						"region": "us-east-1",
+						"env":    "prod",
+					},
 				},
 				CreationDate: &created,
 			}}},
@@ -214,8 +233,8 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 	for _, r := range page.Records {
 		byID[r.KeyID] = r
 	}
-	if len(byID) != 3 {
-		t.Fatalf("expected 3 named records, got %d", len(byID))
+	if len(byID) != 4 {
+		t.Fatalf("expected 4 named records, got %d", len(byID))
 	}
 	cmk := byID[cmkID]
 	if cmk.KeyManager != string(kmstypes.KeyManagerTypeCustomer) {
@@ -237,8 +256,11 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 		t.Fatalf("expected one live grant, got %+v", cmk.Grants)
 	}
 	// Encryption context VALUES must never reach the record.
-	if len(cmk.Grants[0].EncryptionContextKeys) != 1 || cmk.Grants[0].EncryptionContextKeys[0] != "tenant_id" {
-		t.Fatalf("expected only encryption-context key 'tenant_id', got %+v", cmk.Grants[0].EncryptionContextKeys)
+	if got, want := cmk.Grants[0].EncryptionContextKeys, []string{"app", "tenant_id"}; !slices.Equal(got, want) {
+		t.Fatalf("expected sorted encryption-context keys %+v, got %+v", want, got)
+	}
+	if got, want := cmk.Grants[0].EncryptionContextSubsetKeys, []string{"env", "region"}; !slices.Equal(got, want) {
+		t.Fatalf("expected sorted encryption-context subset keys %+v, got %+v", want, got)
 	}
 	for _, key := range cmk.Grants[0].EncryptionContextKeys {
 		if key == "secret-value-we-dont-keep" {
@@ -257,6 +279,10 @@ func TestSDKKMSDecryptReachabilityAPI_FullEnrichment(t *testing.T) {
 	asym := byID[asymmetricID]
 	if asym.RotationSupported {
 		t.Fatalf("asymmetric keys must not be rotation-supported, got %+v", asym)
+	}
+	external := byID[externalID]
+	if external.RotationSupported {
+		t.Fatalf("external-origin imported keys must not be rotation-supported, got %+v", external)
 	}
 	// UnsupportedOperationException must NOT produce a rotation diagnostic.
 	codes := map[string]int{}

--- a/internal/providers/awscontract/contract.go
+++ b/internal/providers/awscontract/contract.go
@@ -165,6 +165,13 @@ func AWSServiceCollectorContract() ServiceCollectorContract {
 			"s3:GetEncryptionConfiguration",
 			"s3:GetBucketTagging",
 			"s3:ListAccessPoints",
+			"kms:ListKeys",
+			"kms:DescribeKey",
+			"kms:GetKeyPolicy",
+			"kms:GetKeyRotationStatus",
+			"kms:ListAliases",
+			"kms:ListGrants",
+			"kms:ListResourceTags",
 		},
 		ReadOnlyBoundaries: []string{
 			"collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -128,6 +128,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws s3 bucket reachability collector: %w", s3Err)
 			}
+			kmsAPI, kmsErr := awsprovider.NewSDKKMSDecryptReachabilityAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if kmsErr != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("initialize aws kms decrypt reachability collector: %w", kmsErr)
+			}
 			scanner = newAWSScanner(
 				iamAPI,
 				cfg.AWSAccountID,
@@ -144,6 +149,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
+				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 			)
 		default:
 			_ = store.Close()
@@ -276,6 +282,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if s3Err != nil {
 			return nil, s3Err
 		}
+		kmsAPI, kmsErr := awsprovider.NewSDKKMSDecryptReachabilityAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		if kmsErr != nil {
+			return nil, kmsErr
+		}
 		scanner := newAWSScanner(
 			iamAPI,
 			connection.AccountID,
@@ -292,6 +302,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewIAMPassRoleRelationshipCollector(iamAPI),
 			awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			awsprovider.NewS3BucketReachabilityCollector(s3API),
+			awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 		)
 		return scanner, nil
 	}

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -985,6 +985,30 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS KMS decrypt reachability inventory with scoped headers and fixture state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', key_count: 5, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectKMSDecryptReachability('workspace/a', 'project 1', 'aws-prod', 'degraded', {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/kms-decrypt-reachability?connector_id=aws-prod&fixture_state=degraded'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS EKS workload identity inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2181,6 +2181,163 @@ export type AWSS3BucketReachabilityInventoryResult = {
   updated_at: string;
 };
 
+export type AWSKMSDecryptReachabilityInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSKMSDecryptReachabilityFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSKMSCoverageGap = {
+  capability: string;
+  status: 'unsupported';
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSKMSIdentityGrant = {
+  principal_arn?: string;
+  principal_type?: string;
+  effect: 'Allow' | 'Deny';
+  actions?: string[];
+  not_action?: boolean;
+  capabilities?: string[];
+  condition_keys?: string[];
+  is_public?: boolean;
+  is_cross_account?: boolean;
+  has_condition?: boolean;
+  statement_sid?: string;
+  wildcard_principal?: boolean;
+};
+
+export type AWSKMSGrant = {
+  grant_id?: string;
+  name?: string;
+  grantee_principal?: string;
+  grantee_principal_type?: string;
+  retiring_principal?: string;
+  issuing_account?: string;
+  operations?: string[];
+  capabilities?: string[];
+  encryption_context_keys?: string[];
+  encryption_context_subset_keys?: string[];
+  has_constraints?: boolean;
+  is_cross_account?: boolean;
+  created_at?: string;
+};
+
+export type AWSKMSDecryptReachabilityRecord = {
+  account_id: string;
+  region: string;
+  service: 'kms';
+  key_arn: string;
+  key_id: string;
+  key_manager?: 'CUSTOMER' | 'AWS' | '';
+  key_state?: string;
+  key_usage?: string;
+  key_spec?: string;
+  origin?: string;
+  description?: string;
+  enabled: boolean;
+  created_at?: string;
+  deletion_date?: string;
+  multi_region?: boolean;
+  multi_region_primary?: boolean;
+  primary_key_arn?: string;
+  replica_key_arns?: string[];
+  rotation_enabled: boolean;
+  rotation_supported: boolean;
+  aliases?: string[];
+  has_key_policy: boolean;
+  key_policy_statement_count: number;
+  iam_delegation_enabled: boolean;
+  identity_grants?: AWSKMSIdentityGrant[];
+  grants?: AWSKMSGrant[];
+  exposure_classification:
+    | 'public'
+    | 'cross_account'
+    | 'restricted'
+    | 'managed_by_iam'
+    | 'managed_by_aws'
+    | 'private_with_grants'
+    | 'private'
+    | 'unknown';
+  exposure_reasons?: string[];
+  tags?: Record<string, string>;
+  source: string;
+  evidence_ref: string;
+  from_node_id: string;
+  relationship_type: 'can_decrypt';
+  confidence: number;
+  collected_at: string;
+  status: 'ready' | 'degraded';
+};
+
+export type AWSKMSDecryptReachabilityEdge = {
+  type: 'can_decrypt';
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+  effect: 'Allow';
+  source: 'key_policy' | 'kms_grant';
+  principal_type: string;
+  capabilities?: string[];
+  has_condition?: boolean;
+};
+
+export type AWSKMSDecryptReachabilityDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSKMSDecryptReachabilityInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSKMSDecryptReachabilityInventoryStatus;
+  fixture_state: AWSKMSDecryptReachabilityFixtureState;
+  confidence: number;
+  key_count: number;
+  customer_managed_key_count: number;
+  aws_managed_key_count: number;
+  public_key_count: number;
+  cross_account_key_count: number;
+  restricted_key_count: number;
+  keys_with_rotation_count: number;
+  keys_missing_rotation_count: number;
+  keys_pending_deletion_count: number;
+  multi_region_key_count: number;
+  identity_grant_count: number;
+  public_grant_count: number;
+  cross_account_grant_count: number;
+  deny_grant_count: number;
+  live_grant_count: number;
+  cross_account_live_grant_count: number;
+  relationship_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSKMSCoverageGap[];
+  records: AWSKMSDecryptReachabilityRecord[];
+  relationships: AWSKMSDecryptReachabilityEdge[];
+  diagnostics: AWSKMSDecryptReachabilityDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSEKSWorkloadIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSEKSWorkloadIdentityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 
@@ -3407,6 +3564,21 @@ export const apiClient = {
   ) {
     return request<{ inventory: AWSS3BucketReachabilityInventoryResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/s3-bucket-reachability${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectKMSDecryptReachability(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSKMSDecryptReachabilityFixtureState,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSKMSDecryptReachabilityInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/kms-decrypt-reachability${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
       })}`,


### PR DESCRIPTION
## Summary

Closes #1489.

Adds a metadata-only KMS inventory collector that captures every key's
configuration (manager, state, spec, multi-region linkage, rotation
status, aliases, tags), the identity grants inferred from the key
policy, and the live KMS grants from `ListGrants`. Each key is
classified into one of `public`, `cross_account`, `restricted`,
`managed_by_iam`, `managed_by_aws`, `private_with_grants`, or
`private`. The API emits `can_decrypt` graph edges only for resolved
Allow grants to real IAM role/user ARNs, tagging each edge with its
source (`key_policy` vs `kms_grant`) and a capability bucket
(`decrypt` / `encrypt` / `admin` / `grant` / `sign`).

The implementation goes beyond a vanilla "list keys" pass:

- Recognises the canonical `EnableIAMUserPermissions` delegation
  statement and classifies it as `managed_by_iam` rather than as a
  finding, so the default policy does not drown out real exposure.
- AWS-managed keys are surfaced as a documented coverage class
  (`managed_by_aws`) and never produce findings, since their policies
  are not customer-actionable.
- Live KMS grants are collected separately from the key policy and
  feed both the exposure classifier and the graph edges.
- Capability buckets are derived deterministically — unknown actions
  are omitted rather than placed in an opaque bucket.
- Multi-region replica linkage and rotation *supported* vs *enabled*
  are surfaced so we don't flag rotation-incapable key types as
  "rotation disabled".
- Encryption-context **values** are never surfaced; only the constraint
  **keys**.

Wires the new
`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability`
endpoint end-to-end:

- collector + SDK adapter (`internal/providers/aws/kms_decrypt_reachability_collector.go`, `sdk_kms_decrypt_reachability.go`, `kms_key_policy_parser.go`)
- normalizer + fixture classifier
- API endpoint + handler with full fixture-state coverage (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`)
- runtime + CLI wiring (composite collector + service-name expectations)
- OpenAPI schemas + path + authz table
- web client types + getter + test
- connector IAM policy update (kms:ListKeys, DescribeKey, GetKeyPolicy, GetKeyRotationStatus, ListAliases, ListGrants, ListResourceTags; no cryptographic actions)
- contract permission list
- operator docs + `aws-collector.md` bullet + CHANGELOG entry

**Never** decrypts, encrypts, signs, verifies, or generates data keys;
never reads ciphertext, plaintext, or CloudTrail event bodies; never
surfaces encryption-context values.

## Test plan
- [x] `go test ./...` (all green, total coverage 80.1%)
- [x] `make fmt-check`
- [x] `go vet ./...`
- [x] `npm run test:ci --prefix web`
- [x] `npm run build --prefix web`
- [ ] Live validation against a real AWS account (per the docs)

---

### AI assistance

If AI tools were used materially for this PR, complete the fields below:

- AI tools used: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only KMS key policy and decrypt reachability collector and API to map who can decrypt each key, now preserving principal types (role vs user). Implements Linear #1489 with metadata-only inventory, exposure classification, safe graph edges, and hardened route authorization.

- **New Features**
  - New endpoint: GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/kms-decrypt-reachability
  - Collects key metadata (manager, state, spec, multi‑region, rotation, aliases, tags) plus parsed key‑policy grants and live ListGrants
  - Preserves principal type for policy and grant principals; derives capability buckets (`decrypt`, `encrypt`, `admin`, `grant`, `sign`) and emits `can_decrypt` edges only for Allow grants to real IAM role/user ARNs, tagged by source (`key_policy` or `kms_grant`)
  - Classifies keys as `public`, `cross_account`, `restricted`, `managed_by_iam`, `managed_by_aws`, `private_with_grants`, or `private`; treats `EnableIAMUserPermissions` as `managed_by_iam` and never flags AWS‑managed keys
  - End‑to‑end wiring: collector + SDK adapter, normalizer + graph, API handler with fixture states (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`), OpenAPI + route authz, web client types/tests, runtime/CLI, docs; never reads ciphertext/plaintext or encryption‑context values

- **Dependencies**
  - Connector IAM policy: adds KMS read‑only actions (ListKeys, DescribeKey, GetKeyPolicy, GetKeyRotationStatus, ListAliases, ListGrants, ListResourceTags); excludes cryptographic or mutating actions
  - Adds `github.com/aws/aws-sdk-go-v2/service/kms` and updates the dependency review allowlist to permit it

<sup>Written for commit cca40c6c8a1593d18472654702614cd67938c403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

