### PR TITLE
Implement AWS Secrets Manager metadata collector

### DIFF
--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -270,3 +270,11 @@ ordered by `kind`, then `source_id`.
   collector never decrypts, encrypts, signs, verifies, or generates data
   keys; never reads ciphertext or plaintext; and never surfaces
   encryption-context *values*.
+- Secrets Manager metadata and workload references are exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata`.
+  The collector records secret metadata, rotation state, resource-policy grant
+  summaries, KMS key references, tags, version-stage metadata, replica-region
+  metadata, and graph-ready `uses_secret` edges for resolved compute
+  `secret_refs`. It never calls `secretsmanager:GetSecretValue`, never reads
+  `SecretString` or `SecretBinary`, and uses `description_present` instead of
+  surfacing description text in operator evidence.

--- a/docs/aws-secrets-manager-metadata.md
+++ b/docs/aws-secrets-manager-metadata.md
@@ -1,0 +1,76 @@
+# AWS Secrets Manager Metadata and References
+
+Issue #1490 adds metadata-only collection for AWS Secrets Manager secrets and
+the workload references that point at them.
+
+## What It Collects
+
+- Secret ARN, name, account, region, tags, lifecycle timestamps, and rotation
+  state.
+- KMS key references from Secrets Manager metadata.
+- Resource-policy grant summaries, including public and cross-account
+  indicators.
+- Version-stage metadata from `ListSecretVersionIds`.
+- Replica-region metadata from `DescribeSecret`.
+- Workload references emitted by compute collectors through `secret_refs`, with
+  graph-ready `uses_secret` edges when a reference resolves to a collected
+  secret.
+
+## What It Never Collects
+
+The collector never calls `secretsmanager:GetSecretValue`. It does not read,
+store, log, or return `SecretString`, `SecretBinary`, plaintext environment
+values, customer payloads, prompts, completions, object contents, database rows,
+or browser output. API responses expose `description_present` rather than using
+secret descriptions as evidence text.
+
+## Required AWS Permissions
+
+Use read-only metadata permissions:
+
+- `secretsmanager:ListSecrets`
+- `secretsmanager:DescribeSecret`
+- `secretsmanager:GetResourcePolicy`
+- `secretsmanager:ListSecretVersionIds`
+
+Do not add `secretsmanager:GetSecretValue` for this capability.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
+```
+
+Optional query parameters:
+
+- `connector_id`: scope the response to one AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for deterministic UI and contract validation.
+
+The response includes operator-visible status, confidence, evidence links,
+failure reasons, remediation hints, diagnostics, records, and `uses_secret`
+relationships.
+
+## Failure States
+
+- `empty`: collection succeeded and no secrets were found.
+- `degraded`: metadata is available but one metadata path, such as version-stage
+  reads, is incomplete.
+- `partial_failure`: some records remain visible while a later metadata read
+  failed.
+- `permission_denied`: required metadata-only permissions are missing.
+
+Unknown or denied states are explicit; they are not reported as successful
+findings.
+
+## Live Validation
+
+Run fixture validation first:
+
+```sh
+go test ./internal/providers/aws ./internal/api
+```
+
+For live AWS validation, use only an authorized test account and record account,
+region, service coverage, and diagnostics. Do not capture secret values or
+customer payloads.

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -90,7 +90,11 @@ The response envelope is:
       "eks:ListNodegroups",
       "eks:DescribeNodegroup",
       "eks:ListFargateProfiles",
