### PR TITLE
Issue 1499: add region availability planning

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -1,8 +1,12 @@
 # AWS Account and Region Coverage Planner
 
-Issue #1497 adds a deterministic, metadata-only planner that expands an AWS
+Issue #1499 adds a deterministic, metadata-only planner that expands an AWS
 connector's configured accounts, regions, and service partitions into explicit
 scan targets.
+
+It also models per-account, per-region, and per-service availability outcomes
+(`blocked`, `unsupported`, `disabled`, and `permission_denied`) so operators can
+see exactly where and why scanning cannot proceed.
 
 ## What It Plans
 
@@ -44,15 +48,20 @@ The response includes tenant, workspace, project, issue metadata, summary
 counts, filtered targets, diagnostics, coverage gaps, remediation hints, and
 evidence links.
 
+When using fixture input or external planner input, `region_availability` and
+`service_availability` constraints are applied after checkpoint replay, so explicit
+blocked/unsupported/permission-denied/disabled states are preserved as
+first-class outcomes.
+
 ## Safety Boundary
 
 The planner performs no AWS mutations and reads no customer payloads. It does
 not read or persist secret values, prompts, completions, object contents,
 database rows, environment variable values, or code-interpreter output.
 
-AWS Organizations account discovery and live region availability discovery are
-outside this issue. This PR plans from configured connector scope and explicit
-checkpoints only.
+AWS Organizations account discovery is an upstream dependency for this issue.
+This planner does not call live AWS APIs during planning and applies explicit
+availability signals and checkpoints only.
 
 ## Failure States
 

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -9,7 +9,7 @@ import (
 	"github.com/identrail/identrail/internal/providers/awscontract"
 )
 
-const awsCoveragePlannerCurrentIssue = 1497
+const awsCoveragePlannerCurrentIssue = 1499
 const awsCoveragePlannerGlobalServiceHomeRegion = "us-east-1"
 
 // AWSCoveragePlanRequest filters and pins the account/region coverage plan.
@@ -224,7 +224,7 @@ func awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState s
 		{
 			Capability:  "live_account_discovery",
 			Status:      "out_of_scope",
-			Reason:      "The planner expands the configured account/region/service targets only; AWS Organizations and region availability discovery are later-wave capabilities.",
+			Reason:      "The planner accepts per-account region and service availability overrides for this issue, while organization-driven account discovery remains an upstream dependency.",
 			Remediation: "Populate accounts and regions from connector configuration or organization discovery before planning.",
 		},
 		{
@@ -256,6 +256,27 @@ func awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState s
 	}
 
 	diagnostics := []AWSCoveragePlanDiagnostic{}
