### PR TITLE
AWS Platform Wave 3.02: add Organizations topology discovery

### DIFF
--- a/docs/aws-organizations-topology.md
+++ b/docs/aws-organizations-topology.md
@@ -1,0 +1,80 @@
+# AWS Organizations topology
+
+AWS Organizations topology is the Wave 3.02 contract for discovering account and OU structure before Identrail fans out AWS machine-identity collection across accounts and regions.
+
+The feature is metadata-only and read-only. It records organization/account/OU facts needed for safe scan planning:
+
+- AWS organization ID, partition, management account, and connector scope
+- organizational units, parent IDs, OU paths, enabled/disabled state, and disabled reasons
+- accounts, account lifecycle status, OU path, management-account indicator, delegated-admin services, scan eligibility, and parent relationships
+- discovery lifecycle state, checkpoint cursor, failure reason, retry attempts, and evidence reference
+
+It intentionally does not collect secret values, customer payloads, prompts, completions, browser output, database rows, object contents, account emails, resource contents, or live mutation output.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology
+```
+
+Query parameters:
+
+- `connector_id`: optional AWS connector ID.
+- `fixture_state`: optional deterministic fixture state: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`.
+- `account`: optional 12-digit AWS account ID filter.
+- `ou`: optional OU ID or OU path filter.
+- `state`: optional discovery state filter: `planned`, `pending`, `in_progress`, `covered`, `partial`, `failed`, `permission_denied`, `unsupported`, `blocked`, or `disabled`.
+- `status`: optional account lifecycle filter: `active`, `suspended`, or `closed`.
+
+The response is wrapped as:
+
+```json
+{
+  "topology": {
+    "status": "ready",
+    "version": "aws-organizations-topology-v1",
+    "organization_id": "o-identrailfixture",
+    "summary": {
+      "account_count": 4,
+      "organizational_unit_count": 4,
+      "scan_eligible_accounts": 3
+    },
+    "organizational_units": [],
+    "accounts": [],
+    "relationships": []
+  }
+}
+```
+
+## Failure states
+
+- `empty`: no accounts or OUs were discovered; operators should confirm the connector is scoped to an organization management or delegated administrator account.
+- `permission_denied`: the connector role cannot read AWS Organizations topology; Identrail reports this as blocked, not successful.
+- `partial_failure` / `degraded`: collection stopped part-way through pagination or retries; cursors and attempts remain visible so operators can rerun safely.
+- suspended or closed accounts: explicit non-eligible account state, not a scan success.
+- disabled OUs: account scan eligibility is blocked with an operator-visible reason.
+
+## AWS permissions
+
+The live collector that feeds this contract should use read-only AWS Organizations actions such as:
+
+- `organizations:DescribeOrganization`
+- `organizations:ListRoots`
+- `organizations:ListAccounts`
+- `organizations:ListAccountsForParent`
+- `organizations:ListParents`
+- `organizations:ListOrganizationalUnitsForParent`
+- `organizations:ListDelegatedAdministrators`
+
+Downstream account/region/service fan-out should join this topology with the coverage planner rather than expanding scan targets from raw connector status alone.
+
+## Validation
+
+Run the focused backend and client checks:
+
+```sh
+go test ./internal/providers/awscontract ./internal/api
+cd web && pnpm exec vitest run src/api/client.test.ts src/productShell.test.tsx
+```
+
+For live validation, use an authorized AWS test organization only. Record account IDs, OU IDs, statuses, delegated-admin services, and failure states; do not record payloads, secrets, account emails, object contents, or resource data.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4706,7 +4706,7 @@ paths:
           name: status
           schema:
             type: string
-            enum: [active, suspended, closed]
+            enum: [active, suspended, pending_activation, pending_closure, closed]
           description: Optional AWS Organizations account lifecycle status filter.
       responses:
         "200":

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -569,6 +569,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
     action: tenancy.read
     resource_type: project
@@ -4645,6 +4650,76 @@ paths:
                     $ref: "#/components/schemas/AWSCoveragePlanResult"
         "400":
           description: Invalid AWS coverage plan request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Organizations account and OU topology
+      operationId: getAWSProjectOrganizationsTopology
+      description: Returns deterministic, project-scoped AWS Organizations account and OU topology for an AWS connector. The response includes account status, management-account and delegated-admin indicators, parent relationships, scan eligibility, cursor/checkpoint state, failure reasons, evidence links, and operator next actions. Read-only and metadata-only - it does not read secret values, customer payloads, object contents, database rows, prompts, completions, or browser output.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope topology discovery.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account
+          schema: { type: string }
+          description: Optional 12-digit AWS account id filter.
+        - in: query
+          name: ou
+          schema: { type: string }
+          description: Optional OU id or OU path filter.
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+          description: Optional discovery lifecycle state filter.
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [active, suspended, closed]
+          description: Optional AWS Organizations account lifecycle status filter.
+      responses:
+        "200":
+          description: AWS Organizations topology
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  topology:
+                    $ref: "#/components/schemas/AWSOrganizationsTopologyResult"
+        "400":
+          description: Invalid AWS Organizations topology request
           content:
             application/json:
               schema:
@@ -10504,6 +10579,155 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSCoveragePlanDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSOrganizationsTopologyAccount:
+      type: object
+      properties:
+        account_id: { type: string }
+        account_name: { type: string }
+        status:
+          type: string
+          enum: [active, suspended, closed]
+        parent_id: { type: string }
+        ou_path: { type: string }
+        partition: { type: string }
+        management: { type: boolean }
+        delegated_admin_services:
+          type: array
+          items: { type: string }
+        connector_scoped: { type: boolean }
+        scan_eligible: { type: boolean }
+        state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        cursor: { type: string }
+        failure_reason: { type: string }
+        attempts: { type: integer }
+        resumable: { type: boolean }
+        next_action: { type: string }
+        evidence_ref: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+        eligibility_failure_reason: { type: string }
+    AWSOrganizationsTopologyOU:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        parent_id: { type: string }
+        path: { type: string }
+        enabled: { type: boolean }
+        reason: { type: string }
+    AWSOrganizationsTopologyRelationship:
+      type: object
+      properties:
+        parent_id: { type: string }
+        child_id: { type: string }
+        child_type:
+          type: string
+          enum: [organizational_unit, account]
+        relationship: { type: string }
+    AWSOrganizationsTopologySummary:
+      type: object
+      properties:
+        account_count: { type: integer }
+        organizational_unit_count: { type: integer }
+        management_account_count: { type: integer }
+        delegated_admin_account_count: { type: integer }
+        suspended_account_count: { type: integer }
+        connector_scoped_accounts: { type: integer }
+        scan_eligible_accounts: { type: integer }
+        blocked_accounts: { type: integer }
+        permission_denied_accounts: { type: integer }
+        failed_accounts: { type: integer }
+        resumable_accounts: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+    AWSOrganizationsTopologyDiagnostic:
+      type: object
+      properties:
+        source: { type: string }
+        scope: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSOrganizationsTopologyCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSOrganizationsTopologyResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        organization_id: { type: string }
+        management_account_id: { type: string }
+        partition: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        filtered_accounts: { type: integer }
+        summary:
+          $ref: "#/components/schemas/AWSOrganizationsTopologySummary"
+        organizational_units:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSOrganizationsTopologyOU"
+        accounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSOrganizationsTopologyAccount"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSOrganizationsTopologyRelationship"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSOrganizationsTopologyCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSOrganizationsTopologyDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10592,7 +10592,7 @@ components:
         account_name: { type: string }
         status:
           type: string
-          enum: [active, suspended, closed]
+          enum: [active, suspended, pending_activation, pending_closure, closed]
         parent_id: { type: string }
         ou_path: { type: string }
         partition: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -757,6 +757,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dynamodb-rds-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/coverage-plan", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ecr-repository-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_organizations_topology.go
