### PR TITLE
Implement AWS account region coverage API

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -1,6 +1,6 @@
 # AWS Account and Region Coverage Planner
 
-Issues #1499, #1501, and #1502 add a deterministic, metadata-only planner that expands
+Issues #1499, #1501, #1502, and #1503 add a deterministic, metadata-only planner and public coverage API that expands
 an AWS connector's configured accounts, regions, service partitions, and
 persisted scan cursors into explicit scan targets.
 
@@ -78,6 +78,38 @@ Optional query parameters:
 The response includes tenant, workspace, project, issue metadata, summary
 counts, filtered targets, normalized `partial_failure_reports`, diagnostics,
 coverage gaps, remediation hints, and evidence links.
+
+## Public Account/Region Coverage API
+
+```http
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/account-region-coverage
+```
+
+This endpoint returns row-oriented coverage records for dashboards, recovery,
+and rerun workflows. It reuses the planner contract but normalizes each target
+into a public `coverage_status`:
+
+- `covered`
+- `missing`
+- `degraded`
+- `unreachable`
+- `suspended`
+- `disabled`
+- `stale`
+- `permission_denied`
+
+Optional query parameters are `connector_id`, `fixture_state`, `account`,
+`region`, `service`, `collector`, `state`, and `status`.
+
+Each record includes account, region, service, collector, lifecycle state,
+public coverage status, cursor/checkpoint, attempts, failure reason,
+retryability, stale flag, evidence reference, timestamps, and next action. The
+summary includes total and filtered record counts plus status, state, and
+collector breakdowns.
+
+Use the planner endpoint when you need target expansion and prerequisites. Use
+the public coverage API when an operator or dashboard needs filterable coverage
+state without reading logs or internal tables.
 
 ## Partial Failure Reports
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -569,6 +569,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/account-region-coverage
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/fanout-execution
     action: tenancy.read
     resource_type: project
@@ -4655,6 +4660,84 @@ paths:
                     $ref: "#/components/schemas/AWSCoveragePlanResult"
         "400":
           description: Invalid AWS coverage plan request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/account-region-coverage:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get public AWS account and region coverage records
+      operationId: getAWSProjectAccountRegionCoverage
+      description: Returns normalized account/region/service/collector coverage records for dashboards, reruns, and operator drill-downs. Supports covered, missing, degraded, unreachable, suspended, disabled, stale, and permission_denied status filters, and returns timestamps, cursor/checkpoint state, evidence references, failure reasons, and next actions. Read-only and metadata-only - this API reads no customer payloads and mutates no AWS state.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and coverage evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account
+          schema: { type: string }
+          description: Optional 12-digit AWS account id filter.
+        - in: query
+          name: region
+          schema: { type: string }
+          description: Optional AWS region code filter.
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Optional AWS service partition filter (for example iam, ec2, lambda).
+        - in: query
+          name: collector
+          schema: { type: string }
+          description: Optional collector name filter.
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+          description: Optional internal coverage lifecycle state filter.
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [covered, missing, degraded, unreachable, suspended, disabled, stale, permission_denied]
+          description: Optional public coverage status filter.
+      responses:
+        "200":
+          description: Public AWS account and region coverage records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  coverage:
+                    $ref: "#/components/schemas/AWSAccountRegionCoverageResult"
+        "400":
+          description: Invalid AWS account-region coverage request
           content:
             application/json:
               schema:
@@ -10680,6 +10763,118 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPartialFailureReport"
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCoveragePlanDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAccountRegionCoverageRecord:
+      type: object
+      properties:
+        key: { type: string }
+        account_id: { type: string }
+        account_name: { type: string }
+        region: { type: string }
+        region_name: { type: string }
+        service: { type: string }
+        service_name: { type: string }
+        collector: { type: string }
+        global: { type: boolean }
+        enabled: { type: boolean }
+        state:
+          type: string
+          enum: [planned, pending, in_progress, covered, partial, failed, permission_denied, unsupported, blocked, disabled]
+        coverage_status:
+          type: string
+          enum: [covered, missing, degraded, unreachable, suspended, disabled, stale, permission_denied]
+        cursor: { type: string }
+        checkpoint: { type: string }
+        attempts: { type: integer }
+        failure_reason: { type: string }
+        retryable: { type: boolean }
+        stale: { type: boolean }
+        evidence_ref: { type: string }
+        next_action: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAccountRegionCoverageSummary:
+      type: object
+      properties:
+        total_records: { type: integer }
+        filtered_records: { type: integer }
+        account_count: { type: integer }
+        region_count: { type: integer }
+        service_count: { type: integer }
+        covered_records: { type: integer }
+        missing_records: { type: integer }
+        degraded_records: { type: integer }
+        unreachable_records: { type: integer }
+        suspended_records: { type: integer }
+        disabled_records: { type: integer }
+        stale_records: { type: integer }
+        permission_denied_records: { type: integer }
+        retryable_records: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        collector_counts:
+          type: object
+          additionalProperties: { type: integer }
+    AWSAccountRegionCoverageResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        summary:
+          $ref: "#/components/schemas/AWSAccountRegionCoverageSummary"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccountRegionCoverageRecord"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
         coverage_gaps:
           type: array
           items:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -757,6 +757,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/dynamodb-rds-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/credential-references", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/coverage-plan", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/account-region-coverage", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/fanout-execution", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -269,6 +269,8 @@ func awsAccountRegionCoverageStatus(target AWSCoveragePlanTarget, stale bool) st
 		return "unreachable"
 	case state == "permission_denied":
 		return "permission_denied"
+	case state == "blocked":
+		return "missing"
 	case state == "planned" || state == "pending" || state == "in_progress":
 		return "missing"
 	default:

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -244,21 +244,6 @@ func staleDiagnosticCursor(diagnostic *AWSCoveragePlanDiagnostic) string {
 	return strings.TrimSpace(diagnostic.Cursor)
 }
 