+	// Capability examples: explicit account-region and account-region-service availability
+	// signals are surfaced here so the UI can show opt-in blocked, unsupported,
+	// and permission-denied behavior before live discovery is implemented.
+	if fixtureState == "degraded" || fixtureState == "partial_failure" || fixtureState == "permission_denied" {
+		config.RegionAvailability = []awscontract.CoverageAccountRegionAvailability{{
+			AccountID:   accountID,
+			Region:      awsCoveragePlanSecondaryRegion(region),
+			State:       awscontract.CoverageStateBlocked,
+			Reason:      "member account has not enabled the secondary region",
+			EvidenceRef: "/docs/aws-account-region-coverage-planner",
+		}}
+		config.ServiceAvailability = []awscontract.CoverageAccountServiceAvailability{{
+			AccountID:   secondaryAccount,
+			Region:      region,
+			Service:     "ecs",
+			State:       awscontract.CoverageStateUnsupported,
+			Reason:      "ecs inventory is not supported in this exact account-region pairing",
+			EvidenceRef: "/docs/aws-service-collector-contract#ecs",
+		}}
+	}
+
 	switch fixtureState {
 	case "permission_denied":
 		config.Checkpoints = []awscontract.CoverageCheckpoint{{

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -30,7 +30,7 @@ func TestGetAWSCoveragePlanSuccess(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready plan, got %+v", result)
 	}
-	if result.CurrentIssueRef != "#1497" || result.Version == "" {
+	if result.CurrentIssueRef != "#1499" || result.Version == "" {
 		t.Fatalf("unexpected metadata: %+v", result)
 	}
 	if result.Summary.AccountCount != 3 || result.Summary.RegionCount != 3 || result.Summary.ServiceCount != 6 {
@@ -160,6 +160,12 @@ func TestGetAWSCoveragePlanEmptyAndDegradedAndDenied(t *testing.T) {
 	if degraded.Summary.FailedTargets == 0 || degraded.Summary.ResumableTargets == 0 {
 		t.Fatalf("expected failed/resumable targets in degraded plan, got %+v", degraded.Summary)
 	}
+	if degraded.Summary.StateCounts["blocked"] == 0 {
+		t.Fatalf("expected blocked availability example in degraded plan: %+v", degraded.Summary.StateCounts)
+	}
+	if degraded.Summary.StateCounts["unsupported"] == 0 {
+		t.Fatalf("expected unsupported availability example in degraded plan: %+v", degraded.Summary.StateCounts)
+	}
 
 	denied, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
 	if err != nil {
@@ -167,6 +173,9 @@ func TestGetAWSCoveragePlanEmptyAndDegradedAndDenied(t *testing.T) {
 	}
 	if denied.Status != awsPlatformDependencyStatusBlocked || denied.Summary.PermissionDenied == 0 || len(denied.Diagnostics) == 0 {
 		t.Fatalf("expected blocked permission-denied plan, got %+v", denied)
+	}
+	if denied.Summary.StateCounts["permission_denied"] == 0 {
+		t.Fatalf("expected permission-denied state in denied plan: %+v", denied.Summary.StateCounts)
 	}
 }
 

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -87,6 +87,32 @@ type CoverageRegion struct {
 	OptIn bool `json:"opt_in,omitempty"`
 }
 
+// CoverageAccountRegionAvailability is an account-aware signal for whether a
+// region can be scanned for that account today.
+type CoverageAccountRegionAvailability struct {
+	AccountID     string        `json:"account_id"`
+	Region        string        `json:"region"`
+	State         CoverageState `json:"state"`
+	Reason        string        `json:"reason,omitempty"`
+	FailureReason string        `json:"failure_reason,omitempty"`
+	EvidenceRef   string        `json:"evidence_ref,omitempty"`
+	ObservedAt    time.Time     `json:"observed_at,omitempty"`
+}
+
+// CoverageAccountServiceAvailability is a per-account and per-region service
+// exception to planner assumptions, such as unsupported or permission-denied
+// service usage in a region.
+type CoverageAccountServiceAvailability struct {
+	AccountID     string        `json:"account_id"`
+	Region        string        `json:"region"`
+	Service       string        `json:"service"`
+	State         CoverageState `json:"state"`
+	Reason        string        `json:"reason,omitempty"`
+	FailureReason string        `json:"failure_reason,omitempty"`
+	EvidenceRef   string        `json:"evidence_ref,omitempty"`
+	ObservedAt    time.Time     `json:"observed_at,omitempty"`
+}
+
 // CoverageService is one AWS service partition in the coverage configuration.
 type CoverageService struct {
 	Service       string           `json:"service"`
@@ -123,11 +149,13 @@ type CoverageCheckpoint struct {
 // CoveragePlanConfig is the connector's expanded account/region/service scan
 // configuration plus any prior checkpoints to resume from.
 type CoveragePlanConfig struct {
-	ConnectorID string               `json:"connector_id,omitempty"`
-	Accounts    []CoverageAccount    `json:"accounts"`
-	Regions     []CoverageRegion     `json:"regions"`
-	Services    []CoverageService    `json:"services"`
-	Checkpoints []CoverageCheckpoint `json:"checkpoints,omitempty"`
+	ConnectorID         string                               `json:"connector_id,omitempty"`
+	Accounts            []CoverageAccount                    `json:"accounts"`
+	Regions             []CoverageRegion                     `json:"regions"`
+	RegionAvailability  []CoverageAccountRegionAvailability  `json:"region_availability,omitempty"`
+	ServiceAvailability []CoverageAccountServiceAvailability `json:"service_availability,omitempty"`
+	Services            []CoverageService                    `json:"services"`
+	Checkpoints         []CoverageCheckpoint                 `json:"checkpoints,omitempty"`
 }
 
 // CoverageTarget is one planned account/region/service scan unit with its
@@ -209,22 +237,48 @@ func PlanCoverage(config CoveragePlanConfig, generatedAt time.Time) (CoveragePla
 	if err != nil {
 		return CoveragePlan{}, err
 	}
+	regionAvailability, err := normalizeCoverageRegionAvailability(config.RegionAvailability)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
+	serviceAvailability, err := normalizeCoverageServiceAvailability(config.ServiceAvailability)
+	if err != nil {
+		return CoveragePlan{}, err
+	}
 	checkpoints, err := indexCoverageCheckpoints(config.Checkpoints)
 	if err != nil {
 		return CoveragePlan{}, err
 	}
+	regionAvailabilityByKey := indexCoverageRegionAvailability(regionAvailability)
+	serviceAvailabilityByKey := indexCoverageServiceAvailability(serviceAvailability)
 
 	targets := []CoverageTarget{}
 	seen := map[string]struct{}{}
 	for _, account := range accounts {
 		for _, service := range services {
 			if service.Global {
-				target := buildCoverageTarget(config.ConnectorID, account, globalCoverageRegion(service), service, checkpoints)
+				target := buildCoverageTarget(
+					config.ConnectorID,
+					account,
+					globalCoverageRegion(service),
+					service,
+					regionAvailabilityByKey,
+					serviceAvailabilityByKey,
+					checkpoints,
+				)
 				appendCoverageTarget(&targets, seen, target)
 				continue
 			}
 			for _, region := range regions {
-				target := buildCoverageTarget(config.ConnectorID, account, region, service, checkpoints)
+				target := buildCoverageTarget(
+					config.ConnectorID,
+					account,
+					region,
+					service,
+					regionAvailabilityByKey,
+					serviceAvailabilityByKey,
+					checkpoints,
+				)
 				appendCoverageTarget(&targets, seen, target)
 			}
 		}
@@ -261,7 +315,15 @@ func globalCoverageRegion(service CoverageService) CoverageRegion {
 	}
 }
 
-func buildCoverageTarget(connectorID string, account CoverageAccount, region CoverageRegion, service CoverageService, checkpoints map[string]CoverageCheckpoint) CoverageTarget {
+func buildCoverageTarget(
+	connectorID string,
+	account CoverageAccount,
+	region CoverageRegion,
+	service CoverageService,
+	regionAvailability map[string]CoverageAccountRegionAvailability,
+	serviceAvailability map[string]CoverageAccountServiceAvailability,
+	checkpoints map[string]CoverageCheckpoint,
+) CoverageTarget {
 	enabled := account.Enabled && region.Enabled && service.Enabled
 	priority, rank := mostUrgentCoveragePriority(account.Priority, region.Priority, service.Priority)
 	prerequisites := mergeCoveragePrerequisites(account, region, service)
@@ -297,8 +359,94 @@ func buildCoverageTarget(connectorID string, account CoverageAccount, region Cov
 	if checkpoint, ok := checkpoints[target.Key]; ok {
 		applyCoverageCheckpoint(&target, checkpoint)
 	}
+	// Explicit availability overrides are authoritative for execution state and
+	// must be preserved over prior checkpoints where they represent true
+	// operator-visible failure modes.
+	applyCoverageAccountRegionAvailability(&target, regionAvailability[coverageRegionKey(target.AccountID, target.Region)])
+	applyCoverageAccountServiceAvailability(&target, serviceAvailability[target.Key])
 	target.Resumable = coverageTargetResumable(target)
 	return target
+}
+
+type coverageAvailabilityHint struct {
+	State         CoverageState
+	Reason        string
+	FailureReason string
+	EvidenceRef   string
+	ObservedAt    time.Time
+}
+
+// applyCoverageAccountRegionAvailability applies account-region constraints after
+// checkpoint replay so explicit availability is authoritative.
+func applyCoverageAccountRegionAvailability(target *CoverageTarget, availability CoverageAccountRegionAvailability) {
+	applyCoverageAvailability(target, coverageAvailabilityHint{
+		State:         availability.State,
+		Reason:        availability.Reason,
+		FailureReason: availability.FailureReason,
+		EvidenceRef:   availability.EvidenceRef,
+		ObservedAt:    availability.ObservedAt,
+	})
+}
+
+// applyCoverageAccountServiceAvailability applies service-specific exceptions after
+// region availability. Service availability can mark a specific service as
+// unsupported or denied in a region even when the region itself is otherwise
+// available.
+func applyCoverageAccountServiceAvailability(target *CoverageTarget, availability CoverageAccountServiceAvailability) {
+	applyCoverageAvailability(target, coverageAvailabilityHint{
+		State:         availability.State,
+		Reason:        availability.Reason,
+		FailureReason: availability.FailureReason,
+		EvidenceRef:   availability.EvidenceRef,
+		ObservedAt:    availability.ObservedAt,
+	})
+}
+
+func applyCoverageAvailability(target *CoverageTarget, availability coverageAvailabilityHint) {
+	if availability.State == "" {
+		return
+	}
+	target.State = availability.State
+	switch availability.State {
+	case CoverageStateDisabled, CoverageStateBlocked, CoverageStateUnsupported, CoverageStatePermissionDenied:
+		target.Enabled = false
+		target.Cursor = ""
+		target.Attempts = 0
+		if failureReason := strings.TrimSpace(availability.FailureReason); failureReason != "" {
+			target.FailureReason = failureReason
+		} else {
+			target.FailureReason = ""
+		}
+	default:
+		if fr := strings.TrimSpace(availability.FailureReason); fr != "" {
+			target.FailureReason = fr
+		}
+	}
+	if reason := strings.TrimSpace(availability.Reason); reason != "" {
+		target.Reason = appendCoverageReason(target.Reason, reason)
+	}
+	if evidenceRef := strings.TrimSpace(availability.EvidenceRef); evidenceRef != "" {
+		target.EvidenceRef = evidenceRef
+	}
+	if !availability.ObservedAt.IsZero() {
+		target.ObservedAt = availability.ObservedAt.UTC()
+	}
+}
+
+func appendCoverageReason(current, next string) string {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return current
+	}
+	qualified := "availability: " + next
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return qualified
+	}
+	if strings.Contains(current, qualified) {
+		return current
+	}
+	return current + "; " + qualified
 }
 
 // applyCoverageCheckpoint replays a persisted target state. A disabled target
@@ -424,6 +572,96 @@ func normalizeCoverageRegions(input []CoverageRegion) ([]CoverageRegion, error) 
 	return out, nil
 }
 
+func normalizeCoverageRegionAvailability(input []CoverageAccountRegionAvailability) ([]CoverageAccountRegionAvailability, error) {
+	out := make([]CoverageAccountRegionAvailability, 0, len(input))
+	for _, item := range input {
+		accountID := strings.TrimSpace(item.AccountID)
+		if !isTwelveDigitAWSAccountID(accountID) {
+			return nil, fmt.Errorf("coverage account region availability account id %q must be 12 digits", item.AccountID)
+		}
+		region := strings.ToLower(strings.TrimSpace(item.Region))
+		if region == "" {
+			return nil, fmt.Errorf("coverage account region availability region is required")
+		}
+		state, err := normalizeCoverageAvailabilityState(item.State)
+		if err != nil {
+			return nil, fmt.Errorf("coverage account region availability state %q is invalid", item.State)
+		}
+		out = append(out, CoverageAccountRegionAvailability{
+			AccountID:     accountID,
+			Region:        region,
+			State:         state,
+			Reason:        strings.TrimSpace(item.Reason),
+			FailureReason: strings.TrimSpace(item.FailureReason),
+			EvidenceRef:   strings.TrimSpace(item.EvidenceRef),
+		})
+		if !item.ObservedAt.IsZero() {
+			out[len(out)-1].ObservedAt = item.ObservedAt.UTC()
+		}
+	}
+	return out, nil
+}
+
+func normalizeCoverageServiceAvailability(input []CoverageAccountServiceAvailability) ([]CoverageAccountServiceAvailability, error) {
+	out := make([]CoverageAccountServiceAvailability, 0, len(input))
+	for _, item := range input {
+		accountID := strings.TrimSpace(item.AccountID)
+		if !isTwelveDigitAWSAccountID(accountID) {
+			return nil, fmt.Errorf("coverage account service availability account id %q must be 12 digits", item.AccountID)
+		}
+		region := strings.ToLower(strings.TrimSpace(item.Region))
+		if region == "" {
+			return nil, fmt.Errorf("coverage account service availability region is required")
+		}
+		service := strings.ToLower(strings.TrimSpace(item.Service))
+		if service == "" {
+			return nil, fmt.Errorf("coverage account service availability service is required")
+		}
+		state, err := normalizeCoverageAvailabilityState(item.State)
+		if err != nil {
+			return nil, fmt.Errorf("coverage account service availability state %q is invalid", item.State)
+		}
+		out = append(out, CoverageAccountServiceAvailability{
+			AccountID:     accountID,
+			Region:        region,
+			Service:       service,
+			State:         state,
+			Reason:        strings.TrimSpace(item.Reason),
+			FailureReason: strings.TrimSpace(item.FailureReason),
+			EvidenceRef:   strings.TrimSpace(item.EvidenceRef),
+		})
+		if !item.ObservedAt.IsZero() {
+			out[len(out)-1].ObservedAt = item.ObservedAt.UTC()
+		}
+	}
+	return out, nil
+}
+
+func normalizeCoverageAvailabilityState(state CoverageState) (CoverageState, error) {
+	switch CoverageState(strings.ToLower(strings.TrimSpace(string(state)))) {
+	case CoverageStateDisabled, CoverageStateBlocked, CoverageStateUnsupported, CoverageStatePermissionDenied:
+		return CoverageState(strings.ToLower(strings.TrimSpace(string(state)))), nil
+	default:
+		return "", fmt.Errorf("coverage availability state %q is unsupported", state)
+	}
+}
+
+func indexCoverageRegionAvailability(input []CoverageAccountRegionAvailability) map[string]CoverageAccountRegionAvailability {
+	index := make(map[string]CoverageAccountRegionAvailability, len(input))
+	for _, availability := range input {
+		index[coverageRegionKey(availability.AccountID, availability.Region)] = availability
+	}
+	return index
+}
+
+func indexCoverageServiceAvailability(input []CoverageAccountServiceAvailability) map[string]CoverageAccountServiceAvailability {
+	index := make(map[string]CoverageAccountServiceAvailability, len(input))
+	for _, availability := range input {
+		index[coverageTargetKey(availability.AccountID, availability.Region, availability.Service)] = availability
+	}
+	return index
+}
+
 func normalizeCoverageServices(input []CoverageService) ([]CoverageService, error) {
 	out := make([]CoverageService, 0, len(input))
 	seen := map[string]struct{}{}
@@ -543,6 +781,13 @@ func coverageTargetKey(accountID, region, service string) string {
 		strings.TrimSpace(accountID),
 		strings.ToLower(strings.TrimSpace(region)),
 		strings.ToLower(strings.TrimSpace(service)),
+	}, "|")
+}
+
+func coverageRegionKey(accountID, region string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(accountID),
+		strings.ToLower(strings.TrimSpace(region)),
 	}, "|")
 }
 

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -408,8 +408,17 @@ func applyCoverageAvailability(target *CoverageTarget, availability coverageAvai
 	}
 	target.State = availability.State
 	switch availability.State {
-	case CoverageStateDisabled, CoverageStateBlocked, CoverageStateUnsupported, CoverageStatePermissionDenied:
+	case CoverageStateDisabled, CoverageStateUnsupported:
 		target.Enabled = false
+		target.Cursor = ""
+		target.Attempts = 0
+		target.ObservedAt = time.Time{}
+		if failureReason := strings.TrimSpace(availability.FailureReason); failureReason != "" {
+			target.FailureReason = failureReason
+		} else {
+			target.FailureReason = ""
+		}
+	case CoverageStateBlocked, CoverageStatePermissionDenied:
 		target.Cursor = ""
 		target.Attempts = 0
 		target.ObservedAt = time.Time{}

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -412,6 +412,7 @@ func applyCoverageAvailability(target *CoverageTarget, availability coverageAvai
 		target.Enabled = false
 		target.Cursor = ""
 		target.Attempts = 0
+		target.ObservedAt = time.Time{}
 		if failureReason := strings.TrimSpace(availability.FailureReason); failureReason != "" {
 			target.FailureReason = failureReason
 		} else {

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -363,7 +363,7 @@ func buildCoverageTarget(
 	// must be preserved over prior checkpoints where they represent true
 	// operator-visible failure modes.
 	applyCoverageAccountRegionAvailability(&target, regionAvailability[coverageRegionKey(target.AccountID, target.Region)])
-	applyCoverageAccountServiceAvailability(&target, serviceAvailability[target.Key])
+	applyCoverageAccountServiceAvailability(&target, serviceAvailability[target.Key], enabled)
 	target.Resumable = coverageTargetResumable(target)
 	return target
 }
@@ -392,7 +392,7 @@ func applyCoverageAccountRegionAvailability(target *CoverageTarget, availability
 // region availability. Service availability can mark a specific service as
 // unsupported or denied in a region even when the region itself is otherwise
 // available.
-func applyCoverageAccountServiceAvailability(target *CoverageTarget, availability CoverageAccountServiceAvailability) {
+func applyCoverageAccountServiceAvailability(target *CoverageTarget, availability CoverageAccountServiceAvailability, configuredEnabled bool) {
 	applyCoverageAvailability(target, coverageAvailabilityHint{
 		State:         availability.State,
 		Reason:        availability.Reason,
@@ -400,6 +400,9 @@ func applyCoverageAccountServiceAvailability(target *CoverageTarget, availabilit
 		EvidenceRef:   availability.EvidenceRef,
 		ObservedAt:    availability.ObservedAt,
 	})
+	if configuredEnabled && (availability.State == CoverageStateBlocked || availability.State == CoverageStatePermissionDenied) {
+		target.Enabled = true
+	}
 }
 
 func applyCoverageAvailability(target *CoverageTarget, availability coverageAvailabilityHint) {

--- a/internal/providers/awscontract/coverage_planner_test.go
+++ b/internal/providers/awscontract/coverage_planner_test.go
@@ -281,6 +281,39 @@ func TestPlanCoverageAvailabilityDoesNotReplayCheckpointForBlockedTarget(t *test
 	}
 }
 
+func TestPlanCoverageAvailabilityClearsStaleCheckpointObservedAt(t *testing.T) {
+	now := time.Now().UTC()
+	checkpointObservedAt := now.Add(-time.Hour)
+	plan, err := PlanCoverage(CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:  []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services: []CoverageService{{Service: "lambda", Enabled: true}},
+		RegionAvailability: []CoverageAccountRegionAvailability{{
+			AccountID: "111111111111",
+			Region:    "us-east-1",
+			State:     CoverageStateBlocked,
+			Reason:    "region is not enabled in this account",
+		}},
+		Checkpoints: []CoverageCheckpoint{{
+			AccountID:  "111111111111",
+			Region:     "us-east-1",
+			Service:    "lambda",
+			State:      CoverageStateCovered,
+			ObservedAt: checkpointObservedAt,
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	target := plan.Targets[0]
+	if target.State != CoverageStateBlocked {
+		t.Fatalf("expected availability to override checkpoint state, got %q", target.State)
+	}
+	if !target.ObservedAt.IsZero() {
+		t.Fatalf("expected stale checkpoint observed_at to be cleared, got %v", target.ObservedAt)
+	}
+}
+
 func TestPlanCoverageCheckpointResumes(t *testing.T) {
 	now := time.Now().UTC()
 	observed := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)

--- a/internal/providers/awscontract/coverage_planner_test.go
+++ b/internal/providers/awscontract/coverage_planner_test.go
@@ -241,6 +241,18 @@ func TestPlanCoverageRegionAndServiceAvailabilityIsPerAccountAware(t *testing.T)
 	if targetByKey["222222222222|us-east-1|ec2"].Enabled {
 		t.Fatalf("expected availability-disabled target to be disabled")
 	}
+	if !targetByKey["111111111111|us-east-1|lambda"].Enabled {
+		t.Fatalf("expected permission-denied target to remain enabled and outstanding")
+	}
+	if !targetByKey["222222222222|eu-west-1|ec2"].Enabled {
+		t.Fatalf("expected blocked target to remain enabled and outstanding")
+	}
+	if targetByKey["111111111111|eu-west-1|lambda"].Enabled {
+		t.Fatalf("expected unsupported target to be removed from enabled coverage")
+	}
+	if plan.Summary.EnabledTargets != 8 || plan.Summary.DisabledTargets != 2 {
+		t.Fatalf("unexpected enabled/disabled summary counts: %+v", plan.Summary)
+	}
 }
 
 func TestPlanCoverageAvailabilityDoesNotReplayCheckpointForBlockedTarget(t *testing.T) {

--- a/internal/providers/awscontract/coverage_planner_test.go
+++ b/internal/providers/awscontract/coverage_planner_test.go
@@ -326,6 +326,55 @@ func TestPlanCoverageAvailabilityClearsStaleCheckpointObservedAt(t *testing.T) {
 	}
 }
 
+func TestPlanCoverageServiceAvailabilityRestoresFixableTargetAfterRegionDisable(t *testing.T) {
+	now := time.Now().UTC()
+	plan, err := PlanCoverage(CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:  []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services: []CoverageService{
+			{Service: "ec2", Enabled: true},
+			{Service: "lambda", Enabled: true},
+		},
+		RegionAvailability: []CoverageAccountRegionAvailability{{
+			AccountID: "111111111111",
+			Region:    "us-east-1",
+			State:     CoverageStateDisabled,
+			Reason:    "region disabled for this account",
+		}},
+		ServiceAvailability: []CoverageAccountServiceAvailability{{
+			AccountID:     "111111111111",
+			Region:        "us-east-1",
+			Service:       "lambda",
+			State:         CoverageStatePermissionDenied,
+			Reason:        "lambda read action denied",
+			FailureReason: "AccessDenied: lambda:ListFunctions",
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	targetByKey := map[string]CoverageTarget{}
+	for _, target := range plan.Targets {
+		targetByKey[target.Key] = target
+	}
+
+	ec2 := targetByKey["111111111111|us-east-1|ec2"]
+	if ec2.State != CoverageStateDisabled || ec2.Enabled {
+		t.Fatalf("expected region-disabled service to stay disabled: %#v", ec2)
+	}
+	lambda := targetByKey["111111111111|us-east-1|lambda"]
+	if lambda.State != CoverageStatePermissionDenied || !lambda.Enabled {
+		t.Fatalf("expected service permission denial to restore enabled target: %#v", lambda)
+	}
+	if lambda.FailureReason == "" {
+		t.Fatalf("expected service permission denial failure reason")
+	}
+	if plan.Summary.EnabledTargets != 1 || plan.Summary.DisabledTargets != 1 || plan.Summary.OutstandingTargets != 1 {
+		t.Fatalf("unexpected summary counts after service availability override: %+v", plan.Summary)
+	}
+}
+
 func TestPlanCoverageCheckpointResumes(t *testing.T) {
 	now := time.Now().UTC()
 	observed := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)

--- a/internal/providers/awscontract/coverage_planner_test.go
+++ b/internal/providers/awscontract/coverage_planner_test.go
@@ -2,6 +2,7 @@ package awscontract
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -155,6 +156,131 @@ func TestPlanCoveragePrerequisitesBlockTarget(t *testing.T) {
 	}
 }
 
+func TestPlanCoverageRegionAndServiceAvailabilityIsPerAccountAware(t *testing.T) {
+	now := time.Now().UTC()
+	config := CoveragePlanConfig{
+		Accounts: []CoverageAccount{
+			{AccountID: "111111111111", Enabled: true},
+			{AccountID: "222222222222", Enabled: true},
+		},
+		Regions: []CoverageRegion{
+			{Region: "us-east-1", Enabled: true},
+			{Region: "eu-west-1", Enabled: true},
+		},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true, Global: true},
+			{Service: "ec2", Enabled: true},
+			{Service: "lambda", Enabled: true},
+		},
+		RegionAvailability: []CoverageAccountRegionAvailability{
+			{
+				AccountID: "222222222222",
+				Region:    "eu-west-1",
+				State:     CoverageStateBlocked,
+				Reason:    "member account has not enabled region opt-in",
+			},
+		},
+		ServiceAvailability: []CoverageAccountServiceAvailability{
+			{
+				AccountID: "111111111111",
+				Region:    "eu-west-1",
+				Service:   "lambda",
+				State:     CoverageStateUnsupported,
+				Reason:    "lambda service not available in account-specific region",
+			},
+			{
+				AccountID: "111111111111",
+				Region:    "us-east-1",
+				Service:   "lambda",
+				State:     CoverageStatePermissionDenied,
+				Reason:    "required read action on this account is denied",
+			},
+			{
+				AccountID: "222222222222",
+				Region:    "us-east-1",
+				Service:   "ec2",
+				State:     CoverageStateDisabled,
+				Reason:    "ec2 collection explicitly disabled for this service scope",
+			},
+		},
+	}
+	plan, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	targetByKey := map[string]CoverageTarget{}
+	for _, target := range plan.Targets {
+		targetByKey[target.Key] = target
+	}
+	if targetByKey["111111111111|us-east-1|lambda"].State != CoverageStatePermissionDenied {
+		t.Fatalf("expected region service to remain permission denied: %#v", targetByKey["111111111111|us-east-1|lambda"])
+	}
+	if targetByKey["111111111111|eu-west-1|lambda"].State != CoverageStateUnsupported {
+		t.Fatalf("expected region service to be unsupported: %#v", targetByKey["111111111111|eu-west-1|lambda"])
+	}
+	if targetByKey["222222222222|eu-west-1|ec2"].State != CoverageStateBlocked {
+		t.Fatalf("expected blocked target from region availability: %#v", targetByKey["222222222222|eu-west-1|ec2"])
+	}
+	if targetByKey["222222222222|eu-west-1|lambda"].State != CoverageStateBlocked {
+		t.Fatalf("expected blocked target from region availability: %#v", targetByKey["222222222222|eu-west-1|lambda"])
+	}
+	if targetByKey["222222222222|us-east-1|ec2"].State != CoverageStateDisabled {
+		t.Fatalf("expected disabled target from service availability: %#v", targetByKey["222222222222|us-east-1|ec2"])
+	}
+	if !strings.Contains(targetByKey["222222222222|us-east-1|ec2"].Reason, "availability:") {
+		t.Fatalf("expected availability reason on service-disabled target, got: %s", targetByKey["222222222222|us-east-1|ec2"].Reason)
+	}
+	if plan.Summary.StateCounts[CoverageStateUnsupported] != 1 ||
+		plan.Summary.StateCounts[CoverageStatePermissionDenied] != 1 ||
+		plan.Summary.StateCounts[CoverageStateBlocked] != 2 {
+		t.Fatalf("unexpected summary state counts: %#v", plan.Summary.StateCounts)
+	}
+	if plan.Summary.StateCounts[CoverageStateDisabled] != 1 {
+		t.Fatalf("expected one disabled target summary: %#v", plan.Summary.StateCounts)
+	}
+	if targetByKey["222222222222|us-east-1|ec2"].Enabled {
+		t.Fatalf("expected availability-disabled target to be disabled")
+	}
+}
+
+func TestPlanCoverageAvailabilityDoesNotReplayCheckpointForBlockedTarget(t *testing.T) {
+	now := time.Now().UTC()
+	observed := now.Add(-time.Minute)
+	plan, err := PlanCoverage(CoveragePlanConfig{
+		Accounts: []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:  []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services: []CoverageService{{Service: "lambda", Enabled: true}},
+		RegionAvailability: []CoverageAccountRegionAvailability{{
+			AccountID:  "111111111111",
+			Region:     "us-east-1",
+			State:      CoverageStateBlocked,
+			Reason:     "region is not enabled in this account",
+			ObservedAt: observed,
+		}},
+		Checkpoints: []CoverageCheckpoint{{
+			AccountID: "111111111111",
+			Region:    "us-east-1",
+			Service:   "lambda",
+			State:     CoverageStateInProgress,
+			Cursor:    "cursor-1",
+			Attempts:  2,
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	target := plan.Targets[0]
+	if target.State != CoverageStateBlocked {
+		t.Fatalf("checkpoint replay should be blocked by region availability, got %q", target.State)
+	}
+	if target.Cursor != "" || target.Attempts != 0 {
+		t.Fatalf("blocked availability target should not replay cursor/attempts: %#v", target)
+	}
+	if target.ObservedAt.IsZero() || !target.ObservedAt.Equal(observed) {
+		t.Fatalf("expected observed_at from availability, got %v", target.ObservedAt)
+	}
+}
+
 func TestPlanCoverageCheckpointResumes(t *testing.T) {
 	now := time.Now().UTC()
 	observed := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
@@ -262,6 +388,29 @@ func TestPlanCoverageRejectsInvalidCheckpointState(t *testing.T) {
 	config.Checkpoints = []CoverageCheckpoint{{AccountID: "111111111111", Region: "us-east-1", Service: "iam", State: "bogus"}}
 	if _, err := PlanCoverage(config, time.Now()); err == nil {
 		t.Fatalf("expected error for invalid checkpoint state")
+	}
+}
+
+func TestPlanCoverageRejectsInvalidAvailabilityState(t *testing.T) {
+	config := sampleCoverageConfig()
+	config.RegionAvailability = []CoverageAccountRegionAvailability{{
+		AccountID: "111111111111",
+		Region:    "us-east-1",
+		State:     CoverageState("bogus"),
+	}}
+	if _, err := PlanCoverage(config, time.Now()); err == nil {
+		t.Fatalf("expected error for invalid region availability state")
+	}
+
+	config = sampleCoverageConfig()
+	config.ServiceAvailability = []CoverageAccountServiceAvailability{{
+		AccountID: "111111111111",
+		Region:    "us-east-1",
+		Service:   "lambda",
+		State:     CoverageState("bogus"),
+	}}
+	if _, err := PlanCoverage(config, time.Now()); err == nil {
+		t.Fatalf("expected error for invalid service availability state")
 	}
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3720,6 +3720,8 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'Planned', value: 'planned' },
         { label: 'Missing', value: 'missing' },
         { label: 'Blocked', value: 'blocked' },
+        { label: 'Unsupported', value: 'unsupported' },
+        { label: 'Disabled', value: 'disabled' },
         { label: 'Degraded', value: 'degraded' },
         { label: 'Failed', value: 'failed' },
         { label: 'Permission denied', value: 'permission_denied' },
@@ -4019,11 +4021,13 @@ function awsCoveragePlanFilterValue(state: string): string {
     case 'in_progress':
       return 'degraded';
     case 'blocked':
-    case 'disabled':
-    case 'unsupported':
     case 'planned':
     case 'pending':
       return 'missing';
+    case 'unsupported':
+      return 'unsupported';
+    case 'disabled':
+      return 'disabled';
     default:
       return 'not-yet-available';
   }
@@ -4037,11 +4041,20 @@ function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
   const details = [`Priority ${formatTokenLabel(target.priority)}`];
   if (target.failure_reason) {
     details.push(target.failure_reason);
-  } else if (target.prerequisites.length > 0) {
+  }
+  if (target.reason) {
+    details.push(target.reason);
+  }
+  if (target.prerequisites.length > 0) {
     details.push(target.prerequisites[0]);
-  } else if (target.cursor) {
+  }
+  if (target.cursor) {
     details.push(`Cursor ${target.cursor}`);
-  } else {
+  }
+  if (target.observed_at) {
+    details.push(`Observed ${formatConnectionTime(target.observed_at)}`);
+  }
+  if (details.length === 1) {
     details.push(target.next_action);
   }
   if (target.attempts) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4037,6 +4037,11 @@ function awsCoveragePlanStage(state: string): AWSCapabilityStage {
   return state === 'covered' ? 'wired' : state === 'disabled' || state === 'unsupported' ? 'not-available' : 'coming';
 }
 
+function hasAWSCoverageObservedAt(value?: string): boolean {
+  const timestamp = value?.trim();
+  return Boolean(timestamp && !timestamp.startsWith('0001-01-01T00:00:00'));
+}
+
 function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
   const details = [`Priority ${formatTokenLabel(target.priority)}`];
   if (target.failure_reason) {
@@ -4051,7 +4056,7 @@ function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
   if (target.cursor) {
     details.push(`Cursor ${target.cursor}`);
   }
-  if (target.observed_at) {
+  if (hasAWSCoverageObservedAt(target.observed_at)) {
     details.push(`Observed ${formatConnectionTime(target.observed_at)}`);
   }
   if (details.length === 1) {


### PR DESCRIPTION
Closes #1499

## Summary
- Add per-account/region and per-account/region/service availability inputs to the AWS coverage planner contract.
- Apply explicit availability states after checkpoint replay so blocked, unsupported, permission_denied, and disabled targets remain authoritative and do not look successful.
- Validate availability payloads and add focused coverage for per-account behavior, invalid states, and checkpoint override behavior.
- Wire availability examples into the AWS coverage-plan API fixtures and expose them in app filtering/details.
- Update the planner docs with the new behavior, safety boundary, and upstream dependency notes.

## Validation
- go test ./internal/providers/awscontract ./internal/api
- cd web && npm run build

## AI Disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-account region and per-service availability to the AWS coverage planner so operators can see exactly where and why scanning can’t proceed. Availability applies after checkpoint replay; fixable targets stay enabled (including service-level overrides), unsupported/disabled are disabled, stale observed_at is cleared, and the UI hides zero timestamps. Implements #1499.

- New Features
  - Accept and validate account-region and account-region-service availability with states: blocked, unsupported, disabled, permission_denied; include fixture examples and summary state_counts.
  - Apply availability after checkpoint replay: clear cursor/attempts; set reason/failure_reason/evidence_ref; keep blocked/permission_denied enabled; disable unsupported/disabled; clear stale observed_at; allow service-level permission_denied to re-enable a target even if the region is disabled.
  - UI/docs: add Unsupported and Disabled filters; map Unsupported/Disabled directly and keep Blocked under Missing; show availability reason and observed_at in target details; hide zero observed timestamps; clarify no live AWS calls during planning and that AWS Organizations account discovery is upstream.

<sup>Written for commit cb95b4a34e69ee1f5dda5abdd166f2d80e6eb4df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

