### PR TITLE
Implement credential and secret reference mapper across AWS workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 ## Unreleased
+- Add **credential and secret reference mapper across AWS workloads** (#1496).
+  A metadata-only derivation over the normalized scan graph (no AWS calls, no
+  added permissions) that extracts the `secret_refs` and credential-suggestive
+  `environment_keys` already emitted by workload collectors (ECS, Lambda,
+  CodeBuild today; any future workload collector automatically) and classifies
+  each reference by provider (`openai`, `anthropic`, `bedrock`, `github`,
+  `slack`, `database`, `webhook`, `aws_secrets_manager`, `aws_ssm`, `generic`),
+  reference kind (`secrets_manager`, `ssm_parameter`, `repository_credentials`,
+  `environment_variable`), and sensitivity. Resolved references reuse
+  `uses_secret` edges to collected secret/parameter nodes; unresolved external
+  provider keys synthesize a `credential_reference` graph node and edge so
+  operators can see a workload uses, for example, an OpenAI or database
+  credential even when it is not an AWS-managed secret. Adds the
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references`
+  endpoint with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states plus `resource_type`, `identity`, and
+  `provider` filters, a provider breakdown and resolved/unresolved counts,
+  OpenAPI schema, web API client types, the AWS resources inventory surface,
+  and operator docs. The mapper reads reference names, ARNs, and source markers
+  only; it never reads secret, parameter, or environment values.
 - Add **SSM Parameter Store metadata and reference collector** (#1491).
   Read-only, metadata-only inventory of SSM parameters capturing name, ARN,
   hierarchy path context, type (`string`, `string_list`, `secure_string`),

--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -317,3 +317,15 @@ ordered by `kind`, then `source_id`.
   or scan-finding detail APIs, and it never stores image layers, manifests,
   SBOMs, customer payloads, prompts, completions, object contents, or database
   rows.
+- Credential and secret references across workloads are exposed through
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references`.
+  This is a derivation over the normalized graph (no AWS calls, no added
+  permissions): it classifies the `secret_refs` and credential-suggestive
+  `environment_keys` already emitted by ECS, Lambda, and CodeBuild collectors
+  (and any future workload collector that surfaces them) by provider (OpenAI,
+  Anthropic, Bedrock, GitHub, Slack, database, webhook, AWS Secrets Manager,
+  AWS SSM, or generic), reference kind, and sensitivity, with resolved/
+  unresolved status. Resolved references reuse `uses_secret` edges to collected
+  secret/parameter nodes; unresolved external provider keys synthesize a
+  `credential_reference` node and edge. It reads reference names, ARNs, and
+  source markers only — never secret, parameter, or environment values.

--- a/docs/aws-credential-references.md
+++ b/docs/aws-credential-references.md
@@ -1,0 +1,103 @@
+# AWS Credential and Secret Reference Mapping
+
+Issue #1496 adds a metadata-only mapper that extracts credential and secret
+references from AWS workloads, classifies the provider behind each reference,
+and emits graph-ready identity-to-reference edges.
+
+## What It Maps
+
+The mapper is a pure derivation over the normalized scan graph — it performs no
+AWS calls of its own. It reads the credential references that workload
+collectors already surface (`secret_refs` and credential-suggestive
+`environment_keys`) for every workload that carries them, currently:
+
+- ECS services and task definitions (`valueFrom` secret references)
+- Lambda functions (environment and secret references)
+- CodeBuild projects (`SECRETS_MANAGER` / `PARAMETER_STORE` environment
+  sources)
+
+Any future workload collector that emits `secret_refs` or `environment_keys`
+(for example SageMaker, Step Functions, or EC2 once they surface environment
+metadata) is mapped automatically without changing this component.
+
+For each reference it records:
+
+- **Provider** by name/metadata pattern: `openai`, `anthropic`, `bedrock`,
+  `github`, `slack`, `database`, `webhook`, plus the AWS-native sources
+  `aws_secrets_manager` and `aws_ssm`, falling back to `generic`.
+- **Reference kind**: `secrets_manager`, `ssm_parameter`,
+  `repository_credentials`, or `environment_variable`.
+- **Sensitivity**: `ai_provider_api_key`, `source_control_token`,
+  `messaging_token`, `database_credential`, `webhook_url`,
+  `aws_managed_secret`, or `generic_secret`.
+- **Resolution status**: whether the reference resolves to a collected Secrets
+  Manager secret or SSM parameter node (`resolved`), or points outside the
+  collected graph (`unresolved`).
+- Workload context, source service, evidence reference, and confidence.
+
+## Graph Output
+
+- Resolved references reuse the existing `uses_secret` edge to the collected
+  secret or parameter node.
+- Unresolved **external** provider keys (AI, source control, database, webhook)
+  synthesize a `credential_reference` graph node and a `uses_secret` edge from
+  the workload, so an operator can see "this workload uses an OpenAI key" even
+  when the key is not an AWS-managed secret.
+- Unresolved generic AWS secret references are recorded as evidence but do not
+  synthesize a node, avoiding dangling graph entries.
+
+## What It Never Collects
+
+The mapper reads reference names, ARNs, and source markers only. It never reads
+or stores secret values, parameter values, environment variable values,
+prompts, completions, object contents, database rows, or customer payloads. It
+adds no AWS permissions of its own; it depends on the metadata-only workload
+collectors that already run.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references
+```
+
+Optional query parameters:
+
+- `connector_id`: scope the response to one AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for deterministic UI and contract validation.
+- `resource_type`: filter to one workload resource type (for example
+  `ecs_service`, `lambda_function`, `codebuild_project`).
+- `identity`: case-insensitive substring filter over the workload identifier and
+  name.
+- `provider`: filter to one credential provider classification.
+
+The response includes operator-visible status, confidence, a provider
+breakdown, resolved/unresolved and external-provider-key counts, evidence
+links, failure reasons, remediation hints, diagnostics, records, and the
+identity-to-reference relationships. Unresolved external provider keys are
+prioritized in the remediation hints for secret-store migration and rotation.
+
+## Failure States
+
+- `empty`: workloads were inventoried and no credential references were found.
+- `degraded`: references are available but one workload's environment was
+  partially redacted by its source collector.
+- `partial_failure`: some workloads mapped while another workload collector
+  partially failed.
+- `permission_denied`: the underlying workload inventory permissions are
+  missing, so no references can be mapped.
+
+Unknown or denied states are explicit; they are not reported as successful
+findings.
+
+## Live Validation
+
+Run fixture validation first:
+
+```sh
+go test ./internal/providers/aws ./internal/api
+```
+
+For live AWS validation, use only an authorized test account and record
+account, region, workload coverage, and the provider breakdown. Do not capture
+secret, parameter, or environment values.

--- a/docs/aws-service-collector-contract.md
+++ b/docs/aws-service-collector-contract.md
@@ -231,6 +231,14 @@ values, parameter history, description and allowed-pattern text as operator
 evidence, and every `ssm:GetParameter*` output are intentionally outside the
 collector contract. SecureString parameters are sensitive metadata only.
 
+The credential and secret reference mapper is a derivation over the normalized
+graph rather than a service collector: it adds no AWS permissions and makes no
+AWS calls. It classifies the `secret_refs` and credential-suggestive
+`environment_keys` already emitted by workload collectors into provider, kind,
+and sensitivity, and emits identity-to-reference edges. It reads reference
+names, ARNs, and source markers only; secret, parameter, and environment values
+are intentionally outside its boundary.
+
 For ECR repositories, records contain repository metadata, tag mutability,
 encryption configuration, scan configuration, repository-policy and
 lifecycle-policy summaries, image counts, tags, and resolved workload

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -559,6 +559,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
     action: tenancy.read
     resource_type: project
@@ -4503,6 +4508,70 @@ paths:
                     $ref: "#/components/schemas/AWSSQSSNSReachabilityInventoryResult"
         "400":
           description: Invalid AWS SQS/SNS reachability inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS credential and secret references across workloads
+      operationId: getAWSProjectCredentialReferences
+      description: Returns scoped credential and secret references extracted from AWS workloads (ECS, Lambda, CodeBuild, and any workload that exposes secret/source references), classified by provider (OpenAI, Anthropic, Bedrock, GitHub, Slack, database, webhook, AWS Secrets Manager, AWS SSM), reference kind, and sensitivity, with resolved/unresolved status and identity-to-reference edges. Metadata-only - reads reference names, ARNs, and source markers; never reads secret, parameter, or environment values.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only reference evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: resource_type
+          schema: { type: string }
+          description: Optional workload resource type filter (for example ecs_service, lambda_function, codebuild_project).
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional case-insensitive substring filter over the workload identifier and name.
+        - in: query
+          name: provider
+          schema:
+            type: string
+            enum: [openai, anthropic, bedrock, github, slack, database, webhook, aws_secrets_manager, aws_ssm, generic]
+          description: Optional credential provider classification filter.
+      responses:
+        "200":
+          description: AWS credential references inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSCredentialReferencesInventoryResult"
+        "400":
+          description: Invalid AWS credential references request
           content:
             application/json:
               schema:
@@ -10099,6 +10168,145 @@ components:
         message: { type: string }
         remediation: { type: string }
         retryable: { type: boolean }
+    AWSCredentialReferenceCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSCredentialReferenceRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        workload_id: { type: string }
+        workload_type: { type: string }
+        workload_name: { type: string }
+        resource_id: { type: string }
+        resource_type: { type: string }
+        source_service: { type: string }
+        reference: { type: string }
+        reference_name: { type: string }
+        reference_kind:
+          type: string
+          enum: [secrets_manager, ssm_parameter, repository_credentials, environment_variable]
+        provider:
+          type: string
+          enum: [openai, anthropic, bedrock, github, slack, database, webhook, aws_secrets_manager, aws_ssm, generic]
+        provider_confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        sensitivity:
+          type: string
+          enum: [ai_provider_api_key, source_control_token, messaging_token, database_credential, webhook_url, aws_managed_secret, generic_secret]
+        resolved: { type: boolean }
+        unresolved: { type: boolean }
+        target_node_id: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+    AWSCredentialReferenceEdge:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [uses_secret]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        source: { type: string }
+        resolved: { type: boolean }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSCredentialReferenceDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSCredentialReferencesInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        reference_count: { type: integer }
+        resolved_reference_count: { type: integer }
+        unresolved_reference_count: { type: integer }
+        external_provider_key_count: { type: integer }
+        ai_provider_key_count: { type: integer }
+        database_credential_count: { type: integer }
+        distinct_workload_count: { type: integer }
+        distinct_provider_count: { type: integer }
+        relationship_count: { type: integer }
+        provider_breakdown:
+          type: object
+          additionalProperties: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCredentialReferenceCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCredentialReferenceRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCredentialReferenceEdge"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCredentialReferenceDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     AWSDynamoDBRDSReachabilityInventoryResult:
       type: object
       properties:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -755,6 +755,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sqs-sns-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dynamodb-rds-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ecr-repository-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_credential_references.go
+++ b/internal/api/aws_credential_references.go
@@ -327,6 +327,7 @@ func awsCredentialReferencesFixtureRecords(accountID, region, fixtureState strin
 			r.ProviderConfidence = 0.88
 			r.Sensitivity = "source_control_token"
 			r.Unresolved = true
+			r.TargetNodeID = "aws:resource:credential-reference:" + strings.ToLower(codeBuildWorkload) + "|github|github_token"
 			r.Confidence = 0.88
 		}),
 		awsCredentialReferenceFixtureRecord(accountID, region, codeBuildWorkload, "release", "codebuild_project", "codebuild", checkedAt, func(r *AWSCredentialReferenceRecord) {
@@ -380,10 +381,16 @@ func awsCredentialReferenceFixtureRecord(accountID, region, workloadID, workload
 
 func awsCredentialReferenceEdges(records []AWSCredentialReferenceRecord) []AWSCredentialReferenceEdge {
 	edges := []AWSCredentialReferenceEdge{}
+	seen := map[string]struct{}{}
 	for _, record := range records {
 		if strings.TrimSpace(record.TargetNodeID) == "" {
 			continue
 		}
+		edgeKey := record.WorkloadID + "|" + record.TargetNodeID
+		if _, exists := seen[edgeKey]; exists {
+			continue
+		}
+		seen[edgeKey] = struct{}{}
 		edges = append(edges, AWSCredentialReferenceEdge{
 			Type:        "uses_secret",
 			FromNodeID:  record.WorkloadID,

--- a/internal/api/aws_credential_references.go
+++ b/internal/api/aws_credential_references.go
@@ -305,7 +305,7 @@ func awsCredentialReferencesFixtureRecords(accountID, region, fixtureState strin
 			r.ProviderConfidence = 0.9
 			r.Sensitivity = "ai_provider_api_key"
 			r.Unresolved = true
-			r.TargetNodeID = "aws:resource:credential-reference:anthropic|anthropic_api_key"
+			r.TargetNodeID = "aws:resource:credential-reference:" + strings.ToLower(ecsWorkload) + "|anthropic|anthropic_api_key"
 			r.Confidence = 0.9
 		}),
 		awsCredentialReferenceFixtureRecord(accountID, region, lambdaWorkload, "summarizer", "lambda_function", "lambda", checkedAt, func(r *AWSCredentialReferenceRecord) {
@@ -316,7 +316,7 @@ func awsCredentialReferencesFixtureRecords(accountID, region, fixtureState strin
 			r.ProviderConfidence = 0.8
 			r.Sensitivity = "database_credential"
 			r.Unresolved = true
-			r.TargetNodeID = "aws:resource:credential-reference:database|database_url"
+			r.TargetNodeID = "aws:resource:credential-reference:" + strings.ToLower(lambdaWorkload) + "|database|database_url"
 			r.Confidence = 0.8
 		}),
 		awsCredentialReferenceFixtureRecord(accountID, region, codeBuildWorkload, "release", "codebuild_project", "codebuild", checkedAt, func(r *AWSCredentialReferenceRecord) {
@@ -337,7 +337,7 @@ func awsCredentialReferencesFixtureRecords(accountID, region, fixtureState strin
 			r.ProviderConfidence = 0.85
 			r.Sensitivity = "messaging_token"
 			r.Unresolved = true
-			r.TargetNodeID = "aws:resource:credential-reference:slack|slack_webhook_url"
+			r.TargetNodeID = "aws:resource:credential-reference:" + strings.ToLower(codeBuildWorkload) + "|slack|slack_webhook_url"
 			r.Confidence = 0.85
 		}),
 	}

--- a/internal/api/aws_credential_references.go
+++ b/internal/api/aws_credential_references.go
@@ -1,0 +1,480 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+const (
+	awsCredentialReferencesCurrentIssue = 1496
+	awsCredentialReferencesVersion      = "aws-credential-references-inventory-v1"
+)
+
+// Credential reference classification vocabulary. These mirror the live mapping
+// engine in internal/providers/aws (which the API package cannot import without
+// a cycle); they are kept in lockstep with that engine's constants.
+const (
+	credentialProviderOpenAI         = "openai"
+	credentialProviderAnthropic      = "anthropic"
+	credentialProviderBedrock        = "bedrock"
+	credentialProviderGitHub         = "github"
+	credentialProviderSlack          = "slack"
+	credentialProviderDatabase       = "database"
+	credentialProviderWebhook        = "webhook"
+	credentialProviderSecretsManager = "aws_secrets_manager"
+	credentialProviderSSM            = "aws_ssm"
+	credentialProviderGeneric        = "generic"
+)
+
+type AWSCredentialReferencesInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	// ResourceType filters records to one workload resource type (for example
+	// ecs_service, lambda_function, codebuild_project).
+	ResourceType string `json:"resource_type,omitempty"`
+	// Identity filters records to those whose workload identifier matches the
+	// supplied substring.
+	Identity string `json:"identity,omitempty"`
+	// Provider filters records to one credential provider classification.
+	Provider string `json:"provider,omitempty"`
+}
+
+type AWSCredentialReferenceCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSCredentialReferencesInventoryResult struct {
+	TenantID                 string                              `json:"tenant_id"`
+	WorkspaceID              string                              `json:"workspace_id"`
+	ProjectID                string                              `json:"project_id"`
+	ConnectorID              string                              `json:"connector_id,omitempty"`
+	AccountID                string                              `json:"account_id,omitempty"`
+	Region                   string                              `json:"region,omitempty"`
+	ParentIssueNumber        int                                 `json:"parent_issue_number"`
+	ParentIssueRef           string                              `json:"parent_issue_ref"`
+	CurrentIssueNumber       int                                 `json:"current_issue_number"`
+	CurrentIssueRef          string                              `json:"current_issue_ref"`
+	Version                  string                              `json:"version"`
+	Status                   string                              `json:"status"`
+	FixtureState             string                              `json:"fixture_state"`
+	Confidence               float64                             `json:"confidence"`
+	ReferenceCount           int                                 `json:"reference_count"`
+	ResolvedReferenceCount   int                                 `json:"resolved_reference_count"`
+	UnresolvedReferenceCount int                                 `json:"unresolved_reference_count"`
+	ExternalProviderKeyCount int                                 `json:"external_provider_key_count"`
+	AIProviderKeyCount       int                                 `json:"ai_provider_key_count"`
+	DatabaseCredentialCount  int                                 `json:"database_credential_count"`
+	DistinctWorkloadCount    int                                 `json:"distinct_workload_count"`
+	DistinctProviderCount    int                                 `json:"distinct_provider_count"`
+	RelationshipCount        int                                 `json:"relationship_count"`
+	ProviderBreakdown        map[string]int                      `json:"provider_breakdown"`
+	FailureReasons           []string                            `json:"failure_reasons"`
+	RemediationHints         []string                            `json:"remediation_hints"`
+	EvidenceLinks            []string                            `json:"evidence_links"`
+	CoverageGaps             []AWSCredentialReferenceCoverageGap `json:"coverage_gaps"`
+	Records                  []AWSCredentialReferenceRecord      `json:"records"`
+	Relationships            []AWSCredentialReferenceEdge        `json:"relationships"`
+	Diagnostics              []AWSCredentialReferenceDiagnostic  `json:"diagnostics"`
+	GeneratedAt              time.Time                           `json:"generated_at"`
+	UpdatedAt                time.Time                           `json:"updated_at"`
+}
+
+type AWSCredentialReferenceRecord struct {
+	AccountID          string    `json:"account_id"`
+	Region             string    `json:"region"`
+	WorkloadID         string    `json:"workload_id"`
+	WorkloadType       string    `json:"workload_type"`
+	WorkloadName       string    `json:"workload_name"`
+	ResourceID         string    `json:"resource_id,omitempty"`
+	ResourceType       string    `json:"resource_type"`
+	SourceService      string    `json:"source_service"`
+	Reference          string    `json:"reference"`
+	ReferenceName      string    `json:"reference_name,omitempty"`
+	ReferenceKind      string    `json:"reference_kind"`
+	Provider           string    `json:"provider"`
+	ProviderConfidence float64   `json:"provider_confidence"`
+	Sensitivity        string    `json:"sensitivity"`
+	Resolved           bool      `json:"resolved"`
+	Unresolved         bool      `json:"unresolved"`
+	TargetNodeID       string    `json:"target_node_id,omitempty"`
+	Source             string    `json:"source"`
+	EvidenceRef        string    `json:"evidence_ref"`
+	Confidence         float64   `json:"confidence"`
+	CollectedAt        time.Time `json:"collected_at"`
+	Status             string    `json:"status"`
+}
+
+type AWSCredentialReferenceEdge struct {
+	Type        string  `json:"type"`
+	FromNodeID  string  `json:"from_node_id"`
+	ToNodeID    string  `json:"to_node_id"`
+	EvidenceRef string  `json:"evidence_ref"`
+	Source      string  `json:"source"`
+	Resolved    bool    `json:"resolved"`
+	Confidence  float64 `json:"confidence"`
+}
+
+type AWSCredentialReferenceDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+func (s *Service) GetAWSCredentialReferencesInventory(ctx context.Context, workspaceID string, projectID string, request AWSCredentialReferencesInventoryRequest) (AWSCredentialReferencesInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSCredentialReferencesInventoryResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSCredentialReferencesInventoryResult{}, err
+	}
+	return buildAWSCredentialReferencesInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSCredentialReferencesInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSCredentialReferencesInventoryRequest, checkedAt time.Time) (AWSCredentialReferencesInventoryResult, error) {
+	fixtureState := normalizeAWSCredentialReferencesFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSCredentialReferencesInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	if !validAWSCredentialProviderFilter(request.Provider) {
+		return AWSCredentialReferencesInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, gaps := awsCredentialReferencesFixtureRecords(accountID, region, fixtureState, checkedAt)
+	records = filterAWSCredentialReferenceRecords(records, request)
+	status, confidence, failures, remediations := summarizeAWSCredentialReferencesInventory(fixtureState, diagnostics, records)
+	relationships := awsCredentialReferenceEdges(records)
+	return AWSCredentialReferencesInventoryResult{
+		TenantID:                 scope.TenantID,
+		WorkspaceID:              project.WorkspaceID,
+		ProjectID:                project.ProjectID,
+		ConnectorID:              connectorID,
+		AccountID:                accountID,
+		Region:                   region,
+		ParentIssueNumber:        awsPlatformDependencyParentIssue,
+		ParentIssueRef:           awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:       awsCredentialReferencesCurrentIssue,
+		CurrentIssueRef:          awsIssueRef(awsCredentialReferencesCurrentIssue),
+		Version:                  awsCredentialReferencesVersion,
+		Status:                   status,
+		FixtureState:             fixtureState,
+		Confidence:               confidence,
+		ReferenceCount:           len(records),
+		ResolvedReferenceCount:   countCredentialReferences(records, func(r AWSCredentialReferenceRecord) bool { return r.Resolved }),
+		UnresolvedReferenceCount: countCredentialReferences(records, func(r AWSCredentialReferenceRecord) bool { return r.Unresolved }),
+		ExternalProviderKeyCount: countCredentialReferences(records, func(r AWSCredentialReferenceRecord) bool { return awsCredentialProviderIsExternal(r.Provider) }),
+		AIProviderKeyCount:       countCredentialReferences(records, func(r AWSCredentialReferenceRecord) bool { return r.Sensitivity == "ai_provider_api_key" }),
+		DatabaseCredentialCount:  countCredentialReferences(records, func(r AWSCredentialReferenceRecord) bool { return r.Provider == credentialProviderDatabase }),
+		DistinctWorkloadCount:    countDistinctCredentialField(records, func(r AWSCredentialReferenceRecord) string { return r.WorkloadID }),
+		DistinctProviderCount:    countDistinctCredentialField(records, func(r AWSCredentialReferenceRecord) string { return r.Provider }),
+		RelationshipCount:        len(relationships),
+		ProviderBreakdown:        awsCredentialProviderBreakdown(records),
+		FailureReasons:           failures,
+		RemediationHints:         remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsCredentialReferencesCurrentIssue),
+			"/docs/aws-credential-references",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  gaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsCredentialReferenceDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSCredentialReferencesFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func validAWSCredentialProviderFilter(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", credentialProviderOpenAI, credentialProviderAnthropic, credentialProviderBedrock,
+		credentialProviderGitHub, credentialProviderSlack, credentialProviderDatabase,
+		credentialProviderWebhook, credentialProviderSecretsManager, credentialProviderSSM,
+		credentialProviderGeneric:
+		return true
+	default:
+		return false
+	}
+}
+
+func awsCredentialProviderIsExternal(provider string) bool {
+	switch provider {
+	case credentialProviderOpenAI, credentialProviderAnthropic, credentialProviderBedrock,
+		credentialProviderGitHub, credentialProviderSlack, credentialProviderDatabase,
+		credentialProviderWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
+func filterAWSCredentialReferenceRecords(records []AWSCredentialReferenceRecord, request AWSCredentialReferencesInventoryRequest) []AWSCredentialReferenceRecord {
+	resourceType := strings.ToLower(strings.TrimSpace(request.ResourceType))
+	identity := strings.ToLower(strings.TrimSpace(request.Identity))
+	provider := strings.ToLower(strings.TrimSpace(request.Provider))
+	if resourceType == "" && identity == "" && provider == "" {
+		return records
+	}
+	filtered := make([]AWSCredentialReferenceRecord, 0, len(records))
+	for _, record := range records {
+		if resourceType != "" && strings.ToLower(record.ResourceType) != resourceType {
+			continue
+		}
+		if provider != "" && record.Provider != provider {
+			continue
+		}
+		if identity != "" && !strings.Contains(strings.ToLower(record.WorkloadID+" "+record.WorkloadName), identity) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered
+}
+
+func awsCredentialReferencesFixtureRecords(accountID, region, fixtureState string, checkedAt time.Time) ([]AWSCredentialReferenceRecord, []providers.SourceError, []AWSCredentialReferenceCoverageGap) {
+	gaps := []AWSCredentialReferenceCoverageGap{{
+		Capability:  "secret_value_inspection",
+		Status:      "unsupported",
+		Reason:      "This mapper reads reference names, ARNs, and source markers only; it never reads a secret, parameter, or environment value.",
+		Remediation: "Inspect values through the owning secret store outside Identrail.",
+	}, {
+		Capability:  "inline_value_provider_detection",
+		Status:      "partial",
+		Reason:      "Provider detection for inline environment variables relies on name patterns; a non-conventional variable name may classify as generic.",
+		Remediation: "Adopt provider-prefixed variable names (for example OPENAI_API_KEY) so references classify precisely.",
+	}}
+	switch fixtureState {
+	case "permission_denied":
+		return nil, []providers.SourceError{{Collector: "credential_reference_mapper", Code: "workload_inventory_unavailable", Message: "AccessDenied: workload collectors could not enumerate references", Retryable: false}}, gaps
+	case "empty":
+		return nil, nil, gaps
+	}
+	partition := awsCredentialReferencePartition(region)
+	ecsWorkload := fmt.Sprintf("arn:%s:ecs:%s:%s:service/prod/agent", partition, region, accountID)
+	lambdaWorkload := fmt.Sprintf("arn:%s:lambda:%s:%s:function:summarizer", partition, region, accountID)
+	codeBuildWorkload := fmt.Sprintf("arn:%s:codebuild:%s:%s:project/release", partition, region, accountID)
+	openAISecret := fmt.Sprintf("arn:%s:secretsmanager:%s:%s:secret:openai/api-key-AbCdEf", partition, region, accountID)
+
+	records := []AWSCredentialReferenceRecord{
+		awsCredentialReferenceFixtureRecord(accountID, region, ecsWorkload, "agent", "ecs_service", "ecs", checkedAt, func(r *AWSCredentialReferenceRecord) {
+			r.Reference = "OPENAI_API_KEY=" + openAISecret
+			r.ReferenceName = "OPENAI_API_KEY"
+			r.ReferenceKind = "secrets_manager"
+			r.Provider = credentialProviderOpenAI
+			r.ProviderConfidence = 0.9
+			r.Sensitivity = "ai_provider_api_key"
+			r.Resolved = true
+			r.TargetNodeID = "aws:resource:secrets-manager-secret:" + openAISecret
+			r.Confidence = 0.95
+		}),
+		awsCredentialReferenceFixtureRecord(accountID, region, ecsWorkload, "agent", "ecs_service", "ecs", checkedAt, func(r *AWSCredentialReferenceRecord) {
+			r.Reference = "ANTHROPIC_API_KEY"
+			r.ReferenceName = "ANTHROPIC_API_KEY"
+			r.ReferenceKind = "environment_variable"
+			r.Provider = credentialProviderAnthropic
+			r.ProviderConfidence = 0.9
+			r.Sensitivity = "ai_provider_api_key"
+			r.Unresolved = true
+			r.TargetNodeID = "aws:resource:credential-reference:anthropic|anthropic_api_key"
+			r.Confidence = 0.9
+		}),
+		awsCredentialReferenceFixtureRecord(accountID, region, lambdaWorkload, "summarizer", "lambda_function", "lambda", checkedAt, func(r *AWSCredentialReferenceRecord) {
+			r.Reference = "DATABASE_URL"
+			r.ReferenceName = "DATABASE_URL"
+			r.ReferenceKind = "environment_variable"
+			r.Provider = credentialProviderDatabase
+			r.ProviderConfidence = 0.8
+			r.Sensitivity = "database_credential"
+			r.Unresolved = true
+			r.TargetNodeID = "aws:resource:credential-reference:database|database_url"
+			r.Confidence = 0.8
+		}),
+		awsCredentialReferenceFixtureRecord(accountID, region, codeBuildWorkload, "release", "codebuild_project", "codebuild", checkedAt, func(r *AWSCredentialReferenceRecord) {
+			r.Reference = "GITHUB_TOKEN=SECRETS_MANAGER:github/ci-token"
+			r.ReferenceName = "GITHUB_TOKEN"
+			r.ReferenceKind = "secrets_manager"
+			r.Provider = credentialProviderGitHub
+			r.ProviderConfidence = 0.88
+			r.Sensitivity = "source_control_token"
+			r.Unresolved = true
+			r.Confidence = 0.88
+		}),
+		awsCredentialReferenceFixtureRecord(accountID, region, codeBuildWorkload, "release", "codebuild_project", "codebuild", checkedAt, func(r *AWSCredentialReferenceRecord) {
+			r.Reference = "SLACK_WEBHOOK_URL"
+			r.ReferenceName = "SLACK_WEBHOOK_URL"
+			r.ReferenceKind = "environment_variable"
+			r.Provider = credentialProviderSlack
+			r.ProviderConfidence = 0.85
+			r.Sensitivity = "messaging_token"
+			r.Unresolved = true
+			r.TargetNodeID = "aws:resource:credential-reference:slack|slack_webhook_url"
+			r.Confidence = 0.85
+		}),
+	}
+	diagnostics := []providers.SourceError{}
+	if fixtureState == "degraded" {
+		records[1].Status = "degraded"
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "credential_reference_mapper", SourceID: ecsWorkload, Code: "workload_environment_partial", Message: "task definition environment was partially redacted by the source collector", Retryable: true})
+	}
+	if fixtureState == "partial_failure" {
+		records = records[:3]
+		diagnostics = append(diagnostics, providers.SourceError{Collector: "credential_reference_mapper", SourceID: codeBuildWorkload, Code: "workload_inventory_partial", Message: "codebuild project batch describe failed for one project", Retryable: true})
+	}
+	return records, diagnostics, gaps
+}
+
+func awsCredentialReferenceFixtureRecord(accountID, region, workloadID, workloadName, resourceType, sourceService string, checkedAt time.Time, mutate func(*AWSCredentialReferenceRecord)) AWSCredentialReferenceRecord {
+	record := AWSCredentialReferenceRecord{
+		AccountID:     accountID,
+		Region:        region,
+		WorkloadID:    workloadID,
+		WorkloadType:  resourceType,
+		WorkloadName:  workloadName,
+		ResourceID:    workloadID,
+		ResourceType:  resourceType,
+		SourceService: sourceService,
+		Provider:      credentialProviderGeneric,
+		Sensitivity:   "generic_secret",
+		ReferenceKind: "environment_variable",
+		Source:        sourceService + "_workload_reference",
+		Confidence:    0.6,
+		CollectedAt:   checkedAt,
+		Status:        "ready",
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	record.EvidenceRef = record.Reference
+	return record
+}
+
+func awsCredentialReferenceEdges(records []AWSCredentialReferenceRecord) []AWSCredentialReferenceEdge {
+	edges := []AWSCredentialReferenceEdge{}
+	for _, record := range records {
+		if strings.TrimSpace(record.TargetNodeID) == "" {
+			continue
+		}
+		edges = append(edges, AWSCredentialReferenceEdge{
+			Type:        "uses_secret",
+			FromNodeID:  record.WorkloadID,
+			ToNodeID:    record.TargetNodeID,
+			EvidenceRef: record.Reference,
+			Source:      record.Source,
+			Resolved:    record.Resolved,
+			Confidence:  record.Confidence,
+		})
+	}
+	return edges
+}
+
+func summarizeAWSCredentialReferencesInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSCredentialReferenceRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.3, []string{"Workload inventory required for credential reference mapping is permission denied."}, []string{"Grant the metadata-only workload collector permissions (ECS, Lambda, CodeBuild describe/list) so references can be mapped."}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72, awsCredentialReferenceMessages(diagnostics), []string{"Review diagnostics and rerun after the affected workload collectors complete."}
+	default:
+		if len(records) == 0 {
+			return awsPlatformDependencyStatusReady, 0.82, nil, []string{"No credential or secret references were found across the inventoried workloads."}
+		}
+		return awsPlatformDependencyStatusReady, 0.93, nil, []string{"Prioritize unresolved external provider keys (AI, source control, database, webhook) for secret-store migration and rotation."}
+	}
+}
+
+func awsCredentialReferenceDiagnostics(diagnostics []providers.SourceError) []AWSCredentialReferenceDiagnostic {
+	result := make([]AWSCredentialReferenceDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSCredentialReferenceDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: "Confirm the metadata-only workload collector permissions; the mapper never reads secret or environment values.",
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func awsCredentialProviderBreakdown(records []AWSCredentialReferenceRecord) map[string]int {
+	breakdown := map[string]int{}
+	for _, record := range records {
+		if record.Provider == "" {
+			continue
+		}
+		breakdown[record.Provider]++
+	}
+	return breakdown
+}
+
+func countCredentialReferences(records []AWSCredentialReferenceRecord, pred func(AWSCredentialReferenceRecord) bool) int {
+	count := 0
+	for _, record := range records {
+		if pred(record) {
+			count++
+		}
+	}
+	return count
+}
+
+func countDistinctCredentialField(records []AWSCredentialReferenceRecord, field func(AWSCredentialReferenceRecord) string) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if value := strings.TrimSpace(field(record)); value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsCredentialReferenceMessages(diagnostics []providers.SourceError) []string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if message := strings.TrimSpace(diagnostic.Message); message != "" {
+			messages = append(messages, message)
+		}
+	}
+	return dedupeStrings(messages)
+}
+
+func awsCredentialReferencePartition(region string) string {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(normalized, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(normalized, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}

--- a/internal/api/aws_credential_references_test.go
+++ b/internal/api/aws_credential_references_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSCredentialReferencesInventoryClassifiesProviders(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 18, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get credential references: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1496" || result.Version != awsCredentialReferencesVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.ReferenceCount != 5 || result.ResolvedReferenceCount != 1 || result.UnresolvedReferenceCount != 4 {
+		t.Fatalf("unexpected counts: %+v", result)
+	}
+	if result.AIProviderKeyCount != 2 || result.DatabaseCredentialCount != 1 || result.ExternalProviderKeyCount != 5 {
+		t.Fatalf("expected provider classification counts, got %+v", result)
+	}
+	if result.ProviderBreakdown[credentialProviderOpenAI] != 1 || result.ProviderBreakdown[credentialProviderGitHub] != 1 {
+		t.Fatalf("expected provider breakdown, got %+v", result.ProviderBreakdown)
+	}
+	// Every record must be reference-only; no values may appear.
+	for _, record := range result.Records {
+		payload, err := json.Marshal(record)
+		if err != nil {
+			t.Fatalf("marshal record: %v", err)
+		}
+		lower := strings.ToLower(string(payload))
+		for _, forbidden := range []string{"getsecretvalue", "getparameter", "secretstring", "=sk-", "plaintext_value"} {
+			if strings.Contains(lower, forbidden) {
+				t.Fatalf("value-like content leaked into record: %s", payload)
+			}
+		}
+	}
+}
+
+func TestGetAWSCredentialReferencesInventoryFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 18, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	openai, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("get provider-filtered inventory: %v", err)
+	}
+	if openai.ReferenceCount != 1 || openai.ProviderBreakdown[credentialProviderOpenAI] != 1 {
+		t.Fatalf("expected one openai reference, got %+v", openai)
+	}
+
+	byType, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", ResourceType: "codebuild_project"})
+	if err != nil {
+		t.Fatalf("get resource-type-filtered inventory: %v", err)
+	}
+	if byType.ReferenceCount != 2 {
+		t.Fatalf("expected two codebuild references, got %+v", byType)
+	}
+
+	byIdentity, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", Identity: "summarizer"})
+	if err != nil {
+		t.Fatalf("get identity-filtered inventory: %v", err)
+	}
+	if byIdentity.ReferenceCount != 1 {
+		t.Fatalf("expected one summarizer reference, got %+v", byIdentity)
+	}
+
+	if _, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", Provider: "bogus"}); err == nil {
+		t.Fatalf("expected invalid provider filter error")
+	}
+}
+
+func TestGetAWSCredentialReferencesInventoryDegradedAndPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 18, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	degraded, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded inventory: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded diagnostics, got %+v", degraded)
+	}
+
+	denied, err := svc.GetAWSCredentialReferencesInventory(ctx, "default", "project-a", AWSCredentialReferencesInventoryRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied inventory: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.ReferenceCount != 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("expected blocked permission-denied inventory, got %+v", denied)
+	}
+}
+
+func TestRouterAWSCredentialReferencesPartialFailureAndInvalid(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 11, 19, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/credential-references?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSCredentialReferencesInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.ReferenceCount == 0 {
+		t.Fatalf("expected degraded partial records, got %+v", body.Inventory)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "provider=bogus"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/credential-references?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2918,6 +2918,39 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/credential-references", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSCredentialReferencesInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSCredentialReferencesInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			ResourceType: strings.TrimSpace(c.Query("resource_type")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			Provider:     strings.TrimSpace(c.Query("provider")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws credential references request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws credential references inventory",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws credential references inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -100,6 +100,7 @@ const (
 	ResourceTypeSageMakerDomain     ResourceType = "sagemaker_domain"
 	ResourceTypeSageMakerWorkload   ResourceType = "sagemaker_workload"
 	ResourceTypeBedrockAgentCore    ResourceType = "bedrock_agentcore"
+	ResourceTypeCredentialReference ResourceType = "credential_reference"
 	ResourceTypeTool                ResourceType = "tool"
 	ResourceTypeAccessNode          ResourceType = "access_node"
 	ResourceTypeRuntimeSession      ResourceType = "runtime_session"

--- a/internal/providers/aws/codebuild_service_role_collector_test.go
+++ b/internal/providers/aws/codebuild_service_role_collector_test.go
@@ -179,14 +179,12 @@ func TestRoleNormalizerAddsCodeBuildServiceRoleRunAsEdge(t *testing.T) {
 	if err := providers.ValidateNormalizedBundle(bundle); err != nil {
 		t.Fatalf("normalized bundle invalid: %v", err)
 	}
-	if len(bundle.Identities) != 1 || len(bundle.Workloads) != 1 || len(bundle.Resources) != 1 {
+	codeBuildResources := resourcesByType(bundle.Resources, domain.ResourceTypeCodeBuildProject)
+	if len(bundle.Identities) != 1 || len(bundle.Workloads) != 1 || len(codeBuildResources) != 1 {
 		t.Fatalf("expected codebuild identity/workload/resource, got identities=%+v workloads=%+v resources=%+v", bundle.Identities, bundle.Workloads, bundle.Resources)
 	}
-	if bundle.Resources[0].Type != domain.ResourceTypeCodeBuildProject {
-		t.Fatalf("expected codebuild project resource, got %+v", bundle.Resources[0])
-	}
-	if strings.Contains(fmtAny(bundle.Resources[0].Metadata["environment_keys"]), "DATABASE_PASSWORD=value") {
-		t.Fatalf("environment values must not be normalized, got %+v", bundle.Resources[0].Metadata)
+	if strings.Contains(fmtAny(codeBuildResources[0].Metadata["environment_keys"]), "DATABASE_PASSWORD=value") {
+		t.Fatalf("environment values must not be normalized, got %+v", codeBuildResources[0].Metadata)
 	}
 
 	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -1,0 +1,436 @@
+package aws
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+// Credential reference providers. Provider detection is metadata/name-pattern
+// only — the mapper never reads a secret value, only the reference that points
+// at one.
+const (
+	credentialProviderOpenAI         = "openai"
+	credentialProviderAnthropic      = "anthropic"
+	credentialProviderBedrock        = "bedrock"
+	credentialProviderGitHub         = "github"
+	credentialProviderSlack          = "slack"
+	credentialProviderDatabase       = "database"
+	credentialProviderWebhook        = "webhook"
+	credentialProviderSecretsManager = "aws_secrets_manager"
+	credentialProviderSSM            = "aws_ssm"
+	credentialProviderGeneric        = "generic"
+)
+
+// Credential reference kinds describe how the workload sources the credential.
+const (
+	credentialKindSecretsManager       = "secrets_manager"
+	credentialKindSSMParameter         = "ssm_parameter"
+	credentialKindRepositoryCredential = "repository_credentials"
+	credentialKindEnvironment          = "environment_variable"
+)
+
+// Credential sensitivity buckets group providers by the kind of secret behind
+// the reference so operators can prioritize.
+const (
+	credentialSensitivityAIProviderKey    = "ai_provider_api_key"
+	credentialSensitivitySourceControl    = "source_control_token"
+	credentialSensitivityMessagingToken   = "messaging_token"
+	credentialSensitivityDatabaseCred     = "database_credential"
+	credentialSensitivityWebhookURL       = "webhook_url"
+	credentialSensitivityAWSManagedSecret = "aws_managed_secret"
+	credentialSensitivityGenericSecret    = "generic_secret"
+)
+
+// CredentialReference is one graph-ready credential or secret reference emitted
+// by an AWS workload. It is metadata-only: Reference and ReferenceName carry
+// names, ARNs, and source markers, never secret values.
+type CredentialReference struct {
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	WorkloadID    string `json:"workload_id,omitempty"`
+	WorkloadType  string `json:"workload_type,omitempty"`
+	WorkloadName  string `json:"workload_name,omitempty"`
+	ResourceID    string `json:"resource_id,omitempty"`
+	ResourceType  string `json:"resource_type,omitempty"`
+	SourceService string `json:"source_service,omitempty"`
+
+	Reference          string  `json:"reference"`
+	ReferenceName      string  `json:"reference_name,omitempty"`
+	ReferenceKind      string  `json:"reference_kind"`
+	Provider           string  `json:"provider"`
+	ProviderConfidence float64 `json:"provider_confidence"`
+	Sensitivity        string  `json:"sensitivity"`
+
+	Resolved     bool   `json:"resolved"`
+	Unresolved   bool   `json:"unresolved"`
+	TargetNodeID string `json:"target_node_id,omitempty"`
+
+	Source      string  `json:"source"`
+	EvidenceRef string  `json:"evidence_ref"`
+	Confidence  float64 `json:"confidence"`
+}
+
+// credentialReferenceNodePrefix namespaces synthesized graph nodes for
+// provider-key references that do not resolve to a collected AWS secret or
+// parameter (for example an inline `OPENAI_API_KEY` environment variable).
+const credentialReferenceNodePrefix = "aws:resource:credential-reference:"
+
+// MapBundleCredentialReferences walks every normalized AWS workload resource,
+// extracts its credential/secret references, classifies the provider, kind,
+// and sensitivity of each, and resolves it against the collected Secrets
+// Manager and SSM Parameter Store nodes. It returns the deduplicated reference
+// records plus the identity→reference graph edges (workload → resolved secret
+// node, or workload → synthesized credential-reference node when the provider
+// key is unresolved). It is a pure function of the bundle and performs no AWS
+// calls and no value reads.
+func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]CredentialReference, []domain.Relationship) {
+	secretIndex := secretsManagerResourceIndex(bundle.Resources)
+	parameterIndex := ssmParameterResourceIndex(bundle.Resources)
+
+	references := []CredentialReference{}
+	relationships := []domain.Relationship{}
+	seenRef := map[string]struct{}{}
+	seenEdge := map[string]struct{}{}
+
+	for _, resource := range bundle.Resources {
+		candidates := credentialCandidateRefs(resource)
+		if len(candidates) == 0 {
+			continue
+		}
+		sourceService := credentialSourceService(resource.Type)
+		fromNodeID := strings.TrimSpace(resource.SourceEntityID)
+		if fromNodeID == "" {
+			fromNodeID = resource.ID
+		}
+		workloadName := strings.TrimSpace(resource.Name)
+		for _, raw := range candidates {
+			ref := classifyCredentialReference(raw, resource, sourceService, secretIndex, parameterIndex)
+			if ref.Reference == "" {
+				continue
+			}
+			ref.WorkloadID = fromNodeID
+			ref.WorkloadName = workloadName
+			ref.AccountID = strings.TrimSpace(resource.AccountID)
+			ref.Region = strings.TrimSpace(resource.Region)
+			ref.ResourceID = resource.ID
+			ref.ResourceType = string(resource.Type)
+
+			refKey := strings.Join([]string{fromNodeID, ref.Reference}, "|")
+			if _, exists := seenRef[refKey]; !exists {
+				seenRef[refKey] = struct{}{}
+				references = append(references, ref)
+			}
+
+			targetNode := ref.TargetNodeID
+			if targetNode == "" {
+				continue
+			}
+			edgeKey := strings.Join([]string{fromNodeID, targetNode}, "|")
+			if _, exists := seenEdge[edgeKey]; exists {
+				continue
+			}
+			seenEdge[edgeKey] = struct{}{}
+			relationships = append(relationships, domain.Relationship{
+				ID:          relationshipID(domain.RelationshipUsesSecret, fromNodeID, targetNode),
+				Type:        domain.RelationshipUsesSecret,
+				FromNodeID:  fromNodeID,
+				ToNodeID:    targetNode,
+				EvidenceRef: ref.Reference,
+			})
+		}
+	}
+
+	sort.SliceStable(references, func(i, j int) bool {
+		if references[i].WorkloadID == references[j].WorkloadID {
+			return references[i].Reference < references[j].Reference
+		}
+		return references[i].WorkloadID < references[j].WorkloadID
+	})
+	sort.SliceStable(relationships, func(i, j int) bool {
+		return relationships[i].ID < relationships[j].ID
+	})
+	return references, relationships
+}
+
+// credentialReferenceNodes returns the synthesized credential-reference
+// resource nodes for unresolved provider-key references, so the graph carries
+// a node for every emitted edge. Resolved references already point at a real
+// Secrets Manager or SSM node and are skipped.
+func credentialReferenceNodes(references []CredentialReference) []domain.Resource {
+	seen := map[string]struct{}{}
+	nodes := []domain.Resource{}
+	for _, ref := range references {
+		if ref.Resolved || ref.TargetNodeID == "" || !strings.HasPrefix(ref.TargetNodeID, credentialReferenceNodePrefix) {
+			continue
+		}
+		if _, exists := seen[ref.TargetNodeID]; exists {
+			continue
+		}
+		seen[ref.TargetNodeID] = struct{}{}
+		nodes = append(nodes, domain.Resource{
+			ID:        ref.TargetNodeID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.ResourceTypeCredentialReference,
+			Name:      firstNonEmptyAWSValue(ref.ReferenceName, ref.Reference),
+			Region:    ref.Region,
+			AccountID: ref.AccountID,
+			Metadata: map[string]any{
+				"provider":       ref.Provider,
+				"sensitivity":    ref.Sensitivity,
+				"reference_kind": ref.ReferenceKind,
+				"unresolved":     true,
+			},
+		})
+	}
+	sort.SliceStable(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	return nodes
+}
+
+// appendCredentialReferenceNodes adds synthesized credential-reference resource
+// nodes for unresolved external provider keys so the graph carries a node for
+// every credential-reference edge the relationship builder will emit. It is a
+// normalizer post-pass: node creation lives in the normalizer, edge creation in
+// the relationship builder, matching the rest of the AWS pipeline.
+func appendCredentialReferenceNodes(bundle *providers.NormalizedBundle, resourceSeen map[string]struct{}) {
+	if bundle == nil {
+		return
+	}
+	references, _ := MapBundleCredentialReferences(*bundle)
+	for _, node := range credentialReferenceNodes(references) {
+		if _, exists := resourceSeen[node.ID]; exists {
+			continue
+		}
+		resourceSeen[node.ID] = struct{}{}
+		bundle.Resources = append(bundle.Resources, node)
+	}
+}
+
+// credentialSourceService maps a workload resource type to the AWS service that
+// owns the credential reference. Any workload that carries credential metadata
+// is mapped; unknown types fall back to the leading segment of the type name so
+// new workload collectors are picked up without changing this mapper.
+func credentialSourceService(resourceType domain.ResourceType) string {
+	switch resourceType {
+	case domain.ResourceTypeECSService, domain.ResourceTypeECSTask:
+		return "ecs"
+	case domain.ResourceTypeLambdaFunction:
+		return "lambda"
+	case domain.ResourceTypeCodeBuildProject:
+		return "codebuild"
+	case domain.ResourceTypeStepFunctions:
+		return "stepfunctions"
+	case domain.ResourceTypeEC2Instance, domain.ResourceTypeEC2InstanceProfile:
+		return "ec2"
+	}
+	typeName := string(resourceType)
+	if idx := strings.Index(typeName, "_"); idx > 0 {
+		return typeName[:idx]
+	}
+	if typeName == "" {
+		return "aws"
+	}
+	return typeName
+}
+
+// credentialCandidateRefs returns every raw reference string worth classifying
+// for one resource: explicit secret/source references plus the subset of
+// environment variable names whose name pattern indicates a provider key or
+// credential. Plain environment keys that are not credential-suggestive are
+// ignored to avoid noise.
+func credentialCandidateRefs(resource domain.Resource) []string {
+	refs := parseStringList(resource.Metadata["secret_refs"])
+	out := append([]string(nil), refs...)
+	for _, key := range parseStringList(resource.Metadata["environment_keys"]) {
+		if credentialSuggestiveName(key) {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// classifyCredentialReference parses one raw reference into a classified
+// CredentialReference, resolving it against the collected secret/parameter
+// indexes. The raw form may be `NAME=SOURCE` (ECS/CodeBuild), a bare ARN, a
+// `PARAMETER_STORE:`/`SECRETS_MANAGER:` source, or a bare environment key.
+func classifyCredentialReference(raw string, resource domain.Resource, sourceService string, secretIndex, parameterIndex map[string]string) CredentialReference {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return CredentialReference{}
+	}
+	name, source := splitCredentialReference(trimmed)
+
+	ref := CredentialReference{
+		WorkloadType:  string(resource.Type),
+		SourceService: sourceService,
+		Reference:     trimmed,
+		ReferenceName: name,
+		Source:        sourceService + "_workload_reference",
+		EvidenceRef:   trimmed,
+	}
+	ref.ReferenceKind = classifyCredentialReferenceKind(name, source)
+
+	// Resolve against collected AWS secret/parameter nodes first; a resolved
+	// node lets provider detection also consider the secret's own name.
+	resolveTarget := firstNonEmptyAWSValue(source, trimmed)
+	if secretID := matchSecretsManagerReference(resolveTarget, secretIndex); secretID != "" {
+		ref.Resolved = true
+		ref.TargetNodeID = secretID
+	} else if parameterID := matchSSMParameterReference(resolveTarget, parameterIndex); parameterID != "" {
+		ref.Resolved = true
+		ref.TargetNodeID = parameterID
+	}
+
+	provider, sensitivity, confidence := classifyCredentialProvider(name, source, ref.ReferenceKind)
+	ref.Provider = provider
+	ref.Sensitivity = sensitivity
+	ref.ProviderConfidence = confidence
+	ref.Confidence = credentialReferenceConfidence(ref)
+
+	if !ref.Resolved {
+		ref.Unresolved = true
+		// Synthesize a stable node only for recognized provider-key references
+		// so the graph gains a node for the emitted edge. AWS-native kinds that
+		// simply were not collected stay edge-less to avoid dangling nodes.
+		if credentialProviderIsExternal(provider) {
+			ref.TargetNodeID = credentialReferenceNodeID(provider, name, source)
+		}
+	}
+	return ref
+}
+
+// splitCredentialReference separates a `NAME=SOURCE` reference into its env-var
+// name and source marker. References without `=` are treated as a bare source
+// (ARN / parameter ref) with no separate name.
+func splitCredentialReference(ref string) (name string, source string) {
+	if idx := strings.Index(ref, "="); idx > 0 {
+		return strings.TrimSpace(ref[:idx]), strings.TrimSpace(ref[idx+1:])
+	}
+	// A bare environment key (no source) is its own name.
+	if !strings.Contains(ref, ":") && !strings.Contains(ref, "/") {
+		return ref, ""
+	}
+	return "", ref
+}
+
+// classifyCredentialReferenceKind determines how the workload sources the
+// credential from the env-var name and source marker.
+func classifyCredentialReferenceKind(name, source string) string {
+	probe := strings.ToLower(source)
+	switch {
+	case strings.Contains(probe, ":secretsmanager:") || strings.HasPrefix(probe, "secrets_manager:"):
+		return credentialKindSecretsManager
+	case strings.Contains(probe, ":ssm:") || strings.Contains(probe, ":parameter/") || strings.HasPrefix(probe, "parameter_store:"):
+		return credentialKindSSMParameter
+	case strings.EqualFold(strings.TrimSpace(name), "repository_credentials"):
+		return credentialKindRepositoryCredential
+	case source == "":
+		return credentialKindEnvironment
+	default:
+		return credentialKindEnvironment
+	}
+}
+
+// classifyCredentialProvider detects the credential provider by name pattern
+// across both the env-var name and the source marker (which may embed a secret
+// or parameter name such as `secret:openai/api-key`). Returns the provider, its
+// sensitivity bucket, and a detection confidence.
+func classifyCredentialProvider(name, source, referenceKind string) (provider string, sensitivity string, confidence float64) {
+	probe := strings.ToLower(name + " " + source)
+	switch {
+	case containsAnyToken(probe, "openai", "open_ai", "gpt_"):
+		return credentialProviderOpenAI, credentialSensitivityAIProviderKey, 0.9
+	case containsAnyToken(probe, "anthropic", "claude"):
+		return credentialProviderAnthropic, credentialSensitivityAIProviderKey, 0.9
+	case containsAnyToken(probe, "bedrock"):
+		return credentialProviderBedrock, credentialSensitivityAIProviderKey, 0.85
+	case containsAnyToken(probe, "github", "gh_token", "gh_pat", "ghp_"):
+		return credentialProviderGitHub, credentialSensitivitySourceControl, 0.88
+	case containsAnyToken(probe, "slack", "xoxb", "xoxp"):
+		return credentialProviderSlack, credentialSensitivityMessagingToken, 0.85
+	case credentialLooksLikeDatabase(probe):
+		return credentialProviderDatabase, credentialSensitivityDatabaseCred, 0.8
+	case containsAnyToken(probe, "webhook", "hook_url", "_hook"):
+		return credentialProviderWebhook, credentialSensitivityWebhookURL, 0.8
+	}
+	switch referenceKind {
+	case credentialKindSecretsManager:
+		return credentialProviderSecretsManager, credentialSensitivityAWSManagedSecret, 0.7
+	case credentialKindSSMParameter:
+		return credentialProviderSSM, credentialSensitivityAWSManagedSecret, 0.7
+	default:
+		return credentialProviderGeneric, credentialSensitivityGenericSecret, 0.6
+	}
+}
+
+func credentialLooksLikeDatabase(probe string) bool {
+	return containsAnyToken(probe,
+		"database_url", "database_password", "db_password", "db_user", "db_host",
+		"postgres", "postgresql", "mysql", "mariadb", "mongodb", "mongo_uri",
+		"redis_url", "rds", "_dsn", "connection_string", "conn_string")
+}
+
+// credentialSuggestiveName reports whether a bare environment variable name is
+// credential-bearing enough to map as a reference on its own. This filters the
+// long tail of non-secret environment keys.
+func credentialSuggestiveName(name string) bool {
+	probe := strings.ToLower(strings.TrimSpace(name))
+	if probe == "" {
+		return false
+	}
+	return containsAnyToken(probe,
+		"secret", "token", "api_key", "apikey", "password", "passwd",
+		"credential", "private_key", "access_key", "client_secret",
+		"openai", "anthropic", "claude", "bedrock", "github", "slack",
+		"webhook", "database_url", "db_password", "connection_string")
+}
+
+// credentialProviderIsExternal reports whether the provider is a non-AWS
+// external service. Only external provider keys synthesize credential-reference
+// graph nodes when unresolved.
+func credentialProviderIsExternal(provider string) bool {
+	switch provider {
+	case credentialProviderOpenAI, credentialProviderAnthropic, credentialProviderBedrock,
+		credentialProviderGitHub, credentialProviderSlack, credentialProviderDatabase,
+		credentialProviderWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
+// credentialReferenceConfidence scores the overall record confidence from
+// resolution status and provider-detection confidence.
+func credentialReferenceConfidence(ref CredentialReference) float64 {
+	switch {
+	case ref.Resolved:
+		// A resolved AWS node is strong evidence regardless of provider guess.
+		if ref.ProviderConfidence > 0.9 {
+			return 0.95
+		}
+		return 0.9
+	case ref.Provider == credentialProviderGeneric:
+		return 0.6
+	default:
+		return ref.ProviderConfidence
+	}
+}
+
+func credentialReferenceNodeID(provider, name, source string) string {
+	return credentialReferenceNodePrefix + strings.Join(normalizeStringList([]string{
+		provider,
+		strings.ToLower(strings.TrimSpace(name)),
+		strings.ToLower(strings.TrimSpace(source)),
+	}), "|")
+}
+
+func containsAnyToken(haystack string, tokens ...string) bool {
+	for _, token := range tokens {
+		if token != "" && strings.Contains(haystack, token) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -101,10 +101,7 @@ func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]Credent
 			continue
 		}
 		sourceService := credentialSourceService(resource.Type)
-		fromNodeID := strings.TrimSpace(resource.SourceEntityID)
-		if fromNodeID == "" {
-			fromNodeID = resource.ID
-		}
+		fromNodeID := credentialWorkloadNodeID(resource)
 		workloadName := strings.TrimSpace(resource.Name)
 		for _, raw := range candidates {
 			ref := classifyCredentialReference(raw, resource, sourceService, secretIndex, parameterIndex)
@@ -295,7 +292,7 @@ func classifyCredentialReference(raw string, resource domain.Resource, sourceSer
 		// so the graph gains a node for the emitted edge. AWS-native kinds that
 		// simply were not collected stay edge-less to avoid dangling nodes.
 		if credentialProviderIsExternal(provider) {
-			ref.TargetNodeID = credentialReferenceNodeID(provider, name, source)
+			ref.TargetNodeID = credentialReferenceNodeID(credentialWorkloadNodeID(resource), provider, name, source)
 		}
 	}
 	return ref
@@ -418,8 +415,23 @@ func credentialReferenceConfidence(ref CredentialReference) float64 {
 	}
 }
 
-func credentialReferenceNodeID(provider, name, source string) string {
+// credentialWorkloadNodeID resolves the workload graph node a reference is
+// anchored to: the workload's source entity, falling back to the resource ID.
+func credentialWorkloadNodeID(resource domain.Resource) string {
+	if id := strings.TrimSpace(resource.SourceEntityID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(resource.ID)
+}
+
+// credentialReferenceNodeID builds the synthesized node ID for an unresolved
+// external provider key. It is scoped per workload: an unresolved reference is
+// not evidence that two workloads share one credential, so distinct workloads
+// (and accounts/regions, which the workload ID already encodes) get distinct
+// nodes rather than collapsing onto a shared, mislabeled node.
+func credentialReferenceNodeID(workloadID, provider, name, source string) string {
 	return credentialReferenceNodePrefix + strings.Join(normalizeStringList([]string{
+		strings.ToLower(strings.TrimSpace(workloadID)),
 		provider,
 		strings.ToLower(strings.TrimSpace(name)),
 		strings.ToLower(strings.TrimSpace(source)),

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -237,13 +237,28 @@ func credentialSourceService(resourceType domain.ResourceType) string {
 // environment variable names whose name pattern indicates a provider key or
 // credential. Plain environment keys that are not credential-suggestive are
 // ignored to avoid noise.
+//
+// An environment key that is already the left-hand side of a `secret_refs`
+// entry (for example a CodeBuild `DATABASE_PASSWORD` sourced from Parameter
+// Store appears in both lists) is skipped, so a secret-store-backed variable
+// is not also reported as a phantom inline credential.
 func credentialCandidateRefs(resource domain.Resource) []string {
 	refs := parseStringList(resource.Metadata["secret_refs"])
 	out := append([]string(nil), refs...)
-	for _, key := range parseStringList(resource.Metadata["environment_keys"]) {
-		if credentialSuggestiveName(key) {
-			out = append(out, key)
+	sourced := map[string]struct{}{}
+	for _, ref := range refs {
+		if name, _ := splitCredentialReference(strings.TrimSpace(ref)); name != "" {
+			sourced[strings.ToLower(name)] = struct{}{}
 		}
+	}
+	for _, key := range parseStringList(resource.Metadata["environment_keys"]) {
+		if !credentialSuggestiveName(key) {
+			continue
+		}
+		if _, exists := sourced[strings.ToLower(strings.TrimSpace(key))]; exists {
+			continue
+		}
+		out = append(out, key)
 	}
 	return out
 }
@@ -269,15 +284,25 @@ func classifyCredentialReference(raw string, resource domain.Resource, sourceSer
 	}
 	ref.ReferenceKind = classifyCredentialReferenceKind(name, source)
 
-	// Resolve against collected AWS secret/parameter nodes first; a resolved
-	// node lets provider detection also consider the secret's own name.
-	resolveTarget := firstNonEmptyAWSValue(source, trimmed)
-	if secretID := matchSecretsManagerReference(resolveTarget, secretIndex); secretID != "" {
-		ref.Resolved = true
-		ref.TargetNodeID = secretID
-	} else if parameterID := matchSSMParameterReference(resolveTarget, parameterIndex); parameterID != "" {
-		ref.Resolved = true
-		ref.TargetNodeID = parameterID
+	// Resolve against collected AWS secret/parameter nodes only when the workload
+	// supplies an explicit source marker. Bare environment variable keys can be
+	// identical to collected names; resolving them here would create false
+	// confidence edges.
+	resolveTarget := strings.TrimSpace(source)
+	if resolveTarget != "" {
+		if secretID := matchSecretsManagerReference(resolveTarget, secretIndex); secretID != "" {
+			ref.Resolved = true
+			ref.ReferenceKind = credentialKindSecretsManager
+			ref.TargetNodeID = secretID
+		} else if parameterID := matchSSMParameterReference(resolveTarget, parameterIndex); parameterID != "" {
+			ref.Resolved = true
+			ref.ReferenceKind = credentialKindSSMParameter
+			ref.TargetNodeID = parameterID
+		}
+	}
+	// Bare env keys must stay explicit as unresolved references.
+	if !ref.Resolved && resolveTarget == "" {
+		ref.ReferenceKind = credentialKindEnvironment
 	}
 
 	provider, sensitivity, confidence := classifyCredentialProvider(name, source, ref.ReferenceKind)

--- a/internal/providers/aws/credential_reference_mapper_test.go
+++ b/internal/providers/aws/credential_reference_mapper_test.go
@@ -1,0 +1,319 @@
+package aws
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+func workloadResource(id, name string, resType domain.ResourceType, secretRefs, envKeys []string) domain.Resource {
+	return domain.Resource{
+		ID:             id,
+		Provider:       domain.ProviderAWS,
+		Type:           resType,
+		Name:           name,
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		SourceEntityID: id,
+		Metadata: map[string]any{
+			"secret_refs":      secretRefs,
+			"environment_keys": envKeys,
+		},
+	}
+}
+
+// resourcesByType returns the bundle resources of one type, used by workload
+// collector tests that assert on their own resource while tolerating the
+// credential-reference nodes the normalizer now synthesizes.
+func resourcesByType(resources []domain.Resource, resType domain.ResourceType) []domain.Resource {
+	out := []domain.Resource{}
+	for _, resource := range resources {
+		if resource.Type == resType {
+			out = append(out, resource)
+		}
+	}
+	return out
+}
+
+func findCredentialReference(refs []CredentialReference, reference string) (CredentialReference, bool) {
+	for _, ref := range refs {
+		if ref.Reference == reference {
+			return ref, true
+		}
+	}
+	return CredentialReference{}, false
+}
+
+func TestMapBundleCredentialReferencesClassifiesProviders(t *testing.T) {
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			workloadResource(
+				"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+				"payments",
+				domain.ResourceTypeECSService,
+				[]string{
+					"OPENAI_API_KEY=arn:aws:secretsmanager:us-east-1:123456789012:secret:openai/key-AbCdEf",
+					"DATABASE_PASSWORD=PARAMETER_STORE:/payments/db/password",
+				},
+				[]string{"ANTHROPIC_API_KEY", "LOG_LEVEL"},
+			),
+			workloadResource(
+				"arn:aws:codebuild:us-east-1:123456789012:project/release",
+				"release",
+				domain.ResourceTypeCodeBuildProject,
+				[]string{
+					"GITHUB_TOKEN=SECRETS_MANAGER:github/ci-token",
+					"SLACK_WEBHOOK_URL=arn:aws:secretsmanager:us-east-1:123456789012:secret:slack/webhook-XyZ",
+				},
+				nil,
+			),
+		},
+	}
+
+	refs, _ := MapBundleCredentialReferences(bundle)
+
+	cases := []struct {
+		reference       string
+		wantProvider    string
+		wantSensitivity string
+		wantKind        string
+	}{
+		{"OPENAI_API_KEY=arn:aws:secretsmanager:us-east-1:123456789012:secret:openai/key-AbCdEf", credentialProviderOpenAI, credentialSensitivityAIProviderKey, credentialKindSecretsManager},
+		{"DATABASE_PASSWORD=PARAMETER_STORE:/payments/db/password", credentialProviderDatabase, credentialSensitivityDatabaseCred, credentialKindSSMParameter},
+		{"ANTHROPIC_API_KEY", credentialProviderAnthropic, credentialSensitivityAIProviderKey, credentialKindEnvironment},
+		{"GITHUB_TOKEN=SECRETS_MANAGER:github/ci-token", credentialProviderGitHub, credentialSensitivitySourceControl, credentialKindSecretsManager},
+		{"SLACK_WEBHOOK_URL=arn:aws:secretsmanager:us-east-1:123456789012:secret:slack/webhook-XyZ", credentialProviderSlack, credentialSensitivityMessagingToken, credentialKindSecretsManager},
+	}
+	for _, tc := range cases {
+		ref, ok := findCredentialReference(refs, tc.reference)
+		if !ok {
+			t.Fatalf("missing reference %q in %+v", tc.reference, refs)
+		}
+		if ref.Provider != tc.wantProvider {
+			t.Fatalf("reference %q provider = %q, want %q", tc.reference, ref.Provider, tc.wantProvider)
+		}
+		if ref.Sensitivity != tc.wantSensitivity {
+			t.Fatalf("reference %q sensitivity = %q, want %q", tc.reference, ref.Sensitivity, tc.wantSensitivity)
+		}
+		if ref.ReferenceKind != tc.wantKind {
+			t.Fatalf("reference %q kind = %q, want %q", tc.reference, ref.ReferenceKind, tc.wantKind)
+		}
+	}
+
+	if _, ok := findCredentialReference(refs, "LOG_LEVEL"); ok {
+		t.Fatalf("non-credential environment key LOG_LEVEL should be ignored")
+	}
+}
+
+func TestMapBundleCredentialReferencesResolvesAgainstCollectedSecrets(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:openai/key-AbCdEf"
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			{
+				ID:        secretsManagerSecretResourceID(secretARN),
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeSecretsManager,
+				Name:      "openai/key",
+				ARN:       secretARN,
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+			},
+			workloadResource(
+				"arn:aws:lambda:us-east-1:123456789012:function:summarizer",
+				"summarizer",
+				domain.ResourceTypeLambdaFunction,
+				[]string{"OPENAI_API_KEY=" + secretARN},
+				nil,
+			),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+
+	ref, ok := findCredentialReference(refs, "OPENAI_API_KEY="+secretARN)
+	if !ok {
+		t.Fatalf("missing resolved reference in %+v", refs)
+	}
+	if !ref.Resolved || ref.Unresolved {
+		t.Fatalf("expected resolved reference, got %+v", ref)
+	}
+	if ref.TargetNodeID != secretsManagerSecretResourceID(secretARN) {
+		t.Fatalf("resolved target = %q, want secret node", ref.TargetNodeID)
+	}
+	if ref.Provider != credentialProviderOpenAI {
+		t.Fatalf("provider = %q, want openai", ref.Provider)
+	}
+	if ref.Confidence < 0.9 {
+		t.Fatalf("resolved reference confidence = %v, want >= 0.9", ref.Confidence)
+	}
+	found := false
+	for _, rel := range relationships {
+		if rel.Type == domain.RelationshipUsesSecret && rel.FromNodeID == "arn:aws:lambda:us-east-1:123456789012:function:summarizer" && rel.ToNodeID == secretsManagerSecretResourceID(secretARN) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected uses_secret edge to resolved secret node, got %+v", relationships)
+	}
+}
+
+func TestMapBundleCredentialReferencesSynthesizesUnresolvedProviderNodes(t *testing.T) {
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			workloadResource(
+				"arn:aws:lambda:us-east-1:123456789012:function:agent",
+				"agent",
+				domain.ResourceTypeLambdaFunction,
+				nil,
+				[]string{"OPENAI_API_KEY"},
+			),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+	ref, ok := findCredentialReference(refs, "OPENAI_API_KEY")
+	if !ok {
+		t.Fatalf("missing unresolved reference in %+v", refs)
+	}
+	if ref.Resolved || !ref.Unresolved {
+		t.Fatalf("expected unresolved reference, got %+v", ref)
+	}
+	if !strings.HasPrefix(ref.TargetNodeID, credentialReferenceNodePrefix) {
+		t.Fatalf("expected synthesized credential-reference node id, got %q", ref.TargetNodeID)
+	}
+
+	nodes := credentialReferenceNodes(refs)
+	if len(nodes) != 1 || nodes[0].Type != domain.ResourceTypeCredentialReference {
+		t.Fatalf("expected one credential-reference node, got %+v", nodes)
+	}
+	if nodes[0].Metadata["provider"] != credentialProviderOpenAI {
+		t.Fatalf("node provider metadata = %v, want openai", nodes[0].Metadata["provider"])
+	}
+
+	found := false
+	for _, rel := range relationships {
+		if rel.ToNodeID == ref.TargetNodeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected edge to synthesized node, got %+v", relationships)
+	}
+}
+
+func TestMapBundleCredentialReferencesGenericAWSSecretStaysEdgeless(t *testing.T) {
+	// A Secrets Manager reference with no provider hint that does not resolve to
+	// a collected secret should be recorded but must not synthesize a node.
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			workloadResource(
+				"arn:aws:ecs:us-east-1:123456789012:service/prod/worker",
+				"worker",
+				domain.ResourceTypeECSService,
+				[]string{"APP_SECRET=arn:aws:secretsmanager:us-east-1:123456789012:secret:app/config-ZzZ"},
+				nil,
+			),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+	ref, ok := findCredentialReference(refs, "APP_SECRET=arn:aws:secretsmanager:us-east-1:123456789012:secret:app/config-ZzZ")
+	if !ok {
+		t.Fatalf("missing reference in %+v", refs)
+	}
+	if ref.Provider != credentialProviderSecretsManager {
+		t.Fatalf("provider = %q, want aws_secrets_manager", ref.Provider)
+	}
+	if ref.TargetNodeID != "" {
+		t.Fatalf("unresolved generic AWS secret should not synthesize a node, got %q", ref.TargetNodeID)
+	}
+	if len(relationships) != 0 {
+		t.Fatalf("expected no edges for unresolved generic AWS secret, got %+v", relationships)
+	}
+	if len(credentialReferenceNodes(refs)) != 0 {
+		t.Fatalf("expected no synthesized nodes for generic AWS secret")
+	}
+}
+
+func TestNormalizerAndGraphEmitCredentialReferenceNodeAndEdge(t *testing.T) {
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     rawKindECSTaskRole,
+		SourceID: "ecs-service",
+		Payload: []byte(`{
+			"account_id":"123456789012",
+			"region":"us-east-1",
+			"service":"ecs",
+			"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/prod",
+			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/agent",
+			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/agent",
+			"workload_type":"ecs_service",
+			"workload_name":"agent",
+			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/agent:3",
+			"role_arn":"arn:aws:iam::123456789012:role/agent-task",
+			"environment_keys":["OPENAI_API_KEY","LOG_LEVEL"]
+		}`),
+	}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := providers.ValidateNormalizedBundle(bundle); err != nil {
+		t.Fatalf("normalized bundle invalid: %v", err)
+	}
+	credentialNodes := resourcesByType(bundle.Resources, domain.ResourceTypeCredentialReference)
+	if len(credentialNodes) != 1 || credentialNodes[0].Metadata["provider"] != credentialProviderOpenAI {
+		t.Fatalf("expected one openai credential-reference node, got %+v", credentialNodes)
+	}
+
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("resolve relationships: %v", err)
+	}
+	if err := providers.ValidateGraphContract(bundle, relationships); err != nil {
+		t.Fatalf("graph contract invalid: %v", err)
+	}
+	found := false
+	for _, rel := range relationships {
+		if rel.Type == domain.RelationshipUsesSecret && rel.ToNodeID == credentialNodes[0].ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected uses_secret edge to credential-reference node, got %+v", relationships)
+	}
+}
+
+func TestMapBundleCredentialReferencesDeterministicAndDeduped(t *testing.T) {
+	resource := workloadResource(
+		"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+		"payments",
+		domain.ResourceTypeECSService,
+		[]string{"OPENAI_API_KEY=https://example.invalid/key", "OPENAI_API_KEY=https://example.invalid/key"},
+		[]string{"GITHUB_TOKEN"},
+	)
+	bundle := providers.NormalizedBundle{Resources: []domain.Resource{resource}}
+
+	firstRefs, firstRels := MapBundleCredentialReferences(bundle)
+	secondRefs, secondRels := MapBundleCredentialReferences(bundle)
+
+	if len(firstRefs) != len(secondRefs) || len(firstRels) != len(secondRels) {
+		t.Fatalf("non-deterministic counts: refs %d/%d rels %d/%d", len(firstRefs), len(secondRefs), len(firstRels), len(secondRels))
+	}
+	for i := range firstRefs {
+		if firstRefs[i].Reference != secondRefs[i].Reference {
+			t.Fatalf("non-deterministic ordering at %d: %q vs %q", i, firstRefs[i].Reference, secondRefs[i].Reference)
+		}
+	}
+	// The duplicated OPENAI ref must be deduped to a single record.
+	count := 0
+	for _, ref := range firstRefs {
+		if ref.Reference == "OPENAI_API_KEY=https://example.invalid/key" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected deduped reference, got %d copies", count)
+	}
+}

--- a/internal/providers/aws/credential_reference_mapper_test.go
+++ b/internal/providers/aws/credential_reference_mapper_test.go
@@ -204,6 +204,49 @@ func TestMapBundleCredentialReferencesSynthesizesUnresolvedProviderNodes(t *test
 	}
 }
 
+func TestMapBundleCredentialReferencesScopesSynthesizedNodesPerWorkload(t *testing.T) {
+	// Two workloads in different accounts both expose an unresolved OPENAI_API_KEY.
+	// An unresolved reference is not evidence they share one credential, so each
+	// must get its own credential-reference node with its own account/region.
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			func() domain.Resource {
+				r := workloadResource("arn:aws:lambda:us-east-1:111111111111:function:a", "a", domain.ResourceTypeLambdaFunction, nil, []string{"OPENAI_API_KEY"})
+				r.AccountID = "111111111111"
+				return r
+			}(),
+			func() domain.Resource {
+				r := workloadResource("arn:aws:lambda:us-west-2:222222222222:function:b", "b", domain.ResourceTypeLambdaFunction, nil, []string{"OPENAI_API_KEY"})
+				r.AccountID = "222222222222"
+				r.Region = "us-west-2"
+				return r
+			}(),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+	nodes := credentialReferenceNodes(refs)
+	if len(nodes) != 2 {
+		t.Fatalf("expected one node per workload, got %+v", nodes)
+	}
+	if nodes[0].ID == nodes[1].ID {
+		t.Fatalf("distinct workloads must not share a credential-reference node id: %q", nodes[0].ID)
+	}
+	accounts := map[string]struct{}{nodes[0].AccountID: {}, nodes[1].AccountID: {}}
+	if _, ok := accounts["111111111111"]; !ok {
+		t.Fatalf("expected per-workload account metadata, got %+v", nodes)
+	}
+	if _, ok := accounts["222222222222"]; !ok {
+		t.Fatalf("expected per-workload account metadata, got %+v", nodes)
+	}
+	if len(relationships) != 2 {
+		t.Fatalf("expected one edge per workload, got %+v", relationships)
+	}
+	if relationships[0].ToNodeID == relationships[1].ToNodeID {
+		t.Fatalf("distinct workloads must not point at the same node: %+v", relationships)
+	}
+}
+
 func TestMapBundleCredentialReferencesGenericAWSSecretStaysEdgeless(t *testing.T) {
 	// A Secrets Manager reference with no provider hint that does not resolve to
 	// a collected secret should be recorded but must not synthesize a node.

--- a/internal/providers/aws/credential_reference_mapper_test.go
+++ b/internal/providers/aws/credential_reference_mapper_test.go
@@ -204,6 +204,145 @@ func TestMapBundleCredentialReferencesSynthesizesUnresolvedProviderNodes(t *test
 	}
 }
 
+func TestMapBundleCredentialReferencesSkipsEnvKeysAlreadySourced(t *testing.T) {
+	// CodeBuild lists a Parameter Store-backed DATABASE_PASSWORD in both
+	// secret_refs (as NAME=source) and environment_keys (bare name). The bare
+	// name must not produce a second, phantom inline credential; only the
+	// sourced reference (here resolving to the collected parameter) survives.
+	paramARN := "arn:aws:ssm:us-east-1:123456789012:parameter/payments/db/password"
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			{
+				ID:        ssmParameterResourceID(paramARN),
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeSSMParameter,
+				Name:      "/payments/db/password",
+				ARN:       paramARN,
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+			},
+			workloadResource(
+				"arn:aws:codebuild:us-east-1:123456789012:project/release",
+				"release",
+				domain.ResourceTypeCodeBuildProject,
+				[]string{"DATABASE_PASSWORD=PARAMETER_STORE:/payments/db/password"},
+				[]string{"DATABASE_PASSWORD", "LOG_LEVEL"},
+			),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+
+	databaseRefs := 0
+	for _, ref := range refs {
+		if ref.Provider == credentialProviderDatabase {
+			databaseRefs++
+		}
+	}
+	if databaseRefs != 1 {
+		t.Fatalf("expected one database reference (the sourced one), got %d: %+v", databaseRefs, refs)
+	}
+	if _, ok := findCredentialReference(refs, "DATABASE_PASSWORD"); ok {
+		t.Fatalf("bare DATABASE_PASSWORD env key must be suppressed when already sourced via secret_refs")
+	}
+	if len(credentialReferenceNodes(refs)) != 0 {
+		t.Fatalf("a secret-store-backed variable must not synthesize a phantom inline node, got %+v", credentialReferenceNodes(refs))
+	}
+	if len(relationships) != 1 || relationships[0].ToNodeID != ssmParameterResourceID(paramARN) {
+		t.Fatalf("expected one edge to the collected parameter node, got %+v", relationships)
+	}
+}
+
+func TestMapBundleCredentialReferencesKeepsBareEnvKeysUnresolvedEvenWhenNameMatchesCollectedSecret(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:OPENAI_API_KEY"
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			{
+				ID:        secretsManagerSecretResourceID(secretARN),
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeSecretsManager,
+				Name:      "OPENAI_API_KEY",
+				ARN:       secretARN,
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+			},
+			workloadResource(
+				"arn:aws:lambda:us-east-1:123456789012:function:agent",
+				"agent",
+				domain.ResourceTypeLambdaFunction,
+				nil,
+				[]string{"OPENAI_API_KEY"},
+			),
+		},
+	}
+
+	refs, relationships := MapBundleCredentialReferences(bundle)
+
+	ref, ok := findCredentialReference(refs, "OPENAI_API_KEY")
+	if !ok {
+		t.Fatalf("missing reference in %+v", refs)
+	}
+	if ref.Resolved {
+		t.Fatalf("bare env key should not resolve from matching secret name: %+v", ref)
+	}
+	if !ref.Unresolved {
+		t.Fatalf("expected unresolved bare env key, got %+v", ref)
+	}
+	if ref.ReferenceKind != credentialKindEnvironment {
+		t.Fatalf("expected environment kind for bare env key, got %q", ref.ReferenceKind)
+	}
+	if ref.Provider != credentialProviderOpenAI {
+		t.Fatalf("expected openai provider for bare OPENAI_API_KEY, got %q", ref.Provider)
+	}
+	for _, rel := range relationships {
+		if rel.ToNodeID == secretsManagerSecretResourceID(secretARN) {
+			t.Fatalf("unexpected relationship to collected secret for bare env key: %+v", rel)
+		}
+	}
+}
+
+func TestMapBundleCredentialReferencesReclassifiesNameOnlySecretRefs(t *testing.T) {
+	paramARN := "arn:aws:ssm:us-east-1:123456789012:parameter/payments/config"
+	bundle := providers.NormalizedBundle{
+		Resources: []domain.Resource{
+			{
+				ID:        ssmParameterResourceID(paramARN),
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeSSMParameter,
+				Name:      "/payments/config",
+				ARN:       paramARN,
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+			},
+			workloadResource(
+				"arn:aws:ecs:us-east-1:123456789012:service/prod/worker",
+				"worker",
+				domain.ResourceTypeECSService,
+				[]string{"APP_CONFIG=/payments/config"},
+				nil,
+			),
+		},
+	}
+
+	refs, _ := MapBundleCredentialReferences(bundle)
+	ref, ok := findCredentialReference(refs, "APP_CONFIG=/payments/config")
+	if !ok {
+		t.Fatalf("missing reference in %+v", refs)
+	}
+	if !ref.Resolved {
+		t.Fatalf("expected resolved reference, got %+v", ref)
+	}
+	if ref.ReferenceKind != credentialKindSSMParameter {
+		t.Fatalf("expected SSM parameter kind, got %q", ref.ReferenceKind)
+	}
+	if ref.Provider != credentialProviderSSM {
+		t.Fatalf("expected aws_ssm provider, got %q", ref.Provider)
+	}
+	if ref.TargetNodeID != ssmParameterResourceID(paramARN) {
+		t.Fatalf("expected target %q, got %q", ssmParameterResourceID(paramARN), ref.TargetNodeID)
+	}
+}
+
 func TestMapBundleCredentialReferencesScopesSynthesizedNodesPerWorkload(t *testing.T) {
 	// Two workloads in different accounts both expose an unresolved OPENAI_API_KEY.
 	// An unresolved reference is not evidence they share one credential, so each

--- a/internal/providers/aws/ecs_task_role_collector_test.go
+++ b/internal/providers/aws/ecs_task_role_collector_test.go
@@ -199,7 +199,8 @@ func TestRoleNormalizerAddsECSTaskAndExecutionRoleEdges(t *testing.T) {
 	if len(bundle.Identities) != 2 || len(bundle.Workloads) != 2 {
 		t.Fatalf("expected task and execution role identities/workloads, got identities=%+v workloads=%+v", bundle.Identities, bundle.Workloads)
 	}
-	if len(bundle.Resources) != 2 {
+	workloadResources := append(resourcesByType(bundle.Resources, domain.ResourceTypeECSService), resourcesByType(bundle.Resources, domain.ResourceTypeECSTask)...)
+	if len(workloadResources) != 2 {
 		t.Fatalf("expected service and task definition resources, got %+v", bundle.Resources)
 	}
 	for _, resource := range bundle.Resources {

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -129,6 +129,9 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 	// reuse the same uses_secret edge IDs as the secret/parameter matching above
 	// (deduped by appendRelationship); unresolved external provider keys add
 	// edges to the synthesized credential-reference nodes from the normalizer.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	_, credentialEdges := MapBundleCredentialReferences(bundle)
 	for _, edge := range credentialEdges {
 		if err := ctx.Err(); err != nil {

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -125,6 +125,19 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 		}
 	}
 
+	// Credential/secret reference edges across workloads. Resolved references
+	// reuse the same uses_secret edge IDs as the secret/parameter matching above
+	// (deduped by appendRelationship); unresolved external provider keys add
+	// edges to the synthesized credential-reference nodes from the normalizer.
+	_, credentialEdges := MapBundleCredentialReferences(bundle)
+	for _, edge := range credentialEdges {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		edge.DiscoveredAt = timestamp
+		appendRelationship(&relationships, seen, edge)
+	}
+
 	for _, policy := range bundle.Policies {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/internal/providers/aws/lambda_execution_role_collector_test.go
+++ b/internal/providers/aws/lambda_execution_role_collector_test.go
@@ -188,14 +188,12 @@ func TestRoleNormalizerAddsLambdaExecutionRoleRunAsEdge(t *testing.T) {
 	if err := providers.ValidateNormalizedBundle(bundle); err != nil {
 		t.Fatalf("normalized bundle invalid: %v", err)
 	}
-	if len(bundle.Identities) != 1 || len(bundle.Workloads) != 1 || len(bundle.Resources) != 1 {
+	lambdaResources := resourcesByType(bundle.Resources, domain.ResourceTypeLambdaFunction)
+	if len(bundle.Identities) != 1 || len(bundle.Workloads) != 1 || len(lambdaResources) != 1 {
 		t.Fatalf("expected lambda identity/workload/resource, got identities=%+v workloads=%+v resources=%+v", bundle.Identities, bundle.Workloads, bundle.Resources)
 	}
-	if bundle.Resources[0].Type != domain.ResourceTypeLambdaFunction {
-		t.Fatalf("expected lambda function resource, got %+v", bundle.Resources[0])
-	}
-	if strings.Contains(fmtAny(bundle.Resources[0].Metadata["environment_keys"]), "DATABASE_PASSWORD=value") {
-		t.Fatalf("environment values must not be normalized, got %+v", bundle.Resources[0].Metadata)
+	if strings.Contains(fmtAny(lambdaResources[0].Metadata["environment_keys"]), "DATABASE_PASSWORD=value") {
+		t.Fatalf("environment values must not be normalized, got %+v", lambdaResources[0].Metadata)
 	}
 
 	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -272,6 +272,7 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 	}
 
 	applyRuntimeSecretReferenceSensitivity(&bundle)
+	appendCredentialReferenceNodes(&bundle, resourceSeen)
 	return bundle, nil
 }
 

--- a/internal/providers/graph_contract.go
+++ b/internal/providers/graph_contract.go
@@ -123,7 +123,8 @@ func validateRelationshipEndpoints(
 			strings.HasPrefix(id, "aws:secret:") ||
 			strings.HasPrefix(id, "k8s:secret:") ||
 			hasResourceType(id, domain.ResourceTypeSSMParameter) ||
-			hasResourceType(id, domain.ResourceTypeSecretsManager)
+			hasResourceType(id, domain.ResourceTypeSecretsManager) ||
+			hasResourceType(id, domain.ResourceTypeCredentialReference)
 	}
 	hasKMSKeyNode := func(id string) bool {
 		return strings.HasPrefix(id, "kms:") ||

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1009,6 +1009,37 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS credential references inventory with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ inventory: { status: 'ready', reference_count: 5, records: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectCredentialReferences(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { resourceType: 'lambda_function', identity: 'summarizer', provider: 'openai' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/credential-references?connector_id=aws-prod&fixture_state=partial_failure&resource_type=lambda_function&identity=summarizer&provider=openai'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2573,6 +2573,119 @@ export type AWSDynamoDBRDSReachabilityDiagnostic = {
   retryable: boolean;
 };
 
+export type AWSCredentialReferencesInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSCredentialReferencesFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSCredentialProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'bedrock'
+  | 'github'
+  | 'slack'
+  | 'database'
+  | 'webhook'
+  | 'aws_secrets_manager'
+  | 'aws_ssm'
+  | 'generic';
+
+export type AWSCredentialReferenceCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSCredentialReferenceRecord = {
+  account_id: string;
+  region: string;
+  workload_id: string;
+  workload_type: string;
+  workload_name: string;
+  resource_id?: string;
+  resource_type: string;
+  source_service: string;
+  reference: string;
+  reference_name?: string;
+  reference_kind: 'secrets_manager' | 'ssm_parameter' | 'repository_credentials' | 'environment_variable';
+  provider: AWSCredentialProvider;
+  provider_confidence: number;
+  sensitivity:
+    | 'ai_provider_api_key'
+    | 'source_control_token'
+    | 'messaging_token'
+    | 'database_credential'
+    | 'webhook_url'
+    | 'aws_managed_secret'
+    | 'generic_secret';
+  resolved: boolean;
+  unresolved: boolean;
+  target_node_id?: string;
+  source: string;
+  evidence_ref: string;
+  confidence: number;
+  collected_at: string;
+  status: string;
+};
+
+export type AWSCredentialReferenceEdge = {
+  type: 'uses_secret';
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+  source: string;
+  resolved: boolean;
+  confidence: number;
+};
+
+export type AWSCredentialReferenceDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSCredentialReferencesInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCredentialReferencesInventoryStatus;
+  fixture_state: AWSCredentialReferencesFixtureState;
+  confidence: number;
+  reference_count: number;
+  resolved_reference_count: number;
+  unresolved_reference_count: number;
+  external_provider_key_count: number;
+  ai_provider_key_count: number;
+  database_credential_count: number;
+  distinct_workload_count: number;
+  distinct_provider_count: number;
+  relationship_count: number;
+  provider_breakdown: Record<string, number>;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSCredentialReferenceCoverageGap[];
+  records: AWSCredentialReferenceRecord[];
+  relationships: AWSCredentialReferenceEdge[];
+  diagnostics: AWSCredentialReferenceDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSDynamoDBRDSReachabilityInventoryResult = {
   tenant_id: string;
   workspace_id: string;
@@ -4288,6 +4401,25 @@ export const apiClient = {
         fixture_state: fixtureState,
         resource_type: resourceType,
         identity
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectCredentialReferences(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSCredentialReferencesFixtureState,
+    filters?: { resourceType?: string; identity?: string; provider?: AWSCredentialProvider },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSCredentialReferencesInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/credential-references${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        resource_type: filters?.resourceType,
+        identity: filters?.identity,
+        provider: filters?.provider
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -55,6 +55,8 @@ import {
   type AWSECRRepositoryMetadataRecord,
   type AWSDynamoDBRDSReachabilityInventoryResult,
   type AWSDynamoDBRDSReachabilityRecord,
+  type AWSCredentialReferencesInventoryResult,
+  type AWSCredentialReferenceRecord,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
   type AWSSQSSNSReachabilityInventoryResult,
@@ -3664,6 +3666,13 @@ type AWSInventoryDynamoDBRDSState = {
   onRetry: () => void;
 };
 
+type AWSInventoryCredentialReferencesState = {
+  inventory: AWSCredentialReferencesInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -5929,6 +5938,7 @@ function AWSResourcesInventoryContent({
   ecrRepositoryState,
   sqsSNSState,
   dynamoDBRDSState,
+  credentialReferencesState,
   filters,
   onFiltersChange
 }: {
@@ -5938,6 +5948,7 @@ function AWSResourcesInventoryContent({
   ecrRepositoryState: AWSInventoryECRRepositoryState;
   sqsSNSState: AWSInventorySQSSNSState;
   dynamoDBRDSState: AWSInventoryDynamoDBRDSState;
+  credentialReferencesState: AWSInventoryCredentialReferencesState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
@@ -5951,9 +5962,12 @@ function AWSResourcesInventoryContent({
   const sqsSNSRows = buildAWSSQSSNSReachabilityRows(sqsSNSInventory, sqsSNSState.loading, connection);
   const dynamoDBRDSInventory = dynamoDBRDSState.inventory;
   const dynamoDBRDSRows = buildAWSDynamoDBRDSReachabilityRows(dynamoDBRDSInventory, dynamoDBRDSState.loading, connection);
+  const credentialReferencesInventory = credentialReferencesState.inventory;
+  const credentialReferencesRows = buildAWSCredentialReferenceRows(credentialReferencesInventory, credentialReferencesState.loading, connection);
   const rows: AWSInventoryTableRow[] = [
     ...secretsRows,
     ...ssmRows,
+    ...credentialReferencesRows,
     ...ecrRows,
     ...sqsSNSRows,
     ...dynamoDBRDSRows,
@@ -6027,6 +6041,12 @@ function AWSResourcesInventoryContent({
           total={1}
           detail={dynamoDBRDSState.loading ? 'Loading' : dynamoDBRDSInventory ? formatTokenLabel(dynamoDBRDSInventory.status) : 'Pending'}
         />
+        <DomainCoverageCard
+          label="Credential references"
+          scanned={credentialReferencesInventory && credentialReferencesInventory.status !== 'blocked' ? 1 : 0}
+          total={1}
+          detail={credentialReferencesState.loading ? 'Loading' : credentialReferencesInventory ? formatTokenLabel(credentialReferencesInventory.status) : 'Pending'}
+        />
         <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
         <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Coming wave" />
       </section>
@@ -6068,6 +6088,14 @@ function AWSResourcesInventoryContent({
           title="DynamoDB/RDS reachability could not load"
           body={dynamoDBRDSState.error}
           retryAction={{ label: 'Retry DynamoDB/RDS reachability', onClick: dynamoDBRDSState.onRetry }}
+        />
+      ) : null}
+      {credentialReferencesState.loading ? <DomainLoadingState label="Loading credential and secret references" /> : null}
+      {credentialReferencesState.error ? (
+        <DomainErrorState
+          title="Credential references could not load"
+          body={credentialReferencesState.error}
+          retryAction={{ label: 'Retry credential references', onClick: credentialReferencesState.onRetry }}
         />
       ) : null}
       <DomainStatusPanel eyebrow="Safety posture" title="No secret value reads" status="Metadata only" tone="success">
@@ -6496,6 +6524,113 @@ function buildAWSSQSSNSReachabilityRows(
   ];
 }
 
+function buildAWSCredentialReferenceRows(
+  inventory: AWSCredentialReferencesInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsCredentialReferenceRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'credential-references-blocked',
+        name: 'Credential references unavailable',
+        category: 'Credential reference',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'Credential reference mapping is blocked by workload inventory permissions.',
+        filters: { category: 'credential-reference', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['credential reference blocked', inventory.account_id, inventory.region])
+      }
+    ];
+  }
+  if (inventory) {
+    const degraded = inventory.status === 'degraded' || inventory.diagnostics.length > 0 || inventory.failure_reasons.length > 0;
+    return [
+      {
+        id: 'credential-references-empty',
+        name: degraded ? 'Credential references incomplete' : 'No credential or secret references found',
+        category: 'Credential reference',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: degraded ? 'degraded' : 'wired now',
+        stage: 'wired',
+        detail: degraded ? (inventory.failure_reasons[0] ?? 'Reference mapping completed with degraded evidence and no retained records.') : 'No workload referenced a secret, parameter, or provider key in this account and region.',
+        filters: { category: 'credential-reference', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['credential reference', inventory.account_id, inventory.region, degraded ? 'degraded empty' : 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'credential-references-loading',
+        name: 'Credential and secret references',
+        category: 'Credential reference',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading provider, kind, sensitivity, and resolved status for workload credential references.',
+        filters: { category: 'credential-reference', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+        searchText: inventorySearchText(['credential reference loading'])
+      }
+    ];
+  }
+  return [
+    {
+      id: 'credential-references',
+      name: 'Credential and secret references',
+      category: 'Credential reference',
+      scope: connection?.region ?? 'Region pending',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Provider-classified credential references (AI, source control, database, webhook, AWS secret stores) across workloads. Names and ARNs only, never values.',
+      filters: { category: 'credential-reference', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['credential', 'secret', 'reference', 'provider key', 'openai', 'github'])
+    }
+  ];
+}
+
+function awsCredentialReferenceRow(record: AWSCredentialReferenceRecord): AWSInventoryTableRow {
+  const external = record.provider !== 'aws_secrets_manager' && record.provider !== 'aws_ssm' && record.provider !== 'generic';
+  const degraded = record.status !== 'ready' || (record.unresolved && external);
+  const status = degraded ? 'degraded' : 'wired now';
+  const resolutionLabel = record.resolved ? 'resolved to collected secret' : 'unresolved reference';
+  const providerLabel = formatTokenLabel(record.provider);
+  return {
+    id: `credential-reference-${record.workload_id}-${record.reference}`,
+    name: record.reference_name || record.reference,
+    category: record.sensitivity === 'ai_provider_api_key' || external ? 'Provider key' : 'Credential reference',
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage: 'wired',
+    detail: `${providerLabel} ${formatTokenLabel(record.reference_kind)} on ${record.workload_name || record.workload_id}; ${formatTokenLabel(record.sensitivity)}; ${resolutionLabel}. Values hidden.`,
+    filters: {
+      category: 'credential-reference',
+      sensitivity: external ? 'credential-reference' : 'secret-bearing',
+      readPosture: 'metadata-only',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.reference,
+      record.reference_name ?? '',
+      record.provider,
+      record.sensitivity,
+      record.reference_kind,
+      record.workload_id,
+      record.workload_name,
+      record.resource_type,
+      record.source_service,
+      record.account_id,
+      record.region,
+      record.resolved ? 'resolved' : 'unresolved',
+      'credential secret reference provider key values hidden'
+    ])
+  };
+}
+
 function buildAWSDynamoDBRDSReachabilityRows(
   inventory: AWSDynamoDBRDSReachabilityInventoryResult | null,
   loading: boolean,
@@ -6710,6 +6845,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [dynamoDBRDSInventoryLoading, setDynamoDBRDSInventoryLoading] = useState(false);
   const [dynamoDBRDSInventoryError, setDynamoDBRDSInventoryError] = useState('');
   const dynamoDBRDSInventoryRequestRef = useRef(0);
+  const [credentialReferencesInventory, setCredentialReferencesInventory] = useState<AWSCredentialReferencesInventoryResult | null>(null);
+  const [credentialReferencesInventoryLoading, setCredentialReferencesInventoryLoading] = useState(false);
+  const [credentialReferencesInventoryError, setCredentialReferencesInventoryError] = useState('');
+  const credentialReferencesInventoryRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -7281,6 +7420,47 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadDynamoDBRDSInventory]);
 
+  const loadCredentialReferencesInventory = useCallback(async () => {
+    const requestID = ++credentialReferencesInventoryRequestRef.current;
+    setCredentialReferencesInventory(null);
+    setCredentialReferencesInventoryError('');
+    if (routeID !== 'resources' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setCredentialReferencesInventoryLoading(false);
+      return;
+    }
+    setCredentialReferencesInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectCredentialReferences(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== credentialReferencesInventoryRequestRef.current) {
+        return;
+      }
+      setCredentialReferencesInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== credentialReferencesInventoryRequestRef.current) {
+        return;
+      }
+      setCredentialReferencesInventoryError(formatAPIError(error, 'Unable to load credential references.'));
+    } finally {
+      if (requestID === credentialReferencesInventoryRequestRef.current) {
+        setCredentialReferencesInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadCredentialReferencesInventory();
+    return () => {
+      credentialReferencesInventoryRequestRef.current += 1;
+    };
+  }, [loadCredentialReferencesInventory]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -7446,6 +7626,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: dynamoDBRDSInventoryLoading,
             error: dynamoDBRDSInventoryError,
             onRetry: () => void loadDynamoDBRDSInventory()
+          }}
+          credentialReferencesState={{
+            inventory: credentialReferencesInventory,
+            loading: credentialReferencesInventoryLoading,
+            error: credentialReferencesInventoryError,
+            onRetry: () => void loadCredentialReferencesInventory()
           }}
           filters={activeFilters}
           onFiltersChange={onFiltersChange}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3779,6 +3779,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'All categories', value: 'all' },
         { label: 'Secrets Manager', value: 'secrets-manager' },
         { label: 'SSM Parameter', value: 'ssm-parameter' },
+        { label: 'Credential reference', value: 'credential-reference' },
         { label: 'ECR repository', value: 'ecr-repository' },
         { label: 'KMS', value: 'kms' },
         { label: 'S3', value: 's3' },


### PR DESCRIPTION
Closes #1496

## Summary

Implements AWS Platform Wave 2.09: a **credential and secret reference mapper across AWS workloads**. It connects machine identities to the secrets, parameters, and external provider keys their workloads reference, and classifies the provider behind each reference (OpenAI, Anthropic, Bedrock, GitHub, Slack, database, webhook, plus AWS Secrets Manager / SSM, falling back to generic).

The blocker (#1476) is closed; branched from current `origin/dev`.

## Design — a derivation, not another collector

The inputs (`secret_refs`, `environment_keys`) are **already collected** by the existing workload collectors (ECS, Lambda, CodeBuild). Adding another SDK collector would be redundant and would "broaden scope," which the issue explicitly forbids. So the mapper is a **pure function over the normalized scan graph** — no AWS calls, no added IAM permissions. The real classification engine is shared by the live scan path; it is not a fixture-only veneer.

- `internal/providers/aws/credential_reference_mapper.go` — the engine: `CredentialReference` records, provider/kind/sensitivity classification, resolution against collected Secrets Manager + SSM nodes, and `MapBundleCredentialReferences(bundle) → (records, edges)`. Deterministic and deduplicated.
- It processes **any** workload resource that carries credential metadata, so SageMaker/Step Functions/EC2 are picked up automatically once their collectors surface references — no change to this component needed.

## Graph output

- **Resolved** references reuse the existing `uses_secret` edge to the real secret/parameter node (deduped against the existing matcher).
- **Unresolved external provider keys** (AI / source-control / database / webhook) synthesize a `credential_reference` graph node + `uses_secret` edge from the workload, so an operator can see "this workload uses an OpenAI/database/GitHub credential" even when it is not an AWS-managed secret.
- **Unresolved generic AWS secret** references are recorded as evidence but stay edgeless — no dangling nodes.

Node creation runs as a normalizer post-pass; edge creation in the relationship builder — matching the rest of the AWS pipeline. The graph contract validator now accepts `credential_reference` as a valid `uses_secret` target.

## Backend / API

`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references` with:
- Fixture states `success` / `empty` / `degraded` / `partial_failure` / `permission_denied`.
- Filters: `resource_type`, `identity` (substring), and `provider` (validated enum; invalid → 400).
- A `provider_breakdown` map plus resolved / unresolved / external-provider-key / AI-provider-key / database-credential counts, relationships, diagnostics, coverage gaps.
- Route policy registry entry, OpenAPI path + schemas.

## App surface

The AWS **Resources** inventory page gains a credential-references section: coverage card, loading / empty / error / degraded / blocked states, and per-record rows showing provider, reference kind, sensitivity, workload, and resolved status — with the existing category/sensitivity/read-posture filters.

## Safety

Reads reference **names, ARNs, and source markers only**. Never reads or stores secret values, parameter values, environment values, prompts, completions, object contents, or database rows. Tests assert no value-like content appears in records.

## Tests

- Engine: provider/kind/sensitivity classification matrix; resolution against collected secrets; unresolved-provider node synthesis; generic-AWS-secret stays edgeless; determinism + dedup.
- Normalizer + graph integration: `credential_reference` node and `uses_secret` edge emitted and pass the graph contract validator.
- API: provider classification, counts, `provider`/`resource_type`/`identity` filters, invalid-filter 400, degraded + permission-denied, router partial-failure.
- Web: client URL/header/filter test; full `tsc` + vitest + production build.
- Updated three workload-collector tests to tolerate the new credential-reference nodes (asserting on their own workload resource type rather than exact bundle size).

## Validation

- `make ci` passes locally (fmt-check, vet, full Go tests with coverage, contract checks incl. OpenAPI route coverage and route-policy registry, web tests, web build, prerender).
- CLI fixture scan (ECS workload with `OPENAI_API_KEY` / `DATABASE_URL` env keys and a `GITHUB_TOKEN` secret ref) runs the full pipeline cleanly; node/edge emission is covered by the integration test.
- No live AWS mutation; mapper is read-only by construction.

## Out of scope (per issue)

- No new AWS API calls or permissions; no workload-collector expansion.
- No secret/parameter/environment value reads.
- Later-wave reasoning/remediation consumers.

## AI disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only mapper that links AWS workloads to the secrets and external provider keys they reference and surfaces them in the graph, API, and Resources inventory. Implements AWS Platform Wave 2.09 and fulfills #1496; unresolved credential nodes are scoped per workload to avoid cross‑workload conflation.

- **New Features**
  - Pure derivation over the normalized scan graph; no AWS calls or new permissions.
  - Classifies references (OpenAI, Anthropic, Bedrock, GitHub, Slack, database, webhook, `aws_secrets_manager`, `aws_ssm`, generic) with kind and sensitivity.
  - Graph: resolved references reuse `uses_secret`; unresolved external keys synthesize per‑workload `credential_reference` nodes + `uses_secret`; unresolved generic AWS secrets stay edgeless; validator accepts `credential_reference` as a `uses_secret` target.
  - API: adds `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/credential-references` with `resource_type`, `identity`, and `provider` filters and a provider breakdown.
  - Resources inventory: adds a “Credential reference” category filter and shows coverage with per‑reference rows and loading/empty/error/degraded/blocked states.
  - Safety: reads names/ARNs/source markers only; never reads secret/parameter/environment values.

- **Bug Fixes**
  - Scope synthesized `credential_reference` node IDs by workload to prevent cross‑workload collapse.
  - Deduplicate identical workload→target edges in the API to avoid double‑counts.
  - Skip the credential‑reference mapping pass when the request context is canceled.
  - Align environment‑source handling for env‑var based references; consistently emit `environment_variable` kind without reading values.

<sup>Written for commit f47ac19683b23da5d4b78edb598a7a94c519a33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