-func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]AWSCoveragePlanDiagnostic {
-	out := map[string]AWSCoveragePlanDiagnostic{}
-	for _, diagnostic := range diagnostics {
-		if strings.ToLower(strings.TrimSpace(diagnostic.Code)) != "stale_cursor_expired" {
-			continue
-		}
-		scope := strings.ToLower(strings.TrimSpace(diagnostic.Scope))
-		if scope == "" {
-			continue
-		}
-		out[scope] = diagnostic
-	}
-	return out
-}
-
 func awsAccountRegionCoverageStatus(target AWSCoveragePlanTarget, stale bool) string {
 	if stale {
 		return "stale"

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -211,10 +211,14 @@ func awsCoverageStaleDiagnostics(diagnostics []AWSCoveragePlanDiagnostic) map[st
 
 func awsCoverageStaleDiagnosticForTarget(staleDiagnostics map[string]AWSCoveragePlanDiagnostic, target AWSCoveragePlanTarget) (*AWSCoveragePlanDiagnostic, bool) {
 	service := strings.ToLower(strings.TrimSpace(target.Service))
+	state := strings.ToLower(strings.TrimSpace(target.State))
 	region := strings.ToLower(strings.TrimSpace(target.Region))
 	exactScope := strings.Join([]string{target.AccountID, region, service}, "/")
 	if diagnostic, ok := staleDiagnostics[exactScope]; ok {
 		return &diagnostic, true
+	}
+	if state == "covered" {
+		return nil, false
 	}
 	if !target.Global {
 		return nil, false

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -165,6 +165,7 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 		if stale && staleDiagnostic != nil {
 			failureReason = firstNonEmptyAWSValue(failureReason, staleDiagnostic.Message)
 		}
+		collector := firstNonEmptyAWSValue(target.Collector, staleDiagnosticCollector(staleDiagnostic))
 		records = append(records, AWSAccountRegionCoverageRecord{
 			Key:            target.Key,
 			AccountID:      target.AccountID,
@@ -173,7 +174,7 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 			RegionName:     target.RegionName,
 			Service:        target.Service,
 			ServiceName:    target.ServiceName,
-			Collector:      target.Collector,
+			Collector:      collector,
 			Global:         target.Global,
 			Enabled:        target.Enabled,
 			State:          target.State,
@@ -242,6 +243,13 @@ func staleDiagnosticCursor(diagnostic *AWSCoveragePlanDiagnostic) string {
 		return ""
 	}
 	return strings.TrimSpace(diagnostic.Cursor)
+}
+
+func staleDiagnosticCollector(diagnostic *AWSCoveragePlanDiagnostic) string {
+	if diagnostic == nil {
+		return ""
+	}
+	return strings.TrimSpace(diagnostic.Collector)
 }
 
 func awsAccountRegionCoverageStatus(target AWSCoveragePlanTarget, stale bool) string {

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -158,8 +158,7 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 	staleScopes := awsCoverageStaleDiagnosticScopes(plan.Diagnostics)
 	records := make([]AWSAccountRegionCoverageRecord, 0, len(plan.Targets))
 	for _, target := range plan.Targets {
-		scope := strings.Join([]string{target.AccountID, strings.ToLower(strings.TrimSpace(target.Region)), strings.ToLower(strings.TrimSpace(target.Service))}, "/")
-		staleMessage, stale := staleScopes[scope]
+		staleMessage, stale := awsCoverageStaleDiagnosticForTarget(staleScopes, target)
 		status := awsAccountRegionCoverageStatus(target, stale)
 		failureReason := firstNonEmptyAWSValue(target.FailureReason, target.Reason)
 		if stale && staleMessage != "" {
@@ -191,6 +190,28 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 		})
 	}
 	return records
+}
+
+func awsCoverageStaleDiagnosticForTarget(staleScopes map[string]string, target AWSCoveragePlanTarget) (string, bool) {
+	service := strings.ToLower(strings.TrimSpace(target.Service))
+	region := strings.ToLower(strings.TrimSpace(target.Region))
+	exactScope := strings.Join([]string{target.AccountID, region, service}, "/")
+	if message, ok := staleScopes[exactScope]; ok {
+		return message, true
+	}
+	if !target.Global {
+		return "", false
+	}
+	for scope, message := range staleScopes {
+		parts := strings.Split(scope, "/")
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] == strings.TrimSpace(target.AccountID) && parts[2] == service {
+			return message, true
+		}
+	}
+	return "", false
 }
 
 func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]string {

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -1,0 +1,350 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+const awsAccountRegionCoverageAPICurrentIssue = 1503
+
+// AWSAccountRegionCoverageRequest filters the public coverage API.
+type AWSAccountRegionCoverageRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	Account      string `json:"account,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Service      string `json:"service,omitempty"`
+	Collector    string `json:"collector,omitempty"`
+	State        string `json:"state,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// AWSAccountRegionCoverageRecord is one public, metadata-only coverage row.
+type AWSAccountRegionCoverageRecord struct {
+	Key            string    `json:"key"`
+	AccountID      string    `json:"account_id"`
+	AccountName    string    `json:"account_name,omitempty"`
+	Region         string    `json:"region"`
+	RegionName     string    `json:"region_name,omitempty"`
+	Service        string    `json:"service"`
+	ServiceName    string    `json:"service_name,omitempty"`
+	Collector      string    `json:"collector,omitempty"`
+	Global         bool      `json:"global"`
+	Enabled        bool      `json:"enabled"`
+	State          string    `json:"state"`
+	CoverageStatus string    `json:"coverage_status"`
+	Cursor         string    `json:"cursor,omitempty"`
+	Checkpoint     string    `json:"checkpoint,omitempty"`
+	Attempts       int       `json:"attempts,omitempty"`
+	FailureReason  string    `json:"failure_reason,omitempty"`
+	Retryable      bool      `json:"retryable"`
+	Stale          bool      `json:"stale"`
+	EvidenceRef    string    `json:"evidence_ref"`
+	NextAction     string    `json:"next_action"`
+	ObservedAt     time.Time `json:"observed_at,omitempty"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// AWSAccountRegionCoverageSummary is optimized for dashboards and filters.
+type AWSAccountRegionCoverageSummary struct {
+	TotalRecords            int            `json:"total_records"`
+	FilteredRecords         int            `json:"filtered_records"`
+	AccountCount            int            `json:"account_count"`
+	RegionCount             int            `json:"region_count"`
+	ServiceCount            int            `json:"service_count"`
+	CoveredRecords          int            `json:"covered_records"`
+	MissingRecords          int            `json:"missing_records"`
+	DegradedRecords         int            `json:"degraded_records"`
+	UnreachableRecords      int            `json:"unreachable_records"`
+	SuspendedRecords        int            `json:"suspended_records"`
+	DisabledRecords         int            `json:"disabled_records"`
+	StaleRecords            int            `json:"stale_records"`
+	PermissionDeniedRecords int            `json:"permission_denied_records"`
+	RetryableRecords        int            `json:"retryable_records"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	StateCounts             map[string]int `json:"state_counts"`
+	CollectorCounts         map[string]int `json:"collector_counts"`
+}
+
+// AWSAccountRegionCoverageResult is the public account/region coverage API.
+type AWSAccountRegionCoverageResult struct {
+	TenantID           string                           `json:"tenant_id"`
+	WorkspaceID        string                           `json:"workspace_id"`
+	ProjectID          string                           `json:"project_id"`
+	ConnectorID        string                           `json:"connector_id,omitempty"`
+	AccountID          string                           `json:"account_id,omitempty"`
+	Region             string                           `json:"region,omitempty"`
+	ParentIssueNumber  int                              `json:"parent_issue_number"`
+	ParentIssueRef     string                           `json:"parent_issue_ref"`
+	CurrentIssueNumber int                              `json:"current_issue_number"`
+	CurrentIssueRef    string                           `json:"current_issue_ref"`
+	Version            string                           `json:"version"`
+	Status             string                           `json:"status"`
+	FixtureState       string                           `json:"fixture_state,omitempty"`
+	Confidence         float64                          `json:"confidence"`
+	Summary            AWSAccountRegionCoverageSummary  `json:"summary"`
+	Records            []AWSAccountRegionCoverageRecord `json:"records"`
+	FailureReasons     []string                         `json:"failure_reasons"`
+	RemediationHints   []string                         `json:"remediation_hints"`
+	EvidenceLinks      []string                         `json:"evidence_links"`
+	CoverageGaps       []AWSCoveragePlanCoverageGap     `json:"coverage_gaps"`
+	Diagnostics        []AWSCoveragePlanDiagnostic      `json:"diagnostics"`
+	GeneratedAt        time.Time                        `json:"generated_at"`
+	UpdatedAt          time.Time                        `json:"updated_at"`
+}
+
+// GetAWSAccountRegionCoverage returns the public, row-oriented coverage API for
+// account, region, service, and collector status. The API is read-only and
+// exposes metadata, cursors, evidence refs, and recovery actions without
+// reading customer payloads or secret values.
+func (s *Service) GetAWSAccountRegionCoverage(ctx context.Context, workspaceID string, projectID string, request AWSAccountRegionCoverageRequest) (AWSAccountRegionCoverageResult, error) {
+	if !validAWSAccountRegionCoverageStatusFilter(request.Status) {
+		return AWSAccountRegionCoverageResult{}, ErrInvalidAWSConnectionRequest
+	}
+	planRequest := AWSCoveragePlanRequest{
+		ConnectorID:  request.ConnectorID,
+		FixtureState: request.FixtureState,
+		Account:      request.Account,
+		Region:       request.Region,
+		Service:      request.Service,
+		State:        request.State,
+	}
+	plan, err := s.GetAWSCoveragePlan(ctx, workspaceID, projectID, planRequest)
+	if err != nil {
+		return AWSAccountRegionCoverageResult{}, err
+	}
+	records := buildAWSAccountRegionCoverageRecords(plan)
+	filtered := filterAWSAccountRegionCoverageRecords(records, request)
+	summary := summarizeAWSAccountRegionCoverage(records, len(filtered))
+	status, confidence, failures, remediations := summarizeAWSAccountRegionCoverageAPI(plan, summary)
+
+	return AWSAccountRegionCoverageResult{
+		TenantID:           plan.TenantID,
+		WorkspaceID:        plan.WorkspaceID,
+		ProjectID:          plan.ProjectID,
+		ConnectorID:        plan.ConnectorID,
+		AccountID:          plan.AccountID,
+		Region:             plan.Region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAccountRegionCoverageAPICurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAccountRegionCoverageAPICurrentIssue),
+		Version:            "aws-account-region-coverage-api-v1",
+		Status:             status,
+		FixtureState:       plan.FixtureState,
+		Confidence:         confidence,
+		Summary:            summary,
+		Records:            filtered,
+		FailureReasons:     failures,
+		RemediationHints:   remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAccountRegionCoverageAPICurrentIssue),
+			awsIssueURL(awsPartialFailureReportingCurrentIssue),
+			awsIssueURL(awsCoveragePlannerCurrentIssue),
+			"/docs/aws-account-region-coverage-planner#public-account-region-coverage-api",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURLFromIDs(plan.TenantID, plan.WorkspaceID, plan.ProjectID),
+		}),
+		CoverageGaps: plan.CoverageGaps,
+		Diagnostics:  plan.Diagnostics,
+		GeneratedAt:  plan.GeneratedAt,
+		UpdatedAt:    plan.UpdatedAt,
+	}, nil
+}
+
+func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccountRegionCoverageRecord {
+	staleScopes := awsCoverageStaleDiagnosticScopes(plan.Diagnostics)
+	records := make([]AWSAccountRegionCoverageRecord, 0, len(plan.Targets))
+	for _, target := range plan.Targets {
+		scope := strings.Join([]string{target.AccountID, strings.ToLower(strings.TrimSpace(target.Region)), strings.ToLower(strings.TrimSpace(target.Service))}, "/")
+		staleMessage, stale := staleScopes[scope]
+		status := awsAccountRegionCoverageStatus(target, stale)
+		failureReason := firstNonEmptyAWSValue(target.FailureReason, target.Reason)
+		if stale && staleMessage != "" {
+			failureReason = firstNonEmptyAWSValue(failureReason, staleMessage)
+		}
+		records = append(records, AWSAccountRegionCoverageRecord{
+			Key:            target.Key,
+			AccountID:      target.AccountID,
+			AccountName:    target.AccountName,
+			Region:         target.Region,
+			RegionName:     target.RegionName,
+			Service:        target.Service,
+			ServiceName:    target.ServiceName,
+			Collector:      target.Collector,
+			Global:         target.Global,
+			Enabled:        target.Enabled,
+			State:          target.State,
+			CoverageStatus: status,
+			Cursor:         target.Cursor,
+			Checkpoint:     target.Cursor,
+			Attempts:       target.Attempts,
+			FailureReason:  failureReason,
+			Retryable:      target.Resumable && status != "covered",
+			Stale:          stale,
+			EvidenceRef:    target.EvidenceRef,
+			NextAction:     awsAccountRegionCoverageNextAction(status, target.NextAction),
+			ObservedAt:     target.ObservedAt,
+			UpdatedAt:      plan.UpdatedAt,
+		})
+	}
+	return records
+}
+
+func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]string {
+	out := map[string]string{}
+	for _, diagnostic := range diagnostics {
+		if strings.ToLower(strings.TrimSpace(diagnostic.Code)) != "stale_cursor_expired" {
+			continue
+		}
+		scope := strings.ToLower(strings.TrimSpace(diagnostic.Scope))
+		if scope == "" {
+			continue
+		}
+		out[scope] = diagnostic.Message
+	}
+	return out
+}
+
+func awsAccountRegionCoverageStatus(target AWSCoveragePlanTarget, stale bool) string {
+	if stale {
+		return "stale"
+	}
+	state := strings.ToLower(strings.TrimSpace(target.State))
+	combined := strings.ToLower(strings.Join([]string{target.Reason, target.FailureReason}, " "))
+	switch {
+	case state == "covered":
+		return "covered"
+	case state == "disabled":
+		return "disabled"
+	case strings.Contains(combined, "suspended"):
+		return "suspended"
+	case strings.Contains(combined, "unreachable"):
+		return "unreachable"
+	case state == "permission_denied":
+		return "permission_denied"
+	case state == "planned" || state == "pending" || state == "in_progress":
+		return "missing"
+	default:
+		return "degraded"
+	}
+}
+
+func awsAccountRegionCoverageNextAction(status string, fallback string) string {
+	switch status {
+	case "covered":
+		return "No action required; rescan on the next scheduled coverage run."
+	case "missing":
+		return "Queue or resume this account/region/service target in the next fan-out run."
+	case "unreachable":
+		return "Fix connector reachability for this account and region, then rerun coverage."
+	case "suspended":
+		return "Exclude or reactivate the suspended account before expecting coverage."
+	case "stale":
+		return "Refresh this stale cursor so the next run starts from a current checkpoint."
+	case "disabled":
+		return "Enable this account, region, or service in connector coverage configuration."
+	case "permission_denied":
+		return "Grant the read-only collector role access, then rerun coverage."
+	default:
+		return fallback
+	}
+}
+
+func filterAWSAccountRegionCoverageRecords(records []AWSAccountRegionCoverageRecord, request AWSAccountRegionCoverageRequest) []AWSAccountRegionCoverageRecord {
+	collector := strings.ToLower(strings.TrimSpace(request.Collector))
+	status := strings.ToLower(strings.TrimSpace(request.Status))
+	if collector == "" && status == "" {
+		return records
+	}
+	filtered := make([]AWSAccountRegionCoverageRecord, 0, len(records))
+	for _, record := range records {
+		if collector != "" && strings.ToLower(strings.TrimSpace(record.Collector)) != collector {
+			continue
+		}
+		if status != "" && strings.ToLower(strings.TrimSpace(record.CoverageStatus)) != status {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered
+}
+
+func summarizeAWSAccountRegionCoverage(records []AWSAccountRegionCoverageRecord, filteredRecords int) AWSAccountRegionCoverageSummary {
+	accounts := map[string]struct{}{}
+	regions := map[string]struct{}{}
+	services := map[string]struct{}{}
+	statusCounts := map[string]int{}
+	stateCounts := map[string]int{}
+	collectorCounts := map[string]int{}
+	summary := AWSAccountRegionCoverageSummary{
+		TotalRecords:    len(records),
+		FilteredRecords: filteredRecords,
+		StatusCounts:    statusCounts,
+		StateCounts:     stateCounts,
+		CollectorCounts: collectorCounts,
+	}
+	for _, record := range records {
+		accounts[record.AccountID] = struct{}{}
+		regions[strings.ToLower(strings.TrimSpace(record.Region))] = struct{}{}
+		services[strings.ToLower(strings.TrimSpace(record.Service))] = struct{}{}
+		statusCounts[record.CoverageStatus]++
+		stateCounts[record.State]++
+		if strings.TrimSpace(record.Collector) != "" {
+			collectorCounts[record.Collector]++
+		}
+		if record.Retryable {
+			summary.RetryableRecords++
+		}
+		switch record.CoverageStatus {
+		case "covered":
+			summary.CoveredRecords++
+		case "missing":
+			summary.MissingRecords++
+		case "degraded":
+			summary.DegradedRecords++
+		case "unreachable":
+			summary.UnreachableRecords++
+		case "suspended":
+			summary.SuspendedRecords++
+		case "disabled":
+			summary.DisabledRecords++
+		case "stale":
+			summary.StaleRecords++
+		case "permission_denied":
+			summary.PermissionDeniedRecords++
+		}
+	}
+	summary.AccountCount = len(accounts)
+	summary.RegionCount = len(regions)
+	summary.ServiceCount = len(services)
+	return summary
+}
+
+func summarizeAWSAccountRegionCoverageAPI(plan AWSCoveragePlanResult, summary AWSAccountRegionCoverageSummary) (string, float64, []string, []string) {
+	failures := append([]string{}, plan.FailureReasons...)
+	remediations := append([]string{}, plan.RemediationHints...)
+	switch {
+	case summary.PermissionDeniedRecords > 0:
+		return awsPlatformDependencyStatusBlocked, 0.35, failures, dedupeStrings(append(remediations, "Repair denied read-only AWS access, then rerun account/region coverage."))
+	case summary.StaleRecords > 0 || summary.DegradedRecords > 0 || summary.UnreachableRecords > 0 || summary.SuspendedRecords > 0:
+		return awsPlatformDependencyStatusDegraded, 0.76, failures, dedupeStrings(append(remediations, "Use coverage status filters to rerun only stale, degraded, unreachable, or suspended targets."))
+	default:
+		return plan.Status, plan.Confidence, failures, remediations
+	}
+}
+
+func validAWSAccountRegionCoverageStatusFilter(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "covered", "missing", "degraded", "unreachable", "suspended", "disabled", "stale", "permission_denied":
+		return true
+	default:
+		return false
+	}
+}
+
+func awsBaselineProjectEvidenceURLFromIDs(tenantID string, workspaceID string, projectID string) string {
+	return "/app/" + strings.TrimSpace(tenantID) + "/workspaces/" + strings.TrimSpace(workspaceID) + "/projects/" + strings.TrimSpace(projectID) + "/aws"
+}

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -155,14 +155,14 @@ func (s *Service) GetAWSAccountRegionCoverage(ctx context.Context, workspaceID s
 }
 
 func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccountRegionCoverageRecord {
-	staleScopes := awsCoverageStaleDiagnosticScopes(plan.Diagnostics)
+	staleDiagnostics := awsCoverageStaleDiagnostics(plan.Diagnostics)
 	records := make([]AWSAccountRegionCoverageRecord, 0, len(plan.Targets))
 	for _, target := range plan.Targets {
-		staleMessage, stale := awsCoverageStaleDiagnosticForTarget(staleScopes, target)
+		staleDiagnostic, stale := awsCoverageStaleDiagnosticForTarget(staleDiagnostics, target)
 		status := awsAccountRegionCoverageStatus(target, stale)
 		failureReason := firstNonEmptyAWSValue(target.FailureReason, target.Reason)
-		if stale && staleMessage != "" {
-			failureReason = firstNonEmptyAWSValue(failureReason, staleMessage)
+		if stale && staleDiagnostic != nil {
+			failureReason = firstNonEmptyAWSValue(failureReason, staleDiagnostic.Message)
 		}
 		records = append(records, AWSAccountRegionCoverageRecord{
 			Key:            target.Key,
@@ -177,8 +177,8 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 			Enabled:        target.Enabled,
 			State:          target.State,
 			CoverageStatus: status,
-			Cursor:         target.Cursor,
-			Checkpoint:     target.Cursor,
+			Cursor:         firstNonEmptyAWSValue(target.Cursor, staleDiagnosticCursor(staleDiagnostic)),
+			Checkpoint:     firstNonEmptyAWSValue(target.Cursor, staleDiagnosticCursor(staleDiagnostic)),
 			Attempts:       target.Attempts,
 			FailureReason:  failureReason,
 			Retryable:      target.Resumable && status != "covered",
@@ -192,26 +192,48 @@ func buildAWSAccountRegionCoverageRecords(plan AWSCoveragePlanResult) []AWSAccou
 	return records
 }
 
-func awsCoverageStaleDiagnosticForTarget(staleScopes map[string]string, target AWSCoveragePlanTarget) (string, bool) {
+func awsCoverageStaleDiagnostics(diagnostics []AWSCoveragePlanDiagnostic) map[string]AWSCoveragePlanDiagnostic {
+	out := map[string]AWSCoveragePlanDiagnostic{}
+	for _, diagnostic := range diagnostics {
+		if strings.ToLower(strings.TrimSpace(diagnostic.Code)) != "stale_cursor_expired" {
+			continue
+		}
+		scope := strings.ToLower(strings.TrimSpace(diagnostic.Scope))
+		if scope == "" {
+			continue
+		}
+		out[scope] = diagnostic
+	}
+	return out
+}
+
+func staleDiagnosticCursor(diagnostic *AWSCoveragePlanDiagnostic) string {
+	if diagnostic == nil {
+		return ""
+	}
+	return strings.TrimSpace(diagnostic.Cursor)
+}
+
+func awsCoverageStaleDiagnosticForTarget(staleDiagnostics map[string]AWSCoveragePlanDiagnostic, target AWSCoveragePlanTarget) (*AWSCoveragePlanDiagnostic, bool) {
 	service := strings.ToLower(strings.TrimSpace(target.Service))
 	region := strings.ToLower(strings.TrimSpace(target.Region))
 	exactScope := strings.Join([]string{target.AccountID, region, service}, "/")
-	if message, ok := staleScopes[exactScope]; ok {
-		return message, true
+	if diagnostic, ok := staleDiagnostics[exactScope]; ok {
+		return &diagnostic, true
 	}
 	if !target.Global {
-		return "", false
+		return nil, false
 	}
-	for scope, message := range staleScopes {
+	for scope, diagnostic := range staleDiagnostics {
 		parts := strings.Split(scope, "/")
 		if len(parts) != 3 {
 			continue
 		}
 		if parts[0] == strings.TrimSpace(target.AccountID) && parts[2] == service {
-			return message, true
+			return &diagnostic, true
 		}
 	}
-	return "", false
+	return nil, false
 }
 
 func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]string {

--- a/internal/api/aws_account_region_coverage.go
+++ b/internal/api/aws_account_region_coverage.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 )
@@ -207,13 +208,6 @@ func awsCoverageStaleDiagnostics(diagnostics []AWSCoveragePlanDiagnostic) map[st
 	return out
 }
 
-func staleDiagnosticCursor(diagnostic *AWSCoveragePlanDiagnostic) string {
-	if diagnostic == nil {
-		return ""
-	}
-	return strings.TrimSpace(diagnostic.Cursor)
-}
-
 func awsCoverageStaleDiagnosticForTarget(staleDiagnostics map[string]AWSCoveragePlanDiagnostic, target AWSCoveragePlanTarget) (*AWSCoveragePlanDiagnostic, bool) {
 	service := strings.ToLower(strings.TrimSpace(target.Service))
 	region := strings.ToLower(strings.TrimSpace(target.Region))
@@ -224,20 +218,34 @@ func awsCoverageStaleDiagnosticForTarget(staleDiagnostics map[string]AWSCoverage
 	if !target.Global {
 		return nil, false
 	}
-	for scope, diagnostic := range staleDiagnostics {
+	scopes := make([]string, 0, len(staleDiagnostics))
+	for scope := range staleDiagnostics {
 		parts := strings.Split(scope, "/")
 		if len(parts) != 3 {
 			continue
 		}
-		if parts[0] == strings.TrimSpace(target.AccountID) && parts[2] == service {
-			return &diagnostic, true
+		if parts[0] != strings.TrimSpace(target.AccountID) || parts[2] != service {
+			continue
 		}
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	if len(scopes) > 0 {
+		diagnostic := staleDiagnostics[scopes[0]]
+		return &diagnostic, true
 	}
 	return nil, false
 }
 
-func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]string {
-	out := map[string]string{}
+func staleDiagnosticCursor(diagnostic *AWSCoveragePlanDiagnostic) string {
+	if diagnostic == nil {
+		return ""
+	}
+	return strings.TrimSpace(diagnostic.Cursor)
+}
+
+func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) map[string]AWSCoveragePlanDiagnostic {
+	out := map[string]AWSCoveragePlanDiagnostic{}
 	for _, diagnostic := range diagnostics {
 		if strings.ToLower(strings.TrimSpace(diagnostic.Code)) != "stale_cursor_expired" {
 			continue
@@ -246,7 +254,7 @@ func awsCoverageStaleDiagnosticScopes(diagnostics []AWSCoveragePlanDiagnostic) m
 		if scope == "" {
 			continue
 		}
-		out[scope] = diagnostic.Message
+		out[scope] = diagnostic
 	}
 	return out
 }

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -87,6 +87,7 @@ type AWSCoveragePlanDiagnostic struct {
 	Message     string `json:"message"`
 	Remediation string `json:"remediation,omitempty"`
 	Retryable   bool   `json:"retryable"`
+	Cursor      string `json:"cursor,omitempty"`
 }
 
 // AWSPartialFailureReport is one normalized account/region/service failure
@@ -751,6 +752,11 @@ func awsCoverageCursorTime(fields map[string]any, fallback time.Time) time.Time 
 }
 
 func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string, code string, message string, retryable bool) AWSCoveragePlanDiagnostic {
+	cursor := ""
+	entries := awsCoverageCursorEntries(row.ScanCursor)
+	if len(entries) > 0 {
+		cursor = awsCoverageCursorString(entries[0].fields, "cursor")
+	}
 	return AWSCoveragePlanDiagnostic{
 		Source:      "scan_cursor",
 		Scope:       strings.Join([]string{row.AccountID, strings.ToLower(strings.TrimSpace(row.Region)), strings.ToLower(strings.TrimSpace(service))}, "/"),
@@ -758,6 +764,7 @@ func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string
 		Message:     message,
 		Remediation: "Refresh this account/region/service scan so Identrail can write a current checkpoint.",
 		Retryable:   retryable,
+		Cursor:      cursor,
 	}
 }
 

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -753,9 +753,12 @@ func awsCoverageCursorTime(fields map[string]any, fallback time.Time) time.Time 
 
 func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string, code string, message string, retryable bool) AWSCoveragePlanDiagnostic {
 	cursor := ""
-	entries := awsCoverageCursorEntries(row.ScanCursor)
-	if len(entries) > 0 {
-		cursor = awsCoverageCursorString(entries[0].fields, "cursor")
+	for _, entry := range awsCoverageCursorEntries(row.ScanCursor) {
+		if strings.ToLower(strings.TrimSpace(entry.service)) != strings.ToLower(strings.TrimSpace(service)) {
+			continue
+		}
+		cursor = awsCoverageCursorString(entry.fields, "cursor")
+		break
 	}
 	return AWSCoveragePlanDiagnostic{
 		Source:      "scan_cursor",

--- a/internal/api/aws_coverage_planner.go
+++ b/internal/api/aws_coverage_planner.go
@@ -88,6 +88,7 @@ type AWSCoveragePlanDiagnostic struct {
 	Remediation string `json:"remediation,omitempty"`
 	Retryable   bool   `json:"retryable"`
 	Cursor      string `json:"cursor,omitempty"`
+	Collector   string `json:"collector,omitempty"`
 }
 
 // AWSPartialFailureReport is one normalized account/region/service failure
@@ -753,11 +754,13 @@ func awsCoverageCursorTime(fields map[string]any, fallback time.Time) time.Time 
 
 func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string, code string, message string, retryable bool) AWSCoveragePlanDiagnostic {
 	cursor := ""
+	collector := ""
 	for _, entry := range awsCoverageCursorEntries(row.ScanCursor) {
 		if strings.ToLower(strings.TrimSpace(entry.service)) != strings.ToLower(strings.TrimSpace(service)) {
 			continue
 		}
 		cursor = awsCoverageCursorString(entry.fields, "cursor")
+		collector = awsCoverageCursorString(entry.fields, "collector")
 		break
 	}
 	return AWSCoveragePlanDiagnostic{
@@ -768,6 +771,7 @@ func awsCoverageCursorDiagnostic(row db.AWSAccountRegionCoverage, service string
 		Remediation: "Refresh this account/region/service scan so Identrail can write a current checkpoint.",
 		Retryable:   retryable,
 		Cursor:      cursor,
+		Collector:   collector,
 	}
 }
 

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -503,6 +503,70 @@ func TestGetAWSAccountRegionCoverageMarksGlobalStaleCursors(t *testing.T) {
 	}
 }
 
+func TestGetAWSAccountRegionCoverageIgnoresStaleGlobalDuplicatesWhenFreshHomeCoverageExists(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 20, 0, 0, time.UTC)
+	old := now.Add(-awsCoverageScanCursorTTL - time.Minute)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam": map[string]any{
+				"collector":   "iam_roles",
+				"state":       "covered",
+				"cursor":      "iam-fresh",
+				"observed_at": now.Format(time.RFC3339Nano),
+			},
+		}},
+		UpdatedAt: now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam": map[string]any{
+				"collector":   "iam_roles",
+				"state":       "in_progress",
+				"cursor":      "iam-stale",
+				"observed_at": old.Format(time.RFC3339Nano),
+			},
+		}},
+		UpdatedAt: old,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	covered, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Status: "covered"})
+	if err != nil {
+		t.Fatalf("get covered account-region coverage: %v", err)
+	}
+	if len(covered.Records) != 1 {
+		t.Fatalf("expected one covered global IAM record, got %+v", covered.Records)
+	}
+	if covered.Records[0].CoverageStatus != "covered" {
+		t.Fatalf("expected covered status, got %+v", covered.Records[0])
+	}
+	if covered.Records[0].Cursor != "iam-fresh" {
+		t.Fatalf("expected fresh global cursor to remain visible, got %+v", covered.Records[0])
+	}
+
+	stale, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Status: "stale"})
+	if err != nil {
+		t.Fatalf("get stale account-region coverage: %v", err)
+	}
+	if len(stale.Records) != 0 {
+		t.Fatalf("expected stale duplicates to be ignored when fresh coverage exists, got %+v", stale)
+	}
+}
+
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -450,6 +450,14 @@ func TestGetAWSAccountRegionCoveragePublicStatuses(t *testing.T) {
 	}
 }
 
