### PR TITLE
Detect bare account-id principals in KMS cross-account grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Fix **KMS cross-account grant detection for bare account-id principals**.
+  Key-policy and live KMS grants whose principal is a bare 12-digit account
+  id (e.g. `"Principal":{"AWS":"999999999999"}`) rather than a full ARN are
+  now flagged `is_cross_account`, so such keys are no longer undercounted in
+  the `cross_account` exposure classification. Adds a shared
+  `accountIDFromPrincipal` helper used by the KMS decrypt reachability
+  collector.
 - Add **KMS key policy and decrypt reachability collector** (#1489).
   Read-only, metadata-only inventory of every KMS key in scope, capturing
   manager (customer vs AWS), state, spec, multi-region linkage, rotation

--- a/internal/providers/aws/kms_decrypt_reachability_collector.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector.go
@@ -374,7 +374,7 @@ func annotateKMSGrants(grants []KMSIdentityGrant, accountID string) []KMSIdentit
 		grant.WildcardPrincipal = grant.WildcardPrincipal || grant.PrincipalARN == "*"
 		grant.IsPublic = grant.IsPublic || grant.WildcardPrincipal
 		if !grant.IsCrossAccount && accountID != "" && grant.PrincipalARN != "" && grant.PrincipalARN != "*" {
-			grantAccount := accountIDFromARN(grant.PrincipalARN)
+			grantAccount := accountIDFromPrincipal(grant.PrincipalARN)
 			if grantAccount != "" && grantAccount != accountID {
 				grant.IsCrossAccount = true
 			}
@@ -404,7 +404,7 @@ func annotateKMSLiveGrants(grants []KMSGrant, accountID string) []KMSGrant {
 		grant.HasConstraints = grant.HasConstraints || len(grant.EncryptionContextKeys) > 0 || len(grant.EncryptionContextSubsetKeys) > 0
 		grant.Capabilities = kmsCapabilitiesForActions(grant.Operations)
 		if !grant.IsCrossAccount && accountID != "" && grant.GranteePrincipal != "" {
-			granteeAccount := accountIDFromARN(grant.GranteePrincipal)
+			granteeAccount := accountIDFromPrincipal(grant.GranteePrincipal)
 			if granteeAccount != "" && granteeAccount != accountID {
 				grant.IsCrossAccount = true
 			}

--- a/internal/providers/aws/kms_decrypt_reachability_collector_test.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector_test.go
@@ -348,6 +348,27 @@ func TestAnnotateKMSGrants_CrossAccountAndCapabilities(t *testing.T) {
 	}
 }
 
+func TestAnnotateKMSGrants_BareAccountIDPrincipal(t *testing.T) {
+	out := annotateKMSGrants([]KMSIdentityGrant{{
+		PrincipalARN: "999999999999",
+		Effect:       "Allow",
+		Actions:      []string{"kms:Decrypt"},
+	}, {
+		PrincipalARN: "123456789012",
+		Effect:       "Allow",
+		Actions:      []string{"kms:Decrypt"},
+	}}, "123456789012")
+	if len(out) != 2 {
+		t.Fatalf("expected two grants, got %+v", out)
+	}
+	if !out[0].IsCrossAccount {
+		t.Fatalf("expected bare external account id to be cross-account, got %+v", out[0])
+	}
+	if out[1].IsCrossAccount {
+		t.Fatalf("expected bare owner account id to stay in-account, got %+v", out[1])
+	}
+}
+
 func TestAnnotateKMSLiveGrants_CrossAccount(t *testing.T) {
 	out := annotateKMSLiveGrants([]KMSGrant{{
 		GranteePrincipal: "arn:aws:iam::999999999999:role/partner",
@@ -358,6 +379,25 @@ func TestAnnotateKMSLiveGrants_CrossAccount(t *testing.T) {
 	}
 	if len(out[0].Capabilities) != 1 || out[0].Capabilities[0] != "decrypt" {
 		t.Fatalf("expected decrypt capability, got %+v", out[0].Capabilities)
+	}
+}
+
+func TestAnnotateKMSLiveGrants_BareAccountIDPrincipal(t *testing.T) {
+	out := annotateKMSLiveGrants([]KMSGrant{{
+		GranteePrincipal: "999999999999",
+		Operations:       []string{"Decrypt"},
+	}, {
+		GranteePrincipal: "123456789012",
+		Operations:       []string{"Decrypt"},
+	}}, "123456789012")
+	if len(out) != 2 {
+		t.Fatalf("expected two grants, got %+v", out)
+	}
+	if !out[0].IsCrossAccount {
+		t.Fatalf("expected bare external account id to be cross-account, got %+v", out[0])
+	}
+	if out[1].IsCrossAccount {
+		t.Fatalf("expected bare owner account id to stay in-account, got %+v", out[1])
 	}
 }
 

--- a/internal/providers/aws/rules.go
+++ b/internal/providers/aws/rules.go
@@ -325,6 +325,27 @@ func accountIDFromARN(arn string) string {
 	return accountID
 }
 
+// accountIDFromPrincipal resolves the owning account for an IAM policy
+// principal. A principal may be a full ARN or a bare 12-digit account id
+// (a valid AWS principal used for account-wide sharing), so check for the
+// bare form before falling back to ARN parsing.
+func accountIDFromPrincipal(principal string) string {
+	trimmed := strings.TrimSpace(principal)
+	if len(trimmed) == 12 {
+		bare := true
+		for _, r := range trimmed {
+			if r < '0' || r > '9' {
+				bare = false
+				break
+			}
+		}
+		if bare {
+			return trimmed
+		}
+	}
+	return accountIDFromARN(trimmed)
+}
+
 func overprivilegedFinding(identity domain.Identity, risks []accessRisk, now time.Time) domain.Finding {
 	evidence := make([]map[string]string, 0, len(risks))
 	path := make([]string, 0, len(risks)+1)

--- a/internal/providers/aws/rules_test.go
+++ b/internal/providers/aws/rules_test.go
@@ -250,6 +250,28 @@ func TestAccountIDFromARN(t *testing.T) {
 	}
 }
 
+func TestAccountIDFromPrincipal(t *testing.T) {
+	tests := []struct {
+		name      string
+		principal string
+		want      string
+	}{
+		{name: "full arn", principal: "arn:aws:iam::123456789012:role/demo", want: "123456789012"},
+		{name: "bare account id", principal: "999999999999", want: "999999999999"},
+		{name: "padded bare account id", principal: " 999999999999 ", want: "999999999999"},
+		{name: "non-numeric 12 chars falls back to arn", principal: "abcdefghijkl", want: ""},
+		{name: "wildcard", principal: "*", want: ""},
+		{name: "empty", principal: "", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := accountIDFromPrincipal(tc.principal); got != tc.want {
+				t.Fatalf("accountIDFromPrincipal(%q) = %q, want %q", tc.principal, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSeveritySortOrder(t *testing.T) {
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	identity := domain.Identity{


### PR DESCRIPTION
## Summary

Cross-account detection for KMS key-policy and live grants relied on `accountIDFromARN`, which returns an empty string for a **bare 12-digit account-id principal** (e.g. `"Principal":{"AWS":"999999999999"}`) rather than a full ARN. Account IDs are valid AWS principals commonly used for account-wide sharing, so those grants were never flagged `is_cross_account` and the affected keys were undercounted in the `cross_account` exposure classification.

This is a follow-up to review feedback on #1594, where the same class of bug was fixed in the Secrets Manager metadata collector; the KMS decrypt reachability collector (#1489) had the identical gap.

## Changes

- Add a shared `accountIDFromPrincipal` helper (in `rules.go`, next to `accountIDFromARN`) that treats a bare 12-digit value as an account id before falling back to ARN parsing.
- Use it in both `annotateKMSGrants` (key-policy grants) and `annotateKMSLiveGrants` (live `ListGrants` grants).
- Tests: bare external account id is flagged cross-account, bare owner account id stays in-account, for both grant paths; table-driven coverage for the new helper.
- CHANGELOG entry under Unreleased.

## Testing

- `go test ./internal/providers/aws/` — pass
- `go vet ./internal/providers/aws/` — clean
- `make fmt` applied

## AI disclosure

- AI-assisted: no


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes KMS cross-account detection when the principal is a bare 12-digit account ID (e.g., "999999999999"). Grants are now correctly flagged `is_cross_account`, fixing undercounting in the `cross_account` exposure.

- Bug Fixes
  - Added `accountIDFromPrincipal` to resolve either a bare 12-digit ID or an ARN.
  - Used in `annotateKMSGrants` and `annotateKMSLiveGrants` to detect cross-account grants.
  - Added tests for bare external vs. owner account IDs and table-driven coverage for the helper.
  - Updated `CHANGELOG.md`.

<sup>Written for commit 462a1f7d2298a83cc31df255a90a74b653ed1c54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

