### PR TITLE
Implement AWS scan cursors

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -1,8 +1,8 @@
 # AWS Account and Region Coverage Planner
 
-Issue #1499 adds a deterministic, metadata-only planner that expands an AWS
-connector's configured accounts, regions, and service partitions into explicit
-scan targets.
+Issues #1499 and #1501 add a deterministic, metadata-only planner that expands
+an AWS connector's configured accounts, regions, service partitions, and
+persisted scan cursors into explicit scan targets.
 
 It also models per-account, per-region, and per-service availability outcomes
 (`blocked`, `unsupported`, `disabled`, and `permission_denied`) so operators can
@@ -23,10 +23,41 @@ Each target records:
 - lifecycle state: `planned`, `pending`, `in_progress`, `covered`, `partial`,
   `failed`, `permission_denied`, `unsupported`, `blocked`, or `disabled`
 - cursor, failure reason, attempts, resumability, and evidence reference
+- collector name when a service checkpoint is owned by a specific collector
 - the next operator action
 
 The planner is deterministic: the same connector configuration and checkpoints
 produce the same ordered plan.
+
+## Scan Cursor Shape
+
+Live planning reads `aws_account_region_coverages.scan_cursor` as a metadata
+envelope scoped by tenant, workspace, project, connector, account, and region.
+Service cursors are keyed below `services`, `service_cursors`, `checkpoints`, or
+`cursors`:
+
+```json
+{
+  "services": {
+    "lambda": {
+      "collector": "lambda_execution_roles",
+      "state": "in_progress",
+      "cursor": "lambda-page-2",
+      "attempts": 1,
+      "observed_at": "2026-06-12T12:00:00Z"
+    }
+  }
+}
+```
+
+Supported states are `planned`, `pending`, `in_progress`, `covered`, `partial`,
+`failed`, `permission_denied`, `unsupported`, `blocked`, and `disabled`.
+Malformed cursor entries are ignored and surfaced as diagnostics instead of
+failing the whole plan.
+
+Resumable cursors in `pending`, `in_progress`, `partial`, or `failed` expire
+after 24 hours. Expired cursors are not replayed; operators see a degraded
+diagnostic and can refresh the target with a new read-only scan.
 
 ## API
 
@@ -59,9 +90,9 @@ The planner performs no AWS mutations and reads no customer payloads. It does
 not read or persist secret values, prompts, completions, object contents,
 database rows, environment variable values, or code-interpreter output.
 
-AWS Organizations account discovery is an upstream dependency for this issue.
-This planner does not call live AWS APIs during planning and applies explicit
-availability signals and checkpoints only.
+The planner does not call live AWS APIs during planning. Default API calls use
+persisted account/region rows and their scan cursors; explicit `fixture_state`
+queries use deterministic fixtures for validation.
 
 ## Failure States
 

--- a/docs/aws-account-region-coverage.md
+++ b/docs/aws-account-region-coverage.md
@@ -34,8 +34,15 @@ Coverage rows can include:
 - `scan_cursor` for scanner-owned pagination or incremental state.
 - `account_suspended`, `region_disabled`, and `region_unreachable` booleans for explicit blocked states.
 
-The scan cursor is an internal JSON object and should not contain secrets.
+The scan cursor is a metadata-only JSON object and should not contain secrets.
+Service cursor entries are stored below keys such as `services.lambda` and may
+include `collector`, `state`, `cursor`, `attempts`, `failure_reason`, and
+`observed_at`. Resumable cursors older than 24 hours are treated as stale by the
+planner and are not reused.
 
 ## Public API posture
 
-The first implementation keeps this registry behind store and service methods. Public HTTP endpoints can be added later when the UI is ready to show AWS estate coverage. Until then, scanner and connector workflows should write and read coverage through the scoped service methods.
+Scanner and connector workflows write coverage through the scoped service
+methods. Operators read normalized plan and execution views through the AWS
+coverage-plan and fan-out execution endpoints instead of reading raw database
+rows.

--- a/docs/aws-account-region-fanout-worker.md
+++ b/docs/aws-account-region-fanout-worker.md
@@ -1,9 +1,9 @@
 # AWS Account and Region Fan-Out Worker
 
-Issue #1500 adds a deterministic, metadata-only execution view for bounded AWS
-account/region/service fan-out. It builds on the coverage planner from issue
-#1499 and makes worker state explicit for operators and downstream recovery
-flows.
+Issues #1500 and #1501 add a deterministic, metadata-only execution view for
+bounded AWS account/region/service fan-out. It builds on the coverage planner
+and makes worker state, persisted scan cursors, and downstream recovery state
+explicit for operators.
 
 ## What It Executes
 
@@ -11,6 +11,7 @@ The fan-out executor consumes an `awscontract.CoveragePlan` and produces one
 worker target for each planned account, region, and service target. It records:
 
 - target account, region, service, priority, coverage state, and worker state
+- collector name when the checkpoint is owned by a specific service collector
 - bounded concurrency slot and queue state
 - attempts, maximum attempts, retryability, retry-after, and checkpoints
 - failure reason, evidence reference, timestamp, and next operator action
@@ -42,9 +43,15 @@ diagnostics, coverage gaps, remediation hints, and evidence links.
 ## Failure And Retry Behavior
 
 One account/region/service failure does not fail the whole execution view.
-Throttled and partial targets preserve their checkpoint and retry metadata so a
-future worker run can resume from the last safe cursor. Permission-denied targets
-are non-retryable until the read-only collector role is repaired.
+Throttled, partial, pending, and in-progress targets preserve their checkpoint
+and retry metadata so a future worker run can resume from the last safe cursor.
+Permission-denied targets are non-retryable until the read-only collector role is
+repaired.
+
+Default API calls replay persisted `scan_cursor` service checkpoints from
+account/region coverage rows. Explicit `fixture_state` calls keep using
+deterministic fixture outcomes for CI and app validation. Resumable cursors older
+than 24 hours are treated as stale and are not reused for continuation.
 
 ## Safety Boundary
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10545,6 +10545,7 @@ components:
         region_name: { type: string }
         service: { type: string }
         service_name: { type: string }
+        collector: { type: string }
         global: { type: boolean }
         enabled: { type: boolean }
         priority:
@@ -10672,6 +10673,7 @@ components:
         account_id: { type: string }
         region: { type: string }
         service: { type: string }