+func TestAWSAccountRegionCoverageStatusMapsBlockedToMissing(t *testing.T) {
+	t.Parallel()
+	got := awsAccountRegionCoverageStatus(AWSCoveragePlanTarget{State: "blocked", Reason: "no persisted account/region coverage row for this pair"}, false)
+	if got != "missing" {
+		t.Fatalf("expected blocked to map to missing, got %q", got)
+	}
+}
+
 func TestGetAWSAccountRegionCoverageMarksGlobalStaleCursors(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -487,6 +487,9 @@ func TestGetAWSAccountRegionCoverageMarksGlobalStaleCursors(t *testing.T) {
 	if record.Service != "iam" || !record.Stale || record.CoverageStatus != "stale" {
 		t.Fatalf("expected global iam cursor to remain stale, got %+v", record)
 	}
+	if record.Cursor != "iam-stale" || record.Checkpoint != "iam-stale" {
+		t.Fatalf("expected stale cursor metadata to be preserved, got %+v", record)
+	}
 }
 
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -450,6 +450,45 @@ func TestGetAWSAccountRegionCoveragePublicStatuses(t *testing.T) {
 	}
 }
 
+func TestGetAWSAccountRegionCoverageMarksGlobalStaleCursors(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 15, 0, 0, time.UTC)
+	old := now.Add(-awsCoverageScanCursorTTL - time.Minute)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam": map[string]any{
+				"collector":   "iam_roles",
+				"state":       "in_progress",
+				"cursor":      "iam-stale",
+				"observed_at": old.Format(time.RFC3339Nano),
+			},
+		}},
+		UpdatedAt: now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Status: "stale"})
+	if err != nil {
+		t.Fatalf("get stale account-region coverage: %v", err)
+	}
+	if len(result.Records) != 1 {
+		t.Fatalf("expected one stale global record, got %+v", result.Records)
+	}
+	record := result.Records[0]
+	if record.Service != "iam" || !record.Stale || record.CoverageStatus != "stale" {
+		t.Fatalf("expected global iam cursor to remain stale, got %+v", record)
+	}
+}
+
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -359,6 +359,97 @@ func TestGetAWSCoveragePlanLiveCursorExpiryAndMalformed(t *testing.T) {
 	}
 }
 
