### PR TITLE
Implement AWS partial failure reporting

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -89,10 +89,11 @@ entry is scoped to one account, region, and service and includes:
 - failure reason, retryability, attempts, and cursor/checkpoint when available
 - evidence reference, timestamp, and next operator action
 
-Reports are emitted for `partial`, `failed`, `permission_denied`,
-`unsupported`, and `blocked` target states. Successful targets remain in the
-response, so operators can see what was preserved while recovering only the
-degraded target.
+Reports are emitted for `partial`, `failed`, and `permission_denied` target
+states. Blocked and unsupported targets stay visible as target states and
+diagnostics, but are not included in the retry-focused partial failure queue.
+Successful targets remain in the response, so operators can see what was
+preserved while recovering only the degraded target.
 
 When using fixture input or external planner input, `region_availability` and
 `service_availability` constraints are applied after checkpoint replay, so explicit

--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -1,6 +1,6 @@
 # AWS Account and Region Coverage Planner
 
-Issues #1499 and #1501 add a deterministic, metadata-only planner that expands
+Issues #1499, #1501, and #1502 add a deterministic, metadata-only planner that expands
 an AWS connector's configured accounts, regions, service partitions, and
 persisted scan cursors into explicit scan targets.
 
@@ -76,8 +76,23 @@ Optional query parameters:
 - `state`: filter to one coverage lifecycle state.
 
 The response includes tenant, workspace, project, issue metadata, summary
-counts, filtered targets, diagnostics, coverage gaps, remediation hints, and
-evidence links.
+counts, filtered targets, normalized `partial_failure_reports`, diagnostics,
+coverage gaps, remediation hints, and evidence links.
+
+## Partial Failure Reports
+
+`partial_failure_reports` is a normalized dashboard and rerun contract. Each
+entry is scoped to one account, region, and service and includes:
+
+- target key, account, region, service, and collector
+- lifecycle state and reason code
+- failure reason, retryability, attempts, and cursor/checkpoint when available
+- evidence reference, timestamp, and next operator action
+
+Reports are emitted for `partial`, `failed`, `permission_denied`,
+`unsupported`, and `blocked` target states. Successful targets remain in the
+response, so operators can see what was preserved while recovering only the
+degraded target.
 
 When using fixture input or external planner input, `region_availability` and
 `service_availability` constraints are applied after checkpoint replay, so explicit
@@ -99,9 +114,10 @@ queries use deterministic fixtures for validation.
 Denied, unsupported, partial, failed, blocked, and disabled targets are explicit
 states. They are never counted as successful coverage.
 
-Use diagnostics and target-level `next_action` values to decide whether to
-deploy missing read-only roles, enable an opt-in region, remove unsupported
-targets, or rerun resumable targets from their checkpoint.
+Use `partial_failure_reports`, diagnostics, and target-level `next_action`
+values to decide whether to deploy missing read-only roles, enable an opt-in
+region, remove unsupported targets, or rerun resumable targets from their
+checkpoint.
 
 ## Validation
 

--- a/docs/aws-account-region-fanout-worker.md
+++ b/docs/aws-account-region-fanout-worker.md
@@ -1,6 +1,6 @@
 # AWS Account and Region Fan-Out Worker
 
-Issues #1500 and #1501 add a deterministic, metadata-only execution view for
+Issues #1500, #1501, and #1502 add a deterministic, metadata-only execution view for
 bounded AWS account/region/service fan-out. It builds on the coverage planner
 and makes worker state, persisted scan cursors, and downstream recovery state
 explicit for operators.
@@ -38,7 +38,8 @@ Optional query parameters:
 - `max_concurrency`: deterministic worker concurrency limit from 1 to 64.
 
 The response includes issue metadata, summary counts, filtered targets,
-diagnostics, coverage gaps, remediation hints, and evidence links.
+normalized `partial_failure_reports`, diagnostics, coverage gaps, remediation
+hints, and evidence links.
 
 ## Failure And Retry Behavior
 