-      "eks:DescribeFargateProfile"
+      "eks:DescribeFargateProfile",
+      "secretsmanager:ListSecrets",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:ListSecretVersionIds"
     ],
     "read_only_boundaries": [
       "collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows"

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -175,6 +175,12 @@ workload identity collector adds metadata-only reads: `eks:ListClusters`, `eks:D
 `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:ListFargateProfiles`, and
 `eks:DescribeFargateProfile`.
 
+The Secrets Manager metadata collector adds metadata-only reads:
+`secretsmanager:ListSecrets`, `secretsmanager:DescribeSecret`,
+`secretsmanager:GetResourcePolicy`, and
+`secretsmanager:ListSecretVersionIds`. It must not add
+`secretsmanager:GetSecretValue`.
+
 Future service collectors may add service-specific read-only metadata
 permissions, but must not add actions that read secret values, object contents,
 prompts, completions, browser pages, code-interpreter output, database rows, or
@@ -188,6 +194,12 @@ For CodeBuild, `secret_refs` are only Parameter Store or Secrets Manager source
 references and `environment_keys` are only variable names. Build logs, source
 contents, artifact contents, plaintext environment values, and secret values are
 intentionally outside the collector contract.
+
+For Secrets Manager, records contain secret metadata, policy-grant summaries,
+KMS references, tags, version stages, replica status, and resolved workload
+reference edges only. `SecretString`, `SecretBinary`, secret descriptions as
+operator evidence, and `GetSecretValue` outputs are intentionally outside the
+collector contract.
 
 For CodePipeline, `configuration_keys` are action configuration key names only.
 Configuration values, source contents, action outputs, artifact contents,

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -549,6 +549,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities
     action: tenancy.read
     resource_type: project
@@ -4418,6 +4423,56 @@ paths:
                     $ref: "#/components/schemas/AWSKMSDecryptReachabilityInventoryResult"
         "400":
           description: Invalid AWS KMS decrypt reachability inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Secrets Manager metadata and references
+      operationId: getAWSProjectSecretsManagerMetadata
+      description: Returns scoped Secrets Manager metadata, rotation state, resource-policy grants, version-stage metadata, KMS references, and workload secret-reference edges. Metadata-only — never calls GetSecretValue and never returns SecretString or SecretBinary.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only Secrets Manager metadata evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+      responses:
+        "200":
+          description: AWS Secrets Manager metadata inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSSecretsManagerMetadataInventoryResult"
+        "400":
+          description: Invalid AWS Secrets Manager metadata request
           content:
             application/json:
               schema:
@@ -9417,6 +9472,225 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSKMSDecryptReachabilityDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretsManagerCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSSecretsManagerIdentityGrant:
+      type: object
+      properties:
+        principal_arn: { type: string }
+        principal_type: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        actions:
+          type: array
+          items: { type: string }
+        condition_keys:
+          type: array
+          items: { type: string }
+        is_public: { type: boolean }
+        is_cross_account: { type: boolean }
+        has_condition: { type: boolean }
+        statement_sid: { type: string }
+        wildcard_principal: { type: boolean }
+    AWSSecretsManagerVersionStage:
+      type: object
+      properties:
+        version_id: { type: string }
+        stages:
+          type: array
+          items: { type: string }
+        created_at: { type: string }
+        last_accessed_at: { type: string }
+        kms_key_ids:
+          type: array
+          items: { type: string }
+    AWSSecretsManagerReplicaRegion:
+      type: object
+      properties:
+        region: { type: string }
+        kms_key_id: { type: string }
+        status: { type: string }
+        status_message: { type: string }
+        last_accessed_at: { type: string }
+    AWSSecretsManagerWorkloadReference:
+      type: object
+      properties:
+        source_service: { type: string }
+        workload_id: { type: string }
+        workload_type: { type: string }
+        workload_name: { type: string }
+        resource_arn: { type: string }
+        resource_id: { type: string }
+        reference: { type: string }
+        reference_kind:
+          type: string
+          enum: [arn, name, source]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSSecretsManagerMetadataRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service:
+          type: string
+          enum: [secretsmanager]
+        secret_arn: { type: string }
+        secret_name: { type: string }
+        description_present: { type: boolean }
+        kms_key_id: { type: string }
+        kms_key_arn: { type: string }
+        owning_service: { type: string }
+        primary_region: { type: string }
+        secret_status: { type: string }
+        rotation_enabled: { type: boolean }
+        rotation_lambda_arn: { type: string }
+        rotation_interval_days: { type: integer }
+        created_at: { type: string }
+        last_changed_at: { type: string }
+        last_accessed_at: { type: string }
+        last_rotated_at: { type: string }
+        deleted_at: { type: string }
+        has_resource_policy: { type: boolean }
+        resource_policy_statement_count: { type: integer }
+        identity_grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerIdentityGrant"
+        version_stages:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerVersionStage"
+        replica_regions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerReplicaRegion"
+        tags:
+          type: object
+          additionalProperties: { type: string }
+        exposure_classification: { type: string }
+        exposure_reasons:
+          type: array
+          items: { type: string }
+        referenced_by:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerWorkloadReference"
+        unresolved_references:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerWorkloadReference"
+        source: { type: string }
+        evidence_ref: { type: string }
+        from_node_id: { type: string }
+        relationship_type: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+    AWSSecretsManagerReferenceEdge:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [uses_secret]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        source: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSSecretsManagerMetadataDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSSecretsManagerMetadataInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        secret_count: { type: integer }
+        referenced_secret_count: { type: integer }
+        unreferenced_secret_count: { type: integer }
+        rotation_enabled_count: { type: integer }
+        missing_rotation_count: { type: integer }
+        resource_policy_count: { type: integer }
+        public_secret_count: { type: integer }
+        cross_account_secret_count: { type: integer }
+        kms_referenced_count: { type: integer }
+        relationship_count: { type: integer }
+        unresolved_reference_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerMetadataRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerReferenceEdge"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsManagerMetadataDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.28 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/aws/aws-sdk-go-v2/service/sagemaker v1.253.0 h1:bQJ9iR4RX5dE03Q3wJsyL
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.253.0/go.mod h1:1FMsp7eC3I0UHWccnlok2ymxq3P8V2vTAP6107bPAz8=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.6 h1:uqKvuoQR6dQmGuPlfEZ2kjjJV+sAgrAouYtEWNBEvO8=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.6/go.mod h1:YjcAUo+VhdCsp9Q0AV/3EObtEdALb789sdTw+8ELrDc=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.2 h1:QMayWWWmfWyQwP4nZf3qdIVS39Pm65Yi5waYj1euCzo=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.2/go.mod h1:4eAXC8WdO1rRt01ZKKq57z8oTzzLkkIo5IReQ+b8hEU=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.42.2 h1:fh1FvGJdVUlyT5aW2u5jIiWrasnkifz/u5exigKi4ew=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.42.2/go.mod h1:3ZyiH89Ot63cpYyK48FXNxJvGpRtt2i8DG9Q3E+YWqM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 h1:YcpVyIPLCbiypN6KSphijN5fC7DDjX114SqA7prnnxg=

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -753,6 +753,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_secrets_manager_metadata.go
+++ b/internal/api/aws_secrets_manager_metadata.go
@@ -1,0 +1,454 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+const (
+	awsSecretsManagerMetadataCurrentIssue = 1490
+	awsSecretsManagerMetadataVersion      = "aws-secrets-manager-metadata-inventory-v1"
+)
+
+type AWSSecretsManagerMetadataInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+}
+
+type AWSSecretsManagerCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSSecretsManagerMetadataInventoryResult struct {
+	TenantID                 string                                `json:"tenant_id"`
+	WorkspaceID              string                                `json:"workspace_id"`
+	ProjectID                string                                `json:"project_id"`
+	ConnectorID              string                                `json:"connector_id,omitempty"`
+	AccountID                string                                `json:"account_id,omitempty"`
+	Region                   string                                `json:"region,omitempty"`
+	ParentIssueNumber        int                                   `json:"parent_issue_number"`
+	ParentIssueRef           string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber       int                                   `json:"current_issue_number"`
+	CurrentIssueRef          string                                `json:"current_issue_ref"`
+	Version                  string                                `json:"version"`
+	Status                   string                                `json:"status"`
+	FixtureState             string                                `json:"fixture_state"`
+	Confidence               float64                               `json:"confidence"`
+	SecretCount              int                                   `json:"secret_count"`
+	ReferencedSecretCount    int                                   `json:"referenced_secret_count"`
+	UnreferencedSecretCount  int                                   `json:"unreferenced_secret_count"`
+	RotationEnabledCount     int                                   `json:"rotation_enabled_count"`
+	MissingRotationCount     int                                   `json:"missing_rotation_count"`
+	ResourcePolicyCount      int                                   `json:"resource_policy_count"`
+	PublicSecretCount        int                                   `json:"public_secret_count"`
+	CrossAccountSecretCount  int                                   `json:"cross_account_secret_count"`
+	KMSReferencedCount       int                                   `json:"kms_referenced_count"`
+	RelationshipCount        int                                   `json:"relationship_count"`
+	UnresolvedReferenceCount int                                   `json:"unresolved_reference_count"`
+	FailureReasons           []string                              `json:"failure_reasons"`
+	RemediationHints         []string                              `json:"remediation_hints"`
+	EvidenceLinks            []string                              `json:"evidence_links"`
+	CoverageGaps             []AWSSecretsManagerCoverageGap        `json:"coverage_gaps"`
+	Records                  []AWSSecretsManagerMetadataRecord     `json:"records"`
+	Relationships            []AWSSecretsManagerReferenceEdge      `json:"relationships"`
+	Diagnostics              []AWSSecretsManagerMetadataDiagnostic `json:"diagnostics"`
+	GeneratedAt              time.Time                             `json:"generated_at"`
+	UpdatedAt                time.Time                             `json:"updated_at"`
+}
+
+type AWSSecretsManagerMetadataRecord struct {
+	AccountID                    string                               `json:"account_id"`
+	Region                       string                               `json:"region"`
+	Service                      string                               `json:"service"`
+	SecretARN                    string                               `json:"secret_arn"`
+	SecretName                   string                               `json:"secret_name"`
+	DescriptionPresent           bool                                 `json:"description_present"`
+	KMSKeyID                     string                               `json:"kms_key_id,omitempty"`
+	KMSKeyARN                    string                               `json:"kms_key_arn,omitempty"`
+	OwningService                string                               `json:"owning_service,omitempty"`
+	PrimaryRegion                string                               `json:"primary_region,omitempty"`
+	SecretStatus                 string                               `json:"secret_status"`
+	RotationEnabled              bool                                 `json:"rotation_enabled"`
+	RotationLambdaARN            string                               `json:"rotation_lambda_arn,omitempty"`
+	RotationInterval             int64                                `json:"rotation_interval_days,omitempty"`
+	CreatedAt                    string                               `json:"created_at,omitempty"`
+	LastChangedAt                string                               `json:"last_changed_at,omitempty"`
+	LastAccessedAt               string                               `json:"last_accessed_at,omitempty"`
+	LastRotatedAt                string                               `json:"last_rotated_at,omitempty"`
+	DeletedAt                    string                               `json:"deleted_at,omitempty"`
+	HasResourcePolicy            bool                                 `json:"has_resource_policy"`
+	ResourcePolicyStatementCount int                                  `json:"resource_policy_statement_count"`
+	IdentityGrants               []AWSSecretsManagerIdentityGrant     `json:"identity_grants,omitempty"`
+	VersionStages                []AWSSecretsManagerVersionStage      `json:"version_stages,omitempty"`
+	ReplicaRegions               []AWSSecretsManagerReplicaRegion     `json:"replica_regions,omitempty"`
+	Tags                         map[string]string                    `json:"tags,omitempty"`
+	ExposureClassification       string                               `json:"exposure_classification"`
+	ExposureReasons              []string                             `json:"exposure_reasons,omitempty"`
+	ReferencedBy                 []AWSSecretsManagerWorkloadReference `json:"referenced_by,omitempty"`
+	UnresolvedReferences         []AWSSecretsManagerWorkloadReference `json:"unresolved_references,omitempty"`
+	Source                       string                               `json:"source"`
+	EvidenceRef                  string                               `json:"evidence_ref"`
+	FromNodeID                   string                               `json:"from_node_id"`
+	RelationshipType             string                               `json:"relationship_type"`
+	Confidence                   float64                              `json:"confidence"`
+	CollectedAt                  time.Time                            `json:"collected_at"`
+	Status                       string                               `json:"status"`
+}
+
+type AWSSecretsManagerIdentityGrant struct {
+	PrincipalARN      string   `json:"principal_arn,omitempty"`
+	PrincipalType     string   `json:"principal_type,omitempty"`
+	Effect            string   `json:"effect"`
+	Actions           []string `json:"actions,omitempty"`
+	ConditionKeys     []string `json:"condition_keys,omitempty"`
+	IsPublic          bool     `json:"is_public,omitempty"`
+	IsCrossAccount    bool     `json:"is_cross_account,omitempty"`
+	HasCondition      bool     `json:"has_condition,omitempty"`
+	StatementSid      string   `json:"statement_sid,omitempty"`
+	WildcardPrincipal bool     `json:"wildcard_principal,omitempty"`
+}
+
+type AWSSecretsManagerVersionStage struct {
+	VersionID    string   `json:"version_id,omitempty"`
+	Stages       []string `json:"stages,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	LastAccessed string   `json:"last_accessed_at,omitempty"`
+	KMSKeyIDs    []string `json:"kms_key_ids,omitempty"`
+}
+
+type AWSSecretsManagerReplicaRegion struct {
+	Region         string `json:"region,omitempty"`
+	KMSKeyID       string `json:"kms_key_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	StatusMessage  string `json:"status_message,omitempty"`
+	LastAccessedAt string `json:"last_accessed_at,omitempty"`
+}
+
+type AWSSecretsManagerWorkloadReference struct {
+	SourceService string  `json:"source_service,omitempty"`
+	WorkloadID    string  `json:"workload_id,omitempty"`
+	WorkloadType  string  `json:"workload_type,omitempty"`
+	WorkloadName  string  `json:"workload_name,omitempty"`
+	ResourceARN   string  `json:"resource_arn,omitempty"`
+	ResourceID    string  `json:"resource_id,omitempty"`
+	Reference     string  `json:"reference"`
+	ReferenceKind string  `json:"reference_kind"`
+	Confidence    float64 `json:"confidence"`
+}
+
+type AWSSecretsManagerReferenceEdge struct {
+	Type        string  `json:"type"`
+	FromNodeID  string  `json:"from_node_id"`
+	ToNodeID    string  `json:"to_node_id"`
+	EvidenceRef string  `json:"evidence_ref"`
+	Source      string  `json:"source"`
+	Confidence  float64 `json:"confidence"`
+}
+
+type AWSSecretsManagerMetadataDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+func (s *Service) GetAWSSecretsManagerMetadataInventory(ctx context.Context, workspaceID string, projectID string, request AWSSecretsManagerMetadataInventoryRequest) (AWSSecretsManagerMetadataInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSecretsManagerMetadataInventoryResult{}, err
+	}
+	var (
+		connection    AWSConnectionStatus
+		hasConnection bool
+	)
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSSecretsManagerMetadataInventoryResult{}, err
+	}
+	return buildAWSSecretsManagerMetadataInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSSecretsManagerMetadataInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSSecretsManagerMetadataInventoryRequest, checkedAt time.Time) (AWSSecretsManagerMetadataInventoryResult, error) {
+	fixtureState := normalizeAWSSecretsManagerMetadataFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSecretsManagerMetadataInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, coverageGaps := awsSecretsManagerMetadataFixtureRecords(accountID, region, fixtureState, checkedAt)
+	status, confidence, failures, remediations := summarizeAWSSecretsManagerMetadataInventory(fixtureState, diagnostics, records)
+	relationships := awsSecretsManagerReferenceEdges(records)
+	return AWSSecretsManagerMetadataInventoryResult{
+		TenantID:                scope.TenantID,
+		WorkspaceID:             project.WorkspaceID,
+		ProjectID:               project.ProjectID,
+		ConnectorID:             connectorID,
+		AccountID:               accountID,
+		Region:                  region,
+		ParentIssueNumber:       awsPlatformDependencyParentIssue,
+		ParentIssueRef:          awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:      awsSecretsManagerMetadataCurrentIssue,
+		CurrentIssueRef:         awsIssueRef(awsSecretsManagerMetadataCurrentIssue),
+		Version:                 awsSecretsManagerMetadataVersion,
+		Status:                  status,
+		FixtureState:            fixtureState,
+		Confidence:              confidence,
+		SecretCount:             len(records),
+		ReferencedSecretCount:   countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return len(r.ReferencedBy) > 0 }),
+		UnreferencedSecretCount: countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return len(r.ReferencedBy) == 0 }),
+		RotationEnabledCount:    countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return r.RotationEnabled }),
+		MissingRotationCount:    countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return !r.RotationEnabled && r.SecretStatus == "active" }),
+		ResourcePolicyCount:     countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return r.HasResourcePolicy }),
+		PublicSecretCount:       countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return r.ExposureClassification == "public" }),
+		CrossAccountSecretCount: countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool { return r.ExposureClassification == "cross_account" }),
+		KMSReferencedCount: countSecrets(records, func(r AWSSecretsManagerMetadataRecord) bool {
+			return strings.TrimSpace(r.KMSKeyARN) != "" || strings.TrimSpace(r.KMSKeyID) != ""
+		}),
+		RelationshipCount:        len(relationships),
+		UnresolvedReferenceCount: countSecretRefs(records, func(r AWSSecretsManagerWorkloadReference) bool { return true }, true),
+		FailureReasons:           failures,
+		RemediationHints:         remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSecretsManagerMetadataCurrentIssue),
+			"/docs/aws-secrets-manager-metadata",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  coverageGaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsSecretsManagerMetadataDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSSecretsManagerMetadataFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsSecretsManagerMetadataFixtureRecords(accountID, region, fixtureState string, checkedAt time.Time) ([]AWSSecretsManagerMetadataRecord, []providers.SourceError, []AWSSecretsManagerCoverageGap) {
+	gaps := []AWSSecretsManagerCoverageGap{{
+		Capability:  "secret_value_collection",
+		Status:      "unsupported",
+		Reason:      "This collector never calls GetSecretValue and never stores SecretString or SecretBinary.",
+		Remediation: "Use existing secret-management rotation procedures for value inspection outside Identrail.",
+	}, {
+		Capability:  "parameter_store_value_collection",
+		Status:      "unsupported",
+		Reason:      "SSM Parameter Store metadata is tracked separately; this issue only models Secrets Manager metadata and references.",
+		Remediation: "Treat SSM references as unresolved until the dedicated SSM metadata collector lands.",
+	}}
+	switch fixtureState {
+	case "permission_denied":
+		return nil, []providers.SourceError{{Collector: "secrets_manager_metadata", Code: "secrets_manager_metadata_page_failed", Message: "AccessDenied: missing secretsmanager:ListSecrets", Retryable: false}}, gaps
+	case "empty":
+		return nil, nil, gaps
+	}
+	partition := awsSecretsManagerPartitionForRegion(region)
+	dbARN := fmt.Sprintf("arn:%s:secretsmanager:%s:%s:secret:payments/db-AbCdEf", partition, region, accountID)
+	apiARN := fmt.Sprintf("arn:%s:secretsmanager:%s:%s:secret:shared/api-token-GhIjKl", partition, region, accountID)
+	partnerARN := fmt.Sprintf("arn:%s:secretsmanager:%s:%s:secret:partner/webhook-MnOpQr", partition, region, accountID)
+	records := []AWSSecretsManagerMetadataRecord{
+		awsSecretsManagerMetadataFixtureRecord(accountID, region, "payments/db", dbARN, checkedAt, func(r *AWSSecretsManagerMetadataRecord) {
+			r.RotationEnabled = true
+			r.RotationInterval = 30
+			r.KMSKeyID = "alias/payments-secrets"
+			r.KMSKeyARN = fmt.Sprintf("arn:%s:kms:%s:%s:key/payments-secrets", partition, region, accountID)
+			r.ReferencedBy = []AWSSecretsManagerWorkloadReference{{
+				SourceService: "ecs",
+				WorkloadID:    fmt.Sprintf("arn:%s:ecs:%s:%s:service/prod/payments", partition, region, accountID),
+				WorkloadType:  "ecs_service",
+				WorkloadName:  "payments",
+				ResourceARN:   fmt.Sprintf("arn:%s:ecs:%s:%s:task-definition/payments:4", partition, region, accountID),
+				Reference:     "DATABASE_PASSWORD=" + dbARN,
+				ReferenceKind: "arn",
+				Confidence:    0.94,
+			}}
+			r.ExposureClassification = "referenced_by_workload"
+			r.ExposureReasons = []string{"workload_references_secret", "rotation_enabled", "customer_kms_key_referenced"}
+		}),
+		awsSecretsManagerMetadataFixtureRecord(accountID, region, "shared/api-token", apiARN, checkedAt, func(r *AWSSecretsManagerMetadataRecord) {
+			r.HasResourcePolicy = true
+			r.ResourcePolicyStatementCount = 1
+			r.IdentityGrants = []AWSSecretsManagerIdentityGrant{{PrincipalARN: "*", PrincipalType: "*", Effect: "Allow", Actions: []string{"secretsmanager:DescribeSecret"}, IsPublic: true, WildcardPrincipal: true}}
+			r.ExposureClassification = "public"
+			r.ExposureReasons = []string{"resource_policy_allow_to_wildcard_principal"}
+		}),
+		awsSecretsManagerMetadataFixtureRecord(accountID, region, "partner/webhook", partnerARN, checkedAt, func(r *AWSSecretsManagerMetadataRecord) {
+			r.HasResourcePolicy = true
+			r.ResourcePolicyStatementCount = 1
+			r.IdentityGrants = []AWSSecretsManagerIdentityGrant{{PrincipalARN: "arn:aws:iam::999999999999:role/partner-reader", PrincipalType: "aws", Effect: "Allow", Actions: []string{"secretsmanager:DescribeSecret"}, IsCrossAccount: true}}
+			r.UnresolvedReferences = []AWSSecretsManagerWorkloadReference{{SourceService: "codebuild", WorkloadName: "partner-sync", Reference: "PARTNER_SECRET=partner/webhook", ReferenceKind: "name", Confidence: 0.72}}
+			r.ExposureClassification = "cross_account"
+			r.ExposureReasons = []string{"resource_policy_allow_to_cross_account_principal"}
+		}),
+	}
+	diagnostics := []providers.SourceError{}
+	if fixtureState == "degraded" {
+		records[0].RotationEnabled = false
+		records[0].Status = "degraded"
+		records[0].ExposureReasons = append(records[0].ExposureReasons, "rotation_status_unavailable")
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "secrets_manager_metadata", SourceID: dbARN, Code: "secrets_manager_versions_failed", Message: "AccessDenied: ListSecretVersionIds", Retryable: true})
+	}
+	if fixtureState == "partial_failure" {
+		records = records[:2]
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "secrets_manager_metadata", SourceID: partnerARN, Code: "secrets_manager_describe_secret_failed", Message: "AccessDenied: DescribeSecret", Retryable: true})
+	}
+	return records, diagnostics, gaps
+}
+
+func awsSecretsManagerMetadataFixtureRecord(accountID, region, name, arn string, checkedAt time.Time, mutate func(*AWSSecretsManagerMetadataRecord)) AWSSecretsManagerMetadataRecord {
+	record := AWSSecretsManagerMetadataRecord{
+		AccountID:              accountID,
+		Region:                 region,
+		Service:                "secretsmanager",
+		SecretARN:              arn,
+		SecretName:             name,
+		DescriptionPresent:     true,
+		SecretStatus:           "active",
+		CreatedAt:              "2026-06-01T12:00:00Z",
+		LastChangedAt:          "2026-06-08T12:00:00Z",
+		LastAccessedAt:         "2026-06-09",
+		VersionStages:          []AWSSecretsManagerVersionStage{{VersionID: "version-current", Stages: []string{"AWSCURRENT"}, CreatedAt: "2026-06-08T12:00:00Z"}},
+		Tags:                   map[string]string{"owner": "payments"},
+		ExposureClassification: "private",
+		ExposureReasons:        []string{},
+		Source:                 "secrets_manager_metadata",
+		EvidenceRef:            arn,
+		FromNodeID:             "aws:resource:secrets-manager-secret:" + arn,
+		RelationshipType:       "metadata",
+		Confidence:             0.86,
+		CollectedAt:            checkedAt,
+		Status:                 "ready",
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	return record
+}
+
+func awsSecretsManagerReferenceEdges(records []AWSSecretsManagerMetadataRecord) []AWSSecretsManagerReferenceEdge {
+	edges := []AWSSecretsManagerReferenceEdge{}
+	for _, record := range records {
+		toNode := "aws:resource:secrets-manager-secret:" + record.SecretARN
+		for _, ref := range record.ReferencedBy {
+			fromNode := firstNonEmptyAWSValue(ref.WorkloadID, ref.ResourceID, ref.ResourceARN)
+			if strings.TrimSpace(fromNode) == "" {
+				continue
+			}
+			edges = append(edges, AWSSecretsManagerReferenceEdge{
+				Type:        "uses_secret",
+				FromNodeID:  fromNode,
+				ToNodeID:    toNode,
+				EvidenceRef: ref.Reference,
+				Source:      ref.SourceService,
+				Confidence:  ref.Confidence,
+			})
+		}
+	}
+	return edges
+}
+
+func summarizeAWSSecretsManagerMetadataInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSSecretsManagerMetadataRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.3, []string{"Secrets Manager metadata collection is permission denied."}, []string{"Grant ListSecrets, DescribeSecret, GetResourcePolicy, and ListSecretVersionIds without GetSecretValue."}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72, awsSecretsManagerSourceErrorMessages(diagnostics), []string{"Review the diagnostics and rerun after metadata-only Secrets Manager permissions are available."}
+	default:
+		if len(records) == 0 {
+			return awsPlatformDependencyStatusReady, 0.82, nil, []string{"No Secrets Manager secrets were found for this account and region."}
+		}
+		return awsPlatformDependencyStatusReady, 0.93, nil, []string{"Use these references to prioritize workload secret reachability and rotation follow-up."}
+	}
+}
+
+func awsSecretsManagerMetadataDiagnostics(diagnostics []providers.SourceError) []AWSSecretsManagerMetadataDiagnostic {
+	result := make([]AWSSecretsManagerMetadataDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSSecretsManagerMetadataDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: "Confirm metadata-only Secrets Manager IAM permissions; do not add GetSecretValue for this collector.",
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func countSecrets(records []AWSSecretsManagerMetadataRecord, pred func(AWSSecretsManagerMetadataRecord) bool) int {
+	count := 0
+	for _, record := range records {
+		if pred(record) {
+			count++
+		}
+	}
+	return count
+}
+
+func countSecretRefs(records []AWSSecretsManagerMetadataRecord, pred func(AWSSecretsManagerWorkloadReference) bool, unresolved bool) int {
+	count := 0
+	for _, record := range records {
+		refs := record.ReferencedBy
+		if unresolved {
+			refs = record.UnresolvedReferences
+		}
+		for _, ref := range refs {
+			if pred(ref) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func awsSecretsManagerSourceErrorMessages(diagnostics []providers.SourceError) []string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if message := strings.TrimSpace(diagnostic.Message); message != "" {
+			messages = append(messages, message)
+		}
+	}
+	return dedupeStrings(messages)
+}
+
+func awsSecretsManagerPartitionForRegion(region string) string {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(normalized, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(normalized, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}

--- a/internal/api/aws_secrets_manager_metadata_test.go
+++ b/internal/api/aws_secrets_manager_metadata_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSSecretsManagerMetadataInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSSecretsManagerMetadataInventory(ctx, "default", "project-a", AWSSecretsManagerMetadataInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get secrets manager metadata: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1490" || result.Version != awsSecretsManagerMetadataVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.SecretCount != 3 || result.RelationshipCount != 1 || result.UnresolvedReferenceCount != 1 {
+		t.Fatalf("unexpected counts: %+v", result)
+	}
+	if result.PublicSecretCount == 0 || result.CrossAccountSecretCount == 0 || result.KMSReferencedCount == 0 {
+		t.Fatalf("expected public/cross-account/kms counts, got %+v", result)
+	}
+	for _, record := range result.Records {
+		evidence := strings.ToLower(record.EvidenceRef + " " + record.Source)
+		if strings.Contains(evidence, "secretstring") || strings.Contains(evidence, "secretbinary") || strings.Contains(evidence, "getsecretvalue") {
+			t.Fatalf("secret value evidence leaked into API response: %+v", record)
+		}
+		if record.DescriptionPresent != true {
+			t.Fatalf("expected description presence flag, got %+v", record)
+		}
+	}
+}
+
+func TestGetAWSSecretsManagerMetadataInventoryDegradedAndPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	degraded, err := svc.GetAWSSecretsManagerMetadataInventory(ctx, "default", "project-a", AWSSecretsManagerMetadataInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded inventory: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || degraded.MissingRotationCount == 0 || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded missing-rotation diagnostics, got %+v", degraded)
+	}
+
+	denied, err := svc.GetAWSSecretsManagerMetadataInventory(ctx, "default", "project-a", AWSSecretsManagerMetadataInventoryRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied inventory: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.SecretCount != 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("expected blocked permission-denied inventory, got %+v", denied)
+	}
+}
+
+func TestRouterAWSSecretsManagerMetadataPartialFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/secrets-manager-metadata?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSSecretsManagerMetadataInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.SecretCount == 0 {
+		t.Fatalf("expected degraded partial records, got %+v", body.Inventory)
+	}
+	foundDiag := false
+	for _, diag := range body.Inventory.Diagnostics {
+		if diag.Code == "secrets_manager_describe_secret_failed" {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected describe diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestRouterAWSSecretsManagerMetadataInvalidFixtureState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 10, 16, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-2")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-2", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-2/aws/secrets-manager-metadata?connector_id=aws-prod&fixture_state=bogus", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2854,6 +2854,36 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSecretsManagerMetadataInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSecretsManagerMetadataInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws secrets manager metadata request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws secrets manager metadata inventory",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws secrets manager metadata inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -642,6 +642,10 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws kms decrypt reachability collector: %w", err)
 			}
+			secretsAPI, err := awsprovider.NewSDKSecretsManagerMetadataAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if err != nil {
+				return app.Scanner{}, fmt.Errorf("initialize aws secrets manager metadata collector: %w", err)
+			}
 			return awsprovider.NewAWSScannerWithServices(iamAPI, cfg.AWSAccountID, cfg.AWSRegion, []awsprovider.AWSServiceCollector{
 				awsprovider.NewEC2InstanceProfileCollector(ec2API),
 				awsprovider.NewECSTaskRoleCollector(ecsAPI),
@@ -656,6 +660,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
 				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
+				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
 			}, awsprovider.NewRuleSet(
 				awsprovider.WithStaleAfter(time.Duration(staleAfterDays)*24*time.Hour),
 			)), nil

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -152,6 +152,13 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	var secretsManagerMetadata SecretsManagerSecretMetadata
+	if err := json.Unmarshal(payload, &secretsManagerMetadata); err == nil {
+		if isSecretsManagerMetadataFixture(secretsManagerMetadata) {
+			return rawKindSecretsManagerMetadata, secretsManagerMetadataSourceID(secretsManagerMetadata)
+		}
+	}
+
 	var managedComputeRole ManagedComputeRole
 	if err := json.Unmarshal(payload, &managedComputeRole); err == nil {
 		sourceID := managedComputeRoleSourceID(managedComputeRole)
@@ -528,4 +535,21 @@ func isKMSDecryptReachabilityFixture(record KMSDecryptReachability) bool {
 		return true
 	}
 	return false
+}
+
+// isSecretsManagerMetadataFixture identifies metadata-only Secrets Manager
+// fixtures without treating arbitrary workload records as secret records.
+func isSecretsManagerMetadataFixture(record SecretsManagerSecretMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(record.Service), secretsManagerServiceName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.CollectorName), secretsManagerMetadataCollectorName) {
+		return true
+	}
+	return strings.TrimSpace(record.SecretARN) != "" ||
+		strings.TrimSpace(record.SecretName) != "" ||
+		strings.TrimSpace(record.KMSKeyID) != "" ||
+		strings.TrimSpace(record.KMSKeyARN) != "" ||
+		len(record.ReferencedBy) > 0 ||
+		len(record.UnresolvedReferences) > 0
 }

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -73,6 +73,33 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 		appendRelationship(&relationships, seen, relationship)
 	}
 
+	secretIndex := secretsManagerResourceIndex(bundle.Resources)
+	for _, resource := range bundle.Resources {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		refs := parseStringList(resource.Metadata["secret_refs"])
+		for _, ref := range refs {
+			secretID := matchSecretsManagerReference(ref, secretIndex)
+			if secretID == "" {
+				continue
+			}
+			fromNodeID := strings.TrimSpace(resource.SourceEntityID)
+			if fromNodeID == "" {
+				fromNodeID = resource.ID
+			}
+			relationship := domain.Relationship{
+				ID:           relationshipID(domain.RelationshipUsesSecret, fromNodeID, secretID),
+				Type:         domain.RelationshipUsesSecret,
+				FromNodeID:   fromNodeID,
+				ToNodeID:     secretID,
+				EvidenceRef:  strings.TrimSpace(ref),
+				DiscoveredAt: timestamp,
+			}
+			appendRelationship(&relationships, seen, relationship)
+		}
+	}
+
 	for _, policy := range bundle.Policies {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -134,6 +161,28 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 	}
 
 	return relationships, nil
+}
+
+func secretsManagerResourceIndex(resources []domain.Resource) map[string]string {
+	index := map[string]string{}
+	for _, resource := range resources {
+		if resource.Type != domain.ResourceTypeSecretsManager {
+			continue
+		}
+		for _, key := range secretsManagerReferenceKeys(resource.ARN, resource.Name) {
+			index[strings.ToLower(key)] = resource.ID
+		}
+	}
+	return index
+}
+
+func matchSecretsManagerReference(ref string, index map[string]string) string {
+	for _, key := range secretsManagerReferenceKeysFromRef(ref) {
+		if id := index[strings.ToLower(key)]; id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 func workloadRelationshipType(workloadType string) domain.RelationshipType {

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -302,7 +302,7 @@ func normalizeSecretsManagerMetadataAsset(asset providers.RawAsset, index int, b
 		AccountID: strings.TrimSpace(record.AccountID),
 		Labels:    copyTags(record.Tags),
 		Metadata: map[string]any{
-			"description_present":             strings.TrimSpace(record.Description) != "",
+			"description_present":             record.DescriptionPresent,
 			"kms_key_id":                      strings.TrimSpace(record.KMSKeyID),
 			"kms_key_arn":                     strings.TrimSpace(record.KMSKeyARN),
 			"owning_service":                  strings.TrimSpace(record.OwningService),

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -47,6 +47,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		if err := ctx.Err(); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
+		if asset.Kind != rawKindSecretsManagerMetadata {
+			continue
+		}
+		if err := normalizeSecretsManagerMetadataAsset(asset, i, &bundle, resourceSeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
 		if asset.Kind != "iam_role" {
 			continue
 		}
@@ -263,6 +275,62 @@ func normalizeIAMRoleAsset(asset providers.RawAsset, index int, bundle *provider
 			bundle.Policies = append(bundle.Policies, *trustPolicy)
 		}
 	}
+	return nil
+}
+
+func normalizeSecretsManagerMetadataAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, resourceSeen map[string]struct{}) error {
+	var record SecretsManagerSecretMetadata
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode secrets manager metadata asset[%d]: %w", index, err)
+	}
+	secretARN := strings.TrimSpace(record.SecretARN)
+	if secretARN == "" {
+		return nil
+	}
+	resourceID := secretsManagerSecretResourceID(secretARN)
+	if _, exists := resourceSeen[resourceID]; exists {
+		return nil
+	}
+	resourceSeen[resourceID] = struct{}{}
+	bundle.Resources = append(bundle.Resources, domain.Resource{
+		ID:        resourceID,
+		Provider:  domain.ProviderAWS,
+		Type:      domain.ResourceTypeSecretsManager,
+		Name:      firstNonEmptyAWSValue(record.SecretName, secretNameFromARN(secretARN), secretARN),
+		ARN:       secretARN,
+		Region:    strings.TrimSpace(record.Region),
+		AccountID: strings.TrimSpace(record.AccountID),
+		Labels:    copyTags(record.Tags),
+		Metadata: map[string]any{
+			"description_present":             strings.TrimSpace(record.Description) != "",
+			"kms_key_id":                      strings.TrimSpace(record.KMSKeyID),
+			"kms_key_arn":                     strings.TrimSpace(record.KMSKeyARN),
+			"owning_service":                  strings.TrimSpace(record.OwningService),
+			"primary_region":                  strings.TrimSpace(record.PrimaryRegion),
+			"secret_status":                   strings.TrimSpace(record.SecretStatus),
+			"rotation_enabled":                record.RotationEnabled,
+			"rotation_lambda_arn":             strings.TrimSpace(record.RotationLambdaARN),
+			"rotation_interval_days":          record.RotationInterval,
+			"created_at":                      strings.TrimSpace(record.CreatedAt),
+			"last_changed_at":                 strings.TrimSpace(record.LastChangedAt),
+			"last_accessed_at":                strings.TrimSpace(record.LastAccessedAt),
+			"last_rotated_at":                 strings.TrimSpace(record.LastRotatedAt),
+			"deleted_at":                      strings.TrimSpace(record.DeletedAt),
+			"has_resource_policy":             record.HasResourcePolicy,
+			"resource_policy_statement_count": record.ResourcePolicyStatementCount,
+			"version_stage_count":             len(record.VersionStages),
+			"replica_region_count":            len(record.ReplicaRegions),
+			"exposure_classification":         record.ExposureClassification,
+			"exposure_reasons":                append([]string(nil), record.ExposureReasons...),
+			"identity_grant_count":            len(record.IdentityGrants),
+			"public_grant_count":              secretsManagerPublicGrantCount(record.IdentityGrants),
+			"cross_account_grant_count":       secretsManagerCrossAccountGrantCount(record.IdentityGrants),
+			"reference_count":                 len(record.ReferencedBy),
+			"referenced_by":                   secretReferenceMetadata(record.ReferencedBy),
+			"unresolved_references":           secretReferenceMetadata(record.UnresolvedReferences),
+		},
+		RawRef: asset.SourceID,
+	})
 	return nil
 }
 
@@ -2163,4 +2231,45 @@ func kmsCrossAccountLiveGrantCount(grants []KMSGrant) int {
 		}
 	}
 	return count
+}
+
+func secretsManagerPublicGrantCount(grants []SecretsManagerIdentityGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if grant.IsPublic {
+			count++
+		}
+	}
+	return count
+}
+
+func secretsManagerCrossAccountGrantCount(grants []SecretsManagerIdentityGrant) int {
+	count := 0
+	for _, grant := range grants {
+		if grant.IsCrossAccount {
+			count++
+		}
+	}
+	return count
+}
+
+func secretReferenceMetadata(refs []SecretWorkloadReference) []map[string]any {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, map[string]any{
+			"source_service": strings.TrimSpace(ref.SourceService),
+			"workload_id":    strings.TrimSpace(ref.WorkloadID),
+			"workload_type":  strings.TrimSpace(ref.WorkloadType),
+			"workload_name":  strings.TrimSpace(ref.WorkloadName),
+			"resource_arn":   strings.TrimSpace(ref.ResourceARN),
+			"resource_id":    strings.TrimSpace(ref.ResourceID),
+			"reference":      strings.TrimSpace(ref.Reference),
+			"reference_kind": strings.TrimSpace(ref.ReferenceKind),
+			"confidence":     ref.Confidence,
+		})
+	}
+	return out
 }

--- a/internal/providers/aws/sdk_secrets_manager_metadata.go
+++ b/internal/providers/aws/sdk_secrets_manager_metadata.go
@@ -147,15 +147,15 @@ func (a *SDKSecretsManagerMetadataAPI) enrichSecretMetadata(ctx context.Context,
 
 func secretMetadataFromListEntry(entry smtypes.SecretListEntry, accountID string, region string) SecretsManagerSecretMetadata {
 	record := SecretsManagerSecretMetadata{
-		SecretARN:         strings.TrimSpace(awsv2.ToString(entry.ARN)),
-		SecretName:        strings.TrimSpace(awsv2.ToString(entry.Name)),
-		Description:       strings.TrimSpace(awsv2.ToString(entry.Description)),
-		KMSKeyID:          strings.TrimSpace(awsv2.ToString(entry.KmsKeyId)),
-		RotationEnabled:   awsv2.ToBool(entry.RotationEnabled),
-		RotationLambdaARN: strings.TrimSpace(awsv2.ToString(entry.RotationLambdaARN)),
-		OwningService:     strings.TrimSpace(awsv2.ToString(entry.OwningService)),
-		PrimaryRegion:     strings.TrimSpace(awsv2.ToString(entry.PrimaryRegion)),
-		Tags:              secretsManagerTags(entry.Tags),
+		SecretARN:          strings.TrimSpace(awsv2.ToString(entry.ARN)),
+		SecretName:         strings.TrimSpace(awsv2.ToString(entry.Name)),
+		DescriptionPresent: strings.TrimSpace(awsv2.ToString(entry.Description)) != "",
+		KMSKeyID:           strings.TrimSpace(awsv2.ToString(entry.KmsKeyId)),
+		RotationEnabled:    awsv2.ToBool(entry.RotationEnabled),
+		RotationLambdaARN:  strings.TrimSpace(awsv2.ToString(entry.RotationLambdaARN)),
+		OwningService:      strings.TrimSpace(awsv2.ToString(entry.OwningService)),
+		PrimaryRegion:      strings.TrimSpace(awsv2.ToString(entry.PrimaryRegion)),
+		Tags:               secretsManagerTags(entry.Tags),
 		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
 			AccountID: strings.TrimSpace(accountID),
 			Region:    strings.TrimSpace(region),
@@ -183,7 +183,7 @@ func secretMetadataFromListEntry(entry smtypes.SecretListEntry, accountID string
 func mergeSecretDescribe(record *SecretsManagerSecretMetadata, describe *secretsmanager.DescribeSecretOutput, accountID string, region string) {
 	record.SecretARN = firstNonEmptyAWSValue(awsv2.ToString(describe.ARN), record.SecretARN)
 	record.SecretName = firstNonEmptyAWSValue(awsv2.ToString(describe.Name), record.SecretName)
-	record.Description = firstNonEmptyAWSValue(awsv2.ToString(describe.Description), record.Description)
+	record.DescriptionPresent = record.DescriptionPresent || strings.TrimSpace(awsv2.ToString(describe.Description)) != ""
 	record.KMSKeyID = firstNonEmptyAWSValue(awsv2.ToString(describe.KmsKeyId), record.KMSKeyID)
 	record.RotationEnabled = awsv2.ToBool(describe.RotationEnabled)
 	record.RotationLambdaARN = firstNonEmptyAWSValue(awsv2.ToString(describe.RotationLambdaARN), record.RotationLambdaARN)

--- a/internal/providers/aws/sdk_secrets_manager_metadata.go
+++ b/internal/providers/aws/sdk_secrets_manager_metadata.go
@@ -1,0 +1,314 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+type SecretsManagerSDKClient interface {
+	ListSecrets(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	DescribeSecret(ctx context.Context, params *secretsmanager.DescribeSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error)
+	GetResourcePolicy(ctx context.Context, params *secretsmanager.GetResourcePolicyInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetResourcePolicyOutput, error)
+	ListSecretVersionIds(ctx context.Context, params *secretsmanager.ListSecretVersionIdsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretVersionIdsOutput, error)
+}
+
+type SDKSecretsManagerMetadataAPI struct {
+	client    SecretsManagerSDKClient
+	accountID string
+	region    string
+}
+
+func NewSDKSecretsManagerMetadataAPI(region string, profile string, accountID string) (SecretsManagerMetadataAPI, error) {
+	return NewSDKSecretsManagerMetadataAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+func NewSDKSecretsManagerMetadataAPIWithContext(ctx context.Context, region string, profile string, accountID string) (SecretsManagerMetadataAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolvedAccountID, err := secretsManagerMetadataAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKSecretsManagerMetadataAPIFromClient(secretsmanager.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKSecretsManagerMetadataAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (SecretsManagerMetadataAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolvedAccountID, err := secretsManagerMetadataAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKSecretsManagerMetadataAPIFromClient(secretsmanager.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKSecretsManagerMetadataAPIFromClient(client SecretsManagerSDKClient, accountID string, region string) SecretsManagerMetadataAPI {
+	return &SDKSecretsManagerMetadataAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+func (a *SDKSecretsManagerMetadataAPI) ListSecretMetadata(ctx context.Context, nextToken string, pageSize int32) (SecretsManagerMetadataPage, error) {
+	if a.client == nil {
+		return SecretsManagerMetadataPage{}, fmt.Errorf("secrets manager metadata api requires client")
+	}
+	input := &secretsmanager.ListSecretsInput{
+		NextToken:  stringPtrOrNil(nextToken),
+		MaxResults: awsv2.Int32(pageSize),
+	}
+	if pageSize <= 0 {
+		input.MaxResults = awsv2.Int32(defaultPageSize)
+	}
+	output, err := a.client.ListSecrets(ctx, input)
+	if err != nil {
+		return SecretsManagerMetadataPage{}, err
+	}
+	if output == nil {
+		return SecretsManagerMetadataPage{}, nil
+	}
+	page := SecretsManagerMetadataPage{
+		Records:   make([]SecretsManagerSecretMetadata, 0, len(output.SecretList)),
+		NextToken: strings.TrimSpace(awsv2.ToString(output.NextToken)),
+	}
+	for _, entry := range output.SecretList {
+		record := secretMetadataFromListEntry(entry, a.accountID, a.region)
+		secretID := firstNonEmptyAWSValue(record.SecretARN, record.SecretName)
+		if secretID == "" {
+			page.Diagnostics = append(page.Diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_secret_id_missing", "listsecrets", "skipped Secrets Manager record without ARN or name", false))
+			continue
+		}
+		a.enrichSecretMetadata(ctx, secretID, &record, &page.Diagnostics)
+		page.Records = append(page.Records, record)
+	}
+	return page, nil
+}
+
+func (a *SDKSecretsManagerMetadataAPI) enrichSecretMetadata(ctx context.Context, secretID string, record *SecretsManagerSecretMetadata, diagnostics *[]providers.SourceError) {
+	describe, err := a.client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: awsv2.String(secretID)})
+	if err != nil {
+		*diagnostics = append(*diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_describe_secret_failed", secretID, fmt.Sprintf("DescribeSecret failed: %v", err), true))
+	} else if describe != nil {
+		mergeSecretDescribe(record, describe, a.accountID, a.region)
+	}
+	policy, err := a.client.GetResourcePolicy(ctx, &secretsmanager.GetResourcePolicyInput{SecretId: awsv2.String(secretID)})
+	if err != nil {
+		if !secretsManagerNoResourcePolicy(err) {
+			*diagnostics = append(*diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_resource_policy_failed", secretID, fmt.Sprintf("GetResourcePolicy failed: %v", err), true))
+		}
+	} else if policy != nil && strings.TrimSpace(awsv2.ToString(policy.ResourcePolicy)) != "" {
+		grants, count, parseErr := parseSecretsManagerResourcePolicyGrants(awsv2.ToString(policy.ResourcePolicy), record.AccountID)
+		if parseErr != nil {
+			*diagnostics = append(*diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_resource_policy_parse_failed", secretID, fmt.Sprintf("parse resource policy failed: %v", parseErr), false))
+		} else {
+			record.HasResourcePolicy = true
+			record.ResourcePolicyStatementCount = count
+			record.IdentityGrants = grants
+		}
+	}
+	versionStages, versionDiagnostics := a.secretVersionStages(ctx, secretID)
+	*diagnostics = append(*diagnostics, versionDiagnostics...)
+	record.VersionStages = versionStages
+}
+
+func secretMetadataFromListEntry(entry smtypes.SecretListEntry, accountID string, region string) SecretsManagerSecretMetadata {
+	record := SecretsManagerSecretMetadata{
+		SecretARN:         strings.TrimSpace(awsv2.ToString(entry.ARN)),
+		SecretName:        strings.TrimSpace(awsv2.ToString(entry.Name)),
+		Description:       strings.TrimSpace(awsv2.ToString(entry.Description)),
+		KMSKeyID:          strings.TrimSpace(awsv2.ToString(entry.KmsKeyId)),
+		RotationEnabled:   awsv2.ToBool(entry.RotationEnabled),
+		RotationLambdaARN: strings.TrimSpace(awsv2.ToString(entry.RotationLambdaARN)),
+		OwningService:     strings.TrimSpace(awsv2.ToString(entry.OwningService)),
+		PrimaryRegion:     strings.TrimSpace(awsv2.ToString(entry.PrimaryRegion)),
+		Tags:              secretsManagerTags(entry.Tags),
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: strings.TrimSpace(accountID),
+			Region:    strings.TrimSpace(region),
+			Service:   secretsManagerServiceName,
+		},
+	}
+	if entry.RotationRules != nil {
+		record.AutomaticallyAfterDays = awsv2.ToInt64(entry.RotationRules.AutomaticallyAfterDays)
+		record.RotationInterval = awsv2.ToInt64(entry.RotationRules.AutomaticallyAfterDays)
+	}
+	record.CreatedAt = awsTimeString(entry.CreatedDate)
+	record.LastChangedAt = awsTimeString(entry.LastChangedDate)
+	record.LastAccessedAt = awsDateString(entry.LastAccessedDate)
+	record.LastRotatedAt = awsTimeString(entry.LastRotatedDate)
+	record.DeletedAt = awsTimeString(entry.DeletedDate)
+	for versionID, stages := range entry.SecretVersionsToStages {
+		record.VersionStages = append(record.VersionStages, SecretsManagerVersionStage{
+			VersionID: strings.TrimSpace(versionID),
+			Stages:    normalizeStringList(stages),
+		})
+	}
+	return record
+}
+
+func mergeSecretDescribe(record *SecretsManagerSecretMetadata, describe *secretsmanager.DescribeSecretOutput, accountID string, region string) {
+	record.SecretARN = firstNonEmptyAWSValue(awsv2.ToString(describe.ARN), record.SecretARN)
+	record.SecretName = firstNonEmptyAWSValue(awsv2.ToString(describe.Name), record.SecretName)
+	record.Description = firstNonEmptyAWSValue(awsv2.ToString(describe.Description), record.Description)
+	record.KMSKeyID = firstNonEmptyAWSValue(awsv2.ToString(describe.KmsKeyId), record.KMSKeyID)
+	record.RotationEnabled = awsv2.ToBool(describe.RotationEnabled)
+	record.RotationLambdaARN = firstNonEmptyAWSValue(awsv2.ToString(describe.RotationLambdaARN), record.RotationLambdaARN)
+	record.OwningService = firstNonEmptyAWSValue(awsv2.ToString(describe.OwningService), record.OwningService)
+	record.PrimaryRegion = firstNonEmptyAWSValue(awsv2.ToString(describe.PrimaryRegion), record.PrimaryRegion)
+	record.AccountID = firstNonEmptyAWSValue(accountID, record.AccountID, accountIDFromARN(record.SecretARN))
+	record.Region = firstNonEmptyAWSValue(region, record.Region, regionFromARN(record.SecretARN))
+	if tags := secretsManagerTags(describe.Tags); len(tags) > 0 {
+		record.Tags = tags
+	}
+	if describe.RotationRules != nil {
+		record.AutomaticallyAfterDays = awsv2.ToInt64(describe.RotationRules.AutomaticallyAfterDays)
+		record.RotationInterval = awsv2.ToInt64(describe.RotationRules.AutomaticallyAfterDays)
+	}
+	record.CreatedAt = firstNonEmptyAWSValue(awsTimeString(describe.CreatedDate), record.CreatedAt)
+	record.LastChangedAt = firstNonEmptyAWSValue(awsTimeString(describe.LastChangedDate), record.LastChangedAt)
+	record.LastAccessedAt = firstNonEmptyAWSValue(awsDateString(describe.LastAccessedDate), record.LastAccessedAt)
+	record.LastRotatedAt = firstNonEmptyAWSValue(awsTimeString(describe.LastRotatedDate), record.LastRotatedAt)
+	record.DeletedAt = firstNonEmptyAWSValue(awsTimeString(describe.DeletedDate), record.DeletedAt)
+	record.ReplicaRegions = secretReplicaRegions(describe.ReplicationStatus)
+}
+
+func (a *SDKSecretsManagerMetadataAPI) secretVersionStages(ctx context.Context, secretID string) ([]SecretsManagerVersionStage, []providers.SourceError) {
+	diagnostics := []providers.SourceError{}
+	stages := []SecretsManagerVersionStage{}
+	nextToken := ""
+	for page := 1; ; page++ {
+		if page > defaultMaxPages {
+			diagnostics = append(diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_versions_page_limit_exceeded", secretID, "ListSecretVersionIds paginated beyond max pages", false))
+			break
+		}
+		output, err := a.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
+			SecretId:  awsv2.String(secretID),
+			NextToken: stringPtrOrNil(nextToken),
+		})
+		if err != nil {
+			diagnostics = append(diagnostics, secretsManagerMetadataDiagnostic("secrets_manager_versions_failed", secretID, fmt.Sprintf("ListSecretVersionIds failed: %v", err), true))
+			break
+		}
+		if output == nil {
+			break
+		}
+		for _, version := range output.Versions {
+			stages = append(stages, SecretsManagerVersionStage{
+				VersionID:    strings.TrimSpace(awsv2.ToString(version.VersionId)),
+				Stages:       normalizeStringList(version.VersionStages),
+				CreatedAt:    awsTimeString(version.CreatedDate),
+				LastAccessed: awsDateString(version.LastAccessedDate),
+				KMSKeyIDs:    normalizeStringList(version.KmsKeyIds),
+			})
+		}
+		nextToken = strings.TrimSpace(awsv2.ToString(output.NextToken))
+		if nextToken == "" {
+			break
+		}
+	}
+	return normalizeSecretsManagerVersionStages(stages), diagnostics
+}
+
+func secretsManagerTags(tags []smtypes.Tag) map[string]string {
+	out := map[string]string{}
+	for _, tag := range tags {
+		key := strings.TrimSpace(awsv2.ToString(tag.Key))
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(awsv2.ToString(tag.Value))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func secretReplicaRegions(replicas []smtypes.ReplicationStatusType) []SecretsManagerReplicaRegion {
+	if len(replicas) == 0 {
+		return nil
+	}
+	out := make([]SecretsManagerReplicaRegion, 0, len(replicas))
+	for _, replica := range replicas {
+		out = append(out, SecretsManagerReplicaRegion{
+			Region:         strings.TrimSpace(awsv2.ToString(replica.Region)),
+			KMSKeyID:       strings.TrimSpace(awsv2.ToString(replica.KmsKeyId)),
+			Status:         string(replica.Status),
+			StatusMessage:  strings.TrimSpace(awsv2.ToString(replica.StatusMessage)),
+			LastAccessedAt: awsDateString(replica.LastAccessedDate),
+		})
+	}
+	return normalizeSecretsManagerReplicaRegions(out)
+}
+
+func awsTimeString(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func awsDateString(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+func secretsManagerNoResourcePolicy(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "resourcenotfoundexception") || strings.Contains(msg, "resource policy") && strings.Contains(msg, "not found")
+}
+
+func secretsManagerMetadataAccountID(ctx context.Context, cfg awsv2.Config, accountID string) (string, error) {
+	trimmed := strings.TrimSpace(accountID)
+	if trimmed != "" {
+		return trimmed, nil
+	}
+	identity, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("read AWS caller identity for secrets manager account id: %w", err)
+	}
+	resolved := strings.TrimSpace(awsv2.ToString(identity.Account))
+	if resolved == "" {
+		return "", fmt.Errorf("read AWS caller identity for secrets manager account id: empty account id")
+	}
+	return resolved, nil
+}

--- a/internal/providers/aws/sdk_secrets_manager_metadata_test.go
+++ b/internal/providers/aws/sdk_secrets_manager_metadata_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,6 +63,7 @@ func TestSDKSecretsManagerMetadataAPI_ListSecretMetadataEnrichesRecord(t *testin
 			SecretList: []smtypes.SecretListEntry{{
 				ARN:             awsv2.String(arn),
 				Name:            awsv2.String("payments/db"),
+				Description:     awsv2.String("sensitive operator note do not persist"),
 				RotationEnabled: awsv2.Bool(true),
 				KmsKeyId:        awsv2.String("alias/payments"),
 				Tags:            []smtypes.Tag{{Key: awsv2.String("owner"), Value: awsv2.String("payments")}},
@@ -70,6 +73,7 @@ func TestSDKSecretsManagerMetadataAPI_ListSecretMetadataEnrichesRecord(t *testin
 			arn: {
 				ARN:             awsv2.String(arn),
 				Name:            awsv2.String("payments/db"),
+				Description:     awsv2.String("another sensitive note"),
 				RotationEnabled: awsv2.Bool(true),
 				RotationRules:   &smtypes.RotationRulesType{AutomaticallyAfterDays: awsv2.Int64(30)},
 				CreatedDate:     &now,
@@ -99,6 +103,16 @@ func TestSDKSecretsManagerMetadataAPI_ListSecretMetadataEnrichesRecord(t *testin
 	record := page.Records[0]
 	if !record.RotationEnabled || record.RotationInterval != 30 {
 		t.Fatalf("rotation metadata not enriched: %+v", record)
+	}
+	if !record.DescriptionPresent {
+		t.Fatalf("expected description presence flag")
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	if strings.Contains(string(payload), "sensitive operator note") || strings.Contains(string(payload), "another sensitive note") {
+		t.Fatalf("description text leaked into metadata payload: %s", payload)
 	}
 	if len(record.IdentityGrants) != 1 || !record.IdentityGrants[0].IsCrossAccount {
 		t.Fatalf("expected cross-account resource policy grant, got %+v", record.IdentityGrants)

--- a/internal/providers/aws/sdk_secrets_manager_metadata_test.go
+++ b/internal/providers/aws/sdk_secrets_manager_metadata_test.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+type fakeSecretsManagerSDKClient struct {
+	listSecrets       *secretsmanager.ListSecretsOutput
+	listSecretsErr    error
+	describe          map[string]*secretsmanager.DescribeSecretOutput
+	describeErr       map[string]error
+	resourcePolicy    map[string]*secretsmanager.GetResourcePolicyOutput
+	resourcePolicyErr map[string]error
+	versions          map[string]*secretsmanager.ListSecretVersionIdsOutput
+	versionsErr       map[string]error
+}
+
+func (f *fakeSecretsManagerSDKClient) ListSecrets(ctx context.Context, input *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+	if f.listSecretsErr != nil {
+		return nil, f.listSecretsErr
+	}
+	return f.listSecrets, nil
+}
+
+func (f *fakeSecretsManagerSDKClient) DescribeSecret(ctx context.Context, input *secretsmanager.DescribeSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+	id := awsv2.ToString(input.SecretId)
+	if err, ok := f.describeErr[id]; ok {
+		return nil, err
+	}
+	return f.describe[id], nil
+}
+
+func (f *fakeSecretsManagerSDKClient) GetResourcePolicy(ctx context.Context, input *secretsmanager.GetResourcePolicyInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetResourcePolicyOutput, error) {
+	id := awsv2.ToString(input.SecretId)
+	if err, ok := f.resourcePolicyErr[id]; ok {
+		return nil, err
+	}
+	return f.resourcePolicy[id], nil
+}
+
+func (f *fakeSecretsManagerSDKClient) ListSecretVersionIds(ctx context.Context, input *secretsmanager.ListSecretVersionIdsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+	id := awsv2.ToString(input.SecretId)
+	if err, ok := f.versionsErr[id]; ok {
+		return nil, err
+	}
+	return f.versions[id], nil
+}
+
+func TestSDKSecretsManagerMetadataAPI_ListSecretMetadataEnrichesRecord(t *testing.T) {
+	arn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf"
+	now := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
+	fake := &fakeSecretsManagerSDKClient{
+		listSecrets: &secretsmanager.ListSecretsOutput{
+			SecretList: []smtypes.SecretListEntry{{
+				ARN:             awsv2.String(arn),
+				Name:            awsv2.String("payments/db"),
+				RotationEnabled: awsv2.Bool(true),
+				KmsKeyId:        awsv2.String("alias/payments"),
+				Tags:            []smtypes.Tag{{Key: awsv2.String("owner"), Value: awsv2.String("payments")}},
+			}},
+		},
+		describe: map[string]*secretsmanager.DescribeSecretOutput{
+			arn: {
+				ARN:             awsv2.String(arn),
+				Name:            awsv2.String("payments/db"),
+				RotationEnabled: awsv2.Bool(true),
+				RotationRules:   &smtypes.RotationRulesType{AutomaticallyAfterDays: awsv2.Int64(30)},
+				CreatedDate:     &now,
+				Tags:            []smtypes.Tag{{Key: awsv2.String("env"), Value: awsv2.String("prod")}},
+			},
+		},
+		resourcePolicy: map[string]*secretsmanager.GetResourcePolicyOutput{
+			arn: {ResourcePolicy: awsv2.String(`{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::999999999999:role/partner"},"Action":"secretsmanager:DescribeSecret","Resource":"*"}]}`)},
+		},
+		versions: map[string]*secretsmanager.ListSecretVersionIdsOutput{
+			arn: {Versions: []smtypes.SecretVersionsListEntry{{
+				VersionId:     awsv2.String("version-current"),
+				VersionStages: []string{"AWSCURRENT"},
+				CreatedDate:   &now,
+			}}},
+		},
+	}
+	api := NewSDKSecretsManagerMetadataAPIFromClient(fake, "123456789012", "us-east-1")
+
+	page, err := api.ListSecretMetadata(context.Background(), "", 25)
+	if err != nil {
+		t.Fatalf("list metadata: %v", err)
+	}
+	if len(page.Diagnostics) != 0 || len(page.Records) != 1 {
+		t.Fatalf("expected one clean record, records=%d diagnostics=%+v", len(page.Records), page.Diagnostics)
+	}
+	record := page.Records[0]
+	if !record.RotationEnabled || record.RotationInterval != 30 {
+		t.Fatalf("rotation metadata not enriched: %+v", record)
+	}
+	if len(record.IdentityGrants) != 1 || !record.IdentityGrants[0].IsCrossAccount {
+		t.Fatalf("expected cross-account resource policy grant, got %+v", record.IdentityGrants)
+	}
+	if got := record.Tags["env"]; got != "prod" {
+		t.Fatalf("expected describe tags to win, got tags=%+v", record.Tags)
+	}
+	if len(record.VersionStages) != 1 || record.VersionStages[0].VersionID != "version-current" {
+		t.Fatalf("expected version metadata, got %+v", record.VersionStages)
+	}
+}
+
+func TestSDKSecretsManagerMetadataAPI_ListSecretsError(t *testing.T) {
+	api := NewSDKSecretsManagerMetadataAPIFromClient(&fakeSecretsManagerSDKClient{listSecretsErr: errors.New("denied")}, "123456789012", "us-east-1")
+	if _, err := api.ListSecretMetadata(context.Background(), "", 25); err == nil {
+		t.Fatalf("expected ListSecrets error")
+	}
+}