+func TestGetAWSAccountRegionCoveragePublicStatuses(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
+	old := now.Add(-awsCoverageScanCursorTTL - time.Minute)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		AccountAlias:   "Production",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor: map[string]any{"services": map[string]any{
+			"iam":    map[string]any{"collector": "iam_roles", "state": "covered", "observed_at": now.Format(time.RFC3339Nano)},
+			"lambda": map[string]any{"collector": "lambda_execution_roles", "state": "partial", "cursor": "lambda-page-2", "attempts": 2, "failure_reason": "Throttling: lambda page failed", "observed_at": now.Format(time.RFC3339Nano)},
+			"ecs":    map[string]any{"collector": "ecs_tasks", "state": "in_progress", "cursor": "ecs-stale-page", "observed_at": old.Format(time.RFC3339Nano)},
+		}},
+		UpdatedAt: now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "222222222222",
+		AccountAlias:   "Archive",
+		Region:         "eu-west-1",
+		CoverageStatus: db.AWSAccountRegionCoverageUnreachable,
+		Unreachable:    true,
+		UpdatedAt:      now,
+	})
+	seedAWSCoverageCursorRow(t, store, ctx, "project-a", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "333333333333",
+		AccountAlias:   "Retired",
+		Region:         "us-west-2",
+		CoverageStatus: db.AWSAccountRegionCoverageDisabled,
+		Disabled:       true,
+		UpdatedAt:      now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get account-region coverage: %v", err)
+	}
+	if result.CurrentIssueRef != "#1503" || result.Version != "aws-account-region-coverage-api-v1" {
+		t.Fatalf("unexpected api metadata: %+v", result)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded public coverage status, got %+v", result)
+	}
+	if result.Summary.CoveredRecords == 0 || result.Summary.DegradedRecords == 0 || result.Summary.StaleRecords == 0 || result.Summary.UnreachableRecords == 0 || result.Summary.DisabledRecords == 0 {
+		t.Fatalf("expected public coverage status counts, got %+v", result.Summary)
+	}
+	recordsByStatus := map[string]int{}
+	for _, record := range result.Records {
+		recordsByStatus[record.CoverageStatus]++
+		if record.EvidenceRef == "" || record.NextAction == "" || record.UpdatedAt.IsZero() {
+			t.Fatalf("record missing public operator fields: %+v", record)
+		}
+	}
+	for _, status := range []string{"covered", "degraded", "stale", "unreachable", "disabled"} {
+		if recordsByStatus[status] == 0 {
+			t.Fatalf("expected status %q in public records: %+v", status, recordsByStatus)
+		}
+	}
+
+	degraded, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Status: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded account-region coverage: %v", err)
+	}
+	if degraded.Summary.FilteredRecords == 0 || len(degraded.Records) != degraded.Summary.FilteredRecords {
+		t.Fatalf("expected degraded records to match filtered count, got %+v", degraded.Summary)
+	}
+	for _, record := range degraded.Records {
+		if record.CoverageStatus != "degraded" {
+			t.Fatalf("degraded status filter leaked %+v", record)
+		}
+	}
+
+	collector, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Collector: "lambda_execution_roles"})
+	if err != nil {
+		t.Fatalf("get collector-filtered account-region coverage: %v", err)
+	}
+	if len(collector.Records) != 1 || collector.Records[0].Collector != "lambda_execution_roles" || collector.Records[0].Checkpoint != "lambda-page-2" {
+		t.Fatalf("expected lambda collector checkpoint, got %+v", collector.Records)
+	}
+
+	if _, err := svc.GetAWSAccountRegionCoverage(ctx, "default", "project-a", AWSAccountRegionCoverageRequest{ConnectorID: "aws-prod", Status: "unknown"}); err == nil {
+		t.Fatalf("expected invalid public status filter error")
+	}
+}
+
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
@@ -415,6 +506,49 @@ func TestRouterAWSCoveragePlanPartialFailureAndInvalid(t *testing.T) {
 		if bad.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
 		}
