### PR TITLE
Implement AWS SSM Parameter Store metadata and reference collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 ## Unreleased
+- Add **SSM Parameter Store metadata and reference collector** (#1491).
+  Read-only, metadata-only inventory of SSM parameters capturing name, ARN,
+  hierarchy path context, type (`string`, `string_list`, `secure_string`),
+  tier, data type, version, KMS key references for SecureString parameters,
+  parameter-policy summaries (type, status, expiration timestamp), tags, and
+  the last-modified IAM principal. Classifies sensitivity
+  (`secure_string_customer_kms`, `secure_string_aws_managed_kms`,
+  `string_list`, `plain_text`) and exposure (`referenced_by_workload`,
+  `scheduled_expiration`, `private`), flags plaintext parameters injected
+  through secret channels, and emits `uses_secret` graph edges for resolved
+  workload `secret_refs` (ECS `valueFrom` and CodeBuild `PARAMETER_STORE`
+  sources, including version/label suffixes). Adds the
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata`
+  endpoint with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states plus `parameter_type` and `identity`
+  record filters, OpenAPI schema, web API client types, the AWS resources
+  inventory surface, runtime/CLI wiring, and operator docs. The collector
+  never calls `ssm:GetParameter`, `ssm:GetParameters`,
+  `ssm:GetParametersByPath`, or `ssm:GetParameterHistory`; never reads
+  parameter values; and treats SecureString parameters as sensitive metadata
+  only.
 - Add **KMS key policy and decrypt reachability collector** (#1489).
   Read-only, metadata-only inventory of every KMS key in scope, capturing
   manager (customer vs AWS), state, spec, multi-region linkage, rotation

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -278,3 +278,13 @@ ordered by `kind`, then `source_id`.
   `secret_refs`. It never calls `secretsmanager:GetSecretValue`, never reads
   `SecretString` or `SecretBinary`, and uses `description_present` instead of
   surfacing description text in operator evidence.
+- SSM Parameter Store metadata and workload references are exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata`.
+  The collector records parameter metadata (type, tier, path context, version,
+  data type), KMS key references for SecureString parameters, parameter-policy
+  summaries, tags, the last-modified IAM principal, and graph-ready
+  `uses_secret` edges for resolved compute `secret_refs` (ECS `valueFrom` and
+  CodeBuild `PARAMETER_STORE` sources). It never calls any `ssm:GetParameter*`
+  action, never reads parameter values, treats SecureString parameters as
+  sensitive metadata only, and uses `description_present` and
+  `allowed_pattern_present` instead of surfacing text in operator evidence.

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -185,6 +185,11 @@ The Secrets Manager metadata collector adds metadata-only reads:
 `secretsmanager:ListSecretVersionIds`. It must not add
 `secretsmanager:GetSecretValue`.
 
+The SSM Parameter Store metadata collector adds metadata-only reads:
+`ssm:DescribeParameters` and `ssm:ListTagsForResource`. It must not add
+`ssm:GetParameter`, `ssm:GetParameters`, `ssm:GetParametersByPath`, or
+`ssm:GetParameterHistory`.
+
 Future service collectors may add service-specific read-only metadata
 permissions, but must not add actions that read secret values, object contents,
 prompts, completions, browser pages, code-interpreter output, database rows, or
@@ -204,6 +209,13 @@ KMS references, tags, version stages, replica status, and resolved workload
 reference edges only. `SecretString`, `SecretBinary`, secret descriptions as
 operator evidence, and `GetSecretValue` outputs are intentionally outside the
 collector contract.
+
+For SSM Parameter Store, records contain parameter metadata, type and tier,
+path context, KMS references, parameter-policy summaries, tags, last-modified
+identity context, and resolved workload reference edges only. Parameter
+values, parameter history, description and allowed-pattern text as operator
+evidence, and every `ssm:GetParameter*` output are intentionally outside the
+collector contract. SecureString parameters are sensitive metadata only.
 
 For CodePipeline, `configuration_keys` are action configuration key names only.
 Configuration values, source contents, action outputs, artifact contents,

--- a/docs/aws-ssm-parameter-metadata.md
+++ b/docs/aws-ssm-parameter-metadata.md
@@ -1,0 +1,90 @@
+# AWS SSM Parameter Store Metadata and References
+
+Issue #1491 adds metadata-only collection for AWS Systems Manager Parameter
+Store parameters and the workload references that point at them.
+
+## What It Collects
+
+- Parameter ARN, name, hierarchy path context, account, region, and tags.
+- Parameter type (`string`, `string_list`, `secure_string`), tier, data type,
+  and version.
+- KMS key references for SecureString parameters, with customer-managed vs
+  AWS-managed key classification.
+- Parameter policy summaries (type, status, and expiration timestamp) without
+  raw policy text.
+- Last-modified timestamp and the IAM principal that last changed the
+  parameter, connecting parameter changes to identities.
+- Workload references emitted by compute collectors through `secret_refs`
+  (ECS `valueFrom` and CodeBuild `PARAMETER_STORE` environment sources), with
+  graph-ready `uses_secret` edges when a reference resolves to a collected
+  parameter.
+
+SecureString parameters are treated as sensitive metadata only: the collector
+records that a secure value exists and how it is encrypted, never the value.
+
+## What It Never Collects
+
+The collector never calls `ssm:GetParameter`, `ssm:GetParameters`,
+`ssm:GetParametersByPath`, or `ssm:GetParameterHistory`. It does not read,
+store, log, or return parameter values, plaintext environment values, customer
+payloads, prompts, completions, object contents, database rows, or browser
+output. API responses expose `description_present` and
+`allowed_pattern_present` rather than using description or pattern text as
+evidence. Parameters shared into the account through AWS RAM are not
+enumerated; this is reported as an explicit coverage gap.
+
+## Required AWS Permissions
+
+Use read-only metadata permissions:
+
+- `ssm:DescribeParameters`
+- `ssm:ListTagsForResource`
+
+Do not add any `ssm:GetParameter*` action for this capability.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata
+```
+
+Optional query parameters:
+
+- `connector_id`: scope the response to one AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for deterministic UI and contract validation.
+- `parameter_type`: limit records to `string`, `string_list`, or
+  `secure_string`.
+- `identity`: case-insensitive substring filter matching the last-modified
+  principal or referencing workload identifiers.
+
+The response includes operator-visible status, confidence, evidence links,
+failure reasons, remediation hints, diagnostics, records, and `uses_secret`
+relationships. Plaintext `String` parameters referenced through secret-style
+injection channels are flagged with the
+`plain_text_parameter_referenced_as_secret` exposure reason so operators can
+move them into SecureString or Secrets Manager.
+
+## Failure States
+
+- `empty`: collection succeeded and no parameters were found.
+- `degraded`: metadata is available but one metadata path, such as tag reads,
+  is incomplete.
+- `partial_failure`: some records remain visible while a later metadata page
+  failed.
+- `permission_denied`: required metadata-only permissions are missing.
+
+Unknown or denied states are explicit; they are not reported as successful
+findings.
+
+## Live Validation
+
+Run fixture validation first:
+
+```sh
+go test ./internal/providers/aws ./internal/api
+```
+
+For live AWS validation, use only an authorized test account and record
+account, region, service coverage, and diagnostics. Do not capture parameter
+values or customer payloads.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -554,6 +554,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities
     action: tenancy.read
     resource_type: project
@@ -4473,6 +4478,66 @@ paths:
                     $ref: "#/components/schemas/AWSSecretsManagerMetadataInventoryResult"
         "400":
           description: Invalid AWS Secrets Manager metadata request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS SSM Parameter Store metadata and references
+      operationId: getAWSProjectSSMParameterMetadata
+      description: Returns scoped SSM parameter metadata, type, tier, KMS references, parameter policies, tags, path context, and workload reference edges. Metadata-only — never calls GetParameter, GetParameters, GetParametersByPath, or GetParameterHistory and never returns parameter values. SecureString parameters are sensitive metadata only.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only SSM parameter metadata evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: parameter_type
+          schema:
+            type: string
+            enum: [string, string_list, secure_string]
+          description: Optional filter limiting records to one canonical parameter type.
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional case-insensitive substring filter matching the last-modified principal or referencing workload identifiers.
+      responses:
+        "200":
+          description: AWS SSM parameter metadata inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSSSMParameterMetadataInventoryResult"
+        "400":
+          description: Invalid AWS SSM parameter metadata request
           content:
             application/json:
               schema:
@@ -9691,6 +9756,189 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSecretsManagerMetadataDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSSMParameterCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status:
+          type: string
+          enum: [unsupported]
+        reason: { type: string }
+        remediation: { type: string }
+    AWSSSMParameterPolicy:
+      type: object
+      properties:
+        policy_type: { type: string }
+        policy_status: { type: string }
+        expires_at: { type: string }
+    AWSSSMParameterWorkloadReference:
+      type: object
+      properties:
+        source_service: { type: string }
+        workload_id: { type: string }
+        workload_type: { type: string }
+        workload_name: { type: string }
+        resource_arn: { type: string }
+        resource_id: { type: string }
+        reference: { type: string }
+        reference_kind: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSSSMParameterMetadataRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service:
+          type: string
+          enum: [ssm]
+        parameter_arn: { type: string }
+        parameter_name: { type: string }
+        parameter_path: { type: string }
+        path_depth: { type: integer }
+        parameter_type:
+          type: string
+          enum: [string, string_list, secure_string]
+        tier:
+          type: string
+          enum: [standard, advanced, intelligent_tiering]
+        data_type: { type: string }
+        version: { type: integer }
+        description_present: { type: boolean }
+        allowed_pattern_present: { type: boolean }
+        kms_key_id: { type: string }
+        kms_key_arn: { type: string }
+        last_modified_at: { type: string }
+        last_modified_by: { type: string }
+        parameter_policies:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterPolicy"
+        tags:
+          type: object
+          additionalProperties: { type: string }
+        sensitive: { type: boolean }
+        sensitivity_classification:
+          type: string
+          enum: [secure_string_customer_kms, secure_string_aws_managed_kms, string_list, plain_text]
+        exposure_classification:
+          type: string
+          enum: [referenced_by_workload, scheduled_expiration, private]
+        exposure_reasons:
+          type: array
+          items: { type: string }
+        referenced_by:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterWorkloadReference"
+        unresolved_references:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterWorkloadReference"
+        source: { type: string }
+        evidence_ref: { type: string }
+        from_node_id: { type: string }
+        relationship_type: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+    AWSSSMParameterReferenceEdge:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [uses_secret]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        source: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSSSMParameterMetadataDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSSSMParameterMetadataInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        parameter_count: { type: integer }
+        secure_string_count: { type: integer }
+        customer_kms_count: { type: integer }
+        referenced_parameter_count: { type: integer }
+        unreferenced_parameter_count: { type: integer }
+        plain_text_referenced_count: { type: integer }
+        expiring_parameter_count: { type: integer }
+        advanced_tier_count: { type: integer }
+        relationship_count: { type: integer }
+        unresolved_reference_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterMetadataRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterReferenceEdge"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSSMParameterMetadataDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/aws/aws-sdk-go-v2/service/sfn v1.42.2 h1:fh1FvGJdVUlyT5aW2u5jIiWrasnk
 github.com/aws/aws-sdk-go-v2/service/sfn v1.42.2/go.mod h1:3ZyiH89Ot63cpYyK48FXNxJvGpRtt2i8DG9Q3E+YWqM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 h1:YcpVyIPLCbiypN6KSphijN5fC7DDjX114SqA7prnnxg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.4/go.mod h1:5ZICS++oFTRPfa1GsBqFDWX/8WamZ/QQOcCzIuU/zLw=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3 h1:58LjP8cp8UEHA1LG/JZ4fG9SobHE82kLYe46mogbSI4=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3/go.mod h1:16Zd02ocSJp68o4r36MQ4Rikf/Ulv4On5qjMpJJf5Mo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.31.2 h1:ySNWu7TPmj5fKFIa1GYvX+Ddxd5ccruqC20aMNuyWDM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.31.2/go.mod h1:A+U9luAOwFeB1kseyWCITVg7/NntoPebCFR9pQ4ch9A=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.5 h1:KSzGGqfk39O+WU3OEyYbx6F7sLDQCqxlOJ+2IksfK6U=

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -754,6 +754,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/baseline", Action: policyActionScansRun, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects/:project_id/github/connect/start", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_ssm_parameter_metadata.go
+++ b/internal/api/aws_ssm_parameter_metadata.go
@@ -1,0 +1,497 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+const (
+	awsSSMParameterMetadataCurrentIssue = 1491
+	awsSSMParameterMetadataVersion      = "aws-ssm-parameter-metadata-inventory-v1"
+)
+
+type AWSSSMParameterMetadataInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	// ParameterType filters records to one canonical parameter type
+	// (string, string_list, secure_string).
+	ParameterType string `json:"parameter_type,omitempty"`
+	// Identity filters records to those last modified by, or referenced
+	// from, the supplied identity or workload identifier substring.
+	Identity string `json:"identity,omitempty"`
+}
+
+type AWSSSMParameterCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSSSMParameterMetadataInventoryResult struct {
+	TenantID                   string                              `json:"tenant_id"`
+	WorkspaceID                string                              `json:"workspace_id"`
+	ProjectID                  string                              `json:"project_id"`
+	ConnectorID                string                              `json:"connector_id,omitempty"`
+	AccountID                  string                              `json:"account_id,omitempty"`
+	Region                     string                              `json:"region,omitempty"`
+	ParentIssueNumber          int                                 `json:"parent_issue_number"`
+	ParentIssueRef             string                              `json:"parent_issue_ref"`
+	CurrentIssueNumber         int                                 `json:"current_issue_number"`
+	CurrentIssueRef            string                              `json:"current_issue_ref"`
+	Version                    string                              `json:"version"`
+	Status                     string                              `json:"status"`
+	FixtureState               string                              `json:"fixture_state"`
+	Confidence                 float64                             `json:"confidence"`
+	ParameterCount             int                                 `json:"parameter_count"`
+	SecureStringCount          int                                 `json:"secure_string_count"`
+	CustomerKMSCount           int                                 `json:"customer_kms_count"`
+	ReferencedParameterCount   int                                 `json:"referenced_parameter_count"`
+	UnreferencedParameterCount int                                 `json:"unreferenced_parameter_count"`
+	PlainTextReferencedCount   int                                 `json:"plain_text_referenced_count"`
+	ExpiringParameterCount     int                                 `json:"expiring_parameter_count"`
+	AdvancedTierCount          int                                 `json:"advanced_tier_count"`
+	RelationshipCount          int                                 `json:"relationship_count"`
+	UnresolvedReferenceCount   int                                 `json:"unresolved_reference_count"`
+	FailureReasons             []string                            `json:"failure_reasons"`
+	RemediationHints           []string                            `json:"remediation_hints"`
+	EvidenceLinks              []string                            `json:"evidence_links"`
+	CoverageGaps               []AWSSSMParameterCoverageGap        `json:"coverage_gaps"`
+	Records                    []AWSSSMParameterMetadataRecord     `json:"records"`
+	Relationships              []AWSSSMParameterReferenceEdge      `json:"relationships"`
+	Diagnostics                []AWSSSMParameterMetadataDiagnostic `json:"diagnostics"`
+	GeneratedAt                time.Time                           `json:"generated_at"`
+	UpdatedAt                  time.Time                           `json:"updated_at"`
+}
+
+type AWSSSMParameterMetadataRecord struct {
+	AccountID                 string                             `json:"account_id"`
+	Region                    string                             `json:"region"`
+	Service                   string                             `json:"service"`
+	ParameterARN              string                             `json:"parameter_arn"`
+	ParameterName             string                             `json:"parameter_name"`
+	ParameterPath             string                             `json:"parameter_path,omitempty"`
+	PathDepth                 int                                `json:"path_depth,omitempty"`
+	ParameterType             string                             `json:"parameter_type"`
+	Tier                      string                             `json:"tier"`
+	DataType                  string                             `json:"data_type,omitempty"`
+	Version                   int64                              `json:"version,omitempty"`
+	DescriptionPresent        bool                               `json:"description_present"`
+	AllowedPatternPresent     bool                               `json:"allowed_pattern_present"`
+	KMSKeyID                  string                             `json:"kms_key_id,omitempty"`
+	KMSKeyARN                 string                             `json:"kms_key_arn,omitempty"`
+	LastModifiedAt            string                             `json:"last_modified_at,omitempty"`
+	LastModifiedBy            string                             `json:"last_modified_by,omitempty"`
+	Policies                  []AWSSSMParameterPolicy            `json:"parameter_policies,omitempty"`
+	Tags                      map[string]string                  `json:"tags,omitempty"`
+	Sensitive                 bool                               `json:"sensitive"`
+	SensitivityClassification string                             `json:"sensitivity_classification"`
+	ExposureClassification    string                             `json:"exposure_classification"`
+	ExposureReasons           []string                           `json:"exposure_reasons,omitempty"`
+	ReferencedBy              []AWSSSMParameterWorkloadReference `json:"referenced_by,omitempty"`
+	UnresolvedReferences      []AWSSSMParameterWorkloadReference `json:"unresolved_references,omitempty"`
+	Source                    string                             `json:"source"`
+	EvidenceRef               string                             `json:"evidence_ref"`
+	FromNodeID                string                             `json:"from_node_id"`
+	RelationshipType          string                             `json:"relationship_type"`
+	Confidence                float64                            `json:"confidence"`
+	CollectedAt               time.Time                          `json:"collected_at"`
+	Status                    string                             `json:"status"`
+}
+
+type AWSSSMParameterPolicy struct {
+	PolicyType   string `json:"policy_type,omitempty"`
+	PolicyStatus string `json:"policy_status,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+type AWSSSMParameterWorkloadReference struct {
+	SourceService string  `json:"source_service,omitempty"`
+	WorkloadID    string  `json:"workload_id,omitempty"`
+	WorkloadType  string  `json:"workload_type,omitempty"`
+	WorkloadName  string  `json:"workload_name,omitempty"`
+	ResourceARN   string  `json:"resource_arn,omitempty"`
+	ResourceID    string  `json:"resource_id,omitempty"`
+	Reference     string  `json:"reference"`
+	ReferenceKind string  `json:"reference_kind"`
+	Confidence    float64 `json:"confidence"`
+}
+
+type AWSSSMParameterReferenceEdge struct {
+	Type        string  `json:"type"`
+	FromNodeID  string  `json:"from_node_id"`
+	ToNodeID    string  `json:"to_node_id"`
+	EvidenceRef string  `json:"evidence_ref"`
+	Source      string  `json:"source"`
+	Confidence  float64 `json:"confidence"`
+}
+
+type AWSSSMParameterMetadataDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+func (s *Service) GetAWSSSMParameterMetadataInventory(ctx context.Context, workspaceID string, projectID string, request AWSSSMParameterMetadataInventoryRequest) (AWSSSMParameterMetadataInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSSMParameterMetadataInventoryResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSSSMParameterMetadataInventoryResult{}, err
+	}
+	return buildAWSSSMParameterMetadataInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSSSMParameterMetadataInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSSSMParameterMetadataInventoryRequest, checkedAt time.Time) (AWSSSMParameterMetadataInventoryResult, error) {
+	fixtureState := normalizeAWSSSMParameterMetadataFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSSMParameterMetadataInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	parameterTypeFilter, ok := normalizeAWSSSMParameterTypeFilter(request.ParameterType)
+	if !ok {
+		return AWSSSMParameterMetadataInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, coverageGaps := awsSSMParameterMetadataFixtureRecords(accountID, region, fixtureState, checkedAt)
+	records = filterAWSSSMParameterRecords(records, parameterTypeFilter, strings.TrimSpace(request.Identity))
+	status, confidence, failures, remediations := summarizeAWSSSMParameterMetadataInventory(fixtureState, diagnostics, records)
+	relationships := awsSSMParameterReferenceEdges(records)
+	return AWSSSMParameterMetadataInventoryResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsSSMParameterMetadataCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsSSMParameterMetadataCurrentIssue),
+		Version:            awsSSMParameterMetadataVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		ParameterCount:     len(records),
+		SecureStringCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return r.ParameterType == "secure_string"
+		}),
+		CustomerKMSCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return r.SensitivityClassification == "secure_string_customer_kms"
+		}),
+		ReferencedParameterCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return len(r.ReferencedBy) > 0
+		}),
+		UnreferencedParameterCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return len(r.ReferencedBy) == 0
+		}),
+		PlainTextReferencedCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return len(r.ReferencedBy) > 0 && r.ParameterType != "secure_string"
+		}),
+		ExpiringParameterCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			for _, policy := range r.Policies {
+				if strings.EqualFold(policy.PolicyType, "Expiration") {
+					return true
+				}
+			}
+			return false
+		}),
+		AdvancedTierCount: countSSMParameters(records, func(r AWSSSMParameterMetadataRecord) bool {
+			return r.Tier == "advanced"
+		}),
+		RelationshipCount:        len(relationships),
+		UnresolvedReferenceCount: countSSMParameterRefs(records, true),
+		FailureReasons:           failures,
+		RemediationHints:         remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSSMParameterMetadataCurrentIssue),
+			"/docs/aws-ssm-parameter-metadata",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  coverageGaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsSSMParameterMetadataDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSSSMParameterMetadataFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func normalizeAWSSSMParameterTypeFilter(requested string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		return "", true
+	case "string", "string_list", "secure_string":
+		return strings.ToLower(strings.TrimSpace(requested)), true
+	default:
+		return "", false
+	}
+}
+
+// filterAWSSSMParameterRecords applies the operator-facing record filters.
+// Identity matches the last-modified principal or any referencing workload
+// identifier, case-insensitively, by substring.
+func filterAWSSSMParameterRecords(records []AWSSSMParameterMetadataRecord, parameterType string, identity string) []AWSSSMParameterMetadataRecord {
+	if parameterType == "" && identity == "" {
+		return records
+	}
+	identity = strings.ToLower(identity)
+	filtered := make([]AWSSSMParameterMetadataRecord, 0, len(records))
+	for _, record := range records {
+		if parameterType != "" && record.ParameterType != parameterType {
+			continue
+		}
+		if identity != "" && !ssmParameterRecordMatchesIdentity(record, identity) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered
+}
+
+func ssmParameterRecordMatchesIdentity(record AWSSSMParameterMetadataRecord, identity string) bool {
+	if strings.Contains(strings.ToLower(record.LastModifiedBy), identity) {
+		return true
+	}
+	for _, refs := range [][]AWSSSMParameterWorkloadReference{record.ReferencedBy, record.UnresolvedReferences} {
+		for _, ref := range refs {
+			haystack := strings.ToLower(strings.Join([]string{ref.WorkloadID, ref.WorkloadName, ref.ResourceARN}, " "))
+			if strings.Contains(haystack, identity) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func awsSSMParameterMetadataFixtureRecords(accountID, region, fixtureState string, checkedAt time.Time) ([]AWSSSMParameterMetadataRecord, []providers.SourceError, []AWSSSMParameterCoverageGap) {
+	gaps := []AWSSSMParameterCoverageGap{{
+		Capability:  "parameter_value_collection",
+		Status:      "unsupported",
+		Reason:      "This collector never calls GetParameter, GetParameters, GetParametersByPath, or GetParameterHistory and never stores parameter values.",
+		Remediation: "Inspect parameter values through existing change-management tooling outside Identrail.",
+	}, {
+		Capability:  "ram_shared_parameter_visibility",
+		Status:      "unsupported",
+		Reason:      "Advanced-tier parameters shared through AWS RAM are not enumerated; only parameters owned by the connected account are inventoried.",
+		Remediation: "Review AWS RAM resource shares directly for cross-account parameter sharing.",
+	}}
+	switch fixtureState {
+	case "permission_denied":
+		return nil, []providers.SourceError{{Collector: "ssm_parameter_metadata", Code: "ssm_parameter_metadata_page_failed", Message: "AccessDenied: missing ssm:DescribeParameters", Retryable: false}}, gaps
+	case "empty":
+		return nil, nil, gaps
+	}
+	partition := awsSecretsManagerPartitionForRegion(region)
+	dbPasswordARN := fmt.Sprintf("arn:%s:ssm:%s:%s:parameter/payments/db/password", partition, region, accountID)
+	dbHostARN := fmt.Sprintf("arn:%s:ssm:%s:%s:parameter/payments/db/host", partition, region, accountID)
+	legacyTokenARN := fmt.Sprintf("arn:%s:ssm:%s:%s:parameter/legacy/export-token", partition, region, accountID)
+	records := []AWSSSMParameterMetadataRecord{
+		awsSSMParameterMetadataFixtureRecord(accountID, region, "/payments/db/password", dbPasswordARN, checkedAt, func(r *AWSSSMParameterMetadataRecord) {
+			r.ParameterPath = "/payments/db"
+			r.PathDepth = 3
+			r.ParameterType = "secure_string"
+			r.Tier = "advanced"
+			r.Sensitive = true
+			r.SensitivityClassification = "secure_string_customer_kms"
+			r.KMSKeyID = "alias/payments-parameters"
+			r.KMSKeyARN = fmt.Sprintf("arn:%s:kms:%s:%s:alias/payments-parameters", partition, region, accountID)
+			r.LastModifiedBy = fmt.Sprintf("arn:%s:iam::%s:role/payments-deployer", partition, accountID)
+			r.ReferencedBy = []AWSSSMParameterWorkloadReference{{
+				SourceService: "ecs",
+				WorkloadID:    fmt.Sprintf("arn:%s:ecs:%s:%s:service/prod/payments", partition, region, accountID),
+				WorkloadType:  "ecs_service",
+				WorkloadName:  "payments",
+				ResourceARN:   fmt.Sprintf("arn:%s:ecs:%s:%s:task-definition/payments:4", partition, region, accountID),
+				Reference:     "DATABASE_PASSWORD=" + dbPasswordARN,
+				ReferenceKind: "arn",
+				Confidence:    0.94,
+			}}
+			r.ExposureClassification = "referenced_by_workload"
+			r.ExposureReasons = []string{"workload_references_parameter", "secure_string_kms_encrypted", "customer_kms_key_referenced"}
+			r.Confidence = 0.9
+		}),
+		awsSSMParameterMetadataFixtureRecord(accountID, region, "/payments/db/host", dbHostARN, checkedAt, func(r *AWSSSMParameterMetadataRecord) {
+			r.ParameterPath = "/payments/db"
+			r.PathDepth = 3
+			r.ParameterType = "string"
+			r.SensitivityClassification = "plain_text"
+			r.LastModifiedBy = fmt.Sprintf("arn:%s:iam::%s:role/payments-deployer", partition, accountID)
+			r.ReferencedBy = []AWSSSMParameterWorkloadReference{{
+				SourceService: "codebuild",
+				WorkloadID:    fmt.Sprintf("arn:%s:codebuild:%s:%s:project/payments-build", partition, region, accountID),
+				WorkloadType:  "codebuild_project",
+				WorkloadName:  "payments-build",
+				Reference:     "DB_HOST=PARAMETER_STORE:/payments/db/host",
+				ReferenceKind: "name",
+				Confidence:    0.9,
+			}}
+			r.ExposureClassification = "referenced_by_workload"
+			r.ExposureReasons = []string{"workload_references_parameter", "plain_text_parameter_referenced_as_secret"}
+			r.Confidence = 0.9
+		}),
+		awsSSMParameterMetadataFixtureRecord(accountID, region, "/legacy/export-token", legacyTokenARN, checkedAt, func(r *AWSSSMParameterMetadataRecord) {
+			r.ParameterPath = "/legacy"
+			r.PathDepth = 2
+			r.ParameterType = "secure_string"
+			r.Sensitive = true
+			r.SensitivityClassification = "secure_string_aws_managed_kms"
+			r.KMSKeyID = "alias/aws/ssm"
+			r.Policies = []AWSSSMParameterPolicy{{PolicyType: "Expiration", PolicyStatus: "pending", ExpiresAt: "2026-12-02T21:34:33Z"}}
+			r.UnresolvedReferences = []AWSSSMParameterWorkloadReference{{
+				SourceService: "codebuild",
+				WorkloadName:  "legacy-export",
+				Reference:     "EXPORT_TOKEN=PARAMETER_STORE:legacy-export-token",
+				ReferenceKind: "name",
+				Confidence:    0.72,
+			}}
+			r.ExposureClassification = "scheduled_expiration"
+			r.ExposureReasons = []string{"secure_string_kms_encrypted", "expiration_policy_present"}
+			r.Confidence = 0.87
+		}),
+	}
+	diagnostics := []providers.SourceError{}
+	if fixtureState == "degraded" {
+		records[0].Tags = nil
+		records[0].Status = "degraded"
+		records[0].ExposureReasons = append(records[0].ExposureReasons, "tag_metadata_unavailable")
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "ssm_parameter_metadata", SourceID: dbPasswordARN, Code: "ssm_parameter_tags_failed", Message: "AccessDenied: ssm:ListTagsForResource", Retryable: true})
+	}
+	if fixtureState == "partial_failure" {
+		records = records[:2]
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "ssm_parameter_metadata", SourceID: legacyTokenARN, Code: "ssm_parameter_metadata_page_failed", Message: "ThrottlingException: DescribeParameters page 2", Retryable: true})
+	}
+	return records, diagnostics, gaps
+}
+
+func awsSSMParameterMetadataFixtureRecord(accountID, region, name, arn string, checkedAt time.Time, mutate func(*AWSSSMParameterMetadataRecord)) AWSSSMParameterMetadataRecord {
+	record := AWSSSMParameterMetadataRecord{
+		AccountID:                 accountID,
+		Region:                    region,
+		Service:                   "ssm",
+		ParameterARN:              arn,
+		ParameterName:             name,
+		ParameterType:             "string",
+		Tier:                      "standard",
+		DataType:                  "text",
+		Version:                   3,
+		DescriptionPresent:        true,
+		AllowedPatternPresent:     false,
+		LastModifiedAt:            "2026-06-08T12:00:00Z",
+		Tags:                      map[string]string{"owner": "payments"},
+		SensitivityClassification: "plain_text",
+		ExposureClassification:    "private",
+		ExposureReasons:           []string{},
+		Source:                    "ssm_parameter_metadata",
+		EvidenceRef:               arn,
+		FromNodeID:                "aws:resource:ssm-parameter:" + arn,
+		RelationshipType:          "metadata",
+		Confidence:                0.85,
+		CollectedAt:               checkedAt,
+		Status:                    "ready",
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	return record
+}
+
+func awsSSMParameterReferenceEdges(records []AWSSSMParameterMetadataRecord) []AWSSSMParameterReferenceEdge {
+	edges := []AWSSSMParameterReferenceEdge{}
+	for _, record := range records {
+		toNode := "aws:resource:ssm-parameter:" + record.ParameterARN
+		for _, ref := range record.ReferencedBy {
+			fromNode := firstNonEmptyAWSValue(ref.WorkloadID, ref.ResourceID, ref.ResourceARN)
+			if strings.TrimSpace(fromNode) == "" {
+				continue
+			}
+			edges = append(edges, AWSSSMParameterReferenceEdge{
+				Type:        "uses_secret",
+				FromNodeID:  fromNode,
+				ToNodeID:    toNode,
+				EvidenceRef: ref.Reference,
+				Source:      ref.SourceService,
+				Confidence:  ref.Confidence,
+			})
+		}
+	}
+	return edges
+}
+
+func summarizeAWSSSMParameterMetadataInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSSSMParameterMetadataRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.3, []string{"SSM parameter metadata collection is permission denied."}, []string{"Grant ssm:DescribeParameters and ssm:ListTagsForResource without any ssm:GetParameter* action."}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72, awsSecretsManagerSourceErrorMessages(diagnostics), []string{"Review the diagnostics and rerun after metadata-only SSM permissions are available."}
+	default:
+		if len(records) == 0 {
+			return awsPlatformDependencyStatusReady, 0.82, nil, []string{"No SSM parameters were found for this account, region, and filters."}
+		}
+		return awsPlatformDependencyStatusReady, 0.93, nil, []string{"Use these references to prioritize SecureString hygiene and move plaintext credentials into SecureString or Secrets Manager."}
+	}
+}
+
+func awsSSMParameterMetadataDiagnostics(diagnostics []providers.SourceError) []AWSSSMParameterMetadataDiagnostic {
+	result := make([]AWSSSMParameterMetadataDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSSSMParameterMetadataDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: "Confirm metadata-only SSM IAM permissions; do not add GetParameter, GetParameters, GetParametersByPath, or GetParameterHistory for this collector.",
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func countSSMParameters(records []AWSSSMParameterMetadataRecord, pred func(AWSSSMParameterMetadataRecord) bool) int {
+	count := 0
+	for _, record := range records {
+		if pred(record) {
+			count++
+		}
+	}
+	return count
+}
+
+func countSSMParameterRefs(records []AWSSSMParameterMetadataRecord, unresolved bool) int {
+	count := 0
+	for _, record := range records {
+		refs := record.ReferencedBy
+		if unresolved {
+			refs = record.UnresolvedReferences
+		}
+		count += len(refs)
+	}
+	return count
+}

--- a/internal/api/aws_ssm_parameter_metadata_test.go
+++ b/internal/api/aws_ssm_parameter_metadata_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSSSMParameterMetadataInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get ssm parameter metadata: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1491" || result.Version != awsSSMParameterMetadataVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.ParameterCount != 3 || result.RelationshipCount != 2 || result.UnresolvedReferenceCount != 1 {
+		t.Fatalf("unexpected counts: %+v", result)
+	}
+	if result.SecureStringCount != 2 || result.CustomerKMSCount != 1 || result.PlainTextReferencedCount != 1 || result.ExpiringParameterCount != 1 {
+		t.Fatalf("expected secure-string/kms/plaintext/expiring counts, got %+v", result)
+	}
+	for _, record := range result.Records {
+		payload, err := json.Marshal(record)
+		if err != nil {
+			t.Fatalf("marshal record: %v", err)
+		}
+		lower := strings.ToLower(string(payload))
+		for _, forbidden := range []string{"parameter_value", "getparameter", "secretstring"} {
+			if strings.Contains(lower, forbidden) {
+				t.Fatalf("parameter value evidence leaked into API response: %s", payload)
+			}
+		}
+		if record.Sensitive && record.ParameterType != "secure_string" {
+			t.Fatalf("only secure strings should be sensitive, got %+v", record)
+		}
+	}
+}
+
+func TestGetAWSSSMParameterMetadataInventoryFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 15, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	secureOnly, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod", ParameterType: "secure_string"})
+	if err != nil {
+		t.Fatalf("get filtered inventory: %v", err)
+	}
+	if secureOnly.ParameterCount != 2 || secureOnly.SecureStringCount != 2 {
+		t.Fatalf("expected two secure strings, got %+v", secureOnly)
+	}
+
+	byIdentity, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod", Identity: "payments-deployer"})
+	if err != nil {
+		t.Fatalf("get identity-filtered inventory: %v", err)
+	}
+	if byIdentity.ParameterCount != 2 {
+		t.Fatalf("expected two parameters last modified by payments-deployer, got %+v", byIdentity)
+	}
+
+	if _, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod", ParameterType: "bogus"}); err == nil {
+		t.Fatalf("expected invalid parameter type error")
+	}
+}
+
+func TestGetAWSSSMParameterMetadataInventoryDegradedAndPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	degraded, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded inventory: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded diagnostics, got %+v", degraded)
+	}
+
+	denied, err := svc.GetAWSSSMParameterMetadataInventory(ctx, "default", "project-a", AWSSSMParameterMetadataInventoryRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied inventory: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.ParameterCount != 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("expected blocked permission-denied inventory, got %+v", denied)
+	}
+	for _, hint := range denied.RemediationHints {
+		if strings.Contains(strings.ToLower(hint), "getparameter ") {
+			t.Fatalf("remediation must never suggest value-reading permissions: %q", hint)
+		}
+	}
+}
+
+func TestRouterAWSSSMParameterMetadataPartialFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/ssm-parameter-metadata?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSSSMParameterMetadataInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.ParameterCount == 0 {
+		t.Fatalf("expected degraded partial records, got %+v", body.Inventory)
+	}
+	foundDiag := false
+	for _, diag := range body.Inventory.Diagnostics {
+		if diag.Code == "ssm_parameter_metadata_page_failed" {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected page-failure diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestRouterAWSSSMParameterMetadataInvalidRequests(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 16, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-2")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-2", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	for _, query := range []string{"fixture_state=bogus", "parameter_type=bogus"} {
+		resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-2/aws/ssm-parameter-metadata?connector_id=aws-prod&"+query, "")
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, resp.Code, resp.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2884,6 +2884,38 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSSMParameterMetadataInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSSMParameterMetadataInventoryRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			ParameterType: strings.TrimSpace(c.Query("parameter_type")),
+			Identity:      strings.TrimSpace(c.Query("identity")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws ssm parameter metadata request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws ssm parameter metadata inventory",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws ssm parameter metadata inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/eks-workload-identities", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -646,6 +646,10 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws secrets manager metadata collector: %w", err)
 			}
+			ssmAPI, err := awsprovider.NewSDKSSMParameterMetadataAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if err != nil {
+				return app.Scanner{}, fmt.Errorf("initialize aws ssm parameter metadata collector: %w", err)
+			}
 			return awsprovider.NewAWSScannerWithServices(iamAPI, cfg.AWSAccountID, cfg.AWSRegion, []awsprovider.AWSServiceCollector{
 				awsprovider.NewEC2InstanceProfileCollector(ec2API),
 				awsprovider.NewECSTaskRoleCollector(ecsAPI),
@@ -661,6 +665,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
 				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+				awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 			}, awsprovider.NewRuleSet(
 				awsprovider.WithStaleAfter(time.Duration(staleAfterDays)*24*time.Hour),
 			)), nil

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager", "ssm"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -152,6 +152,19 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	// SSM parameter metadata must be checked before Secrets Manager metadata.
+	// Both record shapes share the kms_key_id and referenced_by JSON keys, and
+	// the Secrets Manager matcher treats either as a secret signal, so an SSM
+	// fixture would be misclassified if the secrets matcher ran first. The SSM
+	// matcher itself only claims records with ssm service/collector markers or
+	// parameter identifiers.
+	var ssmParameterMetadata SSMParameterMetadata
+	if err := json.Unmarshal(payload, &ssmParameterMetadata); err == nil {
+		if isSSMParameterMetadataFixture(ssmParameterMetadata) {
+			return rawKindSSMParameterMetadata, ssmParameterMetadataSourceID(ssmParameterMetadata)
+		}
+	}
+
 	var secretsManagerMetadata SecretsManagerSecretMetadata
 	if err := json.Unmarshal(payload, &secretsManagerMetadata); err == nil {
 		if isSecretsManagerMetadataFixture(secretsManagerMetadata) {
@@ -535,6 +548,21 @@ func isKMSDecryptReachabilityFixture(record KMSDecryptReachability) bool {
 		return true
 	}
 	return false
+}
+
+// isSSMParameterMetadataFixture identifies metadata-only SSM Parameter Store
+// fixtures. It is intentionally strict — only ssm service/collector markers or
+// parameter identifiers count — so records from other collectors that share
+// field names (kms_key_id, referenced_by) are never claimed.
+func isSSMParameterMetadataFixture(record SSMParameterMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(record.Service), ssmServiceName) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(record.CollectorName), ssmParameterMetadataCollectorName) {
+		return true
+	}
+	return strings.TrimSpace(record.ParameterARN) != "" ||
+		strings.TrimSpace(record.ParameterName) != ""
 }
 
 // isSecretsManagerMetadataFixture identifies metadata-only Secrets Manager

--- a/internal/providers/aws/fixture_collector_test.go
+++ b/internal/providers/aws/fixture_collector_test.go
@@ -112,6 +112,51 @@ func TestFixtureCollectorClassifiesECSTaskRoleWithWorkloadIDAsECS(t *testing.T) 
 	}
 }
 
+func TestFixtureCollectorClassifiesSSMParameterMetadataBeforeSecretsManager(t *testing.T) {
+	// kms_key_id and referenced_by are shared field names with the Secrets
+	// Manager record shape; an SSM fixture carrying them must still classify
+	// as SSM parameter metadata.
+	payload := []byte(`{
+		"service":"ssm",
+		"collector_name":"ssm_parameter_metadata",
+		"account_id":"123456789012",
+		"region":"us-east-1",
+		"parameter_arn":"arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password",
+		"parameter_name":"/payments/db/password",
+		"parameter_type":"secure_string",
+		"kms_key_id":"alias/payments-parameters",
+		"referenced_by":[{"reference":"DATABASE_PASSWORD=arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password","reference_kind":"arn","confidence":0.9}]
+	}`)
+
+	kind, sourceID := fixtureAssetKindAndSourceID(payload)
+	if kind != rawKindSSMParameterMetadata {
+		t.Fatalf("expected SSM parameter metadata fixture, got kind=%q sourceID=%q", kind, sourceID)
+	}
+	if sourceID == "" {
+		t.Fatal("expected SSM parameter source ID")
+	}
+}
+
+func TestFixtureCollectorStillClassifiesSecretsManagerAfterSSMMatcher(t *testing.T) {
+	payload := []byte(`{
+		"service":"secretsmanager",
+		"collector_name":"secrets_manager_metadata",
+		"account_id":"123456789012",
+		"region":"us-east-1",
+		"secret_arn":"arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf",
+		"secret_name":"payments/db",
+		"kms_key_id":"alias/payments"
+	}`)
+
+	kind, sourceID := fixtureAssetKindAndSourceID(payload)
+	if kind != rawKindSecretsManagerMetadata {
+		t.Fatalf("expected Secrets Manager metadata fixture, got kind=%q sourceID=%q", kind, sourceID)
+	}
+	if sourceID == "" {
+		t.Fatal("expected Secrets Manager source ID")
+	}
+}
+
 func TestFixtureCollectorDoesNotClassifyECSClusterARNAsEKS(t *testing.T) {
 	payload := []byte(`{
 		"account_id":"123456789012",

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -74,6 +74,7 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 	}
 
 	secretIndex := secretsManagerResourceIndex(bundle.Resources)
+	parameterIndex := ssmParameterResourceIndex(bundle.Resources)
 	for _, resource := range bundle.Resources {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -81,6 +82,9 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 		refs := parseStringList(resource.Metadata["secret_refs"])
 		for _, ref := range refs {
 			secretID := matchSecretsManagerReference(ref, secretIndex)
+			if secretID == "" {
+				secretID = matchSSMParameterReference(ref, parameterIndex)
+			}
 			if secretID == "" {
 				continue
 			}
@@ -178,6 +182,28 @@ func secretsManagerResourceIndex(resources []domain.Resource) map[string]string 
 
 func matchSecretsManagerReference(ref string, index map[string]string) string {
 	for _, key := range secretsManagerReferenceKeysFromRef(ref) {
+		if id := index[strings.ToLower(key)]; id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func ssmParameterResourceIndex(resources []domain.Resource) map[string]string {
+	index := map[string]string{}
+	for _, resource := range resources {
+		if resource.Type != domain.ResourceTypeSSMParameter {
+			continue
+		}
+		for _, key := range ssmParameterReferenceKeys(resource.ARN, resource.Name) {
+			index[strings.ToLower(key)] = resource.ID
+		}
+	}
+	return index
+}
+
+func matchSSMParameterReference(ref string, index map[string]string) string {
+	for _, key := range ssmParameterReferenceKeysFromRef(ref) {
 		if id := index[strings.ToLower(key)]; id != "" {
 			return id
 		}

--- a/internal/providers/aws/kms_decrypt_reachability_collector.go
+++ b/internal/providers/aws/kms_decrypt_reachability_collector.go
@@ -626,6 +626,26 @@ func kmsDecryptReachabilitySourceID(record KMSDecryptReachability) string {
 	}), "|")
 }
 
+// resolveKMSKeyARN resolves a KMS key reference as AWS services report it.
+// The value can carry a full ARN, an alias (`alias/...`), or a bare key id;
+// only the bare id needs a synthesized key ARN.
+func resolveKMSKeyARN(keyID, accountID, region string) string {
+	trimmed := strings.TrimSpace(keyID)
+	switch {
+	case trimmed == "":
+		return ""
+	case strings.HasPrefix(trimmed, "arn:"):
+		return trimmed
+	case strings.HasPrefix(trimmed, "alias/"):
+		if strings.TrimSpace(accountID) == "" || strings.TrimSpace(region) == "" {
+			return ""
+		}
+		return fmt.Sprintf("arn:%s:kms:%s:%s:%s", awsPartitionForRegion(region), region, accountID, trimmed)
+	default:
+		return kmsKeyARNFromID(trimmed, accountID, region)
+	}
+}
+
 // kmsKeyARNFromID synthesizes a KMS key ARN from the supplied id, region,
 // and account. KMS key ARNs are partition + region + account scoped so we
 // must have all three.

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -59,6 +59,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		if err := ctx.Err(); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
+		if asset.Kind != rawKindSSMParameterMetadata {
+			continue
+		}
+		if err := normalizeSSMParameterMetadataAsset(asset, i, &bundle, resourceSeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
 		if asset.Kind != "iam_role" {
 			continue
 		}
@@ -328,6 +340,56 @@ func normalizeSecretsManagerMetadataAsset(asset providers.RawAsset, index int, b
 			"reference_count":                 len(record.ReferencedBy),
 			"referenced_by":                   secretReferenceMetadata(record.ReferencedBy),
 			"unresolved_references":           secretReferenceMetadata(record.UnresolvedReferences),
+		},
+		RawRef: asset.SourceID,
+	})
+	return nil
+}
+
+func normalizeSSMParameterMetadataAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, resourceSeen map[string]struct{}) error {
+	var record SSMParameterMetadata
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode ssm parameter metadata asset[%d]: %w", index, err)
+	}
+	parameterARN := strings.TrimSpace(record.ParameterARN)
+	if parameterARN == "" {
+		return nil
+	}
+	resourceID := ssmParameterResourceID(parameterARN)
+	if _, exists := resourceSeen[resourceID]; exists {
+		return nil
+	}
+	resourceSeen[resourceID] = struct{}{}
+	bundle.Resources = append(bundle.Resources, domain.Resource{
+		ID:        resourceID,
+		Provider:  domain.ProviderAWS,
+		Type:      domain.ResourceTypeSSMParameter,
+		Name:      firstNonEmptyAWSValue(record.ParameterName, ssmParameterNameFromARN(parameterARN), parameterARN),
+		ARN:       parameterARN,
+		Region:    strings.TrimSpace(record.Region),
+		AccountID: strings.TrimSpace(record.AccountID),
+		Labels:    copyTags(record.Tags),
+		Metadata: map[string]any{
+			"parameter_path":             strings.TrimSpace(record.ParameterPath),
+			"path_depth":                 record.PathDepth,
+			"parameter_type":             strings.TrimSpace(record.ParameterType),
+			"tier":                       strings.TrimSpace(record.Tier),
+			"data_type":                  strings.TrimSpace(record.DataType),
+			"version":                    record.Version,
+			"description_present":        record.DescriptionPresent,
+			"allowed_pattern_present":    record.AllowedPatternPresent,
+			"kms_key_id":                 strings.TrimSpace(record.KMSKeyID),
+			"kms_key_arn":                strings.TrimSpace(record.KMSKeyARN),
+			"last_modified_at":           strings.TrimSpace(record.LastModifiedAt),
+			"last_modified_by":           strings.TrimSpace(record.LastModifiedBy),
+			"parameter_policy_count":     len(record.Policies),
+			"sensitive":                  record.Sensitive,
+			"sensitivity_classification": record.SensitivityClassification,
+			"exposure_classification":    record.ExposureClassification,
+			"exposure_reasons":           append([]string(nil), record.ExposureReasons...),
+			"reference_count":            len(record.ReferencedBy),
+			"referenced_by":              secretReferenceMetadata(record.ReferencedBy),
+			"unresolved_references":      secretReferenceMetadata(record.UnresolvedReferences),
 		},
 		RawRef: asset.SourceID,
 	})

--- a/internal/providers/aws/sdk_secrets_manager_metadata.go
+++ b/internal/providers/aws/sdk_secrets_manager_metadata.go
@@ -39,7 +39,7 @@ func NewSDKSecretsManagerMetadataAPIWithContext(ctx context.Context, region stri
 	if err != nil {
 		return nil, err
 	}
-	resolvedAccountID, err := secretsManagerMetadataAccountID(ctx, cfg, accountID)
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func NewSDKSecretsManagerMetadataAPIFromAssumeRole(ctx context.Context, region s
 		})
 	}
 	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
-	resolvedAccountID, err := secretsManagerMetadataAccountID(ctx, cfg, accountID)
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
 	if err != nil {
 		return nil, err
 	}
@@ -297,18 +297,20 @@ func secretsManagerNoResourcePolicy(err error) bool {
 	return strings.Contains(msg, "resourcenotfoundexception") || strings.Contains(msg, "resource policy") && strings.Contains(msg, "not found")
 }
 
-func secretsManagerMetadataAccountID(ctx context.Context, cfg awsv2.Config, accountID string) (string, error) {
+// awsCallerAccountID resolves the effective AWS account id, preferring the
+// configured value and falling back to STS GetCallerIdentity.
+func awsCallerAccountID(ctx context.Context, cfg awsv2.Config, accountID string) (string, error) {
 	trimmed := strings.TrimSpace(accountID)
 	if trimmed != "" {
 		return trimmed, nil
 	}
 	identity, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		return "", fmt.Errorf("read AWS caller identity for secrets manager account id: %w", err)
+		return "", fmt.Errorf("read AWS caller identity for account id: %w", err)
 	}
 	resolved := strings.TrimSpace(awsv2.ToString(identity.Account))
 	if resolved == "" {
-		return "", fmt.Errorf("read AWS caller identity for secrets manager account id: empty account id")
+		return "", fmt.Errorf("read AWS caller identity for account id: empty account id")
 	}
 	return resolved, nil
 }

--- a/internal/providers/aws/sdk_ssm_parameter_metadata.go
+++ b/internal/providers/aws/sdk_ssm_parameter_metadata.go
@@ -1,0 +1,229 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+// SSMSDKClient is the metadata-only surface of the AWS SSM SDK this collector
+// is allowed to call. GetParameter, GetParameters, GetParametersByPath, and
+// GetParameterHistory are intentionally absent because they return values.
+type SSMSDKClient interface {
+	DescribeParameters(ctx context.Context, params *ssm.DescribeParametersInput, optFns ...func(*ssm.Options)) (*ssm.DescribeParametersOutput, error)
+	ListTagsForResource(ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error)
+}
+
+type SDKSSMParameterMetadataAPI struct {
+	client    SSMSDKClient
+	accountID string
+	region    string
+}
+
+func NewSDKSSMParameterMetadataAPI(region string, profile string, accountID string) (SSMParameterMetadataAPI, error) {
+	return NewSDKSSMParameterMetadataAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+func NewSDKSSMParameterMetadataAPIWithContext(ctx context.Context, region string, profile string, accountID string) (SSMParameterMetadataAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKSSMParameterMetadataAPIFromClient(ssm.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKSSMParameterMetadataAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (SSMParameterMetadataAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKSSMParameterMetadataAPIFromClient(ssm.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKSSMParameterMetadataAPIFromClient(client SSMSDKClient, accountID string, region string) SSMParameterMetadataAPI {
+	return &SDKSSMParameterMetadataAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+func (a *SDKSSMParameterMetadataAPI) ListParameterMetadata(ctx context.Context, nextToken string, pageSize int32) (SSMParameterMetadataPage, error) {
+	if a.client == nil {
+		return SSMParameterMetadataPage{}, fmt.Errorf("ssm parameter metadata api requires client")
+	}
+	input := &ssm.DescribeParametersInput{
+		NextToken:  stringPtrOrNil(nextToken),
+		MaxResults: awsv2.Int32(pageSize),
+	}
+	if pageSize <= 0 {
+		input.MaxResults = awsv2.Int32(defaultPageSize)
+	}
+	output, err := a.client.DescribeParameters(ctx, input)
+	if err != nil {
+		return SSMParameterMetadataPage{}, err
+	}
+	if output == nil {
+		return SSMParameterMetadataPage{}, nil
+	}
+	page := SSMParameterMetadataPage{
+		Records:   make([]SSMParameterMetadata, 0, len(output.Parameters)),
+		NextToken: strings.TrimSpace(awsv2.ToString(output.NextToken)),
+	}
+	for _, entry := range output.Parameters {
+		record := ssmParameterMetadataFromEntry(entry, a.accountID, a.region)
+		if record.ParameterARN == "" && record.ParameterName == "" {
+			page.Diagnostics = append(page.Diagnostics, ssmParameterMetadataDiagnostic("ssm_parameter_id_missing", "describeparameters", "skipped SSM parameter record without ARN or name", false))
+			continue
+		}
+		a.enrichParameterTags(ctx, &record, &page.Diagnostics)
+		page.Records = append(page.Records, record)
+	}
+	return page, nil
+}
+
+func (a *SDKSSMParameterMetadataAPI) enrichParameterTags(ctx context.Context, record *SSMParameterMetadata, diagnostics *[]providers.SourceError) {
+	name := strings.TrimSpace(record.ParameterName)
+	if name == "" {
+		return
+	}
+	output, err := a.client.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{
+		ResourceType: ssmtypes.ResourceTypeForTaggingParameter,
+		ResourceId:   awsv2.String(name),
+	})
+	if err != nil {
+		*diagnostics = append(*diagnostics, ssmParameterMetadataDiagnostic("ssm_parameter_tags_failed", name, fmt.Sprintf("ListTagsForResource failed: %v", err), true))
+		return
+	}
+	if output == nil {
+		return
+	}
+	record.Tags = ssmParameterTags(output.TagList)
+}
+
+func ssmParameterMetadataFromEntry(entry ssmtypes.ParameterMetadata, accountID string, region string) SSMParameterMetadata {
+	record := SSMParameterMetadata{
+		ParameterARN:          strings.TrimSpace(awsv2.ToString(entry.ARN)),
+		ParameterName:         strings.TrimSpace(awsv2.ToString(entry.Name)),
+		ParameterType:         string(entry.Type),
+		Tier:                  string(entry.Tier),
+		DataType:              strings.TrimSpace(awsv2.ToString(entry.DataType)),
+		Version:               entry.Version,
+		DescriptionPresent:    strings.TrimSpace(awsv2.ToString(entry.Description)) != "",
+		AllowedPatternPresent: strings.TrimSpace(awsv2.ToString(entry.AllowedPattern)) != "",
+		KMSKeyID:              strings.TrimSpace(awsv2.ToString(entry.KeyId)),
+		LastModifiedAt:        awsTimeString(entry.LastModifiedDate),
+		LastModifiedBy:        strings.TrimSpace(awsv2.ToString(entry.LastModifiedUser)),
+		Policies:              ssmParameterPoliciesFromInline(entry.Policies),
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: strings.TrimSpace(accountID),
+			Region:    strings.TrimSpace(region),
+			Service:   ssmServiceName,
+		},
+	}
+	return record
+}
+
+// ssmParameterPoliciesFromInline converts the policy summaries returned by
+// DescribeParameters into the metadata-only envelope. Only the policy type,
+// status, and expiration timestamp survive; raw policy text is dropped.
+func ssmParameterPoliciesFromInline(policies []ssmtypes.ParameterInlinePolicy) []SSMParameterPolicy {
+	if len(policies) == 0 {
+		return nil
+	}
+	out := make([]SSMParameterPolicy, 0, len(policies))
+	for _, policy := range policies {
+		summary := SSMParameterPolicy{
+			PolicyType:   strings.TrimSpace(awsv2.ToString(policy.PolicyType)),
+			PolicyStatus: strings.TrimSpace(awsv2.ToString(policy.PolicyStatus)),
+		}
+		text := strings.TrimSpace(awsv2.ToString(policy.PolicyText))
+		if summary.PolicyType == "" || strings.EqualFold(summary.PolicyType, "Expiration") {
+			parsedType, expiresAt := parseSSMParameterPolicyText(text)
+			if summary.PolicyType == "" {
+				summary.PolicyType = parsedType
+			}
+			if strings.EqualFold(summary.PolicyType, "Expiration") {
+				summary.ExpiresAt = expiresAt
+			}
+		}
+		if summary.PolicyType == "" && summary.PolicyStatus == "" {
+			continue
+		}
+		out = append(out, summary)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseSSMParameterPolicyText extracts the policy type and the expiration
+// timestamp attribute from a parameter policy document. Expiration timestamps
+// are lifecycle metadata; no other attribute is persisted.
+func parseSSMParameterPolicyText(text string) (string, string) {
+	if strings.TrimSpace(text) == "" {
+		return "", ""
+	}
+	var doc struct {
+		Type       string `json:"Type"`
+		Attributes struct {
+			Timestamp string `json:"Timestamp"`
+		} `json:"Attributes"`
+	}
+	if err := json.Unmarshal([]byte(text), &doc); err != nil {
+		return "", ""
+	}
+	return strings.TrimSpace(doc.Type), strings.TrimSpace(doc.Attributes.Timestamp)
+}
+
+func ssmParameterTags(tags []ssmtypes.Tag) map[string]string {
+	out := map[string]string{}
+	for _, tag := range tags {
+		key := strings.TrimSpace(awsv2.ToString(tag.Key))
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(awsv2.ToString(tag.Value))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/providers/aws/sdk_ssm_parameter_metadata_test.go
+++ b/internal/providers/aws/sdk_ssm_parameter_metadata_test.go
@@ -1,0 +1,144 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+type fakeSSMSDKClient struct {
+	describeParameters    *ssm.DescribeParametersOutput
+	describeParametersErr error
+	tags                  map[string]*ssm.ListTagsForResourceOutput
+	tagsErr               map[string]error
+}
+
+func (f *fakeSSMSDKClient) DescribeParameters(ctx context.Context, input *ssm.DescribeParametersInput, _ ...func(*ssm.Options)) (*ssm.DescribeParametersOutput, error) {
+	if f.describeParametersErr != nil {
+		return nil, f.describeParametersErr
+	}
+	return f.describeParameters, nil
+}
+
+func (f *fakeSSMSDKClient) ListTagsForResource(ctx context.Context, input *ssm.ListTagsForResourceInput, _ ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error) {
+	id := awsv2.ToString(input.ResourceId)
+	if err, ok := f.tagsErr[id]; ok {
+		return nil, err
+	}
+	return f.tags[id], nil
+}
+
+func TestSDKSSMParameterMetadataAPI_ListParameterMetadataEnrichesRecord(t *testing.T) {
+	arn := "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password"
+	name := "/payments/db/password"
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	fake := &fakeSSMSDKClient{
+		describeParameters: &ssm.DescribeParametersOutput{
+			Parameters: []ssmtypes.ParameterMetadata{{
+				ARN:              awsv2.String(arn),
+				Name:             awsv2.String(name),
+				Type:             ssmtypes.ParameterTypeSecureString,
+				Tier:             ssmtypes.ParameterTierAdvanced,
+				KeyId:            awsv2.String("alias/payments"),
+				Description:      awsv2.String("sensitive operator note do not persist"),
+				AllowedPattern:   awsv2.String("^[a-z]+$"),
+				Version:          4,
+				LastModifiedDate: &now,
+				LastModifiedUser: awsv2.String("arn:aws:iam::123456789012:role/payments-deployer"),
+				Policies: []ssmtypes.ParameterInlinePolicy{{
+					PolicyType:   awsv2.String("Expiration"),
+					PolicyStatus: awsv2.String("Pending"),
+					PolicyText:   awsv2.String(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2026-12-02T21:34:33.000Z"}}`),
+				}},
+			}},
+		},
+		tags: map[string]*ssm.ListTagsForResourceOutput{
+			name: {TagList: []ssmtypes.Tag{{Key: awsv2.String("owner"), Value: awsv2.String("payments")}}},
+		},
+	}
+	api := NewSDKSSMParameterMetadataAPIFromClient(fake, "123456789012", "us-east-1")
+
+	page, err := api.ListParameterMetadata(context.Background(), "", 25)
+	if err != nil {
+		t.Fatalf("list metadata: %v", err)
+	}
+	if len(page.Diagnostics) != 0 || len(page.Records) != 1 {
+		t.Fatalf("expected one clean record, records=%d diagnostics=%+v", len(page.Records), page.Diagnostics)
+	}
+	record := page.Records[0]
+	if record.ParameterARN != arn || record.ParameterName != name {
+		t.Fatalf("identity fields not mapped: %+v", record)
+	}
+	if !record.DescriptionPresent || !record.AllowedPatternPresent {
+		t.Fatalf("expected presence flags, got %+v", record)
+	}
+	if record.LastModifiedBy != "arn:aws:iam::123456789012:role/payments-deployer" {
+		t.Fatalf("expected last-modified identity context, got %q", record.LastModifiedBy)
+	}
+	if len(record.Policies) != 1 || record.Policies[0].PolicyType != "Expiration" || record.Policies[0].ExpiresAt != "2026-12-02T21:34:33.000Z" {
+		t.Fatalf("expected expiration policy summary, got %+v", record.Policies)
+	}
+	if got := record.Tags["owner"]; got != "payments" {
+		t.Fatalf("expected tags enrichment, got %+v", record.Tags)
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	if strings.Contains(string(payload), "sensitive operator note") {
+		t.Fatalf("description text leaked into metadata payload: %s", payload)
+	}
+	if strings.Contains(string(payload), "^[a-z]+$") {
+		t.Fatalf("allowed pattern text leaked into metadata payload: %s", payload)
+	}
+}
+
+func TestSDKSSMParameterMetadataAPI_TagFailureIsDiagnosticNotFatal(t *testing.T) {
+	name := "/payments/db/password"
+	fake := &fakeSSMSDKClient{
+		describeParameters: &ssm.DescribeParametersOutput{
+			Parameters: []ssmtypes.ParameterMetadata{{
+				ARN:  awsv2.String("arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password"),
+				Name: awsv2.String(name),
+				Type: ssmtypes.ParameterTypeString,
+			}},
+		},
+		tagsErr: map[string]error{name: errors.New("AccessDenied: ssm:ListTagsForResource")},
+	}
+	api := NewSDKSSMParameterMetadataAPIFromClient(fake, "123456789012", "us-east-1")
+
+	page, err := api.ListParameterMetadata(context.Background(), "", 25)
+	if err != nil {
+		t.Fatalf("list metadata: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected record despite tag failure, got %+v", page.Records)
+	}
+	if len(page.Diagnostics) != 1 || page.Diagnostics[0].Code != "ssm_parameter_tags_failed" || !page.Diagnostics[0].Retryable {
+		t.Fatalf("expected retryable tag diagnostic, got %+v", page.Diagnostics)
+	}
+}
+
+func TestSDKSSMParameterMetadataAPI_DescribeParametersError(t *testing.T) {
+	api := NewSDKSSMParameterMetadataAPIFromClient(&fakeSSMSDKClient{describeParametersErr: errors.New("denied")}, "123456789012", "us-east-1")
+	if _, err := api.ListParameterMetadata(context.Background(), "", 25); err == nil {
+		t.Fatalf("expected DescribeParameters error")
+	}
+}
+
+func TestParseSSMParameterPolicyText(t *testing.T) {
+	policyType, expiresAt := parseSSMParameterPolicyText(`{"Type":"Expiration","Version":"1.0","Attributes":{"Timestamp":"2026-12-02T21:34:33.000Z"}}`)
+	if policyType != "Expiration" || expiresAt != "2026-12-02T21:34:33.000Z" {
+		t.Fatalf("unexpected parse result: %q %q", policyType, expiresAt)
+	}
+	if policyType, expiresAt := parseSSMParameterPolicyText("not json"); policyType != "" || expiresAt != "" {
+		t.Fatalf("expected empty result for malformed text, got %q %q", policyType, expiresAt)
+	}
+}