@@ -47,6 +48,12 @@ Throttled, partial, pending, and in-progress targets preserve their checkpoint
 and retry metadata so a future worker run can resume from the last safe cursor.
 Permission-denied targets are non-retryable until the read-only collector role is
 repaired.
+
+`partial_failure_reports` provides the recovery queue for degraded fan-out
+state. Each report includes account, region, service, collector, worker state,
+reason code, failure reason, retryability, attempts, checkpoint, evidence
+reference, timestamp, and next action. Successful targets stay visible in the
+same response so operators can retry only the failed target scope.
 
 Default API calls replay persisted `scan_cursor` service checkpoints from
 account/region coverage rows. Explicit `fixture_state` calls keep using

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10605,6 +10605,30 @@ components:
         message: { type: string }
         remediation: { type: string }
         retryable: { type: boolean }
+    AWSPartialFailureReport:
+      type: object
+      properties:
+        key: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        collector: { type: string }
+        state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        worker_state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        reason_code: { type: string }
+        failure_reason: { type: string }
+        retryable: { type: boolean }
+        attempts: { type: integer }
+        cursor: { type: string }
+        evidence_ref: { type: string }
+        next_action: { type: string }
+        observed_at:
+          type: string
+          format: date-time
     AWSCoveragePlanCoverageGap:
       type: object
       properties:
@@ -10652,6 +10676,10 @@ components:
         evidence_links:
           type: array
           items: { type: string }
+        partial_failure_reports:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPartialFailureReport"
         coverage_gaps:
           type: array
           items:
@@ -10753,6 +10781,10 @@ components:
         evidence_links:
           type: array
           items: { type: string }
+        partial_failure_reports:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPartialFailureReport"
         coverage_gaps:
           type: array
           items:

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -14,6 +14,7 @@ import (
 )
 
 const awsCoveragePlannerCurrentIssue = 1501
+const awsPartialFailureReportingCurrentIssue = 1502
 const awsCoveragePlannerGlobalServiceHomeRegion = "us-east-1"
 const awsCoverageScanCursorTTL = 24 * time.Hour
 const awsCoveragePlannerAccountRegionPageSize = 250
@@ -88,6 +89,26 @@ type AWSCoveragePlanDiagnostic struct {
 	Retryable   bool   `json:"retryable"`
 }
 