+	}
+}
+
+func TestRouterAWSAccountRegionCoverage(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	seedAWSCoverageCursorRow(t, store, ctx, "project-1", "aws-prod", db.AWSAccountRegionCoverage{
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		CoverageStatus: db.AWSAccountRegionCoveragePending,
+		ScanCursor:     map[string]any{"services": map[string]any{"iam": map[string]any{"state": "covered", "observed_at": now.Format(time.RFC3339Nano)}}},
+		UpdatedAt:      now,
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/account-region-coverage?connector_id=aws-prod&status=covered", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Coverage AWSAccountRegionCoverageResult `json:"coverage"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Coverage.CurrentIssueRef != "#1503" || len(body.Coverage.Records) == 0 {
+		t.Fatalf("expected public coverage response, got %+v", body.Coverage)
+	}
+	for _, record := range body.Coverage.Records {
+		if record.CoverageStatus != "covered" {
+			t.Fatalf("covered status filter leaked %+v", record)
+		}
+	}
+
+	bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/account-region-coverage?connector_id=aws-prod&status=bogus", "")
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", bad.Code, bad.Body.String())
 	}
 }
 

--- a/internal/api/aws_coverage_planner_test.go
+++ b/internal/api/aws_coverage_planner_test.go
@@ -490,6 +490,9 @@ func TestGetAWSAccountRegionCoverageMarksGlobalStaleCursors(t *testing.T) {
 	if record.Cursor != "iam-stale" || record.Checkpoint != "iam-stale" {
 		t.Fatalf("expected stale cursor metadata to be preserved, got %+v", record)
 	}
+	if record.Collector != "iam_roles" {
+		t.Fatalf("expected stale collector metadata to be preserved, got %+v", record)
+	}
 }
 
 func TestGetAWSCoveragePlanNeverLeaksValues(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2985,6 +2985,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plan": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/account-region-coverage", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAccountRegionCoverage(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAccountRegionCoverageRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			Account:      strings.TrimSpace(c.Query("account")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			Collector:    strings.TrimSpace(c.Query("collector")),
+			State:        strings.TrimSpace(c.Query("state")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws account-region coverage request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws account-region coverage",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws account-region coverage"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"coverage": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/fanout-execution", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2812,6 +2812,79 @@ export type AWSCoveragePlanResult = {
   updated_at: string;
 };
 
+export type AWSAccountRegionCoverageStatus = 'covered' | 'missing' | 'degraded' | 'unreachable' | 'suspended' | 'disabled' | 'stale' | 'permission_denied';
+
+export type AWSAccountRegionCoverageRecord = {
+  key: string;
+  account_id: string;
+  account_name?: string;
+  region: string;
+  region_name?: string;
+  service: string;
+  service_name?: string;
+  collector?: string;
+  global: boolean;
+  enabled: boolean;
+  state: AWSCoverageState;
+  coverage_status: AWSAccountRegionCoverageStatus;
+  cursor?: string;
+  checkpoint?: string;
+  attempts?: number;
+  failure_reason?: string;
+  retryable: boolean;
+  stale: boolean;
+  evidence_ref: string;
+  next_action: string;
+  observed_at?: string;
+  updated_at: string;
+};
+
+export type AWSAccountRegionCoverageSummary = {
+  total_records: number;
+  filtered_records: number;
+  account_count: number;
+  region_count: number;
+  service_count: number;
+  covered_records: number;
+  missing_records: number;
+  degraded_records: number;
+  unreachable_records: number;
+  suspended_records: number;
+  disabled_records: number;
+  stale_records: number;
+  permission_denied_records: number;
+  retryable_records: number;
+  status_counts: Record<string, number>;
+  state_counts: Record<string, number>;
+  collector_counts: Record<string, number>;
+};
+
+export type AWSAccountRegionCoverageResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCoveragePlanStatus;
+  fixture_state?: AWSCoveragePlanFixtureState;
+  confidence: number;
+  summary: AWSAccountRegionCoverageSummary;
+  records: AWSAccountRegionCoverageRecord[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSCoveragePlanCoverageGap[];
+  diagnostics: AWSCoveragePlanDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSFanOutExecutionTarget = {
   key: string;
   account_id: string;
@@ -4727,6 +4800,28 @@ export const apiClient = {
         region: filters?.region,
         service: filters?.service,
         state: filters?.state
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAccountRegionCoverage(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSCoveragePlanFixtureState,
+    filters?: { account?: string; region?: string; service?: string; collector?: string; state?: AWSCoverageState; status?: AWSAccountRegionCoverageStatus },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ coverage: AWSAccountRegionCoverageResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/account-region-coverage${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        account: filters?.account,
+        region: filters?.region,
+        service: filters?.service,
+        collector: filters?.collector,
+        state: filters?.state,
+        status: filters?.status
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -58,6 +58,8 @@ import {
   type AWSDynamoDBRDSReachabilityRecord,
   type AWSCredentialReferencesInventoryResult,
   type AWSCredentialReferenceRecord,
+  type AWSAccountRegionCoverageRecord,
+  type AWSAccountRegionCoverageResult,
   type AWSCoveragePlanResult,
   type AWSCoveragePlanTarget,
   type AWSFanOutExecutionResult,
@@ -3686,6 +3688,13 @@ type AWSInventoryCoveragePlanState = {
   onRetry: () => void;
 };
 
+type AWSInventoryAccountRegionCoverageState = {
+  coverage: AWSAccountRegionCoverageResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryFanOutExecutionState = {
   execution: AWSFanOutExecutionResult | null;
   loading: boolean;
@@ -4043,7 +4052,11 @@ function awsCoveragePlanFilterValue(state: string): string {
 }
 
 function awsCoveragePlanStage(state: string): AWSCapabilityStage {
-  return state === 'covered' ? 'wired' : state === 'disabled' || state === 'unsupported' ? 'not-available' : 'coming';
+  return state === 'covered'
+    ? 'wired'
+    : state === 'disabled' || state === 'unsupported' || state === 'suspended'
+      ? 'not-available'
+      : 'coming';
 }
 
 function hasAWSCoverageObservedAt(value?: string): boolean {
@@ -4078,6 +4091,107 @@ function awsCoveragePlanTargetDetail(target: AWSCoveragePlanTarget): string {
     details.push(`${target.attempts} ${target.attempts === 1 ? 'attempt' : 'attempts'}`);
   }
   return details.join(' · ');
+}
+
+function awsAccountRegionCoverageDetail(record: AWSAccountRegionCoverageRecord): string {
+  const details: string[] = [];
+  if (record.failure_reason) {
+    details.push(record.failure_reason);
+  }
+  if (record.checkpoint || record.cursor) {
+    details.push(`Checkpoint ${record.checkpoint ?? record.cursor}`);
+  }
+  if (record.attempts) {
+    details.push(`${record.attempts} ${record.attempts === 1 ? 'attempt' : 'attempts'}`);
+  }
+  if (record.evidence_ref) {
+    details.push(record.evidence_ref);
+  }
+  if (hasAWSCoverageObservedAt(record.observed_at)) {
+    details.push(`Observed ${formatConnectionTime(record.observed_at)}`);
+  }
+  if (details.length === 0) {
+    details.push(record.next_action);
+  } else {
+    details.push(record.next_action);
+  }
+  return details.join(' · ');
+}
+
+function awsAccountRegionCoverageFilterValue(status: string): string {
+  switch (status) {
+    case 'covered':
+      return 'covered';
+    case 'disabled':
+    case 'suspended':
+      return 'disabled';
+    case 'missing':
+    case 'unreachable':
+      return 'missing';
+    case 'degraded':
+    case 'permission_denied':
+    case 'stale':
+      return 'degraded';
+    default:
+      return awsCoveragePlanFilterValue(status);
+  }
+}
+
+function buildAWSAccountRegionCoverageRows(
+  coverage: AWSAccountRegionCoverageResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryCoverageRow[] {
+  if (coverage?.records.length) {
+    return coverage.records.map((record) => {
+      const filterValue = awsAccountRegionCoverageFilterValue(record.coverage_status);
+      const accountFilter = connection?.account_id && record.account_id === connection.account_id ? 'connected,planned' : 'planned';
+      const regionFilter =
+        connection?.region && record.region.toLowerCase() === connection.region.toLowerCase() ? 'current' : 'uncovered';
+      return {
+        id: record.key,
+        category: `${record.account_name || record.account_id} / ${record.region} / ${formatTokenLabel(record.service)}`,
+        coverage: record.coverage_status,
+        source: record.collector ? formatTokenLabel(record.collector) : record.evidence_ref,
+        status: record.state,
+        detail: awsAccountRegionCoverageDetail(record),
+        filters: {
+          account: accountFilter,
+          region: regionFilter,
+          coverage: `${filterValue},${record.coverage_status},${record.state}`,
+          search: ''
+        },
+        searchText: inventorySearchText([
+          record.account_id,
+          record.account_name,
+          record.region,
+          record.service,
+          record.service_name,
+          record.collector,
+          record.state,
+          record.coverage_status,
+          record.failure_reason,
+          record.next_action,
+          record.evidence_ref
+        ])
+      };
+    });
+  }
+  if (loading) {
+    return [
+      {
+        id: 'account-region-coverage-loading',
+        category: 'Coverage API',
+        coverage: 'planned',
+        source: 'AWS account-region coverage API',
+        status: 'loading',
+        detail: 'Loading public coverage records.',
+        filters: { account: 'planned', region: 'uncovered', coverage: 'planned', search: '' },
+        searchText: inventorySearchText(['coverage api loading'])
+      }
+    ];
+  }
+  return [];
 }
 
 function buildAWSCoveragePlanRows(
@@ -4442,6 +4556,7 @@ function AWSAccountsInventoryContent({
   connection,
   connectPath,
   coveragePlanState,
+  accountRegionCoverageState,
   fanOutExecutionState,
   organizationsTopologyState,
   filters,
@@ -4450,6 +4565,7 @@ function AWSAccountsInventoryContent({
   connection: AWSConnectionStatus | null;
   connectPath: string;
   coveragePlanState: AWSInventoryCoveragePlanState;
+  accountRegionCoverageState: AWSInventoryAccountRegionCoverageState;
   fanOutExecutionState: AWSInventoryFanOutExecutionState;
   organizationsTopologyState: AWSInventoryOrganizationsTopologyState;
   filters: AWSInventoryFilterState;
@@ -4458,9 +4574,11 @@ function AWSAccountsInventoryContent({
   const accountCoverage = awsCoverageState(connection);
   const hasHealthyCoverage = accountCoverage === 'covered';
   const plan = coveragePlanState.plan;
+  const coverageAPI = accountRegionCoverageState.coverage;
   const execution = fanOutExecutionState.execution;
   const topology = organizationsTopologyState.topology;
   const rows = buildAWSCoveragePlanRows(plan, coveragePlanState.loading, connection);
+  const coverageAPIRows = buildAWSAccountRegionCoverageRows(coverageAPI, accountRegionCoverageState.loading, connection);
   const topologyRows = buildAWSOrganizationsTopologyRows(topology, organizationsTopologyState.loading, connection);
   const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
   const totalChecks = connection?.permission_checks.length ?? 0;
@@ -4475,6 +4593,7 @@ function AWSAccountsInventoryContent({
       ? 1
       : 0;
   const displayedRows = filterAWSInventoryRows(rows, filters);
+  const displayedCoverageAPIRows = filterAWSInventoryRows(coverageAPIRows, filters);
   const displayedTopologyRows = filterAWSInventoryRows(topologyRows, filters);
   const partialFailureReports = dedupeAWSPartialFailureReports([
     ...(execution?.partial_failure_reports ?? []),
@@ -4485,6 +4604,7 @@ function AWSAccountsInventoryContent({
     <>
       <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
       {coveragePlanState.loading ? <DomainLoadingState label="Loading account and region coverage plan" /> : null}
+      {accountRegionCoverageState.loading ? <DomainLoadingState label="Loading account and region coverage API" /> : null}
       {fanOutExecutionState.loading ? <DomainLoadingState label="Loading fan-out execution state" /> : null}
       {organizationsTopologyState.loading ? <DomainLoadingState label="Loading AWS Organizations topology" /> : null}
       {coveragePlanState.error ? (
@@ -4492,6 +4612,13 @@ function AWSAccountsInventoryContent({
           title="Coverage plan could not load"
           body={coveragePlanState.error}
           retryAction={{ label: 'Retry coverage plan', onClick: coveragePlanState.onRetry }}
+        />
+      ) : null}
+      {accountRegionCoverageState.error ? (
+        <DomainErrorState
+          title="Coverage API could not load"
+          body={accountRegionCoverageState.error}
+          retryAction={{ label: 'Retry coverage API', onClick: accountRegionCoverageState.onRetry }}
         />
       ) : null}
       {fanOutExecutionState.error ? (
@@ -4519,6 +4646,52 @@ function AWSAccountsInventoryContent({
         />
         <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
       </section>
+      {coverageAPI ? (
+        <DomainStatusPanel
+          eyebrow="Coverage API"
+          title="Public account and region coverage records"
+          status={formatTokenLabel(coverageAPI.status)}
+          tone={coverageAPI.status === 'blocked' ? 'danger' : coverageAPI.status === 'degraded' ? 'warning' : 'success'}
+        >
+          <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage API summary">
+            <DomainCoverageCard
+              label="Covered records"
+              scanned={coverageAPI.summary.covered_records}
+              total={Math.max(coverageAPI.summary.total_records, 1)}
+              detail={`${coverageAPI.summary.account_count} accounts`}
+            />
+            <DomainCoverageCard
+              label="Missing records"
+              scanned={coverageAPI.summary.missing_records}
+              total={Math.max(coverageAPI.summary.total_records, 1)}
+              detail={`${coverageAPI.summary.retryable_records} retryable`}
+            />
+            <DomainCoverageCard
+              label="Degraded records"
+              scanned={coverageAPI.summary.degraded_records + coverageAPI.summary.permission_denied_records}
+              total={Math.max(coverageAPI.summary.total_records, 1)}
+              detail={`${coverageAPI.summary.unreachable_records} unreachable`}
+            />
+            <DomainCoverageCard
+              label="Stale records"
+              scanned={coverageAPI.summary.stale_records}
+              total={Math.max(coverageAPI.summary.total_records, 1)}
+              detail={`${coverageAPI.summary.disabled_records + coverageAPI.summary.suspended_records} disabled or suspended`}
+            />
+          </section>
+          <DomainDataTable
+            label="AWS account-region coverage API records"
+            rows={displayedCoverageAPIRows}
+            getRowKey={(row) => row.id}
+            columns={[
+              { key: 'category', header: 'Coverage scope', render: (row) => <strong>{row.category}</strong> },
+              { key: 'coverage', header: 'Status', render: (row) => <AWSInventoryPill stage={awsCoveragePlanStage(row.coverage)} label={formatTokenLabel(row.coverage)} /> },
+              { key: 'source', header: 'Collector', render: (row) => row.source },
+              { key: 'detail', header: 'Evidence / action', render: (row) => row.detail }
+            ]}
+          />
+        </DomainStatusPanel>
+      ) : null}
       {execution ? (
         <DomainStatusPanel
           eyebrow="Fan-out worker"
@@ -7278,6 +7451,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [coveragePlanLoading, setCoveragePlanLoading] = useState(false);
   const [coveragePlanError, setCoveragePlanError] = useState('');
   const coveragePlanRequestRef = useRef(0);
+  const [accountRegionCoverage, setAccountRegionCoverage] = useState<AWSAccountRegionCoverageResult | null>(null);
+  const [accountRegionCoverageLoading, setAccountRegionCoverageLoading] = useState(false);
+  const [accountRegionCoverageError, setAccountRegionCoverageError] = useState('');
+  const accountRegionCoverageRequestRef = useRef(0);
   const [fanOutExecution, setFanOutExecution] = useState<AWSFanOutExecutionResult | null>(null);
   const [fanOutExecutionLoading, setFanOutExecutionLoading] = useState(false);
   const [fanOutExecutionError, setFanOutExecutionError] = useState('');
@@ -7950,6 +8127,58 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadCoveragePlan]);
 
+  const loadAccountRegionCoverage = useCallback(async () => {
+    const requestID = ++accountRegionCoverageRequestRef.current;
+    setAccountRegionCoverage(null);
+    setAccountRegionCoverageError('');
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setAccountRegionCoverageLoading(false);
+      return;
+    }
+    setAccountRegionCoverageLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAccountRegionCoverage(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== accountRegionCoverageRequestRef.current) {
+        return;
+      }
+      setAccountRegionCoverage(response.coverage);
+    } catch (error) {
+      if (requestID !== accountRegionCoverageRequestRef.current) {
+        return;
+      }
+      setAccountRegionCoverageError(formatAPIError(error, 'Unable to load account and region coverage API.'));
+    } finally {
+      if (requestID === accountRegionCoverageRequestRef.current) {
+        setAccountRegionCoverageLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region,
+    connection?.status,
+    connection?.health_status,
+  ]);
+
+  useEffect(() => {
+    void loadAccountRegionCoverage();
+    return () => {
+      accountRegionCoverageRequestRef.current += 1;
+    };
+  }, [loadAccountRegionCoverage]);
+
   const loadFanOutExecution = useCallback(async () => {
     const requestID = ++fanOutExecutionRequestRef.current;
     setFanOutExecution(null);
@@ -8129,6 +8358,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: coveragePlanLoading,
             error: coveragePlanError,
             onRetry: () => void loadCoveragePlan()
+          }}
+          accountRegionCoverageState={{
+            coverage: accountRegionCoverage,
+            loading: accountRegionCoverageLoading,
+            error: accountRegionCoverageError,
+            onRetry: () => void loadAccountRegionCoverage()
           }}
           fanOutExecutionState={{
             execution: fanOutExecution,


### PR DESCRIPTION
## Summary
- Add a read-only public AWS account/region coverage API that normalizes planner targets into filterable coverage records for covered, missing, degraded, unreachable, suspended, disabled, stale, and permission-denied states.
- Wire the new endpoint through route auth, OpenAPI, typed web client, and the AWS accounts surface with summary cards and drill-down records.
- Add service/router coverage for public status filters, stale cursor visibility, collector checkpoints, and invalid filter handling.

## Validation
- go test ./internal/providers/awscontract ./internal/api
- npm test -- --run src/api/client.test.ts src/productShell.test.tsx
- npm run build

## AI disclosure
No

Closes #1503

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS account/region coverage API with filterable records and a new UI drill-down, without reading customer payloads. Addresses #1503; preserves stale checkpoint/collector, maps planner "blocked" to "missing", and prevents stale regressions when a global service is already covered.

- **New Features**
  - Added GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/account-region-coverage returning normalized account/region/service/collector records with status, checkpoint, attempts, reasons, retryable, stale, evidence, timestamps, and next_action.
  - Filters: connector_id, fixture_state, account, region, service, collector, state, status (covered, missing, degraded, unreachable, suspended, disabled, stale, permission_denied; 400 on invalid).
  - Routed through tenancy auth; documented in OpenAPI v1; added client `apiClient.getAWSProjectAccountRegionCoverage`.
  - UI: AWS Accounts adds a Coverage API panel with summary cards and a drill-down table.

- **Bug Fixes**
  - Finalized global stale matching across regions; preserved stale state in filtered results.
  - Preserved stale cursor and collector from planner diagnostics as checkpoint/collector so API/UI show correct metadata.
  - Mapped planner "blocked" to public "missing".
  - Avoided stale regression for covered global services (ignore stale duplicates when fresh home-region coverage exists).

<sup>Written for commit 9e76a7e49dbf8fa7c94b073bf6144b6e56a24a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