+        collector: { type: string }
         priority:
           type: string
           enum: [critical, high, normal, low]

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -254,6 +254,7 @@ func awsCoveragePlanLiveConfig(connectorID, connectionAccountID, connectionRegio
 	serviceNames := map[string]struct{}{}
 	checkpoints := []awscontract.CoverageCheckpoint{}
 	regionAvailability := []awscontract.CoverageAccountRegionAvailability{}
+	persistedAccountRegions := map[string]struct{}{}
 
 	for _, row := range rows {
 		accountID := strings.TrimSpace(row.AccountID)
@@ -261,6 +262,7 @@ func awsCoveragePlanLiveConfig(connectorID, connectionAccountID, connectionRegio
 		if accountID == "" || region == "" {
 			continue
 		}
+		persistedAccountRegions[awsCoverageAccountRegionKey(accountID, region)] = struct{}{}
 		account := accountsByID[accountID]
 		account.AccountID = accountID
 		account.Enabled = true
@@ -301,13 +303,15 @@ func awsCoveragePlanLiveConfig(connectorID, connectionAccountID, connectionRegio
 	sort.Slice(regions, func(i, j int) bool { return regions[i].Region < regions[j].Region })
 
 	services := awsCoverageServicesWithDiscovered(serviceNames)
+	serviceAvailability := awsCoverageMissingAccountRegionServiceAvailability(accounts, regions, services, persistedAccountRegions, checkedAt)
 	return awscontract.CoveragePlanConfig{
-		ConnectorID:        connectorID,
-		Accounts:           accounts,
-		Regions:            regions,
-		RegionAvailability: regionAvailability,
-		Services:           services,
-		Checkpoints:        checkpoints,
+		ConnectorID:         connectorID,
+		Accounts:            accounts,
+		Regions:             regions,
+		RegionAvailability:  regionAvailability,
+		ServiceAvailability: serviceAvailability,
+		Services:            services,
+		Checkpoints:         checkpoints,
 	}, diagnostics, gaps
 }
 
@@ -336,6 +340,48 @@ func awsCoverageRegionPriority(region, connectionRegion string) awscontract.Cove
 		return awscontract.CoveragePriorityHigh
 	}
 	return awscontract.CoveragePriorityNormal
+}
+
+func awsCoverageMissingAccountRegionServiceAvailability(accounts []awscontract.CoverageAccount, regions []awscontract.CoverageRegion, services []awscontract.CoverageService, persisted map[string]struct{}, checkedAt time.Time) []awscontract.CoverageAccountServiceAvailability {
+	availability := []awscontract.CoverageAccountServiceAvailability{}
+	for _, account := range accounts {
+		accountID := strings.TrimSpace(account.AccountID)
+		if accountID == "" {
+			continue
+		}
+		for _, region := range regions {
+			regionName := strings.ToLower(strings.TrimSpace(region.Region))
+			if regionName == "" {
+				continue
+			}
+			if _, ok := persisted[awsCoverageAccountRegionKey(accountID, regionName)]; ok {
+				continue
+			}
+			for _, service := range services {
+				if service.Global {
+					continue
+				}
+				serviceName := strings.ToLower(strings.TrimSpace(service.Service))
+				if serviceName == "" {
+					continue
+				}
+				availability = append(availability, awscontract.CoverageAccountServiceAvailability{
+					AccountID:   accountID,
+					Region:      regionName,
+					Service:     serviceName,
+					State:       awscontract.CoverageStateBlocked,
+					Reason:      "no persisted account/region coverage row for this pair",
+					EvidenceRef: "aws:coverage:" + strings.Join([]string{accountID, regionName, serviceName}, ":"),
+					ObservedAt:  checkedAt,
+				})
+			}
+		}
+	}
+	return availability
+}
+
+func awsCoverageAccountRegionKey(accountID string, region string) string {
+	return strings.TrimSpace(accountID) + "|" + strings.ToLower(strings.TrimSpace(region))
 }
 
 func awsCoverageAvailabilityFromRow(row db.AWSAccountRegionCoverage, checkedAt time.Time) awscontract.CoverageAccountRegionAvailability {

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -2,6 +2,10 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -9,8 +13,9 @@ import (
 	"github.com/identrail/identrail/internal/providers/awscontract"
 )
 
-const awsCoveragePlannerCurrentIssue = 1499
+const awsCoveragePlannerCurrentIssue = 1501
 const awsCoveragePlannerGlobalServiceHomeRegion = "us-east-1"
+const awsCoverageScanCursorTTL = 24 * time.Hour
 
 // AWSCoveragePlanRequest filters and pins the account/region coverage plan.
 type AWSCoveragePlanRequest struct {
@@ -35,6 +40,7 @@ type AWSCoveragePlanTarget struct {
 	RegionName    string    `json:"region_name,omitempty"`
 	Service       string    `json:"service"`
 	ServiceName   string    `json:"service_name,omitempty"`
+	Collector     string    `json:"collector,omitempty"`
 	Global        bool      `json:"global"`
 	Enabled       bool      `json:"enabled"`
 	Priority      string    `json:"priority"`
@@ -103,7 +109,7 @@ type AWSCoveragePlanResult struct {
 	CurrentIssueRef    string                       `json:"current_issue_ref"`
 	Version            string                       `json:"version"`
 	Status             string                       `json:"status"`
-	FixtureState       string                       `json:"fixture_state"`
+	FixtureState       string                       `json:"fixture_state,omitempty"`
 	Confidence         float64                      `json:"confidence"`
 	FilteredTargets    int                          `json:"filtered_targets"`
 	Summary            AWSCoveragePlanSummary       `json:"summary"`
@@ -129,22 +135,41 @@ func (s *Service) GetAWSCoveragePlan(ctx context.Context, workspaceID string, pr
 	if err != nil {
 		return AWSCoveragePlanResult{}, err
 	}
-	return buildAWSCoveragePlan(scope, project, connection, hasConnection, request, s.Now().UTC())
+	coverageRows := []db.AWSAccountRegionCoverage{}
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection {
+		coverageRows, err = s.Store.ListAWSAccountRegionCoverages(ctx, db.AWSAccountRegionCoverageFilter{
+			WorkspaceID: project.WorkspaceID,
+			ProjectID:   project.ProjectID,
+			ConnectorID: strings.TrimSpace(connection.ConnectorID),
+			Limit:       1000,
+		})
+		if err != nil {
+			return AWSCoveragePlanResult{}, err
+		}
+	}
+	return buildAWSCoveragePlan(scope, project, connection, hasConnection, request, coverageRows, s.Now().UTC())
 }
 
-func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSCoveragePlanRequest, checkedAt time.Time) (AWSCoveragePlanResult, error) {
+func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSCoveragePlanRequest, coverageRows []db.AWSAccountRegionCoverage, checkedAt time.Time) (AWSCoveragePlanResult, error) {
 	fixtureState := normalizeAWSCoveragePlanFixtureState(request.FixtureState, connection, hasConnection)
-	if fixtureState == "" {
+	if strings.TrimSpace(request.FixtureState) != "" && fixtureState == "" {
 		return AWSCoveragePlanResult{}, ErrInvalidAWSConnectionRequest
 	}
 	if !validAWSCoveragePlanStateFilter(request.State) {
 		return AWSCoveragePlanResult{}, ErrInvalidAWSConnectionRequest
 	}
-	accountID := firstNonEmptyAWSValue(connection.AccountID, "111111111111")
-	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
-	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	accountID := firstNonEmptyAWSValue(strings.TrimSpace(connection.AccountID), "111111111111")
+	region := firstNonEmptyAWSValue(strings.TrimSpace(connection.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(strings.TrimSpace(connection.ConnectorID), strings.TrimSpace(request.ConnectorID), "aws-fixture")
 
-	config, diagnostics, gaps := awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	var config awscontract.CoveragePlanConfig
+	var diagnostics []AWSCoveragePlanDiagnostic
+	var gaps []AWSCoveragePlanCoverageGap
+	if fixtureState != "" {
+		config, diagnostics, gaps = awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	} else {
+		config, diagnostics, gaps = awsCoveragePlanLiveConfig(connectorID, accountID, region, hasConnection, connection.Connected, coverageRows, checkedAt)
+	}
 	plan, err := awscontract.PlanCoverage(config, checkedAt)
 	if err != nil {
 		return AWSCoveragePlanResult{}, err
@@ -191,15 +216,98 @@ func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection 
 func normalizeAWSCoveragePlanFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
 	switch strings.ToLower(strings.TrimSpace(requested)) {
 	case "":
-		if hasConnection && !connection.Connected {
-			return "permission_denied"
-		}
-		return "success"
+		return ""
 	case "success", "empty", "degraded", "partial_failure", "permission_denied":
 		return strings.ToLower(strings.TrimSpace(requested))
 	default:
 		return ""
 	}
+}
+
+func awsCoveragePlanLiveConfig(connectorID, connectionAccountID, connectionRegion string, hasConnection bool, connected bool, rows []db.AWSAccountRegionCoverage, checkedAt time.Time) (awscontract.CoveragePlanConfig, []AWSCoveragePlanDiagnostic, []AWSCoveragePlanCoverageGap) {
+	gaps := []AWSCoveragePlanCoverageGap{
+		{
+			Capability:  "secret_value_inspection",
+			Status:      "unsupported",
+			Reason:      "Coverage planning reads no customer payloads, secret values, or object contents; it only plans where read-only collectors will run.",
+			Remediation: "Inspect values through the owning service outside Identrail.",
+		},
+	}
+	diagnostics := []AWSCoveragePlanDiagnostic{}
+	if hasConnection && !connected {
+		diagnostics = append(diagnostics, AWSCoveragePlanDiagnostic{
+			Source:      "coverage_planner",
+			Scope:       connectorID,
+			Code:        "permission_denied",
+			Message:     "AWS connector is not currently healthy enough to plan live scan cursors.",
+			Remediation: "Repair the AWS connector role or health checks, then rerun the coverage plan.",
+			Retryable:   false,
+		})
+	}
+	if len(rows) == 0 {
+		return awscontract.CoveragePlanConfig{ConnectorID: connectorID}, diagnostics, gaps
+	}
+
+	accountsByID := map[string]awscontract.CoverageAccount{}
+	regionsByID := map[string]awscontract.CoverageRegion{}
+	serviceNames := map[string]struct{}{}
+	checkpoints := []awscontract.CoverageCheckpoint{}
+	regionAvailability := []awscontract.CoverageAccountRegionAvailability{}
+
+	for _, row := range rows {
+		accountID := strings.TrimSpace(row.AccountID)
+		region := strings.ToLower(strings.TrimSpace(row.Region))
+		if accountID == "" || region == "" {
+			continue
+		}
+		account := accountsByID[accountID]
+		account.AccountID = accountID
+		account.Enabled = true
+		account.Name = firstNonEmptyAWSValue(strings.TrimSpace(row.AccountAlias), account.Name)
+		account.Priority = awsCoverageAccountPriority(accountID, connectionAccountID)
+		account.Reason = firstNonEmptyAWSValue(account.Reason, "persisted account/region coverage")
+		account.Management = accountID == strings.TrimSpace(connectionAccountID)
+		accountsByID[accountID] = account
+
+		coverageRegion := regionsByID[region]
+		coverageRegion.Region = region
+		coverageRegion.Enabled = true
+		coverageRegion.Priority = awsCoverageRegionPriority(region, connectionRegion)
+		coverageRegion.Reason = firstNonEmptyAWSValue(coverageRegion.Reason, "persisted account/region coverage")
+		regionsByID[region] = coverageRegion
+
+		if availability := awsCoverageAvailabilityFromRow(row, checkedAt); availability.State != "" {
+			regionAvailability = append(regionAvailability, availability)
+		}
+		rowCheckpoints, rowDiagnostics, rowServices := awsCoverageCheckpointsFromScanCursor(row, checkedAt)
+		checkpoints = append(checkpoints, rowCheckpoints...)
+		diagnostics = append(diagnostics, rowDiagnostics...)
+		for _, service := range rowServices {
+			serviceNames[service] = struct{}{}
+		}
+	}
+
+	accounts := make([]awscontract.CoverageAccount, 0, len(accountsByID))
+	for _, account := range accountsByID {
+		accounts = append(accounts, account)
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].AccountID < accounts[j].AccountID })
+
+	regions := make([]awscontract.CoverageRegion, 0, len(regionsByID))
+	for _, region := range regionsByID {
+		regions = append(regions, region)
+	}
+	sort.Slice(regions, func(i, j int) bool { return regions[i].Region < regions[j].Region })
+
+	services := awsCoverageServicesWithDiscovered(serviceNames)
+	return awscontract.CoveragePlanConfig{
+		ConnectorID:        connectorID,
+		Accounts:           accounts,
+		Regions:            regions,
+		RegionAvailability: regionAvailability,
+		Services:           services,
+		Checkpoints:        checkpoints,
+	}, diagnostics, gaps
 }
 
 func validAWSCoveragePlanStateFilter(state string) bool {
@@ -213,6 +321,316 @@ func validAWSCoveragePlanStateFilter(state string) bool {
 	default:
 		return false
 	}
+}
+
+func awsCoverageAccountPriority(accountID, connectionAccountID string) awscontract.CoveragePriority {
+	if strings.TrimSpace(accountID) == strings.TrimSpace(connectionAccountID) {
+		return awscontract.CoveragePriorityCritical
+	}
+	return awscontract.CoveragePriorityHigh
+}
+
+func awsCoverageRegionPriority(region, connectionRegion string) awscontract.CoveragePriority {
+	if strings.EqualFold(strings.TrimSpace(region), strings.TrimSpace(connectionRegion)) {
+		return awscontract.CoveragePriorityHigh
+	}
+	return awscontract.CoveragePriorityNormal
+}
+
+func awsCoverageAvailabilityFromRow(row db.AWSAccountRegionCoverage, checkedAt time.Time) awscontract.CoverageAccountRegionAvailability {
+	status := strings.ToLower(strings.TrimSpace(row.CoverageStatus))
+	reason := ""
+	state := awscontract.CoverageState("")
+	switch {
+	case row.Disabled || status == db.AWSAccountRegionCoverageDisabled:
+		state = awscontract.CoverageStateDisabled
+		reason = "account/region scanning disabled in connector coverage"
+	case row.Suspended || status == db.AWSAccountRegionCoverageSuspended:
+		state = awscontract.CoverageStateBlocked
+		reason = "aws account is suspended"
+	case row.Unreachable || status == db.AWSAccountRegionCoverageUnreachable:
+		state = awscontract.CoverageStateBlocked
+		reason = "account/region is unreachable from the connector role"
+	case status == db.AWSAccountRegionCoverageGap:
+		state = awscontract.CoverageStateBlocked
+		reason = "coverage gap recorded for this account/region"
+	case status == db.AWSAccountRegionCoverageError && awsCoverageErrorLooksDenied(row):
+		state = awscontract.CoverageStatePermissionDenied
+		reason = "aws denied read-only account/region coverage"
+	case status == db.AWSAccountRegionCoverageError:
+		state = awscontract.CoverageStateBlocked
+		reason = "account/region coverage has an unresolved collection error"
+	}
+	if state == "" {
+		return awscontract.CoverageAccountRegionAvailability{}
+	}
+	failure := strings.TrimSpace(row.LastObservedErrorMessage)
+	if failure == "" {
+		failure = strings.TrimSpace(row.LastObservedErrorCode)
+	}
+	observedAt := row.UpdatedAt
+	if observedAt.IsZero() {
+		observedAt = checkedAt
+	}
+	return awscontract.CoverageAccountRegionAvailability{
+		AccountID:     row.AccountID,
+		Region:        row.Region,
+		State:         state,
+		Reason:        reason,
+		FailureReason: failure,
+		EvidenceRef:   awsCoverageRowEvidenceRef(row),
+		ObservedAt:    observedAt.UTC(),
+	}
+}
+
+func awsCoverageErrorLooksDenied(row db.AWSAccountRegionCoverage) bool {
+	combined := strings.ToLower(strings.TrimSpace(row.LastObservedErrorCode + " " + row.LastObservedErrorMessage))
+	return strings.Contains(combined, "accessdenied") ||
+		strings.Contains(combined, "access denied") ||
+		strings.Contains(combined, "unauthorized") ||
+		strings.Contains(combined, "permission")
+}
+
+func awsCoverageCheckpointsFromScanCursor(row db.AWSAccountRegionCoverage, checkedAt time.Time) ([]awscontract.CoverageCheckpoint, []AWSCoveragePlanDiagnostic, []string) {
+	entries := awsCoverageCursorEntries(row.ScanCursor)
+	checkpoints := []awscontract.CoverageCheckpoint{}
+	diagnostics := []AWSCoveragePlanDiagnostic{}
+	services := []string{}
+	for _, entry := range entries {
+		service := strings.ToLower(strings.TrimSpace(entry.service))
+		if service == "" {
+			continue
+		}
+		state, ok := awsCoverageCursorState(entry.fields)
+		if !ok {
+			diagnostics = append(diagnostics, awsCoverageCursorDiagnostic(row, service, "malformed_cursor", "Scan cursor entry does not contain a supported coverage state.", false))
+			continue
+		}
+		observedAt := awsCoverageCursorTime(entry.fields, checkedAt)
+		if awsCoverageCursorExpired(state, observedAt, checkedAt) {
+			diagnostics = append(diagnostics, awsCoverageCursorDiagnostic(row, service, "stale_cursor_expired", "Stored scan cursor is stale and will not be reused for continuation.", true))
+			services = append(services, service)
+			continue
+		}
+		checkpoints = append(checkpoints, awscontract.CoverageCheckpoint{
+			AccountID:     row.AccountID,
+			Region:        row.Region,
+			Service:       service,
+			Collector:     firstNonEmptyAWSValue(awsCoverageCursorString(entry.fields, "collector"), entry.collector),
+			State:         state,
+			Cursor:        awsCoverageCursorString(entry.fields, "cursor"),
+			FailureReason: firstNonEmptyAWSValue(awsCoverageCursorString(entry.fields, "failure_reason"), awsCoverageCursorString(entry.fields, "error"), awsCoverageCursorString(entry.fields, "message")),
+			Attempts:      awsCoverageCursorInt(entry.fields, "attempts"),
+			ObservedAt:    observedAt,
+		})
+		services = append(services, service)
+	}
+	return checkpoints, diagnostics, dedupeStrings(services)
+}
+
+type awsCoverageCursorEntry struct {
+	service   string
+	collector string
+	fields    map[string]any
+}
+
+func awsCoverageCursorEntries(cursor map[string]any) []awsCoverageCursorEntry {
+	if len(cursor) == 0 {
+		return nil
+	}
+	entries := []awsCoverageCursorEntry{}
+	for _, key := range []string{"services", "service_cursors", "checkpoints", "cursors"} {
+		if nested, ok := cursor[key].(map[string]any); ok {
+			entries = append(entries, awsCoverageCursorEntriesFromMap(nested)...)
+		}
+	}
+	entries = append(entries, awsCoverageCursorEntriesFromMap(cursor)...)
+	return entries
+}
+
+func awsCoverageCursorEntriesFromMap(input map[string]any) []awsCoverageCursorEntry {
+	keys := make([]string, 0, len(input))
+	for key := range input {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := []awsCoverageCursorEntry{}
+	for _, key := range keys {
+		if awsCoverageCursorMetaKey(key) {
+			continue
+		}
+		fields, ok := input[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		service, collector := awsCoverageSplitCursorKey(key)
+		out = append(out, awsCoverageCursorEntry{service: service, collector: collector, fields: fields})
+	}
+	return out
+}
+
+func awsCoverageCursorMetaKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "", "cursor", "next_token", "token", "state", "status", "attempts", "observed_at", "updated_at", "collector", "failure_reason", "error", "message",
+		"services", "service_cursors", "checkpoints", "cursors":
+		return true
+	default:
+		return false
+	}
+}
+
+func awsCoverageSplitCursorKey(key string) (string, string) {
+	parts := strings.FieldsFunc(strings.ToLower(strings.TrimSpace(key)), func(r rune) bool {
+		return r == ':' || r == '/' || r == '|'
+	})
+	if len(parts) == 0 {
+		return "", ""
+	}
+	service := strings.TrimSpace(parts[0])
+	collector := ""
+	if len(parts) > 1 {
+		collector = strings.Join(parts[1:], ":")
+	}
+	return service, collector
+}
+
+func awsCoverageCursorState(fields map[string]any) (awscontract.CoverageState, bool) {
+	raw := strings.ToLower(firstNonEmptyAWSValue(awsCoverageCursorString(fields, "state"), awsCoverageCursorString(fields, "status")))
+	switch raw {
+	case "planned":
+		return awscontract.CoverageStatePlanned, true
+	case "pending", "queued":
+		return awscontract.CoverageStatePending, true
+	case "in_progress", "running", "started":
+		return awscontract.CoverageStateInProgress, true
+	case "covered", "complete", "completed", "success", "succeeded":
+		return awscontract.CoverageStateCovered, true
+	case "partial", "partial_failure":
+		return awscontract.CoverageStatePartial, true
+	case "failed", "failure", "error", "throttled":
+		return awscontract.CoverageStateFailed, true
+	case "permission_denied", "access_denied", "denied":
+		return awscontract.CoverageStatePermissionDenied, true
+	case "unsupported":
+		return awscontract.CoverageStateUnsupported, true
+	case "blocked":
+		return awscontract.CoverageStateBlocked, true
+	case "disabled":
+		return awscontract.CoverageStateDisabled, true
+	default:
+		return "", false
+	}
+}
+
+func awsCoverageCursorExpired(state awscontract.CoverageState, observedAt time.Time, checkedAt time.Time) bool {
+	switch state {
+	case awscontract.CoverageStatePending, awscontract.CoverageStateInProgress, awscontract.CoverageStatePartial, awscontract.CoverageStateFailed:
+	default:
+		return false
+	}
+	if observedAt.IsZero() {
+		return false
+	}
+	return !observedAt.Add(awsCoverageScanCursorTTL).After(checkedAt)
+}
+
+func awsCoverageCursorString(fields map[string]any, key string) string {
+	raw, ok := fields[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+}
+
+func awsCoverageCursorInt(fields map[string]any, key string) int {
+	raw, ok := fields[key]
+	if !ok || raw == nil {
+		return 0
+	}
+	switch value := raw.(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		parsed, _ := strconv.Atoi(value.String())
+		return parsed
+	case string:
+		parsed, _ := strconv.Atoi(strings.TrimSpace(value))
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func awsCoverageCursorTime(fields map[string]any, fallback time.Time) time.Time {
+	for _, key := range []string{"observed_at", "updated_at", "checked_at"} {
+		raw := awsCoverageCursorString(fields, key)
+		if raw == "" {
+			continue
+		}
+		if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return fallback.UTC()
+}
+
+func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string, code string, message string, retryable bool) AWSCoveragePlanDiagnostic {
+	return AWSCoveragePlanDiagnostic{
+		Source:      "scan_cursor",
+		Scope:       strings.Join([]string{row.AccountID, strings.ToLower(strings.TrimSpace(row.Region)), strings.ToLower(strings.TrimSpace(service))}, "/"),
+		Code:        code,
+		Message:     message,
+		Remediation: "Refresh this account/region/service scan so Identrail can write a current checkpoint.",
+		Retryable:   retryable,
+	}
+}
+
+func awsCoverageServicesWithDiscovered(discovered map[string]struct{}) []awscontract.CoverageService {
+	services := awscontract.DefaultCoverageServices()
+	seen := map[string]struct{}{}
+	for _, service := range services {
+		seen[strings.ToLower(strings.TrimSpace(service.Service))] = struct{}{}
+	}
+	names := make([]string, 0, len(discovered))
+	for service := range discovered {
+		service = strings.ToLower(strings.TrimSpace(service))
+		if service == "" {
+			continue
+		}
+		if _, ok := seen[service]; ok {
+			continue
+		}
+		names = append(names, service)
+	}
+	sort.Strings(names)
+	for _, service := range names {
+		services = append(services, awscontract.CoverageService{
+			Service: service,
+			Name:    service,
+			Enabled: true,
+			Reason:  "persisted scan cursor service",
+		})
+	}
+	return services
+}
+
+func awsCoverageRowEvidenceRef(row db.AWSAccountRegionCoverage) string {
+	return "aws:coverage:" + strings.Join([]string{
+		strings.TrimSpace(row.ConnectorID),
+		strings.TrimSpace(row.AccountID),
+		strings.ToLower(strings.TrimSpace(row.Region)),
+	}, ":")
 }
 
 // awsCoveragePlanFixtureConfig returns the deterministic connector coverage
@@ -333,6 +751,7 @@ func mapAWSCoveragePlanTargets(targets []awscontract.CoverageTarget) []AWSCovera
 			RegionName:    target.RegionName,
 			Service:       target.Service,
 			ServiceName:   target.ServiceName,
+			Collector:     target.Collector,
 			Global:        target.Global,
 			Enabled:       target.Enabled,
 			Priority:      string(target.Priority),
@@ -446,6 +865,16 @@ func summarizeAWSCoveragePlan(fixtureState string, diagnostics []AWSCoveragePlan
 			awsCoveragePlanDiagnosticMessages(diagnostics),
 			[]string{"Re-run the plan to resume failed and in-progress targets from their checkpoints."}
 	default:
+		if awsCoveragePlanHasDiagnosticCode(diagnostics, "permission_denied") || plan.Summary.PermissionDenied > 0 {
+			return awsPlatformDependencyStatusBlocked, 0.34,
+				awsCoveragePlanDiagnosticMessages(diagnostics),
+				[]string{"Repair denied read-only AWS access, then rerun the coverage plan from persisted scan cursors."}
+		}
+		if len(diagnostics) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.78,
+				awsCoveragePlanDiagnosticMessages(diagnostics),
+				[]string{"Refresh stale or malformed scan cursors so retry and resume behavior stays accurate."}
+		}
 		if plan.Summary.TotalTargets == 0 {
 			return awsPlatformDependencyStatusReady, 0.8, nil,
 				[]string{"No accounts, regions, or services are configured for coverage; add scan targets to the AWS connector."}
@@ -457,6 +886,15 @@ func summarizeAWSCoveragePlan(fixtureState string, diagnostics []AWSCoveragePlan
 		return awsPlatformDependencyStatusReady, 0.94, nil,
 			[]string{"Coverage plan is deterministic and resumable; schedule the fan-out scan worker to execute outstanding targets."}
 	}
+}
+
+func awsCoveragePlanHasDiagnosticCode(diagnostics []AWSCoveragePlanDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if strings.EqualFold(strings.TrimSpace(diagnostic.Code), code) {
+			return true
+		}
+	}
+	return false
 }
 
 func awsCoveragePlanDiagnosticMessages(diagnostics []AWSCoveragePlanDiagnostic) []string {

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -406,7 +406,11 @@ func awsCoverageCheckpointsFromScanCursor(row db.AWSAccountRegionCoverage, check
 			diagnostics = append(diagnostics, awsCoverageCursorDiagnostic(row, service, "malformed_cursor", "Scan cursor entry does not contain a supported coverage state.", false))
 			continue
 		}
-		observedAt := awsCoverageCursorTime(entry.fields, checkedAt)
+		observedFallback := row.UpdatedAt
+		if observedFallback.IsZero() {
+			observedFallback = checkedAt
+		}
+		observedAt := awsCoverageCursorTime(entry.fields, observedFallback)
 		if awsCoverageCursorExpired(state, observedAt, checkedAt) {
 			diagnostics = append(diagnostics, awsCoverageCursorDiagnostic(row, service, "stale_cursor_expired", "Stored scan cursor is stale and will not be reused for continuation.", true))
 			services = append(services, service)

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -16,6 +16,7 @@ import (
 const awsCoveragePlannerCurrentIssue = 1501
 const awsCoveragePlannerGlobalServiceHomeRegion = "us-east-1"
 const awsCoverageScanCursorTTL = 24 * time.Hour
+const awsCoveragePlannerAccountRegionPageSize = 250
 
 // AWSCoveragePlanRequest filters and pins the account/region coverage plan.
 type AWSCoveragePlanRequest struct {
@@ -137,11 +138,11 @@ func (s *Service) GetAWSCoveragePlan(ctx context.Context, workspaceID string, pr
 	}
 	coverageRows := []db.AWSAccountRegionCoverage{}
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection {
-		coverageRows, err = s.Store.ListAWSAccountRegionCoverages(ctx, db.AWSAccountRegionCoverageFilter{
+		coverageRows, err = awsCoverageListRows(ctx, s.Store, db.AWSAccountRegionCoverageFilter{
 			WorkspaceID: project.WorkspaceID,
 			ProjectID:   project.ProjectID,
 			ConnectorID: strings.TrimSpace(connection.ConnectorID),
-			Limit:       1000,
+			Limit:       awsCoveragePlannerAccountRegionPageSize,
 		})
 		if err != nil {
 			return AWSCoveragePlanResult{}, err
@@ -430,6 +431,25 @@ func awsCoverageCheckpointsFromScanCursor(row db.AWSAccountRegionCoverage, check
 		services = append(services, service)
 	}
 	return checkpoints, diagnostics, dedupeStrings(services)
+}
+
+func awsCoverageListRows(ctx context.Context, store db.Store, filter db.AWSAccountRegionCoverageFilter) ([]db.AWSAccountRegionCoverage, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = awsCoveragePlannerAccountRegionPageSize
+	}
+	allRows := []db.AWSAccountRegionCoverage{}
+	for offset := 0; ; offset += filter.Limit {
+		filter.Offset = offset
+		batch, err := store.ListAWSAccountRegionCoverages(ctx, filter)
+		if err != nil {
+			return nil, err
+		}
+		allRows = append(allRows, batch...)
+		if len(batch) < filter.Limit {
+			break
+		}
+	}
+	return allRows, nil
 }
 
 type awsCoverageCursorEntry struct {

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -419,7 +419,7 @@ func awsCoverageCheckpointsFromScanCursor(row db.AWSAccountRegionCoverage, check
 		}
 		checkpoints = append(checkpoints, awscontract.CoverageCheckpoint{
 			AccountID:     row.AccountID,
-			Region:        row.Region,
+			Region:        awsCoverageCheckpointRegion(service, row.Region),
 			Service:       service,
 			Collector:     firstNonEmptyAWSValue(awsCoverageCursorString(entry.fields, "collector"), entry.collector),
 			State:         state,
@@ -431,6 +431,17 @@ func awsCoverageCheckpointsFromScanCursor(row db.AWSAccountRegionCoverage, check
 		services = append(services, service)
 	}
 	return checkpoints, diagnostics, dedupeStrings(services)
+}
+
+func awsCoverageCheckpointRegion(service string, rowRegion string) string {
+	service = strings.ToLower(strings.TrimSpace(service))
+	for _, defaultService := range awscontract.DefaultCoverageServices() {
+		if strings.ToLower(strings.TrimSpace(defaultService.Service)) != service || !defaultService.Global {
+			continue
+		}
+		return firstNonEmptyAWSValue(strings.ToLower(strings.TrimSpace(defaultService.HomeRegion)), awsCoveragePlannerGlobalServiceHomeRegion)
+	}
+	return strings.ToLower(strings.TrimSpace(rowRegion))
 }
 
 func awsCoverageListRows(ctx context.Context, store db.Store, filter db.AWSAccountRegionCoverageFilter) ([]db.AWSAccountRegionCoverage, error) {

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -19,6 +20,17 @@ func TestGetAWSCoveragePlanSuccess(t *testing.T) {
 	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam":    map[string]any{"collector": "iam_roles", "state": "covered", "observed_at": now.Format(time.RFC3339Nano)},
+			"lambda": map[string]any{"collector": "lambda_execution_roles", "state": "in_progress", "cursor": "lambda-page-2", "attempts": 1, "observed_at": now.Format(time.RFC3339Nano)},
+		}},
+		UpdatedAt: now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
@@ -30,17 +42,23 @@ func TestGetAWSCoveragePlanSuccess(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready plan, got %+v", result)
 	}
-	if result.CurrentIssueRef != "#1499" || result.Version == "" {
+	if result.CurrentIssueRef != "#1501" || result.Version == "" {
 		t.Fatalf("unexpected metadata: %+v", result)
 	}
-	if result.Summary.AccountCount != 3 || result.Summary.RegionCount != 3 || result.Summary.ServiceCount != 6 {
+	if result.Summary.AccountCount != 1 || result.Summary.RegionCount != 1 || result.Summary.ServiceCount != 6 {
 		t.Fatalf("unexpected dimension counts: %+v", result.Summary)
 	}
-	if result.Summary.CoveredTargets != 3 || result.Summary.CoveragePercent <= 0 {
+	if result.Summary.CoveredTargets != 1 || result.Summary.ResumableTargets != 1 || result.Summary.CoveragePercent <= 0 {
 		t.Fatalf("expected covered targets and positive coverage percent, got %+v", result.Summary)
 	}
-	if result.Summary.DisabledTargets == 0 {
-		t.Fatalf("expected disabled targets from the decommissioned account, got %+v", result.Summary)
+	var lambda AWSCoveragePlanTarget
+	for _, target := range result.Targets {
+		if target.Service == "lambda" {
+			lambda = target
+		}
+	}
+	if lambda.Collector != "lambda_execution_roles" || lambda.Cursor != "lambda-page-2" || !lambda.Resumable {
+		t.Fatalf("expected lambda checkpoint to be operator-visible, got %+v", lambda)
 	}
 	// Determinism: targets must be sorted by priority rank then key.
 	for i := 1; i < len(result.Targets); i++ {
@@ -66,6 +84,21 @@ func TestGetAWSCoveragePlanGlobalServicePlannedOncePerAccount(t *testing.T) {
 	now := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
+		UpdatedAt:      now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "222222222222",
+		AccountAlias:   "Data",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		UpdatedAt:      now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
@@ -97,6 +130,20 @@ func TestGetAWSCoveragePlanFilters(t *testing.T) {
 	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
+		UpdatedAt:      now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "222222222222",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoverageDisabled,
+		Disabled:       true,
+		UpdatedAt:      now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
@@ -179,6 +226,41 @@ func TestGetAWSCoveragePlanEmptyAndDegradedAndDenied(t *testing.T) {
 	}
 }
 
+func TestGetAWSCoveragePlanLiveCursorExpiryAndMalformed(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 12, 30, 0, 0, time.UTC)
+	old := now.Add(-awsCoverageScanCursorTTL - time.Minute)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"lambda": map[string]any{"state": "in_progress", "cursor": "stale-lambda", "observed_at": old.Format(time.RFC3339Nano)},
+			"ecs":    map[string]any{"cursor": "missing-state"},
+		}},
+		UpdatedAt: now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded || len(result.Diagnostics) != 2 {
+		t.Fatalf("expected degraded stale/malformed cursor diagnostics, got %+v", result)
+	}
+	for _, target := range result.Targets {
+		if target.Service == "lambda" && target.Cursor == "stale-lambda" {
+			t.Fatalf("stale cursor should not be replayed: %+v", target)
+		}
+	}
+}
+
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
@@ -235,5 +317,27 @@ func TestRouterAWSCoveragePlanPartialFailureAndInvalid(t *testing.T) {
 		if bad.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
 		}
+	}
+}
+
+func seedAWSCoverageCursorRow(t *testing.T, store db.Store, ctx context.Context, projectID string, connectorID string, coverage db.AWSAccountRegionCoverage) {
+	t.Helper()
+	if coverage.CoverageStatus == "" {
+		coverage.CoverageStatus = db.AWSAccountRegionCoveragePending
+	}
+	if coverage.Partition == "" {
+		coverage.Partition = "aws"
+	}
+	if coverage.CreatedAt.IsZero() {
+		coverage.CreatedAt = time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	}
+	if coverage.UpdatedAt.IsZero() {
+		coverage.UpdatedAt = coverage.CreatedAt
+	}
+	coverage.WorkspaceID = "default"
+	coverage.ProjectID = projectID
+	coverage.ConnectorID = connectorID
+	if _, err := store.UpsertAWSAccountRegionCoverage(ctx, coverage); err != nil {
+		t.Fatalf("seed aws coverage cursor row: %v", err)
 	}
 }

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -87,7 +87,7 @@ func TestGetAWSCoveragePlanGlobalServicePlannedOncePerAccount(t *testing.T) {
 	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
 		AccountID:      "123456789012",
 		AccountAlias:   "Production",
-		Region:         "us-east-1",
+		Region:         "eu-west-1",
 		CoverageStatus: db.AWSAccountRegionCoveragePending,
 		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
 		UpdatedAt:      now,
@@ -117,10 +117,19 @@ func TestGetAWSCoveragePlanGlobalServicePlannedOncePerAccount(t *testing.T) {
 	if len(perAccount) == 0 {
 		t.Fatalf("expected iam targets")
 	}
+	var productionIAM AWSCoveragePlanTarget
 	for accountID, count := range perAccount {
 		if count != 1 {
 			t.Fatalf("account %s has %d iam targets, want 1 (global)", accountID, count)
 		}
+		for _, target := range result.Targets {
+			if target.AccountID == "123456789012" {
+				productionIAM = target
+			}
+		}
+	}
+	if productionIAM.Region != awsCoveragePlannerGlobalServiceHomeRegion || productionIAM.State != "covered" {
+		t.Fatalf("expected non-home region iam cursor to replay in global home region, got %+v", productionIAM)
 	}
 }
 

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -133,6 +133,50 @@ func TestGetAWSCoveragePlanGlobalServicePlannedOncePerAccount(t *testing.T) {
 	}
 }
 
+func TestGetAWSCoveragePlanBlocksInventedLiveAccountRegionPairs(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "111111111111",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		UpdatedAt:      now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "222222222222",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		UpdatedAt:      now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	targetsByKey := map[string]AWSCoveragePlanTarget{}
+	for _, target := range result.Targets {
+		targetsByKey[target.Key] = target
+	}
+	for _, key := range []string{
+		"111111111111|eu-west-1|lambda",
+		"222222222222|us-east-1|lambda",
+	} {
+		target := targetsByKey[key]
+		if target.State != "blocked" || !strings.Contains(target.Reason, "no persisted account/region coverage row") {
+			t.Fatalf("expected invented regional target %s to be blocked, got %+v", key, target)
+		}
+	}
+	if iam := targetsByKey["222222222222|us-east-1|iam"]; iam.State == "blocked" {
+		t.Fatalf("global iam home-region target should not be blocked as an invented regional pair: %+v", iam)
+	}
+}
+
 func TestGetAWSCoveragePlanFilters(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_fanout_execution.go
+++ b/internal/api/aws_fanout_execution.go
@@ -28,6 +28,7 @@ type AWSFanOutExecutionTarget struct {
 	AccountID       string    `json:"account_id"`
 	Region          string    `json:"region"`
 	Service         string    `json:"service"`
+	Collector       string    `json:"collector,omitempty"`
 	Priority        string    `json:"priority"`
 	State           string    `json:"state"`
 	WorkerState     string    `json:"worker_state"`
@@ -76,7 +77,7 @@ type AWSFanOutExecutionResult struct {
 	CurrentIssueRef    string                       `json:"current_issue_ref"`
 	Version            string                       `json:"version"`
 	Status             string                       `json:"status"`
-	FixtureState       string                       `json:"fixture_state"`
+	FixtureState       string                       `json:"fixture_state,omitempty"`
 	Confidence         float64                      `json:"confidence"`
 	FilteredTargets    int                          `json:"filtered_targets"`
 	Summary            AWSFanOutExecutionSummary    `json:"summary"`
@@ -101,12 +102,24 @@ func (s *Service) GetAWSFanOutExecution(ctx context.Context, workspaceID string,
 	if err != nil {
 		return AWSFanOutExecutionResult{}, err
 	}
-	return buildAWSFanOutExecution(scope, project, connection, hasConnection, request, s.Now().UTC())
+	coverageRows := []db.AWSAccountRegionCoverage{}
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection {
+		coverageRows, err = s.Store.ListAWSAccountRegionCoverages(ctx, db.AWSAccountRegionCoverageFilter{
+			WorkspaceID: project.WorkspaceID,
+			ProjectID:   project.ProjectID,
+			ConnectorID: strings.TrimSpace(connection.ConnectorID),
+			Limit:       1000,
+		})
+		if err != nil {
+			return AWSFanOutExecutionResult{}, err
+		}
+	}
+	return buildAWSFanOutExecution(scope, project, connection, hasConnection, request, coverageRows, s.Now().UTC())
 }
 
-func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSFanOutExecutionRequest, checkedAt time.Time) (AWSFanOutExecutionResult, error) {
+func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSFanOutExecutionRequest, coverageRows []db.AWSAccountRegionCoverage, checkedAt time.Time) (AWSFanOutExecutionResult, error) {
 	fixtureState := normalizeAWSCoveragePlanFixtureState(request.FixtureState, connection, hasConnection)
-	if fixtureState == "" {
+	if strings.TrimSpace(request.FixtureState) != "" && fixtureState == "" {
 		return AWSFanOutExecutionResult{}, ErrInvalidAWSConnectionRequest
 	}
 	if !validAWSCoveragePlanStateFilter(request.State) {
@@ -116,11 +129,18 @@ func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connecti
 	if maxConcurrency < 0 || maxConcurrency > 64 {
 		return AWSFanOutExecutionResult{}, ErrInvalidAWSConnectionRequest
 	}
-	accountID := firstNonEmptyAWSValue(connection.AccountID, "111111111111")
-	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
-	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	accountID := firstNonEmptyAWSValue(strings.TrimSpace(connection.AccountID), "111111111111")
+	region := firstNonEmptyAWSValue(strings.TrimSpace(connection.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(strings.TrimSpace(connection.ConnectorID), strings.TrimSpace(request.ConnectorID), "aws-fixture")
 
-	config, diagnostics, gaps := awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	var config awscontract.CoveragePlanConfig
+	var diagnostics []AWSCoveragePlanDiagnostic
+	var gaps []AWSCoveragePlanCoverageGap
+	if fixtureState != "" {
+		config, diagnostics, gaps = awsCoveragePlanFixtureConfig(connectorID, accountID, region, fixtureState)
+	} else {
+		config, diagnostics, gaps = awsCoveragePlanLiveConfig(connectorID, accountID, region, hasConnection, connection.Connected, coverageRows, checkedAt)
+	}
 	coverage, err := awscontract.PlanCoverage(config, checkedAt)
 	if err != nil {
 		return AWSFanOutExecutionResult{}, err
@@ -175,7 +195,7 @@ func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connecti
 }
 
 func awsFanOutFixtureOutcomes(plan awscontract.CoveragePlan, accountID, region, fixtureState string, checkedAt time.Time) []awscontract.FanOutTargetOutcome {
-	if fixtureState == "empty" || fixtureState == "permission_denied" {
+	if fixtureState == "" || fixtureState == "empty" || fixtureState == "permission_denied" {
 		return nil
 	}
 	outcomes := []awscontract.FanOutTargetOutcome{}
@@ -213,6 +233,7 @@ func mapAWSFanOutExecutionTargets(targets []awscontract.FanOutExecutionTarget) [
 			AccountID:       target.AccountID,
 			Region:          target.Region,
 			Service:         target.Service,
+			Collector:       target.Collector,
 			Priority:        string(target.Priority),
 			State:           string(target.State),
 			WorkerState:     string(target.WorkerState),
@@ -279,12 +300,12 @@ func filterAWSFanOutExecutionTargets(targets []AWSFanOutExecutionTarget, request
 }
 
 func summarizeAWSFanOutExecution(fixtureState string, diagnostics []AWSCoveragePlanDiagnostic, execution awscontract.FanOutExecutionPlan) (string, float64, []string, []string) {
-	if fixtureState == "permission_denied" || execution.Summary.PermissionDeniedTargets > 0 {
+	if fixtureState == "permission_denied" || execution.Summary.PermissionDeniedTargets > 0 || awsCoveragePlanHasDiagnosticCode(diagnostics, "permission_denied") {
 		return awsPlatformDependencyStatusBlocked, 0.34,
 			awsCoveragePlanDiagnosticMessages(diagnostics),
 			[]string{"Deploy read-only collector roles into denied accounts/regions before rerunning fan-out execution."}
 	}
-	if fixtureState == "partial_failure" || fixtureState == "degraded" || execution.Summary.FailedTargets > 0 || execution.Summary.PartialTargets > 0 {
+	if fixtureState == "partial_failure" || fixtureState == "degraded" || execution.Summary.FailedTargets > 0 || execution.Summary.PartialTargets > 0 || len(diagnostics) > 0 {
 		return awsPlatformDependencyStatusDegraded, 0.74,
 			awsCoveragePlanDiagnosticMessages(diagnostics),
 			[]string{"Retry throttled or partial targets with bounded backoff; completed targets stay checkpointed."}

--- a/internal/api/aws_fanout_execution.go
+++ b/internal/api/aws_fanout_execution.go
@@ -104,11 +104,11 @@ func (s *Service) GetAWSFanOutExecution(ctx context.Context, workspaceID string,
 	}
 	coverageRows := []db.AWSAccountRegionCoverage{}
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection {
-		coverageRows, err = s.Store.ListAWSAccountRegionCoverages(ctx, db.AWSAccountRegionCoverageFilter{
+		coverageRows, err = awsCoverageListRows(ctx, s.Store, db.AWSAccountRegionCoverageFilter{
 			WorkspaceID: project.WorkspaceID,
 			ProjectID:   project.ProjectID,
 			ConnectorID: strings.TrimSpace(connection.ConnectorID),
-			Limit:       1000,
+			Limit:       awsCoveragePlannerAccountRegionPageSize,
 		})
 		if err != nil {
 			return AWSFanOutExecutionResult{}, err

--- a/internal/api/aws_fanout_execution_test.go
+++ b/internal/api/aws_fanout_execution_test.go
@@ -18,6 +18,17 @@ func TestGetAWSFanOutExecutionSuccess(t *testing.T) {
 	now := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam":    map[string]any{"collector": "iam_roles", "state": "covered", "observed_at": now.Format(time.RFC3339Nano)},
+			"lambda": map[string]any{"collector": "lambda_execution_roles", "state": "in_progress", "cursor": "lambda-page-2", "attempts": 1, "observed_at": now.Format(time.RFC3339Nano)},
+		}},
+		UpdatedAt: now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
@@ -43,6 +54,16 @@ func TestGetAWSFanOutExecutionSuccess(t *testing.T) {
 			t.Fatalf("target exceeded concurrency limit: %+v", target)
 		}
 	}
+	lambda := result.Targets[0]
+	for _, target := range result.Targets {
+		if target.Service == "lambda" {
+			lambda = target
+			break
+		}
+	}
+	if lambda.Collector != "lambda_execution_roles" || lambda.Checkpoint != "lambda-page-2" {
+		t.Fatalf("expected lambda fan-out target to replay persisted checkpoint, got %+v", lambda)
+	}
 }
 
 func TestGetAWSFanOutExecutionDegradedAndDenied(t *testing.T) {
@@ -51,6 +72,13 @@ func TestGetAWSFanOutExecutionDegradedAndDenied(t *testing.T) {
 	now := time.Date(2026, 6, 12, 15, 30, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
+		UpdatedAt:      now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
@@ -81,6 +109,13 @@ func TestGetAWSFanOutExecutionFilters(t *testing.T) {
 	now := time.Date(2026, 6, 12, 16, 0, 0, 0, time.UTC)
 	seedDefaultProject(t, store, ctx, "project-a")
 	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
+		UpdatedAt:      now,
+	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1741,8 +1741,12 @@ func (m *MemoryStore) ListAWSAccountRegionCoverages(ctx context.Context, filter 
 		return nil, fmt.Errorf("project id is required")
 	}
 	limit := filter.Limit
-	if limit <= 0 {
-		limit = 100
+	if limit < 0 {
+		limit = 0
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
 	}
 	connectorID := strings.TrimSpace(filter.ConnectorID)
 	accountID := strings.TrimSpace(filter.AccountID)
@@ -1772,7 +1776,13 @@ func (m *MemoryStore) ListAWSAccountRegionCoverages(ctx context.Context, filter 
 		}
 		return results[i].Region < results[j].Region
 	})
-	if len(results) > limit {
+	if offset > 0 {
+		if offset >= len(results) {
+			return []AWSAccountRegionCoverage{}, nil
+		}
+		results = results[offset:]
+	}
+	if limit > 0 && len(results) > limit {
 		results = results[:limit]
 	}
 	return results, nil

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -2259,7 +2259,6 @@ func (p *PostgresStore) ListAWSAccountRegionCoverages(ctx context.Context, filte
 	if offset > 0 {
 		query += fmt.Sprintf(" OFFSET $%d", nextArg)
 		args = append(args, offset)
-		nextArg++
 	}
 
 	rows, err := p.queryContext(ctx, query, args...)

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -2221,8 +2221,12 @@ func (p *PostgresStore) ListAWSAccountRegionCoverages(ctx context.Context, filte
 		return nil, fmt.Errorf("project id is required")
 	}
 	limit := filter.Limit
-	if limit <= 0 {
-		limit = 100
+	if limit < 0 {
+		limit = 0
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
 	}
 	query := `SELECT tenant_id, workspace_id, project_id, connector_id, account_id, COALESCE(account_alias, ''), COALESCE(organization_id, ''), COALESCE(ou_path, ''), partition, region, COALESCE(role_arn, ''), coverage_status, last_successful_scan_at, COALESCE(last_observed_error_code, ''), COALESCE(last_observed_error_message, ''), scan_cursor, suspended, disabled, unreachable, created_at, updated_at
 		 FROM aws_account_region_coverages
@@ -2246,8 +2250,17 @@ func (p *PostgresStore) ListAWSAccountRegionCoverages(ctx context.Context, filte
 		args = append(args, region)
 		nextArg++
 	}
-	query += fmt.Sprintf(" ORDER BY connector_id ASC, account_id ASC, region ASC LIMIT $%d", nextArg)
-	args = append(args, limit)
+	query += " ORDER BY connector_id ASC, account_id ASC, region ASC"
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", nextArg)
+		args = append(args, limit)
+		nextArg++
+	}
+	if offset > 0 {
+		query += fmt.Sprintf(" OFFSET $%d", nextArg)
+		args = append(args, offset)
+		nextArg++
+	}
 
 	rows, err := p.queryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1035,6 +1035,7 @@ type AWSAccountRegionCoverageFilter struct {
 	AccountID   string
 	Region      string
 	Limit       int
+	Offset      int
 }
 
 // AWSPlatformBaselineCheck records one operator-visible readiness check for the

--- a/internal/providers/awscontract/coverage_planner.go
+++ b/internal/providers/awscontract/coverage_planner.go
@@ -139,6 +139,7 @@ type CoverageCheckpoint struct {
 	AccountID     string        `json:"account_id"`
 	Region        string        `json:"region"`
 	Service       string        `json:"service"`
+	Collector     string        `json:"collector,omitempty"`
 	State         CoverageState `json:"state"`
 	Cursor        string        `json:"cursor,omitempty"`
 	FailureReason string        `json:"failure_reason,omitempty"`
@@ -168,6 +169,7 @@ type CoverageTarget struct {
 	RegionName    string           `json:"region_name,omitempty"`
 	Service       string           `json:"service"`
 	ServiceName   string           `json:"service_name,omitempty"`
+	Collector     string           `json:"collector,omitempty"`
 	Global        bool             `json:"global,omitempty"`
 	Enabled       bool             `json:"enabled"`
 	Priority      CoveragePriority `json:"priority"`
@@ -475,6 +477,7 @@ func applyCoverageCheckpoint(target *CoverageTarget, checkpoint CoverageCheckpoi
 	if checkpoint.State != "" {
 		target.State = checkpoint.State
 	}
+	target.Collector = strings.TrimSpace(checkpoint.Collector)
 	target.Cursor = strings.TrimSpace(checkpoint.Cursor)
 	target.FailureReason = strings.TrimSpace(checkpoint.FailureReason)
 	if checkpoint.Attempts > 0 {

--- a/internal/providers/awscontract/fanout_executor.go
+++ b/internal/providers/awscontract/fanout_executor.go
@@ -51,6 +51,7 @@ type FanOutExecutionTarget struct {
 	AccountID       string           `json:"account_id"`
 	Region          string           `json:"region"`
 	Service         string           `json:"service"`
+	Collector       string           `json:"collector,omitempty"`
 	Priority        CoveragePriority `json:"priority"`
 	State           CoverageState    `json:"state"`
 	WorkerState     CoverageState    `json:"worker_state"`
@@ -165,6 +166,7 @@ func buildFanOutExecutionTarget(target CoverageTarget, outcome FanOutTargetOutco
 		AccountID:   target.AccountID,
 		Region:      target.Region,
 		Service:     target.Service,
+		Collector:   target.Collector,
 		Priority:    target.Priority,
 		State:       target.State,
 		WorkerState: target.State,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2714,6 +2714,7 @@ export type AWSCoveragePlanTarget = {
   region_name?: string;
   service: string;
   service_name?: string;
+  collector?: string;
   global: boolean;
   enabled: boolean;
   priority: AWSCoveragePriority;
@@ -2778,7 +2779,7 @@ export type AWSCoveragePlanResult = {
   current_issue_ref: string;
   version: string;
   status: AWSCoveragePlanStatus;
-  fixture_state: AWSCoveragePlanFixtureState;
+  fixture_state?: AWSCoveragePlanFixtureState;
   confidence: number;
   filtered_targets: number;
   summary: AWSCoveragePlanSummary;
@@ -2797,6 +2798,7 @@ export type AWSFanOutExecutionTarget = {
   account_id: string;
   region: string;
   service: string;
+  collector?: string;
   priority: AWSCoveragePriority;
   state: AWSCoverageState;
   worker_state: AWSCoverageState;
@@ -2843,7 +2845,7 @@ export type AWSFanOutExecutionResult = {
   current_issue_ref: string;
   version: string;
   status: AWSCoveragePlanStatus;
-  fixture_state: AWSCoveragePlanFixtureState;
+  fixture_state?: AWSCoveragePlanFixtureState;
   confidence: number;
   filtered_targets: number;
   summary: AWSFanOutExecutionSummary;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4064,6 +4064,9 @@ function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
   if (target.cursor) {
     details.push(`Cursor ${target.cursor}`);
   }
+  if (target.collector) {
+    details.push(`Collector ${formatTokenLabel(target.collector)}`);
+  }
   if (hasAWSCoverageObservedAt(target.observed_at)) {
     details.push(`Observed ${formatConnectionTime(target.observed_at)}`);
   }
@@ -4106,6 +4109,7 @@ function buildAWSCoveragePlanRows(
           target.region,
           target.service,
           target.service_name,
+          target.collector,
           target.state,
           target.priority,
           target.failure_reason,


### PR DESCRIPTION
## Summary
- Implement live AWS scan cursor planning from persisted account/region coverage rows.
- Replay per-service collector checkpoints into coverage-plan and fan-out execution responses, including cursor, attempts, failure reason, observed timestamp, and collector.
- Expire stale resumable cursors after 24 hours and surface malformed/stale cursor diagnostics for operators.
- Update API/web contracts, AWS control-center details, OpenAPI, and docs for cursor troubleshooting.

## Validation
- `go test ./internal/providers/awscontract ./internal/api`
- `cd web && npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `cd web && npm run build`

## AI disclosure
No

Closes #1501

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements live AWS scan cursor planning and fan‑out replay from persisted `aws_account_region_coverages` so collectors resume and operators see per‑service progress. Also blocks invented account/region pairs to reflect only persisted coverage, with global services mapped to their home region.

- **New Features**
  - Read and replay per‑service checkpoints from `scan_cursor` under `services`/`service_cursors`/`checkpoints`/`cursors`; include `collector`, attempts, failure_reason, and observed_at; map global service checkpoints to their home region.
  - Expire `pending`/`in_progress`/`partial`/`failed` cursors after 24h using cursor `observed_at` or coverage row `updated_at`; emit stale/malformed diagnostics; status is blocked on `permission_denied` and degraded when diagnostics exist.
  - Paginate coverage row reads with limit/offset and prioritize accounts/regions by connection home; map region availability (disabled/suspended/unreachable/error) with evidence refs; auto‑discover services from cursors and merge with defaults.
  - Only plan persisted account/region pairs; non‑persisted regional targets are marked `blocked` (global services unaffected).
  - OpenAPI/web: add optional `collector` on plan and fan‑out targets; make `fixture_state` optional; UI shows collector in target details.

- **Migration**
  - Clients should handle optional `fixture_state` and `collector` on targets.
  - Scanners continue writing metadata‑only `scan_cursor` entries; no secrets. Resumable entries older than 24h are ignored.

<sup>Written for commit 58ff9ff77d5e6744d1ab6f30a64a0b0262eac6b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