+// AWSPartialFailureReport is one normalized account/region/service failure
+// signal for dashboards, reruns, and operator recovery workflows.
+type AWSPartialFailureReport struct {
+	Key           string    `json:"key"`
+	AccountID     string    `json:"account_id"`
+	Region        string    `json:"region"`
+	Service       string    `json:"service"`
+	Collector     string    `json:"collector,omitempty"`
+	State         string    `json:"state"`
+	WorkerState   string    `json:"worker_state,omitempty"`
+	ReasonCode    string    `json:"reason_code"`
+	FailureReason string    `json:"failure_reason,omitempty"`
+	Retryable     bool      `json:"retryable"`
+	Attempts      int       `json:"attempts,omitempty"`
+	Cursor        string    `json:"cursor,omitempty"`
+	EvidenceRef   string    `json:"evidence_ref"`
+	NextAction    string    `json:"next_action"`
+	ObservedAt    time.Time `json:"observed_at,omitempty"`
+}
+
 // AWSCoveragePlanCoverageGap names an explicit limit of the planner.
 type AWSCoveragePlanCoverageGap struct {
 	Capability  string `json:"capability"`
@@ -118,6 +139,7 @@ type AWSCoveragePlanResult struct {
 	FailureReasons     []string                     `json:"failure_reasons"`
 	RemediationHints   []string                     `json:"remediation_hints"`
 	EvidenceLinks      []string                     `json:"evidence_links"`
+	PartialFailures    []AWSPartialFailureReport    `json:"partial_failure_reports"`
 	CoverageGaps       []AWSCoveragePlanCoverageGap `json:"coverage_gaps"`
 	Diagnostics        []AWSCoveragePlanDiagnostic  `json:"diagnostics"`
 	GeneratedAt        time.Time                    `json:"generated_at"`
@@ -189,8 +211,8 @@ func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection 
 		Region:             region,
 		ParentIssueNumber:  awsPlatformDependencyParentIssue,
 		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
-		CurrentIssueNumber: awsCoveragePlannerCurrentIssue,
-		CurrentIssueRef:    awsIssueRef(awsCoveragePlannerCurrentIssue),
+		CurrentIssueNumber: awsPartialFailureReportingCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPartialFailureReportingCurrentIssue),
 		Version:            plan.Version,
 		Status:             status,
 		FixtureState:       fixtureState,
@@ -202,15 +224,17 @@ func buildAWSCoveragePlan(scope db.Scope, project db.TenancyProject, connection 
 		RemediationHints:   remediations,
 		EvidenceLinks: dedupeStrings([]string{
 			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPartialFailureReportingCurrentIssue),
 			awsIssueURL(awsCoveragePlannerCurrentIssue),
 			"/docs/aws-account-region-coverage-planner",
 			"/docs/aws-service-collector-contract",
 			awsBaselineProjectEvidenceURL(scope, project),
 		}),
-		CoverageGaps: gaps,
-		Diagnostics:  diagnostics,
-		GeneratedAt:  checkedAt,
-		UpdatedAt:    checkedAt,
+		PartialFailures: buildAWSCoveragePartialFailureReports(filtered),
+		CoverageGaps:    gaps,
+		Diagnostics:     diagnostics,
+		GeneratedAt:     checkedAt,
+		UpdatedAt:       checkedAt,
 	}, nil
 }
 
