### PR TITLE
AWS Platform Wave 3.01: add account and region coverage planner

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -1,0 +1,76 @@
+# AWS Account and Region Coverage Planner
+
+Issue #1497 adds a deterministic, metadata-only planner that expands an AWS
+connector's configured accounts, regions, and service partitions into explicit
+scan targets.
+
+## What It Plans
+
+The planner creates one target per account, region, and service combination.
+Global services such as IAM are planned once per account in a home region so the
+plan reflects where the scan runs instead of pretending IAM is regional.
+
+Each target records:
+
+- account, region, service, and whether the service is global
+- enabled or disabled status
+- priority and the reason for the target
+- prerequisites such as member-account onboarding or opt-in region enablement
+- lifecycle state: `planned`, `pending`, `in_progress`, `covered`, `partial`,
+  `failed`, `permission_denied`, `unsupported`, `blocked`, or `disabled`
+- cursor, failure reason, attempts, resumability, and evidence reference
+- the next operator action
+
+The planner is deterministic: the same connector configuration and checkpoints
+produce the same ordered plan.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/coverage-plan
+```
+
+Optional query parameters:
+
+- `connector_id`: scope the response to one AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for UI and contract validation.
+- `account`: filter to one 12-digit AWS account.
+- `region`: filter to one region.
+- `service`: filter to one service partition.
+- `state`: filter to one coverage lifecycle state.
+
+The response includes tenant, workspace, project, issue metadata, summary
+counts, filtered targets, diagnostics, coverage gaps, remediation hints, and
+evidence links.
+
+## Safety Boundary
+
+The planner performs no AWS mutations and reads no customer payloads. It does
+not read or persist secret values, prompts, completions, object contents,
+database rows, environment variable values, or code-interpreter output.
+
+AWS Organizations account discovery and live region availability discovery are
+outside this issue. This PR plans from configured connector scope and explicit
+checkpoints only.
+
+## Failure States
+
+Denied, unsupported, partial, failed, blocked, and disabled targets are explicit
+states. They are never counted as successful coverage.
+
+Use diagnostics and target-level `next_action` values to decide whether to
+deploy missing read-only roles, enable an opt-in region, remove unsupported
+targets, or rerun resumable targets from their checkpoint.
+
+## Validation
+
+Run fixture validation before merging:
+
+```sh
+go test ./internal/providers/awscontract ./internal/api
+```
+
+For live validation, use only an authorized test account and record account,
+region, service, state, and evidence references. Do not capture customer
+payloads or secret values.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -564,6 +564,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/coverage-plan
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
     action: tenancy.read
     resource_type: project
@@ -4572,6 +4577,74 @@ paths:
                     $ref: "#/components/schemas/AWSCredentialReferencesInventoryResult"
         "400":
           description: Invalid AWS credential references request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/coverage-plan:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS account and region coverage plan
+      operationId: getAWSProjectCoveragePlan
+      description: Returns the deterministic account/region/service coverage plan for an AWS connector. Each target carries enabled/disabled status, priority, reason, prerequisites, an explicit coverage state (planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled), a resumable cursor/checkpoint, failure reason, and the operator's next action. Global-scope services (for example IAM) are planned once per account in their home region instead of per region. Read-only and metadata-only - the planner reads no customer payloads and mutates no AWS state.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only coverage evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account
+          schema: { type: string }
+          description: Optional 12-digit AWS account id filter over plan targets.
+        - in: query
+          name: region
+          schema: { type: string }
+          description: Optional AWS region code filter over plan targets.
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Optional AWS service partition filter (for example iam, ec2, lambda).
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+          description: Optional coverage lifecycle state filter over plan targets.
+      responses:
+        "200":
+          description: AWS account and region coverage plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plan:
+                    $ref: "#/components/schemas/AWSCoveragePlanResult"
+        "400":
+          description: Invalid AWS coverage plan request
           content:
             application/json:
               schema:
@@ -10301,6 +10374,136 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSCredentialReferenceDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSCoveragePlanTarget:
+      type: object
+      properties:
+        key: { type: string }
+        account_id: { type: string }
+        account_name: { type: string }
+        region: { type: string }
+        region_name: { type: string }
+        service: { type: string }
+        service_name: { type: string }
+        global: { type: boolean }
+        enabled: { type: boolean }
+        priority:
+          type: string
+          enum: [critical, high, normal, low]
+        priority_rank: { type: integer }
+        reason: { type: string }
+        prerequisites:
+          type: array
+          items: { type: string }
+        state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        cursor: { type: string }
+        failure_reason: { type: string }
+        attempts: { type: integer }
+        resumable: { type: boolean }
+        next_action: { type: string }
+        evidence_ref: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+    AWSCoveragePlanSummary:
+      type: object
+      properties:
+        total_targets: { type: integer }
+        enabled_targets: { type: integer }
+        disabled_targets: { type: integer }
+        account_count: { type: integer }
+        region_count: { type: integer }
+        service_count: { type: integer }
+        outstanding_targets: { type: integer }
+        covered_targets: { type: integer }
+        blocked_targets: { type: integer }
+        failed_targets: { type: integer }
+        permission_denied_targets: { type: integer }
+        resumable_targets: { type: integer }
+        coverage_percent:
+          type: number
+          minimum: 0
+          maximum: 100
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        priority_counts:
+          type: object
+          additionalProperties: { type: integer }
+        prerequisites:
+          type: array
+          items: { type: string }
+    AWSCoveragePlanDiagnostic:
+      type: object
+      properties:
+        source: { type: string }
+        scope: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSCoveragePlanCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSCoveragePlanResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        filtered_targets: { type: integer }
+        summary:
+          $ref: "#/components/schemas/AWSCoveragePlanSummary"
+        targets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanTarget"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -756,6 +756,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sqs-sns-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dynamodb-rds-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/coverage-plan", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ecr-repository-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -1,0 +1,468 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const awsCoveragePlannerCurrentIssue = 1497
+
+// AWSCoveragePlanRequest filters and pins the account/region coverage plan.
+type AWSCoveragePlanRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	// Account filters targets to one 12-digit AWS account id.
+	Account string `json:"account,omitempty"`
+	// Region filters targets to one AWS region code.
+	Region string `json:"region,omitempty"`
+	// Service filters targets to one AWS service partition (for example iam, lambda).
+	Service string `json:"service,omitempty"`
+	// State filters targets to one coverage lifecycle state.
+	State string `json:"state,omitempty"`
+}
+
+// AWSCoveragePlanTarget is one operator-visible account/region/service scan unit.
+type AWSCoveragePlanTarget struct {
+	Key           string    `json:"key"`
+	AccountID     string    `json:"account_id"`
+	AccountName   string    `json:"account_name,omitempty"`
+	Region        string    `json:"region"`
+	RegionName    string    `json:"region_name,omitempty"`
+	Service       string    `json:"service"`
+	ServiceName   string    `json:"service_name,omitempty"`
+	Global        bool      `json:"global"`
+	Enabled       bool      `json:"enabled"`
+	Priority      string    `json:"priority"`
+	PriorityRank  int       `json:"priority_rank"`
+	Reason        string    `json:"reason,omitempty"`
+	Prerequisites []string  `json:"prerequisites"`
+	State         string    `json:"state"`
+	Cursor        string    `json:"cursor,omitempty"`
+	FailureReason string    `json:"failure_reason,omitempty"`
+	Attempts      int       `json:"attempts,omitempty"`
+	Resumable     bool      `json:"resumable"`
+	NextAction    string    `json:"next_action"`
+	EvidenceRef   string    `json:"evidence_ref"`
+	ObservedAt    time.Time `json:"observed_at,omitempty"`
+}
+
+// AWSCoveragePlanSummary mirrors the planner summary for dashboards.
+type AWSCoveragePlanSummary struct {
+	TotalTargets       int            `json:"total_targets"`
+	EnabledTargets     int            `json:"enabled_targets"`
+	DisabledTargets    int            `json:"disabled_targets"`
+	AccountCount       int            `json:"account_count"`
+	RegionCount        int            `json:"region_count"`
+	ServiceCount       int            `json:"service_count"`
+	OutstandingTargets int            `json:"outstanding_targets"`
+	CoveredTargets     int            `json:"covered_targets"`
+	BlockedTargets     int            `json:"blocked_targets"`
+	FailedTargets      int            `json:"failed_targets"`
+	PermissionDenied   int            `json:"permission_denied_targets"`
+	ResumableTargets   int            `json:"resumable_targets"`
+	CoveragePercent    float64        `json:"coverage_percent"`
+	StateCounts        map[string]int `json:"state_counts"`
+	PriorityCounts     map[string]int `json:"priority_counts"`
+	Prerequisites      []string       `json:"prerequisites"`
+}
+
+// AWSCoveragePlanDiagnostic carries a deterministic planning/execution failure.
+type AWSCoveragePlanDiagnostic struct {
+	Source      string `json:"source"`
+	Scope       string `json:"scope,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSCoveragePlanCoverageGap names an explicit limit of the planner.
+type AWSCoveragePlanCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSCoveragePlanResult is the full account/region coverage planning response.
+type AWSCoveragePlanResult struct {
+	TenantID           string                       `json:"tenant_id"`
+	WorkspaceID        string                       `json:"workspace_id"`
+	ProjectID          string                       `json:"project_id"`
+	ConnectorID        string                       `json:"connector_id,omitempty"`
+	AccountID          string                       `json:"account_id,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	ParentIssueNumber  int                          `json:"parent_issue_number"`
+	ParentIssueRef     string                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                          `json:"current_issue_number"`
+	CurrentIssueRef    string                       `json:"current_issue_ref"`
+	Version            string                       `json:"version"`
+	Status             string                       `json:"status"`
+	FixtureState       string                       `json:"fixture_state"`
+	Confidence         float64                      `json:"confidence"`
+	FilteredTargets    int                          `json:"filtered_targets"`
+	Summary            AWSCoveragePlanSummary       `json:"summary"`
+	Targets            []AWSCoveragePlanTarget      `json:"targets"`
+	FailureReasons     []string                     `json:"failure_reasons"`
+	RemediationHints   []string                     `json:"remediation_hints"`
+	EvidenceLinks      []string                     `json:"evidence_links"`
+	CoverageGaps       []AWSCoveragePlanCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSCoveragePlanDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	UpdatedAt          time.Time                    `json:"updated_at"`
+}
+
+// GetAWSCoveragePlan returns the deterministic account/region/service coverage
+// plan for a project's AWS connector. It is read-only and metadata-only: it
+// reads no customer payloads and mutates no AWS state.
+func (s *Service) GetAWSCoveragePlan(ctx context.Context, workspaceID string, projectID string, request AWSCoveragePlanRequest) (AWSCoveragePlanResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSCoveragePlanResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSCoveragePlanResult{}, err
+	}
+	return buildAWSCoveragePlan(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSCoveragePlanRequest, checkedAt time.Time) (AWSCoveragePlanResult, error) {
+	fixtureState := normalizeAWSCoveragePlanFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSCoveragePlanResult{}, ErrInvalidAWSConnectionRequest
+	}
+	if !validAWSCoveragePlanStateFilter(request.State) {
+		return AWSCoveragePlanResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "111111111111")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	config, diagnostics, gaps := awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	plan, err := awscontract.PlanCoverage(config, checkedAt)
+	if err != nil {
+		return AWSCoveragePlanResult{}, err
+	}
+	summary := mapAWSCoveragePlanSummary(plan.Summary)
+	targets := mapAWSCoveragePlanTargets(plan.Targets)
+	filtered := filterAWSCoveragePlanTargets(targets, request)
+	status, confidence, failures, remediations := summarizeAWSCoveragePlan(fixtureState, diagnostics, plan)
+
+	return AWSCoveragePlanResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsCoveragePlannerCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsCoveragePlannerCurrentIssue),
+		Version:            plan.Version,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		FilteredTargets:    len(filtered),
+		Summary:            summary,
+		Targets:            filtered,
+		FailureReasons:     failures,
+		RemediationHints:   remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsCoveragePlannerCurrentIssue),
+			"/docs/aws-account-region-coverage-planner",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func normalizeAWSCoveragePlanFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func validAWSCoveragePlanStateFilter(state string) bool {
+	switch awscontract.CoverageState(strings.ToLower(strings.TrimSpace(state))) {
+	case "",
+		awscontract.CoverageStateDisabled, awscontract.CoverageStateBlocked, awscontract.CoverageStatePlanned,
+		awscontract.CoverageStatePending, awscontract.CoverageStateInProgress, awscontract.CoverageStateCovered,
+		awscontract.CoverageStatePartial, awscontract.CoverageStateFailed, awscontract.CoverageStatePermissionDenied,
+		awscontract.CoverageStateUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+// awsCoveragePlanFixtureConfig returns the deterministic connector coverage
+// configuration, prior checkpoints, diagnostics, and gaps for a fixture state.
+// The configuration is fed to the real planner so the API exercises the same
+// code path operators will run against live connectors.
+func awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState string) (awscontract.CoveragePlanConfig, []AWSCoveragePlanDiagnostic, []AWSCoveragePlanCoverageGap) {
+	gaps := []AWSCoveragePlanCoverageGap{
+		{
+			Capability:  "live_account_discovery",
+			Status:      "out_of_scope",
+			Reason:      "The planner expands the configured account/region/service targets only; AWS Organizations and region availability discovery are later-wave capabilities.",
+			Remediation: "Populate accounts and regions from connector configuration or organization discovery before planning.",
+		},
+		{
+			Capability:  "secret_value_inspection",
+			Status:      "unsupported",
+			Reason:      "Coverage planning reads no customer payloads, secret values, or object contents; it only plans where read-only collectors will run.",
+			Remediation: "Inspect values through the owning service outside Identrail.",
+		},
+	}
+
+	if fixtureState == "empty" {
+		return awscontract.CoveragePlanConfig{ConnectorID: connectorID}, nil, gaps
+	}
+
+	secondaryAccount := awsCoveragePlanSiblingAccount(accountID)
+	config := awscontract.CoveragePlanConfig{
+		ConnectorID: connectorID,
+		Accounts: []awscontract.CoverageAccount{
+			{AccountID: accountID, Name: "production", Enabled: true, Priority: awscontract.CoveragePriorityCritical, Management: true, Reason: "primary production estate"},
+			{AccountID: secondaryAccount, Name: "data", Enabled: true, Priority: awscontract.CoveragePriorityHigh, Reason: "regulated data workloads"},
+			{AccountID: "999999999999", Name: "retired-sandbox", Enabled: false, Reason: "account decommissioned"},
+		},
+		Regions: []awscontract.CoverageRegion{
+			{Region: region, Enabled: true, Priority: awscontract.CoveragePriorityHigh, Reason: "connector home region"},
+			{Region: awsCoveragePlanSecondaryRegion(region), Enabled: true, Reason: "secondary workload region"},
+			{Region: "ap-east-1", Enabled: false, OptIn: true, Reason: "opt-in region not enabled"},
+		},
+		Services: awscontract.DefaultCoverageServices(),
+	}
+
+	diagnostics := []AWSCoveragePlanDiagnostic{}
+	switch fixtureState {
+	case "permission_denied":
+		config.Checkpoints = []awscontract.CoverageCheckpoint{{
+			AccountID: secondaryAccount, Region: region, Service: "iam",
+			State: awscontract.CoverageStatePermissionDenied, FailureReason: "AccessDenied: iam:ListRoles denied in member account",
+		}}
+		diagnostics = append(diagnostics, AWSCoveragePlanDiagnostic{
+			Source:      "coverage_planner",
+			Scope:       secondaryAccount + "/" + region + "/iam",
+			Code:        "permission_denied",
+			Message:     "Connector role cannot assume into account " + secondaryAccount + " for read-only IAM enumeration.",
+			Remediation: "Deploy the read-only collector role into the member account and re-run the plan.",
+			Retryable:   false,
+		})
+	case "degraded", "partial_failure":
+		config.Checkpoints = []awscontract.CoverageCheckpoint{
+			{AccountID: accountID, Region: region, Service: "iam", State: awscontract.CoverageStateCovered},
+			{AccountID: accountID, Region: region, Service: "lambda", State: awscontract.CoverageStateCovered},
+			{AccountID: secondaryAccount, Region: awsCoveragePlanSecondaryRegion(region), Service: "ecs", State: awscontract.CoverageStateFailed, FailureReason: "Throttling: ecs:ListServices throttled after retries", Attempts: 3},
+			{AccountID: secondaryAccount, Region: region, Service: "lambda", State: awscontract.CoverageStateInProgress, Cursor: "marker:page-3", Attempts: 1},
+		}
+		diagnostics = append(diagnostics, AWSCoveragePlanDiagnostic{
+			Source:      "coverage_planner",
+			Scope:       secondaryAccount + "/" + awsCoveragePlanSecondaryRegion(region) + "/ecs",
+			Code:        "partial_failure",
+			Message:     "ecs:ListServices was throttled after bounded retries; this target is resumable.",
+			Remediation: "Re-run the plan to resume the failed target from its checkpoint.",
+			Retryable:   true,
+		})
+	default:
+		// Success: mark a couple of targets covered so coverage percent is meaningful.
+		config.Checkpoints = []awscontract.CoverageCheckpoint{
+			{AccountID: accountID, Region: region, Service: "iam", State: awscontract.CoverageStateCovered},
+			{AccountID: accountID, Region: region, Service: "ec2", State: awscontract.CoverageStateCovered},
+			{AccountID: accountID, Region: region, Service: "lambda", State: awscontract.CoverageStateCovered},
+		}
+	}
+	return config, diagnostics, gaps
+}
+
+func mapAWSCoveragePlanTargets(targets []awscontract.CoverageTarget) []AWSCoveragePlanTarget {
+	out := make([]AWSCoveragePlanTarget, 0, len(targets))
+	for _, target := range targets {
+		prerequisites := target.Prerequisites
+		if prerequisites == nil {
+			prerequisites = []string{}
+		}
+		out = append(out, AWSCoveragePlanTarget{
+			Key:           target.Key,
+			AccountID:     target.AccountID,
+			AccountName:   target.AccountName,
+			Region:        target.Region,
+			RegionName:    target.RegionName,
+			Service:       target.Service,
+			ServiceName:   target.ServiceName,
+			Global:        target.Global,
+			Enabled:       target.Enabled,
+			Priority:      string(target.Priority),
+			PriorityRank:  target.PriorityRank,
+			Reason:        target.Reason,
+			Prerequisites: prerequisites,
+			State:         string(target.State),
+			Cursor:        target.Cursor,
+			FailureReason: target.FailureReason,
+			Attempts:      target.Attempts,
+			Resumable:     target.Resumable,
+			NextAction:    awsCoveragePlanNextAction(target),
+			EvidenceRef:   target.EvidenceRef,
+			ObservedAt:    target.ObservedAt,
+		})
+	}
+	return out
+}
+
+// awsCoveragePlanNextAction translates a target state into the operator's next
+// step so the app surface never requires reading logs to decide what to do.
+func awsCoveragePlanNextAction(target awscontract.CoverageTarget) string {
+	switch target.State {
+	case awscontract.CoverageStateDisabled:
+		return "Enable the account, region, and service in connector coverage configuration to scan this target."
+	case awscontract.CoverageStateBlocked:
+		return "Satisfy prerequisites (member-account onboarding or opt-in region enablement) before this target can be scanned."
+	case awscontract.CoverageStateCovered:
+		return "No action required; rescan on the next scheduled coverage run."
+	case awscontract.CoverageStateFailed, awscontract.CoverageStatePartial:
+		return "Re-run the plan to resume this target from its checkpoint."
+	case awscontract.CoverageStateInProgress, awscontract.CoverageStatePending:
+		return "Scan in flight; wait for the fan-out worker to advance this target."
+	case awscontract.CoverageStatePermissionDenied:
+		return "Grant the read-only collector role access in this account/region and re-run the plan."
+	case awscontract.CoverageStateUnsupported:
+		return "Remove the unsupported region/service from coverage configuration."
+	default:
+		return "Queue this target for the next coverage scan run."
+	}
+}
+
+func mapAWSCoveragePlanSummary(summary awscontract.CoveragePlanSummary) AWSCoveragePlanSummary {
+	stateCounts := map[string]int{}
+	for state, count := range summary.StateCounts {
+		stateCounts[string(state)] = count
+	}
+	priorityCounts := map[string]int{}
+	for priority, count := range summary.PriorityCounts {
+		priorityCounts[string(priority)] = count
+	}
+	prerequisites := summary.Prerequisites
+	if prerequisites == nil {
+		prerequisites = []string{}
+	}
+	return AWSCoveragePlanSummary{
+		TotalTargets:       summary.TotalTargets,
+		EnabledTargets:     summary.EnabledTargets,
+		DisabledTargets:    summary.DisabledTargets,
+		AccountCount:       summary.AccountCount,
+		RegionCount:        summary.RegionCount,
+		ServiceCount:       summary.ServiceCount,
+		OutstandingTargets: summary.OutstandingTargets,
+		CoveredTargets:     summary.CoveredTargets,
+		BlockedTargets:     summary.BlockedTargets,
+		FailedTargets:      summary.FailedTargets,
+		PermissionDenied:   summary.PermissionDenied,
+		ResumableTargets:   summary.ResumableTargets,
+		CoveragePercent:    summary.CoveragePercent,
+		StateCounts:        stateCounts,
+		PriorityCounts:     priorityCounts,
+		Prerequisites:      prerequisites,
+	}
+}
+
+func filterAWSCoveragePlanTargets(targets []AWSCoveragePlanTarget, request AWSCoveragePlanRequest) []AWSCoveragePlanTarget {
+	account := strings.TrimSpace(request.Account)
+	region := strings.ToLower(strings.TrimSpace(request.Region))
+	service := strings.ToLower(strings.TrimSpace(request.Service))
+	state := strings.ToLower(strings.TrimSpace(request.State))
+	if account == "" && region == "" && service == "" && state == "" {
+		return targets
+	}
+	filtered := make([]AWSCoveragePlanTarget, 0, len(targets))
+	for _, target := range targets {
+		if account != "" && target.AccountID != account {
+			continue
+		}
+		if region != "" && strings.ToLower(target.Region) != region {
+			continue
+		}
+		if service != "" && strings.ToLower(target.Service) != service {
+			continue
+		}
+		if state != "" && strings.ToLower(target.State) != state {
+			continue
+		}
+		filtered = append(filtered, target)
+	}
+	return filtered
+}
+
+func summarizeAWSCoveragePlan(fixtureState string, diagnostics []AWSCoveragePlanDiagnostic, plan awscontract.CoveragePlan) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.3,
+			awsCoveragePlanDiagnosticMessages(diagnostics),
+			[]string{"Deploy the read-only collector role into denied accounts/regions, then re-run the coverage plan."}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72,
+			awsCoveragePlanDiagnosticMessages(diagnostics),
+			[]string{"Re-run the plan to resume failed and in-progress targets from their checkpoints."}
+	default:
+		if plan.Summary.TotalTargets == 0 {
+			return awsPlatformDependencyStatusReady, 0.8, nil,
+				[]string{"No accounts, regions, or services are configured for coverage; add scan targets to the AWS connector."}
+		}
+		if plan.Summary.BlockedTargets > 0 {
+			return awsPlatformDependencyStatusReady, 0.9, nil,
+				[]string{"Onboard member accounts and enable opt-in regions to clear blocked targets, then re-run the plan."}
+		}
+		return awsPlatformDependencyStatusReady, 0.94, nil,
+			[]string{"Coverage plan is deterministic and resumable; schedule the fan-out scan worker to execute outstanding targets."}
+	}
+}
+
+func awsCoveragePlanDiagnosticMessages(diagnostics []AWSCoveragePlanDiagnostic) []string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if message := strings.TrimSpace(diagnostic.Message); message != "" {
+			messages = append(messages, message)
+		}
+	}
+	return dedupeStrings(messages)
+}
+
+// awsCoveragePlanSiblingAccount derives a deterministic second 12-digit account
+// id from the connection account so multi-account fixtures stay stable.
+func awsCoveragePlanSiblingAccount(accountID string) string {
+	digits := strings.TrimSpace(accountID)
+	if len(digits) != 12 {
+		return "222222222222"
+	}
+	last := digits[11]
+	if last == '9' {
+		return digits[:11] + "0"
+	}
+	return digits[:11] + string(last+1)
+}
+
+func awsCoveragePlanSecondaryRegion(region string) string {
+	if strings.EqualFold(strings.TrimSpace(region), "eu-west-1") {
+		return "us-east-1"
+	}
+	return "eu-west-1"
+}

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -10,6 +10,7 @@ import (
 )
 
 const awsCoveragePlannerCurrentIssue = 1497
+const awsCoveragePlannerGlobalServiceHomeRegion = "us-east-1"
 
 // AWSCoveragePlanRequest filters and pins the account/region coverage plan.
 type AWSCoveragePlanRequest struct {
@@ -259,7 +260,8 @@ func awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState s
 	case "permission_denied":
 		config.Checkpoints = []awscontract.CoverageCheckpoint{{
 			AccountID: secondaryAccount, Region: region, Service: "iam",
-			State: awscontract.CoverageStatePermissionDenied, FailureReason: "AccessDenied: iam:ListRoles denied in member account",
+			Region: awsCoveragePlannerGlobalServiceHomeRegion,
+			State:  awscontract.CoverageStatePermissionDenied, FailureReason: "AccessDenied: iam:ListRoles denied in member account",
 		}}
 		diagnostics = append(diagnostics, AWSCoveragePlanDiagnostic{
 			Source:      "coverage_planner",

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -259,7 +259,7 @@ func awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState s
 	switch fixtureState {
 	case "permission_denied":
 		config.Checkpoints = []awscontract.CoverageCheckpoint{{
-			AccountID: secondaryAccount, Region: region, Service: "iam",
+			AccountID: secondaryAccount, Service: "iam",
 			Region: awsCoveragePlannerGlobalServiceHomeRegion,
 			State:  awscontract.CoverageStatePermissionDenied, FailureReason: "AccessDenied: iam:ListRoles denied in member account",
 		}}

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSCoveragePlanSuccess(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready plan, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1497" || result.Version == "" {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.Summary.AccountCount != 3 || result.Summary.RegionCount != 3 || result.Summary.ServiceCount != 6 {
+		t.Fatalf("unexpected dimension counts: %+v", result.Summary)
+	}
+	if result.Summary.CoveredTargets != 3 || result.Summary.CoveragePercent <= 0 {
+		t.Fatalf("expected covered targets and positive coverage percent, got %+v", result.Summary)
+	}
+	if result.Summary.DisabledTargets == 0 {
+		t.Fatalf("expected disabled targets from the decommissioned account, got %+v", result.Summary)
+	}
+	// Determinism: targets must be sorted by priority rank then key.
+	for i := 1; i < len(result.Targets); i++ {
+		prev, cur := result.Targets[i-1], result.Targets[i]
+		if prev.PriorityRank > cur.PriorityRank {
+			t.Fatalf("targets out of priority order at %d", i)
+		}
+		if prev.PriorityRank == cur.PriorityRank && prev.Key > cur.Key {
+			t.Fatalf("targets out of key order at %d", i)
+		}
+	}
+	// Every target carries an explicit state, evidence ref, and next action.
+	for _, target := range result.Targets {
+		if target.State == "" || target.EvidenceRef == "" || target.NextAction == "" {
+			t.Fatalf("target missing explicit fields: %+v", target)
+		}
+	}
+}
+
+func TestGetAWSCoveragePlanGlobalServicePlannedOncePerAccount(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", Service: "iam"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	perAccount := map[string]int{}
+	for _, target := range result.Targets {
+		if !target.Global {
+			t.Fatalf("iam targets should be global, got %+v", target)
+		}
+		perAccount[target.AccountID]++
+	}
+	if len(perAccount) == 0 {
+		t.Fatalf("expected iam targets")
+	}
+	for accountID, count := range perAccount {
+		if count != 1 {
+			t.Fatalf("account %s has %d iam targets, want 1 (global)", accountID, count)
+		}
+	}
+}
+
+func TestGetAWSCoveragePlanFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	covered, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", State: "covered"})
+	if err != nil {
+		t.Fatalf("get state-filtered plan: %v", err)
+	}
+	if covered.FilteredTargets != covered.Summary.CoveredTargets || covered.FilteredTargets == 0 {
+		t.Fatalf("state filter mismatch: filtered=%d covered=%d", covered.FilteredTargets, covered.Summary.CoveredTargets)
+	}
+	for _, target := range covered.Targets {
+		if target.State != "covered" {
+			t.Fatalf("state filter leaked %q", target.State)
+		}
+	}
+
+	disabled, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", State: "disabled"})
+	if err != nil {
+		t.Fatalf("get disabled plan: %v", err)
+	}
+	for _, target := range disabled.Targets {
+		if target.Enabled {
+			t.Fatalf("disabled filter returned enabled target: %+v", target)
+		}
+	}
+
+	if _, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", State: "bogus"}); err == nil {
+		t.Fatalf("expected invalid state filter error")
+	}
+}
+
+func TestGetAWSCoveragePlanEmptyAndDegradedAndDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	empty, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("get empty plan: %v", err)
+	}
+	if empty.Status != awsPlatformDependencyStatusReady || empty.Summary.TotalTargets != 0 {
+		t.Fatalf("expected empty ready plan, got %+v", empty.Summary)
+	}
+	if len(empty.RemediationHints) == 0 {
+		t.Fatalf("empty plan should hint at configuring targets")
+	}
+
+	degraded, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded plan: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded diagnostics, got %+v", degraded)
+	}
+	if degraded.Summary.FailedTargets == 0 || degraded.Summary.ResumableTargets == 0 {
+		t.Fatalf("expected failed/resumable targets in degraded plan, got %+v", degraded.Summary)
+	}
+
+	denied, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied plan: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.Summary.PermissionDenied == 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("expected blocked permission-denied plan, got %+v", denied)
+	}
+}
+
+func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	lower := strings.ToLower(string(payload))
+	for _, forbidden := range []string{"getsecretvalue", "secretstring", "plaintext", "password=", "=sk-"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("value-like content leaked into plan: %s", payload)
+		}
+	}
+}
+
+func TestRouterAWSCoveragePlanPartialFailureAndInvalid(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 13, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/coverage-plan?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plan AWSCoveragePlanResult `json:"plan"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Plan.Status != awsPlatformDependencyStatusDegraded || body.Plan.Summary.FailedTargets == 0 {
+		t.Fatalf("expected degraded partial plan, got %+v", body.Plan)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "state=bogus"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/coverage-plan?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2951,6 +2951,40 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/coverage-plan", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSCoveragePlan(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSCoveragePlanRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			Account:      strings.TrimSpace(c.Query("account")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			State:        strings.TrimSpace(c.Query("state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws coverage plan request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws coverage plan",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws coverage plan"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plan": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -308,6 +308,9 @@ func applyCoverageCheckpoint(target *CoverageTarget, checkpoint CoverageCheckpoi
 	if !target.Enabled {
 		return
 	}
+	if checkpoint.State == CoverageStateDisabled {
+		return
+	}
 	if checkpoint.State != "" {
 		target.State = checkpoint.State
 	}

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -1,0 +1,608 @@
+package awscontract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CoveragePlannerVersion is the stable contract version operators and downstream
+// fan-out workers cite when persisting or reconciling a coverage plan.
+const CoveragePlannerVersion = "aws-account-region-coverage-planner-v1"
+
+// CoverageState is the explicit lifecycle state of one account/region/service
+// scan target. Unknown, denied, unsupported, and partially failed states are
+// first-class so operators never read a partial or blocked target as a success.
+type CoverageState string
+
+const (
+	// CoverageStateDisabled marks a target whose account, region, or service is
+	// explicitly disabled in the connector coverage configuration.
+	CoverageStateDisabled CoverageState = "disabled"
+	// CoverageStateBlocked marks an enabled target whose prerequisites are not
+	// yet satisfied (for example a member account that has not been onboarded or
+	// an opt-in region that is not enabled on the account).
+	CoverageStateBlocked CoverageState = "blocked"
+	// CoverageStatePlanned marks an enabled, unblocked target that has not been
+	// attempted yet.
+	CoverageStatePlanned CoverageState = "planned"
+	// CoverageStatePending marks a target queued for execution.
+	CoverageStatePending CoverageState = "pending"
+	// CoverageStateInProgress marks a target whose scan is running and may carry a
+	// resumable cursor.
+	CoverageStateInProgress CoverageState = "in_progress"
+	// CoverageStateCovered marks a target whose scan completed successfully.
+	CoverageStateCovered CoverageState = "covered"
+	// CoverageStatePartial marks a target that completed with a partial failure
+	// and must be reconciled or rerun.
+	CoverageStatePartial CoverageState = "partial"
+	// CoverageStateFailed marks a target whose scan failed and is retryable.
+	CoverageStateFailed CoverageState = "failed"
+	// CoverageStatePermissionDenied marks a target the connector role cannot scan
+	// because AWS denied a required read-only action.
+	CoverageStatePermissionDenied CoverageState = "permission_denied"
+	// CoverageStateUnsupported marks a target whose region or service is not
+	// available (for example a service that is not offered in a region).
+	CoverageStateUnsupported CoverageState = "unsupported"
+)
+
+// CoveragePriority orders how urgently a target should be scanned. The most
+// urgent priority among a target's account, region, and service wins.
+type CoveragePriority string
+
+const (
+	CoveragePriorityCritical CoveragePriority = "critical"
+	CoveragePriorityHigh     CoveragePriority = "high"
+	CoveragePriorityNormal   CoveragePriority = "normal"
+	CoveragePriorityLow      CoveragePriority = "low"
+)
+
+// defaultGlobalServiceHomeRegion is where global-scope services (for example
+// IAM) are planned once per account rather than fanned out per region.
+const defaultGlobalServiceHomeRegion = "us-east-1"
+
+// CoverageAccount is one AWS account in the connector's coverage configuration.
+type CoverageAccount struct {
+	AccountID     string           `json:"account_id"`
+	Name          string           `json:"name,omitempty"`
+	Enabled       bool             `json:"enabled"`
+	Priority      CoveragePriority `json:"priority,omitempty"`
+	Reason        string           `json:"reason,omitempty"`
+	Prerequisites []string         `json:"prerequisites,omitempty"`
+	// Management marks the organization management/payer account.
+	Management bool `json:"management,omitempty"`
+}
+
+// CoverageRegion is one AWS region in the connector's coverage configuration.
+type CoverageRegion struct {
+	Region        string           `json:"region"`
+	Name          string           `json:"name,omitempty"`
+	Enabled       bool             `json:"enabled"`
+	Priority      CoveragePriority `json:"priority,omitempty"`
+	Reason        string           `json:"reason,omitempty"`
+	Prerequisites []string         `json:"prerequisites,omitempty"`
+	// OptIn marks a region that AWS disables by default and that must be opted
+	// into on each account before it can be scanned.
+	OptIn bool `json:"opt_in,omitempty"`
+}
+
+// CoverageService is one AWS service partition in the coverage configuration.
+type CoverageService struct {
+	Service       string           `json:"service"`
+	Name          string           `json:"name,omitempty"`
+	Enabled       bool             `json:"enabled"`
+	Priority      CoveragePriority `json:"priority,omitempty"`
+	Reason        string           `json:"reason,omitempty"`
+	Prerequisites []string         `json:"prerequisites,omitempty"`
+	// Global marks a service whose inventory is account-global (for example IAM).
+	// Global services are planned once per account in HomeRegion instead of being
+	// fanned out across every region, which keeps the plan honest about where the
+	// scan actually runs.
+	Global bool `json:"global,omitempty"`
+	// HomeRegion overrides where a global service is planned. Defaults to
+	// us-east-1 when empty.
+	HomeRegion string `json:"home_region,omitempty"`
+}
+
+// CoverageCheckpoint is the persisted prior state of one target, used to make
+// the plan resumable. The fan-out worker writes checkpoints as targets advance;
+// the planner replays them so a rerun continues from the last cursor instead of
+// rescanning covered targets.
+type CoverageCheckpoint struct {
+	AccountID     string        `json:"account_id"`
+	Region        string        `json:"region"`
+	Service       string        `json:"service"`
+	State         CoverageState `json:"state"`
+	Cursor        string        `json:"cursor,omitempty"`
+	FailureReason string        `json:"failure_reason,omitempty"`
+	Attempts      int           `json:"attempts,omitempty"`
+	ObservedAt    time.Time     `json:"observed_at,omitempty"`
+}
+
+// CoveragePlanConfig is the connector's expanded account/region/service scan
+// configuration plus any prior checkpoints to resume from.
+type CoveragePlanConfig struct {
+	ConnectorID string               `json:"connector_id,omitempty"`
+	Accounts    []CoverageAccount    `json:"accounts"`
+	Regions     []CoverageRegion     `json:"regions"`
+	Services    []CoverageService    `json:"services"`
+	Checkpoints []CoverageCheckpoint `json:"checkpoints,omitempty"`
+}
+
+// CoverageTarget is one planned account/region/service scan unit with its
+// expectation (reason, priority, prerequisites) and current coverage state.
+type CoverageTarget struct {
+	Key           string           `json:"key"`
+	AccountID     string           `json:"account_id"`
+	AccountName   string           `json:"account_name,omitempty"`
+	Region        string           `json:"region"`
+	RegionName    string           `json:"region_name,omitempty"`
+	Service       string           `json:"service"`
+	ServiceName   string           `json:"service_name,omitempty"`
+	Global        bool             `json:"global,omitempty"`
+	Enabled       bool             `json:"enabled"`
+	Priority      CoveragePriority `json:"priority"`
+	PriorityRank  int              `json:"priority_rank"`
+	Reason        string           `json:"reason,omitempty"`
+	Prerequisites []string         `json:"prerequisites,omitempty"`
+	State         CoverageState    `json:"state"`
+	Cursor        string           `json:"cursor,omitempty"`
+	FailureReason string           `json:"failure_reason,omitempty"`
+	Attempts      int              `json:"attempts,omitempty"`
+	Resumable     bool             `json:"resumable"`
+	EvidenceRef   string           `json:"evidence_ref"`
+	ObservedAt    time.Time        `json:"observed_at,omitempty"`
+}
+
+// CoveragePlanSummary aggregates a plan for dashboards, recovery, and reruns.
+type CoveragePlanSummary struct {
+	TotalTargets       int                      `json:"total_targets"`
+	EnabledTargets     int                      `json:"enabled_targets"`
+	DisabledTargets    int                      `json:"disabled_targets"`
+	AccountCount       int                      `json:"account_count"`
+	RegionCount        int                      `json:"region_count"`
+	ServiceCount       int                      `json:"service_count"`
+	OutstandingTargets int                      `json:"outstanding_targets"`
+	CoveredTargets     int                      `json:"covered_targets"`
+	BlockedTargets     int                      `json:"blocked_targets"`
+	FailedTargets      int                      `json:"failed_targets"`
+	PermissionDenied   int                      `json:"permission_denied_targets"`
+	ResumableTargets   int                      `json:"resumable_targets"`
+	CoveragePercent    float64                  `json:"coverage_percent"`
+	StateCounts        map[CoverageState]int    `json:"state_counts"`
+	PriorityCounts     map[CoveragePriority]int `json:"priority_counts"`
+	Prerequisites      []string                 `json:"prerequisites"`
+}
+
+// CoveragePlan is the deterministic output of the planner.
+type CoveragePlan struct {
+	ConnectorID string              `json:"connector_id,omitempty"`
+	Version     string              `json:"version"`
+	Targets     []CoverageTarget    `json:"targets"`
+	Summary     CoveragePlanSummary `json:"summary"`
+	GeneratedAt time.Time           `json:"generated_at"`
+}
+
+// PlanCoverage expands a connector coverage configuration into a deterministic,
+// resumable set of account/region/service scan targets. It is a pure function:
+// the same configuration and checkpoints always produce the same ordered plan,
+// so persistence, dashboards, and fan-out reruns stay reconcilable. It performs
+// no AWS calls and reads no customer payloads.
+//
+// A target is enabled only when its account, region, and service are all
+// enabled. Global-scope services are planned once per account in their home
+// region instead of being fanned out across every region. Prior checkpoints are
+// replayed so a covered target stays covered and an interrupted target keeps its
+// cursor. The most urgent priority among a target's account, region, and service
+// wins, and targets are ordered by priority, then account, region, and service.
+func PlanCoverage(config CoveragePlanConfig, generatedAt time.Time) (CoveragePlan, error) {
+	accounts, err := normalizeCoverageAccounts(config.Accounts)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
+	regions, err := normalizeCoverageRegions(config.Regions)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
+	services, err := normalizeCoverageServices(config.Services)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
+	checkpoints, err := indexCoverageCheckpoints(config.Checkpoints)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
+
+	targets := []CoverageTarget{}
+	seen := map[string]struct{}{}
+	for _, account := range accounts {
+		for _, service := range services {
+			if service.Global {
+				target := buildCoverageTarget(config.ConnectorID, account, globalCoverageRegion(service), service, checkpoints)
+				appendCoverageTarget(&targets, seen, target)
+				continue
+			}
+			for _, region := range regions {
+				target := buildCoverageTarget(config.ConnectorID, account, region, service, checkpoints)
+				appendCoverageTarget(&targets, seen, target)
+			}
+		}
+	}
+
+	sort.SliceStable(targets, func(i, j int) bool {
+		if targets[i].PriorityRank != targets[j].PriorityRank {
+			return targets[i].PriorityRank < targets[j].PriorityRank
+		}
+		return targets[i].Key < targets[j].Key
+	})
+
+	return CoveragePlan{
+		ConnectorID: strings.TrimSpace(config.ConnectorID),
+		Version:     CoveragePlannerVersion,
+		Targets:     targets,
+		Summary:     summarizeCoveragePlan(targets, len(accounts), len(regions), len(services)),
+		GeneratedAt: generatedAt.UTC(),
+	}, nil
+}
+
+// globalCoverageRegion synthesizes the home-region pseudo-region a global
+// service is planned in. It is always enabled so a global service is never
+// suppressed by a disabled member region; its prerequisites still apply.
+func globalCoverageRegion(service CoverageService) CoverageRegion {
+	home := strings.TrimSpace(service.HomeRegion)
+	if home == "" {
+		home = defaultGlobalServiceHomeRegion
+	}
+	return CoverageRegion{
+		Region:  home,
+		Name:    "global (" + home + ")",
+		Enabled: true,
+	}
+}
+
+func buildCoverageTarget(connectorID string, account CoverageAccount, region CoverageRegion, service CoverageService, checkpoints map[string]CoverageCheckpoint) CoverageTarget {
+	enabled := account.Enabled && region.Enabled && service.Enabled
+	priority, rank := mostUrgentCoveragePriority(account.Priority, region.Priority, service.Priority)
+	prerequisites := mergeCoveragePrerequisites(account, region, service)
+
+	target := CoverageTarget{
+		Key:           coverageTargetKey(account.AccountID, region.Region, service.Service),
+		AccountID:     account.AccountID,
+		AccountName:   strings.TrimSpace(account.Name),
+		Region:        region.Region,
+		RegionName:    strings.TrimSpace(region.Name),
+		Service:       service.Service,
+		ServiceName:   strings.TrimSpace(service.Name),
+		Global:        service.Global,
+		Enabled:       enabled,
+		Priority:      priority,
+		PriorityRank:  rank,
+		Reason:        composeCoverageReason(account, region, service),
+		Prerequisites: prerequisites,
+		EvidenceRef:   coverageEvidenceRef(connectorID, account.AccountID, region.Region, service.Service),
+	}
+
+	switch {
+	case !enabled:
+		target.State = CoverageStateDisabled
+	case len(prerequisites) > 0:
+		// Prerequisites that are not yet provably satisfied keep the target out of
+		// the ready queue. A checkpoint can later promote it to a live state.
+		target.State = CoverageStateBlocked
+	default:
+		target.State = CoverageStatePlanned
+	}
+
+	if checkpoint, ok := checkpoints[target.Key]; ok {
+		applyCoverageCheckpoint(&target, checkpoint)
+	}
+	target.Resumable = coverageTargetResumable(target)
+	return target
+}
+
+// applyCoverageCheckpoint replays a persisted target state. A disabled target
+// stays disabled regardless of checkpoint so configuration always wins over a
+// stale prior run.
+func applyCoverageCheckpoint(target *CoverageTarget, checkpoint CoverageCheckpoint) {
+	if !target.Enabled {
+		return
+	}
+	if checkpoint.State != "" {
+		target.State = checkpoint.State
+	}
+	target.Cursor = strings.TrimSpace(checkpoint.Cursor)
+	target.FailureReason = strings.TrimSpace(checkpoint.FailureReason)
+	if checkpoint.Attempts > 0 {
+		target.Attempts = checkpoint.Attempts
+	}
+	if !checkpoint.ObservedAt.IsZero() {
+		target.ObservedAt = checkpoint.ObservedAt.UTC()
+	}
+}
+
+func coverageTargetResumable(target CoverageTarget) bool {
+	switch target.State {
+	case CoverageStateInProgress, CoverageStatePending, CoverageStateFailed, CoverageStatePartial:
+		return true
+	default:
+		return false
+	}
+}
+
+func appendCoverageTarget(targets *[]CoverageTarget, seen map[string]struct{}, target CoverageTarget) {
+	if _, exists := seen[target.Key]; exists {
+		return
+	}
+	seen[target.Key] = struct{}{}
+	*targets = append(*targets, target)
+}
+
+func summarizeCoveragePlan(targets []CoverageTarget, accountCount, regionCount, serviceCount int) CoveragePlanSummary {
+	summary := CoveragePlanSummary{
+		TotalTargets:   len(targets),
+		AccountCount:   accountCount,
+		RegionCount:    regionCount,
+		ServiceCount:   serviceCount,
+		StateCounts:    map[CoverageState]int{},
+		PriorityCounts: map[CoveragePriority]int{},
+	}
+	prerequisites := []string{}
+	for _, target := range targets {
+		summary.StateCounts[target.State]++
+		summary.PriorityCounts[target.Priority]++
+		if target.Enabled {
+			summary.EnabledTargets++
+		} else {
+			summary.DisabledTargets++
+		}
+		if target.Resumable {
+			summary.ResumableTargets++
+		}
+		switch target.State {
+		case CoverageStateCovered:
+			summary.CoveredTargets++
+		case CoverageStateBlocked:
+			summary.BlockedTargets++
+		case CoverageStateFailed:
+			summary.FailedTargets++
+		case CoverageStatePermissionDenied:
+			summary.PermissionDenied++
+		}
+		if target.Enabled && target.State != CoverageStateCovered {
+			summary.OutstandingTargets++
+		}
+		prerequisites = append(prerequisites, target.Prerequisites...)
+	}
+	summary.Prerequisites = dedupeSortedCoverageStrings(prerequisites)
+	if summary.EnabledTargets > 0 {
+		summary.CoveragePercent = roundCoveragePercent(float64(summary.CoveredTargets) / float64(summary.EnabledTargets) * 100)
+	}
+	return summary
+}
+
+func normalizeCoverageAccounts(input []CoverageAccount) ([]CoverageAccount, error) {
+	out := make([]CoverageAccount, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, account := range input {
+		accountID := strings.TrimSpace(account.AccountID)
+		if !isTwelveDigitAWSAccountID(accountID) {
+			return nil, fmt.Errorf("coverage account id %q must be 12 digits", account.AccountID)
+		}
+		if _, ok := seen[accountID]; ok {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		account.AccountID = accountID
+		account.Priority = NormalizeCoveragePriority(account.Priority)
+		account.Prerequisites = dedupeSortedCoverageStrings(account.Prerequisites)
+		out = append(out, account)
+	}
+	return out, nil
+}
+
+func normalizeCoverageRegions(input []CoverageRegion) ([]CoverageRegion, error) {
+	out := make([]CoverageRegion, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, region := range input {
+		code := strings.ToLower(strings.TrimSpace(region.Region))
+		if code == "" {
+			return nil, fmt.Errorf("coverage region code is required")
+		}
+		if _, ok := seen[code]; ok {
+			continue
+		}
+		seen[code] = struct{}{}
+		region.Region = code
+		region.Priority = NormalizeCoveragePriority(region.Priority)
+		region.Prerequisites = dedupeSortedCoverageStrings(region.Prerequisites)
+		out = append(out, region)
+	}
+	return out, nil
+}
+
+func normalizeCoverageServices(input []CoverageService) ([]CoverageService, error) {
+	out := make([]CoverageService, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, service := range input {
+		name := strings.ToLower(strings.TrimSpace(service.Service))
+		if name == "" {
+			return nil, fmt.Errorf("coverage service name is required")
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		service.Service = name
+		service.HomeRegion = strings.ToLower(strings.TrimSpace(service.HomeRegion))
+		service.Priority = NormalizeCoveragePriority(service.Priority)
+		service.Prerequisites = dedupeSortedCoverageStrings(service.Prerequisites)
+		out = append(out, service)
+	}
+	return out, nil
+}
+
+func indexCoverageCheckpoints(input []CoverageCheckpoint) (map[string]CoverageCheckpoint, error) {
+	index := make(map[string]CoverageCheckpoint, len(input))
+	for _, checkpoint := range input {
+		accountID := strings.TrimSpace(checkpoint.AccountID)
+		region := strings.ToLower(strings.TrimSpace(checkpoint.Region))
+		service := strings.ToLower(strings.TrimSpace(checkpoint.Service))
+		if accountID == "" || region == "" || service == "" {
+			return nil, fmt.Errorf("coverage checkpoint requires account, region, and service")
+		}
+		if checkpoint.State != "" && !validCoverageState(checkpoint.State) {
+			return nil, fmt.Errorf("coverage checkpoint has invalid state %q", checkpoint.State)
+		}
+		key := coverageTargetKey(accountID, region, service)
+		// Last checkpoint for a key wins; callers pass at most one per target.
+		index[key] = checkpoint
+	}
+	return index, nil
+}
+
+// NormalizeCoveragePriority maps a raw priority onto the supported set,
+// defaulting to normal.
+func NormalizeCoveragePriority(priority CoveragePriority) CoveragePriority {
+	switch CoveragePriority(strings.ToLower(strings.TrimSpace(string(priority)))) {
+	case CoveragePriorityCritical:
+		return CoveragePriorityCritical
+	case CoveragePriorityHigh:
+		return CoveragePriorityHigh
+	case CoveragePriorityLow:
+		return CoveragePriorityLow
+	default:
+		return CoveragePriorityNormal
+	}
+}
+
+func coveragePriorityRank(priority CoveragePriority) int {
+	switch NormalizeCoveragePriority(priority) {
+	case CoveragePriorityCritical:
+		return 0
+	case CoveragePriorityHigh:
+		return 1
+	case CoveragePriorityLow:
+		return 3
+	default:
+		return 2
+	}
+}
+
+// mostUrgentCoveragePriority returns the most urgent (lowest rank) priority
+// among the dimensions so a critical account or service is never buried behind a
+// normal one.
+func mostUrgentCoveragePriority(priorities ...CoveragePriority) (CoveragePriority, int) {
+	best := CoveragePriorityLow
+	bestRank := coveragePriorityRank(best)
+	for _, priority := range priorities {
+		if rank := coveragePriorityRank(priority); rank < bestRank {
+			best = NormalizeCoveragePriority(priority)
+			bestRank = rank
+		}
+	}
+	return best, bestRank
+}
+
+func composeCoverageReason(account CoverageAccount, region CoverageRegion, service CoverageService) string {
+	parts := []string{}
+	if reason := strings.TrimSpace(account.Reason); reason != "" {
+		parts = append(parts, "account: "+reason)
+	}
+	if reason := strings.TrimSpace(region.Reason); reason != "" {
+		parts = append(parts, "region: "+reason)
+	}
+	if reason := strings.TrimSpace(service.Reason); reason != "" {
+		parts = append(parts, "service: "+reason)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// mergeCoveragePrerequisites unions the dimension prerequisites with derived
+// prerequisites (opt-in region enablement, management-account scoping) so an
+// operator sees exactly what must be true before the target can be scanned.
+func mergeCoveragePrerequisites(account CoverageAccount, region CoverageRegion, service CoverageService) []string {
+	prerequisites := []string{}
+	prerequisites = append(prerequisites, account.Prerequisites...)
+	prerequisites = append(prerequisites, region.Prerequisites...)
+	prerequisites = append(prerequisites, service.Prerequisites...)
+	if region.OptIn {
+		prerequisites = append(prerequisites, fmt.Sprintf("opt-in region %s must be enabled on account %s", region.Region, account.AccountID))
+	}
+	if account.Management {
+		prerequisites = append(prerequisites, fmt.Sprintf("management account %s requires organization read access", account.AccountID))
+	}
+	return dedupeSortedCoverageStrings(prerequisites)
+}
+
+func coverageTargetKey(accountID, region, service string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(accountID),
+		strings.ToLower(strings.TrimSpace(region)),
+		strings.ToLower(strings.TrimSpace(service)),
+	}, "|")
+}
+
+func coverageEvidenceRef(connectorID, accountID, region, service string) string {
+	connector := strings.TrimSpace(connectorID)
+	if connector == "" {
+		connector = "connector"
+	}
+	return "aws:coverage:" + strings.Join([]string{
+		connector,
+		strings.TrimSpace(accountID),
+		strings.ToLower(strings.TrimSpace(region)),
+		strings.ToLower(strings.TrimSpace(service)),
+	}, ":")
+}
+
+func validCoverageState(state CoverageState) bool {
+	switch state {
+	case CoverageStateDisabled, CoverageStateBlocked, CoverageStatePlanned, CoverageStatePending,
+		CoverageStateInProgress, CoverageStateCovered, CoverageStatePartial, CoverageStateFailed,
+		CoverageStatePermissionDenied, CoverageStateUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+func dedupeSortedCoverageStrings(items []string) []string {
+	if len(items) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func roundCoveragePercent(value float64) float64 {
+	return float64(int64(value*100+0.5)) / 100
+}
+
+// DefaultCoverageServices returns the baseline AWS service partitions the
+// machine-identity scanner plans for, with IAM marked global so it is planned
+// once per account instead of per region. Callers may extend or override the
+// catalog; it exists so operators and tests share one deterministic default.
+func DefaultCoverageServices() []CoverageService {
+	return []CoverageService{
+		{Service: "iam", Name: "IAM roles and policies", Enabled: true, Priority: CoveragePriorityCritical, Global: true, HomeRegion: defaultGlobalServiceHomeRegion, Reason: "account-global machine identity inventory"},
+		{Service: "ec2", Name: "EC2 instance profiles", Enabled: true, Priority: CoveragePriorityHigh, Reason: "compute workload identities"},
+		{Service: "ecs", Name: "ECS task and execution roles", Enabled: true, Priority: CoveragePriorityHigh, Reason: "container workload identities"},
+		{Service: "lambda", Name: "Lambda execution roles", Enabled: true, Priority: CoveragePriorityHigh, Reason: "serverless workload identities"},
+		{Service: "eks", Name: "EKS workload identities", Enabled: true, Priority: CoveragePriorityNormal, Reason: "Kubernetes workload identities"},
+		{Service: "secretsmanager", Name: "Secrets Manager references", Enabled: true, Priority: CoveragePriorityNormal, Reason: "credential reference mapping"},
+	}
+}

--- a/internal/providers/awscontract/coverage_planner_test.go
+++ b/internal/providers/awscontract/coverage_planner_test.go
@@ -1,0 +1,291 @@
+package awscontract
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func sampleCoverageConfig() CoveragePlanConfig {
+	return CoveragePlanConfig{
+		ConnectorID: "aws-conn-1",
+		Accounts: []CoverageAccount{
+			{AccountID: "111111111111", Name: "prod", Enabled: true, Priority: CoveragePriorityCritical, Reason: "production estate"},
+			{AccountID: "222222222222", Name: "sandbox", Enabled: false, Reason: "decommissioned"},
+		},
+		Regions: []CoverageRegion{
+			{Region: "us-east-1", Enabled: true, Priority: CoveragePriorityHigh},
+			{Region: "eu-west-1", Enabled: true},
+		},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true, Priority: CoveragePriorityCritical, Global: true},
+			{Service: "lambda", Enabled: true, Priority: CoveragePriorityNormal},
+		},
+	}
+}
+
+func TestPlanCoverageIsDeterministic(t *testing.T) {
+	now := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	first, err := PlanCoverage(sampleCoverageConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := PlanCoverage(sampleCoverageConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("plan is not deterministic across identical inputs")
+	}
+	if first.Version != CoveragePlannerVersion {
+		t.Fatalf("expected version %q, got %q", CoveragePlannerVersion, first.Version)
+	}
+}
+
+func TestPlanCoverageGlobalServicePlannedOncePerAccount(t *testing.T) {
+	now := time.Now().UTC()
+	plan, err := PlanCoverage(sampleCoverageConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 2 accounts: iam (global -> 1 region each) + lambda (2 regions each) = 2*(1+2) = 6.
+	if len(plan.Targets) != 6 {
+		t.Fatalf("expected 6 targets, got %d", len(plan.Targets))
+	}
+	iamRegions := map[string]int{}
+	for _, target := range plan.Targets {
+		if target.Service != "iam" {
+			continue
+		}
+		if !target.Global {
+			t.Fatalf("iam target should be marked global")
+		}
+		iamRegions[target.AccountID]++
+		if target.Region != defaultGlobalServiceHomeRegion {
+			t.Fatalf("global iam target should pin home region, got %q", target.Region)
+		}
+	}
+	for accountID, count := range iamRegions {
+		if count != 1 {
+			t.Fatalf("account %s has %d iam targets, want 1", accountID, count)
+		}
+	}
+}
+
+func TestPlanCoverageDisabledDimensionDisablesTarget(t *testing.T) {
+	now := time.Now().UTC()
+	plan, err := PlanCoverage(sampleCoverageConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, target := range plan.Targets {
+		if target.AccountID == "222222222222" {
+			if target.Enabled {
+				t.Fatalf("disabled account target should not be enabled: %s", target.Key)
+			}
+			if target.State != CoverageStateDisabled {
+				t.Fatalf("disabled account target state should be disabled, got %q", target.State)
+			}
+		}
+	}
+	if plan.Summary.DisabledTargets != 3 {
+		t.Fatalf("expected 3 disabled targets for sandbox account, got %d", plan.Summary.DisabledTargets)
+	}
+	if plan.Summary.EnabledTargets != 3 {
+		t.Fatalf("expected 3 enabled targets for prod account, got %d", plan.Summary.EnabledTargets)
+	}
+}
+
+func TestPlanCoverageMostUrgentPriorityWins(t *testing.T) {
+	now := time.Now().UTC()
+	config := CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "111111111111", Enabled: true, Priority: CoveragePriorityLow}},
+		Regions:  []CoverageRegion{{Region: "us-east-1", Enabled: true, Priority: CoveragePriorityNormal}},
+		Services: []CoverageService{{Service: "iam", Enabled: true, Priority: CoveragePriorityCritical}},
+	}
+	plan, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(plan.Targets))
+	}
+	if plan.Targets[0].Priority != CoveragePriorityCritical || plan.Targets[0].PriorityRank != 0 {
+		t.Fatalf("expected critical priority to win, got %q (rank %d)", plan.Targets[0].Priority, plan.Targets[0].PriorityRank)
+	}
+}
+
+func TestPlanCoverageOrdersByPriorityThenKey(t *testing.T) {
+	now := time.Now().UTC()
+	plan, err := PlanCoverage(sampleCoverageConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 1; i < len(plan.Targets); i++ {
+		prev, cur := plan.Targets[i-1], plan.Targets[i]
+		if prev.PriorityRank > cur.PriorityRank {
+			t.Fatalf("targets not ordered by priority rank at %d", i)
+		}
+		if prev.PriorityRank == cur.PriorityRank && prev.Key > cur.Key {
+			t.Fatalf("targets not ordered by key within priority at %d", i)
+		}
+	}
+}
+
+func TestPlanCoveragePrerequisitesBlockTarget(t *testing.T) {
+	now := time.Now().UTC()
+	config := CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "111111111111", Enabled: true, Management: true}},
+		Regions:  []CoverageRegion{{Region: "ap-east-1", Enabled: true, OptIn: true}},
+		Services: []CoverageService{{Service: "iam", Enabled: true, Global: false}},
+	}
+	plan, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	target := plan.Targets[0]
+	if target.State != CoverageStateBlocked {
+		t.Fatalf("expected blocked target, got %q", target.State)
+	}
+	if len(target.Prerequisites) != 2 {
+		t.Fatalf("expected derived opt-in + management prerequisites, got %v", target.Prerequisites)
+	}
+	if plan.Summary.BlockedTargets != 1 {
+		t.Fatalf("expected 1 blocked target, got %d", plan.Summary.BlockedTargets)
+	}
+}
+
+func TestPlanCoverageCheckpointResumes(t *testing.T) {
+	now := time.Now().UTC()
+	observed := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+	config := sampleCoverageConfig()
+	config.Checkpoints = []CoverageCheckpoint{
+		{AccountID: "111111111111", Region: "us-east-1", Service: "iam", State: CoverageStateCovered, ObservedAt: observed},
+		{AccountID: "111111111111", Region: "eu-west-1", Service: "lambda", State: CoverageStateInProgress, Cursor: "page-2", Attempts: 1},
+		{AccountID: "111111111111", Region: "us-east-1", Service: "lambda", State: CoverageStateFailed, FailureReason: "throttled", Attempts: 3},
+		// Checkpoint for a disabled target must not resurrect it.
+		{AccountID: "222222222222", Region: "us-east-1", Service: "lambda", State: CoverageStateCovered},
+	}
+	plan, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byKey := map[string]CoverageTarget{}
+	for _, target := range plan.Targets {
+		byKey[target.Key] = target
+	}
+	covered := byKey["111111111111|us-east-1|iam"]
+	if covered.State != CoverageStateCovered || covered.Resumable {
+		t.Fatalf("covered target wrong: %+v", covered)
+	}
+	if !covered.ObservedAt.Equal(observed) {
+		t.Fatalf("covered target should keep observed time, got %v", covered.ObservedAt)
+	}
+	inProgress := byKey["111111111111|eu-west-1|lambda"]
+	if inProgress.State != CoverageStateInProgress || inProgress.Cursor != "page-2" || !inProgress.Resumable {
+		t.Fatalf("in-progress target wrong: %+v", inProgress)
+	}
+	failed := byKey["111111111111|us-east-1|lambda"]
+	if failed.State != CoverageStateFailed || failed.FailureReason != "throttled" || failed.Attempts != 3 {
+		t.Fatalf("failed target wrong: %+v", failed)
+	}
+	disabled := byKey["222222222222|us-east-1|lambda"]
+	if disabled.State != CoverageStateDisabled || disabled.Enabled {
+		t.Fatalf("disabled target should ignore checkpoint: %+v", disabled)
+	}
+	if plan.Summary.CoveredTargets != 1 || plan.Summary.FailedTargets != 1 || plan.Summary.ResumableTargets != 2 {
+		t.Fatalf("summary counts wrong: %+v", plan.Summary)
+	}
+	// Coverage percent = covered (1) / enabled (3) -> 33.33.
+	if plan.Summary.CoveragePercent < 33.32 || plan.Summary.CoveragePercent > 33.34 {
+		t.Fatalf("unexpected coverage percent: %v", plan.Summary.CoveragePercent)
+	}
+}
+
+func TestPlanCoverageEmptyConfig(t *testing.T) {
+	plan, err := PlanCoverage(CoveragePlanConfig{}, time.Now())
+	if err != nil {
+		t.Fatalf("empty config should not error, got %v", err)
+	}
+	if len(plan.Targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(plan.Targets))
+	}
+	if plan.Summary.CoveragePercent != 0 {
+		t.Fatalf("expected zero coverage percent, got %v", plan.Summary.CoveragePercent)
+	}
+	if plan.Targets == nil {
+		t.Fatalf("targets should be a non-nil empty slice for stable JSON")
+	}
+}
+
+func TestPlanCoverageDeduplicatesDimensions(t *testing.T) {
+	now := time.Now().UTC()
+	config := CoveragePlanConfig{
+		Accounts: []CoverageAccount{
+			{AccountID: "111111111111", Enabled: true},
+			{AccountID: " 111111111111 ", Enabled: false},
+		},
+		Regions: []CoverageRegion{
+			{Region: "us-east-1", Enabled: true},
+			{Region: "US-EAST-1", Enabled: true},
+		},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true},
+			{Service: "IAM", Enabled: true},
+		},
+	}
+	plan, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Targets) != 1 {
+		t.Fatalf("expected dimensions deduped to 1 target, got %d", len(plan.Targets))
+	}
+	if !plan.Targets[0].Enabled {
+		t.Fatalf("first account occurrence should win and stay enabled")
+	}
+}
+
+func TestPlanCoverageRejectsInvalidAccountID(t *testing.T) {
+	_, err := PlanCoverage(CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "123", Enabled: true}},
+		Regions:  []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services: []CoverageService{{Service: "iam", Enabled: true}},
+	}, time.Now())
+	if err == nil {
+		t.Fatalf("expected error for invalid account id")
+	}
+}
+
+func TestPlanCoverageRejectsInvalidCheckpointState(t *testing.T) {
+	config := sampleCoverageConfig()
+	config.Checkpoints = []CoverageCheckpoint{{AccountID: "111111111111", Region: "us-east-1", Service: "iam", State: "bogus"}}
+	if _, err := PlanCoverage(config, time.Now()); err == nil {
+		t.Fatalf("expected error for invalid checkpoint state")
+	}
+}
+
+func TestDefaultCoverageServicesHasGlobalIAM(t *testing.T) {
+	services := DefaultCoverageServices()
+	if len(services) == 0 {
+		t.Fatalf("expected default services")
+	}
+	var iam *CoverageService
+	for i := range services {
+		if services[i].Service == "iam" {
+			iam = &services[i]
+		}
+	}
+	if iam == nil || !iam.Global {
+		t.Fatalf("expected default IAM service to be global")
+	}
+}
+
+func TestNormalizeCoveragePriorityDefaultsToNormal(t *testing.T) {
+	if got := NormalizeCoveragePriority(""); got != CoveragePriorityNormal {
+		t.Fatalf("expected normal default, got %q", got)
+	}
+	if got := NormalizeCoveragePriority("CRITICAL"); got != CoveragePriorityCritical {
+		t.Fatalf("expected critical, got %q", got)
+	}
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1040,6 +1040,37 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS coverage plan with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan: { status: 'ready', summary: { total_targets: 6 }, targets: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectCoveragePlan(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { account: '111111111111', region: 'us-east-1', service: 'iam', state: 'failed' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/coverage-plan?connector_id=aws-prod&fixture_state=partial_failure&account=111111111111&region=us-east-1&service=iam&state=failed'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2686,6 +2686,112 @@ export type AWSCredentialReferencesInventoryResult = {
   updated_at: string;
 };
 
+export type AWSCoveragePlanStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSCoveragePlanFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSCoveragePriority = 'critical' | 'high' | 'normal' | 'low';
+export type AWSCoverageState =
+  | 'planned'
+  | 'pending'
+  | 'in_progress'
+  | 'covered'
+  | 'partial'
+  | 'failed'
+  | 'permission_denied'
+  | 'unsupported'
+  | 'blocked'
+  | 'disabled';
+
+export type AWSCoveragePlanTarget = {
+  key: string;
+  account_id: string;
+  account_name?: string;
+  region: string;
+  region_name?: string;
+  service: string;
+  service_name?: string;
+  global: boolean;
+  enabled: boolean;
+  priority: AWSCoveragePriority;
+  priority_rank: number;
+  reason?: string;
+  prerequisites: string[];
+  state: AWSCoverageState;
+  cursor?: string;
+  failure_reason?: string;
+  attempts?: number;
+  resumable: boolean;
+  next_action: string;
+  evidence_ref: string;
+  observed_at?: string;
+};
+
+export type AWSCoveragePlanSummary = {
+  total_targets: number;
+  enabled_targets: number;
+  disabled_targets: number;
+  account_count: number;
+  region_count: number;
+  service_count: number;
+  outstanding_targets: number;
+  covered_targets: number;
+  blocked_targets: number;
+  failed_targets: number;
+  permission_denied_targets: number;
+  resumable_targets: number;
+  coverage_percent: number;
+  state_counts: Record<string, number>;
+  priority_counts: Record<string, number>;
+  prerequisites: string[];
+};
+
+export type AWSCoveragePlanDiagnostic = {
+  source: string;
+  scope?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSCoveragePlanCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSCoveragePlanResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCoveragePlanStatus;
+  fixture_state: AWSCoveragePlanFixtureState;
+  confidence: number;
+  filtered_targets: number;
+  summary: AWSCoveragePlanSummary;
+  targets: AWSCoveragePlanTarget[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSCoveragePlanCoverageGap[];
+  diagnostics: AWSCoveragePlanDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSDynamoDBRDSReachabilityInventoryResult = {
   tenant_id: string;
   workspace_id: string;
@@ -4420,6 +4526,26 @@ export const apiClient = {
         resource_type: filters?.resourceType,
         identity: filters?.identity,
         provider: filters?.provider
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectCoveragePlan(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSCoveragePlanFixtureState,
+    filters?: { account?: string; region?: string; service?: string; state?: AWSCoverageState },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plan: AWSCoveragePlanResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/coverage-plan${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        account: filters?.account,
+        region: filters?.region,
+        service: filters?.service,
+        state: filters?.state
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7614,7 +7614,18 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         setCoveragePlanLoading(false);
       }
     }
-  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connector_id]);
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region,
+    connection?.status,
+    connection?.health_status,
+  ]);
 
   useEffect(() => {
     void loadCoveragePlan();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -57,6 +57,8 @@ import {
   type AWSDynamoDBRDSReachabilityRecord,
   type AWSCredentialReferencesInventoryResult,
   type AWSCredentialReferenceRecord,
+  type AWSCoveragePlanResult,
+  type AWSCoveragePlanTarget,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
   type AWSSQSSNSReachabilityInventoryResult,
@@ -3673,6 +3675,13 @@ type AWSInventoryCredentialReferencesState = {
   onRetry: () => void;
 };
 
+type AWSInventoryCoveragePlanState = {
+  plan: AWSCoveragePlanResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -3699,8 +3708,12 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       options: [
         { label: 'All coverage', value: 'all' },
         { label: 'Covered', value: 'covered' },
+        { label: 'Planned', value: 'planned' },
         { label: 'Missing', value: 'missing' },
+        { label: 'Blocked', value: 'blocked' },
         { label: 'Degraded', value: 'degraded' },
+        { label: 'Failed', value: 'failed' },
+        { label: 'Permission denied', value: 'permission_denied' },
         { label: 'Not yet available', value: 'not-yet-available' }
       ]
     }
@@ -3987,6 +4000,137 @@ function AWSInventoryPill({
   return <span className={`idt-aws-inventory-pill is-${awsInventoryPillTone(stage)}`}>{label ?? awsStageLabel(stage)}</span>;
 }
 
+function awsCoveragePlanFilterValue(state: string): string {
+  switch (state) {
+    case 'covered':
+      return 'covered';
+    case 'failed':
+    case 'partial':
+    case 'permission_denied':
+    case 'in_progress':
+      return 'degraded';
+    case 'blocked':
+    case 'disabled':
+    case 'unsupported':
+    case 'planned':
+    case 'pending':
+      return 'missing';
+    default:
+      return 'not-yet-available';
+  }
+}
+
+function awsCoveragePlanStage(state: string): AWSCapabilityStage {
+  return state === 'covered' ? 'wired' : state === 'disabled' || state === 'unsupported' ? 'not-available' : 'coming';
+}
+
+function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
+  const details = [`Priority ${formatTokenLabel(target.priority)}`];
+  if (target.failure_reason) {
+    details.push(target.failure_reason);
+  } else if (target.prerequisites.length > 0) {
+    details.push(target.prerequisites[0]);
+  } else if (target.cursor) {
+    details.push(`Cursor ${target.cursor}`);
+  } else {
+    details.push(target.next_action);
+  }
+  if (target.attempts) {
+    details.push(`${target.attempts} ${target.attempts === 1 ? 'attempt' : 'attempts'}`);
+  }
+  return details.join(' · ');
+}
+
+function buildAWSCoveragePlanRows(
+  plan: AWSCoveragePlanResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryCoverageRow[] {
+  if (plan?.targets.length) {
+    return plan.targets.map((target) => {
+      const coverage = awsCoveragePlanFilterValue(target.state);
+      const accountFilter = connection?.account_id && target.account_id === connection.account_id ? 'connected,planned' : 'planned';
+      const regionFilter =
+        connection?.region && target.region.toLowerCase() === connection.region.toLowerCase() ? 'current' : 'uncovered';
+      return {
+        id: target.key,
+        category: `${target.account_name || target.account_id} / ${target.region} / ${formatTokenLabel(target.service)}`,
+        coverage: target.state,
+        source: target.evidence_ref,
+        status: target.state,
+        detail: awsCoveragePlanTargetDetail(target),
+        filters: {
+          account: accountFilter,
+          region: regionFilter,
+          coverage: `${coverage},${target.state}`,
+          search: ''
+        },
+        searchText: inventorySearchText([
+          target.account_id,
+          target.account_name,
+          target.region,
+          target.service,
+          target.service_name,
+          target.state,
+          target.priority,
+          target.failure_reason,
+          target.next_action,
+          target.evidence_ref,
+          ...target.prerequisites
+        ])
+      };
+    });
+  }
+  if (loading) {
+    return [
+      {
+        id: 'coverage-plan-loading',
+        category: 'Coverage plan',
+        coverage: 'planned',
+        source: 'AWS coverage planner',
+        status: 'loading',
+        detail: 'Loading account, region, and service targets.',
+        filters: { account: 'planned', region: 'uncovered', coverage: 'planned', search: '' },
+        searchText: inventorySearchText(['coverage plan loading'])
+      }
+    ];
+  }
+  const accountCoverage = awsCoverageState(connection);
+  const currentCoverageFilter = accountCoverage === 'covered' ? 'covered' : accountCoverage === 'degraded' ? 'degraded' : 'missing';
+  return [
+    {
+      id: 'current-account',
+      category: connection?.account_id ? `AWS account ${connection.account_id}` : 'Selected AWS account',
+      coverage: accountCoverage,
+      source: connection?.display_name ?? 'Connect AWS',
+      status: connection?.connected ? 'covered' : 'missing',
+      detail: connection?.region ? `Validated in ${connection.region}` : 'Region coverage starts after validation.',
+      filters: {
+        account: connection?.account_id ? 'connected' : 'planned',
+        region: connection?.region ? 'current' : 'uncovered',
+        coverage: currentCoverageFilter,
+        search: ''
+      },
+      searchText: inventorySearchText([connection?.account_id, connection?.region, connection?.display_name, 'current account', 'covered', 'missing'])
+    },
+    {
+      id: 'current-region',
+      category: connection?.region ? `Region ${connection.region}` : 'Current region',
+      coverage: accountCoverage,
+      source: 'AWS connector payload',
+      status: accountCoverage,
+      detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.',
+      filters: {
+        account: connection?.account_id ? 'connected' : 'planned',
+        region: connection?.region ? 'current' : 'uncovered',
+        coverage: currentCoverageFilter,
+        search: ''
+      },
+      searchText: inventorySearchText([connection?.region, 'region', 'coverage', 'region coverage'])
+    }
+  ];
+}
+
 function AWSInventoryFilterSet({
   routeID,
   filters,
@@ -4161,110 +4305,75 @@ function AWSInventoryPrerequisites({
 function AWSAccountsInventoryContent({
   connection,
   connectPath,
+  coveragePlanState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
   connectPath: string;
+  coveragePlanState: AWSInventoryCoveragePlanState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const accountCoverage = awsCoverageState(connection);
   const hasHealthyCoverage = accountCoverage === 'covered';
-  const currentCoverageFilter = accountCoverage === 'covered' ? 'covered' : accountCoverage === 'degraded' ? 'degraded' : 'missing';
-  const rows: AWSInventoryCoverageRow[] = [
-    {
-      id: 'current-account',
-      category: connection?.account_id ? `AWS account ${connection.account_id}` : 'Selected AWS account',
-      coverage: accountCoverage,
-      source: connection?.display_name ?? 'Connect AWS',
-      status: connection?.connected ? 'covered' : 'missing',
-      detail: connection?.region ? `Validated in ${connection.region}` : 'Region coverage starts after validation.',
-      filters: {
-        account: connection?.account_id ? 'connected' : 'planned',
-        region: connection?.region ? 'current' : 'uncovered',
-        coverage: currentCoverageFilter,
-        search: ''
-      },
-      searchText: inventorySearchText([connection?.account_id, connection?.region, connection?.display_name, 'current account', 'covered', 'missing'])
-      },
-      {
-        id: 'current-region',
-        category: connection?.region ? `Region ${connection.region}` : 'Current region',
-        coverage: accountCoverage,
-        source: 'AWS connector payload',
-        status: accountCoverage,
-        detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.',
-        filters: {
-          account: connection?.account_id ? 'connected' : 'planned',
-          region: connection?.region ? 'current' : 'uncovered',
-          coverage: currentCoverageFilter,
-          search: ''
-        },
-        searchText: inventorySearchText([connection?.region, 'region', 'coverage', 'region coverage'])
-      },
-    {
-      id: 'org-planner',
-      category: 'Organization account planner',
-      coverage: 'not yet available',
-      source: 'Future AWS inventory API',
-      status: 'not yet available',
-      detail: 'Will track account enrollment, incremental cursors, and partial account failure.',
-      filters: {
-        account: 'planned',
-        region: 'uncovered',
-        coverage: 'not-yet-available',
-        search: ''
-      },
-      searchText: inventorySearchText([
-        'organization',
-        'planner',
-        'account',
-        'not yet available'
-      ])
-    },
-    {
-      id: 'region-planner',
-      category: 'Multi-region scan planner',
-      coverage: 'not yet available',
-      source: 'Future AWS inventory API',
-      status: 'not yet available',
-      detail: 'Will track service-by-region coverage and degraded or unreachable regions.',
-      filters: {
-        account: 'planned',
-        region: 'uncovered',
-        coverage: 'not-yet-available',
-        search: ''
-      },
-      searchText: inventorySearchText([
-        'multi-region',
-        'planner',
-        'coverage',
-        'not yet available',
-        'degraded',
-        'region'
-      ])
-    }
-  ];
+  const plan = coveragePlanState.plan;
+  const rows = buildAWSCoveragePlanRows(plan, coveragePlanState.loading, connection);
   const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
   const totalChecks = connection?.permission_checks.length ?? 0;
+  const coveredAccounts = plan
+    ? new Set(plan.targets.filter((target) => target.state === 'covered').map((target) => target.account_id)).size
+    : hasHealthyCoverage
+      ? 1
+      : 0;
+  const coveredRegions = plan
+    ? new Set(plan.targets.filter((target) => target.state === 'covered').map((target) => target.region)).size
+    : hasHealthyCoverage
+      ? 1
+      : 0;
   const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
       <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
+      {coveragePlanState.loading ? <DomainLoadingState label="Loading account and region coverage plan" /> : null}
+      {coveragePlanState.error ? (
+        <DomainErrorState
+          title="Coverage plan could not load"
+          body={coveragePlanState.error}
+          retryAction={{ label: 'Retry coverage plan', onClick: coveragePlanState.onRetry }}
+        />
+      ) : null}
       <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage map">
-        <DomainCoverageCard label="Account coverage" scanned={hasHealthyCoverage ? 1 : 0} total={1} detail="Selected environment" />
-        <DomainCoverageCard label="Region coverage" scanned={hasHealthyCoverage ? 1 : 0} total={1} detail={hasHealthyCoverage ? connection?.region ?? 'Pending' : 'Pending'} />
+        <DomainCoverageCard label="Account coverage" scanned={coveredAccounts} total={plan?.summary.account_count ?? 1} detail="Configured accounts" />
+        <DomainCoverageCard label="Region coverage" scanned={coveredRegions} total={plan?.summary.region_count ?? 1} detail={plan ? `${plan.summary.coverage_percent}% target coverage` : hasHealthyCoverage ? connection?.region ?? 'Pending' : 'Pending'} />
         <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
       </section>
+      {plan?.diagnostics.length ? (
+        <DomainStatusPanel
+          eyebrow="Coverage diagnostics"
+          title="Planner found explicit recovery work"
+          status={formatTokenLabel(plan.status)}
+          tone={plan.status === 'blocked' ? 'danger' : 'warning'}
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS coverage plan diagnostics">
+            {plan.diagnostics.map((diagnostic) => (
+              <article key={`${diagnostic.code}-${diagnostic.scope ?? diagnostic.source}`}>
+                <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                <p>{diagnostic.message}</p>
+                {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
       <DomainDataTable
         label="AWS account and region coverage"
         rows={displayedRows}
         getRowKey={(row) => row.id}
         columns={[
           { key: 'category', header: 'Coverage scope', render: (row) => <strong>{row.category}</strong> },
-          { key: 'coverage', header: 'Coverage', render: (row) => <AWSInventoryPill stage={row.coverage === 'covered' ? 'wired' : row.coverage === 'not yet available' ? 'not-available' : 'coming'} label={formatTokenLabel(row.coverage)} /> },
+          { key: 'coverage', header: 'Coverage', render: (row) => <AWSInventoryPill stage={awsCoveragePlanStage(row.coverage)} label={formatTokenLabel(row.coverage)} /> },
           { key: 'source', header: 'Source', render: (row) => row.source },
           { key: 'detail', header: 'Detail', render: (row) => row.detail }
         ]}
@@ -4277,9 +4386,16 @@ function AWSAccountsInventoryContent({
         actions={[{ label: 'Open Connect AWS', to: connectPath, variant: 'secondary' }]}
       >
         <p>
-          Account and region coverage uses the current AWS connector when it exists. Organization-wide scale, cursor health,
-          and partial-region failure reporting stay labeled as future AWS inventory work.
+          Account and region coverage uses the current AWS connector when it exists. The plan stays metadata-only,
+          keeps cursor and failure state explicit, and never treats denied or partial targets as successful coverage.
         </p>
+        {plan?.remediation_hints.length ? (
+          <ul className="idt-domain-charter-list">
+            {plan.remediation_hints.map((hint) => (
+              <li key={hint}>{hint}</li>
+            ))}
+          </ul>
+        ) : null}
       </DomainStatusPanel>
     </>
   );
@@ -6850,6 +6966,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [credentialReferencesInventoryLoading, setCredentialReferencesInventoryLoading] = useState(false);
   const [credentialReferencesInventoryError, setCredentialReferencesInventoryError] = useState('');
   const credentialReferencesInventoryRequestRef = useRef(0);
+  const [coveragePlan, setCoveragePlan] = useState<AWSCoveragePlanResult | null>(null);
+  const [coveragePlanLoading, setCoveragePlanLoading] = useState(false);
+  const [coveragePlanError, setCoveragePlanError] = useState('');
+  const coveragePlanRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -7462,6 +7582,47 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadCredentialReferencesInventory]);
 
+  const loadCoveragePlan = useCallback(async () => {
+    const requestID = ++coveragePlanRequestRef.current;
+    setCoveragePlan(null);
+    setCoveragePlanError('');
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setCoveragePlanLoading(false);
+      return;
+    }
+    setCoveragePlanLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectCoveragePlan(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== coveragePlanRequestRef.current) {
+        return;
+      }
+      setCoveragePlan(response.plan);
+    } catch (error) {
+      if (requestID !== coveragePlanRequestRef.current) {
+        return;
+      }
+      setCoveragePlanError(formatAPIError(error, 'Unable to load account and region coverage plan.'));
+    } finally {
+      if (requestID === coveragePlanRequestRef.current) {
+        setCoveragePlanLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadCoveragePlan();
+    return () => {
+      coveragePlanRequestRef.current += 1;
+    };
+  }, [loadCoveragePlan]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -7529,7 +7690,18 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       ) : null}
 
       {routeID === 'accounts' ? (
-        <AWSAccountsInventoryContent connection={connection} connectPath={connectPath} filters={activeFilters} onFiltersChange={onFiltersChange} />
+        <AWSAccountsInventoryContent
+          connection={connection}
+          connectPath={connectPath}
+          coveragePlanState={{
+            plan: coveragePlan,
+            loading: coveragePlanLoading,
+            error: coveragePlanError,
+            onRetry: () => void loadCoveragePlan()
+          }}
+          filters={activeFilters}
+          onFiltersChange={onFiltersChange}
+        />
       ) : null}
       {routeID === 'identities' ? (
         <AWSMachineIdentitiesContent

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7586,7 +7586,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++coveragePlanRequestRef.current;
     setCoveragePlan(null);
     setCoveragePlanError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connected) {
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setCoveragePlanLoading(false);
       return;
     }
@@ -7614,7 +7614,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         setCoveragePlanLoading(false);
       }
     }
-  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connector_id]);
 
   useEffect(() => {
     void loadCoveragePlan();


### PR DESCRIPTION
## Summary
- Adds a deterministic AWS account/region/service coverage planner with explicit target states, priorities, prerequisites, cursors, failure reasons, evidence refs, and next actions.
- Exposes the planner through `/aws/coverage-plan`, OpenAPI, route auth, and the typed web client.
- Wires the AWS Accounts page to render the plan, diagnostics, coverage filters, and metadata-only remediation hints.
- Documents the planner contract and safety boundary.

## Safety boundary
- Read-only and metadata-only: no AWS mutations and no secret values, prompts, completions, object contents, database rows, or customer payloads are read or persisted.
- Unknown, denied, partial, failed, blocked, disabled, and unsupported states remain explicit and are not counted as successful coverage.

## Validation
- `go test ./internal/providers/awscontract ./internal/api`
- `pnpm tsc --noEmit`
- `pnpm exec vitest run src/api/client.test.ts src/productShell.test.tsx`

## AI disclosure
No

Closes #1497

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic, metadata-only AWS account/region/service coverage planner, exposed via API and the Accounts UI, to make coverage targets, states, and next actions explicit without touching customer data. Implements #1497.

- New Features
  - Planner in `internal/providers/awscontract` creates one target per account/region/service; global services are planned once per account.
  - Each target records enabled flag, priority, prerequisites, lifecycle state, cursor/failure/evidence, and next action.
  - New GET endpoint `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/coverage-plan` with filters (`connector_id`, `fixture_state`, `account`, `region`, `service`, `state`); OpenAPI and route auth updated.
  - Typed web client `getAWSProjectCoveragePlan`; Accounts UI renders the plan with filters, diagnostics, and metadata-only remediation hints.
  - Safety boundary: read-only and metadata-only; unknown/denied/partial/blocked/disabled/unsupported stay explicit and don’t count as covered.

- Bug Fixes
  - Global-service checkpoint region fixed: IAM targets pinned to home region `us-east-1`.
  - API/client/UI polish: proper URL encoding and scoped headers, support for `fixture_state` and target filters, improved UI filters (Planned, Missing), and auto-refetch when connector health updates.
  - Ignore disabled checkpoints for enabled targets to avoid false blocks or failures.

<sup>Written for commit 1b058f4ad452cd5fbb3a0e69d77f519f8d9d1245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