--- a/internal/providers/aws/secrets_manager_metadata_collector.go
+++ b/internal/providers/aws/secrets_manager_metadata_collector.go
@@ -290,20 +290,7 @@ func normalizeSecretsManagerMetadataScope(scope AWSCollectorScope, record Secret
 // ARN. The field can carry a full ARN, an alias (`alias/...`), or a bare key
 // id; only the bare id needs a synthesized key ARN.
 func secretsManagerKMSKeyARN(keyID, accountID, region string) string {
-	trimmed := strings.TrimSpace(keyID)
-	switch {
-	case trimmed == "":
-		return ""
-	case strings.HasPrefix(trimmed, "arn:"):
-		return trimmed
-	case strings.HasPrefix(trimmed, "alias/"):
-		if strings.TrimSpace(accountID) == "" || strings.TrimSpace(region) == "" {
-			return ""
-		}
-		return fmt.Sprintf("arn:%s:kms:%s:%s:%s", awsPartitionForRegion(region), region, accountID, trimmed)
-	default:
-		return kmsKeyARNFromID(trimmed, accountID, region)
-	}
+	return resolveKMSKeyARN(keyID, accountID, region)
 }
 
 // secretsManagerPrincipalAccountID extracts the owning account from a policy

--- a/internal/providers/aws/ssm_parameter_metadata_collector.go
+++ b/internal/providers/aws/ssm_parameter_metadata_collector.go
@@ -1,0 +1,565 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindSSMParameterMetadata       = "ssm_parameter_metadata"
+	ssmParameterMetadataCollectorName = "ssm_parameter_metadata"
+	ssmServiceName                    = "ssm"
+)
+
+// SSMParameterMetadata is the metadata-only view of one AWS Systems Manager
+// Parameter Store parameter. It intentionally excludes parameter values and
+// every API that can return them (GetParameter, GetParameters,
+// GetParametersByPath, GetParameterHistory). SecureString parameters are
+// treated as sensitive metadata only.
+type SSMParameterMetadata struct {
+	awscontract.ServiceCollectorRecord
+
+	ParameterARN  string `json:"parameter_arn,omitempty"`
+	ParameterName string `json:"parameter_name,omitempty"`
+	ParameterPath string `json:"parameter_path,omitempty"`
+	PathDepth     int    `json:"path_depth,omitempty"`
+	ParameterType string `json:"parameter_type,omitempty"`
+	Tier          string `json:"tier,omitempty"`
+	DataType      string `json:"data_type,omitempty"`
+	Version       int64  `json:"version,omitempty"`
+
+	DescriptionPresent    bool `json:"description_present,omitempty"`
+	AllowedPatternPresent bool `json:"allowed_pattern_present,omitempty"`
+
+	KMSKeyID  string `json:"kms_key_id,omitempty"`
+	KMSKeyARN string `json:"kms_key_arn,omitempty"`
+
+	LastModifiedAt string `json:"last_modified_at,omitempty"`
+	LastModifiedBy string `json:"last_modified_by,omitempty"`
+
+	Policies []SSMParameterPolicy `json:"parameter_policies,omitempty"`
+	Tags     map[string]string    `json:"tags,omitempty"`
+
+	Sensitive                 bool     `json:"sensitive,omitempty"`
+	SensitivityClassification string   `json:"sensitivity_classification,omitempty"`
+	ExposureClassification    string   `json:"exposure_classification,omitempty"`
+	ExposureReasons           []string `json:"exposure_reasons,omitempty"`
+
+	ReferenceCount       int                       `json:"reference_count,omitempty"`
+	ReferencedBy         []SecretWorkloadReference `json:"referenced_by,omitempty"`
+	UnresolvedReferences []SecretWorkloadReference `json:"unresolved_references,omitempty"`
+}
+
+// SSMParameterPolicy summarizes one parameter policy without persisting the
+// raw policy text. Expiration timestamps are operational metadata, not
+// parameter values, so they stay inside the evidence boundary.
+type SSMParameterPolicy struct {
+	PolicyType   string `json:"policy_type,omitempty"`
+	PolicyStatus string `json:"policy_status,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+type SSMParameterMetadataPage struct {
+	Records     []SSMParameterMetadata
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+type SSMParameterMetadataAPI interface {
+	ListParameterMetadata(ctx context.Context, nextToken string, pageSize int32) (SSMParameterMetadataPage, error)
+}
+
+type SSMParameterMetadataCollector struct {
+	client   SSMParameterMetadataAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+type SSMParameterMetadataOption func(*SSMParameterMetadataCollector)
+
+func WithSSMParameterMetadataPageSize(pageSize int32) SSMParameterMetadataOption {
+	return func(c *SSMParameterMetadataCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+func WithSSMParameterMetadataMaxPages(maxPages int) SSMParameterMetadataOption {
+	return func(c *SSMParameterMetadataCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+func WithSSMParameterMetadataClock(now func() time.Time) SSMParameterMetadataOption {
+	return func(c *SSMParameterMetadataCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+func NewSSMParameterMetadataCollector(client SSMParameterMetadataAPI, opts ...SSMParameterMetadataOption) *SSMParameterMetadataCollector {
+	c := &SSMParameterMetadataCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *SSMParameterMetadataCollector) ServiceName() string {
+	return ssmServiceName
+}
+
+func (c *SSMParameterMetadataCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: ssmServiceName})
+	return assets, err
+}
+
+func (c *SSMParameterMetadataCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("ssm parameter metadata collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(ssmParameterMetadataDiagnostic("ssm_parameter_metadata_page_limit_exceeded", firstNonEmptyAWSValue(nextToken, "page"), fmt.Sprintf("ssm parameter metadata collection exceeded max pages (%d)", c.maxPages), false))
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("ssm parameter metadata collection exceeded max pages (%d)", c.maxPages)
+		}
+		response, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (SSMParameterMetadataPage, error) {
+			return c.client.ListParameterMetadata(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list ssm parameter metadata page %d: %w", page, err)
+			addIssue(ssmParameterMetadataDiagnostic("ssm_parameter_metadata_page_failed", firstNonEmptyAWSValue(nextToken, "page"), wrapped.Error(), isRetryable(err)))
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, diagnostic := range response.Diagnostics {
+			addIssue(diagnostic)
+		}
+		for _, record := range response.Records {
+			normalized := normalizeSSMParameterMetadataScope(scope, record, collectedAt)
+			if strings.TrimSpace(normalized.ParameterARN) == "" && strings.TrimSpace(normalized.ParameterName) == "" {
+				addIssue(ssmParameterMetadataDiagnostic("malformed_ssm_parameter_record", "", "skipped ssm parameter record without an ARN or name", false))
+				continue
+			}
+			sourceID := ssmParameterMetadataSourceID(normalized)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, err := json.Marshal(normalized)
+			if err != nil {
+				return nil, nil, fmt.Errorf("marshal ssm parameter metadata %q: %w", sourceID, err)
+			}
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindSSMParameterMetadata,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+		if strings.TrimSpace(response.NextToken) == "" {
+			break
+		}
+		nextToken = strings.TrimSpace(response.NextToken)
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+func normalizeSSMParameterMetadataScope(scope AWSCollectorScope, record SSMParameterMetadata, collectedAt time.Time) SSMParameterMetadata {
+	normalized := record
+	normalized.AccountID = firstNonEmptyAWSValue(record.AccountID, scope.AccountID, accountIDFromARN(record.ParameterARN))
+	normalized.Region = firstNonEmptyAWSValue(record.Region, scope.Region, regionFromARN(record.ParameterARN))
+	normalized.Service = firstNonEmptyAWSValue(record.Service, ssmServiceName)
+	normalized.ParameterName = firstNonEmptyAWSValue(record.ParameterName, ssmParameterNameFromARN(record.ParameterARN))
+	normalized.ParameterARN = firstNonEmptyAWSValue(record.ParameterARN, ssmParameterARNFromName(normalized.ParameterName, normalized.AccountID, normalized.Region))
+	normalized.ParameterPath, normalized.PathDepth = ssmParameterPathContext(normalized.ParameterName)
+	normalized.ParameterType = canonicalSSMParameterType(record.ParameterType)
+	normalized.Tier = canonicalSSMParameterTier(record.Tier)
+	normalized.DataType = firstNonEmptyAWSValue(strings.TrimSpace(record.DataType), "text")
+	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, "ssm_parameter")
+	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.ParameterName, normalized.ParameterARN)
+	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.ParameterARN, normalized.ParameterName)
+	normalized.Source = firstNonEmptyAWSValue(record.Source, "ssm_parameter_metadata")
+	normalized.EvidenceRef = firstNonEmptyAWSValue(record.EvidenceRef, normalized.ParameterARN, normalized.ParameterName)
+	normalized.CollectorName = firstNonEmptyAWSValue(record.CollectorName, ssmParameterMetadataCollectorName)
+	normalized.ScanID = firstNonEmptyAWSValue(record.ScanID, scope.ScanID, "aws-ssm-parameter-metadata-fixture")
+	normalized.ConnectorID = firstNonEmptyAWSValue(record.ConnectorID, scope.ConnectorID, "aws-connector")
+	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
+	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
+	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
+	normalized.KMSKeyID = strings.TrimSpace(record.KMSKeyID)
+	if normalized.ParameterType == "secure_string" {
+		normalized.KMSKeyARN = firstNonEmptyAWSValue(record.KMSKeyARN, resolveKMSKeyARN(normalized.KMSKeyID, normalized.AccountID, normalized.Region))
+	} else {
+		normalized.KMSKeyARN = strings.TrimSpace(record.KMSKeyARN)
+	}
+	normalized.LastModifiedAt = strings.TrimSpace(record.LastModifiedAt)
+	normalized.LastModifiedBy = strings.TrimSpace(record.LastModifiedBy)
+	normalized.Policies = normalizeSSMParameterPolicies(record.Policies)
+	normalized.Tags = copyTags(record.Tags)
+	normalized.ReferencedBy = normalizeSecretWorkloadReferences(record.ReferencedBy)
+	normalized.UnresolvedReferences = normalizeSecretWorkloadReferences(record.UnresolvedReferences)
+	normalized.ReferenceCount = len(normalized.ReferencedBy)
+	normalized.Sensitive, normalized.SensitivityClassification = classifySSMParameterSensitivity(normalized)
+	normalized.ExposureClassification, normalized.ExposureReasons = classifySSMParameterExposure(normalized)
+	normalized.CollectedAt = collectedAt
+	if normalized.Confidence <= 0 {
+		normalized.Confidence = ssmParameterMetadataConfidence(normalized)
+	}
+	return normalized
+}
+
+func canonicalSSMParameterType(parameterType string) string {
+	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(parameterType), "_", "")) {
+	case "securestring":
+		return "secure_string"
+	case "stringlist":
+		return "string_list"
+	case "string":
+		return "string"
+	case "":
+		return ""
+	default:
+		return strings.ToLower(strings.TrimSpace(parameterType))
+	}
+}
+
+func canonicalSSMParameterTier(tier string) string {
+	switch strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(tier), "-", ""), "_", "")) {
+	case "advanced":
+		return "advanced"
+	case "intelligenttiering":
+		return "intelligent_tiering"
+	case "standard", "":
+		return "standard"
+	default:
+		return strings.ToLower(strings.TrimSpace(tier))
+	}
+}
+
+// ssmParameterPathContext derives the hierarchy prefix and depth for a
+// parameter name. Hierarchical names start with "/" and use "/" separators;
+// flat names have no path and depth one.
+func ssmParameterPathContext(name string) (string, int) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", 0
+	}
+	if !strings.HasPrefix(trimmed, "/") {
+		return "", 1
+	}
+	segments := []string{}
+	for _, segment := range strings.Split(strings.Trim(trimmed, "/"), "/") {
+		if strings.TrimSpace(segment) != "" {
+			segments = append(segments, segment)
+		}
+	}
+	if len(segments) <= 1 {
+		return "", len(segments)
+	}
+	return "/" + strings.Join(segments[:len(segments)-1], "/"), len(segments)
+}
+
+func normalizeSSMParameterPolicies(policies []SSMParameterPolicy) []SSMParameterPolicy {
+	if len(policies) == 0 {
+		return nil
+	}
+	out := make([]SSMParameterPolicy, 0, len(policies))
+	for _, policy := range policies {
+		policy.PolicyType = strings.TrimSpace(policy.PolicyType)
+		policy.PolicyStatus = strings.ToLower(strings.TrimSpace(policy.PolicyStatus))
+		policy.ExpiresAt = strings.TrimSpace(policy.ExpiresAt)
+		if policy.PolicyType == "" && policy.PolicyStatus == "" && policy.ExpiresAt == "" {
+			continue
+		}
+		out = append(out, policy)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].PolicyType == out[j].PolicyType {
+			return out[i].ExpiresAt < out[j].ExpiresAt
+		}
+		return out[i].PolicyType < out[j].PolicyType
+	})
+	return out
+}
+
+func classifySSMParameterSensitivity(record SSMParameterMetadata) (bool, string) {
+	switch record.ParameterType {
+	case "secure_string":
+		if ssmParameterUsesCustomerKMSKey(record.KMSKeyID, record.KMSKeyARN) {
+			return true, "secure_string_customer_kms"
+		}
+		return true, "secure_string_aws_managed_kms"
+	case "string_list":
+		return false, "string_list"
+	default:
+		return false, "plain_text"
+	}
+}
+
+// ssmParameterUsesCustomerKMSKey reports whether a SecureString parameter is
+// encrypted with a customer-managed key rather than the AWS-managed
+// `alias/aws/ssm` default.
+func ssmParameterUsesCustomerKMSKey(keyID string, keyARN string) bool {
+	trimmedID := strings.ToLower(strings.TrimSpace(keyID))
+	trimmedARN := strings.ToLower(strings.TrimSpace(keyARN))
+	if trimmedID == "" && trimmedARN == "" {
+		return false
+	}
+	return trimmedID != "alias/aws/ssm" && !strings.HasSuffix(trimmedARN, ":alias/aws/ssm")
+}
+
+func classifySSMParameterExposure(record SSMParameterMetadata) (string, []string) {
+	reasons := []string{}
+	if record.ReferenceCount > 0 {
+		reasons = append(reasons, "workload_references_parameter")
+		if record.ParameterType != "secure_string" {
+			reasons = append(reasons, "plain_text_parameter_referenced_as_secret")
+		}
+	}
+	if record.ParameterType == "secure_string" {
+		reasons = append(reasons, "secure_string_kms_encrypted")
+		if ssmParameterUsesCustomerKMSKey(record.KMSKeyID, record.KMSKeyARN) {
+			reasons = append(reasons, "customer_kms_key_referenced")
+		}
+	}
+	expiring := false
+	for _, policy := range record.Policies {
+		if strings.EqualFold(policy.PolicyType, "Expiration") {
+			expiring = true
+			reasons = append(reasons, "expiration_policy_present")
+			break
+		}
+	}
+	switch {
+	case record.ReferenceCount > 0:
+		return "referenced_by_workload", dedupeStrings(reasons)
+	case expiring:
+		return "scheduled_expiration", dedupeStrings(reasons)
+	default:
+		return "private", dedupeStrings(reasons)
+	}
+}
+
+func ssmParameterMetadataConfidence(record SSMParameterMetadata) float64 {
+	switch record.ExposureClassification {
+	case "referenced_by_workload":
+		return 0.9
+	case "scheduled_expiration":
+		return 0.87
+	case "private":
+		if record.Sensitive {
+			return 0.86
+		}
+		return 0.85
+	default:
+		return 0.72
+	}
+}
+
+func ssmParameterMetadataSourceID(record SSMParameterMetadata) string {
+	return strings.Join(normalizeStringList([]string{
+		record.Service,
+		record.ParameterARN,
+		record.Region,
+	}), "|")
+}
+
+func ssmParameterResourceID(parameterARN string) string {
+	return "aws:resource:ssm-parameter:" + strings.TrimSpace(parameterARN)
+}
+
+// ssmParameterNameFromARN extracts the parameter name from an SSM parameter
+// ARN. Hierarchical names keep their leading slash:
+// `arn:aws:ssm:us-east-1:123456789012:parameter/payments/db` -> `/payments/db`.
+func ssmParameterNameFromARN(arn string) string {
+	parts := strings.SplitN(strings.TrimSpace(arn), ":", 6)
+	if len(parts) < 6 || !strings.EqualFold(parts[2], ssmServiceName) {
+		return ""
+	}
+	resource := parts[5]
+	if !strings.HasPrefix(resource, "parameter/") {
+		return ""
+	}
+	name := strings.TrimPrefix(resource, "parameter")
+	if strings.Count(strings.Trim(name, "/"), "/") == 0 {
+		// Flat parameter names are stored without the leading slash.
+		return strings.TrimPrefix(name, "/")
+	}
+	return name
+}
+
+// ssmParameterARNFromName synthesizes a parameter ARN when DescribeParameters
+// does not return one. The resource segment always uses a single separator
+// slash regardless of whether the name is hierarchical.
+func ssmParameterARNFromName(name string, accountID string, region string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || strings.TrimSpace(accountID) == "" || strings.TrimSpace(region) == "" {
+		return ""
+	}
+	partition := awsPartitionForRegion(region)
+	return fmt.Sprintf("arn:%s:ssm:%s:%s:parameter/%s", partition, region, accountID, strings.TrimPrefix(trimmed, "/"))
+}
+
+// ssmParameterReferenceKeys returns every lookup key one parameter should be
+// indexed under: the ARN plus slash and no-slash variants of the name, so
+// `valueFrom: /payments/db` and `valueFrom: payments/db` both resolve.
+func ssmParameterReferenceKeys(parameterARN string, parameterName string) []string {
+	keys := []string{}
+	if arn := strings.TrimSpace(parameterARN); arn != "" {
+		keys = append(keys, arn)
+		if name := ssmParameterNameFromARN(arn); name != "" {
+			keys = append(keys, name)
+		}
+	}
+	if name := strings.TrimSpace(parameterName); name != "" {
+		keys = append(keys, name)
+	}
+	expanded := append([]string(nil), keys...)
+	for _, key := range keys {
+		if strings.HasPrefix(key, "arn:") {
+			continue
+		}
+		expanded = append(expanded, strings.TrimPrefix(key, "/"), "/"+strings.TrimPrefix(key, "/"))
+	}
+	return dedupeStrings(expanded)
+}
+
+// ssmParameterReferenceKeysFromRef expands one workload reference (ECS
+// `NAME=valueFrom`, CodeBuild `NAME=PARAMETER_STORE:ref`) into candidate
+// lookup keys, stripping env-var assignment, source prefixes, and version or
+// label suffixes. Parameter names cannot contain ":", so any colon in a
+// non-ARN candidate separates a version/label suffix.
+func ssmParameterReferenceKeysFromRef(ref string) []string {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return nil
+	}
+	type referenceCandidate struct {
+		value         string
+		allowNameBase bool
+	}
+	candidates := []referenceCandidate{{value: trimmed}}
+	if idx := strings.LastIndex(trimmed, "="); idx >= 0 && idx < len(trimmed)-1 {
+		candidates = append(candidates, referenceCandidate{
+			value:         strings.TrimSpace(trimmed[idx+1:]),
+			allowNameBase: true,
+		})
+	}
+	for _, prefix := range []string{"PARAMETER_STORE:", "parameter_store:", "ParameterStore:", "ssm:", "SSM:"} {
+		for _, candidate := range append([]referenceCandidate(nil), candidates...) {
+			if strings.HasPrefix(candidate.value, prefix) {
+				candidates = append(candidates, referenceCandidate{
+					value:         strings.TrimSpace(strings.TrimPrefix(candidate.value, prefix)),
+					allowNameBase: true,
+				})
+			}
+		}
+	}
+	out := []string{}
+	for _, candidate := range candidates {
+		value := strings.TrimSpace(candidate.value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+		if base := ssmParameterReferenceBase(value, candidate.allowNameBase); base != "" && base != value {
+			out = append(out, base)
+			value = base
+		}
+		if name := ssmParameterNameFromARN(value); name != "" {
+			out = append(out, name, strings.TrimPrefix(name, "/"))
+		} else if !strings.HasPrefix(value, "arn:") {
+			out = append(out, strings.TrimPrefix(value, "/"), "/"+strings.TrimPrefix(value, "/"))
+		}
+	}
+	return dedupeStrings(out)
+}
+
+// ssmParameterReferenceBase strips a trailing `:version` or `:label` suffix.
+// For ARNs the suffix follows the `parameter/...` resource segment; for bare
+// names any colon starts the suffix because names cannot contain colons.
+func ssmParameterReferenceBase(ref string, allowNameBase bool) string {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Contains(trimmed, ":parameter/") {
+		idx := strings.Index(trimmed, ":parameter/")
+		resource := trimmed[idx+len(":parameter/"):]
+		if colon := strings.Index(resource, ":"); colon > 0 {
+			return trimmed[:idx+len(":parameter/")] + resource[:colon]
+		}
+		return trimmed
+	}
+	if allowNameBase && !strings.HasPrefix(trimmed, "arn:") {
+		if idx := strings.Index(trimmed, ":"); idx > 0 {
+			return strings.TrimSpace(trimmed[:idx])
+		}
+	}
+	return trimmed
+}
+
+func ssmParameterMetadataDiagnostic(code string, sourceID string, message string, retryable bool) providers.SourceError {
+	return providers.SourceError{
+		Collector: ssmParameterMetadataCollectorName,
+		SourceID:  strings.TrimSpace(sourceID),
+		Code:      strings.TrimSpace(code),
+		Message:   strings.TrimSpace(message),
+		Retryable: retryable,
+	}
+}
+
+var _ AWSServiceCollector = (*SSMParameterMetadataCollector)(nil)
+var _ providers.Collector = (*SSMParameterMetadataCollector)(nil)

--- a/internal/providers/aws/ssm_parameter_metadata_collector.go
+++ b/internal/providers/aws/ssm_parameter_metadata_collector.go
@@ -18,6 +18,14 @@ const (
 	rawKindSSMParameterMetadata       = "ssm_parameter_metadata"
 	ssmParameterMetadataCollectorName = "ssm_parameter_metadata"
 	ssmServiceName                    = "ssm"
+
+	// ssmParameterMetadataMaxPages bounds pagination for the SSM collector.
+	// DescribeParameters caps page size at 50 items (ssmDescribeParametersMaxResults),
+	// and an Advanced-tier account can hold up to 100,000 parameters, so the
+	// budget must cover 100,000 / 50 = 2,000 pages — the shared 500-page
+	// default would otherwise abort large accounts after only 25,000
+	// parameters.
+	ssmParameterMetadataMaxPages = 2000
 )
 
 // SSMParameterMetadata is the metadata-only view of one AWS Systems Manager
@@ -119,7 +127,7 @@ func NewSSMParameterMetadataCollector(client SSMParameterMetadataAPI, opts ...SS
 	c := &SSMParameterMetadataCollector{
 		client:   client,
 		pageSize: defaultPageSize,
-		maxPages: defaultMaxPages,
+		maxPages: ssmParameterMetadataMaxPages,
 		retry: RetryPolicy{
 			MaxRetries: defaultRetryCount,
 			BaseDelay:  defaultBaseDelay,

--- a/internal/providers/aws/ssm_parameter_metadata_collector_test.go
+++ b/internal/providers/aws/ssm_parameter_metadata_collector_test.go
@@ -1,0 +1,352 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+type fakeSSMParameterMetadataAPI struct {
+	pages     []SSMParameterMetadataPage
+	calls     int
+	err       error
+	errOnCall int
+}
+
+func (f *fakeSSMParameterMetadataAPI) ListParameterMetadata(ctx context.Context, nextToken string, pageSize int32) (SSMParameterMetadataPage, error) {
+	f.calls++
+	if f.err != nil && (f.errOnCall == 0 || f.calls >= f.errOnCall) {
+		return SSMParameterMetadataPage{}, f.err
+	}
+	if len(f.pages) == 0 {
+		return SSMParameterMetadataPage{}, nil
+	}
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func TestSSMParameterMetadataCollectorCollectsMetadataOnly(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	api := &fakeSSMParameterMetadataAPI{pages: []SSMParameterMetadataPage{{
+		Records: []SSMParameterMetadata{{
+			ParameterARN:  "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password",
+			ParameterName: "/payments/db/password",
+			ParameterType: "SecureString",
+			Tier:          "Advanced",
+			KMSKeyID:      "alias/payments",
+			Version:       4,
+			Tags:          map[string]string{"owner": "payments"},
+		}},
+	}}}
+	collector := NewSSMParameterMetadataCollector(api, WithSSMParameterMetadataClock(func() time.Time { return now }))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		ConnectorID: "aws-prod",
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(diagnostics) != 0 || len(assets) != 1 {
+		t.Fatalf("expected one clean asset, assets=%d diagnostics=%+v", len(assets), diagnostics)
+	}
+	var record SSMParameterMetadata
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if record.ConnectorID != "aws-prod" || record.AccountID != "123456789012" || record.Region != "us-east-1" {
+		t.Fatalf("scope not applied: %+v", record.ServiceCollectorRecord)
+	}
+	if record.ParameterType != "secure_string" || record.Tier != "advanced" {
+		t.Fatalf("expected canonical type and tier, got %q %q", record.ParameterType, record.Tier)
+	}
+	if record.ParameterPath != "/payments/db" || record.PathDepth != 3 {
+		t.Fatalf("unexpected path context: %q depth=%d", record.ParameterPath, record.PathDepth)
+	}
+	if record.KMSKeyARN != "arn:aws:kms:us-east-1:123456789012:alias/payments" {
+		t.Fatalf("unexpected KMS key ARN: %s", record.KMSKeyARN)
+	}
+	if !record.Sensitive || record.SensitivityClassification != "secure_string_customer_kms" {
+		t.Fatalf("expected sensitive customer-kms classification, got %+v", record)
+	}
+	payload := strings.ToLower(string(assets[0].Payload))
+	for _, forbidden := range []string{"parameter_value", "getparameter", "secretstring"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("value material leaked into collector payload: %s", payload)
+		}
+	}
+}
+
+func TestSSMParameterMetadataCollectorPartialFailureReturnsDiagnostics(t *testing.T) {
+	api := &fakeSSMParameterMetadataAPI{
+		pages: []SSMParameterMetadataPage{{
+			Records: []SSMParameterMetadata{{
+				ParameterARN:  "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password",
+				ParameterName: "/payments/db/password",
+				ParameterType: "SecureString",
+			}},
+			NextToken: "next",
+		}},
+		err:       errors.New("throttled"),
+		errOnCall: 2,
+	}
+	collector := NewSSMParameterMetadataCollector(api, WithSSMParameterMetadataMaxPages(3))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{AccountID: "123456789012", Region: "us-east-1"})
+	if err == nil {
+		t.Fatalf("expected second-page error")
+	}
+	if len(assets) != 1 || len(diagnostics) == 0 {
+		t.Fatalf("expected partial asset plus diagnostics, assets=%d diagnostics=%+v", len(assets), diagnostics)
+	}
+	if diagnostics[0].Code != "ssm_parameter_metadata_page_failed" {
+		t.Fatalf("unexpected diagnostic: %+v", diagnostics)
+	}
+}
+
+func TestSSMParameterMetadataCollectorSkipsMalformedRecords(t *testing.T) {
+	api := &fakeSSMParameterMetadataAPI{pages: []SSMParameterMetadataPage{{
+		Records: []SSMParameterMetadata{{ParameterType: "String"}},
+	}}}
+	collector := NewSSMParameterMetadataCollector(api)
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(assets) != 0 || len(diagnostics) != 1 || diagnostics[0].Code != "malformed_ssm_parameter_record" {
+		t.Fatalf("expected one malformed-record diagnostic, assets=%d diagnostics=%+v", len(assets), diagnostics)
+	}
+}
+
+func TestClassifySSMParameterSensitivityAndExposure(t *testing.T) {
+	tests := []struct {
+		name            string
+		record          SSMParameterMetadata
+		wantSensitive   bool
+		wantSensitivity string
+		wantExposure    string
+		wantReason      string
+	}{
+		{
+			name:            "secure string customer kms",
+			record:          SSMParameterMetadata{ParameterType: "secure_string", KMSKeyID: "alias/payments"},
+			wantSensitive:   true,
+			wantSensitivity: "secure_string_customer_kms",
+			wantExposure:    "private",
+			wantReason:      "customer_kms_key_referenced",
+		},
+		{
+			name:            "secure string aws managed kms",
+			record:          SSMParameterMetadata{ParameterType: "secure_string", KMSKeyID: "alias/aws/ssm"},
+			wantSensitive:   true,
+			wantSensitivity: "secure_string_aws_managed_kms",
+			wantExposure:    "private",
+			wantReason:      "secure_string_kms_encrypted",
+		},
+		{
+			name: "plain text referenced by workload",
+			record: SSMParameterMetadata{ParameterType: "string", ReferenceCount: 1, ReferencedBy: []SecretWorkloadReference{{
+				Reference: "DB_HOST=/payments/db/host", ReferenceKind: "name", Confidence: 0.8,
+			}}},
+			wantSensitivity: "plain_text",
+			wantExposure:    "referenced_by_workload",
+			wantReason:      "plain_text_parameter_referenced_as_secret",
+		},
+		{
+			name: "expiring parameter",
+			record: SSMParameterMetadata{ParameterType: "string", Policies: []SSMParameterPolicy{{
+				PolicyType: "Expiration", PolicyStatus: "pending", ExpiresAt: "2026-12-02T21:34:33Z",
+			}}},
+			wantSensitivity: "plain_text",
+			wantExposure:    "scheduled_expiration",
+			wantReason:      "expiration_policy_present",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sensitive, sensitivity := classifySSMParameterSensitivity(tc.record)
+			if sensitive != tc.wantSensitive || sensitivity != tc.wantSensitivity {
+				t.Fatalf("sensitivity = (%t, %q), want (%t, %q)", sensitive, sensitivity, tc.wantSensitive, tc.wantSensitivity)
+			}
+			exposure, reasons := classifySSMParameterExposure(tc.record)
+			if exposure != tc.wantExposure {
+				t.Fatalf("exposure = %q, want %q (reasons %+v)", exposure, tc.wantExposure, reasons)
+			}
+			if !containsString(reasons, tc.wantReason) {
+				t.Fatalf("expected reason %q in %+v", tc.wantReason, reasons)
+			}
+		})
+	}
+}
+
+func TestSSMParameterPathContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantPath  string
+		wantDepth int
+	}{
+		{name: "/payments/db/password", wantPath: "/payments/db", wantDepth: 3},
+		{name: "/payments", wantPath: "", wantDepth: 1},
+		{name: "db-password", wantPath: "", wantDepth: 1},
+		{name: "", wantPath: "", wantDepth: 0},
+	}
+	for _, tc := range tests {
+		path, depth := ssmParameterPathContext(tc.name)
+		if path != tc.wantPath || depth != tc.wantDepth {
+			t.Fatalf("ssmParameterPathContext(%q) = (%q, %d), want (%q, %d)", tc.name, path, depth, tc.wantPath, tc.wantDepth)
+		}
+	}
+}
+
+func TestSSMParameterNameFromARN(t *testing.T) {
+	tests := []struct {
+		arn  string
+		want string
+	}{
+		{arn: "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password", want: "/payments/db/password"},
+		{arn: "arn:aws:ssm:us-east-1:123456789012:parameter/db-password", want: "db-password"},
+		{arn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/db-AbCdEf", want: ""},
+		{arn: "not-an-arn", want: ""},
+	}
+	for _, tc := range tests {
+		if got := ssmParameterNameFromARN(tc.arn); got != tc.want {
+			t.Fatalf("ssmParameterNameFromARN(%q) = %q, want %q", tc.arn, got, tc.want)
+		}
+	}
+}
+
+func TestSSMParameterReferenceKeysFromRefStripsPrefixesAndSuffixes(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want []string
+	}{
+		{
+			name: "ecs valuefrom arn with version",
+			ref:  "DATABASE_PASSWORD=arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password:3",
+			want: []string{
+				"arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password",
+				"/payments/db/password",
+				"payments/db/password",
+			},
+		},
+		{
+			name: "codebuild parameter store prefix",
+			ref:  "DB_HOST=PARAMETER_STORE:/payments/db/host",
+			want: []string{
+				"/payments/db/host",
+				"payments/db/host",
+			},
+		},
+		{
+			name: "bare name with label suffix",
+			ref:  "db-password:prod",
+			want: []string{
+				"db-password:prod",
+				"/db-password:prod",
+			},
+		},
+		{
+			name: "env assignment with label suffix",
+			ref:  "DB_PASSWORD=db-password:prod",
+			want: []string{
+				"db-password",
+				"/db-password",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keys := ssmParameterReferenceKeysFromRef(tc.ref)
+			for _, want := range tc.want {
+				if !containsString(keys, want) {
+					t.Fatalf("expected key %q in %+v", want, keys)
+				}
+			}
+		})
+	}
+}
+
+func TestSSMParameterMetadataNormalizeAndGraphUsesParameter(t *testing.T) {
+	parameter := SSMParameterMetadata{
+		ParameterARN:           "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password",
+		ParameterName:          "/payments/db/password",
+		ParameterType:          "secure_string",
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{},
+	}
+	parameter.AccountID = "123456789012"
+	parameter.Region = "us-east-1"
+	parameter.Service = ssmServiceName
+	payload, err := json.Marshal(parameter)
+	if err != nil {
+		t.Fatalf("marshal parameter: %v", err)
+	}
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     rawKindSSMParameterMetadata,
+		SourceID: ssmParameterMetadataSourceID(parameter),
+		Payload:  payload,
+	}, {
+		Kind:     rawKindECSTaskRole,
+		SourceID: "ecs-service",
+		Payload: []byte(`{
+			"account_id":"123456789012",
+			"region":"us-east-1",
+			"service":"ecs",
+			"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/prod",
+			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+			"workload_type":"ecs_service",
+			"workload_name":"payments",
+			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:4",
+			"role_arn":"arn:aws:iam::123456789012:role/payments-task",
+			"secret_refs":["DATABASE_PASSWORD=arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password:3"]
+		}`),
+	}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	foundResource := false
+	for _, resource := range bundle.Resources {
+		if resource.Type == domain.ResourceTypeSSMParameter {
+			foundResource = true
+			if resource.ID != ssmParameterResourceID(parameter.ParameterARN) {
+				t.Fatalf("unexpected resource id: %+v", resource)
+			}
+		}
+	}
+	if !foundResource {
+		t.Fatalf("expected normalized ssm parameter resource, got %+v", bundle.Resources)
+	}
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("relationships: %v", err)
+	}
+	for _, relationship := range relationships {
+		if relationship.Type == domain.RelationshipUsesSecret {
+			if relationship.ToNodeID != ssmParameterResourceID(parameter.ParameterARN) {
+				t.Fatalf("unexpected target: %+v", relationship)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected uses_secret relationship to ssm parameter, got %+v", relationships)
+}
+
+func TestResolveKMSKeyARNSharedHelper(t *testing.T) {
+	if got := resolveKMSKeyARN("alias/payments", "123456789012", "us-east-1"); got != "arn:aws:kms:us-east-1:123456789012:alias/payments" {
+		t.Fatalf("unexpected alias resolution: %q", got)
+	}
+	if got := resolveKMSKeyARN("arn:aws:kms:eu-west-1:999999999999:key/key123", "123456789012", "us-east-1"); got != "arn:aws:kms:eu-west-1:999999999999:key/key123" {
+		t.Fatalf("expected ARN passthrough, got %q", got)
+	}
+}

--- a/internal/providers/aws/ssm_parameter_metadata_collector_test.go
+++ b/internal/providers/aws/ssm_parameter_metadata_collector_test.go
@@ -86,6 +86,17 @@ func TestSSMParameterMetadataCollectorCollectsMetadataOnly(t *testing.T) {
 	}
 }
 
+func TestSSMParameterMetadataCollectorPageBudgetCoversAdvancedTierCeiling(t *testing.T) {
+	// DescribeParameters returns at most 50 items per page and an Advanced-tier
+	// account can hold up to 100,000 parameters, so the default page budget must
+	// be able to reach the full inventory rather than aborting at 25,000.
+	collector := NewSSMParameterMetadataCollector(&fakeSSMParameterMetadataAPI{})
+	const advancedTierCeiling = 100_000
+	if got := int64(collector.maxPages) * int64(ssmDescribeParametersMaxResults); got < advancedTierCeiling {
+		t.Fatalf("page budget covers %d parameters, want >= %d (maxPages=%d, pageSize=%d)", got, advancedTierCeiling, collector.maxPages, ssmDescribeParametersMaxResults)
+	}
+}
+
 func TestSSMParameterMetadataCollectorPartialFailureReturnsDiagnostics(t *testing.T) {
 	api := &fakeSSMParameterMetadataAPI{
 		pages: []SSMParameterMetadataPage{{

--- a/internal/providers/awscontract/contract.go
+++ b/internal/providers/awscontract/contract.go
@@ -176,6 +176,8 @@ func AWSServiceCollectorContract() ServiceCollectorContract {
 			"secretsmanager:DescribeSecret",
 			"secretsmanager:GetResourcePolicy",
 			"secretsmanager:ListSecretVersionIds",
+			"ssm:DescribeParameters",
+			"ssm:ListTagsForResource",
 		},
 		ReadOnlyBoundaries: []string{
 			"collect metadata and policy documents only; never collect secret values, customer payloads, prompts, completions, object contents, or database rows",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -138,6 +138,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws secrets manager metadata collector: %w", secretsErr)
 			}
+			ssmAPI, ssmErr := awsprovider.NewSDKSSMParameterMetadataAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if ssmErr != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("initialize aws ssm parameter metadata collector: %w", ssmErr)
+			}
 			scanner = newAWSScanner(
 				iamAPI,
 				cfg.AWSAccountID,
@@ -156,6 +161,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewS3BucketReachabilityCollector(s3API),
 				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+				awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 			)
 		default:
 			_ = store.Close()
@@ -296,6 +302,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if secretsErr != nil {
 			return nil, secretsErr
 		}
+		ssmAPI, ssmErr := awsprovider.NewSDKSSMParameterMetadataAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		if ssmErr != nil {
+			return nil, ssmErr
+		}
 		scanner := newAWSScanner(
 			iamAPI,
 			connection.AccountID,
@@ -314,6 +324,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewS3BucketReachabilityCollector(s3API),
 			awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 			awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+			awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 		)
 		return scanner, nil
 	}

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager", "ssm"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "secretsmanager", "ssm"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1033,6 +1033,37 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS SSM parameter metadata inventory with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', parameter_count: 3, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectSSMParameterMetadata(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { parameterType: 'secure_string', identity: 'payments-deployer' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/ssm-parameter-metadata?connector_id=aws-prod&fixture_state=partial_failure&parameter_type=secure_string&identity=payments-deployer'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS EKS workload identity inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2488,6 +2488,129 @@ export type AWSSecretsManagerMetadataInventoryResult = {
   updated_at: string;
 };
 
+export type AWSSSMParameterMetadataInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSSMParameterMetadataFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSSSMParameterTypeFilter = 'string' | 'string_list' | 'secure_string';
+
+export type AWSSSMParameterCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSSSMParameterPolicy = {
+  policy_type?: string;
+  policy_status?: string;
+  expires_at?: string;
+};
+
+export type AWSSSMParameterWorkloadReference = {
+  source_service?: string;
+  workload_id?: string;
+  workload_type?: string;
+  workload_name?: string;
+  resource_arn?: string;
+  resource_id?: string;
+  reference: string;
+  reference_kind: string;
+  confidence: number;
+};
+
+export type AWSSSMParameterMetadataRecord = {
+  account_id: string;
+  region: string;
+  service: 'ssm';
+  parameter_arn: string;
+  parameter_name: string;
+  parameter_path?: string;
+  path_depth?: number;
+  parameter_type: string;
+  tier: string;
+  data_type?: string;
+  version?: number;
+  description_present: boolean;
+  allowed_pattern_present: boolean;
+  kms_key_id?: string;
+  kms_key_arn?: string;
+  last_modified_at?: string;
+  last_modified_by?: string;
+  parameter_policies?: AWSSSMParameterPolicy[];
+  tags?: Record<string, string>;
+  sensitive: boolean;
+  sensitivity_classification: string;
+  exposure_classification: string;
+  exposure_reasons?: string[];
+  referenced_by?: AWSSSMParameterWorkloadReference[];
+  unresolved_references?: AWSSSMParameterWorkloadReference[];
+  source: string;
+  evidence_ref: string;
+  from_node_id: string;
+  relationship_type: string;
+  confidence: number;
+  collected_at: string;
+  status: string;
+};
+
+export type AWSSSMParameterReferenceEdge = {
+  type: 'uses_secret';
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+  source: string;
+  confidence: number;
+};
+
+export type AWSSSMParameterMetadataDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSSSMParameterMetadataInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSSMParameterMetadataInventoryStatus;
+  fixture_state: AWSSSMParameterMetadataFixtureState;
+  confidence: number;
+  parameter_count: number;
+  secure_string_count: number;
+  customer_kms_count: number;
+  referenced_parameter_count: number;
+  unreferenced_parameter_count: number;
+  plain_text_referenced_count: number;
+  expiring_parameter_count: number;
+  advanced_tier_count: number;
+  relationship_count: number;
+  unresolved_reference_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSSSMParameterCoverageGap[];
+  records: AWSSSMParameterMetadataRecord[];
+  relationships: AWSSSMParameterReferenceEdge[];
+  diagnostics: AWSSSMParameterMetadataDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSEKSWorkloadIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSEKSWorkloadIdentityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 
@@ -3746,6 +3869,24 @@ export const apiClient = {
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secrets-manager-metadata${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSSMParameterMetadata(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSSSMParameterMetadataFixtureState,
+    filters?: { parameterType?: AWSSSMParameterTypeFilter; identity?: string },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSSSMParameterMetadataInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/ssm-parameter-metadata${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        parameter_type: filters?.parameterType,
+        identity: filters?.identity
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -53,6 +53,8 @@ import {
   type AWSServiceCollectorContractResult,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
+  type AWSSSMParameterMetadataInventoryResult,
+  type AWSSSMParameterMetadataRecord,
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
   type ExecutiveReport,
@@ -3628,6 +3630,13 @@ type AWSInventorySecretsManagerState = {
   onRetry: () => void;
 };
 
+type AWSInventorySSMParameterState = {
+  inventory: AWSSSMParameterMetadataInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -5873,29 +5882,23 @@ function AWSAgentIdentitiesContent({
 function AWSResourcesInventoryContent({
   connection,
   secretsManagerState,
+  ssmParameterState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
   secretsManagerState: AWSInventorySecretsManagerState;
+  ssmParameterState: AWSInventorySSMParameterState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const secretsInventory = secretsManagerState.inventory;
   const secretsRows = buildAWSSecretsManagerMetadataRows(secretsInventory, secretsManagerState.loading, connection);
+  const ssmInventory = ssmParameterState.inventory;
+  const ssmRows = buildAWSSSMParameterMetadataRows(ssmInventory, ssmParameterState.loading, connection);
   const rows: AWSInventoryTableRow[] = [
     ...secretsRows,
-    {
-      id: 'ssm-parameters',
-      name: 'SSM Parameter metadata',
-      category: 'Credential reference',
-      scope: connection?.region ?? 'Region pending',
-      status: 'coming',
-      stage: 'coming',
-      detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.',
-      filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
-      searchText: inventorySearchText(['ssm parameter', 'reference', 'tags', 'encryption'])
-    },
+    ...ssmRows,
     {
       id: 'kms',
       name: 'KMS key reachability',
@@ -5942,6 +5945,12 @@ function AWSResourcesInventoryContent({
           total={1}
           detail={secretsManagerState.loading ? 'Loading' : secretsInventory ? formatTokenLabel(secretsInventory.status) : 'Pending'}
         />
+        <DomainCoverageCard
+          label="SSM parameters"
+          scanned={ssmInventory && ssmInventory.status !== 'blocked' ? 1 : 0}
+          total={1}
+          detail={ssmParameterState.loading ? 'Loading' : ssmInventory ? formatTokenLabel(ssmInventory.status) : 'Pending'}
+        />
         <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
         <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Coming wave" />
       </section>
@@ -5951,6 +5960,14 @@ function AWSResourcesInventoryContent({
           title="Secrets Manager metadata could not load"
           body={secretsManagerState.error}
           retryAction={{ label: 'Retry Secrets Manager metadata', onClick: secretsManagerState.onRetry }}
+        />
+      ) : null}
+      {ssmParameterState.loading ? <DomainLoadingState label="Loading SSM Parameter metadata" /> : null}
+      {ssmParameterState.error ? (
+        <DomainErrorState
+          title="SSM Parameter metadata could not load"
+          body={ssmParameterState.error}
+          retryAction={{ label: 'Retry SSM Parameter metadata', onClick: ssmParameterState.onRetry }}
         />
       ) : null}
       <DomainStatusPanel eyebrow="Safety posture" title="No secret value reads" status="Metadata only" tone="success">
@@ -6080,6 +6097,117 @@ function awsSecretsManagerMetadataRow(record: AWSSecretsManagerMetadataRecord): 
   };
 }
 
+function buildAWSSSMParameterMetadataRows(
+  inventory: AWSSSMParameterMetadataInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsSSMParameterMetadataRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'ssm-parameters-blocked',
+        name: 'SSM Parameter metadata unavailable',
+        category: 'Credential reference',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'SSM parameter metadata collection is blocked.',
+        filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['ssm parameter', 'blocked', inventory.account_id, inventory.region])
+      }
+    ];
+  }
+  if (inventory) {
+    const degraded = inventory.status === 'degraded' || inventory.diagnostics.length > 0 || inventory.failure_reasons.length > 0;
+    return [
+      {
+        id: 'ssm-parameters-empty',
+        name: degraded ? 'SSM Parameter metadata incomplete' : 'No SSM parameters found',
+        category: 'Credential reference',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: degraded ? 'degraded' : 'wired now',
+        stage: 'wired',
+        detail: degraded ? (inventory.failure_reasons[0] ?? 'SSM parameter metadata collection completed with degraded evidence and no retained records.') : 'The collector completed without SSM parameters in this account and region.',
+        filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['ssm parameter', inventory.account_id, inventory.region, degraded ? 'degraded empty' : 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'ssm-parameters-loading',
+        name: 'SSM Parameter metadata',
+        category: 'Credential reference',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading parameter type, tier, path, KMS references, policies, and workload references.',
+        filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['ssm parameter', 'metadata', 'loading'])
+      }
+    ];
+  }
+  return [
+    {
+      id: 'ssm-parameters',
+      name: 'SSM Parameter metadata',
+      category: 'Credential reference',
+      scope: connection?.region ?? 'Region pending',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.',
+      filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['ssm parameter', 'reference', 'tags', 'encryption'])
+    }
+  ];
+}
+
+function awsSSMParameterMetadataRow(record: AWSSSMParameterMetadataRecord): AWSInventoryTableRow {
+  const plainTextReferenced = (record.referenced_by?.length ?? 0) > 0 && record.parameter_type !== 'secure_string';
+  const degraded = record.status !== 'ready' || plainTextReferenced;
+  const status = degraded ? 'degraded' : 'wired now';
+  const typeLabel = record.parameter_type === 'secure_string' ? `SecureString (${record.sensitivity_classification === 'secure_string_customer_kms' ? 'customer KMS' : 'AWS-managed KMS'})` : record.parameter_type;
+  const referenceLabel = record.referenced_by?.length ? `${record.referenced_by.length} workload references` : 'no resolved workload references';
+  const expirationPolicy = (record.parameter_policies ?? []).find((policy) => (policy.policy_type ?? '').toLowerCase() === 'expiration');
+  const lifecycleLabel = expirationPolicy ? `expires ${expirationPolicy.expires_at ?? 'per policy'}` : 'no expiration policy';
+  const modifiedLabel = record.last_modified_by ? `last modified by ${record.last_modified_by.split('/').pop() ?? record.last_modified_by}` : 'modifier unknown';
+  return {
+    id: `ssm-parameter-${record.parameter_arn}`,
+    name: record.parameter_name || record.parameter_arn,
+    category: record.sensitive ? 'Secret-bearing' : 'Credential reference',
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage: 'wired',
+    detail: `${typeLabel}, ${record.tier} tier; ${referenceLabel}; ${lifecycleLabel}; ${modifiedLabel}. Values hidden.`,
+    filters: {
+      category: 'ssm-parameter',
+      sensitivity: record.sensitive ? 'secret-bearing' : 'credential-reference',
+      readPosture: 'metadata-only',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.parameter_arn,
+      record.parameter_name,
+      record.parameter_path ?? '',
+      record.account_id,
+      record.region,
+      record.parameter_type,
+      record.tier,
+      record.sensitivity_classification,
+      record.exposure_classification,
+      record.last_modified_by ?? '',
+      ...(record.exposure_reasons ?? []),
+      ...(record.referenced_by ?? []).map((ref) => `${ref.source_service ?? ''} ${ref.workload_name ?? ''} ${ref.reference}`),
+      ...(record.unresolved_references ?? []).map((ref) => `${ref.source_service ?? ''} ${ref.workload_name ?? ''} ${ref.reference}`),
+      'ssm parameter metadata type tier path kms references values hidden'
+    ])
+  };
+}
+
 function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) {
   const data = useAWSInventoryData();
   const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
@@ -6127,6 +6255,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [secretsManagerInventoryLoading, setSecretsManagerInventoryLoading] = useState(false);
   const [secretsManagerInventoryError, setSecretsManagerInventoryError] = useState('');
   const secretsManagerInventoryRequestRef = useRef(0);
+  const [ssmParameterInventory, setSSMParameterInventory] = useState<AWSSSMParameterMetadataInventoryResult | null>(null);
+  const [ssmParameterInventoryLoading, setSSMParameterInventoryLoading] = useState(false);
+  const [ssmParameterInventoryError, setSSMParameterInventoryError] = useState('');
+  const ssmParameterInventoryRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -6536,6 +6668,47 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadSecretsManagerInventory]);
 
+  const loadSSMParameterInventory = useCallback(async () => {
+    const requestID = ++ssmParameterInventoryRequestRef.current;
+    setSSMParameterInventory(null);
+    setSSMParameterInventoryError('');
+    if (routeID !== 'resources' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSSMParameterInventoryLoading(false);
+      return;
+    }
+    setSSMParameterInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSSMParameterMetadata(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== ssmParameterInventoryRequestRef.current) {
+        return;
+      }
+      setSSMParameterInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== ssmParameterInventoryRequestRef.current) {
+        return;
+      }
+      setSSMParameterInventoryError(formatAPIError(error, 'Unable to load SSM Parameter metadata.'));
+    } finally {
+      if (requestID === ssmParameterInventoryRequestRef.current) {
+        setSSMParameterInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadSSMParameterInventory();
+    return () => {
+      ssmParameterInventoryRequestRef.current += 1;
+    };
+  }, [loadSSMParameterInventory]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -6677,6 +6850,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: secretsManagerInventoryLoading,
             error: secretsManagerInventoryError,
             onRetry: () => void loadSecretsManagerInventory()
+          }}
+          ssmParameterState={{
+            inventory: ssmParameterInventory,
+            loading: ssmParameterInventoryLoading,
+            error: ssmParameterInventoryError,
+            onRetry: () => void loadSSMParameterInventory()
           }}
           filters={activeFilters}
           onFiltersChange={onFiltersChange}


### PR DESCRIPTION
Closes #1491

## Summary

Implements AWS Platform Wave 2.04: the **SSM Parameter Store metadata and reference collector**, following the established AWS service collector contract (#1476) and mirroring the structure of the merged Secrets Manager (#1594), KMS (#1593), and S3 (#1592) wave-2 collectors.

## What it collects (metadata only)

- Parameter ARN, name, hierarchy **path context** (`parameter_path`, `path_depth`), account, region, tags.
- **Type** (`string` / `string_list` / `secure_string`), **tier** (`standard` / `advanced` / `intelligent_tiering`), data type, version.
- **KMS references** for SecureString parameters (full ARN / `alias/...` / bare key id all resolved correctly), classified as customer-managed vs AWS-managed (`alias/aws/ssm`).
- **Parameter policy summaries** — type, status, and expiration timestamp only; raw policy text is dropped.
- **Last-modified identity context** (`last_modified_by` IAM principal ARN + timestamp), connecting parameter changes to identities.
- **Workload references** resolved from compute `secret_refs` (ECS `valueFrom` and CodeBuild `PARAMETER_STORE` sources, including `name:version` / `name:label` and ARN `:version` suffixes) into graph-ready `uses_secret` edges targeting `ssm_parameter` resource nodes.

## Sensitivity and exposure classification

- Sensitivity: `secure_string_customer_kms` / `secure_string_aws_managed_kms` / `string_list` / `plain_text`; SecureString ⇒ `sensitive: true` (metadata only).
- Exposure: `referenced_by_workload` > `scheduled_expiration` > `private`, with explicit reasons including `plain_text_parameter_referenced_as_secret` — a plaintext `String` parameter injected through a secret channel is exactly the hygiene smell operators should act on.

## Safety boundaries

- The SDK client interface exposes **only** `DescribeParameters` and `ListTagsForResource`. `GetParameter`, `GetParameters`, `GetParametersByPath`, and `GetParameterHistory` are structurally absent — they cannot be called.
- Required permissions added to the collector contract: `ssm:DescribeParameters`, `ssm:ListTagsForResource`. The contract validator already rejects every `ssm:GetParameter*` action as payload-reading.
- Description and allowed-pattern text are reduced to `description_present` / `allowed_pattern_present` flags; tests assert the text never appears in marshaled payloads.
- RAM-shared parameters and value collection are reported as explicit coverage gaps, not silent omissions.

## Backend / API

- `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata` with `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` fixture states, counts, evidence links, remediation hints, diagnostics, records, and `uses_secret` relationship edges.
- Record filters: `parameter_type` (validated enum) and `identity` (substring match on last-modified principal and referencing workload identifiers); invalid filters return 400.
- Route policy registry, OpenAPI path + schemas, runtime scanner (config-credential and connector assume-role paths), worker, and CLI wiring.

## App surface

The AWS **Resources** inventory page replaces the previous "coming" SSM placeholder with live records: coverage card, loading / empty / error / degraded / permission-denied states, per-record type+tier/KMS/expiration/last-modified detail, and existing category/sensitivity/read-posture filters.

## Implementation improvements over prior wave collectors

- Extracted shared `resolveKMSKeyARN` (ARN/alias/bare-id resolution) and `awsCallerAccountID` helpers instead of duplicating them per collector; the Secrets Manager collector now delegates to them.
- Reused `SecretWorkloadReference` and its normalization for SSM references rather than introducing a parallel type.
- Fixture classifier orders the SSM matcher ahead of the Secrets Manager matcher with regression tests for both directions (the two record shapes share `kms_key_id` / `referenced_by` JSON keys).

## Tests

- Collector: metadata-only payload assertions, scope normalization, canonical type/tier, path context, partial failure, malformed records, page-limit, dedupe.
- SDK adapter: enrichment (tags, policies, expiration parse), tag-failure-as-diagnostic, error propagation, description/pattern leak checks.
- Classification: sensitivity × exposure matrix; reference-key expansion for ECS/CodeBuild forms with version/label suffixes.
- End-to-end: fixture → normalizer → `ssm_parameter` resource node → `uses_secret` edge.
- API: scoped records, counts, filters (type + identity + invalid), degraded / permission-denied, router partial-failure and 400 paths.
- Web: client URL/header/filter test; full `tsc` + vitest + production build.
- Fixture classifier ordering regression tests.

## Validation evidence

- `make ci` passes locally (fmt-check, vet, full Go tests with coverage, contract checks, web tests, web build, prerender).
- CLI fixture smoke test: `go run ./cmd/cli scan --fixture <role fixture> --fixture <ssm parameter fixture>` ingests both assets and completes cleanly.
- Example fixture API responses:
  - `?fixture_state=success` → `status: ready`, 3 records, 2 `uses_secret` relationships, 1 unresolved reference, counts `secure_string_count: 2`, `customer_kms_count: 1`, `plain_text_referenced_count: 1`, `expiring_parameter_count: 1`.
  - `?fixture_state=permission_denied` → `status: blocked` with `AccessDenied: missing ssm:DescribeParameters` diagnostic and metadata-only remediation hint.
  - `?parameter_type=secure_string` → 2 records; `?identity=payments-deployer` → 2 records.
- No live AWS mutation; collector is read-only by construction.

## Out of scope (per issue)

- RAM-shared parameter enumeration (explicit coverage gap).
- Parameter value or history reads (never).
- Later-wave reasoning/remediation consumers.

## AI disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS SSM Parameter Store collector and new API/UI to inventory parameters and link workload references, without reading parameter values. Improves visibility into SecureString usage, KMS keys, policy expirations, and where parameters are consumed. Closes #1491.

- **New Features**
  - Collector captures name/ARN, path context, type/tier/data type/version, tags, last-modified principal/time, KMS refs for SecureString (customer vs AWS-managed), and policy summaries (type/status/expiry); no values.
  - Safety: uses only `ssm:DescribeParameters` and `ssm:ListTagsForResource`; never calls `ssm:GetParameter*`; description/allowed-pattern are presence flags.
  - Graph: resolves ECS `valueFrom` and CodeBuild `PARAMETER_STORE` refs (name:version, name:label, ARN:version) into `uses_secret` edges; flags plaintext parameters injected via secret channels.
  - API: GET `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/ssm-parameter-metadata` with fixture states (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`) and filters (`parameter_type`, `identity`; invalid → 400).
  - App: Resources inventory shows SSM parameters with type/tier, KMS, expiration, and last-modified details; replaces prior placeholder and supports existing filters.
  - Scale: raises the SSM page budget to 2,000 (50 items/page) to cover up to 100k parameters in advanced-tier accounts.

- **Refactors**
  - Extracted `resolveKMSKeyARN` and `awsCallerAccountID`; Secrets Manager now uses them. Adopted shared `accountIDFromPrincipal` from dev to remove duplicate parsing.
  - Updated normalizer, relationship builder (match SSM refs), fixture classifier (prioritize SSM over Secrets Manager), route policy, OpenAPI, CLI, and runtime scanner wiring.
  - Added dependency `github.com/aws/aws-sdk-go-v2/service/ssm`.

<sup>Written for commit 7e5b3782c8bbfa032899ea1e9f2e80cac1e35734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