@@ -382,6 +406,66 @@ func awsCoverageMissingAccountRegionServiceAvailability(accounts []awscontract.C
 
 func awsCoverageAccountRegionKey(accountID string, region string) string {
 	return strings.TrimSpace(accountID) + "|" + strings.ToLower(strings.TrimSpace(region))
+}
+
+func buildAWSCoveragePartialFailureReports(targets []AWSCoveragePlanTarget) []AWSPartialFailureReport {
+	reports := []AWSPartialFailureReport{}
+	for _, target := range targets {
+		state := strings.ToLower(strings.TrimSpace(target.State))
+		if !awsCoverageStateIsPartialFailure(state) {
+			continue
+		}
+		reports = append(reports, AWSPartialFailureReport{
+			Key:           target.Key,
+			AccountID:     target.AccountID,
+			Region:        target.Region,
+			Service:       target.Service,
+			Collector:     target.Collector,
+			State:         state,
+			ReasonCode:    awsCoveragePartialFailureReasonCode(state, target.FailureReason, target.Reason),
+			FailureReason: firstNonEmptyAWSValue(target.FailureReason, target.Reason),
+			Retryable:     target.Resumable && (state == string(awscontract.CoverageStatePartial) || state == string(awscontract.CoverageStateFailed)),
+			Attempts:      target.Attempts,
+			Cursor:        target.Cursor,
+			EvidenceRef:   target.EvidenceRef,
+			NextAction:    target.NextAction,
+			ObservedAt:    target.ObservedAt,
+		})
+	}
+	return reports
+}
+
+func awsCoverageStateIsPartialFailure(state string) bool {
+	switch awscontract.CoverageState(strings.ToLower(strings.TrimSpace(state))) {
+	case awscontract.CoverageStatePartial, awscontract.CoverageStateFailed, awscontract.CoverageStatePermissionDenied, awscontract.CoverageStateUnsupported, awscontract.CoverageStateBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func awsCoveragePartialFailureReasonCode(state string, values ...string) string {
+	combined := strings.ToLower(strings.Join(values, " "))
+	switch {
+	case strings.Contains(combined, "throttl"):
+		return "throttled"
+	case strings.Contains(combined, "accessdenied") || strings.Contains(combined, "access denied") || strings.Contains(combined, "permission") || state == string(awscontract.CoverageStatePermissionDenied):
+		return "permission_denied"
+	case strings.Contains(combined, "unsupported") || state == string(awscontract.CoverageStateUnsupported):
+		return "unsupported"
+	case strings.Contains(combined, "stale"):
+		return "stale_cursor"
+	case strings.Contains(combined, "no persisted account/region"):
+		return "missing_account_region_coverage"
+	case state == string(awscontract.CoverageStateBlocked):
+		return "blocked"
+	case state == string(awscontract.CoverageStatePartial):
+		return "partial_failure"
+	case state == string(awscontract.CoverageStateFailed):
+		return "failed"
+	default:
+		return state
+	}
 }
 
 func awsCoverageAvailabilityFromRow(row db.AWSAccountRegionCoverage, checkedAt time.Time) awscontract.CoverageAccountRegionAvailability {
@@ -956,6 +1040,11 @@ func summarizeAWSCoveragePlan(fixtureState string, diagnostics []AWSCoveragePlan
 				awsCoveragePlanDiagnosticMessages(diagnostics),
 				[]string{"Refresh stale or malformed scan cursors so retry and resume behavior stays accurate."}
 		}
+		if plan.Summary.FailedTargets > 0 || awsCoveragePlanStateCount(plan, awscontract.CoverageStatePartial) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.74,
+				awsCoveragePlanDiagnosticMessages(diagnostics),
+				[]string{"Use partial failure reports to retry only failed account/region/service targets; successful targets stay preserved."}
+		}
 		if plan.Summary.TotalTargets == 0 {
 			return awsPlatformDependencyStatusReady, 0.8, nil,
 				[]string{"No accounts, regions, or services are configured for coverage; add scan targets to the AWS connector."}
@@ -967,6 +1056,13 @@ func summarizeAWSCoveragePlan(fixtureState string, diagnostics []AWSCoveragePlan
 		return awsPlatformDependencyStatusReady, 0.94, nil,
 			[]string{"Coverage plan is deterministic and resumable; schedule the fan-out scan worker to execute outstanding targets."}
 	}
+}
+
+func awsCoveragePlanStateCount(plan awscontract.CoveragePlan, state awscontract.CoverageState) int {
+	if plan.Summary.StateCounts == nil {
+		return 0
+	}
+	return plan.Summary.StateCounts[state]
 }
 
 func awsCoveragePlanHasDiagnosticCode(diagnostics []AWSCoveragePlanDiagnostic, code string) bool {

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -437,7 +437,7 @@ func buildAWSCoveragePartialFailureReports(targets []AWSCoveragePlanTarget) []AW
 
 func awsCoverageStateIsPartialFailure(state string) bool {
 	switch awscontract.CoverageState(strings.ToLower(strings.TrimSpace(state))) {
-	case awscontract.CoverageStatePartial, awscontract.CoverageStateFailed, awscontract.CoverageStatePermissionDenied, awscontract.CoverageStateUnsupported, awscontract.CoverageStateBlocked:
+	case awscontract.CoverageStatePartial, awscontract.CoverageStateFailed, awscontract.CoverageStatePermissionDenied:
 		return true
 	default:
 		return false

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -42,7 +42,7 @@ func TestGetAWSCoveragePlanSuccess(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready plan, got %+v", result)
 	}
-	if result.CurrentIssueRef != "#1501" || result.Version == "" {
+	if result.CurrentIssueRef != "#1502" || result.Version == "" {
 		t.Fatalf("unexpected metadata: %+v", result)
 	}
 	if result.Summary.AccountCount != 1 || result.Summary.RegionCount != 1 || result.Summary.ServiceCount != 6 {
@@ -174,6 +174,48 @@ func TestGetAWSCoveragePlanBlocksInventedLiveAccountRegionPairs(t *testing.T) {
 	}
 	if iam := targetsByKey["222222222222|us-east-1|iam"]; iam.State == "blocked" {
 		t.Fatalf("global iam home-region target should not be blocked as an invented regional pair: %+v", iam)
+	}
+}
+
+func TestGetAWSCoveragePlanPartialFailureReports(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 50, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"lambda": map[string]any{
+				"collector":      "lambda_execution_roles",
+				"state":          "partial",
+				"cursor":         "lambda-page-3",
+				"attempts":       2,
+				"failure_reason": "Throttling: lambda ListFunctions after partial page",
+				"observed_at":    now.Format(time.RFC3339Nano),
+			},
+		}},
+		UpdatedAt: now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSCoveragePlan(ctx, "default", "project-a", AWSCoveragePlanRequest{ConnectorID: "aws-prod", State: "partial"})
+	if err != nil {
+		t.Fatalf("get coverage plan: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded || len(result.PartialFailures) != 1 {
+		t.Fatalf("expected one degraded partial failure report, got %+v", result)
+	}
+	report := result.PartialFailures[0]
+	if report.AccountID != "123456789012" || report.Region != "us-east-1" || report.Service != "lambda" || report.Collector != "lambda_execution_roles" {
+		t.Fatalf("unexpected report scope: %+v", report)
+	}
+	if report.ReasonCode != "throttled" || !report.Retryable || report.Cursor != "lambda-page-3" || report.Attempts != 2 {
+		t.Fatalf("expected retryable throttled cursor report, got %+v", report)
 	}
 }
 

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -175,6 +175,9 @@ func TestGetAWSCoveragePlanBlocksInventedLiveAccountRegionPairs(t *testing.T) {
 	if iam := targetsByKey["222222222222|us-east-1|iam"]; iam.State == "blocked" {
 		t.Fatalf("global iam home-region target should not be blocked as an invented regional pair: %+v", iam)
 	}
+	if len(result.PartialFailures) != 0 {
+		t.Fatalf("blocked prerequisite gaps should not become retry-focused partial failure reports: %+v", result.PartialFailures)
+	}
 }
 
 func TestGetAWSCoveragePlanPartialFailureReports(t *testing.T) {

--- a/internal/api/aws_fanout_execution.go
+++ b/internal/api/aws_fanout_execution.go
@@ -85,6 +85,7 @@ type AWSFanOutExecutionResult struct {
 	FailureReasons     []string                     `json:"failure_reasons"`
 	RemediationHints   []string                     `json:"remediation_hints"`
 	EvidenceLinks      []string                     `json:"evidence_links"`
+	PartialFailures    []AWSPartialFailureReport    `json:"partial_failure_reports"`
 	CoverageGaps       []AWSCoveragePlanCoverageGap `json:"coverage_gaps"`
 	Diagnostics        []AWSCoveragePlanDiagnostic  `json:"diagnostics"`
 	GeneratedAt        time.Time                    `json:"generated_at"`
@@ -169,8 +170,8 @@ func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connecti
 		Region:             region,
 		ParentIssueNumber:  awsPlatformDependencyParentIssue,
 		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
-		CurrentIssueNumber: awsFanOutExecutionCurrentIssue,
-		CurrentIssueRef:    awsIssueRef(awsFanOutExecutionCurrentIssue),
+		CurrentIssueNumber: awsPartialFailureReportingCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPartialFailureReportingCurrentIssue),
 		Version:            execution.Version,
 		Status:             status,
 		FixtureState:       fixtureState,
@@ -182,15 +183,17 @@ func buildAWSFanOutExecution(scope db.Scope, project db.TenancyProject, connecti
 		RemediationHints:   remediations,
 		EvidenceLinks: dedupeStrings([]string{
 			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPartialFailureReportingCurrentIssue),
 			awsIssueURL(awsFanOutExecutionCurrentIssue),
 			"/docs/aws-account-region-fanout-worker",
 			"/docs/aws-account-region-coverage-planner",
 			awsBaselineProjectEvidenceURL(scope, project),
 		}),
-		CoverageGaps: gaps,
-		Diagnostics:  diagnostics,
-		GeneratedAt:  checkedAt,
-		UpdatedAt:    checkedAt,
+		PartialFailures: buildAWSFanOutPartialFailureReports(filtered),
+		CoverageGaps:    gaps,
+		Diagnostics:     diagnostics,
+		GeneratedAt:     checkedAt,
+		UpdatedAt:       checkedAt,
 	}, nil
 }
 
@@ -297,6 +300,37 @@ func filterAWSFanOutExecutionTargets(targets []AWSFanOutExecutionTarget, request
 		filtered = append(filtered, target)
 	}
 	return filtered
+}
+
+func buildAWSFanOutPartialFailureReports(targets []AWSFanOutExecutionTarget) []AWSPartialFailureReport {
+	reports := []AWSPartialFailureReport{}
+	for _, target := range targets {
+		state := strings.ToLower(strings.TrimSpace(target.WorkerState))
+		if state == "" {
+			state = strings.ToLower(strings.TrimSpace(target.State))
+		}
+		if !awsCoverageStateIsPartialFailure(state) {
+			continue
+		}
+		reports = append(reports, AWSPartialFailureReport{
+			Key:           target.Key,
+			AccountID:     target.AccountID,
+			Region:        target.Region,
+			Service:       target.Service,
+			Collector:     target.Collector,
+			State:         strings.ToLower(strings.TrimSpace(target.State)),
+			WorkerState:   state,
+			ReasonCode:    awsCoveragePartialFailureReasonCode(state, target.FailureReason, target.NextAction),
+			FailureReason: target.FailureReason,
+			Retryable:     target.Retryable,
+			Attempts:      target.Attempts,
+			Cursor:        target.Checkpoint,
+			EvidenceRef:   target.EvidenceRef,
+			NextAction:    target.NextAction,
+			ObservedAt:    target.ObservedAt,
+		})
+	}
+	return reports
 }
 
 func summarizeAWSFanOutExecution(fixtureState string, diagnostics []AWSCoveragePlanDiagnostic, execution awscontract.FanOutExecutionPlan) (string, float64, []string, []string) {

--- a/internal/api/aws_fanout_execution_test.go
+++ b/internal/api/aws_fanout_execution_test.go
@@ -37,7 +37,7 @@ func TestGetAWSFanOutExecutionSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get fan-out execution: %v", err)
 	}
-	if result.Status != awsPlatformDependencyStatusReady || result.CurrentIssueRef != "#1500" {
+	if result.Status != awsPlatformDependencyStatusReady || result.CurrentIssueRef != "#1502" {
 		t.Fatalf("unexpected execution metadata: %+v", result)
 	}
 	if result.Summary.ConcurrencyLimit != 2 || result.Summary.InProgressTargets > 2 {
@@ -92,6 +92,19 @@ func TestGetAWSFanOutExecutionDegradedAndDenied(t *testing.T) {
 	}
 	if len(degraded.Diagnostics) == 0 || len(degraded.RemediationHints) == 0 {
 		t.Fatalf("degraded execution should carry diagnostics and hints: %+v", degraded)
+	}
+	if len(degraded.PartialFailures) == 0 {
+		t.Fatalf("degraded execution should carry partial failure reports: %+v", degraded)
+	}
+	var partialReport AWSPartialFailureReport
+	for _, report := range degraded.PartialFailures {
+		if report.Service == "lambda" && report.WorkerState == "partial" {
+			partialReport = report
+			break
+		}
+	}
+	if partialReport.ReasonCode != "partial_failure" || !partialReport.Retryable || partialReport.Cursor != "lambda-page-3" {
+		t.Fatalf("expected retryable lambda partial failure report, got %+v", partialReport)
 	}
 
 	denied, err := svc.GetAWSFanOutExecution(ctx, "default", "project-a", AWSFanOutExecutionRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2759,6 +2759,24 @@ export type AWSCoveragePlanDiagnostic = {
   retryable: boolean;
 };
 
+export type AWSPartialFailureReport = {
+  key: string;
+  account_id: string;
+  region: string;
+  service: string;
+  collector?: string;
+  state: AWSCoverageState;
+  worker_state?: AWSCoverageState;
+  reason_code: string;
+  failure_reason?: string;
+  retryable: boolean;
+  attempts?: number;
+  cursor?: string;
+  evidence_ref: string;
+  next_action: string;
+  observed_at?: string;
+};
+
 export type AWSCoveragePlanCoverageGap = {
   capability: string;
   status: string;
@@ -2787,6 +2805,7 @@ export type AWSCoveragePlanResult = {
   failure_reasons: string[];
   remediation_hints: string[];
   evidence_links: string[];
+  partial_failure_reports: AWSPartialFailureReport[];
   coverage_gaps: AWSCoveragePlanCoverageGap[];
   diagnostics: AWSCoveragePlanDiagnostic[];
   generated_at: string;
@@ -2853,6 +2872,7 @@ export type AWSFanOutExecutionResult = {
   failure_reasons: string[];
   remediation_hints: string[];
   evidence_links: string[];
+  partial_failure_reports: AWSPartialFailureReport[];
   coverage_gaps: AWSCoveragePlanCoverageGap[];
   diagnostics: AWSCoveragePlanDiagnostic[];
   generated_at: string;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4476,10 +4476,10 @@ function AWSAccountsInventoryContent({
       : 0;
   const displayedRows = filterAWSInventoryRows(rows, filters);
   const displayedTopologyRows = filterAWSInventoryRows(topologyRows, filters);
-  const partialFailureReports = [
+  const partialFailureReports = dedupeAWSPartialFailureReports([
     ...(execution?.partial_failure_reports ?? []),
     ...(plan?.partial_failure_reports ?? [])
-  ];
+  ]);
 
   return (
     <>
@@ -4597,7 +4597,7 @@ function AWSAccountsInventoryContent({
           status={`${partialFailureReports.length} target${partialFailureReports.length === 1 ? '' : 's'}`}
           tone="warning"
         >
-          <AWSPartialFailureReportList reports={partialFailureReports.slice(0, 12)} label="AWS partial failure reports" />
+          <AWSPartialFailureReportList reports={partialFailureReports} label="AWS partial failure reports" />
         </DomainStatusPanel>
       ) : null}
       {topology?.diagnostics.length ? (
@@ -4668,6 +4668,20 @@ function AWSAccountsInventoryContent({
       </DomainStatusPanel>
     </>
   );
+}
+
+function dedupeAWSPartialFailureReports(reports: AWSPartialFailureReport[]) {
+  const seen = new Set<string>();
+  const deduped: AWSPartialFailureReport[] = [];
+  for (const report of reports) {
+    const key = report.key || `${report.account_id}|${report.region}|${report.service}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(report);
+  }
+  return deduped;
 }
 
 function AWSPartialFailureReportList({ reports, label }: { reports: AWSPartialFailureReport[]; label: string }) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -51,6 +51,7 @@ import {
   type AWSPlatformDependencyIndexResult,
   type AWSPlatformValidationHarnessResult,
   type AWSServiceCollectorContractResult,
+  type AWSPartialFailureReport,
   type AWSECRRepositoryMetadataInventoryResult,
   type AWSECRRepositoryMetadataRecord,
   type AWSDynamoDBRDSReachabilityInventoryResult,
@@ -4475,6 +4476,10 @@ function AWSAccountsInventoryContent({
       : 0;
   const displayedRows = filterAWSInventoryRows(rows, filters);
   const displayedTopologyRows = filterAWSInventoryRows(topologyRows, filters);
+  const partialFailureReports = [
+    ...(execution?.partial_failure_reports ?? []),
+    ...(plan?.partial_failure_reports ?? [])
+  ];
 
   return (
     <>
@@ -4585,6 +4590,16 @@ function AWSAccountsInventoryContent({
           </div>
         </DomainStatusPanel>
       ) : null}
+      {partialFailureReports.length ? (
+        <DomainStatusPanel
+          eyebrow="Partial failure reporting"
+          title="Degraded targets stay scoped and recoverable"
+          status={`${partialFailureReports.length} target${partialFailureReports.length === 1 ? '' : 's'}`}
+          tone="warning"
+        >
+          <AWSPartialFailureReportList reports={partialFailureReports.slice(0, 12)} label="AWS partial failure reports" />
+        </DomainStatusPanel>
+      ) : null}
       {topology?.diagnostics.length ? (
         <DomainStatusPanel
           eyebrow="Organizations diagnostics"
@@ -4652,6 +4667,31 @@ function AWSAccountsInventoryContent({
         ) : null}
       </DomainStatusPanel>
     </>
+  );
+}
+
+function AWSPartialFailureReportList({ reports, label }: { reports: AWSPartialFailureReport[]; label: string }) {
+  return (
+    <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label={label}>
+      {reports.map((report) => (
+        <article key={`${report.key}-${report.worker_state ?? report.state}-${report.reason_code}`}>
+          <strong>
+            {formatTokenLabel(report.service)} · {formatTokenLabel(report.reason_code)}
+          </strong>
+          <p>
+            {report.account_id} / {report.region}
+            {report.collector ? ` / ${formatTokenLabel(report.collector)}` : ''}
+          </p>
+          <small>
+            {formatTokenLabel(report.worker_state ?? report.state)} · {report.retryable ? 'Retryable' : 'Not retryable'}
+            {report.attempts ? ` · ${report.attempts} attempts` : ''}
+            {report.cursor ? ` · ${report.cursor}` : ''}
+          </small>
+          {report.failure_reason ? <p>{report.failure_reason}</p> : null}
+          <small>{report.next_action}</small>
+        </article>
+      ))}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add normalized `partial_failure_reports` to AWS coverage-plan and fan-out execution responses for account/region/service scoped recovery.
- Mark the enhanced reporting capability as issue #1502 in API metadata while preserving the existing planner/executor versions and evidence links.
- Surface partial failure reports in the AWS account/region UI so operators can see reason codes, retryability, attempts, checkpoints, evidence, and next actions without reading logs.
- Update OpenAPI and AWS coverage/fan-out docs for the new reporting contract.

## Validation
- `go test ./internal/providers/awscontract ./internal/api`
- `cd web && npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `cd web && npm run build`

## AI disclosure
No

Closes #1502

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements normalized partial failure reporting for AWS coverage and fan-out so operators can see scoped failures and retry only what failed. Addresses #1502 with API fields, docs, UI, and client types.

- New Features
  - Add `partial_failure_reports` to coverage plan and fan-out responses with `AWSPartialFailureReport` (key, account, region, service, collector, state/worker_state, reason_code, failure_reason, retryable, attempts, cursor, evidence_ref, next_action, observed_at).
  - Set current API metadata to issue `#1502` while preserving existing versions and evidence links.
  - Update OpenAPI v1 schemas and TypeScript client to include `AWSPartialFailureReport` and the new response fields.
  - Show a compact “Partial failure reporting” panel in the AWS Accounts UI, deduping reports from plan and execution; successful targets stay visible.
  - Refresh planner and fan-out docs with the reporting contract and recovery flow.

<sup>Written for commit 055d268766a60efd8face9da04d4805d847cc6a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