+++ b/internal/api/aws_organizations_topology.go
@@ -221,7 +221,12 @@ func validAWSOrganizationsTopologyFilters(request AWSOrganizationsTopologyReques
 		return false
 	}
 	switch awscontract.OrganizationAccountStatus(strings.ToLower(strings.TrimSpace(request.Status))) {
-	case "", awscontract.OrganizationAccountActive, awscontract.OrganizationAccountSuspended, awscontract.OrganizationAccountClosed:
+	case "",
+		awscontract.OrganizationAccountActive,
+		awscontract.OrganizationAccountSuspended,
+		awscontract.OrganizationAccountClosed,
+		awscontract.OrganizationAccountPendingActivation,
+		awscontract.OrganizationAccountPendingClosure:
 		return true
 	default:
 		return false

--- a/internal/api/aws_organizations_topology.go
+++ b/internal/api/aws_organizations_topology.go
@@ -1,0 +1,472 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const awsOrganizationsTopologyCurrentIssue = 1498
+
+// AWSOrganizationsTopologyRequest filters the Organizations topology result.
+type AWSOrganizationsTopologyRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	Account      string `json:"account,omitempty"`
+	OU           string `json:"ou,omitempty"`
+	State        string `json:"state,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// AWSOrganizationsTopologyAccount is one operator-visible Organizations account.
+type AWSOrganizationsTopologyAccount struct {
+	AccountID                string    `json:"account_id"`
+	AccountName              string    `json:"account_name,omitempty"`
+	Status                   string    `json:"status"`
+	ParentID                 string    `json:"parent_id,omitempty"`
+	OUPath                   string    `json:"ou_path,omitempty"`
+	Partition                string    `json:"partition"`
+	Management               bool      `json:"management"`
+	DelegatedAdminServices   []string  `json:"delegated_admin_services"`
+	ConnectorScoped          bool      `json:"connector_scoped"`
+	ScanEligible             bool      `json:"scan_eligible"`
+	State                    string    `json:"state"`
+	Cursor                   string    `json:"cursor,omitempty"`
+	FailureReason            string    `json:"failure_reason,omitempty"`
+	Attempts                 int       `json:"attempts,omitempty"`
+	Resumable                bool      `json:"resumable"`
+	NextAction               string    `json:"next_action"`
+	EvidenceRef              string    `json:"evidence_ref"`
+	ObservedAt               time.Time `json:"observed_at,omitempty"`
+	EligibilityFailureReason string    `json:"eligibility_failure_reason,omitempty"`
+}
+
+// AWSOrganizationsTopologyOU is one OU/root in the topology tree.
+type AWSOrganizationsTopologyOU struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+	Path     string `json:"path"`
+	Enabled  bool   `json:"enabled"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// AWSOrganizationsTopologyRelationship links a parent OU/root to a child OU or account.
+type AWSOrganizationsTopologyRelationship struct {
+	ParentID     string `json:"parent_id"`
+	ChildID      string `json:"child_id"`
+	ChildType    string `json:"child_type"`
+	Relationship string `json:"relationship"`
+}
+
+// AWSOrganizationsTopologySummary aggregates Organizations discovery state.
+type AWSOrganizationsTopologySummary struct {
+	AccountCount               int            `json:"account_count"`
+	OrganizationalUnitCount    int            `json:"organizational_unit_count"`
+	ManagementAccountCount     int            `json:"management_account_count"`
+	DelegatedAdminAccountCount int            `json:"delegated_admin_account_count"`
+	SuspendedAccountCount      int            `json:"suspended_account_count"`
+	ConnectorScopedAccounts    int            `json:"connector_scoped_accounts"`
+	ScanEligibleAccounts       int            `json:"scan_eligible_accounts"`
+	BlockedAccounts            int            `json:"blocked_accounts"`
+	PermissionDeniedAccounts   int            `json:"permission_denied_accounts"`
+	FailedAccounts             int            `json:"failed_accounts"`
+	ResumableAccounts          int            `json:"resumable_accounts"`
+	StateCounts                map[string]int `json:"state_counts"`
+	StatusCounts               map[string]int `json:"status_counts"`
+}
+
+// AWSOrganizationsTopologyDiagnostic carries a deterministic discovery failure.
+type AWSOrganizationsTopologyDiagnostic struct {
+	Source      string `json:"source"`
+	Scope       string `json:"scope,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSOrganizationsTopologyCoverageGap names an explicit limitation.
+type AWSOrganizationsTopologyCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSOrganizationsTopologyResult is the project-scoped Organizations topology.
+type AWSOrganizationsTopologyResult struct {
+	TenantID            string                                 `json:"tenant_id"`
+	WorkspaceID         string                                 `json:"workspace_id"`
+	ProjectID           string                                 `json:"project_id"`
+	ConnectorID         string                                 `json:"connector_id,omitempty"`
+	AccountID           string                                 `json:"account_id,omitempty"`
+	Region              string                                 `json:"region,omitempty"`
+	ParentIssueNumber   int                                    `json:"parent_issue_number"`
+	ParentIssueRef      string                                 `json:"parent_issue_ref"`
+	CurrentIssueNumber  int                                    `json:"current_issue_number"`
+	CurrentIssueRef     string                                 `json:"current_issue_ref"`
+	OrganizationID      string                                 `json:"organization_id,omitempty"`
+	ManagementAccountID string                                 `json:"management_account_id,omitempty"`
+	Partition           string                                 `json:"partition"`
+	Version             string                                 `json:"version"`
+	Status              string                                 `json:"status"`
+	FixtureState        string                                 `json:"fixture_state"`
+	Confidence          float64                                `json:"confidence"`
+	FilteredAccounts    int                                    `json:"filtered_accounts"`
+	Summary             AWSOrganizationsTopologySummary        `json:"summary"`
+	OrganizationalUnits []AWSOrganizationsTopologyOU           `json:"organizational_units"`
+	Accounts            []AWSOrganizationsTopologyAccount      `json:"accounts"`
+	Relationships       []AWSOrganizationsTopologyRelationship `json:"relationships"`
+	FailureReasons      []string                               `json:"failure_reasons"`
+	RemediationHints    []string                               `json:"remediation_hints"`
+	EvidenceLinks       []string                               `json:"evidence_links"`
+	CoverageGaps        []AWSOrganizationsTopologyCoverageGap  `json:"coverage_gaps"`
+	Diagnostics         []AWSOrganizationsTopologyDiagnostic   `json:"diagnostics"`
+	GeneratedAt         time.Time                              `json:"generated_at"`
+	UpdatedAt           time.Time                              `json:"updated_at"`
+}
+
+// GetAWSOrganizationsTopology returns deterministic AWS Organizations topology
+// for a project's connector. It is read-only and metadata-only.
+func (s *Service) GetAWSOrganizationsTopology(ctx context.Context, workspaceID string, projectID string, request AWSOrganizationsTopologyRequest) (AWSOrganizationsTopologyResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSOrganizationsTopologyResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSOrganizationsTopologyResult{}, err
+	}
+	return buildAWSOrganizationsTopology(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSOrganizationsTopology(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSOrganizationsTopologyRequest, checkedAt time.Time) (AWSOrganizationsTopologyResult, error) {
+	fixtureState := normalizeAWSOrganizationsFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" || !validAWSOrganizationsTopologyFilters(request) {
+		return AWSOrganizationsTopologyResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "111111111111")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	config, diagnostics, gaps := awsOrganizationsTopologyFixtureConfig(connectorID, accountID, fixtureState)
+	topology, err := awscontract.PlanOrganizationsTopology(config, checkedAt)
+	if err != nil {
+		return AWSOrganizationsTopologyResult{}, err
+	}
+	summary := mapAWSOrganizationsTopologySummary(topology.Summary)
+	accounts := mapAWSOrganizationsTopologyAccounts(topology.Accounts)
+	filteredAccounts := filterAWSOrganizationsTopologyAccounts(accounts, request)
+	status, confidence, failures, remediations := summarizeAWSOrganizationsTopology(fixtureState, diagnostics, topology)
+
+	return AWSOrganizationsTopologyResult{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		AccountID:           accountID,
+		Region:              region,
+		ParentIssueNumber:   awsPlatformDependencyParentIssue,
+		ParentIssueRef:      awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:  awsOrganizationsTopologyCurrentIssue,
+		CurrentIssueRef:     awsIssueRef(awsOrganizationsTopologyCurrentIssue),
+		OrganizationID:      topology.OrganizationID,
+		ManagementAccountID: topology.ManagementAccountID,
+		Partition:           topology.Partition,
+		Version:             topology.Version,
+		Status:              status,
+		FixtureState:        fixtureState,
+		Confidence:          confidence,
+		FilteredAccounts:    len(filteredAccounts),
+		Summary:             summary,
+		OrganizationalUnits: mapAWSOrganizationsTopologyOUs(topology.OrganizationalUnits),
+		Accounts:            filteredAccounts,
+		Relationships:       mapAWSOrganizationsTopologyRelationships(topology.Relationships),
+		FailureReasons:      failures,
+		RemediationHints:    remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsOrganizationsTopologyCurrentIssue),
+			"/docs/aws-organizations-topology",
+			"/docs/aws-account-region-coverage-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func normalizeAWSOrganizationsFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func validAWSOrganizationsTopologyFilters(request AWSOrganizationsTopologyRequest) bool {
+	if !validAWSCoveragePlanStateFilter(request.State) {
+		return false
+	}
+	switch awscontract.OrganizationAccountStatus(strings.ToLower(strings.TrimSpace(request.Status))) {
+	case "", awscontract.OrganizationAccountActive, awscontract.OrganizationAccountSuspended, awscontract.OrganizationAccountClosed:
+		return true
+	default:
+		return false
+	}
+}
+
+func awsOrganizationsTopologyFixtureConfig(connectorID, accountID, fixtureState string) (awscontract.OrganizationsTopologyConfig, []AWSOrganizationsTopologyDiagnostic, []AWSOrganizationsTopologyCoverageGap) {
+	gaps := []AWSOrganizationsTopologyCoverageGap{
+		{
+			Capability:  "live_region_enablement",
+			Status:      "planned_downstream",
+			Reason:      "This topology maps Organizations accounts and OUs; per-account region opt-in discovery is handled by the account/region coverage planner.",
+			Remediation: "Join this topology with coverage-plan targets before scheduling regional fan-out scans.",
+		},
+		{
+			Capability:  "customer_payload_collection",
+			Status:      "unsupported",
+			Reason:      "Organizations topology only records account, OU, status, parent, delegated-admin, cursor, and evidence metadata.",
+			Remediation: "Use the owning AWS service for payload inspection outside Identrail.",
+		},
+	}
+	if fixtureState == "empty" {
+		return awscontract.OrganizationsTopologyConfig{ConnectorID: connectorID, Partition: "aws"}, nil, gaps
+	}
+
+	productionAccount := awsCoveragePlanSiblingAccount(accountID)
+	dataAccount := awsOrganizationsTopologyNextAccount(productionAccount)
+	sandboxAccount := awsOrganizationsTopologyNextAccount(dataAccount)
+	config := awscontract.OrganizationsTopologyConfig{
+		ConnectorID:         connectorID,
+		OrganizationID:      "o-identrailfixture",
+		ManagementAccountID: accountID,
+		Partition:           "aws",
+		OrganizationalUnits: []awscontract.OrganizationUnit{
+			{ID: "r-identrail", Name: "Root", Path: "/", Enabled: true},
+			{ID: "ou-prod", Name: "Production", ParentID: "r-identrail", Path: "/Production", Enabled: true},
+			{ID: "ou-data", Name: "Data", ParentID: "r-identrail", Path: "/Data", Enabled: true},
+			{ID: "ou-sandbox", Name: "Sandbox", ParentID: "r-identrail", Path: "/Sandbox", Enabled: false, Reason: "sandbox OU disabled for read-only scans"},
+		},
+		Accounts: []awscontract.OrganizationAccount{
+			{AccountID: accountID, Name: "management", ParentID: "r-identrail", Status: awscontract.OrganizationAccountActive, ConnectorScoped: true},
+			{AccountID: productionAccount, Name: "production", ParentID: "ou-prod", Status: awscontract.OrganizationAccountActive, ConnectorScoped: true, DelegatedAdminServices: []string{"guardduty.amazonaws.com", "securityhub.amazonaws.com"}},
+			{AccountID: dataAccount, Name: "data", ParentID: "ou-data", Status: awscontract.OrganizationAccountActive, ConnectorScoped: true, DelegatedAdminServices: []string{"access-analyzer.amazonaws.com"}},
+			{AccountID: sandboxAccount, Name: "retired-sandbox", ParentID: "ou-sandbox", Status: awscontract.OrganizationAccountSuspended, ConnectorScoped: true},
+		},
+	}
+
+	diagnostics := []AWSOrganizationsTopologyDiagnostic{}
+	switch fixtureState {
+	case "permission_denied":
+		config.Checkpoints = []awscontract.OrganizationsCheckpoint{{
+			AccountID:     productionAccount,
+			State:         awscontract.CoverageStatePermissionDenied,
+			FailureReason: "AccessDenied: organizations:ListParents denied for member account",
+		}}
+		diagnostics = append(diagnostics, AWSOrganizationsTopologyDiagnostic{
+			Source:      "organizations_topology",
+			Scope:       productionAccount,
+			Code:        "permission_denied",
+			Message:     "Connector role cannot read AWS Organizations parent relationships for a member account.",
+			Remediation: "Grant read-only organizations:ListAccounts, ListParents, ListRoots, ListOrganizationalUnitsForParent, and ListDelegatedAdministrators to the connector role.",
+			Retryable:   false,
+		})
+	case "degraded", "partial_failure":
+		config.Checkpoints = []awscontract.OrganizationsCheckpoint{
+			{AccountID: accountID, State: awscontract.CoverageStateCovered},
+			{AccountID: productionAccount, State: awscontract.CoverageStateCovered},
+			{AccountID: dataAccount, State: awscontract.CoverageStateFailed, Cursor: "organizations:accounts-page-2", FailureReason: "Throttling: organizations:ListAccounts after bounded retries", Attempts: 3},
+		}
+		diagnostics = append(diagnostics, AWSOrganizationsTopologyDiagnostic{
+			Source:      "organizations_topology",
+			Scope:       dataAccount,
+			Code:        "partial_failure",
+			Message:     "AWS Organizations pagination stopped after throttling; account discovery is resumable from the stored cursor.",
+			Remediation: "Re-run Organizations discovery to continue from the checkpoint cursor.",
+			Retryable:   true,
+		})
+	default:
+		config.Checkpoints = []awscontract.OrganizationsCheckpoint{
+			{AccountID: accountID, State: awscontract.CoverageStateCovered},
+			{AccountID: productionAccount, State: awscontract.CoverageStateCovered},
+			{AccountID: dataAccount, State: awscontract.CoverageStateCovered},
+		}
+	}
+	return config, diagnostics, gaps
+}
+
+func mapAWSOrganizationsTopologySummary(summary awscontract.OrganizationsTopologySummary) AWSOrganizationsTopologySummary {
+	stateCounts := map[string]int{}
+	for state, count := range summary.StateCounts {
+		stateCounts[string(state)] = count
+	}
+	statusCounts := map[string]int{}
+	for status, count := range summary.StatusCounts {
+		statusCounts[string(status)] = count
+	}
+	return AWSOrganizationsTopologySummary{
+		AccountCount:               summary.AccountCount,
+		OrganizationalUnitCount:    summary.OrganizationalUnitCount,
+		ManagementAccountCount:     summary.ManagementAccountCount,
+		DelegatedAdminAccountCount: summary.DelegatedAdminAccountCount,
+		SuspendedAccountCount:      summary.SuspendedAccountCount,
+		ConnectorScopedAccounts:    summary.ConnectorScopedAccounts,
+		ScanEligibleAccounts:       summary.ScanEligibleAccounts,
+		BlockedAccounts:            summary.BlockedAccounts,
+		PermissionDeniedAccounts:   summary.PermissionDeniedAccounts,
+		FailedAccounts:             summary.FailedAccounts,
+		ResumableAccounts:          summary.ResumableAccounts,
+		StateCounts:                stateCounts,
+		StatusCounts:               statusCounts,
+	}
+}
+
+func mapAWSOrganizationsTopologyAccounts(accounts []awscontract.OrganizationAccount) []AWSOrganizationsTopologyAccount {
+	out := make([]AWSOrganizationsTopologyAccount, 0, len(accounts))
+	for _, account := range accounts {
+		out = append(out, AWSOrganizationsTopologyAccount{
+			AccountID:                account.AccountID,
+			AccountName:              account.Name,
+			Status:                   string(account.Status),
+			ParentID:                 account.ParentID,
+			OUPath:                   account.OUPath,
+			Partition:                account.Partition,
+			Management:               account.Management,
+			DelegatedAdminServices:   account.DelegatedAdminServices,
+			ConnectorScoped:          account.ConnectorScoped,
+			ScanEligible:             account.ScanEligible,
+			State:                    string(account.State),
+			Cursor:                   account.Cursor,
+			FailureReason:            account.FailureReason,
+			Attempts:                 account.Attempts,
+			Resumable:                account.Resumable,
+			NextAction:               awsOrganizationsTopologyNextAction(account),
+			EvidenceRef:              account.EvidenceRef,
+			ObservedAt:               account.ObservedAt,
+			EligibilityFailureReason: account.EligibilityFailureReason,
+		})
+	}
+	return out
+}
+
+func mapAWSOrganizationsTopologyOUs(units []awscontract.OrganizationUnit) []AWSOrganizationsTopologyOU {
+	out := make([]AWSOrganizationsTopologyOU, 0, len(units))
+	for _, unit := range units {
+		out = append(out, AWSOrganizationsTopologyOU{
+			ID:       unit.ID,
+			Name:     unit.Name,
+			ParentID: unit.ParentID,
+			Path:     unit.Path,
+			Enabled:  unit.Enabled,
+			Reason:   unit.Reason,
+		})
+	}
+	return out
+}
+
+func mapAWSOrganizationsTopologyRelationships(relationships []awscontract.OrganizationRelationship) []AWSOrganizationsTopologyRelationship {
+	out := make([]AWSOrganizationsTopologyRelationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		out = append(out, AWSOrganizationsTopologyRelationship{
+			ParentID:     relationship.ParentID,
+			ChildID:      relationship.ChildID,
+			ChildType:    relationship.ChildType,
+			Relationship: relationship.Relationship,
+		})
+	}
+	return out
+}
+
+func filterAWSOrganizationsTopologyAccounts(accounts []AWSOrganizationsTopologyAccount, request AWSOrganizationsTopologyRequest) []AWSOrganizationsTopologyAccount {
+	accountFilter := strings.TrimSpace(request.Account)
+	ouFilter := strings.ToLower(strings.TrimSpace(request.OU))
+	stateFilter := strings.ToLower(strings.TrimSpace(request.State))
+	statusFilter := strings.ToLower(strings.TrimSpace(request.Status))
+	filtered := make([]AWSOrganizationsTopologyAccount, 0, len(accounts))
+	for _, account := range accounts {
+		if accountFilter != "" && account.AccountID != accountFilter {
+			continue
+		}
+		if ouFilter != "" && strings.ToLower(account.ParentID) != ouFilter && strings.ToLower(account.OUPath) != ouFilter {
+			continue
+		}
+		if stateFilter != "" && strings.ToLower(account.State) != stateFilter {
+			continue
+		}
+		if statusFilter != "" && strings.ToLower(account.Status) != statusFilter {
+			continue
+		}
+		filtered = append(filtered, account)
+	}
+	return filtered
+}
+
+func awsOrganizationsTopologyNextAction(account awscontract.OrganizationAccount) string {
+	switch account.State {
+	case awscontract.CoverageStateCovered:
+		return "Use this account and OU context to seed account/region coverage and downstream identity graph collection."
+	case awscontract.CoverageStatePermissionDenied:
+		return "Grant read-only AWS Organizations permissions to the connector role, then rerun topology discovery."
+	case awscontract.CoverageStateFailed, awscontract.CoverageStatePartial:
+		return "Rerun Organizations discovery to resume from the stored checkpoint cursor."
+	case awscontract.CoverageStateDisabled:
+		return "Reactivate the AWS account or leave it excluded from scan fan-out."
+	case awscontract.CoverageStateUnsupported:
+		return "Add the account to connector scope before scheduling scan targets."
+	case awscontract.CoverageStateBlocked:
+		if account.EligibilityFailureReason != "" {
+			return account.EligibilityFailureReason
+		}
+		return "Resolve parent OU or connector-scope prerequisites before scanning this account."
+	default:
+		return "Queue read-only Organizations discovery and persist account, OU, status, and delegated-admin metadata."
+	}
+}
+
+func summarizeAWSOrganizationsTopology(fixtureState string, diagnostics []AWSOrganizationsTopologyDiagnostic, topology awscontract.OrganizationsTopology) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.32,
+			awsOrganizationsDiagnosticMessages(diagnostics),
+			[]string{"Grant read-only AWS Organizations permissions and rerun topology discovery."}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.74,
+			awsOrganizationsDiagnosticMessages(diagnostics),
+			[]string{"Rerun Organizations discovery to resume from failed account cursors."}
+	default:
+		if topology.Summary.AccountCount == 0 {
+			return awsPlatformDependencyStatusReady, 0.82, nil,
+				[]string{"No AWS Organizations accounts were discovered; confirm the connector is scoped to an organization management or delegated administrator account."}
+		}
+		return awsPlatformDependencyStatusReady, 0.94, nil,
+			[]string{"Organizations topology is ready to seed account/region coverage and downstream identity graph collection."}
+	}
+}
+
+func awsOrganizationsDiagnosticMessages(diagnostics []AWSOrganizationsTopologyDiagnostic) []string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if message := strings.TrimSpace(diagnostic.Message); message != "" {
+			messages = append(messages, message)
+		}
+	}
+	return dedupeStrings(messages)
+}
+
+func awsOrganizationsTopologyNextAccount(accountID string) string {
+	return awsCoveragePlanSiblingAccount(accountID)
+}

--- a/internal/api/aws_organizations_topology_test.go
+++ b/internal/api/aws_organizations_topology_test.go
@@ -85,6 +85,31 @@ func TestGetAWSOrganizationsTopologyFilters(t *testing.T) {
 	}
 }
 
+func TestGetAWSOrganizationsTopologyFiltersPendingStatuses(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 17, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	for _, status := range []string{"pending_activation", "pending_closure"} {
+		status := status
+		result, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{
+			ConnectorID: "aws-prod",
+			Status:      status,
+		})
+		if err != nil {
+			t.Fatalf("pending status %q should be accepted: %v", status, err)
+		}
+		if result.FilteredAccounts != 0 {
+			t.Fatalf("expected no matched accounts for %q with fixture dataset, got %d", status, result.FilteredAccounts)
+		}
+	}
+}
+
 func TestGetAWSOrganizationsTopologyEmptyDegradedAndDenied(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_organizations_topology_test.go
+++ b/internal/api/aws_organizations_topology_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSOrganizationsTopologySuccess(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get organizations topology: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready topology, got %+v", result)
+	}
+	if result.CurrentIssueRef != "#1498" || result.Version == "" || result.OrganizationID == "" {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.Summary.AccountCount != 4 || result.Summary.OrganizationalUnitCount != 4 {
+		t.Fatalf("unexpected topology counts: %+v", result.Summary)
+	}
+	if result.Summary.ManagementAccountCount != 1 || result.Summary.DelegatedAdminAccountCount != 2 {
+		t.Fatalf("expected management and delegated admin counts, got %+v", result.Summary)
+	}
+	if result.Summary.SuspendedAccountCount != 1 || result.Summary.ScanEligibleAccounts != 3 {
+		t.Fatalf("expected suspended and eligible account counts, got %+v", result.Summary)
+	}
+	if len(result.Relationships) == 0 {
+		t.Fatalf("expected parent relationships")
+	}
+	for _, account := range result.Accounts {
+		if account.State == "" || account.EvidenceRef == "" || account.NextAction == "" {
+			t.Fatalf("account missing explicit state/evidence/action: %+v", account)
+		}
+	}
+}
+
+func TestGetAWSOrganizationsTopologyFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	filtered, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{
+		ConnectorID: "aws-prod",
+		OU:          "/Production",
+		State:       "covered",
+		Status:      "active",
+	})
+	if err != nil {
+		t.Fatalf("get filtered organizations topology: %v", err)
+	}
+	if filtered.FilteredAccounts != 1 {
+		t.Fatalf("expected one filtered account, got %d", filtered.FilteredAccounts)
+	}
+	if filtered.Accounts[0].OUPath != "/Production" || filtered.Accounts[0].State != "covered" || filtered.Accounts[0].Status != "active" {
+		t.Fatalf("filter returned wrong account: %+v", filtered.Accounts[0])
+	}
+	if _, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod", State: "bogus"}); err == nil {
+		t.Fatalf("expected invalid state filter error")
+	}
+	if _, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod", Status: "bogus"}); err == nil {
+		t.Fatalf("expected invalid status filter error")
+	}
+}
+
+func TestGetAWSOrganizationsTopologyEmptyDegradedAndDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	empty, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("get empty topology: %v", err)
+	}
+	if empty.Status != awsPlatformDependencyStatusReady || empty.Summary.AccountCount != 0 || len(empty.RemediationHints) == 0 {
+		t.Fatalf("expected ready empty topology with hint, got %+v", empty)
+	}
+
+	degraded, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("get degraded topology: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || degraded.Summary.FailedAccounts == 0 || degraded.Summary.ResumableAccounts == 0 {
+		t.Fatalf("expected degraded resumable topology, got %+v", degraded)
+	}
+
+	denied, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied topology: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.Summary.PermissionDeniedAccounts == 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("expected blocked permission-denied topology, got %+v", denied)
+	}
+}
+
+func TestGetAWSOrganizationsTopologyNeverLeaksPayloads(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSOrganizationsTopology(ctx, "default", "project-a", AWSOrganizationsTopologyRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get organizations topology: %v", err)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	lower := strings.ToLower(string(payload))
+	for _, forbidden := range []string{"@", "secretstring", "plaintext", "password=", "=sk-", "database row", "object content"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("payload-like content leaked into topology: %s", payload)
+		}
+	}
+}
+
+func TestRouterAWSOrganizationsTopologyPartialFailureAndInvalid(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/organizations-topology?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Topology AWSOrganizationsTopologyResult `json:"topology"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Topology.Status != awsPlatformDependencyStatusDegraded || body.Topology.Summary.FailedAccounts == 0 {
+		t.Fatalf("expected degraded partial topology, got %+v", body.Topology)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "state=bogus", "status=bogus"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/organizations-topology?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2985,6 +2985,40 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plan": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSOrganizationsTopology(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSOrganizationsTopologyRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			Account:      strings.TrimSpace(c.Query("account")),
+			OU:           strings.TrimSpace(c.Query("ou")),
+			State:        strings.TrimSpace(c.Query("state")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws organizations topology request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws organizations topology",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws organizations topology"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"topology": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/awscontract/organizations_topology.go
+++ b/internal/providers/awscontract/organizations_topology.go
@@ -250,8 +250,10 @@ func normalizeOrganizationAccountStatus(status OrganizationAccountStatus) Organi
 		return OrganizationAccountActive
 	case OrganizationAccountSuspended:
 		return OrganizationAccountSuspended
-	case OrganizationAccountClosed, OrganizationAccountPendingActivation, OrganizationAccountPendingClosure:
+	case OrganizationAccountClosed, OrganizationAccountPendingClosure:
 		return OrganizationAccountClosed
+	case OrganizationAccountPendingActivation:
+		return OrganizationAccountPendingActivation
 	default:
 		return OrganizationAccountClosed
 	}
@@ -261,7 +263,7 @@ func initialOrganizationAccountState(account OrganizationAccount) CoverageState 
 	switch {
 	case !account.ConnectorScoped:
 		return CoverageStateUnsupported
-	case account.Status == OrganizationAccountSuspended || account.Status == OrganizationAccountClosed:
+	case account.Status == OrganizationAccountSuspended || account.Status == OrganizationAccountClosed || account.Status == OrganizationAccountPendingClosure || account.Status == OrganizationAccountPendingActivation:
 		return CoverageStateDisabled
 	case account.EligibilityFailureReason != "":
 		return CoverageStateBlocked

--- a/internal/providers/awscontract/organizations_topology.go
+++ b/internal/providers/awscontract/organizations_topology.go
@@ -1,0 +1,409 @@
+package awscontract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// OrganizationsTopologyVersion is the stable contract version for AWS
+// Organizations account and OU discovery output.
+const OrganizationsTopologyVersion = "aws-organizations-topology-v1"
+
+// OrganizationAccountStatus mirrors the AWS Organizations lifecycle values that
+// affect scan eligibility.
+type OrganizationAccountStatus string
+
+const (
+	OrganizationAccountActive    OrganizationAccountStatus = "active"
+	OrganizationAccountSuspended OrganizationAccountStatus = "suspended"
+	OrganizationAccountClosed    OrganizationAccountStatus = "closed"
+)
+
+// OrganizationUnit is one AWS Organizations OU or root-like container.
+type OrganizationUnit struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+	Path     string `json:"path"`
+	Enabled  bool   `json:"enabled"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// OrganizationAccount is one account discovered from AWS Organizations.
+type OrganizationAccount struct {
+	AccountID                string                    `json:"account_id"`
+	Name                     string                    `json:"name,omitempty"`
+	Status                   OrganizationAccountStatus `json:"status"`
+	ParentID                 string                    `json:"parent_id,omitempty"`
+	OUPath                   string                    `json:"ou_path,omitempty"`
+	Partition                string                    `json:"partition"`
+	Management               bool                      `json:"management,omitempty"`
+	DelegatedAdminServices   []string                  `json:"delegated_admin_services"`
+	ConnectorScoped          bool                      `json:"connector_scoped"`
+	ScanEligible             bool                      `json:"scan_eligible"`
+	State                    CoverageState             `json:"state"`
+	Cursor                   string                    `json:"cursor,omitempty"`
+	FailureReason            string                    `json:"failure_reason,omitempty"`
+	Attempts                 int                       `json:"attempts,omitempty"`
+	Resumable                bool                      `json:"resumable"`
+	EvidenceRef              string                    `json:"evidence_ref"`
+	ObservedAt               time.Time                 `json:"observed_at,omitempty"`
+	EligibilityFailureReason string                    `json:"eligibility_failure_reason,omitempty"`
+}
+
+// OrganizationRelationship records a parent-child topology edge.
+type OrganizationRelationship struct {
+	ParentID     string `json:"parent_id"`
+	ChildID      string `json:"child_id"`
+	ChildType    string `json:"child_type"`
+	Relationship string `json:"relationship"`
+}
+
+// OrganizationsCheckpoint is a prior account discovery state used for
+// resumable topology collection.
+type OrganizationsCheckpoint struct {
+	AccountID     string        `json:"account_id"`
+	State         CoverageState `json:"state"`
+	Cursor        string        `json:"cursor,omitempty"`
+	FailureReason string        `json:"failure_reason,omitempty"`
+	Attempts      int           `json:"attempts,omitempty"`
+	ObservedAt    time.Time     `json:"observed_at,omitempty"`
+}
+
+// OrganizationsTopologyConfig is the normalized Organizations discovery input.
+type OrganizationsTopologyConfig struct {
+	ConnectorID         string                    `json:"connector_id,omitempty"`
+	OrganizationID      string                    `json:"organization_id,omitempty"`
+	ManagementAccountID string                    `json:"management_account_id,omitempty"`
+	Partition           string                    `json:"partition,omitempty"`
+	OrganizationalUnits []OrganizationUnit        `json:"organizational_units,omitempty"`
+	Accounts            []OrganizationAccount     `json:"accounts,omitempty"`
+	Checkpoints         []OrganizationsCheckpoint `json:"checkpoints,omitempty"`
+}
+
+// OrganizationsTopologySummary aggregates the topology for dashboards and
+// operator recovery.
+type OrganizationsTopologySummary struct {
+	AccountCount               int                               `json:"account_count"`
+	OrganizationalUnitCount    int                               `json:"organizational_unit_count"`
+	ManagementAccountCount     int                               `json:"management_account_count"`
+	DelegatedAdminAccountCount int                               `json:"delegated_admin_account_count"`
+	SuspendedAccountCount      int                               `json:"suspended_account_count"`
+	ConnectorScopedAccounts    int                               `json:"connector_scoped_accounts"`
+	ScanEligibleAccounts       int                               `json:"scan_eligible_accounts"`
+	BlockedAccounts            int                               `json:"blocked_accounts"`
+	PermissionDeniedAccounts   int                               `json:"permission_denied_accounts"`
+	FailedAccounts             int                               `json:"failed_accounts"`
+	ResumableAccounts          int                               `json:"resumable_accounts"`
+	StateCounts                map[CoverageState]int             `json:"state_counts"`
+	StatusCounts               map[OrganizationAccountStatus]int `json:"status_counts"`
+}
+
+// OrganizationsTopology is the deterministic output of Organizations discovery.
+type OrganizationsTopology struct {
+	ConnectorID         string                       `json:"connector_id,omitempty"`
+	OrganizationID      string                       `json:"organization_id,omitempty"`
+	ManagementAccountID string                       `json:"management_account_id,omitempty"`
+	Partition           string                       `json:"partition"`
+	Version             string                       `json:"version"`
+	Summary             OrganizationsTopologySummary `json:"summary"`
+	OrganizationalUnits []OrganizationUnit           `json:"organizational_units"`
+	Accounts            []OrganizationAccount        `json:"accounts"`
+	Relationships       []OrganizationRelationship   `json:"relationships"`
+	GeneratedAt         time.Time                    `json:"generated_at"`
+}
+
+// PlanOrganizationsTopology normalizes AWS Organizations account/OU discovery
+// into deterministic, metadata-only topology output. It performs no AWS calls
+// and never carries customer payloads.
+func PlanOrganizationsTopology(config OrganizationsTopologyConfig, generatedAt time.Time) (OrganizationsTopology, error) {
+	partition := normalizeOrganizationsPartition(config.Partition)
+	ous, ouByID, err := normalizeOrganizationUnits(config.OrganizationalUnits)
+	if err != nil {
+		return OrganizationsTopology{}, err
+	}
+	checkpoints, err := indexOrganizationsCheckpoints(config.Checkpoints)
+	if err != nil {
+		return OrganizationsTopology{}, err
+	}
+	accounts, err := normalizeOrganizationAccounts(config, partition, ouByID, checkpoints)
+	if err != nil {
+		return OrganizationsTopology{}, err
+	}
+	relationships := buildOrganizationRelationships(ous, accounts)
+
+	sort.SliceStable(accounts, func(i, j int) bool {
+		if accounts[i].OUPath != accounts[j].OUPath {
+			return accounts[i].OUPath < accounts[j].OUPath
+		}
+		return accounts[i].AccountID < accounts[j].AccountID
+	})
+
+	return OrganizationsTopology{
+		ConnectorID:         strings.TrimSpace(config.ConnectorID),
+		OrganizationID:      strings.TrimSpace(config.OrganizationID),
+		ManagementAccountID: strings.TrimSpace(config.ManagementAccountID),
+		Partition:           partition,
+		Version:             OrganizationsTopologyVersion,
+		Summary:             summarizeOrganizationsTopology(accounts, len(ous)),
+		OrganizationalUnits: ous,
+		Accounts:            accounts,
+		Relationships:       relationships,
+		GeneratedAt:         generatedAt.UTC(),
+	}, nil
+}
+
+func normalizeOrganizationsPartition(partition string) string {
+	out := strings.ToLower(strings.TrimSpace(partition))
+	if out == "" {
+		return "aws"
+	}
+	return out
+}
+
+func normalizeOrganizationUnits(input []OrganizationUnit) ([]OrganizationUnit, map[string]OrganizationUnit, error) {
+	seen := map[string]struct{}{}
+	out := make([]OrganizationUnit, 0, len(input))
+	for _, item := range input {
+		unit := item
+		unit.ID = strings.TrimSpace(item.ID)
+		if unit.ID == "" {
+			return nil, nil, fmt.Errorf("organization unit id is required")
+		}
+		if _, ok := seen[unit.ID]; ok {
+			continue
+		}
+		seen[unit.ID] = struct{}{}
+		unit.Name = strings.TrimSpace(item.Name)
+		unit.ParentID = strings.TrimSpace(item.ParentID)
+		unit.Path = strings.TrimSpace(item.Path)
+		if unit.Path == "" {
+			unit.Path = "/" + firstNonEmptyContractString(unit.Name, unit.ID)
+		}
+		if !strings.HasPrefix(unit.Path, "/") {
+			unit.Path = "/" + unit.Path
+		}
+		unit.Reason = strings.TrimSpace(item.Reason)
+		out = append(out, unit)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].ID < out[j].ID
+	})
+	byID := make(map[string]OrganizationUnit, len(out))
+	for _, unit := range out {
+		byID[unit.ID] = unit
+	}
+	return out, byID, nil
+}
+
+func normalizeOrganizationAccounts(config OrganizationsTopologyConfig, partition string, ouByID map[string]OrganizationUnit, checkpoints map[string]OrganizationsCheckpoint) ([]OrganizationAccount, error) {
+	seen := map[string]struct{}{}
+	out := make([]OrganizationAccount, 0, len(config.Accounts))
+	for _, item := range config.Accounts {
+		account := item
+		account.AccountID = strings.TrimSpace(item.AccountID)
+		if !validOrganizationsAccountID(account.AccountID) {
+			return nil, fmt.Errorf("organization account id must be 12 digits")
+		}
+		if _, ok := seen[account.AccountID]; ok {
+			continue
+		}
+		seen[account.AccountID] = struct{}{}
+		account.Name = strings.TrimSpace(item.Name)
+		account.ParentID = strings.TrimSpace(item.ParentID)
+		account.Partition = normalizeOrganizationsPartition(firstNonEmptyContractString(item.Partition, partition))
+		account.Status = normalizeOrganizationAccountStatus(item.Status)
+		account.Management = account.Management || account.AccountID == strings.TrimSpace(config.ManagementAccountID)
+		account.DelegatedAdminServices = dedupeSortedCoverageStrings(item.DelegatedAdminServices)
+		account.OUPath = strings.TrimSpace(item.OUPath)
+		if unit, ok := ouByID[account.ParentID]; ok {
+			if account.OUPath == "" {
+				account.OUPath = unit.Path
+			}
+			if !unit.Enabled {
+				account.EligibilityFailureReason = firstNonEmptyContractString(unit.Reason, "parent organizational unit is disabled")
+			}
+		}
+		account.ConnectorScoped = item.ConnectorScoped
+		account.ScanEligible = account.ConnectorScoped && account.Status == OrganizationAccountActive && account.EligibilityFailureReason == ""
+		account.State = initialOrganizationAccountState(account)
+		account.EvidenceRef = organizationEvidenceRef(config.ConnectorID, config.OrganizationID, account.AccountID)
+		if checkpoint, ok := checkpoints[account.AccountID]; ok {
+			applyOrganizationsCheckpoint(&account, checkpoint)
+		}
+		account.Resumable = coverageTargetResumable(CoverageTarget{State: account.State})
+		out = append(out, account)
+	}
+	return out, nil
+}
+
+func normalizeOrganizationAccountStatus(status OrganizationAccountStatus) OrganizationAccountStatus {
+	switch OrganizationAccountStatus(strings.ToLower(strings.TrimSpace(string(status)))) {
+	case OrganizationAccountSuspended:
+		return OrganizationAccountSuspended
+	case OrganizationAccountClosed:
+		return OrganizationAccountClosed
+	default:
+		return OrganizationAccountActive
+	}
+}
+
+func initialOrganizationAccountState(account OrganizationAccount) CoverageState {
+	switch {
+	case !account.ConnectorScoped:
+		return CoverageStateUnsupported
+	case account.Status == OrganizationAccountSuspended || account.Status == OrganizationAccountClosed:
+		return CoverageStateDisabled
+	case account.EligibilityFailureReason != "":
+		return CoverageStateBlocked
+	default:
+		return CoverageStatePlanned
+	}
+}
+
+func indexOrganizationsCheckpoints(input []OrganizationsCheckpoint) (map[string]OrganizationsCheckpoint, error) {
+	out := make(map[string]OrganizationsCheckpoint, len(input))
+	for _, checkpoint := range input {
+		accountID := strings.TrimSpace(checkpoint.AccountID)
+		if !validOrganizationsAccountID(accountID) {
+			return nil, fmt.Errorf("organization checkpoint account id must be 12 digits")
+		}
+		if checkpoint.State != "" && !validCoverageState(checkpoint.State) {
+			return nil, fmt.Errorf("organization checkpoint has invalid state %q", checkpoint.State)
+		}
+		checkpoint.AccountID = accountID
+		out[accountID] = checkpoint
+	}
+	return out, nil
+}
+
+func applyOrganizationsCheckpoint(account *OrganizationAccount, checkpoint OrganizationsCheckpoint) {
+	if !account.ScanEligible {
+		return
+	}
+	if checkpoint.State == CoverageStateDisabled {
+		return
+	}
+	if checkpoint.State != "" {
+		account.State = checkpoint.State
+	}
+	account.Cursor = strings.TrimSpace(checkpoint.Cursor)
+	account.FailureReason = strings.TrimSpace(checkpoint.FailureReason)
+	if checkpoint.Attempts > 0 {
+		account.Attempts = checkpoint.Attempts
+	}
+	if !checkpoint.ObservedAt.IsZero() {
+		account.ObservedAt = checkpoint.ObservedAt.UTC()
+	}
+}
+
+func buildOrganizationRelationships(ous []OrganizationUnit, accounts []OrganizationAccount) []OrganizationRelationship {
+	relationships := make([]OrganizationRelationship, 0, len(ous)+len(accounts))
+	for _, unit := range ous {
+		if unit.ParentID == "" {
+			continue
+		}
+		relationships = append(relationships, OrganizationRelationship{
+			ParentID:     unit.ParentID,
+			ChildID:      unit.ID,
+			ChildType:    "organizational_unit",
+			Relationship: "contains",
+		})
+	}
+	for _, account := range accounts {
+		if account.ParentID == "" {
+			continue
+		}
+		relationships = append(relationships, OrganizationRelationship{
+			ParentID:     account.ParentID,
+			ChildID:      account.AccountID,
+			ChildType:    "account",
+			Relationship: "contains",
+		})
+	}
+	sort.SliceStable(relationships, func(i, j int) bool {
+		if relationships[i].ParentID != relationships[j].ParentID {
+			return relationships[i].ParentID < relationships[j].ParentID
+		}
+		return relationships[i].ChildID < relationships[j].ChildID
+	})
+	return relationships
+}
+
+func summarizeOrganizationsTopology(accounts []OrganizationAccount, ouCount int) OrganizationsTopologySummary {
+	summary := OrganizationsTopologySummary{
+		AccountCount:            len(accounts),
+		OrganizationalUnitCount: ouCount,
+		StateCounts:             map[CoverageState]int{},
+		StatusCounts:            map[OrganizationAccountStatus]int{},
+	}
+	for _, account := range accounts {
+		summary.StateCounts[account.State]++
+		summary.StatusCounts[account.Status]++
+		if account.Management {
+			summary.ManagementAccountCount++
+		}
+		if len(account.DelegatedAdminServices) > 0 {
+			summary.DelegatedAdminAccountCount++
+		}
+		if account.Status == OrganizationAccountSuspended {
+			summary.SuspendedAccountCount++
+		}
+		if account.ConnectorScoped {
+			summary.ConnectorScopedAccounts++
+		}
+		if account.ScanEligible {
+			summary.ScanEligibleAccounts++
+		}
+		switch account.State {
+		case CoverageStateBlocked:
+			summary.BlockedAccounts++
+		case CoverageStatePermissionDenied:
+			summary.PermissionDeniedAccounts++
+		case CoverageStateFailed, CoverageStatePartial:
+			summary.FailedAccounts++
+		}
+		if account.Resumable {
+			summary.ResumableAccounts++
+		}
+	}
+	return summary
+}
+
+func organizationEvidenceRef(connectorID, organizationID, accountID string) string {
+	parts := []string{"aws-organizations"}
+	if connectorID != "" {
+		parts = append(parts, strings.TrimSpace(connectorID))
+	}
+	if organizationID != "" {
+		parts = append(parts, strings.TrimSpace(organizationID))
+	}
+	parts = append(parts, strings.TrimSpace(accountID))
+	return strings.Join(parts, ":")
+}
+
+func firstNonEmptyContractString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func validOrganizationsAccountID(accountID string) bool {
+	if len(accountID) != 12 {
+		return false
+	}
+	for _, char := range accountID {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providers/awscontract/organizations_topology.go
+++ b/internal/providers/awscontract/organizations_topology.go
@@ -250,10 +250,12 @@ func normalizeOrganizationAccountStatus(status OrganizationAccountStatus) Organi
 		return OrganizationAccountActive
 	case OrganizationAccountSuspended:
 		return OrganizationAccountSuspended
-	case OrganizationAccountClosed, OrganizationAccountPendingClosure:
+	case OrganizationAccountClosed:
 		return OrganizationAccountClosed
 	case OrganizationAccountPendingActivation:
 		return OrganizationAccountPendingActivation
+	case OrganizationAccountPendingClosure:
+		return OrganizationAccountPendingClosure
 	default:
 		return OrganizationAccountClosed
 	}

--- a/internal/providers/awscontract/organizations_topology.go
+++ b/internal/providers/awscontract/organizations_topology.go
@@ -16,9 +16,11 @@ const OrganizationsTopologyVersion = "aws-organizations-topology-v1"
 type OrganizationAccountStatus string
 
 const (
-	OrganizationAccountActive    OrganizationAccountStatus = "active"
-	OrganizationAccountSuspended OrganizationAccountStatus = "suspended"
-	OrganizationAccountClosed    OrganizationAccountStatus = "closed"
+	OrganizationAccountActive            OrganizationAccountStatus = "active"
+	OrganizationAccountSuspended         OrganizationAccountStatus = "suspended"
+	OrganizationAccountClosed            OrganizationAccountStatus = "closed"
+	OrganizationAccountPendingActivation OrganizationAccountStatus = "pending_activation"
+	OrganizationAccountPendingClosure    OrganizationAccountStatus = "pending_closure"
 )
 
 // OrganizationUnit is one AWS Organizations OU or root-like container.
@@ -244,12 +246,14 @@ func normalizeOrganizationAccounts(config OrganizationsTopologyConfig, partition
 
 func normalizeOrganizationAccountStatus(status OrganizationAccountStatus) OrganizationAccountStatus {
 	switch OrganizationAccountStatus(strings.ToLower(strings.TrimSpace(string(status)))) {
+	case OrganizationAccountActive:
+		return OrganizationAccountActive
 	case OrganizationAccountSuspended:
 		return OrganizationAccountSuspended
-	case OrganizationAccountClosed:
+	case OrganizationAccountClosed, OrganizationAccountPendingActivation, OrganizationAccountPendingClosure:
 		return OrganizationAccountClosed
 	default:
-		return OrganizationAccountActive
+		return OrganizationAccountClosed
 	}
 }
 

--- a/internal/providers/awscontract/organizations_topology_test.go
+++ b/internal/providers/awscontract/organizations_topology_test.go
@@ -146,10 +146,10 @@ func TestNormalizeOrganizationAccountStatus(t *testing.T) {
 		}
 	})
 
-	t.Run("pending_closure_normalized_to_closed", func(t *testing.T) {
+	t.Run("pending_closure_normalized_to_pending_closure", func(t *testing.T) {
 		got := normalizeOrganizationAccountStatus(OrganizationAccountPendingClosure)
-		if got != OrganizationAccountClosed {
-			t.Fatalf("expected %q, got %q", OrganizationAccountClosed, got)
+		if got != OrganizationAccountPendingClosure {
+			t.Fatalf("expected %q, got %q", OrganizationAccountPendingClosure, got)
 		}
 	})
 
@@ -202,6 +202,16 @@ func TestInitialOrganizationAccountState(t *testing.T) {
 				ConnectorScoped: false,
 			},
 			want: CoverageStateUnsupported,
+		},
+		{
+			name: "active_with_eligibility_failure_is_blocked",
+			account: OrganizationAccount{
+				AccountID:                "111111111115",
+				Status:                   OrganizationAccountActive,
+				ConnectorScoped:          true,
+				EligibilityFailureReason: "parent organizational unit is disabled",
+			},
+			want: CoverageStateBlocked,
 		},
 	}
 

--- a/internal/providers/awscontract/organizations_topology_test.go
+++ b/internal/providers/awscontract/organizations_topology_test.go
@@ -137,3 +137,81 @@ func TestPlanOrganizationsTopologyRejectsInvalidInput(t *testing.T) {
 		t.Fatal("expected invalid checkpoint state error")
 	}
 }
+
+func TestNormalizeOrganizationAccountStatus(t *testing.T) {
+	t.Run("pending_activation_preserved", func(t *testing.T) {
+		got := normalizeOrganizationAccountStatus(OrganizationAccountPendingActivation)
+		if got != OrganizationAccountPendingActivation {
+			t.Fatalf("expected %q, got %q", OrganizationAccountPendingActivation, got)
+		}
+	})
+
+	t.Run("pending_closure_normalized_to_closed", func(t *testing.T) {
+		got := normalizeOrganizationAccountStatus(OrganizationAccountPendingClosure)
+		if got != OrganizationAccountClosed {
+			t.Fatalf("expected %q, got %q", OrganizationAccountClosed, got)
+		}
+	})
+
+	t.Run("unknown_status_defaults_to_closed", func(t *testing.T) {
+		got := normalizeOrganizationAccountStatus(OrganizationAccountStatus("stale_state"))
+		if got != OrganizationAccountClosed {
+			t.Fatalf("expected %q, got %q", OrganizationAccountClosed, got)
+		}
+	})
+}
+
+func TestInitialOrganizationAccountState(t *testing.T) {
+	cases := []struct {
+		name    string
+		account OrganizationAccount
+		want    CoverageState
+	}{
+		{
+			name: "pending_activation_is_disabled",
+			account: OrganizationAccount{
+				AccountID:       "111111111111",
+				Status:          OrganizationAccountPendingActivation,
+				ConnectorScoped: true,
+			},
+			want: CoverageStateDisabled,
+		},
+		{
+			name: "pending_closure_is_disabled",
+			account: OrganizationAccount{
+				AccountID:       "111111111112",
+				Status:          OrganizationAccountPendingClosure,
+				ConnectorScoped: true,
+			},
+			want: CoverageStateDisabled,
+		},
+		{
+			name: "active_is_planned_when_connector_scoped",
+			account: OrganizationAccount{
+				AccountID:       "111111111113",
+				Status:          OrganizationAccountActive,
+				ConnectorScoped: true,
+			},
+			want: CoverageStatePlanned,
+		},
+		{
+			name: "unsupported_when_not_connector_scoped",
+			account: OrganizationAccount{
+				AccountID:       "111111111114",
+				Status:          OrganizationAccountActive,
+				ConnectorScoped: false,
+			},
+			want: CoverageStateUnsupported,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := initialOrganizationAccountState(tc.account)
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/providers/awscontract/organizations_topology_test.go
+++ b/internal/providers/awscontract/organizations_topology_test.go
@@ -1,0 +1,139 @@
+package awscontract
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func sampleOrganizationsTopologyConfig() OrganizationsTopologyConfig {
+	return OrganizationsTopologyConfig{
+		ConnectorID:         "aws-prod",
+		OrganizationID:      "o-example",
+		ManagementAccountID: "111111111111",
+		Partition:           "aws",
+		OrganizationalUnits: []OrganizationUnit{
+			{ID: "r-root", Name: "Root", Path: "/", Enabled: true},
+			{ID: "ou-prod", Name: "Production", ParentID: "r-root", Path: "/Production", Enabled: true},
+			{ID: "ou-data", Name: "Data", ParentID: "r-root", Path: "/Data", Enabled: true},
+			{ID: "ou-sandbox", Name: "Sandbox", ParentID: "r-root", Path: "/Sandbox", Enabled: false, Reason: "sandbox OU disabled for scans"},
+		},
+		Accounts: []OrganizationAccount{
+			{AccountID: "111111111111", Name: "management", ParentID: "r-root", Status: OrganizationAccountActive, ConnectorScoped: true},
+			{AccountID: "222222222222", Name: "production", ParentID: "ou-prod", Status: OrganizationAccountActive, ConnectorScoped: true, DelegatedAdminServices: []string{"guardduty.amazonaws.com", "securityhub.amazonaws.com"}},
+			{AccountID: "333333333333", Name: "data", ParentID: "ou-data", Status: OrganizationAccountActive, ConnectorScoped: true},
+			{AccountID: "444444444444", Name: "retired-sandbox", ParentID: "ou-sandbox", Status: OrganizationAccountSuspended, ConnectorScoped: true},
+		},
+	}
+}
+
+func TestPlanOrganizationsTopologyIsDeterministic(t *testing.T) {
+	now := time.Date(2026, 6, 12, 1, 0, 0, 0, time.UTC)
+	first, err := PlanOrganizationsTopology(sampleOrganizationsTopologyConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := PlanOrganizationsTopology(sampleOrganizationsTopologyConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("organizations topology is not deterministic")
+	}
+	if first.Version != OrganizationsTopologyVersion {
+		t.Fatalf("expected version %q, got %q", OrganizationsTopologyVersion, first.Version)
+	}
+}
+
+func TestPlanOrganizationsTopologyMapsAccountsOUsAndRelationships(t *testing.T) {
+	topology, err := PlanOrganizationsTopology(sampleOrganizationsTopologyConfig(), time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topology.Summary.AccountCount != 4 || topology.Summary.OrganizationalUnitCount != 4 {
+		t.Fatalf("unexpected summary counts: %+v", topology.Summary)
+	}
+	if topology.Summary.ManagementAccountCount != 1 || topology.Summary.DelegatedAdminAccountCount != 1 {
+		t.Fatalf("expected management and delegated admin indicators, got %+v", topology.Summary)
+	}
+	if topology.Summary.SuspendedAccountCount != 1 || topology.Summary.ScanEligibleAccounts != 3 {
+		t.Fatalf("expected explicit suspended and scan-eligible counts, got %+v", topology.Summary)
+	}
+	if len(topology.Relationships) != 7 {
+		t.Fatalf("expected 7 parent relationships, got %d: %+v", len(topology.Relationships), topology.Relationships)
+	}
+	byAccount := map[string]OrganizationAccount{}
+	for _, account := range topology.Accounts {
+		byAccount[account.AccountID] = account
+	}
+	if byAccount["222222222222"].OUPath != "/Production" {
+		t.Fatalf("expected OU path from parent relationship, got %+v", byAccount["222222222222"])
+	}
+	if byAccount["444444444444"].State != CoverageStateDisabled || byAccount["444444444444"].ScanEligible {
+		t.Fatalf("suspended account should be disabled and ineligible, got %+v", byAccount["444444444444"])
+	}
+}
+
+func TestPlanOrganizationsTopologyCheckpointsAndStaleDisabledState(t *testing.T) {
+	observed := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
+	config := sampleOrganizationsTopologyConfig()
+	config.Checkpoints = []OrganizationsCheckpoint{
+		{AccountID: "222222222222", State: CoverageStatePermissionDenied, FailureReason: "AccessDenied: organizations:ListParents denied", ObservedAt: observed},
+		{AccountID: "333333333333", State: CoverageStateInProgress, Cursor: "account-page-3", Attempts: 1},
+		{AccountID: "111111111111", State: CoverageStateDisabled},
+	}
+	topology, err := PlanOrganizationsTopology(config, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byAccount := map[string]OrganizationAccount{}
+	for _, account := range topology.Accounts {
+		byAccount[account.AccountID] = account
+	}
+	denied := byAccount["222222222222"]
+	if denied.State != CoverageStatePermissionDenied || denied.FailureReason == "" || !denied.ObservedAt.Equal(observed) {
+		t.Fatalf("permission denied checkpoint was not applied: %+v", denied)
+	}
+	inProgress := byAccount["333333333333"]
+	if inProgress.State != CoverageStateInProgress || inProgress.Cursor != "account-page-3" || !inProgress.Resumable {
+		t.Fatalf("in-progress checkpoint was not resumable: %+v", inProgress)
+	}
+	management := byAccount["111111111111"]
+	if management.State == CoverageStateDisabled {
+		t.Fatalf("enabled account should ignore stale disabled checkpoint: %+v", management)
+	}
+	if topology.Summary.PermissionDeniedAccounts != 1 || topology.Summary.ResumableAccounts != 1 {
+		t.Fatalf("unexpected checkpoint summary: %+v", topology.Summary)
+	}
+}
+
+func TestPlanOrganizationsTopologyEmptyConfig(t *testing.T) {
+	topology, err := PlanOrganizationsTopology(OrganizationsTopologyConfig{}, time.Now())
+	if err != nil {
+		t.Fatalf("empty config should not error: %v", err)
+	}
+	if len(topology.Accounts) != 0 || len(topology.OrganizationalUnits) != 0 || topology.Summary.AccountCount != 0 {
+		t.Fatalf("expected empty topology, got %+v", topology)
+	}
+	if topology.Partition != "aws" {
+		t.Fatalf("expected default aws partition, got %q", topology.Partition)
+	}
+}
+
+func TestPlanOrganizationsTopologyRejectsInvalidInput(t *testing.T) {
+	if _, err := PlanOrganizationsTopology(OrganizationsTopologyConfig{
+		Accounts: []OrganizationAccount{{AccountID: "not-an-account", ConnectorScoped: true}},
+	}, time.Now()); err == nil {
+		t.Fatal("expected invalid account id error")
+	}
+	if _, err := PlanOrganizationsTopology(OrganizationsTopologyConfig{
+		OrganizationalUnits: []OrganizationUnit{{Name: "missing-id"}},
+	}, time.Now()); err == nil {
+		t.Fatal("expected missing OU id error")
+	}
+	if _, err := PlanOrganizationsTopology(OrganizationsTopologyConfig{
+		Checkpoints: []OrganizationsCheckpoint{{AccountID: "111111111111", State: CoverageState("bogus")}},
+	}, time.Now()); err == nil {
+		t.Fatal("expected invalid checkpoint state error")
+	}
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1071,6 +1071,37 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS Organizations topology with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ topology: { status: 'ready', summary: { account_count: 4 }, accounts: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectOrganizationsTopology(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { account: '111111111111', ou: '/Production', state: 'failed', status: 'active' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/organizations-topology?connector_id=aws-prod&fixture_state=partial_failure&account=111111111111&ou=%2FProduction&state=failed&status=active'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2792,14 +2792,9 @@ export type AWSCoveragePlanResult = {
   updated_at: string;
 };
 
-export type AWSOrganizationsTopologyStatus = 'ready' | 'degraded' | 'blocked';
-export type AWSOrganizationsTopologyFixtureState =
-  | 'success'
-  | 'empty'
-  | 'degraded'
-  | 'partial_failure'
-  | 'permission_denied';
-export type AWSOrganizationsAccountStatus = 'active' | 'suspended' | 'closed';
+export type AWSOrganizationsTopologyStatus = AWSCoveragePlanStatus;
+export type AWSOrganizationsTopologyFixtureState = AWSCoveragePlanFixtureState;
+export type AWSOrganizationsAccountStatus = 'active' | 'suspended' | 'closed' | 'pending_activation' | 'pending_closure';
 
 export type AWSOrganizationsTopologyAccount = {
   account_id: string;
@@ -2855,21 +2850,9 @@ export type AWSOrganizationsTopologySummary = {
   status_counts: Record<string, number>;
 };
 
-export type AWSOrganizationsTopologyDiagnostic = {
-  source: string;
-  scope?: string;
-  code: string;
-  message: string;
-  remediation?: string;
-  retryable: boolean;
-};
+export type AWSOrganizationsTopologyDiagnostic = AWSCoveragePlanDiagnostic;
 
-export type AWSOrganizationsTopologyCoverageGap = {
-  capability: string;
-  status: string;
-  reason: string;
-  remediation?: string;
-};
+export type AWSOrganizationsTopologyCoverageGap = AWSCoveragePlanCoverageGap;
 
 export type AWSOrganizationsTopologyResult = {
   tenant_id: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2792,6 +2792,117 @@ export type AWSCoveragePlanResult = {
   updated_at: string;
 };
 
+export type AWSOrganizationsTopologyStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSOrganizationsTopologyFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSOrganizationsAccountStatus = 'active' | 'suspended' | 'closed';
+
+export type AWSOrganizationsTopologyAccount = {
+  account_id: string;
+  account_name?: string;
+  status: AWSOrganizationsAccountStatus;
+  parent_id?: string;
+  ou_path?: string;
+  partition: string;
+  management: boolean;
+  delegated_admin_services: string[];
+  connector_scoped: boolean;
+  scan_eligible: boolean;
+  state: AWSCoverageState;
+  cursor?: string;
+  failure_reason?: string;
+  attempts?: number;
+  resumable: boolean;
+  next_action: string;
+  evidence_ref: string;
+  observed_at?: string;
+  eligibility_failure_reason?: string;
+};
+
+export type AWSOrganizationsTopologyOU = {
+  id: string;
+  name?: string;
+  parent_id?: string;
+  path: string;
+  enabled: boolean;
+  reason?: string;
+};
+
+export type AWSOrganizationsTopologyRelationship = {
+  parent_id: string;
+  child_id: string;
+  child_type: 'organizational_unit' | 'account';
+  relationship: string;
+};
+
+export type AWSOrganizationsTopologySummary = {
+  account_count: number;
+  organizational_unit_count: number;
+  management_account_count: number;
+  delegated_admin_account_count: number;
+  suspended_account_count: number;
+  connector_scoped_accounts: number;
+  scan_eligible_accounts: number;
+  blocked_accounts: number;
+  permission_denied_accounts: number;
+  failed_accounts: number;
+  resumable_accounts: number;
+  state_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+};
+
+export type AWSOrganizationsTopologyDiagnostic = {
+  source: string;
+  scope?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSOrganizationsTopologyCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSOrganizationsTopologyResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  organization_id?: string;
+  management_account_id?: string;
+  partition: string;
+  version: string;
+  status: AWSOrganizationsTopologyStatus;
+  fixture_state: AWSOrganizationsTopologyFixtureState;
+  confidence: number;
+  filtered_accounts: number;
+  summary: AWSOrganizationsTopologySummary;
+  organizational_units: AWSOrganizationsTopologyOU[];
+  accounts: AWSOrganizationsTopologyAccount[];
+  relationships: AWSOrganizationsTopologyRelationship[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSOrganizationsTopologyCoverageGap[];
+  diagnostics: AWSOrganizationsTopologyDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSDynamoDBRDSReachabilityInventoryResult = {
   tenant_id: string;
   workspace_id: string;
@@ -4546,6 +4657,26 @@ export const apiClient = {
         region: filters?.region,
         service: filters?.service,
         state: filters?.state
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectOrganizationsTopology(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSOrganizationsTopologyFixtureState,
+    filters?: { account?: string; ou?: string; state?: AWSCoverageState; status?: AWSOrganizationsAccountStatus },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ topology: AWSOrganizationsTopologyResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/organizations-topology${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        account: filters?.account,
+        ou: filters?.ou,
+        state: filters?.state,
+        status: filters?.status
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2312,6 +2312,41 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectCoveragePlan').mockResolvedValue({
+      plan: {
+        status: 'ready',
+        summary: { account_count: 1, region_count: 1, coverage_percent: 100 },
+        targets: [],
+        diagnostics: [],
+        remediation_hints: []
+      } as any
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectOrganizationsTopology').mockResolvedValue({
+      topology: {
+        status: 'ready',
+        summary: { account_count: 1, organizational_unit_count: 1, scan_eligible_accounts: 1 },
+        accounts: [
+          {
+            account_id: '123456789012',
+            account_name: 'Production',
+            status: 'active',
+            parent_id: 'r-identrail',
+            ou_path: '/',
+            partition: 'aws',
+            management: true,
+            delegated_admin_services: [],
+            connector_scoped: true,
+            scan_eligible: true,
+            state: 'covered',
+            resumable: false,
+            next_action: 'Use this account for downstream coverage.',
+            evidence_ref: 'aws-organizations:aws-connector-1:123456789012'
+          }
+        ],
+        diagnostics: [],
+        remediation_hints: []
+      } as any
+    });
 
     const { ProductAWSControlCenterPage } = await import('./productShell');
 
@@ -2447,6 +2482,7 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Accounts' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS Organizations topology' })).toBeInTheDocument();
     expect(screen.getByRole('table', { name: 'AWS account and region coverage' })).toBeInTheDocument();
     expect(screen.getAllByText(/AWS account 123456789012/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Region us-east-1/i).length).toBeGreaterThan(0);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4185,10 +4185,7 @@ function buildAWSOrganizationsTopologyRows(
   if (topology?.accounts.length) {
     return topology.accounts.map((account) => {
       const coverage = awsOrganizationsTopologyFilterValue(account);
-      const coverageTokens = [coverage];
-      if (coverage !== 'missing' || account.state === 'planned') {
-        coverageTokens.push(account.state);
-      }
+      const coverageTokens = [coverage, account.state];
       if (account.status !== 'active') {
         coverageTokens.push(account.status);
       }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4141,7 +4141,14 @@ function buildAWSCoveragePlanRows(
 }
 
 function awsOrganizationsTopologyFilterValue(account: AWSOrganizationsTopologyAccount): string {
-  if (account.status === 'suspended' || account.status === 'closed' || account.state === 'disabled' || account.state === 'unsupported') {
+  if (
+    account.status === 'suspended' ||
+    account.status === 'closed' ||
+    account.status === 'pending_activation' ||
+    account.status === 'pending_closure' ||
+    account.state === 'disabled' ||
+    account.state === 'unsupported'
+  ) {
     return 'missing';
   }
   return awsCoveragePlanFilterValue(account.state);
@@ -4178,6 +4185,13 @@ function buildAWSOrganizationsTopologyRows(
   if (topology?.accounts.length) {
     return topology.accounts.map((account) => {
       const coverage = awsOrganizationsTopologyFilterValue(account);
+      const coverageTokens = [coverage];
+      if (coverage !== 'missing' || account.state === 'planned') {
+        coverageTokens.push(account.state);
+      }
+      if (account.status !== 'active') {
+        coverageTokens.push(account.status);
+      }
       const accountFilter = connection?.account_id && account.account_id === connection.account_id ? 'connected,planned' : 'planned';
       return {
         id: `org-${account.account_id}`,
@@ -4189,7 +4203,7 @@ function buildAWSOrganizationsTopologyRows(
         filters: {
           account: accountFilter,
           region: 'current,uncovered',
-          coverage: `${coverage},${account.state},${account.status}`,
+          coverage: [...new Set(coverageTokens)].join(','),
           search: ''
         },
         searchText: inventorySearchText([

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -59,6 +59,8 @@ import {
   type AWSCredentialReferenceRecord,
   type AWSCoveragePlanResult,
   type AWSCoveragePlanTarget,
+  type AWSOrganizationsTopologyAccount,
+  type AWSOrganizationsTopologyResult,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
   type AWSSQSSNSReachabilityInventoryResult,
@@ -3682,6 +3684,13 @@ type AWSInventoryCoveragePlanState = {
   onRetry: () => void;
 };
 
+type AWSInventoryOrganizationsTopologyState = {
+  topology: AWSOrganizationsTopologyResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -4131,6 +4140,91 @@ function buildAWSCoveragePlanRows(
   ];
 }
 
+function awsOrganizationsTopologyFilterValue(account: AWSOrganizationsTopologyAccount): string {
+  if (account.status === 'suspended' || account.status === 'closed' || account.state === 'disabled' || account.state === 'unsupported') {
+    return 'missing';
+  }
+  return awsCoveragePlanFilterValue(account.state);
+}
+
+function awsOrganizationsTopologyDetail(account: AWSOrganizationsTopologyAccount): string {
+  const details: string[] = [];
+  if (account.management) {
+    details.push('Management account');
+  }
+  if (account.delegated_admin_services.length > 0) {
+    details.push(`Delegated admin for ${account.delegated_admin_services.map(formatTokenLabel).join(', ')}`);
+  }
+  if (account.failure_reason) {
+    details.push(account.failure_reason);
+  } else if (account.eligibility_failure_reason) {
+    details.push(account.eligibility_failure_reason);
+  } else if (account.cursor) {
+    details.push(`Cursor ${account.cursor}`);
+  } else {
+    details.push(account.next_action);
+  }
+  if (account.attempts) {
+    details.push(`${account.attempts} ${account.attempts === 1 ? 'attempt' : 'attempts'}`);
+  }
+  return details.join(' · ');
+}
+
+function buildAWSOrganizationsTopologyRows(
+  topology: AWSOrganizationsTopologyResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryCoverageRow[] {
+  if (topology?.accounts.length) {
+    return topology.accounts.map((account) => {
+      const coverage = awsOrganizationsTopologyFilterValue(account);
+      const accountFilter = connection?.account_id && account.account_id === connection.account_id ? 'connected,planned' : 'planned';
+      return {
+        id: `org-${account.account_id}`,
+        category: `${account.account_name || account.account_id} / ${account.ou_path || account.parent_id || 'Root'}`,
+        coverage: account.state,
+        source: account.evidence_ref,
+        status: account.status,
+        detail: awsOrganizationsTopologyDetail(account),
+        filters: {
+          account: accountFilter,
+          region: 'current,uncovered',
+          coverage: `${coverage},${account.state},${account.status}`,
+          search: ''
+        },
+        searchText: inventorySearchText([
+          account.account_id,
+          account.account_name,
+          account.status,
+          account.parent_id,
+          account.ou_path,
+          account.state,
+          account.failure_reason,
+          account.eligibility_failure_reason,
+          account.next_action,
+          account.evidence_ref,
+          ...account.delegated_admin_services
+        ])
+      };
+    });
+  }
+  if (loading) {
+    return [
+      {
+        id: 'organizations-topology-loading',
+        category: 'AWS Organizations topology',
+        coverage: 'planned',
+        source: 'AWS Organizations discovery',
+        status: 'loading',
+        detail: 'Loading accounts, OUs, parent relationships, and delegated-admin metadata.',
+        filters: { account: 'planned', region: 'current,uncovered', coverage: 'planned', search: '' },
+        searchText: inventorySearchText(['organizations topology loading'])
+      }
+    ];
+  }
+  return [];
+}
+
 function AWSInventoryFilterSet({
   routeID,
   filters,
@@ -4306,19 +4400,23 @@ function AWSAccountsInventoryContent({
   connection,
   connectPath,
   coveragePlanState,
+  organizationsTopologyState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
   connectPath: string;
   coveragePlanState: AWSInventoryCoveragePlanState;
+  organizationsTopologyState: AWSInventoryOrganizationsTopologyState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const accountCoverage = awsCoverageState(connection);
   const hasHealthyCoverage = accountCoverage === 'covered';
   const plan = coveragePlanState.plan;
+  const topology = organizationsTopologyState.topology;
   const rows = buildAWSCoveragePlanRows(plan, coveragePlanState.loading, connection);
+  const topologyRows = buildAWSOrganizationsTopologyRows(topology, organizationsTopologyState.loading, connection);
   const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
   const totalChecks = connection?.permission_checks.length ?? 0;
   const coveredAccounts = plan
@@ -4332,11 +4430,13 @@ function AWSAccountsInventoryContent({
       ? 1
       : 0;
   const displayedRows = filterAWSInventoryRows(rows, filters);
+  const displayedTopologyRows = filterAWSInventoryRows(topologyRows, filters);
 
   return (
     <>
       <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
       {coveragePlanState.loading ? <DomainLoadingState label="Loading account and region coverage plan" /> : null}
+      {organizationsTopologyState.loading ? <DomainLoadingState label="Loading AWS Organizations topology" /> : null}
       {coveragePlanState.error ? (
         <DomainErrorState
           title="Coverage plan could not load"
@@ -4344,9 +4444,22 @@ function AWSAccountsInventoryContent({
           retryAction={{ label: 'Retry coverage plan', onClick: coveragePlanState.onRetry }}
         />
       ) : null}
+      {organizationsTopologyState.error ? (
+        <DomainErrorState
+          title="Organizations topology could not load"
+          body={organizationsTopologyState.error}
+          retryAction={{ label: 'Retry Organizations topology', onClick: organizationsTopologyState.onRetry }}
+        />
+      ) : null}
       <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage map">
         <DomainCoverageCard label="Account coverage" scanned={coveredAccounts} total={plan?.summary.account_count ?? 1} detail="Configured accounts" />
         <DomainCoverageCard label="Region coverage" scanned={coveredRegions} total={plan?.summary.region_count ?? 1} detail={plan ? `${plan.summary.coverage_percent}% target coverage` : hasHealthyCoverage ? connection?.region ?? 'Pending' : 'Pending'} />
+        <DomainCoverageCard
+          label="Organizations accounts"
+          scanned={topology?.summary.scan_eligible_accounts ?? coveredAccounts}
+          total={topology?.summary.account_count ?? plan?.summary.account_count ?? 1}
+          detail={topology ? `${topology.summary.organizational_unit_count} OUs` : 'Topology pending'}
+        />
         <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
       </section>
       {plan?.diagnostics.length ? (
@@ -4367,6 +4480,35 @@ function AWSAccountsInventoryContent({
           </div>
         </DomainStatusPanel>
       ) : null}
+      {topology?.diagnostics.length ? (
+        <DomainStatusPanel
+          eyebrow="Organizations diagnostics"
+          title="Topology discovery has explicit recovery work"
+          status={formatTokenLabel(topology.status)}
+          tone={topology.status === 'blocked' ? 'danger' : 'warning'}
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS Organizations topology diagnostics">
+            {topology.diagnostics.map((diagnostic) => (
+              <article key={`${diagnostic.code}-${diagnostic.scope ?? diagnostic.source}`}>
+                <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                <p>{diagnostic.message}</p>
+                {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+      <DomainDataTable
+        label="AWS Organizations topology"
+        rows={displayedTopologyRows}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'category', header: 'Account / OU', render: (row) => <strong>{row.category}</strong> },
+          { key: 'coverage', header: 'Discovery', render: (row) => <AWSInventoryPill stage={awsCoveragePlanStage(row.coverage)} label={formatTokenLabel(row.coverage)} /> },
+          { key: 'status', header: 'Account status', render: (row) => formatTokenLabel(row.status) },
+          { key: 'detail', header: 'Detail', render: (row) => row.detail }
+        ]}
+      />
       <DomainDataTable
         label="AWS account and region coverage"
         rows={displayedRows}
@@ -4392,6 +4534,13 @@ function AWSAccountsInventoryContent({
         {plan?.remediation_hints.length ? (
           <ul className="idt-domain-charter-list">
             {plan.remediation_hints.map((hint) => (
+              <li key={hint}>{hint}</li>
+            ))}
+          </ul>
+        ) : null}
+        {topology?.remediation_hints.length ? (
+          <ul className="idt-domain-charter-list">
+            {topology.remediation_hints.map((hint) => (
               <li key={hint}>{hint}</li>
             ))}
           </ul>
@@ -6970,6 +7119,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [coveragePlanLoading, setCoveragePlanLoading] = useState(false);
   const [coveragePlanError, setCoveragePlanError] = useState('');
   const coveragePlanRequestRef = useRef(0);
+  const [organizationsTopology, setOrganizationsTopology] = useState<AWSOrganizationsTopologyResult | null>(null);
+  const [organizationsTopologyLoading, setOrganizationsTopologyLoading] = useState(false);
+  const [organizationsTopologyError, setOrganizationsTopologyError] = useState('');
+  const organizationsTopologyRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -7634,6 +7787,58 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadCoveragePlan]);
 
+  const loadOrganizationsTopology = useCallback(async () => {
+    const requestID = ++organizationsTopologyRequestRef.current;
+    setOrganizationsTopology(null);
+    setOrganizationsTopologyError('');
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setOrganizationsTopologyLoading(false);
+      return;
+    }
+    setOrganizationsTopologyLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectOrganizationsTopology(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== organizationsTopologyRequestRef.current) {
+        return;
+      }
+      setOrganizationsTopology(response.topology);
+    } catch (error) {
+      if (requestID !== organizationsTopologyRequestRef.current) {
+        return;
+      }
+      setOrganizationsTopologyError(formatAPIError(error, 'Unable to load AWS Organizations topology.'));
+    } finally {
+      if (requestID === organizationsTopologyRequestRef.current) {
+        setOrganizationsTopologyLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region,
+    connection?.status,
+    connection?.health_status,
+  ]);
+
+  useEffect(() => {
+    void loadOrganizationsTopology();
+    return () => {
+      organizationsTopologyRequestRef.current += 1;
+    };
+  }, [loadOrganizationsTopology]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -7709,6 +7914,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: coveragePlanLoading,
             error: coveragePlanError,
             onRetry: () => void loadCoveragePlan()
+          }}
+          organizationsTopologyState={{
+            topology: organizationsTopology,
+            loading: organizationsTopologyLoading,
+            error: organizationsTopologyError,
+            onRetry: () => void loadOrganizationsTopology()
           }}
           filters={activeFilters}
           onFiltersChange={onFiltersChange}


### PR DESCRIPTION
## Summary
- add a deterministic AWS Organizations topology contract for accounts, OUs, parent relationships, delegated-admin indicators, account lifecycle status, scan eligibility, checkpoints, and failure states
- expose `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology` with fixture states, filters, diagnostics, evidence links, and remediation hints
- surface Organizations topology on the AWS Accounts page beside account/region coverage, including loading/error/diagnostic states and a searchable table
- document the capability, read-only permissions, safety boundary, failure modes, and validation steps

## Safety boundary
- Read-only and metadata-only.
- Does not collect secret values, account emails, customer payloads, prompts, completions, browser output, database rows, object contents, or live mutation output.
- Preserves tenant, workspace, project, connector, account, and region scope in the API result.

## Validation
- `go test ./internal/providers/awscontract ./internal/api`
- `cd web && pnpm tsc --noEmit && pnpm exec vitest run src/api/client.test.ts src/productShell.test.tsx`

## AI disclosure
No

Closes #1498

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only AWS Organizations topology discovery and surfaces it on the AWS Accounts page to plan safe account/region coverage with clear OU relationships, lifecycle status (including pending states), and diagnostics. Aligns coverage filtering and treats pending accounts as disabled for scan planning.

- **New Features**
  - Deterministic Organizations topology planner in `internal/providers/awscontract` (accounts, OUs, parent links, delegated-admin, eligibility, checkpoints); sets `next_action`, `resumable`, `observed_at`, and evidence refs.
  - `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology` with filters (`connector_id`, `account`, `ou`, `state`, `status`) and fixture states (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`); OpenAPI + route auth added; `status` supports `pending_activation` and `pending_closure`. Response includes summary, confidence, filtered_accounts, OUs, accounts, relationships, diagnostics, remediation hints, evidence links, coverage_gaps, and parent/current issue refs.
  - Client method `apiClient.getAWSProjectOrganizationsTopology` with tests; UI on the AWS Accounts page adds an Organizations topology table, diagnostics panel, and an “Organizations accounts” coverage card; suspended/closed/pending accounts show as missing; loading/error/search states.
  - Docs in `docs/aws-organizations-topology.md` covering API, permissions, failure states, and validation.

- **Bug Fixes**
  - Preserve `pending_closure` and `pending_activation`; treat pending accounts as disabled/ineligible; align topology coverage filtering; add blocked-state unit test for OU-disabled accounts.

<sup>Written for commit 1a7a6645492c7211dc1909c74b38c6fc65221448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