--- a/internal/providers/aws/secrets_manager_metadata_collector.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector.go
@@ -1,0 +1,611 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindSecretsManagerMetadata       = "secrets_manager_metadata"
+	secretsManagerMetadataCollectorName = "secrets_manager_metadata"
+	secretsManagerServiceName           = "secretsmanager"
+)
+
+// SecretsManagerSecretMetadata is the metadata-only view of one AWS Secrets
+// Manager secret. It intentionally excludes SecretString, SecretBinary, and
+// every API that can return secret material.
+type SecretsManagerSecretMetadata struct {
+	awscontract.ServiceCollectorRecord
+
+	SecretARN     string `json:"secret_arn,omitempty"`
+	SecretName    string `json:"secret_name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	KMSKeyID      string `json:"kms_key_id,omitempty"`
+	KMSKeyARN     string `json:"kms_key_arn,omitempty"`
+	OwningService string `json:"owning_service,omitempty"`
+	PrimaryRegion string `json:"primary_region,omitempty"`
+	SecretStatus  string `json:"secret_status,omitempty"`
+
+	RotationEnabled        bool   `json:"rotation_enabled,omitempty"`
+	RotationLambdaARN      string `json:"rotation_lambda_arn,omitempty"`
+	RotationInterval       int64  `json:"rotation_interval_days,omitempty"`
+	AutomaticallyAfterDays int64  `json:"automatically_after_days,omitempty"`
+
+	CreatedAt      string `json:"created_at,omitempty"`
+	LastChangedAt  string `json:"last_changed_at,omitempty"`
+	LastAccessedAt string `json:"last_accessed_at,omitempty"`
+	LastRotatedAt  string `json:"last_rotated_at,omitempty"`
+	DeletedAt      string `json:"deleted_at,omitempty"`
+
+	HasResourcePolicy            bool                          `json:"has_resource_policy,omitempty"`
+	ResourcePolicyStatementCount int                           `json:"resource_policy_statement_count,omitempty"`
+	IdentityGrants               []SecretsManagerIdentityGrant `json:"identity_grants,omitempty"`
+	VersionStages                []SecretsManagerVersionStage  `json:"version_stages,omitempty"`
+	ReplicaRegions               []SecretsManagerReplicaRegion `json:"replica_regions,omitempty"`
+	Tags                         map[string]string             `json:"tags,omitempty"`
+
+	ExposureClassification string                    `json:"exposure_classification,omitempty"`
+	ExposureReasons        []string                  `json:"exposure_reasons,omitempty"`
+	ReferenceCount         int                       `json:"reference_count,omitempty"`
+	ReferencedBy           []SecretWorkloadReference `json:"referenced_by,omitempty"`
+	UnresolvedReferences   []SecretWorkloadReference `json:"unresolved_references,omitempty"`
+}
+
+type SecretsManagerIdentityGrant struct {
+	PrincipalARN      string   `json:"principal_arn,omitempty"`
+	PrincipalType     string   `json:"principal_type,omitempty"`
+	Effect            string   `json:"effect"`
+	Actions           []string `json:"actions,omitempty"`
+	ConditionKeys     []string `json:"condition_keys,omitempty"`
+	IsPublic          bool     `json:"is_public,omitempty"`
+	IsCrossAccount    bool     `json:"is_cross_account,omitempty"`
+	HasCondition      bool     `json:"has_condition,omitempty"`
+	StatementSid      string   `json:"statement_sid,omitempty"`
+	WildcardPrincipal bool     `json:"wildcard_principal,omitempty"`
+}
+
+type SecretsManagerVersionStage struct {
+	VersionID    string   `json:"version_id,omitempty"`
+	Stages       []string `json:"stages,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	LastAccessed string   `json:"last_accessed_at,omitempty"`
+	KMSKeyIDs    []string `json:"kms_key_ids,omitempty"`
+}
+
+type SecretsManagerReplicaRegion struct {
+	Region         string `json:"region,omitempty"`
+	KMSKeyID       string `json:"kms_key_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	StatusMessage  string `json:"status_message,omitempty"`
+	LastAccessedAt string `json:"last_accessed_at,omitempty"`
+}
+
+type SecretWorkloadReference struct {
+	SourceService string  `json:"source_service,omitempty"`
+	WorkloadID    string  `json:"workload_id,omitempty"`
+	WorkloadType  string  `json:"workload_type,omitempty"`
+	WorkloadName  string  `json:"workload_name,omitempty"`
+	ResourceARN   string  `json:"resource_arn,omitempty"`
+	ResourceID    string  `json:"resource_id,omitempty"`
+	Reference     string  `json:"reference"`
+	ReferenceKind string  `json:"reference_kind"`
+	Confidence    float64 `json:"confidence"`
+}
+
+type SecretsManagerMetadataPage struct {
+	Records     []SecretsManagerSecretMetadata
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+type SecretsManagerMetadataAPI interface {
+	ListSecretMetadata(ctx context.Context, nextToken string, pageSize int32) (SecretsManagerMetadataPage, error)
+}
+
+type SecretsManagerMetadataCollector struct {
+	client   SecretsManagerMetadataAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+type SecretsManagerMetadataOption func(*SecretsManagerMetadataCollector)
+
+func WithSecretsManagerMetadataPageSize(pageSize int32) SecretsManagerMetadataOption {
+	return func(c *SecretsManagerMetadataCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+func WithSecretsManagerMetadataMaxPages(maxPages int) SecretsManagerMetadataOption {
+	return func(c *SecretsManagerMetadataCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+func WithSecretsManagerMetadataClock(now func() time.Time) SecretsManagerMetadataOption {
+	return func(c *SecretsManagerMetadataCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+func NewSecretsManagerMetadataCollector(client SecretsManagerMetadataAPI, opts ...SecretsManagerMetadataOption) *SecretsManagerMetadataCollector {
+	c := &SecretsManagerMetadataCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *SecretsManagerMetadataCollector) ServiceName() string {
+	return secretsManagerServiceName
+}
+
+func (c *SecretsManagerMetadataCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: secretsManagerServiceName})
+	return assets, err
+}
+
+func (c *SecretsManagerMetadataCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("secrets manager metadata collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(secretsManagerMetadataDiagnostic("secrets_manager_metadata_page_limit_exceeded", firstNonEmptyAWSValue(nextToken, "page"), fmt.Sprintf("secrets manager metadata collection exceeded max pages (%d)", c.maxPages), false))
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("secrets manager metadata collection exceeded max pages (%d)", c.maxPages)
+		}
+		response, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (SecretsManagerMetadataPage, error) {
+			return c.client.ListSecretMetadata(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list secrets manager metadata page %d: %w", page, err)
+			addIssue(secretsManagerMetadataDiagnostic("secrets_manager_metadata_page_failed", firstNonEmptyAWSValue(nextToken, "page"), wrapped.Error(), isRetryable(err)))
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, diagnostic := range response.Diagnostics {
+			addIssue(diagnostic)
+		}
+		for _, record := range response.Records {
+			normalized := normalizeSecretsManagerMetadataScope(scope, record, collectedAt)
+			if strings.TrimSpace(normalized.SecretARN) == "" && strings.TrimSpace(normalized.SecretName) == "" {
+				addIssue(secretsManagerMetadataDiagnostic("malformed_secrets_manager_record", "", "skipped secrets manager record without an ARN or name", false))
+				continue
+			}
+			sourceID := secretsManagerMetadataSourceID(normalized)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, err := json.Marshal(normalized)
+			if err != nil {
+				return nil, nil, fmt.Errorf("marshal secrets manager metadata %q: %w", sourceID, err)
+			}
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindSecretsManagerMetadata,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+		if strings.TrimSpace(response.NextToken) == "" {
+			break
+		}
+		nextToken = strings.TrimSpace(response.NextToken)
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record SecretsManagerSecretMetadata, collectedAt time.Time) SecretsManagerSecretMetadata {
+	normalized := record
+	normalized.AccountID = firstNonEmptyAWSValue(record.AccountID, scope.AccountID, accountIDFromARN(record.SecretARN))
+	normalized.Region = firstNonEmptyAWSValue(record.Region, scope.Region, regionFromARN(record.SecretARN))
+	normalized.Service = firstNonEmptyAWSValue(record.Service, secretsManagerServiceName)
+	normalized.SecretARN = strings.TrimSpace(record.SecretARN)
+	normalized.SecretName = firstNonEmptyAWSValue(record.SecretName, secretNameFromARN(record.SecretARN))
+	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, "secrets_manager_secret")
+	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.SecretName, normalized.SecretARN)
+	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.SecretARN, normalized.SecretName)
+	normalized.Source = firstNonEmptyAWSValue(record.Source, "secrets_manager_metadata")
+	normalized.EvidenceRef = firstNonEmptyAWSValue(record.EvidenceRef, normalized.SecretARN, normalized.SecretName)
+	normalized.CollectorName = firstNonEmptyAWSValue(record.CollectorName, secretsManagerMetadataCollectorName)
+	normalized.ScanID = firstNonEmptyAWSValue(record.ScanID, scope.ScanID, "aws-secrets-manager-metadata-fixture")
+	normalized.ConnectorID = firstNonEmptyAWSValue(record.ConnectorID, scope.ConnectorID, "aws-connector")
+	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
+	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
+	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
+	normalized.Description = strings.TrimSpace(record.Description)
+	normalized.KMSKeyID = strings.TrimSpace(record.KMSKeyID)
+	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, kmsKeyARNFromID(record.KMSKeyID, normalized.Region, normalized.AccountID))
+	normalized.OwningService = strings.TrimSpace(record.OwningService)
+	normalized.PrimaryRegion = strings.TrimSpace(record.PrimaryRegion)
+	normalized.SecretStatus = firstNonEmptyAWSValue(record.SecretStatus, secretsManagerSecretStatus(record))
+	normalized.IdentityGrants = annotateSecretsManagerGrants(record.IdentityGrants, normalized.AccountID)
+	normalized.VersionStages = normalizeSecretsManagerVersionStages(record.VersionStages)
+	normalized.ReplicaRegions = normalizeSecretsManagerReplicaRegions(record.ReplicaRegions)
+	normalized.Tags = copyTags(record.Tags)
+	normalized.ReferencedBy = normalizeSecretWorkloadReferences(record.ReferencedBy)
+	normalized.UnresolvedReferences = normalizeSecretWorkloadReferences(record.UnresolvedReferences)
+	normalized.ReferenceCount = len(normalized.ReferencedBy)
+	normalized.ExposureClassification, normalized.ExposureReasons = classifySecretsManagerExposure(normalized)
+	normalized.CollectedAt = collectedAt
+	if normalized.Confidence <= 0 {
+		normalized.Confidence = secretsManagerMetadataConfidence(normalized)
+	}
+	return normalized
+}
+
+func annotateSecretsManagerGrants(grants []SecretsManagerIdentityGrant, accountID string) []SecretsManagerIdentityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]SecretsManagerIdentityGrant, 0, len(grants))
+	for _, grant := range grants {
+		grant.PrincipalARN = strings.TrimSpace(grant.PrincipalARN)
+		grant.PrincipalType = strings.ToLower(strings.TrimSpace(grant.PrincipalType))
+		grant.Effect = canonicalKMSGrantEffect(grant.Effect)
+		grant.Actions = normalizeStringList(grant.Actions)
+		grant.ConditionKeys = normalizeStringList(grant.ConditionKeys)
+		grant.WildcardPrincipal = grant.WildcardPrincipal || grant.PrincipalARN == "*"
+		grant.IsPublic = grant.IsPublic || grant.WildcardPrincipal
+		if !grant.IsCrossAccount && accountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
+			grantAccount := accountIDFromARN(grant.PrincipalARN)
+			if grantAccount != "" && grantAccount != accountID {
+				grant.IsCrossAccount = true
+			}
+		}
+		grant.HasCondition = grant.HasCondition || len(grant.ConditionKeys) > 0
+		out = append(out, grant)
+	}
+	return out
+}
+
+func normalizeSecretsManagerVersionStages(stages []SecretsManagerVersionStage) []SecretsManagerVersionStage {
+	if len(stages) == 0 {
+		return nil
+	}
+	out := append([]SecretsManagerVersionStage(nil), stages...)
+	for i := range out {
+		out[i].VersionID = strings.TrimSpace(out[i].VersionID)
+		out[i].Stages = normalizeStringList(out[i].Stages)
+		out[i].KMSKeyIDs = normalizeStringList(out[i].KMSKeyIDs)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].VersionID < out[j].VersionID })
+	return out
+}
+
+func normalizeSecretsManagerReplicaRegions(replicas []SecretsManagerReplicaRegion) []SecretsManagerReplicaRegion {
+	if len(replicas) == 0 {
+		return nil
+	}
+	out := append([]SecretsManagerReplicaRegion(nil), replicas...)
+	for i := range out {
+		out[i].Region = strings.TrimSpace(out[i].Region)
+		out[i].KMSKeyID = strings.TrimSpace(out[i].KMSKeyID)
+		out[i].Status = strings.TrimSpace(out[i].Status)
+		out[i].StatusMessage = strings.TrimSpace(out[i].StatusMessage)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Region < out[j].Region })
+	return out
+}
+
+func normalizeSecretWorkloadReferences(refs []SecretWorkloadReference) []SecretWorkloadReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := append([]SecretWorkloadReference(nil), refs...)
+	for i := range out {
+		out[i].SourceService = strings.TrimSpace(out[i].SourceService)
+		out[i].WorkloadID = strings.TrimSpace(out[i].WorkloadID)
+		out[i].WorkloadType = strings.TrimSpace(out[i].WorkloadType)
+		out[i].WorkloadName = strings.TrimSpace(out[i].WorkloadName)
+		out[i].ResourceARN = strings.TrimSpace(out[i].ResourceARN)
+		out[i].ResourceID = strings.TrimSpace(out[i].ResourceID)
+		out[i].Reference = strings.TrimSpace(out[i].Reference)
+		out[i].ReferenceKind = strings.TrimSpace(out[i].ReferenceKind)
+		if out[i].Confidence <= 0 {
+			out[i].Confidence = 0.82
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].WorkloadID == out[j].WorkloadID {
+			return out[i].Reference < out[j].Reference
+		}
+		return out[i].WorkloadID < out[j].WorkloadID
+	})
+	return out
+}
+
+func classifySecretsManagerExposure(record SecretsManagerSecretMetadata) (string, []string) {
+	reasons := []string{}
+	public := false
+	crossAccount := false
+	for _, grant := range record.IdentityGrants {
+		if !strings.EqualFold(grant.Effect, "Allow") {
+			continue
+		}
+		if grant.IsPublic && !grant.HasCondition {
+			public = true
+			reasons = append(reasons, "resource_policy_allow_to_wildcard_principal")
+		}
+		if grant.IsCrossAccount && !grant.HasCondition {
+			crossAccount = true
+			reasons = append(reasons, "resource_policy_allow_to_cross_account_principal")
+		}
+	}
+	if record.RotationEnabled {
+		reasons = append(reasons, "rotation_enabled")
+	}
+	if record.KMSKeyARN != "" {
+		reasons = append(reasons, "customer_kms_key_referenced")
+	}
+	if record.ReferenceCount > 0 {
+		reasons = append(reasons, "workload_references_secret")
+	}
+	switch {
+	case public:
+		return "public", dedupeStrings(reasons)
+	case crossAccount:
+		return "cross_account", dedupeStrings(reasons)
+	case record.HasResourcePolicy:
+		return "resource_policy_scoped", dedupeStrings(reasons)
+	case record.ReferenceCount > 0:
+		return "referenced_by_workload", dedupeStrings(reasons)
+	case record.SecretStatus == "scheduled_deletion":
+		return "scheduled_deletion", dedupeStrings(reasons)
+	default:
+		return "private", dedupeStrings(reasons)
+	}
+}
+
+func secretsManagerSecretStatus(record SecretsManagerSecretMetadata) string {
+	if strings.TrimSpace(record.DeletedAt) != "" {
+		return "scheduled_deletion"
+	}
+	return "active"
+}
+
+func secretsManagerMetadataConfidence(record SecretsManagerSecretMetadata) float64 {
+	switch record.ExposureClassification {
+	case "public":
+		return 0.95
+	case "cross_account":
+		return 0.92
+	case "resource_policy_scoped":
+		return 0.89
+	case "referenced_by_workload":
+		return 0.88
+	case "private":
+		return 0.86
+	default:
+		return 0.72
+	}
+}
+
+func secretsManagerMetadataSourceID(record SecretsManagerSecretMetadata) string {
+	return strings.Join(normalizeStringList([]string{
+		record.Service,
+		record.SecretARN,
+		record.Region,
+	}), "|")
+}
+
+func secretsManagerSecretResourceID(secretARN string) string {
+	return "aws:resource:secrets-manager-secret:" + strings.TrimSpace(secretARN)
+}
+
+func secretsManagerReferenceKeys(secretARN string, secretName string) []string {
+	keys := []string{}
+	if arn := strings.TrimSpace(secretARN); arn != "" {
+		keys = append(keys, arn)
+		if name := secretNameFromARN(arn); name != "" {
+			keys = append(keys, name)
+		}
+	}
+	if name := strings.TrimSpace(secretName); name != "" {
+		keys = append(keys, name)
+	}
+	return dedupeStrings(keys)
+}
+
+func secretsManagerReferenceKeysFromRef(ref string) []string {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return nil
+	}
+	candidates := []string{trimmed}
+	if idx := strings.LastIndex(trimmed, "="); idx >= 0 && idx < len(trimmed)-1 {
+		candidates = append(candidates, strings.TrimSpace(trimmed[idx+1:]))
+	}
+	for _, prefix := range []string{"SECRETS_MANAGER:", "secretsmanager:", "SecretsManager:"} {
+		for _, candidate := range append([]string(nil), candidates...) {
+			if strings.HasPrefix(candidate, prefix) {
+				candidates = append(candidates, strings.TrimSpace(strings.TrimPrefix(candidate, prefix)))
+			}
+		}
+	}
+	out := []string{}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		out = append(out, candidate)
+		if strings.Contains(candidate, ":secretsmanager:") {
+			out = append(out, secretNameFromARN(candidate))
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func secretNameFromARN(arn string) string {
+	parts := strings.SplitN(strings.TrimSpace(arn), ":", 7)
+	if len(parts) < 7 {
+		return ""
+	}
+	resource := strings.TrimPrefix(parts[6], "secret:")
+	if idx := strings.LastIndex(resource, "-"); idx > 0 && len(resource)-idx == 7 {
+		return resource[:idx]
+	}
+	return resource
+}
+
+func regionFromARN(arn string) string {
+	parts := strings.SplitN(strings.TrimSpace(arn), ":", 6)
+	if len(parts) < 4 {
+		return ""
+	}
+	return strings.TrimSpace(parts[3])
+}
+
+func secretsManagerMetadataDiagnostic(code string, sourceID string, message string, retryable bool) providers.SourceError {
+	return providers.SourceError{
+		Collector: secretsManagerMetadataCollectorName,
+		SourceID:  strings.TrimSpace(sourceID),
+		Code:      strings.TrimSpace(code),
+		Message:   strings.TrimSpace(message),
+		Retryable: retryable,
+	}
+}
+
+type secretsManagerPolicyDocument struct {
+	Statement secretsManagerPolicyStmtList `json:"Statement"`
+}
+
+type secretsManagerPolicyStmtList []secretsManagerPolicyStatement
+
+type secretsManagerPolicyStatement struct {
+	Sid          string         `json:"Sid,omitempty"`
+	Effect       string         `json:"Effect"`
+	Principal    any            `json:"Principal,omitempty"`
+	NotPrincipal any            `json:"NotPrincipal,omitempty"`
+	Action       any            `json:"Action,omitempty"`
+	NotAction    any            `json:"NotAction,omitempty"`
+	Condition    map[string]any `json:"Condition,omitempty"`
+}
+
+func (s *secretsManagerPolicyStmtList) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*s = nil
+		return nil
+	}
+	var single secretsManagerPolicyStatement
+	if err := json.Unmarshal(data, &single); err == nil && single.Effect != "" {
+		*s = []secretsManagerPolicyStatement{single}
+		return nil
+	}
+	var many []secretsManagerPolicyStatement
+	if err := json.Unmarshal(data, &many); err == nil {
+		*s = many
+		return nil
+	}
+	return errors.New("invalid secrets manager policy statement shape")
+}
+
+func parseSecretsManagerResourcePolicyGrants(raw string, ownerAccountID string) ([]SecretsManagerIdentityGrant, int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, 0, nil
+	}
+	decoded := trimmed
+	if strings.Contains(trimmed, "%") {
+		if unescaped, err := url.QueryUnescape(trimmed); err == nil {
+			decoded = unescaped
+		}
+	}
+	var doc secretsManagerPolicyDocument
+	if err := json.Unmarshal([]byte(decoded), &doc); err != nil {
+		return nil, 0, err
+	}
+	grants := []SecretsManagerIdentityGrant{}
+	for _, statement := range doc.Statement {
+		effect := canonicalKMSGrantEffect(statement.Effect)
+		if effect == "" || statement.Principal == nil && statement.NotPrincipal != nil {
+			continue
+		}
+		if len(parseStringList(statement.NotAction)) > 0 {
+			continue
+		}
+		principals := kmsExtractPrincipals(statement.Principal)
+		if len(principals) == 0 {
+			continue
+		}
+		actions := normalizeStringList(parseStringList(statement.Action))
+		conditionKeys := kmsCollectConditionKeys(statement.Condition)
+		for _, principal := range principals {
+			grant := SecretsManagerIdentityGrant{
+				PrincipalARN:      principal.Value,
+				PrincipalType:     principal.Type,
+				Effect:            effect,
+				Actions:           actions,
+				ConditionKeys:     conditionKeys,
+				HasCondition:      len(conditionKeys) > 0,
+				StatementSid:      strings.TrimSpace(statement.Sid),
+				WildcardPrincipal: principal.Wildcard,
+			}
+			if grant.WildcardPrincipal {
+				grant.IsPublic = true
+			}
+			if ownerAccountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
+				grantAccount := accountIDFromARN(grant.PrincipalARN)
+				grant.IsCrossAccount = grantAccount != "" && grantAccount != ownerAccountID
+			}
+			grants = append(grants, grant)
+		}
+	}
+	return grants, len(doc.Statement), nil
+}
+
+var _ AWSServiceCollector = (*SecretsManagerMetadataCollector)(nil)
+var _ providers.Collector = (*SecretsManagerMetadataCollector)(nil)

--- a/internal/providers/aws/secrets_manager_metadata_collector.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector.go
@@ -267,7 +267,7 @@ func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record Secret
 	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
 	normalized.DescriptionPresent = record.DescriptionPresent
 	normalized.KMSKeyID = strings.TrimSpace(record.KMSKeyID)
-	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, kmsKeyARNFromID(record.KMSKeyID, normalized.AccountID, normalized.Region))
+	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, secretsManagerKMSKeyARN(record.KMSKeyID, normalized.AccountID, normalized.Region))
 	normalized.OwningService = strings.TrimSpace(record.OwningService)
 	normalized.PrimaryRegion = strings.TrimSpace(record.PrimaryRegion)
 	normalized.SecretStatus = firstNonEmptyAWSValue(record.SecretStatus, secretsManagerSecretStatus(record))
@@ -286,6 +286,42 @@ func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record Secret
 	return normalized
 }
 
+// secretsManagerKMSKeyARN resolves a Secrets Manager KmsKeyId value to a key
+// ARN. The field can carry a full ARN, an alias (`alias/...`), or a bare key
+// id; only the bare id needs a synthesized key ARN.
+func secretsManagerKMSKeyARN(keyID, accountID, region string) string {
+	trimmed := strings.TrimSpace(keyID)
+	switch {
+	case trimmed == "":
+		return ""
+	case strings.HasPrefix(trimmed, "arn:"):
+		return trimmed
+	case strings.HasPrefix(trimmed, "alias/"):
+		if strings.TrimSpace(accountID) == "" || strings.TrimSpace(region) == "" {
+			return ""
+		}
+		return fmt.Sprintf("arn:%s:kms:%s:%s:%s", awsPartitionForRegion(region), region, accountID, trimmed)
+	default:
+		return kmsKeyARNFromID(trimmed, accountID, region)
+	}
+}
+
+// secretsManagerPrincipalAccountID extracts the owning account from a policy
+// principal. Bare 12-digit account ids are valid AWS principals alongside
+// full ARNs.
+func secretsManagerPrincipalAccountID(principal string) string {
+	trimmed := strings.TrimSpace(principal)
+	if len(trimmed) == 12 {
+		for _, r := range trimmed {
+			if r < '0' || r > '9' {
+				return accountIDFromARN(trimmed)
+			}
+		}
+		return trimmed
+	}
+	return accountIDFromARN(trimmed)
+}
+
 func annotateSecretsManagerGrants(grants []SecretsManagerIdentityGrant, accountID string) []SecretsManagerIdentityGrant {
 	if len(grants) == 0 {
 		return nil
@@ -300,7 +336,7 @@ func annotateSecretsManagerGrants(grants []SecretsManagerIdentityGrant, accountI
 		grant.WildcardPrincipal = grant.WildcardPrincipal || grant.PrincipalARN == "*"
 		grant.IsPublic = grant.IsPublic || grant.WildcardPrincipal
 		if !grant.IsCrossAccount && accountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
-			grantAccount := accountIDFromARN(grant.PrincipalARN)
+			grantAccount := secretsManagerPrincipalAccountID(grant.PrincipalARN)
 			if grantAccount != "" && grantAccount != accountID {
 				grant.IsCrossAccount = true
 			}
@@ -464,36 +500,46 @@ func secretsManagerReferenceKeysFromRef(ref string) []string {
 	if trimmed == "" {
 		return nil
 	}
-	candidates := []string{trimmed}
+	type referenceCandidate struct {
+		value         string
+		allowNameBase bool
+	}
+	candidates := []referenceCandidate{{value: trimmed}}
 	if idx := strings.LastIndex(trimmed, "="); idx >= 0 && idx < len(trimmed)-1 {
-		candidates = append(candidates, strings.TrimSpace(trimmed[idx+1:]))
+		candidates = append(candidates, referenceCandidate{
+			value:         strings.TrimSpace(trimmed[idx+1:]),
+			allowNameBase: true,
+		})
 	}
 	for _, prefix := range []string{"SECRETS_MANAGER:", "secretsmanager:", "SecretsManager:"} {
-		for _, candidate := range append([]string(nil), candidates...) {
-			if strings.HasPrefix(candidate, prefix) {
-				candidates = append(candidates, strings.TrimSpace(strings.TrimPrefix(candidate, prefix)))
+		for _, candidate := range append([]referenceCandidate(nil), candidates...) {
+			if strings.HasPrefix(candidate.value, prefix) {
+				candidates = append(candidates, referenceCandidate{
+					value:         strings.TrimSpace(strings.TrimPrefix(candidate.value, prefix)),
+					allowNameBase: true,
+				})
 			}
 		}
 	}
 	out := []string{}
 	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" {
+		value := strings.TrimSpace(candidate.value)
+		if value == "" {
 			continue
 		}
-		out = append(out, candidate)
-		if base := secretsManagerReferenceBase(candidate); base != "" && base != candidate {
+		out = append(out, value)
+		if base := secretsManagerReferenceBase(value, candidate.allowNameBase); base != "" && base != value {
 			out = append(out, base)
-			candidate = base
+			value = base
 		}
-		if strings.Contains(candidate, ":secretsmanager:") {
-			out = append(out, secretNameFromARN(candidate))
+		if strings.Contains(value, ":secretsmanager:") {
+			out = append(out, secretNameFromARN(value))
 		}
 	}
 	return dedupeStrings(out)
 }
 
-func secretsManagerReferenceBase(ref string) string {
+func secretsManagerReferenceBase(ref string, allowNameBase bool) string {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
 		return ""
@@ -509,8 +555,10 @@ func secretsManagerReferenceBase(ref string) string {
 		}
 		return parts[0] + ":secret:" + resource
 	}
-	if idx := strings.Index(trimmed, ":"); idx > 0 {
-		return strings.TrimSpace(trimmed[:idx])
+	if allowNameBase {
+		if idx := strings.Index(trimmed, ":"); idx > 0 {
+			return strings.TrimSpace(trimmed[:idx])
+		}
 	}
 	return trimmed
 }
@@ -627,7 +675,7 @@ func parseSecretsManagerResourcePolicyGrants(raw string, ownerAccountID string) 
 				grant.IsPublic = true
 			}
 			if ownerAccountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
-				grantAccount := accountIDFromARN(grant.PrincipalARN)
+				grantAccount := secretsManagerPrincipalAccountID(grant.PrincipalARN)
 				grant.IsCrossAccount = grantAccount != "" && grantAccount != ownerAccountID
 			}
 			grants = append(grants, grant)

--- a/internal/providers/aws/secrets_manager_metadata_collector.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector.go
@@ -27,14 +27,14 @@ const (
 type SecretsManagerSecretMetadata struct {
 	awscontract.ServiceCollectorRecord
 
-	SecretARN     string `json:"secret_arn,omitempty"`
-	SecretName    string `json:"secret_name,omitempty"`
-	Description   string `json:"description,omitempty"`
-	KMSKeyID      string `json:"kms_key_id,omitempty"`
-	KMSKeyARN     string `json:"kms_key_arn,omitempty"`
-	OwningService string `json:"owning_service,omitempty"`
-	PrimaryRegion string `json:"primary_region,omitempty"`
-	SecretStatus  string `json:"secret_status,omitempty"`
+	SecretARN          string `json:"secret_arn,omitempty"`
+	SecretName         string `json:"secret_name,omitempty"`
+	DescriptionPresent bool   `json:"description_present,omitempty"`
+	KMSKeyID           string `json:"kms_key_id,omitempty"`
+	KMSKeyARN          string `json:"kms_key_arn,omitempty"`
+	OwningService      string `json:"owning_service,omitempty"`
+	PrimaryRegion      string `json:"primary_region,omitempty"`
+	SecretStatus       string `json:"secret_status,omitempty"`
 
 	RotationEnabled        bool   `json:"rotation_enabled,omitempty"`
 	RotationLambdaARN      string `json:"rotation_lambda_arn,omitempty"`
@@ -265,7 +265,7 @@ func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record Secret
 	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
 	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
 	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
-	normalized.Description = strings.TrimSpace(record.Description)
+	normalized.DescriptionPresent = record.DescriptionPresent
 	normalized.KMSKeyID = strings.TrimSpace(record.KMSKeyID)
 	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, kmsKeyARNFromID(record.KMSKeyID, normalized.Region, normalized.AccountID))
 	normalized.OwningService = strings.TrimSpace(record.OwningService)

--- a/internal/providers/aws/secrets_manager_metadata_collector.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector.go
@@ -267,7 +267,7 @@ func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record Secret
 	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
 	normalized.DescriptionPresent = record.DescriptionPresent
 	normalized.KMSKeyID = strings.TrimSpace(record.KMSKeyID)
-	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, kmsKeyARNFromID(record.KMSKeyID, normalized.Region, normalized.AccountID))
+	normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, kmsKeyARNFromID(record.KMSKeyID, normalized.AccountID, normalized.Region))
 	normalized.OwningService = strings.TrimSpace(record.OwningService)
 	normalized.PrimaryRegion = strings.TrimSpace(record.PrimaryRegion)
 	normalized.SecretStatus = firstNonEmptyAWSValue(record.SecretStatus, secretsManagerSecretStatus(record))
@@ -482,11 +482,37 @@ func secretsManagerReferenceKeysFromRef(ref string) []string {
 			continue
 		}
 		out = append(out, candidate)
+		if base := secretsManagerReferenceBase(candidate); base != "" && base != candidate {
+			out = append(out, base)
+			candidate = base
+		}
 		if strings.Contains(candidate, ":secretsmanager:") {
 			out = append(out, secretNameFromARN(candidate))
 		}
 	}
 	return dedupeStrings(out)
+}
+
+func secretsManagerReferenceBase(ref string) string {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Contains(trimmed, ":secretsmanager:") && strings.Contains(trimmed, ":secret:") {
+		parts := strings.SplitN(trimmed, ":secret:", 2)
+		if len(parts) != 2 {
+			return trimmed
+		}
+		resource := strings.TrimSpace(parts[1])
+		if idx := strings.Index(resource, ":"); idx > 0 {
+			resource = resource[:idx]
+		}
+		return parts[0] + ":secret:" + resource
+	}
+	if idx := strings.Index(trimmed, ":"); idx > 0 {
+		return strings.TrimSpace(trimmed[:idx])
+	}
+	return trimmed
 }
 
 func secretNameFromARN(arn string) string {
@@ -495,6 +521,9 @@ func secretNameFromARN(arn string) string {
 		return ""
 	}
 	resource := strings.TrimPrefix(parts[6], "secret:")
+	if idx := strings.Index(resource, ":"); idx > 0 {
+		resource = resource[:idx]
+	}
 	if idx := strings.LastIndex(resource, "-"); idx > 0 && len(resource)-idx == 7 {
 		return resource[:idx]
 	}

--- a/internal/providers/aws/secrets_manager_metadata_collector_test.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector_test.go
@@ -64,6 +64,9 @@ func TestSecretsManagerMetadataCollectorCollectsMetadataOnly(t *testing.T) {
 	if record.ConnectorID != "aws-prod" || record.AccountID != "123456789012" || record.Region != "us-east-1" {
 		t.Fatalf("scope not applied: %+v", record.ServiceCollectorRecord)
 	}
+	if record.KMSKeyARN != "arn:aws:kms:us-east-1:123456789012:key/alias/payments" {
+		t.Fatalf("unexpected KMS key ARN: %s", record.KMSKeyARN)
+	}
 	payload := strings.ToLower(string(assets[0].Payload))
 	if strings.Contains(payload, "secretstring") || strings.Contains(payload, "secretbinary") || strings.Contains(payload, "getsecretvalue") {
 		t.Fatalf("secret value material leaked into collector payload: %s", payload)
@@ -145,11 +148,11 @@ func TestSecretsManagerMetadataNormalizeAndGraphUsesSecret(t *testing.T) {
 			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
 			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
 			"workload_type":"ecs_service",
-			"workload_name":"payments",
-			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
-			"role_arn":"arn:aws:iam::123456789012:role/payments-task",
-			"secret_refs":["DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf"]
-		}`),
+				"workload_name":"payments",
+				"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
+				"role_arn":"arn:aws:iam::123456789012:role/payments-task",
+				"secret_refs":["DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password"]
+			}`),
 	}})
 	if err != nil {
 		t.Fatalf("normalize: %v", err)
@@ -170,4 +173,52 @@ func TestSecretsManagerMetadataNormalizeAndGraphUsesSecret(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected uses_secret relationship, got %+v", relationships)
+}
+
+func TestSecretsManagerReferenceKeysFromRefStripsValueSuffixes(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want []string
+	}{
+		{
+			name: "arn json key suffix",
+			ref:  "DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password",
+			want: []string{
+				"DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password",
+				"arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password",
+				"arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf",
+				"payments/db",
+			},
+		},
+		{
+			name: "name json key suffix",
+			ref:  "SECRETS_MANAGER:payments/db:password",
+			want: []string{
+				"SECRETS_MANAGER:payments/db:password",
+				"payments/db:password",
+				"payments/db",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keys := secretsManagerReferenceKeysFromRef(tc.ref)
+			for _, want := range tc.want {
+				if !containsString(keys, want) {
+					t.Fatalf("expected key %q in %+v", want, keys)
+				}
+			}
+		})
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/providers/aws/secrets_manager_metadata_collector_test.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector_test.go
@@ -64,7 +64,7 @@ func TestSecretsManagerMetadataCollectorCollectsMetadataOnly(t *testing.T) {
 	if record.ConnectorID != "aws-prod" || record.AccountID != "123456789012" || record.Region != "us-east-1" {
 		t.Fatalf("scope not applied: %+v", record.ServiceCollectorRecord)
 	}
-	if record.KMSKeyARN != "arn:aws:kms:us-east-1:123456789012:key/alias/payments" {
+	if record.KMSKeyARN != "arn:aws:kms:us-east-1:123456789012:alias/payments" {
 		t.Fatalf("unexpected KMS key ARN: %s", record.KMSKeyARN)
 	}
 	payload := strings.ToLower(string(assets[0].Payload))
@@ -103,20 +103,48 @@ func TestParseSecretsManagerResourcePolicyGrantsPublicAndCrossAccount(t *testing
 	grants, count, err := parseSecretsManagerResourcePolicyGrants(`{
 		"Statement": [
 			{"Sid":"PublicDescribe","Effect":"Allow","Principal":"*","Action":"secretsmanager:DescribeSecret","Resource":"*"},
-			{"Sid":"Partner","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::999999999999:role/partner"},"Action":["secretsmanager:GetResourcePolicy"],"Resource":"*"}
+			{"Sid":"Partner","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::999999999999:role/partner"},"Action":["secretsmanager:GetResourcePolicy"],"Resource":"*"},
+			{"Sid":"PartnerAccount","Effect":"Allow","Principal":{"AWS":"999999999999"},"Action":["secretsmanager:DescribeSecret"],"Resource":"*"},
+			{"Sid":"SameAccount","Effect":"Allow","Principal":{"AWS":"123456789012"},"Action":["secretsmanager:DescribeSecret"],"Resource":"*"}
 		]
 	}`, "123456789012")
 	if err != nil {
 		t.Fatalf("parse policy: %v", err)
 	}
-	if count != 2 || len(grants) != 2 {
-		t.Fatalf("expected two grants, count=%d grants=%+v", count, grants)
+	if count != 4 || len(grants) != 4 {
+		t.Fatalf("expected four grants, count=%d grants=%+v", count, grants)
 	}
 	if !grants[0].IsPublic || !grants[0].WildcardPrincipal {
 		t.Fatalf("expected public wildcard grant, got %+v", grants[0])
 	}
 	if !grants[1].IsCrossAccount {
 		t.Fatalf("expected cross-account grant, got %+v", grants[1])
+	}
+	if !grants[2].IsCrossAccount {
+		t.Fatalf("expected bare account-id principal to be cross-account, got %+v", grants[2])
+	}
+	if grants[3].IsCrossAccount {
+		t.Fatalf("expected same-account bare principal to stay in-account, got %+v", grants[3])
+	}
+}
+
+func TestSecretsManagerKMSKeyARN(t *testing.T) {
+	tests := []struct {
+		name  string
+		keyID string
+		want  string
+	}{
+		{name: "empty", keyID: "", want: ""},
+		{name: "bare key id", keyID: "key123", want: "arn:aws:kms:us-east-1:123456789012:key/key123"},
+		{name: "alias", keyID: "alias/payments", want: "arn:aws:kms:us-east-1:123456789012:alias/payments"},
+		{name: "full arn passthrough", keyID: "arn:aws:kms:eu-west-1:999999999999:key/key123", want: "arn:aws:kms:eu-west-1:999999999999:key/key123"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secretsManagerKMSKeyARN(tc.keyID, "123456789012", "us-east-1"); got != tc.want {
+				t.Fatalf("secretsManagerKMSKeyARN(%q) = %q, want %q", tc.keyID, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -148,11 +176,11 @@ func TestSecretsManagerMetadataNormalizeAndGraphUsesSecret(t *testing.T) {
 			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
 			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
 			"workload_type":"ecs_service",
-				"workload_name":"payments",
-				"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
-				"role_arn":"arn:aws:iam::123456789012:role/payments-task",
-				"secret_refs":["DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password"]
-			}`),
+			"workload_name":"payments",
+			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
+			"role_arn":"arn:aws:iam::123456789012:role/payments-task",
+			"secret_refs":["DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf:password"]
+		}`),
 	}})
 	if err != nil {
 		t.Fatalf("normalize: %v", err)
@@ -180,6 +208,7 @@ func TestSecretsManagerReferenceKeysFromRefStripsValueSuffixes(t *testing.T) {
 		name string
 		ref  string
 		want []string
+		not  []string
 	}{
 		{
 			name: "arn json key suffix",
@@ -200,6 +229,22 @@ func TestSecretsManagerReferenceKeysFromRefStripsValueSuffixes(t *testing.T) {
 				"payments/db",
 			},
 		},
+		{
+			name: "prefixed ref is not stripped before prefix removal",
+			ref:  "SECRETS_MANAGER:payments:password",
+			want: []string{
+				"SECRETS_MANAGER:payments:password",
+				"payments:password",
+				"payments",
+			},
+			not: []string{"SECRETS_MANAGER"},
+		},
+		{
+			name: "arbitrary colon ref is not stripped",
+			ref:  "not-a-secret:maybe",
+			want: []string{"not-a-secret:maybe"},
+			not:  []string{"not-a-secret"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -208,6 +253,11 @@ func TestSecretsManagerReferenceKeysFromRefStripsValueSuffixes(t *testing.T) {
 			for _, want := range tc.want {
 				if !containsString(keys, want) {
 					t.Fatalf("expected key %q in %+v", want, keys)
+				}
+			}
+			for _, not := range tc.not {
+				if containsString(keys, not) {
+					t.Fatalf("did not expect key %q in %+v", not, keys)
 				}
 			}
 		})

--- a/internal/providers/aws/secrets_manager_metadata_collector_test.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector_test.go
@@ -1,0 +1,173 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+type fakeSecretsManagerMetadataAPI struct {
+	pages     []SecretsManagerMetadataPage
+	calls     int
+	err       error
+	errOnCall int
+}
+
+func (f *fakeSecretsManagerMetadataAPI) ListSecretMetadata(ctx context.Context, nextToken string, pageSize int32) (SecretsManagerMetadataPage, error) {
+	f.calls++
+	if f.err != nil && (f.errOnCall == 0 || f.calls >= f.errOnCall) {
+		return SecretsManagerMetadataPage{}, f.err
+	}
+	if len(f.pages) == 0 {
+		return SecretsManagerMetadataPage{}, nil
+	}
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func TestSecretsManagerMetadataCollectorCollectsMetadataOnly(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	api := &fakeSecretsManagerMetadataAPI{pages: []SecretsManagerMetadataPage{{
+		Records: []SecretsManagerSecretMetadata{{
+			SecretARN:       "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf",
+			SecretName:      "payments/db",
+			KMSKeyID:        "alias/payments",
+			RotationEnabled: true,
+			Tags:            map[string]string{"owner": "payments"},
+		}},
+	}}}
+	collector := NewSecretsManagerMetadataCollector(api, WithSecretsManagerMetadataClock(func() time.Time { return now }))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		ConnectorID: "aws-prod",
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(diagnostics) != 0 || len(assets) != 1 {
+		t.Fatalf("expected one clean asset, assets=%d diagnostics=%+v", len(assets), diagnostics)
+	}
+	var record SecretsManagerSecretMetadata
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if record.ConnectorID != "aws-prod" || record.AccountID != "123456789012" || record.Region != "us-east-1" {
+		t.Fatalf("scope not applied: %+v", record.ServiceCollectorRecord)
+	}
+	payload := strings.ToLower(string(assets[0].Payload))
+	if strings.Contains(payload, "secretstring") || strings.Contains(payload, "secretbinary") || strings.Contains(payload, "getsecretvalue") {
+		t.Fatalf("secret value material leaked into collector payload: %s", payload)
+	}
+}
+
+func TestSecretsManagerMetadataCollectorPartialFailureReturnsDiagnostics(t *testing.T) {
+	api := &fakeSecretsManagerMetadataAPI{
+		pages: []SecretsManagerMetadataPage{{
+			Records: []SecretsManagerSecretMetadata{{
+				SecretARN:  "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf",
+				SecretName: "payments/db",
+			}},
+			NextToken: "next",
+		}},
+		err:       errors.New("throttled"),
+		errOnCall: 2,
+	}
+	collector := NewSecretsManagerMetadataCollector(api, WithSecretsManagerMetadataMaxPages(3))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{AccountID: "123456789012", Region: "us-east-1"})
+	if err == nil {
+		t.Fatalf("expected second-page error")
+	}
+	if len(assets) != 1 || len(diagnostics) == 0 {
+		t.Fatalf("expected partial asset plus diagnostics, assets=%d diagnostics=%+v", len(assets), diagnostics)
+	}
+	if diagnostics[0].Code != "secrets_manager_metadata_page_failed" {
+		t.Fatalf("unexpected diagnostic: %+v", diagnostics)
+	}
+}
+
+func TestParseSecretsManagerResourcePolicyGrantsPublicAndCrossAccount(t *testing.T) {
+	grants, count, err := parseSecretsManagerResourcePolicyGrants(`{
+		"Statement": [
+			{"Sid":"PublicDescribe","Effect":"Allow","Principal":"*","Action":"secretsmanager:DescribeSecret","Resource":"*"},
+			{"Sid":"Partner","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::999999999999:role/partner"},"Action":["secretsmanager:GetResourcePolicy"],"Resource":"*"}
+		]
+	}`, "123456789012")
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+	if count != 2 || len(grants) != 2 {
+		t.Fatalf("expected two grants, count=%d grants=%+v", count, grants)
+	}
+	if !grants[0].IsPublic || !grants[0].WildcardPrincipal {
+		t.Fatalf("expected public wildcard grant, got %+v", grants[0])
+	}
+	if !grants[1].IsCrossAccount {
+		t.Fatalf("expected cross-account grant, got %+v", grants[1])
+	}
+}
+
+func TestSecretsManagerMetadataNormalizeAndGraphUsesSecret(t *testing.T) {
+	secret := SecretsManagerSecretMetadata{
+		SecretARN:              "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf",
+		SecretName:             "payments/db",
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{},
+	}
+	secret.AccountID = "123456789012"
+	secret.Region = "us-east-1"
+	secret.Service = secretsManagerServiceName
+	payload, err := json.Marshal(secret)
+	if err != nil {
+		t.Fatalf("marshal secret: %v", err)
+	}
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     rawKindSecretsManagerMetadata,
+		SourceID: secretsManagerMetadataSourceID(secret),
+		Payload:  payload,
+	}, {
+		Kind:     rawKindECSTaskRole,
+		SourceID: "ecs-service",
+		Payload: []byte(`{
+			"account_id":"123456789012",
+			"region":"us-east-1",
+			"service":"ecs",
+			"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/prod",
+			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+			"workload_type":"ecs_service",
+			"workload_name":"payments",
+			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
+			"role_arn":"arn:aws:iam::123456789012:role/payments-task",
+			"secret_refs":["DATABASE_PASSWORD=arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf"]
+		}`),
+	}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(bundle.Resources) == 0 {
+		t.Fatalf("expected normalized resources")
+	}
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("relationships: %v", err)
+	}
+	for _, relationship := range relationships {
+		if relationship.Type == domain.RelationshipUsesSecret {
+			if relationship.ToNodeID != secretsManagerSecretResourceID(secret.SecretARN) {
+				t.Fatalf("unexpected target: %+v", relationship)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected uses_secret relationship, got %+v", relationships)
+}

--- a/internal/providers/awscontract/contract.go
+++ b/internal/providers/awscontract/contract.go
@@ -172,6 +172,10 @@ func AWSServiceCollectorContract() ServiceCollectorContract {
 			"kms:ListAliases",
 			"kms:ListGrants",
 			"kms:ListResourceTags",
+			"secretsmanager:ListSecrets",
+			"secretsmanager:DescribeSecret",
+			"secretsmanager:GetResourcePolicy",
+			"secretsmanager:ListSecretVersionIds",
 		},
 		ReadOnlyBoundaries: []string{
 			"collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -133,6 +133,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws kms decrypt reachability collector: %w", kmsErr)
 			}
+			secretsAPI, secretsErr := awsprovider.NewSDKSecretsManagerMetadataAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if secretsErr != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("initialize aws secrets manager metadata collector: %w", secretsErr)
+			}
 			scanner = newAWSScanner(
 				iamAPI,
 				cfg.AWSAccountID,
@@ -150,6 +155,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
 				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
+				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
 			)
 		default:
 			_ = store.Close()
@@ -286,6 +292,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if kmsErr != nil {
 			return nil, kmsErr
 		}
+		secretsAPI, secretsErr := awsprovider.NewSDKSecretsManagerMetadataAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		if secretsErr != nil {
+			return nil, secretsErr
+		}
 		scanner := newAWSScanner(
 			iamAPI,
 			connection.AccountID,
@@ -303,6 +313,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewEKSWorkloadIdentityCollector(eksAPI),
 			awsprovider.NewS3BucketReachabilityCollector(s3API),
 			awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
+			awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
 		)
 		return scanner, nil
 	}

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1009,6 +1009,30 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', secret_count: 3, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectSecretsManagerMetadata('workspace/a', 'project 1', 'aws-prod', 'partial_failure', {
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace/a',
+      bearerToken: 'token-a'
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/secrets-manager-metadata?connector_id=aws-prod&fixture_state=partial_failure'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS EKS workload identity inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2338,6 +2338,156 @@ export type AWSKMSDecryptReachabilityInventoryResult = {
   updated_at: string;
 };
 
+export type AWSSecretsManagerMetadataInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSecretsManagerMetadataFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSSecretsManagerCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSSecretsManagerIdentityGrant = {
+  principal_arn?: string;
+  principal_type?: string;
+  effect: string;
+  actions?: string[];
+  condition_keys?: string[];
+  is_public?: boolean;
+  is_cross_account?: boolean;
+  has_condition?: boolean;
+  statement_sid?: string;
+  wildcard_principal?: boolean;
+};
+
+export type AWSSecretsManagerVersionStage = {
+  version_id?: string;
+  stages?: string[];
+  created_at?: string;
+  last_accessed_at?: string;
+  kms_key_ids?: string[];
+};
+
+export type AWSSecretsManagerReplicaRegion = {
+  region?: string;
+  kms_key_id?: string;
+  status?: string;
+  status_message?: string;
+  last_accessed_at?: string;
+};
+
+export type AWSSecretsManagerWorkloadReference = {
+  source_service?: string;
+  workload_id?: string;
+  workload_type?: string;
+  workload_name?: string;
+  resource_arn?: string;
+  resource_id?: string;
+  reference: string;
+  reference_kind: string;
+  confidence: number;
+};
+
+export type AWSSecretsManagerMetadataRecord = {
+  account_id: string;
+  region: string;
+  service: 'secretsmanager';
+  secret_arn: string;
+  secret_name: string;
+  description_present: boolean;
+  kms_key_id?: string;
+  kms_key_arn?: string;
+  owning_service?: string;
+  primary_region?: string;
+  secret_status: string;
+  rotation_enabled: boolean;
+  rotation_lambda_arn?: string;
+  rotation_interval_days?: number;
+  created_at?: string;
+  last_changed_at?: string;
+  last_accessed_at?: string;
+  last_rotated_at?: string;
+  deleted_at?: string;
+  has_resource_policy: boolean;
+  resource_policy_statement_count: number;
+  identity_grants?: AWSSecretsManagerIdentityGrant[];
+  version_stages?: AWSSecretsManagerVersionStage[];
+  replica_regions?: AWSSecretsManagerReplicaRegion[];
+  tags?: Record<string, string>;
+  exposure_classification: string;
+  exposure_reasons?: string[];
+  referenced_by?: AWSSecretsManagerWorkloadReference[];
+  unresolved_references?: AWSSecretsManagerWorkloadReference[];
+  source: string;
+  evidence_ref: string;
+  from_node_id: string;
+  relationship_type: string;
+  confidence: number;
+  collected_at: string;
+  status: string;
+};
+
+export type AWSSecretsManagerReferenceEdge = {
+  type: 'uses_secret';
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+  source: string;
+  confidence: number;
+};
+
+export type AWSSecretsManagerMetadataDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSSecretsManagerMetadataInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSecretsManagerMetadataInventoryStatus;
+  fixture_state: AWSSecretsManagerMetadataFixtureState;
+  confidence: number;
+  secret_count: number;
+  referenced_secret_count: number;
+  unreferenced_secret_count: number;
+  rotation_enabled_count: number;
+  missing_rotation_count: number;
+  resource_policy_count: number;
+  public_secret_count: number;
+  cross_account_secret_count: number;
+  kms_referenced_count: number;
+  relationship_count: number;
+  unresolved_reference_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSSecretsManagerCoverageGap[];
+  records: AWSSecretsManagerMetadataRecord[];
+  relationships: AWSSecretsManagerReferenceEdge[];
+  diagnostics: AWSSecretsManagerMetadataDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSEKSWorkloadIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSEKSWorkloadIdentityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 
@@ -3579,6 +3729,21 @@ export const apiClient = {
   ) {
     return request<{ inventory: AWSKMSDecryptReachabilityInventoryResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/kms-decrypt-reachability${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSecretsManagerMetadata(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSSecretsManagerMetadataFixtureState,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSSecretsManagerMetadataInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secrets-manager-metadata${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
       })}`,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -51,6 +51,8 @@ import {
   type AWSPlatformDependencyIndexResult,
   type AWSPlatformValidationHarnessResult,
   type AWSServiceCollectorContractResult,
+  type AWSSecretsManagerMetadataInventoryResult,
+  type AWSSecretsManagerMetadataRecord,
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
   type ExecutiveReport,
@@ -3619,6 +3621,13 @@ type AWSInventoryEKSState = {
   onRetry: () => void;
 };
 
+type AWSInventorySecretsManagerState = {
+  inventory: AWSSecretsManagerMetadataInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -5863,25 +5872,19 @@ function AWSAgentIdentitiesContent({
 
 function AWSResourcesInventoryContent({
   connection,
+  secretsManagerState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
+  secretsManagerState: AWSInventorySecretsManagerState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
+  const secretsInventory = secretsManagerState.inventory;
+  const secretsRows = buildAWSSecretsManagerMetadataRows(secretsInventory, secretsManagerState.loading, connection);
   const rows: AWSInventoryTableRow[] = [
-    {
-      id: 'secrets-manager',
-      name: 'Secrets Manager metadata',
-      category: 'Secret-bearing',
-      scope: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
-      status: 'coming',
-      stage: 'coming',
-      detail: 'Name, tags, rotation, policy, and reference metadata only. Secret values are out of scope.',
-      filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
-      searchText: inventorySearchText(['secrets manager', 'secret', 'metadata', 'category'])
-    },
+    ...secretsRows,
     {
       id: 'ssm-parameters',
       name: 'SSM Parameter metadata',
@@ -5933,10 +5936,23 @@ function AWSResourcesInventoryContent({
     <>
       <AWSInventoryFilterSet routeID="resources" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-resource-coverage-grid" aria-label="AWS resource category coverage">
-        <DomainCoverageCard label="Secrets metadata" scanned={0} total={1} detail="Coming wave" />
+        <DomainCoverageCard
+          label="Secrets metadata"
+          scanned={secretsInventory && secretsInventory.status !== 'blocked' ? 1 : 0}
+          total={1}
+          detail={secretsManagerState.loading ? 'Loading' : secretsInventory ? formatTokenLabel(secretsInventory.status) : 'Pending'}
+        />
         <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
         <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Coming wave" />
       </section>
+      {secretsManagerState.loading ? <DomainLoadingState label="Loading Secrets Manager metadata" /> : null}
+      {secretsManagerState.error ? (
+        <DomainErrorState
+          title="Secrets Manager metadata could not load"
+          body={secretsManagerState.error}
+          retryAction={{ label: 'Retry Secrets Manager metadata', onClick: secretsManagerState.onRetry }}
+        />
+      ) : null}
       <DomainStatusPanel eyebrow="Safety posture" title="No secret value reads" status="Metadata only" tone="success">
         <p>
           Resource inventory is designed around reachability and metadata. Secrets Manager, SSM Parameter, and external AI
@@ -5957,6 +5973,111 @@ function AWSResourcesInventoryContent({
       />
     </>
   );
+}
+
+function buildAWSSecretsManagerMetadataRows(
+  inventory: AWSSecretsManagerMetadataInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsSecretsManagerMetadataRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'secrets-manager-blocked',
+        name: 'Secrets Manager metadata unavailable',
+        category: 'Secret-bearing',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'Secrets Manager metadata collection is blocked.',
+        filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['secrets manager', 'blocked', inventory.account_id, inventory.region])
+      }
+    ];
+  }
+  if (inventory) {
+    const degraded = inventory.status === 'degraded' || inventory.diagnostics.length > 0 || inventory.failure_reasons.length > 0;
+    return [
+      {
+        id: 'secrets-manager-empty',
+        name: degraded ? 'Secrets Manager metadata incomplete' : 'No Secrets Manager secrets found',
+        category: 'Secret-bearing',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: degraded ? 'degraded' : 'wired now',
+        stage: 'wired',
+        detail: degraded ? (inventory.failure_reasons[0] ?? 'Secrets Manager metadata collection completed with degraded evidence and no retained records.') : 'The collector completed without Secrets Manager records in this account and region.',
+        filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['secrets manager', inventory.account_id, inventory.region, degraded ? 'degraded empty' : 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'secrets-manager-loading',
+        name: 'Secrets Manager metadata',
+        category: 'Secret-bearing',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading secret metadata, rotation state, resource-policy grants, KMS references, and workload references.',
+        filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['secrets manager', 'metadata', 'loading'])
+      }
+    ];
+  }
+  return [
+    {
+      id: 'secrets-manager',
+      name: 'Secrets Manager metadata',
+      category: 'Secret-bearing',
+      scope: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Name, tags, rotation, policy, and reference metadata only. Secret values are out of scope.',
+      filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['secrets manager', 'secret', 'metadata', 'category'])
+    }
+  ];
+}
+
+function awsSecretsManagerMetadataRow(record: AWSSecretsManagerMetadataRecord): AWSInventoryTableRow {
+  const degraded = record.status !== 'ready' || record.exposure_classification === 'public' || record.exposure_classification === 'cross_account' || !record.rotation_enabled;
+  const status = degraded ? 'degraded' : 'wired now';
+  const referenceLabel = record.referenced_by?.length ? `${record.referenced_by.length} workload references` : 'no resolved workload references';
+  const policyLabel = record.has_resource_policy ? `${record.resource_policy_statement_count} policy statements` : 'no resource policy';
+  const rotationLabel = record.rotation_enabled ? `rotation enabled${record.rotation_interval_days ? ` every ${record.rotation_interval_days} days` : ''}` : 'rotation not enabled';
+  const kmsLabel = record.kms_key_arn || record.kms_key_id ? 'KMS referenced' : 'default encryption metadata';
+  return {
+    id: `secrets-manager-${record.secret_arn}`,
+    name: record.secret_name || record.secret_arn,
+    category: 'Secret-bearing',
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage: 'wired',
+    detail: `${rotationLabel}; ${policyLabel}; ${referenceLabel}; ${kmsLabel}. Values hidden.`,
+    filters: {
+      category: 'secrets-manager',
+      sensitivity: record.referenced_by?.length ? 'credential-reference' : 'secret-bearing',
+      readPosture: 'metadata-only',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.secret_arn,
+      record.secret_name,
+      record.account_id,
+      record.region,
+      record.secret_status,
+      record.exposure_classification,
+      ...(record.exposure_reasons ?? []),
+      ...(record.referenced_by ?? []).map((ref) => `${ref.source_service ?? ''} ${ref.workload_name ?? ''} ${ref.reference}`),
+      ...(record.unresolved_references ?? []).map((ref) => `${ref.source_service ?? ''} ${ref.workload_name ?? ''} ${ref.reference}`),
+      'secrets manager metadata rotation policy kms references values hidden'
+    ])
+  };
 }
 
 function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) {
@@ -6002,6 +6123,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [eksInventoryLoading, setEKSInventoryLoading] = useState(false);
   const [eksInventoryError, setEKSInventoryError] = useState('');
   const eksInventoryRequestRef = useRef(0);
+  const [secretsManagerInventory, setSecretsManagerInventory] = useState<AWSSecretsManagerMetadataInventoryResult | null>(null);
+  const [secretsManagerInventoryLoading, setSecretsManagerInventoryLoading] = useState(false);
+  const [secretsManagerInventoryError, setSecretsManagerInventoryError] = useState('');
+  const secretsManagerInventoryRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -6371,6 +6496,46 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadEKSInventory]);
 
+  const loadSecretsManagerInventory = useCallback(async () => {
+    const requestID = ++secretsManagerInventoryRequestRef.current;
+    setSecretsManagerInventory(null);
+    setSecretsManagerInventoryError('');
+    if (routeID !== 'resources' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSecretsManagerInventoryLoading(false);
+      return;
+    }
+    setSecretsManagerInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSecretsManagerMetadata(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== secretsManagerInventoryRequestRef.current) {
+        return;
+      }
+      setSecretsManagerInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== secretsManagerInventoryRequestRef.current) {
+        return;
+      }
+      setSecretsManagerInventoryError(formatAPIError(error, 'Unable to load Secrets Manager metadata.'));
+    } finally {
+      if (requestID === secretsManagerInventoryRequestRef.current) {
+        setSecretsManagerInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadSecretsManagerInventory();
+    return () => {
+      secretsManagerInventoryRequestRef.current += 1;
+    };
+  }, [loadSecretsManagerInventory]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -6505,7 +6670,17 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         <AWSAgentIdentitiesContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
       ) : null}
       {routeID === 'resources' ? (
-        <AWSResourcesInventoryContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+        <AWSResourcesInventoryContent
+          connection={connection}
+          secretsManagerState={{
+            inventory: secretsManagerInventory,
+            loading: secretsManagerInventoryLoading,
+            error: secretsManagerInventoryError,
+            onRetry: () => void loadSecretsManagerInventory()
+          }}
+          filters={activeFilters}
+          onFiltersChange={onFiltersChange}
+        />
       ) : null}
     </DomainPageShell>
   );


