### PR TITLE
Issue 1500: add AWS fan-out execution worker view

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 
 - Architecture overview: `architecture.md`
 - AWS collector details: `aws-collector.md`
+- AWS account/region fan-out worker: `aws-account-region-fanout-worker.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-account-region-fanout-worker.md
+++ b/docs/aws-account-region-fanout-worker.md
@@ -1,0 +1,67 @@
+# AWS Account and Region Fan-Out Worker
+
+Issue #1500 adds a deterministic, metadata-only execution view for bounded AWS
+account/region/service fan-out. It builds on the coverage planner from issue
+#1499 and makes worker state explicit for operators and downstream recovery
+flows.
+
+## What It Executes
+
+The fan-out executor consumes an `awscontract.CoveragePlan` and produces one
+worker target for each planned account, region, and service target. It records:
+
+- target account, region, service, priority, coverage state, and worker state
+- bounded concurrency slot and queue state
+- attempts, maximum attempts, retryability, retry-after, and checkpoints
+- failure reason, evidence reference, timestamp, and next operator action
+
+Targets that are `disabled`, `unsupported`, or `blocked` are skipped instead of
+being queued. `permission_denied`, `partial`, and `failed` remain explicit
+states and never count as successful coverage.
+
+## API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution
+```
+
+Optional query parameters:
+
+- `connector_id`: scope the response to one AWS connector.
+- `fixture_state`: one of `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for UI and contract validation.
+- `account`: filter to one 12-digit AWS account.
+- `region`: filter to one region.
+- `service`: filter to one service partition.
+- `state`: filter by lifecycle or worker state.
+- `max_concurrency`: deterministic worker concurrency limit from 1 to 64.
+
+The response includes issue metadata, summary counts, filtered targets,
+diagnostics, coverage gaps, remediation hints, and evidence links.
+
+## Failure And Retry Behavior
+
+One account/region/service failure does not fail the whole execution view.
+Throttled and partial targets preserve their checkpoint and retry metadata so a
+future worker run can resume from the last safe cursor. Permission-denied targets
+are non-retryable until the read-only collector role is repaired.
+
+## Safety Boundary
+
+This issue does not mutate AWS state and does not collect customer payloads,
+secret values, prompts, completions, browser output, database rows, object
+contents, or code-interpreter output. The deterministic fixture path is safe for
+CI and UI validation.
+
+## Validation
+
+Run:
+
+```sh
+go test ./internal/providers/awscontract ./internal/api
+cd web && npm run build
+```
+
+For live validation, use only an authorized test account and record
+account/region/service coverage, worker state, retry status, and evidence
+references without exposing sensitive payloads.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10687,6 +10687,7 @@ components:
         concurrency_slot: { type: integer }
         checkpoint: { type: string }
         retryable: { type: boolean }
+        throttled: { type: boolean }
         retry_after: { type: string }
         failure_reason: { type: string }
         evidence_ref: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -569,6 +569,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/organizations-topology
     action: tenancy.read
     resource_type: project
@@ -4650,6 +4655,81 @@ paths:
                     $ref: "#/components/schemas/AWSCoveragePlanResult"
         "400":
           description: Invalid AWS coverage plan request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS account and region fan-out execution state
+      operationId: getAWSProjectFanOutExecution
+      description: Returns the deterministic account/region/service fan-out worker state for an AWS connector. Each target carries worker state, bounded concurrency slot, checkpoint, retry metadata, failure reason, evidence reference, and next action. Read-only and metadata-only - the execution view reads no customer payloads and mutates no AWS state.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only worker evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account
+          schema: { type: string }
+          description: Optional 12-digit AWS account id filter over execution targets.
+        - in: query
+          name: region
+          schema: { type: string }
+          description: Optional AWS region code filter over execution targets.
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Optional AWS service partition filter (for example iam, ec2, lambda).
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+          description: Optional lifecycle or worker state filter over execution targets.
+        - in: query
+          name: max_concurrency
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 64
+          description: Optional bounded worker concurrency limit for deterministic fixture execution.
+      responses:
+        "200":
+          description: AWS account and region fan-out execution state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  execution:
+                    $ref: "#/components/schemas/AWSFanOutExecutionResult"
+        "400":
+          description: Invalid AWS fan-out execution request
           content:
             application/json:
               schema:
@@ -10562,6 +10642,105 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSCoveragePlanTarget"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSFanOutExecutionTarget:
+      type: object
+      properties:
+        key: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        priority:
+          type: string
+          enum: [critical, high, normal, low]
+        state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        worker_state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        enabled: { type: boolean }
+        attempts: { type: integer }
+        max_attempts: { type: integer }
+        concurrency_slot: { type: integer }
+        checkpoint: { type: string }
+        retryable: { type: boolean }
+        retry_after: { type: string }
+        failure_reason: { type: string }
+        evidence_ref: { type: string }
+        next_action: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+    AWSFanOutExecutionSummary:
+      type: object
+      properties:
+        total_targets: { type: integer }
+        executable_targets: { type: integer }
+        skipped_targets: { type: integer }
+        queued_targets: { type: integer }
+        in_progress_targets: { type: integer }
+        covered_targets: { type: integer }
+        partial_targets: { type: integer }
+        failed_targets: { type: integer }
+        permission_denied_targets: { type: integer }
+        throttled_targets: { type: integer }
+        retryable_targets: { type: integer }
+        concurrency_limit: { type: integer }
+        max_attempts: { type: integer }
+    AWSFanOutExecutionResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        filtered_targets: { type: integer }
+        summary:
+          $ref: "#/components/schemas/AWSFanOutExecutionSummary"
+        targets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSFanOutExecutionTarget"
         failure_reasons:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -757,6 +757,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dynamodb-rds-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/coverage-plan", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/fanout-execution", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_fanout_execution.go
+++ b/internal/api/aws_fanout_execution.go
@@ -1,0 +1,305 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const awsFanOutExecutionCurrentIssue = 1500
+
+// AWSFanOutExecutionRequest filters and pins the deterministic fan-out worker view.
+type AWSFanOutExecutionRequest struct {
+	ConnectorID    string `json:"connector_id,omitempty"`
+	FixtureState   string `json:"fixture_state,omitempty"`
+	Account        string `json:"account,omitempty"`
+	Region         string `json:"region,omitempty"`
+	Service        string `json:"service,omitempty"`
+	State          string `json:"state,omitempty"`
+	MaxConcurrency int    `json:"max_concurrency,omitempty"`
+}
+
+// AWSFanOutExecutionTarget is one operator-visible worker execution unit.
+type AWSFanOutExecutionTarget struct {
+	Key             string    `json:"key"`
+	AccountID       string    `json:"account_id"`
+	Region          string    `json:"region"`
+	Service         string    `json:"service"`
+	Priority        string    `json:"priority"`
+	State           string    `json:"state"`
+	WorkerState     string    `json:"worker_state"`
+	Enabled         bool      `json:"enabled"`
+	Attempts        int       `json:"attempts"`
+	MaxAttempts     int       `json:"max_attempts"`
+	ConcurrencySlot int       `json:"concurrency_slot,omitempty"`
+	Checkpoint      string    `json:"checkpoint,omitempty"`
+	Retryable       bool      `json:"retryable"`
+	RetryAfter      string    `json:"retry_after,omitempty"`
+	FailureReason   string    `json:"failure_reason,omitempty"`
+	EvidenceRef     string    `json:"evidence_ref"`
+	NextAction      string    `json:"next_action"`
+	ObservedAt      time.Time `json:"observed_at,omitempty"`
+}
+
+// AWSFanOutExecutionSummary aggregates bounded worker state for dashboards.
+type AWSFanOutExecutionSummary struct {
+	TotalTargets            int `json:"total_targets"`
+	ExecutableTargets       int `json:"executable_targets"`
+	SkippedTargets          int `json:"skipped_targets"`
+	QueuedTargets           int `json:"queued_targets"`
+	InProgressTargets       int `json:"in_progress_targets"`
+	CoveredTargets          int `json:"covered_targets"`
+	PartialTargets          int `json:"partial_targets"`
+	FailedTargets           int `json:"failed_targets"`
+	PermissionDeniedTargets int `json:"permission_denied_targets"`
+	ThrottledTargets        int `json:"throttled_targets"`
+	RetryableTargets        int `json:"retryable_targets"`
+	ConcurrencyLimit        int `json:"concurrency_limit"`
+	MaxAttempts             int `json:"max_attempts"`
+}
+
+// AWSFanOutExecutionResult is the full deterministic fan-out worker response.
+type AWSFanOutExecutionResult struct {
+	TenantID           string                       `json:"tenant_id"`
+	WorkspaceID        string                       `json:"workspace_id"`
+	ProjectID          string                       `json:"project_id"`
+	ConnectorID        string                       `json:"connector_id,omitempty"`
+	AccountID          string                       `json:"account_id,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	ParentIssueNumber  int                          `json:"parent_issue_number"`
+	ParentIssueRef     string                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                          `json:"current_issue_number"`
+	CurrentIssueRef    string                       `json:"current_issue_ref"`
+	Version            string                       `json:"version"`
+	Status             string                       `json:"status"`
+	FixtureState       string                       `json:"fixture_state"`
+	Confidence         float64                      `json:"confidence"`
+	FilteredTargets    int                          `json:"filtered_targets"`
+	Summary            AWSFanOutExecutionSummary    `json:"summary"`
+	Targets            []AWSFanOutExecutionTarget   `json:"targets"`
+	FailureReasons     []string                     `json:"failure_reasons"`
+	RemediationHints   []string                     `json:"remediation_hints"`
+	EvidenceLinks      []string                     `json:"evidence_links"`
+	CoverageGaps       []AWSCoveragePlanCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSCoveragePlanDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	UpdatedAt          time.Time                    `json:"updated_at"`
+}
+
+// GetAWSFanOutExecution returns the deterministic account/region/service fan-out
+// worker state for a project's AWS connector. It is metadata-only and read-only.
+func (s *Service) GetAWSFanOutExecution(ctx context.Context, workspaceID string, projectID string, request AWSFanOutExecutionRequest) (AWSFanOutExecutionResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSFanOutExecutionResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSFanOutExecutionResult{}, err
+	}
+	return buildAWSFanOutExecution(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSFanOutExecutionRequest, checkedAt time.Time) (AWSFanOutExecutionResult, error) {
+	fixtureState := normalizeAWSCoveragePlanFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSFanOutExecutionResult{}, ErrInvalidAWSConnectionRequest
+	}
+	if !validAWSCoveragePlanStateFilter(request.State) {
+		return AWSFanOutExecutionResult{}, ErrInvalidAWSConnectionRequest
+	}
+	maxConcurrency := request.MaxConcurrency
+	if maxConcurrency < 0 || maxConcurrency > 64 {
+		return AWSFanOutExecutionResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "111111111111")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	config, diagnostics, gaps := awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	coverage, err := awscontract.PlanCoverage(config, checkedAt)
+	if err != nil {
+		return AWSFanOutExecutionResult{}, err
+	}
+	execution, err := awscontract.PlanFanOutExecution(awscontract.FanOutExecutionConfig{
+		Plan:               coverage,
+		MaxConcurrency:     firstPositiveInt(maxConcurrency, 4),
+		MaxAttempts:        3,
+		ThrottleRetryAfter: 30 * time.Second,
+		Outcomes:           awsFanOutFixtureOutcomes(coverage, accountID, region, fixtureState, checkedAt),
+		StartedAt:          checkedAt,
+	})
+	if err != nil {
+		return AWSFanOutExecutionResult{}, err
+	}
+	targets := mapAWSFanOutExecutionTargets(execution.Targets)
+	filtered := filterAWSFanOutExecutionTargets(targets, request)
+	status, confidence, failures, remediations := summarizeAWSFanOutExecution(fixtureState, diagnostics, execution)
+
+	return AWSFanOutExecutionResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsFanOutExecutionCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsFanOutExecutionCurrentIssue),
+		Version:            execution.Version,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		FilteredTargets:    len(filtered),
+		Summary:            mapAWSFanOutExecutionSummary(execution.Summary),
+		Targets:            filtered,
+		FailureReasons:     failures,
+		RemediationHints:   remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsFanOutExecutionCurrentIssue),
+			"/docs/aws-account-region-fanout-worker",
+			"/docs/aws-account-region-coverage-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func awsFanOutFixtureOutcomes(plan awscontract.CoveragePlan, accountID, region, fixtureState string, checkedAt time.Time) []awscontract.FanOutTargetOutcome {
+	if fixtureState == "empty" || fixtureState == "permission_denied" {
+		return nil
+	}
+	outcomes := []awscontract.FanOutTargetOutcome{}
+	add := func(key string, outcome awscontract.FanOutExecutionOutcome, cursor string, failure string, retryable bool) {
+		if hasCoverageTarget(plan, key) {
+			outcomes = append(outcomes, awscontract.FanOutTargetOutcome{Key: key, Outcome: outcome, Cursor: cursor, FailureReason: failure, Retryable: retryable, ObservedAt: checkedAt})
+		}
+	}
+	add(accountID+"|"+awsCoveragePlannerGlobalServiceHomeRegion+"|iam", awscontract.FanOutExecutionOutcomeCovered, "", "", false)
+	add(accountID+"|"+region+"|lambda", awscontract.FanOutExecutionOutcomeCovered, "", "", false)
+
+	if fixtureState == "degraded" || fixtureState == "partial_failure" {
+		secondaryAccount := awsCoveragePlanSiblingAccount(accountID)
+		secondaryRegion := awsCoveragePlanSecondaryRegion(region)
+		add(secondaryAccount+"|"+secondaryRegion+"|ecs", awscontract.FanOutExecutionOutcomeThrottled, "ecs-page-2", "Throttling: ecs:ListServices throttled after bounded retries", true)
+		add(secondaryAccount+"|"+region+"|lambda", awscontract.FanOutExecutionOutcomePartial, "lambda-page-3", "lambda returned partial page before retry window elapsed", true)
+	}
+	return outcomes
+}
+
+func hasCoverageTarget(plan awscontract.CoveragePlan, key string) bool {
+	for _, target := range plan.Targets {
+		if target.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func mapAWSFanOutExecutionTargets(targets []awscontract.FanOutExecutionTarget) []AWSFanOutExecutionTarget {
+	out := make([]AWSFanOutExecutionTarget, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, AWSFanOutExecutionTarget{
+			Key:             target.Key,
+			AccountID:       target.AccountID,
+			Region:          target.Region,
+			Service:         target.Service,
+			Priority:        string(target.Priority),
+			State:           string(target.State),
+			WorkerState:     string(target.WorkerState),
+			Enabled:         target.Enabled,
+			Attempts:        target.Attempts,
+			MaxAttempts:     target.MaxAttempts,
+			ConcurrencySlot: target.ConcurrencySlot,
+			Checkpoint:      target.Checkpoint,
+			Retryable:       target.Retryable,
+			RetryAfter:      target.RetryAfter,
+			FailureReason:   target.FailureReason,
+			EvidenceRef:     target.EvidenceRef,
+			NextAction:      target.NextAction,
+			ObservedAt:      target.ObservedAt,
+		})
+	}
+	return out
+}
+
+func mapAWSFanOutExecutionSummary(summary awscontract.FanOutExecutionSummary) AWSFanOutExecutionSummary {
+	return AWSFanOutExecutionSummary{
+		TotalTargets:            summary.TotalTargets,
+		ExecutableTargets:       summary.ExecutableTargets,
+		SkippedTargets:          summary.SkippedTargets,
+		QueuedTargets:           summary.QueuedTargets,
+		InProgressTargets:       summary.InProgressTargets,
+		CoveredTargets:          summary.CoveredTargets,
+		PartialTargets:          summary.PartialTargets,
+		FailedTargets:           summary.FailedTargets,
+		PermissionDeniedTargets: summary.PermissionDeniedTargets,
+		ThrottledTargets:        summary.ThrottledTargets,
+		RetryableTargets:        summary.RetryableTargets,
+		ConcurrencyLimit:        summary.ConcurrencyLimit,
+		MaxAttempts:             summary.MaxAttempts,
+	}
+}
+
+func filterAWSFanOutExecutionTargets(targets []AWSFanOutExecutionTarget, request AWSFanOutExecutionRequest) []AWSFanOutExecutionTarget {
+	account := strings.TrimSpace(request.Account)
+	region := strings.ToLower(strings.TrimSpace(request.Region))
+	service := strings.ToLower(strings.TrimSpace(request.Service))
+	state := strings.ToLower(strings.TrimSpace(request.State))
+	if account == "" && region == "" && service == "" && state == "" {
+		return targets
+	}
+	filtered := make([]AWSFanOutExecutionTarget, 0, len(targets))
+	for _, target := range targets {
+		if account != "" && target.AccountID != account {
+			continue
+		}
+		if region != "" && strings.ToLower(target.Region) != region {
+			continue
+		}
+		if service != "" && strings.ToLower(target.Service) != service {
+			continue
+		}
+		if state != "" && strings.ToLower(target.WorkerState) != state && strings.ToLower(target.State) != state {
+			continue
+		}
+		filtered = append(filtered, target)
+	}
+	return filtered
+}
+
+func summarizeAWSFanOutExecution(fixtureState string, diagnostics []AWSCoveragePlanDiagnostic, execution awscontract.FanOutExecutionPlan) (string, float64, []string, []string) {
+	if fixtureState == "permission_denied" || execution.Summary.PermissionDeniedTargets > 0 {
+		return awsPlatformDependencyStatusBlocked, 0.34,
+			awsCoveragePlanDiagnosticMessages(diagnostics),
+			[]string{"Deploy read-only collector roles into denied accounts/regions before rerunning fan-out execution."}
+	}
+	if fixtureState == "partial_failure" || fixtureState == "degraded" || execution.Summary.FailedTargets > 0 || execution.Summary.PartialTargets > 0 {
+		return awsPlatformDependencyStatusDegraded, 0.74,
+			awsCoveragePlanDiagnosticMessages(diagnostics),
+			[]string{"Retry throttled or partial targets with bounded backoff; completed targets stay checkpointed."}
+	}
+	if execution.Summary.TotalTargets == 0 {
+		return awsPlatformDependencyStatusReady, 0.8, nil,
+			[]string{"No executable AWS targets are configured; add accounts, regions, and services before starting fan-out execution."}
+	}
+	return awsPlatformDependencyStatusReady, 0.94, nil,
+		[]string{"Fan-out execution is bounded, target-scoped, and resumable across account/region/service checkpoints."}
+}
+
+func firstPositiveInt(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/api/aws_fanout_execution.go
+++ b/internal/api/aws_fanout_execution.go
@@ -37,6 +37,7 @@ type AWSFanOutExecutionTarget struct {
 	ConcurrencySlot int       `json:"concurrency_slot,omitempty"`
 	Checkpoint      string    `json:"checkpoint,omitempty"`
 	Retryable       bool      `json:"retryable"`
+	Throttled       bool      `json:"throttled"`
 	RetryAfter      string    `json:"retry_after,omitempty"`
 	FailureReason   string    `json:"failure_reason,omitempty"`
 	EvidenceRef     string    `json:"evidence_ref"`
@@ -221,6 +222,7 @@ func mapAWSFanOutExecutionTargets(targets []awscontract.FanOutExecutionTarget) [
 			ConcurrencySlot: target.ConcurrencySlot,
 			Checkpoint:      target.Checkpoint,
 			Retryable:       target.Retryable,
+			Throttled:       target.Throttled,
 			RetryAfter:      target.RetryAfter,
 			FailureReason:   target.FailureReason,
 			EvidenceRef:     target.EvidenceRef,

--- a/internal/api/aws_fanout_execution_test.go
+++ b/internal/api/aws_fanout_execution_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSFanOutExecutionSuccess(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", MaxConcurrency: 2})
+	if err != nil {
+		t.Fatalf("get fan-out execution: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.CurrentIssueRef != "#1500" {
+		t.Fatalf("unexpected execution metadata: %+v", result)
+	}
+	if result.Summary.ConcurrencyLimit != 2 || result.Summary.InProgressTargets > 2 {
+		t.Fatalf("expected bounded execution, got %+v", result.Summary)
+	}
+	if result.Summary.CoveredTargets == 0 || result.Summary.QueuedTargets == 0 {
+		t.Fatalf("expected covered and queued execution state, got %+v", result.Summary)
+	}
+	for _, target := range result.Targets {
+		if target.WorkerState == "" || target.EvidenceRef == "" || target.NextAction == "" {
+			t.Fatalf("target missing operator-visible execution fields: %+v", target)
+		}
+		if target.ConcurrencySlot > 2 {
+			t.Fatalf("target exceeded concurrency limit: %+v", target)
+		}
+	}
+}
+
+func TestGetAWSFanOutExecutionDegradedAndDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 15, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	degraded, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("get degraded fan-out execution: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || degraded.Summary.RetryableTargets == 0 || degraded.Summary.ThrottledTargets == 0 {
+		t.Fatalf("expected retryable degraded execution, got %+v", degraded)
+	}
+	if len(degraded.Diagnostics) == 0 || len(degraded.RemediationHints) == 0 {
+		t.Fatalf("degraded execution should carry diagnostics and hints: %+v", degraded)
+	}
+
+	denied, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied fan-out execution: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.Summary.PermissionDeniedTargets == 0 {
+		t.Fatalf("expected blocked permission-denied execution, got %+v", denied)
+	}
+}
+
+func TestGetAWSFanOutExecutionFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 16, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	covered, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", State: "covered"})
+	if err != nil {
+		t.Fatalf("get covered fan-out execution: %v", err)
+	}
+	if covered.FilteredTargets == 0 {
+		t.Fatalf("expected covered targets")
+	}
+	for _, target := range covered.Targets {
+		if target.State != "covered" && target.WorkerState != "covered" {
+			t.Fatalf("state filter leaked non-covered target: %+v", target)
+		}
+	}
+
+	if _, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", State: "bogus"}); err == nil {
+		t.Fatalf("expected invalid state error")
+	}
+	if _, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", MaxConcurrency: 65}); err == nil {
+		t.Fatalf("expected invalid max concurrency error")
+	}
+}
+
+func TestRouterAWSFanOutExecutionPartialFailureAndInvalid(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 16, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/fanout-execution?connector_id=aws-prod&fixture_state=partial_failure&max_concurrency=2", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Execution AWSFanOutExecutionResult `json:"execution"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Execution.Status != awsPlatformDependencyStatusDegraded || body.Execution.Summary.ThrottledTargets == 0 {
+		t.Fatalf("expected degraded fan-out execution, got %+v", body.Execution)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "state=bogus", "max_concurrency=bad"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/fanout-execution?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2985,6 +2985,50 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plan": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/fanout-execution", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		maxConcurrency := 0
+		if raw := strings.TrimSpace(c.Query("max_concurrency")); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws fan-out execution request"})
+				return
+			}
+			maxConcurrency = parsed
+		}
+		record, err := svc.GetAWSFanOutExecution(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSFanOutExecutionRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			Account:        strings.TrimSpace(c.Query("account")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			Service:        strings.TrimSpace(c.Query("service")),
+			State:          strings.TrimSpace(c.Query("state")),
+			MaxConcurrency: maxConcurrency,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws fan-out execution request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws fan-out execution",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws fan-out execution"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"execution": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -1,0 +1,334 @@
+package awscontract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// FanOutExecutorVersion is the stable contract operators and APIs cite for
+// account/region/service execution state.
+const FanOutExecutorVersion = "aws-account-region-fanout-executor-v1"
+
+// FanOutExecutionOutcome is the simulated or persisted worker outcome for one
+// target attempt.
+type FanOutExecutionOutcome string
+
+const (
+	FanOutExecutionOutcomeCovered          FanOutExecutionOutcome = "covered"
+	FanOutExecutionOutcomePartial          FanOutExecutionOutcome = "partial"
+	FanOutExecutionOutcomeFailed           FanOutExecutionOutcome = "failed"
+	FanOutExecutionOutcomePermissionDenied FanOutExecutionOutcome = "permission_denied"
+	FanOutExecutionOutcomeThrottled        FanOutExecutionOutcome = "throttled"
+)
+
+// FanOutExecutionConfig controls bounded fan-out over a coverage plan.
+type FanOutExecutionConfig struct {
+	Plan               CoveragePlan
+	MaxConcurrency     int
+	MaxAttempts        int
+	ThrottleRetryAfter time.Duration
+	Outcomes           []FanOutTargetOutcome
+	StartedAt          time.Time
+}
+
+// FanOutTargetOutcome supplies known execution results for deterministic worker
+// planning and persisted-state replay.
+type FanOutTargetOutcome struct {
+	Key           string
+	Outcome       FanOutExecutionOutcome
+	Cursor        string
+	FailureReason string
+	Retryable     bool
+	ObservedAt    time.Time
+}
+
+// FanOutExecutionTarget is one executable worker unit with its scheduling and
+// checkpoint state.
+type FanOutExecutionTarget struct {
+	Key             string           `json:"key"`
+	AccountID       string           `json:"account_id"`
+	Region          string           `json:"region"`
+	Service         string           `json:"service"`
+	Priority        CoveragePriority `json:"priority"`
+	State           CoverageState    `json:"state"`
+	WorkerState     CoverageState    `json:"worker_state"`
+	Enabled         bool             `json:"enabled"`
+	Attempts        int              `json:"attempts"`
+	MaxAttempts     int              `json:"max_attempts"`
+	ConcurrencySlot int              `json:"concurrency_slot"`
+	Checkpoint      string           `json:"checkpoint,omitempty"`
+	Retryable       bool             `json:"retryable"`
+	RetryAfter      string           `json:"retry_after,omitempty"`
+	FailureReason   string           `json:"failure_reason,omitempty"`
+	EvidenceRef     string           `json:"evidence_ref"`
+	NextAction      string           `json:"next_action"`
+	ObservedAt      time.Time        `json:"observed_at,omitempty"`
+}
+
+// FanOutExecutionSummary aggregates worker-visible execution state.
+type FanOutExecutionSummary struct {
+	TotalTargets            int `json:"total_targets"`
+	ExecutableTargets       int `json:"executable_targets"`
+	SkippedTargets          int `json:"skipped_targets"`
+	QueuedTargets           int `json:"queued_targets"`
+	InProgressTargets       int `json:"in_progress_targets"`
+	CoveredTargets          int `json:"covered_targets"`
+	PartialTargets          int `json:"partial_targets"`
+	FailedTargets           int `json:"failed_targets"`
+	PermissionDeniedTargets int `json:"permission_denied_targets"`
+	ThrottledTargets        int `json:"throttled_targets"`
+	RetryableTargets        int `json:"retryable_targets"`
+	ConcurrencyLimit        int `json:"concurrency_limit"`
+	MaxAttempts             int `json:"max_attempts"`
+}
+
+// FanOutExecutionPlan is the deterministic worker execution view.
+type FanOutExecutionPlan struct {
+	Version   string                  `json:"version"`
+	Targets   []FanOutExecutionTarget `json:"targets"`
+	Summary   FanOutExecutionSummary  `json:"summary"`
+	StartedAt time.Time               `json:"started_at"`
+	UpdatedAt time.Time               `json:"updated_at"`
+}
+
+// PlanFanOutExecution maps a coverage plan onto bounded worker state. It does
+// not call AWS, mutate AWS, or inspect customer payloads.
+func PlanFanOutExecution(config FanOutExecutionConfig) (FanOutExecutionPlan, error) {
+	concurrency := config.MaxConcurrency
+	if concurrency <= 0 {
+		concurrency = 4
+	}
+	attempts := config.MaxAttempts
+	if attempts <= 0 {
+		attempts = 3
+	}
+	startedAt := config.StartedAt
+	if startedAt.IsZero() {
+		startedAt = config.Plan.GeneratedAt
+	}
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	outcomes, err := indexFanOutOutcomes(config.Outcomes)
+	if err != nil {
+		return FanOutExecutionPlan{}, err
+	}
+
+	targets := make([]FanOutExecutionTarget, 0, len(config.Plan.Targets))
+	summary := FanOutExecutionSummary{
+		TotalTargets:     len(config.Plan.Targets),
+		ConcurrencyLimit: concurrency,
+		MaxAttempts:      attempts,
+	}
+	runningSlot := 0
+	for _, coverageTarget := range config.Plan.Targets {
+		target := buildFanOutExecutionTarget(coverageTarget, outcomes[coverageTarget.Key], attempts, config.ThrottleRetryAfter, &runningSlot, concurrency, startedAt)
+		targets = append(targets, target)
+		summarizeFanOutExecutionTarget(&summary, target)
+	}
+
+	sort.SliceStable(targets, func(i, j int) bool {
+		if targets[i].ConcurrencySlot != targets[j].ConcurrencySlot {
+			return targets[i].ConcurrencySlot < targets[j].ConcurrencySlot
+		}
+		return targets[i].Key < targets[j].Key
+	})
+
+	return FanOutExecutionPlan{
+		Version:   FanOutExecutorVersion,
+		Targets:   targets,
+		Summary:   summary,
+		StartedAt: startedAt.UTC(),
+		UpdatedAt: startedAt.UTC(),
+	}, nil
+}
+
+func buildFanOutExecutionTarget(target CoverageTarget, outcome FanOutTargetOutcome, maxAttempts int, throttleRetryAfter time.Duration, runningSlot *int, concurrency int, observedAt time.Time) FanOutExecutionTarget {
+	execution := FanOutExecutionTarget{
+		Key:         target.Key,
+		AccountID:   target.AccountID,
+		Region:      target.Region,
+		Service:     target.Service,
+		Priority:    target.Priority,
+		State:       target.State,
+		WorkerState: target.State,
+		Enabled:     target.Enabled,
+		Attempts:    target.Attempts,
+		MaxAttempts: maxAttempts,
+		EvidenceRef: target.EvidenceRef,
+		ObservedAt:  target.ObservedAt,
+	}
+	if execution.ObservedAt.IsZero() {
+		execution.ObservedAt = observedAt.UTC()
+	}
+	if target.Cursor != "" {
+		execution.Checkpoint = target.Cursor
+	}
+	if target.FailureReason != "" {
+		execution.FailureReason = target.FailureReason
+	}
+
+	if !target.Enabled || target.State == CoverageStateDisabled || target.State == CoverageStateUnsupported || target.State == CoverageStateBlocked {
+		execution.WorkerState = target.State
+		execution.NextAction = fanOutSkippedNextAction(target.State)
+		return execution
+	}
+
+	if outcome.Key != "" {
+		applyFanOutOutcome(&execution, outcome, maxAttempts, throttleRetryAfter)
+		return execution
+	}
+
+	switch target.State {
+	case CoverageStateCovered, CoverageStatePermissionDenied, CoverageStateFailed, CoverageStatePartial:
+		execution.WorkerState = target.State
+		execution.Retryable = target.State == CoverageStateFailed || target.State == CoverageStatePartial
+	case CoverageStateInProgress:
+		execution.WorkerState = CoverageStateInProgress
+		execution.Retryable = true
+		if execution.Checkpoint == "" {
+			execution.Checkpoint = target.Key + ":cursor"
+		}
+	default:
+		if *runningSlot < concurrency {
+			*runningSlot++
+			execution.ConcurrencySlot = *runningSlot
+			execution.WorkerState = CoverageStateInProgress
+			execution.Retryable = true
+			execution.Attempts++
+			execution.Checkpoint = target.Key + ":started"
+		} else {
+			execution.WorkerState = CoverageStatePending
+			execution.Retryable = true
+		}
+	}
+	execution.NextAction = fanOutNextAction(execution)
+	return execution
+}
+
+func applyFanOutOutcome(target *FanOutExecutionTarget, outcome FanOutTargetOutcome, maxAttempts int, throttleRetryAfter time.Duration) {
+	if outcome.Cursor != "" {
+		target.Checkpoint = strings.TrimSpace(outcome.Cursor)
+	}
+	if outcome.FailureReason != "" {
+		target.FailureReason = strings.TrimSpace(outcome.FailureReason)
+	}
+	if !outcome.ObservedAt.IsZero() {
+		target.ObservedAt = outcome.ObservedAt.UTC()
+	}
+	switch outcome.Outcome {
+	case FanOutExecutionOutcomeCovered:
+		target.WorkerState = CoverageStateCovered
+		target.State = CoverageStateCovered
+		target.Retryable = false
+		target.FailureReason = ""
+	case FanOutExecutionOutcomePartial:
+		target.WorkerState = CoverageStatePartial
+		target.State = CoverageStatePartial
+		target.Retryable = true
+	case FanOutExecutionOutcomePermissionDenied:
+		target.WorkerState = CoverageStatePermissionDenied
+		target.State = CoverageStatePermissionDenied
+		target.Retryable = false
+	case FanOutExecutionOutcomeThrottled:
+		target.WorkerState = CoverageStateFailed
+		target.State = CoverageStateFailed
+		target.Retryable = true
+		if throttleRetryAfter > 0 {
+			target.RetryAfter = throttleRetryAfter.String()
+		}
+	case FanOutExecutionOutcomeFailed:
+		target.WorkerState = CoverageStateFailed
+		target.State = CoverageStateFailed
+		target.Retryable = outcome.Retryable
+	default:
+		target.WorkerState = CoverageStateFailed
+		target.State = CoverageStateFailed
+		target.Retryable = true
+	}
+	target.Attempts++
+	if target.Attempts >= maxAttempts && target.WorkerState == CoverageStateFailed {
+		target.Retryable = false
+	}
+	target.NextAction = fanOutNextAction(*target)
+}
+
+func fanOutSkippedNextAction(state CoverageState) string {
+	switch state {
+	case CoverageStateBlocked:
+		return "Resolve account onboarding or region prerequisites before queueing this target."
+	case CoverageStateUnsupported:
+		return "Keep unsupported account/region/service targets out of the worker queue."
+	case CoverageStateDisabled:
+		return "Enable the target in coverage configuration before queueing."
+	default:
+		return "Target is not executable in its current coverage state."
+	}
+}
+
+func fanOutNextAction(target FanOutExecutionTarget) string {
+	switch target.WorkerState {
+	case CoverageStateCovered:
+		return "Persist covered checkpoint and continue with the next target."
+	case CoverageStateInProgress:
+		return "Worker is collecting this target within the concurrency limit."
+	case CoverageStatePending:
+		return "Keep queued until a worker slot is available."
+	case CoverageStatePartial:
+		return "Persist partial evidence and resume from the checkpoint on rerun."
+	case CoverageStateFailed:
+		if target.Retryable {
+			return "Retry with bounded backoff and preserve the checkpoint."
+		}
+		return "Record terminal failure and require operator review before rerun."
+	case CoverageStatePermissionDenied:
+		return "Record permission denied and wait for read-only role remediation."
+	default:
+		return "Queue target for the next bounded fan-out execution."
+	}
+}
+
+func summarizeFanOutExecutionTarget(summary *FanOutExecutionSummary, target FanOutExecutionTarget) {
+	if target.Enabled && target.WorkerState != CoverageStateBlocked && target.WorkerState != CoverageStateUnsupported && target.WorkerState != CoverageStateDisabled {
+		summary.ExecutableTargets++
+	} else {
+		summary.SkippedTargets++
+	}
+	if target.Retryable {
+		summary.RetryableTargets++
+	}
+	switch target.WorkerState {
+	case CoverageStatePending:
+		summary.QueuedTargets++
+	case CoverageStateInProgress:
+		summary.InProgressTargets++
+	case CoverageStateCovered:
+		summary.CoveredTargets++
+	case CoverageStatePartial:
+		summary.PartialTargets++
+	case CoverageStateFailed:
+		summary.FailedTargets++
+		if target.RetryAfter != "" {
+			summary.ThrottledTargets++
+		}
+	case CoverageStatePermissionDenied:
+		summary.PermissionDeniedTargets++
+	}
+}
+
+func indexFanOutOutcomes(input []FanOutTargetOutcome) (map[string]FanOutTargetOutcome, error) {
+	index := make(map[string]FanOutTargetOutcome, len(input))
+	for _, outcome := range input {
+		key := strings.TrimSpace(outcome.Key)
+		if key == "" {
+			return nil, fmt.Errorf("fan-out outcome key is required")
+		}
+		outcome.Key = key
+		outcome.Cursor = strings.TrimSpace(outcome.Cursor)
+		outcome.FailureReason = strings.TrimSpace(outcome.FailureReason)
+		index[key] = outcome
+	}
+	return index, nil
+}

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -124,10 +124,23 @@ func PlanFanOutExecution(config FanOutExecutionConfig) (FanOutExecutionPlan, err
 		MaxAttempts:      attempts,
 	}
 	runningSlot := 0
-	for _, coverageTarget := range config.Plan.Targets {
+	planned := make(map[string]struct{}, len(config.Plan.Targets))
+	appendTarget := func(coverageTarget CoverageTarget) {
 		target := buildFanOutExecutionTarget(coverageTarget, outcomes[coverageTarget.Key], attempts, config.ThrottleRetryAfter, &runningSlot, concurrency, startedAt)
 		targets = append(targets, target)
 		summarizeFanOutExecutionTarget(&summary, target)
+		planned[coverageTarget.Key] = struct{}{}
+	}
+	for _, coverageTarget := range config.Plan.Targets {
+		if coverageTarget.State == CoverageStateInProgress && outcomes[coverageTarget.Key].Key == "" {
+			appendTarget(coverageTarget)
+		}
+	}
+	for _, coverageTarget := range config.Plan.Targets {
+		if _, ok := planned[coverageTarget.Key]; ok {
+			continue
+		}
+		appendTarget(coverageTarget)
 	}
 
 	sort.SliceStable(targets, func(i, j int) bool {
@@ -186,7 +199,7 @@ func buildFanOutExecutionTarget(target CoverageTarget, outcome FanOutTargetOutco
 	case CoverageStateCovered, CoverageStatePermissionDenied, CoverageStateFailed, CoverageStatePartial:
 		execution.WorkerState = target.State
 		execution.Retryable = target.State == CoverageStateFailed || target.State == CoverageStatePartial
-		if target.State == CoverageStateFailed && execution.Attempts >= maxAttempts {
+		if execution.Retryable && execution.Attempts >= maxAttempts {
 			execution.Retryable = false
 		}
 	case CoverageStateInProgress:
@@ -260,7 +273,7 @@ func applyFanOutOutcome(target *FanOutExecutionTarget, outcome FanOutTargetOutco
 		target.Retryable = true
 	}
 	target.Attempts++
-	if target.Attempts >= maxAttempts && target.WorkerState == CoverageStateFailed {
+	if target.Attempts >= maxAttempts && (target.WorkerState == CoverageStateFailed || target.WorkerState == CoverageStatePartial) {
 		target.Retryable = false
 	}
 	target.NextAction = fanOutNextAction(*target)

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -186,10 +186,16 @@ func buildFanOutExecutionTarget(target CoverageTarget, outcome FanOutTargetOutco
 		execution.WorkerState = target.State
 		execution.Retryable = target.State == CoverageStateFailed || target.State == CoverageStatePartial
 	case CoverageStateInProgress:
-		execution.WorkerState = CoverageStateInProgress
 		execution.Retryable = true
 		if execution.Checkpoint == "" {
 			execution.Checkpoint = target.Key + ":cursor"
+		}
+		if *runningSlot < concurrency {
+			*runningSlot++
+			execution.ConcurrencySlot = *runningSlot
+			execution.WorkerState = CoverageStateInProgress
+		} else {
+			execution.WorkerState = CoverageStatePending
 		}
 	default:
 		if *runningSlot < concurrency {

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -60,6 +60,7 @@ type FanOutExecutionTarget struct {
 	ConcurrencySlot int              `json:"concurrency_slot"`
 	Checkpoint      string           `json:"checkpoint,omitempty"`
 	Retryable       bool             `json:"retryable"`
+	Throttled       bool             `json:"throttled"`
 	RetryAfter      string           `json:"retry_after,omitempty"`
 	FailureReason   string           `json:"failure_reason,omitempty"`
 	EvidenceRef     string           `json:"evidence_ref"`
@@ -242,6 +243,7 @@ func applyFanOutOutcome(target *FanOutExecutionTarget, outcome FanOutTargetOutco
 		target.WorkerState = CoverageStateFailed
 		target.State = CoverageStateFailed
 		target.Retryable = true
+		target.Throttled = true
 		if throttleRetryAfter > 0 {
 			target.RetryAfter = throttleRetryAfter.String()
 		}
@@ -316,7 +318,7 @@ func summarizeFanOutExecutionTarget(summary *FanOutExecutionSummary, target FanO
 		summary.PartialTargets++
 	case CoverageStateFailed:
 		summary.FailedTargets++
-		if target.RetryAfter != "" {
+		if target.Throttled {
 			summary.ThrottledTargets++
 		}
 	case CoverageStatePermissionDenied:

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -186,6 +186,9 @@ func buildFanOutExecutionTarget(target CoverageTarget, outcome FanOutTargetOutco
 	case CoverageStateCovered, CoverageStatePermissionDenied, CoverageStateFailed, CoverageStatePartial:
 		execution.WorkerState = target.State
 		execution.Retryable = target.State == CoverageStateFailed || target.State == CoverageStatePartial
+		if target.State == CoverageStateFailed && execution.Attempts >= maxAttempts {
+			execution.Retryable = false
+		}
 	case CoverageStateInProgress:
 		execution.Retryable = true
 		if execution.Checkpoint == "" {

--- a/internal/providers/awscontract/fanout_executor_test.go
+++ b/internal/providers/awscontract/fanout_executor_test.go
@@ -95,6 +95,61 @@ func TestPlanFanOutExecutionCountsResumedWorkAgainstConcurrency(t *testing.T) {
 	}
 }
 
+func TestPlanFanOutExecutionPrioritizesResumedWorkBeforeNewTargets(t *testing.T) {
+	now := time.Date(2026, 6, 12, 13, 50, 0, 0, time.UTC)
+	plan := CoveragePlan{
+		ConnectorID: "aws-prod",
+		GeneratedAt: now,
+		Targets: []CoverageTarget{
+			{
+				Key:         "111111111111|us-east-1|iam",
+				AccountID:   "111111111111",
+				Region:      "us-east-1",
+				Service:     "iam",
+				Enabled:     true,
+				Priority:    CoveragePriorityCritical,
+				State:       CoverageStatePlanned,
+				EvidenceRef: "aws://aws-prod/111111111111/us-east-1/iam",
+			},
+			{
+				Key:         "111111111111|eu-west-1|lambda",
+				AccountID:   "111111111111",
+				Region:      "eu-west-1",
+				Service:     "lambda",
+				Enabled:     true,
+				Priority:    CoveragePriorityHigh,
+				State:       CoverageStateInProgress,
+				Cursor:      "lambda-page-2",
+				Attempts:    1,
+				EvidenceRef: "aws://aws-prod/111111111111/eu-west-1/lambda",
+			},
+		},
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:           plan,
+		MaxConcurrency: 1,
+		MaxAttempts:    3,
+		StartedAt:      now,
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+
+	targetByKey := map[string]FanOutExecutionTarget{}
+	for _, target := range execution.Targets {
+		targetByKey[target.Key] = target
+	}
+	resumed := targetByKey["111111111111|eu-west-1|lambda"]
+	if resumed.WorkerState != CoverageStateInProgress || resumed.ConcurrencySlot != 1 {
+		t.Fatalf("resumed checkpoint should reserve the first slot before new work: %+v", resumed)
+	}
+	planned := targetByKey["111111111111|us-east-1|iam"]
+	if planned.WorkerState != CoverageStatePending || planned.ConcurrencySlot != 0 {
+		t.Fatalf("new work should stay queued while resumed work is active: %+v", planned)
+	}
+}
+
 func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
 	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
 	coverage, err := PlanCoverage(CoveragePlanConfig{
@@ -152,7 +207,7 @@ func TestPlanFanOutExecutionHonorsReplayedFailureAttemptLimit(t *testing.T) {
 		ConnectorID: "aws-prod",
 		Accounts:    []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
 		Regions:     []CoverageRegion{{Region: "us-east-1", Enabled: true}},
-		Services:    []CoverageService{{Service: "lambda", Enabled: true}},
+		Services:    []CoverageService{{Service: "lambda", Enabled: true}, {Service: "ecs", Enabled: true}},
 		Checkpoints: []CoverageCheckpoint{
 			{
 				AccountID:     "111111111111",
@@ -160,6 +215,14 @@ func TestPlanFanOutExecutionHonorsReplayedFailureAttemptLimit(t *testing.T) {
 				Service:       "lambda",
 				State:         CoverageStateFailed,
 				FailureReason: "Throttling: lambda ListFunctions",
+				Attempts:      3,
+			},
+			{
+				AccountID:     "111111111111",
+				Region:        "us-east-1",
+				Service:       "ecs",
+				State:         CoverageStatePartial,
+				FailureReason: "partial page timeout",
 				Attempts:      3,
 			},
 		},
@@ -176,15 +239,63 @@ func TestPlanFanOutExecutionHonorsReplayedFailureAttemptLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan fan-out execution: %v", err)
 	}
-	if execution.Summary.FailedTargets != 1 || execution.Summary.RetryableTargets != 0 {
-		t.Fatalf("failed checkpoint at max attempts should be terminal, got %+v", execution.Summary)
+	if execution.Summary.FailedTargets != 1 || execution.Summary.PartialTargets != 1 || execution.Summary.RetryableTargets != 0 {
+		t.Fatalf("failed and partial checkpoints at max attempts should be terminal, got %+v", execution.Summary)
 	}
-	if len(execution.Targets) != 1 {
-		t.Fatalf("expected one target, got %d", len(execution.Targets))
+	targetByKey := map[string]FanOutExecutionTarget{}
+	for _, target := range execution.Targets {
+		targetByKey[target.Key] = target
+	}
+	failed := targetByKey["111111111111|us-east-1|lambda"]
+	if failed.WorkerState != CoverageStateFailed || failed.Retryable || failed.Attempts != 3 {
+		t.Fatalf("replayed failure should stay non-retryable at max attempts: %+v", failed)
+	}
+	partial := targetByKey["111111111111|us-east-1|ecs"]
+	if partial.WorkerState != CoverageStatePartial || partial.Retryable || partial.Attempts != 3 {
+		t.Fatalf("replayed partial should stay non-retryable at max attempts: %+v", partial)
+	}
+}
+
+func TestPlanFanOutExecutionHonorsFreshPartialAttemptLimit(t *testing.T) {
+	now := time.Date(2026, 6, 12, 14, 20, 0, 0, time.UTC)
+	plan := CoveragePlan{
+		ConnectorID: "aws-prod",
+		GeneratedAt: now,
+		Targets: []CoverageTarget{{
+			Key:         "111111111111|us-east-1|lambda",
+			AccountID:   "111111111111",
+			Region:      "us-east-1",
+			Service:     "lambda",
+			Enabled:     true,
+			Priority:    CoveragePriorityHigh,
+			State:       CoverageStatePlanned,
+			Attempts:    2,
+			EvidenceRef: "aws://aws-prod/111111111111/us-east-1/lambda",
+		}},
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:        plan,
+		MaxAttempts: 3,
+		StartedAt:   now,
+		Outcomes: []FanOutTargetOutcome{{
+			Key:           "111111111111|us-east-1|lambda",
+			Outcome:       FanOutExecutionOutcomePartial,
+			Cursor:        "lambda-page-3",
+			FailureReason: "partial page timeout",
+			Retryable:     true,
+			ObservedAt:    now,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+	if execution.Summary.PartialTargets != 1 || execution.Summary.RetryableTargets != 0 {
+		t.Fatalf("fresh partial outcome at max attempts should be terminal, got %+v", execution.Summary)
 	}
 	target := execution.Targets[0]
-	if target.WorkerState != CoverageStateFailed || target.Retryable || target.Attempts != 3 {
-		t.Fatalf("replayed failure should stay non-retryable at max attempts: %+v", target)
+	if target.WorkerState != CoverageStatePartial || target.Retryable || target.Attempts != 3 {
+		t.Fatalf("fresh partial should stop retrying at max attempts: %+v", target)
 	}
 }
 

--- a/internal/providers/awscontract/fanout_executor_test.go
+++ b/internal/providers/awscontract/fanout_executor_test.go
@@ -146,6 +146,48 @@ func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
 	}
 }
 
+func TestPlanFanOutExecutionHonorsReplayedFailureAttemptLimit(t *testing.T) {
+	now := time.Date(2026, 6, 12, 14, 15, 0, 0, time.UTC)
+	coverage, err := PlanCoverage(CoveragePlanConfig{
+		ConnectorID: "aws-prod",
+		Accounts:    []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:     []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services:    []CoverageService{{Service: "lambda", Enabled: true}},
+		Checkpoints: []CoverageCheckpoint{
+			{
+				AccountID:     "111111111111",
+				Region:        "us-east-1",
+				Service:       "lambda",
+				State:         CoverageStateFailed,
+				FailureReason: "Throttling: lambda ListFunctions",
+				Attempts:      3,
+			},
+		},
+	}, now)
+	if err != nil {
+		t.Fatalf("plan coverage: %v", err)
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:        coverage,
+		MaxAttempts: 3,
+		StartedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+	if execution.Summary.FailedTargets != 1 || execution.Summary.RetryableTargets != 0 {
+		t.Fatalf("failed checkpoint at max attempts should be terminal, got %+v", execution.Summary)
+	}
+	if len(execution.Targets) != 1 {
+		t.Fatalf("expected one target, got %d", len(execution.Targets))
+	}
+	target := execution.Targets[0]
+	if target.WorkerState != CoverageStateFailed || target.Retryable || target.Attempts != 3 {
+		t.Fatalf("replayed failure should stay non-retryable at max attempts: %+v", target)
+	}
+}
+
 func TestPlanFanOutExecutionSkipsNonExecutableTargets(t *testing.T) {
 	now := time.Date(2026, 6, 12, 14, 30, 0, 0, time.UTC)
 	coverage, err := PlanCoverage(CoveragePlanConfig{

--- a/internal/providers/awscontract/fanout_executor_test.go
+++ b/internal/providers/awscontract/fanout_executor_test.go
@@ -112,11 +112,10 @@ func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
 	}
 
 	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
-		Plan:               coverage,
-		MaxConcurrency:     3,
-		MaxAttempts:        3,
-		ThrottleRetryAfter: 30 * time.Second,
-		StartedAt:          now,
+		Plan:           coverage,
+		MaxConcurrency: 3,
+		MaxAttempts:    3,
+		StartedAt:      now,
 		Outcomes: []FanOutTargetOutcome{
 			{Key: "111111111111|us-east-1|iam", Outcome: FanOutExecutionOutcomeCovered, ObservedAt: now},
 			{Key: "111111111111|us-east-1|lambda", Outcome: FanOutExecutionOutcomeThrottled, Cursor: "lambda-page-2", FailureReason: "Throttling: lambda ListFunctions", Retryable: true, ObservedAt: now},
@@ -138,8 +137,8 @@ func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
 		targetByKey[target.Key] = target
 	}
 	throttled := targetByKey["111111111111|us-east-1|lambda"]
-	if throttled.WorkerState != CoverageStateFailed || !throttled.Retryable || throttled.Checkpoint != "lambda-page-2" || throttled.RetryAfter == "" {
-		t.Fatalf("expected retryable throttled target with checkpoint: %+v", throttled)
+	if throttled.WorkerState != CoverageStateFailed || !throttled.Retryable || !throttled.Throttled || throttled.Checkpoint != "lambda-page-2" || throttled.RetryAfter != "" {
+		t.Fatalf("expected retryable throttled target with checkpoint and no retry-after requirement: %+v", throttled)
 	}
 	denied := targetByKey["111111111111|us-east-1|ecs"]
 	if denied.WorkerState != CoverageStatePermissionDenied || denied.Retryable {

--- a/internal/providers/awscontract/fanout_executor_test.go
+++ b/internal/providers/awscontract/fanout_executor_test.go
@@ -47,6 +47,54 @@ func TestPlanFanOutExecutionBoundsConcurrency(t *testing.T) {
 	}
 }
 
+func TestPlanFanOutExecutionCountsResumedWorkAgainstConcurrency(t *testing.T) {
+	now := time.Date(2026, 6, 12, 13, 45, 0, 0, time.UTC)
+	config := sampleCoverageConfig()
+	config.Services = []CoverageService{
+		{Service: "iam", Enabled: true, Priority: CoveragePriorityCritical, Global: true},
+		{Service: "lambda", Enabled: true, Priority: CoveragePriorityHigh},
+	}
+	config.Checkpoints = []CoverageCheckpoint{
+		{AccountID: "111111111111", Region: "eu-west-1", Service: "lambda", State: CoverageStateInProgress, Cursor: "lambda-page-2", Attempts: 1},
+	}
+	coverage, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("plan coverage: %v", err)
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:           coverage,
+		MaxConcurrency: 1,
+		MaxAttempts:    3,
+		StartedAt:      now,
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+
+	if execution.Summary.ConcurrencyLimit != 1 || execution.Summary.InProgressTargets != 1 {
+		t.Fatalf("expected exactly one resumed target to occupy the worker slot, got %+v", execution.Summary)
+	}
+	if execution.Summary.QueuedTargets == 0 {
+		t.Fatalf("expected new executable targets to remain queued while resumed work is running: %+v", execution.Summary)
+	}
+	var resumed FanOutExecutionTarget
+	for _, target := range execution.Targets {
+		if target.Key == "111111111111|eu-west-1|lambda" {
+			resumed = target
+			break
+		}
+	}
+	if resumed.WorkerState != CoverageStateInProgress || resumed.ConcurrencySlot != 1 || resumed.Checkpoint != "lambda-page-2" || resumed.Attempts != 1 {
+		t.Fatalf("resumed target should keep its checkpoint and consume the only slot: %+v", resumed)
+	}
+	for _, target := range execution.Targets {
+		if target.Key != resumed.Key && target.WorkerState == CoverageStateInProgress {
+			t.Fatalf("new target started even though resumed work already consumed concurrency: %+v", target)
+		}
+	}
+}
+
 func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
 	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
 	coverage, err := PlanCoverage(CoveragePlanConfig{

--- a/internal/providers/awscontract/fanout_executor_test.go
+++ b/internal/providers/awscontract/fanout_executor_test.go
@@ -1,0 +1,134 @@
+package awscontract
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPlanFanOutExecutionBoundsConcurrency(t *testing.T) {
+	now := time.Date(2026, 6, 12, 13, 30, 0, 0, time.UTC)
+	config := sampleCoverageConfig()
+	config.Services = []CoverageService{
+		{Service: "iam", Enabled: true, Priority: CoveragePriorityCritical, Global: true},
+		{Service: "ec2", Enabled: true, Priority: CoveragePriorityHigh},
+		{Service: "lambda", Enabled: true, Priority: CoveragePriorityHigh},
+	}
+	coverage, err := PlanCoverage(config, now)
+	if err != nil {
+		t.Fatalf("plan coverage: %v", err)
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:           coverage,
+		MaxConcurrency: 2,
+		MaxAttempts:    3,
+		StartedAt:      now,
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+
+	if execution.Version != FanOutExecutorVersion {
+		t.Fatalf("unexpected version %q", execution.Version)
+	}
+	if execution.Summary.ConcurrencyLimit != 2 || execution.Summary.InProgressTargets != 2 {
+		t.Fatalf("expected two running targets, got %+v", execution.Summary)
+	}
+	if execution.Summary.QueuedTargets == 0 {
+		t.Fatalf("expected remaining executable targets to stay queued: %+v", execution.Summary)
+	}
+	for _, target := range execution.Targets {
+		if target.ConcurrencySlot > 2 {
+			t.Fatalf("target exceeded concurrency limit: %+v", target)
+		}
+		if target.WorkerState == CoverageStateInProgress && target.Checkpoint == "" {
+			t.Fatalf("in-progress target should carry a checkpoint: %+v", target)
+		}
+	}
+}
+
+func TestPlanFanOutExecutionKeepsFailuresTargetScoped(t *testing.T) {
+	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
+	coverage, err := PlanCoverage(CoveragePlanConfig{
+		ConnectorID: "aws-prod",
+		Accounts:    []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:     []CoverageRegion{{Region: "us-east-1", Enabled: true}},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true, Global: true},
+			{Service: "lambda", Enabled: true},
+			{Service: "ecs", Enabled: true},
+		},
+	}, now)
+	if err != nil {
+		t.Fatalf("plan coverage: %v", err)
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{
+		Plan:               coverage,
+		MaxConcurrency:     3,
+		MaxAttempts:        3,
+		ThrottleRetryAfter: 30 * time.Second,
+		StartedAt:          now,
+		Outcomes: []FanOutTargetOutcome{
+			{Key: "111111111111|us-east-1|iam", Outcome: FanOutExecutionOutcomeCovered, ObservedAt: now},
+			{Key: "111111111111|us-east-1|lambda", Outcome: FanOutExecutionOutcomeThrottled, Cursor: "lambda-page-2", FailureReason: "Throttling: lambda ListFunctions", Retryable: true, ObservedAt: now},
+			{Key: "111111111111|us-east-1|ecs", Outcome: FanOutExecutionOutcomePermissionDenied, FailureReason: "AccessDenied: ecs ListClusters", ObservedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+
+	if execution.Summary.CoveredTargets != 1 || execution.Summary.FailedTargets != 1 || execution.Summary.PermissionDeniedTargets != 1 {
+		t.Fatalf("unexpected execution summary: %+v", execution.Summary)
+	}
+	if execution.Summary.ThrottledTargets != 1 || execution.Summary.RetryableTargets != 1 {
+		t.Fatalf("expected exactly one retryable throttled target: %+v", execution.Summary)
+	}
+	targetByKey := map[string]FanOutExecutionTarget{}
+	for _, target := range execution.Targets {
+		targetByKey[target.Key] = target
+	}
+	throttled := targetByKey["111111111111|us-east-1|lambda"]
+	if throttled.WorkerState != CoverageStateFailed || !throttled.Retryable || throttled.Checkpoint != "lambda-page-2" || throttled.RetryAfter == "" {
+		t.Fatalf("expected retryable throttled target with checkpoint: %+v", throttled)
+	}
+	denied := targetByKey["111111111111|us-east-1|ecs"]
+	if denied.WorkerState != CoverageStatePermissionDenied || denied.Retryable {
+		t.Fatalf("permission denied should be explicit and non-retryable: %+v", denied)
+	}
+}
+
+func TestPlanFanOutExecutionSkipsNonExecutableTargets(t *testing.T) {
+	now := time.Date(2026, 6, 12, 14, 30, 0, 0, time.UTC)
+	coverage, err := PlanCoverage(CoveragePlanConfig{
+		ConnectorID: "aws-prod",
+		Accounts:    []CoverageAccount{{AccountID: "111111111111", Enabled: true}},
+		Regions:     []CoverageRegion{{Region: "us-east-1", Enabled: true}, {Region: "eu-west-1", Enabled: true, OptIn: true}},
+		Services:    []CoverageService{{Service: "lambda", Enabled: true}},
+		ServiceAvailability: []CoverageAccountServiceAvailability{{
+			AccountID: "111111111111",
+			Region:    "us-east-1",
+			Service:   "lambda",
+			State:     CoverageStateUnsupported,
+			Reason:    "lambda unsupported in fixture service scope",
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("plan coverage: %v", err)
+	}
+
+	execution, err := PlanFanOutExecution(FanOutExecutionConfig{Plan: coverage, MaxConcurrency: 2, StartedAt: now})
+	if err != nil {
+		t.Fatalf("plan fan-out execution: %v", err)
+	}
+
+	if execution.Summary.SkippedTargets != 2 || execution.Summary.ExecutableTargets != 0 {
+		t.Fatalf("blocked and unsupported targets should be skipped, got %+v", execution.Summary)
+	}
+	for _, target := range execution.Targets {
+		if target.WorkerState == CoverageStateInProgress || target.WorkerState == CoverageStatePending {
+			t.Fatalf("non-executable target was queued: %+v", target)
+		}
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2792,6 +2792,70 @@ export type AWSCoveragePlanResult = {
   updated_at: string;
 };
 
+export type AWSFanOutExecutionTarget = {
+  key: string;
+  account_id: string;
+  region: string;
+  service: string;
+  priority: AWSCoveragePriority;
+  state: AWSCoverageState;
+  worker_state: AWSCoverageState;
+  enabled: boolean;
+  attempts: number;
+  max_attempts: number;
+  concurrency_slot?: number;
+  checkpoint?: string;
+  retryable: boolean;
+  retry_after?: string;
+  failure_reason?: string;
+  evidence_ref: string;
+  next_action: string;
+  observed_at?: string;
+};
+
+export type AWSFanOutExecutionSummary = {
+  total_targets: number;
+  executable_targets: number;
+  skipped_targets: number;
+  queued_targets: number;
+  in_progress_targets: number;
+  covered_targets: number;
+  partial_targets: number;
+  failed_targets: number;
+  permission_denied_targets: number;
+  throttled_targets: number;
+  retryable_targets: number;
+  concurrency_limit: number;
+  max_attempts: number;
+};
+
+export type AWSFanOutExecutionResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCoveragePlanStatus;
+  fixture_state: AWSCoveragePlanFixtureState;
+  confidence: number;
+  filtered_targets: number;
+  summary: AWSFanOutExecutionSummary;
+  targets: AWSFanOutExecutionTarget[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSCoveragePlanCoverageGap[];
+  diagnostics: AWSCoveragePlanDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSOrganizationsTopologyStatus = AWSCoveragePlanStatus;
 export type AWSOrganizationsTopologyFixtureState = AWSCoveragePlanFixtureState;
 export type AWSOrganizationsAccountStatus = 'active' | 'suspended' | 'closed' | 'pending_activation' | 'pending_closure';
@@ -4640,6 +4704,27 @@ export const apiClient = {
         region: filters?.region,
         service: filters?.service,
         state: filters?.state
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectFanOutExecution(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSCoveragePlanFixtureState,
+    filters?: { account?: string; region?: string; service?: string; state?: AWSCoverageState; maxConcurrency?: number },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ execution: AWSFanOutExecutionResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/fanout-execution${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        account: filters?.account,
+        region: filters?.region,
+        service: filters?.service,
+        state: filters?.state,
+        max_concurrency: filters?.maxConcurrency
       })}`,
       auth
     );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2806,6 +2806,7 @@ export type AWSFanOutExecutionTarget = {
   concurrency_slot?: number;
   checkpoint?: string;
   retryable: boolean;
+  throttled: boolean;
   retry_after?: string;
   failure_reason?: string;
   evidence_ref: string;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -59,6 +59,7 @@ import {
   type AWSCredentialReferenceRecord,
   type AWSCoveragePlanResult,
   type AWSCoveragePlanTarget,
+  type AWSFanOutExecutionResult,
   type AWSOrganizationsTopologyAccount,
   type AWSOrganizationsTopologyResult,
   type AWSSecretsManagerMetadataInventoryResult,
@@ -3684,6 +3685,13 @@ type AWSInventoryCoveragePlanState = {
   onRetry: () => void;
 };
 
+type AWSInventoryFanOutExecutionState = {
+  execution: AWSFanOutExecutionResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryOrganizationsTopologyState = {
   topology: AWSOrganizationsTopologyResult | null;
   loading: boolean;
@@ -4429,6 +4437,7 @@ function AWSAccountsInventoryContent({
   connection,
   connectPath,
   coveragePlanState,
+  fanOutExecutionState,
   organizationsTopologyState,
   filters,
   onFiltersChange
@@ -4436,6 +4445,7 @@ function AWSAccountsInventoryContent({
   connection: AWSConnectionStatus | null;
   connectPath: string;
   coveragePlanState: AWSInventoryCoveragePlanState;
+  fanOutExecutionState: AWSInventoryFanOutExecutionState;
   organizationsTopologyState: AWSInventoryOrganizationsTopologyState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
@@ -4443,6 +4453,7 @@ function AWSAccountsInventoryContent({
   const accountCoverage = awsCoverageState(connection);
   const hasHealthyCoverage = accountCoverage === 'covered';
   const plan = coveragePlanState.plan;
+  const execution = fanOutExecutionState.execution;
   const topology = organizationsTopologyState.topology;
   const rows = buildAWSCoveragePlanRows(plan, coveragePlanState.loading, connection);
   const topologyRows = buildAWSOrganizationsTopologyRows(topology, organizationsTopologyState.loading, connection);
@@ -4465,12 +4476,20 @@ function AWSAccountsInventoryContent({
     <>
       <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
       {coveragePlanState.loading ? <DomainLoadingState label="Loading account and region coverage plan" /> : null}
+      {fanOutExecutionState.loading ? <DomainLoadingState label="Loading fan-out execution state" /> : null}
       {organizationsTopologyState.loading ? <DomainLoadingState label="Loading AWS Organizations topology" /> : null}
       {coveragePlanState.error ? (
         <DomainErrorState
           title="Coverage plan could not load"
           body={coveragePlanState.error}
           retryAction={{ label: 'Retry coverage plan', onClick: coveragePlanState.onRetry }}
+        />
+      ) : null}
+      {fanOutExecutionState.error ? (
+        <DomainErrorState
+          title="Fan-out execution could not load"
+          body={fanOutExecutionState.error}
+          retryAction={{ label: 'Retry fan-out execution', onClick: fanOutExecutionState.onRetry }}
         />
       ) : null}
       {organizationsTopologyState.error ? (
@@ -4491,6 +4510,59 @@ function AWSAccountsInventoryContent({
         />
         <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
       </section>
+      {execution ? (
+        <DomainStatusPanel
+          eyebrow="Fan-out worker"
+          title="Account and region execution is target-scoped"
+          status={formatTokenLabel(execution.status)}
+          tone={execution.status === 'blocked' ? 'danger' : execution.status === 'degraded' ? 'warning' : 'success'}
+        >
+          <section className="idt-aws-inventory-coverage" aria-label="AWS fan-out execution status">
+            <DomainCoverageCard
+              label="Worker slots"
+              scanned={execution.summary.in_progress_targets}
+              total={Math.max(execution.summary.concurrency_limit, 1)}
+              detail={`${execution.summary.queued_targets} queued`}
+            />
+            <DomainCoverageCard
+              label="Completed targets"
+              scanned={execution.summary.covered_targets}
+              total={Math.max(execution.summary.executable_targets, 1)}
+              detail={`${execution.summary.skipped_targets} skipped`}
+            />
+            <DomainCoverageCard
+              label="Retryable targets"
+              scanned={execution.summary.retryable_targets}
+              total={Math.max(execution.summary.executable_targets, 1)}
+              detail={`${execution.summary.throttled_targets} throttled`}
+            />
+            <DomainCoverageCard
+              label="Denied targets"
+              scanned={execution.summary.permission_denied_targets}
+              total={Math.max(execution.summary.executable_targets, 1)}
+              detail={`${execution.summary.failed_targets + execution.summary.partial_targets} degraded`}
+            />
+          </section>
+          {execution.diagnostics.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS fan-out execution diagnostics">
+              {execution.diagnostics.map((diagnostic) => (
+                <article key={`${diagnostic.code}-${diagnostic.scope ?? diagnostic.source}`}>
+                  <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+          {execution.remediation_hints.length ? (
+            <ul className="idt-domain-charter-list">
+              {execution.remediation_hints.map((hint) => (
+                <li key={hint}>{hint}</li>
+              ))}
+            </ul>
+          ) : null}
+        </DomainStatusPanel>
+      ) : null}
       {plan?.diagnostics.length ? (
         <DomainStatusPanel
           eyebrow="Coverage diagnostics"
@@ -7148,6 +7220,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [coveragePlanLoading, setCoveragePlanLoading] = useState(false);
   const [coveragePlanError, setCoveragePlanError] = useState('');
   const coveragePlanRequestRef = useRef(0);
+  const [fanOutExecution, setFanOutExecution] = useState<AWSFanOutExecutionResult | null>(null);
+  const [fanOutExecutionLoading, setFanOutExecutionLoading] = useState(false);
+  const [fanOutExecutionError, setFanOutExecutionError] = useState('');
+  const fanOutExecutionRequestRef = useRef(0);
   const [organizationsTopology, setOrganizationsTopology] = useState<AWSOrganizationsTopologyResult | null>(null);
   const [organizationsTopologyLoading, setOrganizationsTopologyLoading] = useState(false);
   const [organizationsTopologyError, setOrganizationsTopologyError] = useState('');
@@ -7816,6 +7892,58 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadCoveragePlan]);
 
+  const loadFanOutExecution = useCallback(async () => {
+    const requestID = ++fanOutExecutionRequestRef.current;
+    setFanOutExecution(null);
+    setFanOutExecutionError('');
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setFanOutExecutionLoading(false);
+      return;
+    }
+    setFanOutExecutionLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectFanOutExecution(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        { maxConcurrency: 4 },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== fanOutExecutionRequestRef.current) {
+        return;
+      }
+      setFanOutExecution(response.execution);
+    } catch (error) {
+      if (requestID !== fanOutExecutionRequestRef.current) {
+        return;
+      }
+      setFanOutExecutionError(formatAPIError(error, 'Unable to load fan-out execution state.'));
+    } finally {
+      if (requestID === fanOutExecutionRequestRef.current) {
+        setFanOutExecutionLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region,
+    connection?.status,
+    connection?.health_status
+  ]);
+
+  useEffect(() => {
+    void loadFanOutExecution();
+    return () => {
+      fanOutExecutionRequestRef.current += 1;
+    };
+  }, [loadFanOutExecution]);
+
   const loadOrganizationsTopology = useCallback(async () => {
     const requestID = ++organizationsTopologyRequestRef.current;
     setOrganizationsTopology(null);
@@ -7943,6 +8071,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: coveragePlanLoading,
             error: coveragePlanError,
             onRetry: () => void loadCoveragePlan()
+          }}
+          fanOutExecutionState={{
+            execution: fanOutExecution,
+            loading: fanOutExecutionLoading,
+            error: fanOutExecutionError,
+            onRetry: () => void loadFanOutExecution()
           }}
           organizationsTopologyState={{
             topology: organizationsTopology,


### PR DESCRIPTION
## Summary

Adds the AWS account/region/service fan-out execution layer for issue #1500.

This PR introduces a deterministic `awscontract` fan-out executor over the existing coverage planner, exposes the worker state through a new project-scoped API endpoint, and shows bounded worker progress in the AWS accounts app surface.

## Why

AWS estates with many accounts and regions need explicit target-scoped worker state. Without this, operators cannot tell which targets are queued, running, retryable, checkpointed, throttled, denied, skipped, or completed without reading logs.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Implemented:

- Deterministic `aws-account-region-fanout-executor-v1` contract with bounded concurrency, retry/checkpoint metadata, throttling awareness, permission-denied handling, and target-scoped partial failures.
- `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution` with filters, authz route policy, OpenAPI schema, diagnostics, evidence links, and fixture states.
- AWS accounts UI panel for worker slots, queued targets, completed targets, retryable/throttled targets, denied targets, diagnostics, and remediation hints.
- Operator docs for expected outputs, limitations, safety boundaries, and validation.

## Validation

```bash
go test ./internal/providers/awscontract ./internal/api
go test ./internal/providers/aws ./internal/providers/awscontract ./internal/api
cd web && npm run build
cd web && npm test -- --run productShell
git diff --check
```

All checks passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic AWS account/region/service fan‑out execution view with bounded concurrency and explicit target state. New API and UI show queued, running, retryable, throttled, denied, skipped, and completed targets; addresses Issue #1500.

- **New Features**
  - Deterministic executor in `awscontract` (`aws-account-region-fanout-executor-v1`) with concurrency limits, retries/checkpoints, throttling, and permission‑denied handling.
  - New API: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution` with filters and authz; OpenAPI and router wired.
  - Web: typed client (`apiClient.getAWSProjectFanOutExecution`) and AWS Accounts panel showing worker slots, completed/retryable/denied targets, diagnostics, and remediation hints.

- **Bug Fixes**
  - Count resumed in‑progress targets against concurrency so new work stays queued.
  - Prioritize resumed checkpoints before starting new targets.
  - Correct throttled target summary and retryable counts.
  - Honor max‑attempts on replayed failures; failures at the limit are non‑retryable.

<sup>Written for commit 5005348ee351e586f4ba9f6efa448566a8c09c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