### PR DESCRIPTION
## Summary
- Adds a metadata-only AWS Secrets Manager collector for secret ARNs, names, tags, rotation state, KMS references, resource-policy grant summaries, version stages, replica regions, and account/region scope.
- Normalizes Secrets Manager secrets into AWS resources and emits graph-ready `uses_secret` edges from compute `secret_refs` without reading secret values.
- Adds the operator API route, OpenAPI/authz metadata, web API client types, and a Resources page surface with loading, empty, degraded, blocked, and error states.
- Documents required permissions and the safety boundary.

## Safety
- Never calls `secretsmanager:GetSecretValue`.
- Does not read or expose `SecretString`, `SecretBinary`, plaintext environment values, customer payloads, prompts, completions, object contents, database rows, or browser output.
- Uses `description_present` for operator evidence instead of surfacing secret description text.

## Validation
- `go test ./...`
- `npm --prefix web run build`
- `npm --prefix web test -- --run src/api/client.test.ts src/productShell.test.tsx`

Closes #1490

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS Secrets Manager collector and GET API to inventory secrets and link workloads that reference them, without reading secret values. Implements #1490 and surfaces results in Resources and CLI with OpenAPI, authz, runtime wiring, docs, and tests.

- New Features
  - Collects secret ARN/name, tags, rotation state, KMS key IDs and alias ARNs, version stages, replica regions, and account/region scope.
  - Summarizes resource-policy grants (public/cross-account; detects wildcard and bare account‑ID principals).
  - Normalizes secrets as resources and resolves graph `uses_secret` edges from compute `secret_refs`.
  - Adds GET `/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata` with OpenAPI schemas, route authz, and `connector_id`/`fixture_state` query params; response includes status, `secret_count`, coverage gaps, and records.
  - Web: API client/types and Resources wiring with loading/empty/degraded/blocked/error states; tests cover scoped headers and `fixture_state`.
  - Safety: never calls `secretsmanager:GetSecretValue`; no `SecretString`/`SecretBinary`; uses `description_present` for operator evidence. CLI/runtime: wired into scanners and service builder; includes SDK client, fixtures, normalizer, relationship resolution, tests; service contract updated with read‑only actions.

- Dependencies
  - Adds `github.com/aws/aws-sdk-go-v2/service/secretsmanager` v1.39.2.

<sup>Written for commit 91940394f20e5b26e0214bb2d44d9f6adda88e29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

