### PR TITLE
Implement AWS Organization StackSet onboarding app flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS Organization StackSet onboarding app flow** (#1504). A deterministic,
+  read-only, metadata-only planner in `internal/providers/awscontract` turns the
+  connector + Organizations topology + coverage plan + checkpoint set into an
+  ordered, resumable onboarding plan with explicit lifecycle states (`pending`,
+  `validating`, `blocked`, `deploying`, `active`, `degraded`, `failed`,
+  `permission_denied`, `unsupported`, `suspended`, `canceled`). The API at
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/stackset-onboarding`
+  surfaces a validation verdict with blocking/advisory prerequisites, a
+  permission preview (read-only discovery tier plus *unavailable* write tiers),
+  the target accounts/OUs/regions, per-instance state with resumable cursors and
+  failure reasons, projected coverage expectations from the existing coverage
+  planner, recovery actions for failed/permission-denied/suspended instances,
+  and the AWS console launch URL for the StackSet operator action. Supports
+  `service_managed` and `self_managed` deployment modes plus `success`, `empty`,
+  `degraded`, `partial_failure`, and `permission_denied` fixture states. Adds a
+  `BuildCloudFormationStackSetLaunchURL` console-URL builder that pins the
+  template URL, parameter set, permission model, organizational units, account
+  ids, and regions without embedding any secret values. Adds the AWS app surface
+  in `web/src/productShell.tsx` (`AWS → Accounts`) showing the validation
+  verdict, prerequisites, target counts, expected coverage, instance state
+  table, diagnostics, and the StackSet launch button. The planner never reads
+  AWS state directly, never carries customer payloads, and never executes the
+  StackSet on the operator's behalf — Identrail surfaces the AWS console URL
+  and the operator authorizes the operation. See
+  [docs/aws-stackset-onboarding.md](docs/aws-stackset-onboarding.md).
 - Add **credential and secret reference mapper across AWS workloads** (#1496).
   A metadata-only derivation over the normalized scan graph (no AWS calls, no
   added permissions) that extracts the `secret_refs` and credential-suggestive

--- a/docs/aws-stackset-onboarding.md
+++ b/docs/aws-stackset-onboarding.md
@@ -1,0 +1,151 @@
+# AWS Organization StackSet onboarding
+
+Implements [#1504](https://github.com/identrail/identrail/issues/1504). This is
+the operator-facing app flow that previews, launches, and recovers the
+organization-wide CloudFormation StackSet that deploys Identrail's read-only
+AWS connector role into member accounts.
+
+The implementation is **read-only**, **metadata-only**, and **non-mutating**.
+Identrail never executes the StackSet on the operator's behalf — it generates a
+deterministic plan, surfaces the AWS console launch URL, and tracks per-instance
+state for recovery. Customer payloads, secret values, database rows, and object
+contents are never read.
+
+## What this issue ships
+
+- A deterministic planner in `internal/providers/awscontract/stackset_onboarding.go`
+  that turns a connector + Organizations topology + coverage plan + checkpoint set
+  into a stable, resumable onboarding plan. The same inputs always produce the
+  same output.
+- A scoped API at
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/stackset-onboarding`
+  with `success`, `empty`, `degraded`, `partial_failure`, and `permission_denied`
+  fixture states, a `deployment_mode` query parameter (`service_managed` or
+  `self_managed`), and explicit failure reasons, recovery actions, and evidence
+  links.
+- A CloudFormation StackSet console launch URL builder in
+  `internal/connectors/aws/cfn.go` that pins the template URL, parameter set,
+  permission model, organizational units, account ids, and target regions
+  without ever embedding a secret value in the URL.
+- A web app surface (`AWS → Accounts`) that renders the validation verdict,
+  prerequisites, permission preview, target accounts/OUs/regions, per-instance
+  state, coverage expectations, recovery actions, and the StackSet launch
+  button. Loading, error, empty, blocked, degraded, and permission-denied
+  states are explicit; partial failures keep their resumable cursor.
+
+## Prerequisites
+
+- AWS Organizations is enabled in the management account.
+- For **service-managed** deployments, trusted access is enabled for
+  CloudFormation StackSets in AWS Organizations (or a delegated administrator
+  is registered).
+- For **self-managed** deployments, an
+  `AWSCloudFormationStackSetAdministrationRole` is reachable from the management
+  account and `AWSCloudFormationStackSetExecutionRole` is bootstrapped in each
+  target account.
+- The Identrail read-only connector template URL and checksum are configured on
+  the runtime (`AWSCloudFormationTemplateURL`).
+- An external ID is generated for the connector trust policy.
+
+The planner reports each prerequisite (`stackset.template_pinned`,
+`stackset.external_id_configured`, `stackset.trusted_access_enabled`,
+`stackset.delegated_admin_registered`,
+`stackset.administration_role_configured`, `stackset.targets_present`,
+`stackset.suspended_accounts_excluded`) with a `blocking` or `advisory`
+severity, a human-readable reason, and a remediation hint.
+
+## API output
+
+The response includes:
+
+- `stack_set_name`, `template_url`, `template_checksum`, `launch_url`,
+  `deployment_mode`, and `partition`.
+- `validation` — `ready` / `degraded` / `blocked` / `permission_denied` with
+  blocking/advisory prerequisite counts, failure reasons, and remediation hints.
+- `permission_preview` — the read-only discovery permission tier (and the
+  separate runtime-evidence, remediation-plan, advisory, approved-remediation,
+  and authorization-enforcement tiers that are advertised as *unavailable* so
+  write tiers are never granted silently).
+- `targets` — target accounts (with OU path, management flag, suspended flag),
+  target regions (with opt-in flag), and the OU tree.
+- `instances` — one row per account/region pair with `state`, `stack_id`,
+  `operation_id`, `failure_reason`, `attempts`, `resumable`, `next_action`,
+  `coverage_targets`, `evidence_ref`, and `observed_at`.
+- `coverage_expectation` — projected accounts, regions, instances, coverage
+  targets, and percent coverage when the StackSet succeeds, calculated against
+  the existing coverage planner output. Global services (for example IAM) are
+  anchored to a single home-region instance per account, not fanned out per
+  region.
+- `recovery_actions` — operator-actionable recovery for retry-failed-instances,
+  fix-permission-denied, and remove-suspended-accounts (plus one
+  `fix-*` action per unsatisfied blocking prerequisite).
+- `summary` — totals across instance states, deployed percent.
+- `diagnostics`, `coverage_gaps`, `evidence_links`, `failure_reasons`,
+  `remediation_hints`.
+
+The console `launch_url` carries no secret values — only the pinned template
+URL, parameter names (`IdentrailAccountId`, `ExternalId`, `RoleName`), the
+permission model, the target OU IDs, and the target regions.
+
+## Instance state lifecycle
+
+| State | Meaning |
+| --- | --- |
+| `pending` | Deployment has not started. |
+| `validating` | Prerequisites are being checked. |
+| `blocked` | Blocking prerequisites are unmet. |
+| `deploying` | CloudFormation operation is in flight. |
+| `active` | Instance deployed; collector is emitting coverage. |
+| `degraded` | Instance succeeded but validation drifted. |
+| `failed` | Deployment failed; retryable. |
+| `permission_denied` | AWS rejected the StackSet operation; recovery action surfaces the fix. |
+| `unsupported` | Region or account class is not supported. |
+| `suspended` | Account is suspended; remove or reactivate. |
+| `canceled` | Operator canceled before completion. |
+
+`active` and `canceled` are non-resumable; every other state is resumable so the
+operator can re-run a focused recovery.
+
+## What is intentionally not collected
+
+- Secret values, parameter values, environment values, database rows, object
+  contents, prompts, completions, or browser pages.
+- Live StackSet execution — the operator launches the StackSet via the AWS
+  console URL Identrail surfaces; Identrail does not call CloudFormation on the
+  operator's behalf.
+- Write or remediation tiers — the bundled template only grants the read-only
+  discovery tier. Remediation, approved-remediation, and
+  authorization-enforcement tiers must be granted through a dedicated write
+  role.
+
+## Fixture states
+
+- `success` — three target accounts × two regions with two active checkpoints
+  and a ready validation verdict.
+- `empty` — no target accounts/regions, blocking on `stackset.targets_present`.
+- `degraded` — delegated administrator missing, one suspended account in the
+  target set, two active instances.
+- `partial_failure` — one failed and one permission-denied instance with
+  resumable cursors and operator recovery actions.
+- `permission_denied` — trusted access disabled and external ID missing,
+  validation `blocked`.
+
+## Live validation
+
+1. From the project's AWS surface, open `AWS → Accounts` once a connector is
+   active.
+2. Confirm the StackSet onboarding panel shows the validation verdict, target
+   counts, expected coverage, and prerequisites.
+3. Resolve any blocking prerequisites (trusted access, external ID, template
+   URL).
+4. Click **Open StackSet launch URL** to open the AWS console and authorize
+   the operation. Identrail does not execute the StackSet.
+5. As CloudFormation operation status changes, re-fetch the onboarding plan;
+   per-instance state, cursors, and recovery actions reflect the latest
+   checkpoints.
+
+## Out of scope (next-wave issues)
+
+- Live execution of the StackSet operation from Identrail.
+- Drift detection across deployed stack instances.
+- Deletion / rollback orchestration.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -584,6 +584,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/stackset-onboarding
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-manager-metadata
     action: tenancy.read
     resource_type: project
@@ -4883,6 +4888,62 @@ paths:
                     $ref: "#/components/schemas/AWSOrganizationsTopologyResult"
         "400":
           description: Invalid AWS Organizations topology request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/stackset-onboarding:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Organization StackSet onboarding plan
+      operationId: getAWSProjectStackSetOnboarding
+      description: Returns the deterministic AWS Organization StackSet onboarding plan for an AWS connector. The response includes a permission preview, prerequisites with severity, validation verdict, target accounts/OUs/regions, per-instance lifecycle state with explicit failure reasons and resumable cursors, the AWS console launch URL, projected scan coverage expectations, and operator recovery actions. Read-only and metadata-only - it does not read secret values, customer payloads, object contents, database rows, prompts, or completions, and never mutates AWS state on the operator's behalf.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope onboarding planning.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: deployment_mode
+          schema:
+            type: string
+            enum: [service_managed, self_managed]
+          description: StackSet deployment mode. Service-managed uses AWS Organizations trusted access; self-managed uses operator-provided administration/execution roles.
+      responses:
+        "200":
+          description: AWS Organization StackSet onboarding plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  onboarding:
+                    $ref: "#/components/schemas/AWSStackSetOnboardingResult"
+        "400":
+          description: Invalid AWS StackSet onboarding request
           content:
             application/json:
               schema:
@@ -11137,6 +11198,261 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSOrganizationsTopologyDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSStackSetOnboardingPrerequisite:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        severity:
+          type: string
+          enum: [blocking, advisory]
+        satisfied: { type: boolean }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSStackSetOnboardingPermissionPreviewItem:
+      type: object
+      properties:
+        service: { type: string }
+        actions:
+          type: array
+          items: { type: string }
+        resources:
+          type: array
+          items: { type: string }
+        reason: { type: string }
+    AWSStackSetOnboardingPermissionPreview:
+      type: object
+      properties:
+        capability: { type: string }
+        tier: { type: string }
+        available: { type: boolean }
+        summary: { type: string }
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingPermissionPreviewItem"
+    AWSStackSetOnboardingValidation:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [ready, degraded, blocked, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        blocking_count: { type: integer }
+        advisory_count: { type: integer }
+        prerequisites:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingPrerequisite"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+    AWSStackSetOnboardingTargetAccount:
+      type: object
+      properties:
+        account_id: { type: string }
+        name: { type: string }
+        ou_path: { type: string }
+        management: { type: boolean }
+        suspended: { type: boolean }
+    AWSStackSetOnboardingTargetRegion:
+      type: object
+      properties:
+        region: { type: string }
+        name: { type: string }
+        opt_in: { type: boolean }
+    AWSStackSetOnboardingOU:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        parent_id: { type: string }
+        path: { type: string }
+        enabled: { type: boolean }
+        reason: { type: string }
+    AWSStackSetOnboardingTargets:
+      type: object
+      properties:
+        organization_id: { type: string }
+        organizational_units:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingOU"
+        accounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingTargetAccount"
+        regions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingTargetRegion"
+    AWSStackSetOnboardingInstance:
+      type: object
+      properties:
+        key: { type: string }
+        account_id: { type: string }
+        account_name: { type: string }
+        ou_path: { type: string }
+        region: { type: string }
+        region_name: { type: string }
+        state:
+          type: string
+          enum: [pending, validating, blocked, deploying, active, degraded, failed, permission_denied, unsupported, suspended, canceled]
+        stack_id: { type: string }
+        operation_id: { type: string }
+        failure_reason: { type: string }
+        attempts: { type: integer }
+        resumable: { type: boolean }
+        suspended: { type: boolean }
+        opt_in_region: { type: boolean }
+        next_action: { type: string }
+        coverage_targets: { type: integer }
+        evidence_ref: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+    AWSStackSetOnboardingCoverageExpectation:
+      type: object
+      properties:
+        expected_accounts: { type: integer }
+        expected_regions: { type: integer }
+        expected_instances: { type: integer }
+        expected_coverage_targets: { type: integer }
+        coverage_percent:
+          type: number
+          minimum: 0
+          maximum: 100
+        global_service_notes: { type: string }
+    AWSStackSetOnboardingRecoveryAction:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        targets:
+          type: array
+          items: { type: string }
+    AWSStackSetOnboardingSummary:
+      type: object
+      properties:
+        target_accounts: { type: integer }
+        target_regions: { type: integer }
+        total_instances: { type: integer }
+        pending_instances: { type: integer }
+        active_instances: { type: integer }
+        blocked_instances: { type: integer }
+        failed_instances: { type: integer }
+        degraded_instances: { type: integer }
+        suspended_instances: { type: integer }
+        permission_denied_instances: { type: integer }
+        unsupported_instances: { type: integer }
+        resumable_instances: { type: integer }
+        deployed_percent:
+          type: number
+          minimum: 0
+          maximum: 100
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+    AWSStackSetOnboardingDiagnostic:
+      type: object
+      properties:
+        source: { type: string }
+        scope: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSStackSetOnboardingCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSStackSetOnboardingResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        organization_id: { type: string }
+        management_account_id: { type: string }
+        stack_set_name: { type: string }
+        template_url: { type: string }
+        template_checksum: { type: string }
+        launch_url: { type: string }
+        deployment_mode:
+          type: string
+          enum: [service_managed, self_managed]
+        partition: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        validation:
+          $ref: "#/components/schemas/AWSStackSetOnboardingValidation"
+        permission_preview:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingPermissionPreview"
+        targets:
+          $ref: "#/components/schemas/AWSStackSetOnboardingTargets"
+        instances:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingInstance"
+        coverage_expectation:
+          $ref: "#/components/schemas/AWSStackSetOnboardingCoverageExpectation"
+        recovery_actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingRecoveryAction"
+        summary:
+          $ref: "#/components/schemas/AWSStackSetOnboardingSummary"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSStackSetOnboardingDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -760,6 +760,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/account-region-coverage", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/fanout-execution", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/organizations-topology", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/stackset-onboarding", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ssm-parameter-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ecr-repository-metadata", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_stackset_onboarding.go
+++ b/internal/api/aws_stackset_onboarding.go
@@ -1,0 +1,786 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsStackSetOnboardingCurrentIssue = 1504
+)
+
+// AWSStackSetOnboardingRequest pins the connector context and optional fixture
+// state used to project StackSet onboarding planning output.
+type AWSStackSetOnboardingRequest struct {
+	ConnectorID    string `json:"connector_id,omitempty"`
+	FixtureState   string `json:"fixture_state,omitempty"`
+	DeploymentMode string `json:"deployment_mode,omitempty"`
+}
+
+// AWSStackSetOnboardingPrerequisite is one operator-visible prerequisite check.
+type AWSStackSetOnboardingPrerequisite struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Severity    string `json:"severity"`
+	Satisfied   bool   `json:"satisfied"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSStackSetOnboardingPermissionPreview is one tier of pre-launch permission
+// rationale shared with the connector capabilities surface.
+type AWSStackSetOnboardingPermissionPreview struct {
+	Capability  string                                       `json:"capability"`
+	Tier        string                                       `json:"tier"`
+	Available   bool                                         `json:"available"`
+	Summary     string                                       `json:"summary"`
+	Permissions []AWSStackSetOnboardingPermissionPreviewItem `json:"permissions"`
+}
+
+// AWSStackSetOnboardingPermissionPreviewItem mirrors PermissionPreviewItem.
+type AWSStackSetOnboardingPermissionPreviewItem struct {
+	Service   string   `json:"service"`
+	Actions   []string `json:"actions"`
+	Resources []string `json:"resources"`
+	Reason    string   `json:"reason"`
+}
+
+// AWSStackSetOnboardingValidation is the high-level pre-launch verdict.
+type AWSStackSetOnboardingValidation struct {
+	Status           string                              `json:"status"`
+	Confidence       float64                             `json:"confidence"`
+	BlockingCount    int                                 `json:"blocking_count"`
+	AdvisoryCount    int                                 `json:"advisory_count"`
+	Prerequisites    []AWSStackSetOnboardingPrerequisite `json:"prerequisites"`
+	FailureReasons   []string                            `json:"failure_reasons"`
+	RemediationHints []string                            `json:"remediation_hints"`
+}
+
+// AWSStackSetOnboardingTargetAccount is one account in the StackSet target set.
+type AWSStackSetOnboardingTargetAccount struct {
+	AccountID  string `json:"account_id"`
+	Name       string `json:"name,omitempty"`
+	OUPath     string `json:"ou_path,omitempty"`
+	Management bool   `json:"management,omitempty"`
+	Suspended  bool   `json:"suspended,omitempty"`
+}
+
+// AWSStackSetOnboardingTargetRegion is one region in the StackSet target set.
+type AWSStackSetOnboardingTargetRegion struct {
+	Region string `json:"region"`
+	Name   string `json:"name,omitempty"`
+	OptIn  bool   `json:"opt_in,omitempty"`
+}
+
+// AWSStackSetOnboardingTargets is the full operator-visible target set.
+type AWSStackSetOnboardingTargets struct {
+	OrganizationID      string                               `json:"organization_id,omitempty"`
+	OrganizationalUnits []AWSStackSetOnboardingOU            `json:"organizational_units"`
+	Accounts            []AWSStackSetOnboardingTargetAccount `json:"accounts"`
+	Regions             []AWSStackSetOnboardingTargetRegion  `json:"regions"`
+}
+
+// AWSStackSetOnboardingOU is one operator-visible organizational unit.
+type AWSStackSetOnboardingOU struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Enabled  bool   `json:"enabled"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// AWSStackSetOnboardingInstance is one operator-visible StackSet instance.
+type AWSStackSetOnboardingInstance struct {
+	Key             string    `json:"key"`
+	AccountID       string    `json:"account_id"`
+	AccountName     string    `json:"account_name,omitempty"`
+	OUPath          string    `json:"ou_path,omitempty"`
+	Region          string    `json:"region"`
+	RegionName      string    `json:"region_name,omitempty"`
+	State           string    `json:"state"`
+	StackID         string    `json:"stack_id,omitempty"`
+	OperationID     string    `json:"operation_id,omitempty"`
+	FailureReason   string    `json:"failure_reason,omitempty"`
+	Attempts        int       `json:"attempts,omitempty"`
+	Resumable       bool      `json:"resumable"`
+	Suspended       bool      `json:"suspended,omitempty"`
+	OptInRegion     bool      `json:"opt_in_region,omitempty"`
+	NextAction      string    `json:"next_action"`
+	CoverageTargets int       `json:"coverage_targets"`
+	EvidenceRef     string    `json:"evidence_ref"`
+	ObservedAt      time.Time `json:"observed_at,omitempty"`
+}
+
+// AWSStackSetOnboardingCoverageExpectation projects post-launch scan coverage.
+type AWSStackSetOnboardingCoverageExpectation struct {
+	ExpectedAccounts        int     `json:"expected_accounts"`
+	ExpectedRegions         int     `json:"expected_regions"`
+	ExpectedInstances       int     `json:"expected_instances"`
+	ExpectedCoverageTargets int     `json:"expected_coverage_targets"`
+	CoveragePercent         float64 `json:"coverage_percent"`
+	GlobalServiceNotes      string  `json:"global_service_notes"`
+}
+
+// AWSStackSetOnboardingRecoveryAction is one operator recovery action.
+type AWSStackSetOnboardingRecoveryAction struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Targets     []string `json:"targets"`
+}
+
+// AWSStackSetOnboardingSummary aggregates the onboarding plan for dashboards.
+type AWSStackSetOnboardingSummary struct {
+	TargetAccounts       int            `json:"target_accounts"`
+	TargetRegions        int            `json:"target_regions"`
+	TotalInstances       int            `json:"total_instances"`
+	PendingInstances     int            `json:"pending_instances"`
+	ActiveInstances      int            `json:"active_instances"`
+	BlockedInstances     int            `json:"blocked_instances"`
+	FailedInstances      int            `json:"failed_instances"`
+	DegradedInstances    int            `json:"degraded_instances"`
+	SuspendedInstances   int            `json:"suspended_instances"`
+	PermissionDenied     int            `json:"permission_denied_instances"`
+	UnsupportedInstances int            `json:"unsupported_instances"`
+	ResumableInstances   int            `json:"resumable_instances"`
+	DeployedPercent      float64        `json:"deployed_percent"`
+	StateCounts          map[string]int `json:"state_counts"`
+}
+
+// AWSStackSetOnboardingDiagnostic is one planning/execution diagnostic.
+type AWSStackSetOnboardingDiagnostic struct {
+	Source      string `json:"source"`
+	Scope       string `json:"scope,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSStackSetOnboardingCoverageGap names a deliberate boundary of the planner.
+type AWSStackSetOnboardingCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSStackSetOnboardingResult is the full StackSet onboarding response.
+type AWSStackSetOnboardingResult struct {
+	TenantID            string                                   `json:"tenant_id"`
+	WorkspaceID         string                                   `json:"workspace_id"`
+	ProjectID           string                                   `json:"project_id"`
+	ConnectorID         string                                   `json:"connector_id,omitempty"`
+	AccountID           string                                   `json:"account_id,omitempty"`
+	Region              string                                   `json:"region,omitempty"`
+	OrganizationID      string                                   `json:"organization_id,omitempty"`
+	ManagementAccountID string                                   `json:"management_account_id,omitempty"`
+	StackSetName        string                                   `json:"stack_set_name"`
+	TemplateURL         string                                   `json:"template_url,omitempty"`
+	TemplateChecksum    string                                   `json:"template_checksum,omitempty"`
+	LaunchURL           string                                   `json:"launch_url,omitempty"`
+	DeploymentMode      string                                   `json:"deployment_mode"`
+	Partition           string                                   `json:"partition"`
+	ParentIssueNumber   int                                      `json:"parent_issue_number"`
+	ParentIssueRef      string                                   `json:"parent_issue_ref"`
+	CurrentIssueNumber  int                                      `json:"current_issue_number"`
+	CurrentIssueRef     string                                   `json:"current_issue_ref"`
+	Version             string                                   `json:"version"`
+	Status              string                                   `json:"status"`
+	FixtureState        string                                   `json:"fixture_state,omitempty"`
+	Confidence          float64                                  `json:"confidence"`
+	Validation          AWSStackSetOnboardingValidation          `json:"validation"`
+	PermissionPreview   []AWSStackSetOnboardingPermissionPreview `json:"permission_preview"`
+	Targets             AWSStackSetOnboardingTargets             `json:"targets"`
+	Instances           []AWSStackSetOnboardingInstance          `json:"instances"`
+	CoverageExpectation AWSStackSetOnboardingCoverageExpectation `json:"coverage_expectation"`
+	RecoveryActions     []AWSStackSetOnboardingRecoveryAction    `json:"recovery_actions"`
+	Summary             AWSStackSetOnboardingSummary             `json:"summary"`
+	FailureReasons      []string                                 `json:"failure_reasons"`
+	RemediationHints    []string                                 `json:"remediation_hints"`
+	EvidenceLinks       []string                                 `json:"evidence_links"`
+	CoverageGaps        []AWSStackSetOnboardingCoverageGap       `json:"coverage_gaps"`
+	Diagnostics         []AWSStackSetOnboardingDiagnostic        `json:"diagnostics"`
+	GeneratedAt         time.Time                                `json:"generated_at"`
+	UpdatedAt           time.Time                                `json:"updated_at"`
+}
+
+// GetAWSStackSetOnboarding returns the deterministic AWS Organization StackSet
+// onboarding plan for a project. It is read-only and metadata-only: it issues
+// no AWS API calls and never mutates AWS state. Fixture states drive
+// deterministic loading/empty/degraded/permission-denied/partial-failure
+// projections for the operator UI and contract tests.
+func (s *Service) GetAWSStackSetOnboarding(ctx context.Context, workspaceID string, projectID string, request AWSStackSetOnboardingRequest) (AWSStackSetOnboardingResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSStackSetOnboardingResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSStackSetOnboardingResult{}, err
+	}
+	return s.buildAWSStackSetOnboarding(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func (s *Service) buildAWSStackSetOnboarding(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSStackSetOnboardingRequest, checkedAt time.Time) (AWSStackSetOnboardingResult, error) {
+	fixtureState := normalizeAWSStackSetFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSStackSetOnboardingResult{}, ErrInvalidAWSConnectionRequest
+	}
+	deploymentMode := normalizeAWSStackSetDeploymentMode(request.DeploymentMode)
+	if deploymentMode == "" {
+		return AWSStackSetOnboardingResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(strings.TrimSpace(connection.AccountID), "111111111111")
+	region := firstNonEmptyAWSValue(strings.TrimSpace(connection.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(strings.TrimSpace(connection.ConnectorID), strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	config, diagnostics, gaps := awsStackSetFixtureConfig(
+		connectorID,
+		accountID,
+		region,
+		fixtureState,
+		awscontract.StackSetDeploymentMode(deploymentMode),
+		strings.TrimSpace(s.AWSCloudFormationTemplateURL),
+		strings.TrimSpace(connection.ExternalID),
+	)
+
+	plan, err := awscontract.PlanStackSetOnboarding(config, checkedAt)
+	if err != nil {
+		return AWSStackSetOnboardingResult{}, err
+	}
+
+	launchURL := awsconnector.BuildCloudFormationStackSetLaunchURL(awsconnector.CloudFormationStackSetLaunchInput{
+		TemplateURL:           plan.TemplateURL,
+		Region:                region,
+		StackSetName:          plan.StackSetName,
+		IdentrailAccountID:    strings.TrimSpace(s.AWSAccountID),
+		ExternalID:            strings.TrimSpace(config.ExternalID),
+		RoleName:              "IdentrailReadOnly",
+		PermissionModel:       awsStackSetPermissionModel(plan.DeploymentMode),
+		OrganizationalUnitIDs: collectStackSetOUIDs(plan.Targets.OrganizationalUnits),
+		TargetAccountIDs:      collectStackSetAccountIDs(plan.Targets.Accounts),
+		TargetRegions:         collectStackSetRegionCodes(plan.Targets.Regions),
+	})
+
+	status, confidence, failures, remediations := summarizeAWSStackSetOnboarding(fixtureState, plan, diagnostics)
+
+	return AWSStackSetOnboardingResult{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		AccountID:           accountID,
+		Region:              region,
+		OrganizationID:      plan.OrganizationID,
+		ManagementAccountID: plan.ManagementAccountID,
+		StackSetName:        plan.StackSetName,
+		TemplateURL:         plan.TemplateURL,
+		TemplateChecksum:    plan.TemplateChecksum,
+		LaunchURL:           launchURL,
+		DeploymentMode:      string(plan.DeploymentMode),
+		Partition:           plan.Partition,
+		ParentIssueNumber:   awsPlatformDependencyParentIssue,
+		ParentIssueRef:      awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:  awsStackSetOnboardingCurrentIssue,
+		CurrentIssueRef:     awsIssueRef(awsStackSetOnboardingCurrentIssue),
+		Version:             plan.Version,
+		Status:              status,
+		FixtureState:        fixtureState,
+		Confidence:          confidence,
+		Validation:          mapAWSStackSetValidation(plan.Validation),
+		PermissionPreview:   awsStackSetPermissionPreview(),
+		Targets:             mapAWSStackSetTargets(plan.Targets),
+		Instances:           mapAWSStackSetInstances(plan.Instances),
+		CoverageExpectation: mapAWSStackSetCoverageExpectation(plan.CoverageExpectation),
+		RecoveryActions:     mapAWSStackSetRecoveryActions(plan.RecoveryActions),
+		Summary:             mapAWSStackSetSummary(plan.Summary),
+		FailureReasons:      failures,
+		RemediationHints:    remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsStackSetOnboardingCurrentIssue),
+			awsIssueURL(awsCoveragePlannerCurrentIssue),
+			"/docs/aws-stackset-onboarding",
+			"/docs/auth/aws-connector",
+			"/docs/aws-account-region-coverage-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func normalizeAWSStackSetFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func normalizeAWSStackSetDeploymentMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", string(awscontract.StackSetDeploymentServiceManaged):
+		return string(awscontract.StackSetDeploymentServiceManaged)
+	case string(awscontract.StackSetDeploymentSelfManaged):
+		return string(awscontract.StackSetDeploymentSelfManaged)
+	default:
+		return ""
+	}
+}
+
+func awsStackSetPermissionModel(mode awscontract.StackSetDeploymentMode) awsconnector.StackSetLaunchPermissionModel {
+	if mode == awscontract.StackSetDeploymentSelfManaged {
+		return awsconnector.StackSetLaunchPermissionModelSelfManaged
+	}
+	return awsconnector.StackSetLaunchPermissionModelServiceManaged
+}
+
+// awsStackSetFixtureConfig returns the deterministic StackSet onboarding config,
+// diagnostics, and coverage gaps for one fixture state. The planner consumes the
+// resulting config so the API exercises the same code path operators will run
+// against live connectors.
+func awsStackSetFixtureConfig(
+	connectorID,
+	accountID,
+	region,
+	fixtureState string,
+	deploymentMode awscontract.StackSetDeploymentMode,
+	templateURL,
+	connectorExternalID string,
+) (awscontract.StackSetOnboardingConfig, []AWSStackSetOnboardingDiagnostic, []AWSStackSetOnboardingCoverageGap) {
+	gaps := []AWSStackSetOnboardingCoverageGap{
+		{
+			Capability:  "live_stackset_execution",
+			Status:      "out_of_scope",
+			Reason:      "Identrail does not execute the StackSet on behalf of operators; the app surface previews and recovers the operation but the operator launches it via the AWS console URL.",
+			Remediation: "Use the launch_url to open the AWS console and authorize the StackSet operation.",
+		},
+		{
+			Capability:  "secret_value_inspection",
+			Status:      "unsupported",
+			Reason:      "Onboarding reads no customer payloads, secret values, or object contents; it only plans where the read-only collector role will be deployed.",
+			Remediation: "Inspect values through the owning service outside Identrail.",
+		},
+	}
+	gaps = append(gaps, AWSStackSetOnboardingCoverageGap{
+		Capability:  "write_capabilities_excluded",
+		Status:      "out_of_scope",
+		Reason:      "The StackSet template only grants the read-only discovery tier. Remediation and authorization-enforcement tiers must be granted through a dedicated write role.",
+		Remediation: "Use the connector capability tiers surface to plan separate write-tier onboarding when required.",
+	})
+
+	pinnedTemplate := strings.TrimSpace(templateURL)
+	if pinnedTemplate == "" {
+		pinnedTemplate = "https://fixture.identrail.invalid/templates/identrail-readonly-stackset.yaml"
+	}
+
+	if fixtureState == "empty" {
+		// Empty: no targets configured. The planner will block on the
+		// targets-present prerequisite.
+		return awscontract.StackSetOnboardingConfig{
+			ConnectorID:         connectorID,
+			OrganizationID:      "o-fixture",
+			ManagementAccountID: accountID,
+			StackSetName:        "identrail-readonly-connector-stackset",
+			TemplateURL:         pinnedTemplate,
+			TemplateChecksum:    "sha256:fixture-empty",
+			DeploymentMode:      deploymentMode,
+			Partition:           awsStackSetPartition(region),
+			TrustedAccessReady:  true,
+			DelegatedAdminReady: true,
+			ExternalID:          firstNonEmptyAWSValue(connectorExternalID, "external-id-fixture"),
+			Targets:             awscontract.StackSetOnboardingTargets{},
+		}, nil, gaps
+	}
+
+	siblingAccount := awsStackSetSiblingAccount(accountID)
+	tertiaryAccount := awsStackSetSiblingAccount(siblingAccount)
+	secondaryRegion := awsStackSetSecondaryRegion(region)
+
+	config := awscontract.StackSetOnboardingConfig{
+		ConnectorID:         connectorID,
+		OrganizationID:      "o-fixture",
+		ManagementAccountID: accountID,
+		StackSetName:        "identrail-readonly-connector-stackset",
+		TemplateURL:         pinnedTemplate,
+		TemplateChecksum:    "sha256:fixture-success",
+		DeploymentMode:      deploymentMode,
+		Partition:           awsStackSetPartition(region),
+		TrustedAccessReady:  true,
+		DelegatedAdminReady: true,
+		ExternalID:          firstNonEmptyAWSValue(connectorExternalID, "external-id-fixture"),
+		Targets: awscontract.StackSetOnboardingTargets{
+			OrganizationID: "o-fixture",
+			OrganizationalUnits: []awscontract.OrganizationUnit{
+				{ID: "ou-prod", Name: "Production", Path: "/Root/Production", Enabled: true},
+				{ID: "ou-data", Name: "Data", Path: "/Root/Data", Enabled: true},
+			},
+			Accounts: []awscontract.StackSetOnboardingTargetAccount{
+				{AccountID: accountID, Name: "management", Management: true, OUPath: "/Root"},
+				{AccountID: siblingAccount, Name: "production", OUPath: "/Root/Production"},
+				{AccountID: tertiaryAccount, Name: "data", OUPath: "/Root/Data"},
+			},
+			Regions: []awscontract.StackSetOnboardingTargetRegion{
+				{Region: region},
+				{Region: secondaryRegion},
+			},
+		},
+	}
+
+	switch fixtureState {
+	case "permission_denied":
+		config.TrustedAccessReady = false
+		config.ExternalID = ""
+	case "degraded":
+		config.DelegatedAdminReady = false
+		config.Targets.Accounts = append(config.Targets.Accounts, awscontract.StackSetOnboardingTargetAccount{AccountID: awsStackSetSiblingAccount(tertiaryAccount), Name: "retired-sandbox", Suspended: true, OUPath: "/Root/Sandbox"})
+		config.Checkpoints = []awscontract.StackSetOnboardingCheckpoint{
+			{AccountID: accountID, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-1"},
+			{AccountID: siblingAccount, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-2"},
+		}
+	case "partial_failure":
+		config.Checkpoints = []awscontract.StackSetOnboardingCheckpoint{
+			{AccountID: accountID, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-1"},
+			{AccountID: siblingAccount, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-2"},
+			{AccountID: tertiaryAccount, Region: region, State: awscontract.StackSetStateFailed, FailureReason: "Throttling: CreateStackInstances throttled after retries", Attempts: 3},
+			{AccountID: tertiaryAccount, Region: secondaryRegion, State: awscontract.StackSetStatePermissionDenied, FailureReason: "AccessDenied: assume into member account failed"},
+		}
+	default:
+		// success
+		config.Checkpoints = []awscontract.StackSetOnboardingCheckpoint{
+			{AccountID: accountID, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-1"},
+			{AccountID: siblingAccount, Region: region, State: awscontract.StackSetStateActive, StackID: "stack-fixture-2"},
+		}
+	}
+
+	diagnostics := []AWSStackSetOnboardingDiagnostic{}
+	switch fixtureState {
+	case "permission_denied":
+		diagnostics = append(diagnostics, AWSStackSetOnboardingDiagnostic{
+			Source:      "stackset_onboarding_planner",
+			Scope:       "organizations.trusted_access",
+			Code:        "trusted_access_disabled",
+			Message:     "AWS Organizations trusted access for CloudFormation StackSets is not enabled in this organization.",
+			Remediation: "From the management account, enable trusted access for CloudFormation StackSets, then re-run onboarding.",
+			Retryable:   false,
+		})
+	case "partial_failure":
+		diagnostics = append(diagnostics, AWSStackSetOnboardingDiagnostic{
+			Source:      "stackset_onboarding_planner",
+			Scope:       tertiaryAccount + "/" + region,
+			Code:        "create_stack_instance_throttled",
+			Message:     "AWS throttled CreateStackInstances for one account/region pair after bounded retries; this instance is resumable.",
+			Remediation: "Retry this instance from the onboarding surface after the throttle window passes.",
+			Retryable:   true,
+		})
+	case "degraded":
+		diagnostics = append(diagnostics, AWSStackSetOnboardingDiagnostic{
+			Source:      "stackset_onboarding_planner",
+			Scope:       "organizations.delegated_admin",
+			Code:        "delegated_admin_missing",
+			Message:     "Onboarding is running from the management account because a delegated administrator is not registered.",
+			Remediation: "Register a CloudFormation StackSets delegated administrator account to reduce blast radius.",
+			Retryable:   true,
+		})
+	}
+
+	return config, diagnostics, gaps
+}
+
+func mapAWSStackSetValidation(validation awscontract.StackSetOnboardingValidation) AWSStackSetOnboardingValidation {
+	prereqs := make([]AWSStackSetOnboardingPrerequisite, 0, len(validation.Prerequisites))
+	for _, prereq := range validation.Prerequisites {
+		prereqs = append(prereqs, AWSStackSetOnboardingPrerequisite{
+			ID:          prereq.ID,
+			Title:       prereq.Title,
+			Severity:    string(prereq.Severity),
+			Satisfied:   prereq.Satisfied,
+			Reason:      prereq.Reason,
+			Remediation: prereq.Remediation,
+		})
+	}
+	failures := validation.FailureReasons
+	if failures == nil {
+		failures = []string{}
+	}
+	remediations := validation.RemediationHints
+	if remediations == nil {
+		remediations = []string{}
+	}
+	return AWSStackSetOnboardingValidation{
+		Status:           string(validation.Status),
+		Confidence:       validation.Confidence,
+		BlockingCount:    validation.BlockingCount,
+		AdvisoryCount:    validation.AdvisoryCount,
+		Prerequisites:    prereqs,
+		FailureReasons:   failures,
+		RemediationHints: remediations,
+	}
+}
+
+func mapAWSStackSetTargets(targets awscontract.StackSetOnboardingTargets) AWSStackSetOnboardingTargets {
+	out := AWSStackSetOnboardingTargets{
+		OrganizationID:      strings.TrimSpace(targets.OrganizationID),
+		OrganizationalUnits: make([]AWSStackSetOnboardingOU, 0, len(targets.OrganizationalUnits)),
+		Accounts:            make([]AWSStackSetOnboardingTargetAccount, 0, len(targets.Accounts)),
+		Regions:             make([]AWSStackSetOnboardingTargetRegion, 0, len(targets.Regions)),
+	}
+	for _, ou := range targets.OrganizationalUnits {
+		out.OrganizationalUnits = append(out.OrganizationalUnits, AWSStackSetOnboardingOU{
+			ID:       ou.ID,
+			Name:     ou.Name,
+			ParentID: ou.ParentID,
+			Path:     ou.Path,
+			Enabled:  ou.Enabled,
+			Reason:   ou.Reason,
+		})
+	}
+	for _, account := range targets.Accounts {
+		out.Accounts = append(out.Accounts, AWSStackSetOnboardingTargetAccount{
+			AccountID:  account.AccountID,
+			Name:       account.Name,
+			OUPath:     account.OUPath,
+			Management: account.Management,
+			Suspended:  account.Suspended,
+		})
+	}
+	for _, region := range targets.Regions {
+		out.Regions = append(out.Regions, AWSStackSetOnboardingTargetRegion{
+			Region: region.Region,
+			Name:   region.Name,
+			OptIn:  region.OptIn,
+		})
+	}
+	return out
+}
+
+func mapAWSStackSetInstances(instances []awscontract.StackSetOnboardingInstance) []AWSStackSetOnboardingInstance {
+	out := make([]AWSStackSetOnboardingInstance, 0, len(instances))
+	for _, instance := range instances {
+		out = append(out, AWSStackSetOnboardingInstance{
+			Key:             instance.Key,
+			AccountID:       instance.AccountID,
+			AccountName:     instance.AccountName,
+			OUPath:          instance.OUPath,
+			Region:          instance.Region,
+			RegionName:      instance.RegionName,
+			State:           string(instance.State),
+			StackID:         instance.StackID,
+			OperationID:     instance.OperationID,
+			FailureReason:   instance.FailureReason,
+			Attempts:        instance.Attempts,
+			Resumable:       instance.Resumable,
+			Suspended:       instance.Suspended,
+			OptInRegion:     instance.OptInRegion,
+			NextAction:      instance.NextAction,
+			CoverageTargets: instance.CoverageTargets,
+			EvidenceRef:     instance.EvidenceRef,
+			ObservedAt:      instance.ObservedAt,
+		})
+	}
+	return out
+}
+
+func mapAWSStackSetCoverageExpectation(expectation awscontract.StackSetOnboardingCoverageExpectation) AWSStackSetOnboardingCoverageExpectation {
+	return AWSStackSetOnboardingCoverageExpectation{
+		ExpectedAccounts:        expectation.ExpectedAccounts,
+		ExpectedRegions:         expectation.ExpectedRegions,
+		ExpectedInstances:       expectation.ExpectedInstances,
+		ExpectedCoverageTargets: expectation.ExpectedCoverage,
+		CoveragePercent:         expectation.CoveragePercent,
+		GlobalServiceNotes:      expectation.GlobalServiceNotes,
+	}
+}
+
+func mapAWSStackSetRecoveryActions(actions []awscontract.StackSetOnboardingRecoveryAction) []AWSStackSetOnboardingRecoveryAction {
+	out := make([]AWSStackSetOnboardingRecoveryAction, 0, len(actions))
+	for _, action := range actions {
+		targets := action.Targets
+		if targets == nil {
+			targets = []string{}
+		}
+		out = append(out, AWSStackSetOnboardingRecoveryAction{
+			ID:          action.ID,
+			Title:       action.Title,
+			Description: action.Description,
+			Targets:     targets,
+		})
+	}
+	return out
+}
+
+func mapAWSStackSetSummary(summary awscontract.StackSetOnboardingSummary) AWSStackSetOnboardingSummary {
+	stateCounts := map[string]int{}
+	for state, count := range summary.StateCounts {
+		stateCounts[string(state)] = count
+	}
+	return AWSStackSetOnboardingSummary{
+		TargetAccounts:       summary.TargetAccounts,
+		TargetRegions:        summary.TargetRegions,
+		TotalInstances:       summary.TotalInstances,
+		PendingInstances:     summary.PendingInstances,
+		ActiveInstances:      summary.ActiveInstances,
+		BlockedInstances:     summary.BlockedInstances,
+		FailedInstances:      summary.FailedInstances,
+		DegradedInstances:    summary.DegradedInstances,
+		SuspendedInstances:   summary.SuspendedInstances,
+		PermissionDenied:     summary.PermissionDenied,
+		UnsupportedInstances: summary.UnsupportedInstances,
+		ResumableInstances:   summary.ResumableInstances,
+		DeployedPercent:      summary.DeployedPercent,
+		StateCounts:          stateCounts,
+	}
+}
+
+func awsStackSetPermissionPreview() []AWSStackSetOnboardingPermissionPreview {
+	tiers := awsconnector.CapabilityPermissionTiers()
+	out := make([]AWSStackSetOnboardingPermissionPreview, 0, len(tiers))
+	for _, tier := range tiers {
+		items := make([]AWSStackSetOnboardingPermissionPreviewItem, 0, len(tier.Permissions))
+		for _, item := range tier.Permissions {
+			items = append(items, AWSStackSetOnboardingPermissionPreviewItem{
+				Service:   item.Service,
+				Actions:   item.Actions,
+				Resources: item.Resources,
+				Reason:    item.Reason,
+			})
+		}
+		out = append(out, AWSStackSetOnboardingPermissionPreview{
+			Capability:  string(tier.Capability),
+			Tier:        string(tier.Tier),
+			Available:   tier.Available,
+			Summary:     tier.Summary,
+			Permissions: items,
+		})
+	}
+	return out
+}
+
+func summarizeAWSStackSetOnboarding(fixtureState string, plan awscontract.StackSetOnboardingPlan, diagnostics []AWSStackSetOnboardingDiagnostic) (string, float64, []string, []string) {
+	failures := append([]string{}, plan.Validation.FailureReasons...)
+	remediations := append([]string{}, plan.Validation.RemediationHints...)
+	for _, diagnostic := range diagnostics {
+		if msg := strings.TrimSpace(diagnostic.Message); msg != "" {
+			failures = append(failures, msg)
+		}
+		if rem := strings.TrimSpace(diagnostic.Remediation); rem != "" {
+			remediations = append(remediations, rem)
+		}
+	}
+
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35, dedupeStrings(failures),
+			dedupeStrings(append(remediations, "Enable trusted access in AWS Organizations, then retry the StackSet onboarding."))
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72, dedupeStrings(failures),
+			dedupeStrings(append(remediations, "Re-run failed instances after the AWS error window resolves."))
+	default:
+		if plan.Summary.TotalInstances == 0 {
+			return awsPlatformDependencyStatusReady, 0.78, nil,
+				dedupeStrings(append(remediations, "Select at least one target account/OU and one region before launching the StackSet."))
+		}
+		switch plan.Validation.Status {
+		case awscontract.StackSetValidationBlocked:
+			return awsPlatformDependencyStatusBlocked, 0.4, dedupeStrings(failures), dedupeStrings(remediations)
+		case awscontract.StackSetValidationDegraded:
+			return awsPlatformDependencyStatusDegraded, 0.72, dedupeStrings(failures), dedupeStrings(remediations)
+		default:
+			return awsPlatformDependencyStatusReady, 0.94, dedupeStrings(failures),
+				dedupeStrings(append(remediations, "Open the StackSet console launch URL to deploy the read-only connector across the target accounts."))
+		}
+	}
+}
+
+func collectStackSetOUIDs(units []awscontract.OrganizationUnit) []string {
+	out := make([]string, 0, len(units))
+	for _, ou := range units {
+		if id := strings.TrimSpace(ou.ID); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func collectStackSetAccountIDs(accounts []awscontract.StackSetOnboardingTargetAccount) []string {
+	out := make([]string, 0, len(accounts))
+	for _, account := range accounts {
+		if !account.Suspended {
+			out = append(out, account.AccountID)
+		}
+	}
+	return out
+}
+
+func collectStackSetRegionCodes(regions []awscontract.StackSetOnboardingTargetRegion) []string {
+	out := make([]string, 0, len(regions))
+	for _, region := range regions {
+		out = append(out, region.Region)
+	}
+	return out
+}
+
+func awsStackSetPartition(region string) string {
+	switch {
+	case strings.HasPrefix(strings.ToLower(strings.TrimSpace(region)), "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(strings.ToLower(strings.TrimSpace(region)), "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}
+
+func awsStackSetSiblingAccount(accountID string) string {
+	digits := strings.TrimSpace(accountID)
+	if len(digits) != 12 {
+		return "222222222222"
+	}
+	last := digits[11]
+	if last == '9' {
+		return digits[:11] + "0"
+	}
+	return digits[:11] + string(last+1)
+}
+
+func awsStackSetSecondaryRegion(region string) string {
+	if strings.EqualFold(strings.TrimSpace(region), "eu-west-1") {
+		return "us-east-1"
+	}
+	return "eu-west-1"
+}
+
+// AWSStackSetOnboardingState is an exported coverage-state alias so the OpenAPI
+// spec can enumerate the planner's lifecycle states without leaking the
+// awscontract package directly.
+func AWSStackSetOnboardingStates() []string {
+	return []string{
+		string(awscontract.StackSetStatePending),
+		string(awscontract.StackSetStateValidating),
+		string(awscontract.StackSetStateBlocked),
+		string(awscontract.StackSetStateDeploying),
+		string(awscontract.StackSetStateActive),
+		string(awscontract.StackSetStateDegraded),
+		string(awscontract.StackSetStateFailed),
+		string(awscontract.StackSetStatePermissionDenied),
+		string(awscontract.StackSetStateUnsupported),
+		string(awscontract.StackSetStateSuspended),
+		string(awscontract.StackSetStateCanceled),
+	}
+}

--- a/internal/api/aws_stackset_onboarding_test.go
+++ b/internal/api/aws_stackset_onboarding_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAWSStackSetService(t *testing.T, store db.Store, now time.Time) *Service {
+	t.Helper()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudFormationTemplateURL = "https://cdn.example.com/identrail-readonly-stackset.yaml"
+	svc.AWSAccountID = "987654321098"
+	return svc
+}
+
+func TestGetAWSStackSetOnboardingSuccess(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := newAWSStackSetService(t, store, now)
+
+	result, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get stackset onboarding: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready onboarding, got status=%q confidence=%v failures=%v", result.Status, result.Confidence, result.FailureReasons)
+	}
+	if result.CurrentIssueRef != "#1504" || result.Version == "" {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.Validation.Status != "ready" || result.Validation.BlockingCount != 0 {
+		t.Fatalf("expected ready validation, got %+v", result.Validation)
+	}
+	// Default: 3 accounts × 2 regions = 6 instances.
+	if result.Summary.TotalInstances != 6 {
+		t.Fatalf("expected 6 instances, got %d", result.Summary.TotalInstances)
+	}
+	if result.Summary.ActiveInstances < 2 {
+		t.Fatalf("expected at least 2 active instances from checkpoints, got %+v", result.Summary)
+	}
+	if result.LaunchURL == "" || !strings.Contains(result.LaunchURL, "stacksets/create") {
+		t.Fatalf("expected stackset console launch URL, got %q", result.LaunchURL)
+	}
+	if !strings.Contains(result.LaunchURL, "permissionModel=SERVICE_MANAGED") {
+		t.Fatalf("expected SERVICE_MANAGED permission model in launch URL, got %q", result.LaunchURL)
+	}
+	if len(result.PermissionPreview) == 0 {
+		t.Fatalf("expected permission preview tiers")
+	}
+	// Every instance carries an evidence ref and next action.
+	for _, instance := range result.Instances {
+		if instance.EvidenceRef == "" || instance.NextAction == "" {
+			t.Fatalf("instance missing evidence/next action: %+v", instance)
+		}
+	}
+}
+
+func TestGetAWSStackSetOnboardingSelfManaged(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 5, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := newAWSStackSetService(t, store, now)
+
+	result, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", DeploymentMode: "self_managed"})
+	if err != nil {
+		t.Fatalf("get self-managed onboarding: %v", err)
+	}
+	if result.DeploymentMode != "self_managed" {
+		t.Fatalf("expected self_managed deployment mode, got %q", result.DeploymentMode)
+	}
+	// Self-managed without an admin role ARN should block validation.
+	if result.Validation.Status != "blocked" || result.Validation.BlockingCount == 0 {
+		t.Fatalf("expected blocked self-managed validation, got %+v", result.Validation)
+	}
+}
+
+func TestGetAWSStackSetOnboardingFixtureStates(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newAWSStackSetService(t, store, now)
+
+	empty, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("get empty plan: %v", err)
+	}
+	if empty.Summary.TotalInstances != 0 {
+		t.Fatalf("expected zero instances in empty state, got %d", empty.Summary.TotalInstances)
+	}
+	if empty.Validation.Status != "blocked" {
+		t.Fatalf("empty state should block validation (no targets), got %q", empty.Validation.Status)
+	}
+
+	degraded, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("get degraded plan: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded state with diagnostics, got %+v", degraded)
+	}
+	if degraded.Summary.SuspendedInstances == 0 {
+		t.Fatalf("expected suspended instances from the degraded fixture")
+	}
+
+	partial, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("get partial plan: %v", err)
+	}
+	if partial.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded for partial_failure, got %q", partial.Status)
+	}
+	if partial.Summary.FailedInstances == 0 || partial.Summary.PermissionDenied == 0 {
+		t.Fatalf("expected failed + permission_denied instances in partial fixture, got %+v", partial.Summary)
+	}
+	if len(partial.RecoveryActions) == 0 {
+		t.Fatalf("expected recovery actions in partial fixture")
+	}
+
+	denied, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get denied plan: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked {
+		t.Fatalf("expected blocked denied plan, got %q", denied.Status)
+	}
+	if denied.Validation.BlockingCount == 0 {
+		t.Fatalf("expected blocking prereqs when trusted access unavailable, got %+v", denied.Validation)
+	}
+}
+
+func TestGetAWSStackSetOnboardingRejectsInvalidInputs(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newAWSStackSetService(t, store, now)
+
+	if _, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", FixtureState: "bogus"}); err == nil {
+		t.Fatalf("expected invalid fixture_state error")
+	}
+	if _, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod", DeploymentMode: "bogus"}); err == nil {
+		t.Fatalf("expected invalid deployment_mode error")
+	}
+}
+
+func TestGetAWSStackSetOnboardingNeverLeaksValues(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 10, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newAWSStackSetService(t, store, now)
+
+	result, err := svc.GetAWSStackSetOnboarding(ctx, "default", "project-a", AWSStackSetOnboardingRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get stackset onboarding: %v", err)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	lower := strings.ToLower(string(payload))
+	for _, forbidden := range []string{"getsecretvalue", "secretstring", "password=", "=sk-", "plaintext"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("value-like content leaked into onboarding payload: %s", payload)
+		}
+	}
+}
+
+func TestRouterAWSStackSetOnboarding(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 13, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := newAWSStackSetService(t, store, now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/stackset-onboarding?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Onboarding AWSStackSetOnboardingResult `json:"onboarding"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Onboarding.Status != awsPlatformDependencyStatusDegraded || body.Onboarding.Summary.FailedInstances == 0 {
+		t.Fatalf("expected degraded partial onboarding, got %+v", body.Onboarding)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "deployment_mode=bogus"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/stackset-onboarding?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3099,6 +3099,37 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"topology": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/stackset-onboarding", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSStackSetOnboarding(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSStackSetOnboardingRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			DeploymentMode: strings.TrimSpace(c.Query("deployment_mode")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws stackset onboarding request"})
+			default:
+				if logger != nil {
+					logger.Error("get aws stackset onboarding",
+						zap.String("workspace_id", c.Param("workspace_id")),
+						zap.String("project_id", c.Param("project_id")),
+						telemetry.ZapError(err),
+					)
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws stackset onboarding"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"onboarding": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-manager-metadata", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/connectors/aws/cfn.go
+++ b/internal/connectors/aws/cfn.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-const defaultStackName = "identrail-readonly-connector"
+const (
+	defaultStackName = "identrail-readonly-connector"
+)
 
 var awsRegionPattern = regexp.MustCompile(`^[a-z]{2}(-gov)?-[a-z]+-[0-9]$`)
 
@@ -43,6 +45,77 @@ func BuildCloudFormationLaunchURL(input CloudFormationLaunchInput) string {
 	values.Set("param_RoleName", roleName)
 
 	return "https://" + consoleHostForRegion(region) + "/cloudformation/home?region=" + url.QueryEscape(region) + "#/stacks/create/review?" + values.Encode()
+}
+
+// StackSetLaunchPermissionModel names how the StackSet authenticates into
+// member accounts. SERVICE_MANAGED uses AWS Organizations trusted access;
+// SELF_MANAGED uses operator-provided administration/execution roles.
+type StackSetLaunchPermissionModel string
+
+const (
+	StackSetLaunchPermissionModelServiceManaged StackSetLaunchPermissionModel = "SERVICE_MANAGED"
+	StackSetLaunchPermissionModelSelfManaged    StackSetLaunchPermissionModel = "SELF_MANAGED"
+)
+
+const defaultStackSetName = "identrail-readonly-connector-stackset"
+
+// CloudFormationStackSetLaunchInput contains the parameters for an AWS console
+// StackSet launch URL. The URL never carries secret values; only the pinned
+// template URL, parameter names, and target metadata.
+type CloudFormationStackSetLaunchInput struct {
+	TemplateURL           string
+	Region                string
+	StackSetName          string
+	IdentrailAccountID    string
+	ExternalID            string
+	RoleName              string
+	PermissionModel       StackSetLaunchPermissionModel
+	OrganizationalUnitIDs []string
+	TargetAccountIDs      []string
+	TargetRegions         []string
+}
+
+// BuildCloudFormationStackSetLaunchURL creates an AWS console deep link for
+// creating the read-only connector StackSet. It returns an empty string when
+// inputs are insufficient so callers can surface a deterministic blocked state
+// instead of an obviously malformed URL.
+func BuildCloudFormationStackSetLaunchURL(input CloudFormationStackSetLaunchInput) string {
+	region := NormalizeRegion(input.Region)
+	stackSetName := strings.TrimSpace(input.StackSetName)
+	if stackSetName == "" {
+		stackSetName = defaultStackSetName
+	}
+	roleName := strings.TrimSpace(input.RoleName)
+	if roleName == "" {
+		roleName = "IdentrailReadOnly"
+	}
+	templateURL := strings.TrimSpace(input.TemplateURL)
+	if templateURL == "" {
+		return ""
+	}
+	permissionModel := strings.ToUpper(strings.TrimSpace(string(input.PermissionModel)))
+	if permissionModel != string(StackSetLaunchPermissionModelServiceManaged) && permissionModel != string(StackSetLaunchPermissionModelSelfManaged) {
+		permissionModel = string(StackSetLaunchPermissionModelServiceManaged)
+	}
+
+	values := url.Values{}
+	values.Set("templateURL", templateURL)
+	values.Set("stackSetName", stackSetName)
+	values.Set("permissionModel", permissionModel)
+	values.Set("param_IdentrailAccountId", strings.TrimSpace(input.IdentrailAccountID))
+	values.Set("param_ExternalId", strings.TrimSpace(input.ExternalID))
+	values.Set("param_RoleName", roleName)
+	if len(input.OrganizationalUnitIDs) > 0 {
+		values.Set("organizationalUnitIds", strings.Join(input.OrganizationalUnitIDs, ","))
+	}
+	if len(input.TargetAccountIDs) > 0 {
+		values.Set("accounts", strings.Join(input.TargetAccountIDs, ","))
+	}
+	if len(input.TargetRegions) > 0 {
+		values.Set("regions", strings.Join(input.TargetRegions, ","))
+	}
+
+	return "https://" + consoleHostForRegion(region) + "/cloudformation/home?region=" + url.QueryEscape(region) + "#/stacksets/create?" + values.Encode()
 }
 
 // NormalizeRegion returns a safe region default for connector setup.

--- a/internal/connectors/aws/cfn_test.go
+++ b/internal/connectors/aws/cfn_test.go
@@ -73,6 +73,51 @@ func TestBuildCloudFormationLaunchURL(t *testing.T) {
 	}
 }
 
+func TestBuildCloudFormationStackSetLaunchURL(t *testing.T) {
+	launchURL := BuildCloudFormationStackSetLaunchURL(CloudFormationStackSetLaunchInput{
+		TemplateURL:           "https://cdn.example.com/identrail-readonly.yaml",
+		Region:                "us-east-1",
+		StackSetName:          "identrail-prod-stackset",
+		IdentrailAccountID:    "123456789012",
+		ExternalID:            "external-id",
+		RoleName:              "IdentrailReadOnlyProd",
+		PermissionModel:       StackSetLaunchPermissionModelServiceManaged,
+		OrganizationalUnitIDs: []string{"ou-xxxx-1", "ou-yyyy-2"},
+		TargetRegions:         []string{"us-east-1", "eu-west-1"},
+	})
+	parsed, err := url.Parse(launchURL)
+	if err != nil || parsed.Scheme != "https" {
+		t.Fatalf("parse stackset launch URL: %v / %s", err, launchURL)
+	}
+	if !strings.Contains(parsed.Fragment, "permissionModel=SERVICE_MANAGED") {
+		t.Fatalf("expected permission model in fragment, got %q", parsed.Fragment)
+	}
+	if !strings.Contains(parsed.Fragment, "organizationalUnitIds=ou-xxxx-1,ou-yyyy-2") {
+		t.Fatalf("expected OU ids in fragment, got %q", parsed.Fragment)
+	}
+	if !strings.Contains(parsed.Fragment, "regions=us-east-1,eu-west-1") {
+		t.Fatalf("expected target regions in fragment, got %q", parsed.Fragment)
+	}
+	if !strings.Contains(parsed.Fragment, "stacksets/create") {
+		t.Fatalf("expected stacksets/create fragment, got %q", parsed.Fragment)
+	}
+
+	// Missing template URL yields empty so the surface can render a blocked state instead of a malformed URL.
+	if got := BuildCloudFormationStackSetLaunchURL(CloudFormationStackSetLaunchInput{Region: "us-east-1"}); got != "" {
+		t.Fatalf("expected empty URL without template, got %q", got)
+	}
+
+	// Unknown permission model defaults to service-managed.
+	defaulted := BuildCloudFormationStackSetLaunchURL(CloudFormationStackSetLaunchInput{
+		TemplateURL:     "https://cdn.example.com/identrail-readonly.yaml",
+		Region:          "us-east-1",
+		PermissionModel: StackSetLaunchPermissionModel("bogus"),
+	})
+	if !strings.Contains(defaulted, "permissionModel=SERVICE_MANAGED") {
+		t.Fatalf("expected default service-managed model, got %q", defaulted)
+	}
+}
+
 func TestNormalizeRegion(t *testing.T) {
 	if got := NormalizeRegion("us-gov-west-1"); got != "us-gov-west-1" {
 		t.Fatalf("expected gov region to be preserved, got %q", got)

--- a/internal/providers/awscontract/stackset_onboarding.go
+++ b/internal/providers/awscontract/stackset_onboarding.go
@@ -1,0 +1,863 @@
+package awscontract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// StackSetOnboardingVersion is the stable contract version operators cite when
+// persisting or reconciling a StackSet onboarding plan.
+const StackSetOnboardingVersion = "aws-stackset-onboarding-v1"
+
+// StackSetOnboardingState is the lifecycle state of one stack instance, the
+// overall onboarding plan, or a recovery action. Permission denied, unsupported,
+// suspended, and partial states are explicit so onboarding never silently
+// reports false success.
+type StackSetOnboardingState string
+
+const (
+	// StackSetStatePending marks an instance whose deployment has not started.
+	StackSetStatePending StackSetOnboardingState = "pending"
+	// StackSetStateValidating marks an instance whose prerequisites are being
+	// checked (for example trusted-access enablement or opt-in region status).
+	StackSetStateValidating StackSetOnboardingState = "validating"
+	// StackSetStateBlocked marks an instance whose prerequisites are unmet.
+	StackSetStateBlocked StackSetOnboardingState = "blocked"
+	// StackSetStateDeploying marks an instance whose stack create/update is
+	// in flight.
+	StackSetStateDeploying StackSetOnboardingState = "deploying"
+	// StackSetStateActive marks an instance that has been deployed and is
+	// emitting scan coverage for downstream pipelines.
+	StackSetStateActive StackSetOnboardingState = "active"
+	// StackSetStateDegraded marks an instance whose deployment succeeded but
+	// whose connector role failed validation or drifted.
+	StackSetStateDegraded StackSetOnboardingState = "degraded"
+	// StackSetStateFailed marks an instance whose deployment failed and is
+	// retryable.
+	StackSetStateFailed StackSetOnboardingState = "failed"
+	// StackSetStatePermissionDenied marks an instance whose account or region
+	// rejected the StackSet operation due to a permission gap.
+	StackSetStatePermissionDenied StackSetOnboardingState = "permission_denied"
+	// StackSetStateUnsupported marks an instance whose region or account class is
+	// not supported (for example a closed account or non-opt-in region).
+	StackSetStateUnsupported StackSetOnboardingState = "unsupported"
+	// StackSetStateSuspended marks an instance whose AWS account is suspended.
+	StackSetStateSuspended StackSetOnboardingState = "suspended"
+	// StackSetStateCanceled marks an instance whose deployment was canceled by
+	// the operator before completing.
+	StackSetStateCanceled StackSetOnboardingState = "canceled"
+)
+
+// StackSetDeploymentMode is the deployment model the StackSet uses to fan out
+// across accounts and regions.
+type StackSetDeploymentMode string
+
+const (
+	// StackSetDeploymentServiceManaged uses AWS Organizations trusted access to
+	// deploy to all member accounts targeted by OU. This is the recommended mode
+	// for org-wide onboarding.
+	StackSetDeploymentServiceManaged StackSetDeploymentMode = "service_managed"
+	// StackSetDeploymentSelfManaged uses operator-provided AdministrationRoleARN
+	// + ExecutionRoleName to deploy to a discrete account set, used by orgs that
+	// don't enable trusted access.
+	StackSetDeploymentSelfManaged StackSetDeploymentMode = "self_managed"
+)
+
+// StackSetOnboardingPrerequisiteSeverity orders prerequisite gaps so operators
+// see blocking issues before advisory ones.
+type StackSetOnboardingPrerequisiteSeverity string
+
+const (
+	StackSetPrerequisiteBlocking StackSetOnboardingPrerequisiteSeverity = "blocking"
+	StackSetPrerequisiteAdvisory StackSetOnboardingPrerequisiteSeverity = "advisory"
+)
+
+// StackSetOnboardingPrerequisite is one named environmental check an operator
+// must satisfy before onboarding can proceed.
+type StackSetOnboardingPrerequisite struct {
+	ID          string                                 `json:"id"`
+	Title       string                                 `json:"title"`
+	Severity    StackSetOnboardingPrerequisiteSeverity `json:"severity"`
+	Satisfied   bool                                   `json:"satisfied"`
+	Reason      string                                 `json:"reason"`
+	Remediation string                                 `json:"remediation,omitempty"`
+}
+
+// StackSetOnboardingTargetAccount is one account in the StackSet target set.
+type StackSetOnboardingTargetAccount struct {
+	AccountID  string `json:"account_id"`
+	Name       string `json:"name,omitempty"`
+	OUPath     string `json:"ou_path,omitempty"`
+	Management bool   `json:"management,omitempty"`
+	Suspended  bool   `json:"suspended,omitempty"`
+}
+
+// StackSetOnboardingTargetRegion is one region in the StackSet target set.
+type StackSetOnboardingTargetRegion struct {
+	Region string `json:"region"`
+	Name   string `json:"name,omitempty"`
+	OptIn  bool   `json:"opt_in,omitempty"`
+}
+
+// StackSetOnboardingTargets is the deterministic target set for the StackSet.
+type StackSetOnboardingTargets struct {
+	OrganizationID      string                            `json:"organization_id,omitempty"`
+	OrganizationalUnits []OrganizationUnit                `json:"organizational_units,omitempty"`
+	Accounts            []StackSetOnboardingTargetAccount `json:"accounts"`
+	Regions             []StackSetOnboardingTargetRegion  `json:"regions"`
+}
+
+// StackSetOnboardingCheckpoint is the persisted prior state of one stack
+// instance, used to make the onboarding plan resumable across UI refreshes and
+// process restarts.
+type StackSetOnboardingCheckpoint struct {
+	AccountID     string                  `json:"account_id"`
+	Region        string                  `json:"region"`
+	State         StackSetOnboardingState `json:"state"`
+	StackID       string                  `json:"stack_id,omitempty"`
+	OperationID   string                  `json:"operation_id,omitempty"`
+	FailureReason string                  `json:"failure_reason,omitempty"`
+	Attempts      int                     `json:"attempts,omitempty"`
+	ObservedAt    time.Time               `json:"observed_at,omitempty"`
+}
+
+// StackSetOnboardingConfig is the input to PlanStackSetOnboarding.
+type StackSetOnboardingConfig struct {
+	ConnectorID         string                         `json:"connector_id,omitempty"`
+	OrganizationID      string                         `json:"organization_id,omitempty"`
+	ManagementAccountID string                         `json:"management_account_id,omitempty"`
+	StackSetName        string                         `json:"stack_set_name,omitempty"`
+	TemplateURL         string                         `json:"template_url,omitempty"`
+	TemplateChecksum    string                         `json:"template_checksum,omitempty"`
+	DeploymentMode      StackSetDeploymentMode         `json:"deployment_mode"`
+	Partition           string                         `json:"partition,omitempty"`
+	TrustedAccessReady  bool                           `json:"trusted_access_ready"`
+	DelegatedAdminReady bool                           `json:"delegated_admin_ready"`
+	OperatorRoleARN     string                         `json:"operator_role_arn,omitempty"`
+	ExternalID          string                         `json:"external_id,omitempty"`
+	Targets             StackSetOnboardingTargets      `json:"targets"`
+	Checkpoints         []StackSetOnboardingCheckpoint `json:"checkpoints,omitempty"`
+	CoveragePlan        *CoveragePlan                  `json:"coverage_plan,omitempty"`
+}
+
+// StackSetOnboardingInstance is one operator-visible stack instance the
+// StackSet will create in a target account/region pair.
+type StackSetOnboardingInstance struct {
+	Key             string                  `json:"key"`
+	AccountID       string                  `json:"account_id"`
+	AccountName     string                  `json:"account_name,omitempty"`
+	OUPath          string                  `json:"ou_path,omitempty"`
+	Region          string                  `json:"region"`
+	RegionName      string                  `json:"region_name,omitempty"`
+	State           StackSetOnboardingState `json:"state"`
+	StackID         string                  `json:"stack_id,omitempty"`
+	OperationID     string                  `json:"operation_id,omitempty"`
+	FailureReason   string                  `json:"failure_reason,omitempty"`
+	Attempts        int                     `json:"attempts,omitempty"`
+	Resumable       bool                    `json:"resumable"`
+	Suspended       bool                    `json:"suspended,omitempty"`
+	OptInRegion     bool                    `json:"opt_in_region,omitempty"`
+	NextAction      string                  `json:"next_action"`
+	EvidenceRef     string                  `json:"evidence_ref"`
+	CoverageTargets int                     `json:"coverage_targets"`
+	ObservedAt      time.Time               `json:"observed_at,omitempty"`
+}
+
+// StackSetOnboardingCoverageExpectation projects how the StackSet's account
+// and region target set is expected to translate into scan coverage once
+// active, so operators can preview blast radius before launch.
+type StackSetOnboardingCoverageExpectation struct {
+	ExpectedAccounts   int     `json:"expected_accounts"`
+	ExpectedRegions    int     `json:"expected_regions"`
+	ExpectedInstances  int     `json:"expected_instances"`
+	ExpectedCoverage   int     `json:"expected_coverage_targets"`
+	CoveragePercent    float64 `json:"coverage_percent"`
+	GlobalServiceNotes string  `json:"global_service_notes"`
+}
+
+// StackSetOnboardingRecoveryAction is one re-runnable action the operator can
+// take to advance a failed or blocked instance.
+type StackSetOnboardingRecoveryAction struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Targets     []string `json:"targets"`
+}
+
+// StackSetOnboardingValidationStatus is the high-level pre-launch verdict.
+type StackSetOnboardingValidationStatus string
+
+const (
+	StackSetValidationReady            StackSetOnboardingValidationStatus = "ready"
+	StackSetValidationDegraded         StackSetOnboardingValidationStatus = "degraded"
+	StackSetValidationBlocked          StackSetOnboardingValidationStatus = "blocked"
+	StackSetValidationPermissionDenied StackSetOnboardingValidationStatus = "permission_denied"
+)
+
+// StackSetOnboardingValidation summarizes prerequisite + target feasibility so
+// the app surface and CFN preview share one verdict.
+type StackSetOnboardingValidation struct {
+	Status           StackSetOnboardingValidationStatus `json:"status"`
+	Confidence       float64                            `json:"confidence"`
+	BlockingCount    int                                `json:"blocking_count"`
+	AdvisoryCount    int                                `json:"advisory_count"`
+	Prerequisites    []StackSetOnboardingPrerequisite   `json:"prerequisites"`
+	FailureReasons   []string                           `json:"failure_reasons"`
+	RemediationHints []string                           `json:"remediation_hints"`
+}
+
+// StackSetOnboardingSummary aggregates the onboarding plan for dashboards.
+type StackSetOnboardingSummary struct {
+	TargetAccounts       int                             `json:"target_accounts"`
+	TargetRegions        int                             `json:"target_regions"`
+	TotalInstances       int                             `json:"total_instances"`
+	PendingInstances     int                             `json:"pending_instances"`
+	ActiveInstances      int                             `json:"active_instances"`
+	BlockedInstances     int                             `json:"blocked_instances"`
+	FailedInstances      int                             `json:"failed_instances"`
+	DegradedInstances    int                             `json:"degraded_instances"`
+	SuspendedInstances   int                             `json:"suspended_instances"`
+	PermissionDenied     int                             `json:"permission_denied_instances"`
+	UnsupportedInstances int                             `json:"unsupported_instances"`
+	ResumableInstances   int                             `json:"resumable_instances"`
+	DeployedPercent      float64                         `json:"deployed_percent"`
+	StateCounts          map[StackSetOnboardingState]int `json:"state_counts"`
+}
+
+// StackSetOnboardingPlan is the deterministic output of PlanStackSetOnboarding.
+type StackSetOnboardingPlan struct {
+	ConnectorID         string                                `json:"connector_id,omitempty"`
+	OrganizationID      string                                `json:"organization_id,omitempty"`
+	ManagementAccountID string                                `json:"management_account_id,omitempty"`
+	StackSetName        string                                `json:"stack_set_name"`
+	TemplateURL         string                                `json:"template_url,omitempty"`
+	TemplateChecksum    string                                `json:"template_checksum,omitempty"`
+	DeploymentMode      StackSetDeploymentMode                `json:"deployment_mode"`
+	Partition           string                                `json:"partition"`
+	Version             string                                `json:"version"`
+	Validation          StackSetOnboardingValidation          `json:"validation"`
+	Targets             StackSetOnboardingTargets             `json:"targets"`
+	Instances           []StackSetOnboardingInstance          `json:"instances"`
+	CoverageExpectation StackSetOnboardingCoverageExpectation `json:"coverage_expectation"`
+	RecoveryActions     []StackSetOnboardingRecoveryAction    `json:"recovery_actions"`
+	Summary             StackSetOnboardingSummary             `json:"summary"`
+	GeneratedAt         time.Time                             `json:"generated_at"`
+}
+
+// defaultStackSetName is used when callers do not pin a name. It mirrors the
+// single-stack naming used for one-account onboarding.
+const defaultStackSetName = "identrail-readonly-connector-stackset"
+
+// PlanStackSetOnboarding turns an Organizations + StackSet onboarding
+// configuration into a deterministic, resumable onboarding plan. It is a pure
+// function: identical inputs always produce identical output so the API,
+// dashboards, and recovery UI stay reconcilable. It performs no AWS calls,
+// reads no customer payloads, and never mutates AWS state.
+//
+// The planner expands the configured account/region target set into one
+// instance per account/region pair, derives prerequisites from the deployment
+// mode + topology + partition, replays prior checkpoints, projects coverage
+// expectations, and synthesizes recovery actions.
+func PlanStackSetOnboarding(config StackSetOnboardingConfig, generatedAt time.Time) (StackSetOnboardingPlan, error) {
+	mode := normalizeStackSetDeploymentMode(config.DeploymentMode)
+	stackSetName := strings.TrimSpace(config.StackSetName)
+	if stackSetName == "" {
+		stackSetName = defaultStackSetName
+	}
+	partition := normalizeOrganizationsPartition(config.Partition)
+	accounts, err := normalizeStackSetTargetAccounts(config.Targets.Accounts)
+	if err != nil {
+		return StackSetOnboardingPlan{}, err
+	}
+	regions, err := normalizeStackSetTargetRegions(config.Targets.Regions)
+	if err != nil {
+		return StackSetOnboardingPlan{}, err
+	}
+	checkpoints, err := indexStackSetCheckpoints(config.Checkpoints)
+	if err != nil {
+		return StackSetOnboardingPlan{}, err
+	}
+
+	prerequisites := evaluateStackSetPrerequisites(config, mode, accounts, regions)
+	validation := summarizeStackSetValidation(prerequisites)
+
+	instances := []StackSetOnboardingInstance{}
+	for _, account := range accounts {
+		for _, region := range regions {
+			instance := buildStackSetInstance(config.ConnectorID, account, region, checkpoints, prerequisites, validation, config.CoveragePlan)
+			instances = append(instances, instance)
+		}
+	}
+	sort.SliceStable(instances, func(i, j int) bool { return instances[i].Key < instances[j].Key })
+
+	summary := summarizeStackSetInstances(instances, len(accounts), len(regions))
+	expectation := projectStackSetCoverage(config.CoveragePlan, accounts, regions)
+	recovery := synthesizeStackSetRecoveryActions(instances, prerequisites, mode)
+
+	return StackSetOnboardingPlan{
+		ConnectorID:         strings.TrimSpace(config.ConnectorID),
+		OrganizationID:      strings.TrimSpace(config.OrganizationID),
+		ManagementAccountID: strings.TrimSpace(config.ManagementAccountID),
+		StackSetName:        stackSetName,
+		TemplateURL:         strings.TrimSpace(config.TemplateURL),
+		TemplateChecksum:    strings.TrimSpace(config.TemplateChecksum),
+		DeploymentMode:      mode,
+		Partition:           partition,
+		Version:             StackSetOnboardingVersion,
+		Validation:          validation,
+		Targets: StackSetOnboardingTargets{
+			OrganizationID:      strings.TrimSpace(config.OrganizationID),
+			OrganizationalUnits: append([]OrganizationUnit(nil), config.Targets.OrganizationalUnits...),
+			Accounts:            accounts,
+			Regions:             regions,
+		},
+		Instances:           instances,
+		CoverageExpectation: expectation,
+		RecoveryActions:     recovery,
+		Summary:             summary,
+		GeneratedAt:         generatedAt.UTC(),
+	}, nil
+}
+
+func normalizeStackSetDeploymentMode(mode StackSetDeploymentMode) StackSetDeploymentMode {
+	switch StackSetDeploymentMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case StackSetDeploymentServiceManaged, StackSetDeploymentSelfManaged:
+		return StackSetDeploymentMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	default:
+		return StackSetDeploymentServiceManaged
+	}
+}
+
+func normalizeStackSetTargetAccounts(input []StackSetOnboardingTargetAccount) ([]StackSetOnboardingTargetAccount, error) {
+	out := make([]StackSetOnboardingTargetAccount, 0, len(input))
+	outByID := map[string]int{}
+	for _, account := range input {
+		accountID := strings.TrimSpace(account.AccountID)
+		if !isTwelveDigitAWSAccountID(accountID) {
+			return nil, fmt.Errorf("stackset target account id %q must be 12 digits", account.AccountID)
+		}
+		account.AccountID = accountID
+		account.Name = strings.TrimSpace(account.Name)
+		account.OUPath = strings.TrimSpace(account.OUPath)
+		if mergeIndex, ok := outByID[accountID]; ok {
+			merge := &out[mergeIndex]
+			merge.Management = merge.Management || account.Management
+			merge.Suspended = merge.Suspended || account.Suspended
+			if account.Name != "" && (merge.Name == "" || account.Name < merge.Name) {
+				merge.Name = account.Name
+			}
+			if account.OUPath != "" && (merge.OUPath == "" || account.OUPath < merge.OUPath) {
+				merge.OUPath = account.OUPath
+			}
+			continue
+		}
+		outByID[accountID] = len(out)
+		out = append(out, account)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].AccountID < out[j].AccountID })
+	return out, nil
+}
+
+func normalizeStackSetTargetRegions(input []StackSetOnboardingTargetRegion) ([]StackSetOnboardingTargetRegion, error) {
+	out := make([]StackSetOnboardingTargetRegion, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, region := range input {
+		code := strings.ToLower(strings.TrimSpace(region.Region))
+		if code == "" {
+			return nil, fmt.Errorf("stackset target region code is required")
+		}
+		if _, ok := seen[code]; ok {
+			continue
+		}
+		seen[code] = struct{}{}
+		region.Region = code
+		out = append(out, region)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Region < out[j].Region })
+	return out, nil
+}
+
+func indexStackSetCheckpoints(input []StackSetOnboardingCheckpoint) (map[string]StackSetOnboardingCheckpoint, error) {
+	index := make(map[string]StackSetOnboardingCheckpoint, len(input))
+	for _, checkpoint := range input {
+		accountID := strings.TrimSpace(checkpoint.AccountID)
+		region := strings.ToLower(strings.TrimSpace(checkpoint.Region))
+		if accountID == "" || region == "" {
+			return nil, fmt.Errorf("stackset checkpoint requires account and region")
+		}
+		if checkpoint.State != "" && !validStackSetOnboardingState(checkpoint.State) {
+			return nil, fmt.Errorf("stackset checkpoint has invalid state %q", checkpoint.State)
+		}
+		index[stackSetInstanceKey(accountID, region)] = checkpoint
+	}
+	return index, nil
+}
+
+func evaluateStackSetPrerequisites(config StackSetOnboardingConfig, mode StackSetDeploymentMode, accounts []StackSetOnboardingTargetAccount, regions []StackSetOnboardingTargetRegion) []StackSetOnboardingPrerequisite {
+	prereqs := []StackSetOnboardingPrerequisite{}
+
+	templateOK := strings.TrimSpace(config.TemplateURL) != "" && strings.TrimSpace(config.TemplateChecksum) != ""
+	prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+		ID:        "stackset.template_pinned",
+		Title:     "Connector CloudFormation template is pinned",
+		Severity:  StackSetPrerequisiteBlocking,
+		Satisfied: templateOK,
+		Reason: func() string {
+			if templateOK {
+				return "Template URL and integrity checksum are configured."
+			}
+			return "Template URL or integrity checksum is missing; the StackSet cannot be launched without a pinned template."
+		}(),
+		Remediation: "Configure AWSCloudFormationTemplateURL and the template checksum on the runtime so the read-only connector template is reproducible.",
+	})
+
+	externalIDOK := strings.TrimSpace(config.ExternalID) != ""
+	prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+		ID:        "stackset.external_id_configured",
+		Title:     "External ID is configured for trust",
+		Severity:  StackSetPrerequisiteBlocking,
+		Satisfied: externalIDOK,
+		Reason: func() string {
+			if externalIDOK {
+				return "An external ID is pinned for the read-only role trust policy."
+			}
+			return "No external ID is configured; the StackSet cannot launch a role trust without it."
+		}(),
+		Remediation: "Generate an external ID on the connector before opening the StackSet console launch URL.",
+	})
+
+	if mode == StackSetDeploymentServiceManaged {
+		prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+			ID:        "stackset.trusted_access_enabled",
+			Title:     "Trusted access for CloudFormation StackSets is enabled",
+			Severity:  StackSetPrerequisiteBlocking,
+			Satisfied: config.TrustedAccessReady,
+			Reason: func() string {
+				if config.TrustedAccessReady {
+					return "Service-managed StackSets can deploy to org targets."
+				}
+				return "Service-managed StackSets require trusted access between AWS Organizations and CloudFormation."
+			}(),
+			Remediation: "From the management account, enable trusted access for CloudFormation StackSets in AWS Organizations.",
+		})
+		prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+			ID:        "stackset.delegated_admin_registered",
+			Title:     "CloudFormation delegated administrator is registered",
+			Severity:  StackSetPrerequisiteAdvisory,
+			Satisfied: config.DelegatedAdminReady,
+			Reason: func() string {
+				if config.DelegatedAdminReady {
+					return "Onboarding can run from the delegated administrator account."
+				}
+				return "Without a delegated administrator, onboarding must run from the management account itself."
+			}(),
+			Remediation: "Register a delegated administrator for CloudFormation StackSets so onboarding does not require the management account.",
+		})
+	} else {
+		hasAdminRole := strings.TrimSpace(config.OperatorRoleARN) != ""
+		prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+			ID:        "stackset.administration_role_configured",
+			Title:     "AdministrationRoleARN is configured for self-managed deployment",
+			Severity:  StackSetPrerequisiteBlocking,
+			Satisfied: hasAdminRole,
+			Reason: func() string {
+				if hasAdminRole {
+					return "Self-managed StackSet has an administration role ARN."
+				}
+				return "Self-managed StackSets require an AWSCloudFormationStackSetAdministrationRole ARN."
+			}(),
+			Remediation: "Provide a working AdministrationRoleARN and ensure ExecutionRoleName is bootstrapped in each target account.",
+		})
+	}
+
+	prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+		ID:        "stackset.targets_present",
+		Title:     "At least one target account and region are configured",
+		Severity:  StackSetPrerequisiteBlocking,
+		Satisfied: len(accounts) > 0 && len(regions) > 0,
+		Reason: func() string {
+			if len(accounts) > 0 && len(regions) > 0 {
+				return fmt.Sprintf("Onboarding will create %d instance(s) across %d account(s) and %d region(s).", len(accounts)*len(regions), len(accounts), len(regions))
+			}
+			return "Onboarding has no account or region targets; nothing would be deployed."
+		}(),
+		Remediation: "Use Organizations topology and region availability discovery to select target OUs/accounts and regions.",
+	})
+
+	// Advisory: warn if any target account is suspended.
+	suspended := 0
+	for _, account := range accounts {
+		if account.Suspended {
+			suspended++
+		}
+	}
+	if suspended > 0 {
+		prereqs = append(prereqs, StackSetOnboardingPrerequisite{
+			ID:          "stackset.suspended_accounts_excluded",
+			Title:       fmt.Sprintf("%d suspended account(s) will be skipped", suspended),
+			Severity:    StackSetPrerequisiteAdvisory,
+			Satisfied:   false,
+			Reason:      "Suspended accounts cannot host StackSet deployments and are reported as suspended.",
+			Remediation: "Reactivate or remove suspended accounts from the target set if you want them covered.",
+		})
+	}
+
+	return prereqs
+}
+
+func summarizeStackSetValidation(prereqs []StackSetOnboardingPrerequisite) StackSetOnboardingValidation {
+	validation := StackSetOnboardingValidation{
+		Status:        StackSetValidationReady,
+		Confidence:    0.95,
+		Prerequisites: prereqs,
+	}
+	failures := []string{}
+	remediations := []string{}
+	for _, prereq := range prereqs {
+		switch {
+		case !prereq.Satisfied && prereq.Severity == StackSetPrerequisiteBlocking:
+			validation.BlockingCount++
+			failures = append(failures, prereq.Reason)
+			if r := strings.TrimSpace(prereq.Remediation); r != "" {
+				remediations = append(remediations, r)
+			}
+		case !prereq.Satisfied && prereq.Severity == StackSetPrerequisiteAdvisory:
+			validation.AdvisoryCount++
+			if r := strings.TrimSpace(prereq.Remediation); r != "" {
+				remediations = append(remediations, r)
+			}
+		}
+	}
+	switch {
+	case validation.BlockingCount > 0:
+		validation.Status = StackSetValidationBlocked
+		validation.Confidence = 0.35
+	case validation.AdvisoryCount > 0:
+		validation.Status = StackSetValidationDegraded
+		validation.Confidence = 0.72
+	}
+	validation.FailureReasons = dedupeSortedCoverageStrings(failures)
+	validation.RemediationHints = dedupeSortedCoverageStrings(remediations)
+	return validation
+}
+
+func buildStackSetInstance(connectorID string, account StackSetOnboardingTargetAccount, region StackSetOnboardingTargetRegion, checkpoints map[string]StackSetOnboardingCheckpoint, prereqs []StackSetOnboardingPrerequisite, validation StackSetOnboardingValidation, plan *CoveragePlan) StackSetOnboardingInstance {
+	key := stackSetInstanceKey(account.AccountID, region.Region)
+	state := StackSetStatePending
+	switch {
+	case account.Suspended:
+		state = StackSetStateSuspended
+	case validation.Status == StackSetValidationBlocked:
+		state = StackSetStateBlocked
+	}
+
+	instance := StackSetOnboardingInstance{
+		Key:             key,
+		AccountID:       account.AccountID,
+		AccountName:     strings.TrimSpace(account.Name),
+		OUPath:          strings.TrimSpace(account.OUPath),
+		Region:          region.Region,
+		RegionName:      strings.TrimSpace(region.Name),
+		State:           state,
+		OptInRegion:     region.OptIn,
+		Suspended:       account.Suspended,
+		EvidenceRef:     stackSetEvidenceRef(connectorID, account.AccountID, region.Region),
+		CoverageTargets: coverageTargetsForAccountRegion(plan, account.AccountID, region.Region),
+	}
+
+	if checkpoint, ok := checkpoints[key]; ok {
+		applyStackSetCheckpoint(&instance, checkpoint)
+	}
+
+	instance.Resumable = stackSetInstanceResumable(instance)
+	instance.NextAction = stackSetInstanceNextAction(instance, validation)
+	return instance
+}
+
+func applyStackSetCheckpoint(instance *StackSetOnboardingInstance, checkpoint StackSetOnboardingCheckpoint) {
+	// Suspended accounts win over any checkpoint; AWS will reject the operation.
+	if instance.State == StackSetStateSuspended {
+		return
+	}
+	if checkpoint.State != "" {
+		instance.State = checkpoint.State
+	}
+	instance.StackID = strings.TrimSpace(checkpoint.StackID)
+	instance.OperationID = strings.TrimSpace(checkpoint.OperationID)
+	instance.FailureReason = strings.TrimSpace(checkpoint.FailureReason)
+	if checkpoint.Attempts > 0 {
+		instance.Attempts = checkpoint.Attempts
+	}
+	if !checkpoint.ObservedAt.IsZero() {
+		instance.ObservedAt = checkpoint.ObservedAt.UTC()
+	}
+}
+
+func stackSetInstanceResumable(instance StackSetOnboardingInstance) bool {
+	switch instance.State {
+	case StackSetStateFailed, StackSetStateDegraded, StackSetStatePending, StackSetStateDeploying, StackSetStateValidating, StackSetStateBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func stackSetInstanceNextAction(instance StackSetOnboardingInstance, validation StackSetOnboardingValidation) string {
+	switch instance.State {
+	case StackSetStateActive:
+		return "No action; this instance is contributing scan coverage."
+	case StackSetStateDeploying, StackSetStateValidating:
+		return "CloudFormation operation in flight; wait for AWS to settle the operation."
+	case StackSetStatePending:
+		if validation.Status == StackSetValidationBlocked {
+			return "Resolve blocking prerequisites before launching this StackSet instance."
+		}
+		return "Open the StackSet console launch URL to create this instance."
+	case StackSetStateBlocked:
+		return "Resolve blocking prerequisites; this instance cannot launch yet."
+	case StackSetStateFailed:
+		return "Retry this StackSet instance once the underlying AWS error has been remediated."
+	case StackSetStateDegraded:
+		return "Re-validate the instance role and rerun connector validation; coverage may be incomplete."
+	case StackSetStatePermissionDenied:
+		return "Grant trusted access or the self-managed AdministrationRole permission to this account, then rerun."
+	case StackSetStateSuspended:
+		return "Remove the suspended account from the target set or reactivate it before retrying."
+	case StackSetStateUnsupported:
+		return "Remove the unsupported region or account from the target set."
+	case StackSetStateCanceled:
+		return "Re-open the StackSet console launch URL to restart the operation."
+	default:
+		return "Queue this account/region pair for the next StackSet operation."
+	}
+}
+
+func summarizeStackSetInstances(instances []StackSetOnboardingInstance, accountCount, regionCount int) StackSetOnboardingSummary {
+	summary := StackSetOnboardingSummary{
+		TargetAccounts: accountCount,
+		TargetRegions:  regionCount,
+		TotalInstances: len(instances),
+		StateCounts:    map[StackSetOnboardingState]int{},
+	}
+	for _, instance := range instances {
+		summary.StateCounts[instance.State]++
+		if instance.Resumable {
+			summary.ResumableInstances++
+		}
+		switch instance.State {
+		case StackSetStateActive:
+			summary.ActiveInstances++
+		case StackSetStatePending, StackSetStateValidating, StackSetStateDeploying:
+			summary.PendingInstances++
+		case StackSetStateBlocked:
+			summary.BlockedInstances++
+		case StackSetStateFailed:
+			summary.FailedInstances++
+		case StackSetStateDegraded:
+			summary.DegradedInstances++
+		case StackSetStateSuspended:
+			summary.SuspendedInstances++
+		case StackSetStatePermissionDenied:
+			summary.PermissionDenied++
+		case StackSetStateUnsupported:
+			summary.UnsupportedInstances++
+		}
+	}
+	if summary.TotalInstances > 0 {
+		summary.DeployedPercent = roundCoveragePercent(float64(summary.ActiveInstances) / float64(summary.TotalInstances) * 100)
+	}
+	return summary
+}
+
+func projectStackSetCoverage(plan *CoveragePlan, accounts []StackSetOnboardingTargetAccount, regions []StackSetOnboardingTargetRegion) StackSetOnboardingCoverageExpectation {
+	expectation := StackSetOnboardingCoverageExpectation{
+		ExpectedAccounts:   len(accounts),
+		ExpectedRegions:    len(regions),
+		ExpectedInstances:  len(accounts) * len(regions),
+		GlobalServiceNotes: "Global-scope AWS services (for example IAM) are planned once per account at the global home region; per-region StackSet instances supply other services.",
+	}
+	if plan == nil {
+		return expectation
+	}
+	accountSet := map[string]struct{}{}
+	regionSet := map[string]struct{}{}
+	for _, account := range accounts {
+		accountSet[account.AccountID] = struct{}{}
+	}
+	for _, region := range regions {
+		regionSet[strings.ToLower(region.Region)] = struct{}{}
+	}
+	expected := 0
+	covered := 0
+	for _, target := range plan.Targets {
+		if !target.Enabled {
+			continue
+		}
+		if _, ok := accountSet[target.AccountID]; !ok {
+			continue
+		}
+		// Global services are anchored to a single home region. Count them only
+		// when that home region appears in the StackSet region set.
+		if !target.Global {
+			if _, ok := regionSet[strings.ToLower(target.Region)]; !ok {
+				continue
+			}
+		} else if _, ok := regionSet[strings.ToLower(target.Region)]; !ok {
+			continue
+		}
+		expected++
+		if target.State == CoverageStateCovered {
+			covered++
+		}
+	}
+	expectation.ExpectedCoverage = expected
+	if expected > 0 {
+		expectation.CoveragePercent = roundCoveragePercent(float64(covered) / float64(expected) * 100)
+	}
+	return expectation
+}
+
+func coverageTargetsForAccountRegion(plan *CoveragePlan, accountID, region string) int {
+	if plan == nil {
+		return 0
+	}
+	count := 0
+	for _, target := range plan.Targets {
+		if !target.Enabled {
+			continue
+		}
+		if target.AccountID != accountID {
+			continue
+		}
+		if target.Global {
+			// Global service is anchored once per account at its home region; the
+			// instance for the home region carries the count.
+			if strings.EqualFold(target.Region, region) {
+				count++
+			}
+			continue
+		}
+		if strings.EqualFold(target.Region, region) {
+			count++
+		}
+	}
+	return count
+}
+
+func synthesizeStackSetRecoveryActions(instances []StackSetOnboardingInstance, prereqs []StackSetOnboardingPrerequisite, mode StackSetDeploymentMode) []StackSetOnboardingRecoveryAction {
+	actions := []StackSetOnboardingRecoveryAction{}
+
+	for _, prereq := range prereqs {
+		if prereq.Satisfied || prereq.Severity != StackSetPrerequisiteBlocking {
+			continue
+		}
+		actions = append(actions, StackSetOnboardingRecoveryAction{
+			ID:          "fix-" + prereq.ID,
+			Title:       "Resolve " + prereq.Title,
+			Description: firstNonEmpty(prereq.Remediation, "Resolve the prerequisite before retrying."),
+			Targets:     []string{},
+		})
+	}
+
+	failed := stackSetInstancesInState(instances, StackSetStateFailed)
+	if len(failed) > 0 {
+		actions = append(actions, StackSetOnboardingRecoveryAction{
+			ID:          "retry-failed-instances",
+			Title:       fmt.Sprintf("Retry %d failed StackSet instance(s)", len(failed)),
+			Description: "Re-run the StackSet operation for the failed account/region pairs after addressing the AWS error.",
+			Targets:     stackSetInstanceTargets(failed),
+		})
+	}
+
+	denied := stackSetInstancesInState(instances, StackSetStatePermissionDenied)
+	if len(denied) > 0 {
+		title := "Grant trusted access in member accounts and retry"
+		if mode == StackSetDeploymentSelfManaged {
+			title = "Bootstrap AWSCloudFormationStackSetExecutionRole in member accounts and retry"
+		}
+		actions = append(actions, StackSetOnboardingRecoveryAction{
+			ID:          "fix-permission-denied",
+			Title:       title,
+			Description: "AWS rejected the deployment because the management account cannot assume into the targets.",
+			Targets:     stackSetInstanceTargets(denied),
+		})
+	}
+
+	suspended := stackSetInstancesInState(instances, StackSetStateSuspended)
+	if len(suspended) > 0 {
+		actions = append(actions, StackSetOnboardingRecoveryAction{
+			ID:          "remove-suspended-accounts",
+			Title:       fmt.Sprintf("Remove %d suspended account(s) from the target set", uniqueAccounts(suspended)),
+			Description: "Suspended accounts cannot host StackSet deployments.",
+			Targets:     stackSetInstanceTargets(suspended),
+		})
+	}
+
+	sort.SliceStable(actions, func(i, j int) bool { return actions[i].ID < actions[j].ID })
+	return actions
+}
+
+func stackSetInstancesInState(instances []StackSetOnboardingInstance, state StackSetOnboardingState) []StackSetOnboardingInstance {
+	out := []StackSetOnboardingInstance{}
+	for _, instance := range instances {
+		if instance.State == state {
+			out = append(out, instance)
+		}
+	}
+	return out
+}
+
+func stackSetInstanceTargets(instances []StackSetOnboardingInstance) []string {
+	out := make([]string, 0, len(instances))
+	for _, instance := range instances {
+		out = append(out, instance.Key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueAccounts(instances []StackSetOnboardingInstance) int {
+	seen := map[string]struct{}{}
+	for _, instance := range instances {
+		seen[instance.AccountID] = struct{}{}
+	}
+	return len(seen)
+}
+
+func validStackSetOnboardingState(state StackSetOnboardingState) bool {
+	switch state {
+	case StackSetStatePending, StackSetStateValidating, StackSetStateBlocked, StackSetStateDeploying,
+		StackSetStateActive, StackSetStateDegraded, StackSetStateFailed, StackSetStatePermissionDenied,
+		StackSetStateUnsupported, StackSetStateSuspended, StackSetStateCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func stackSetInstanceKey(accountID, region string) string {
+	return strings.TrimSpace(accountID) + "|" + strings.ToLower(strings.TrimSpace(region))
+}
+
+func stackSetEvidenceRef(connectorID, accountID, region string) string {
+	connector := strings.TrimSpace(connectorID)
+	if connector == "" {
+		connector = "connector"
+	}
+	return "aws:stackset:" + strings.Join([]string{
+		connector,
+		strings.TrimSpace(accountID),
+		strings.ToLower(strings.TrimSpace(region)),
+	}, ":")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if v := strings.TrimSpace(value); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/providers/awscontract/stackset_onboarding_test.go
+++ b/internal/providers/awscontract/stackset_onboarding_test.go
@@ -1,0 +1,348 @@
+package awscontract
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func sampleStackSetConfig() StackSetOnboardingConfig {
+	return StackSetOnboardingConfig{
+		ConnectorID:         "aws-conn-1",
+		OrganizationID:      "o-test",
+		ManagementAccountID: "111111111111",
+		StackSetName:        "identrail-readonly-connector-stackset",
+		TemplateURL:         "https://example.invalid/templates/identrail-readonly.yaml",
+		TemplateChecksum:    "sha256:00",
+		ExternalID:          "external-id-1",
+		DeploymentMode:      StackSetDeploymentServiceManaged,
+		Partition:           "aws",
+		TrustedAccessReady:  true,
+		DelegatedAdminReady: true,
+		Targets: StackSetOnboardingTargets{
+			Accounts: []StackSetOnboardingTargetAccount{
+				{AccountID: "111111111111", Name: "mgmt", Management: true},
+				{AccountID: "222222222222", Name: "data"},
+			},
+			Regions: []StackSetOnboardingTargetRegion{
+				{Region: "us-east-1"},
+				{Region: "eu-west-1"},
+			},
+		},
+	}
+}
+
+func TestPlanStackSetOnboardingIsDeterministic(t *testing.T) {
+	now := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	first, err := PlanStackSetOnboarding(sampleStackSetConfig(), now)
+	if err != nil {
+		t.Fatalf("plan err: %v", err)
+	}
+	second, err := PlanStackSetOnboarding(sampleStackSetConfig(), now)
+	if err != nil {
+		t.Fatalf("plan err: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("StackSet onboarding plan is not deterministic across identical inputs")
+	}
+	if first.Version != StackSetOnboardingVersion {
+		t.Fatalf("expected version %q, got %q", StackSetOnboardingVersion, first.Version)
+	}
+}
+
+func TestPlanStackSetOnboardingExpandsAccountRegionMatrix(t *testing.T) {
+	now := time.Now().UTC()
+	plan, err := PlanStackSetOnboarding(sampleStackSetConfig(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Instances) != 4 {
+		t.Fatalf("expected 4 instances (2 accounts x 2 regions), got %d", len(plan.Instances))
+	}
+	// Sorted by key (account|region) for determinism.
+	for i := 1; i < len(plan.Instances); i++ {
+		if plan.Instances[i-1].Key > plan.Instances[i].Key {
+			t.Fatalf("instances not ordered by key at %d", i)
+		}
+	}
+}
+
+func TestPlanStackSetOnboardingValidationReadyByDefault(t *testing.T) {
+	plan, err := PlanStackSetOnboarding(sampleStackSetConfig(), time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Validation.Status != StackSetValidationReady {
+		t.Fatalf("expected ready validation, got %q (failures=%v)", plan.Validation.Status, plan.Validation.FailureReasons)
+	}
+	if plan.Validation.BlockingCount != 0 {
+		t.Fatalf("expected 0 blocking prereqs, got %d", plan.Validation.BlockingCount)
+	}
+}
+
+func TestPlanStackSetOnboardingBlocksWhenPrerequisitesMissing(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.TrustedAccessReady = false
+	config.ExternalID = ""
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Validation.Status != StackSetValidationBlocked {
+		t.Fatalf("expected blocked validation, got %q", plan.Validation.Status)
+	}
+	if plan.Validation.BlockingCount < 2 {
+		t.Fatalf("expected at least 2 blocking prereqs, got %d", plan.Validation.BlockingCount)
+	}
+	// Every instance should also be blocked.
+	for _, instance := range plan.Instances {
+		if instance.State != StackSetStateBlocked {
+			t.Fatalf("expected all instances blocked, got %+v", instance)
+		}
+		if !instance.Resumable {
+			t.Fatalf("blocked instances should be resumable so retry is exposed")
+		}
+	}
+}
+
+func TestPlanStackSetOnboardingSelfManagedRequiresAdminRole(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.DeploymentMode = StackSetDeploymentSelfManaged
+	config.OperatorRoleARN = ""
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Validation.Status != StackSetValidationBlocked {
+		t.Fatalf("expected blocked self-managed validation, got %q", plan.Validation.Status)
+	}
+}
+
+func TestPlanStackSetOnboardingSuspendedAccountStaysSuspended(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.Targets.Accounts = []StackSetOnboardingTargetAccount{
+		{AccountID: "111111111111", Name: "mgmt", Management: true},
+		{AccountID: "222222222222", Name: "data", Suspended: true},
+	}
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	suspendedCount := 0
+	for _, instance := range plan.Instances {
+		if instance.AccountID == "222222222222" {
+			if instance.State != StackSetStateSuspended {
+				t.Fatalf("expected suspended state, got %q", instance.State)
+			}
+			suspendedCount++
+		}
+	}
+	if suspendedCount == 0 {
+		t.Fatalf("expected suspended instances")
+	}
+	// Validation should advise about the suspended account.
+	if plan.Validation.AdvisoryCount == 0 {
+		t.Fatalf("expected advisory prereq for suspended accounts, got %+v", plan.Validation)
+	}
+}
+
+func TestPlanStackSetOnboardingCheckpointReplays(t *testing.T) {
+	now := time.Now().UTC()
+	observed := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+	config := sampleStackSetConfig()
+	config.Checkpoints = []StackSetOnboardingCheckpoint{
+		{AccountID: "111111111111", Region: "us-east-1", State: StackSetStateActive, StackID: "stack-1", ObservedAt: observed},
+		{AccountID: "111111111111", Region: "eu-west-1", State: StackSetStateFailed, FailureReason: "Throttled", Attempts: 2},
+		{AccountID: "222222222222", Region: "us-east-1", State: StackSetStatePermissionDenied, FailureReason: "AccessDenied"},
+	}
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byKey := map[string]StackSetOnboardingInstance{}
+	for _, instance := range plan.Instances {
+		byKey[instance.Key] = instance
+	}
+	if active := byKey["111111111111|us-east-1"]; active.State != StackSetStateActive || active.Resumable {
+		t.Fatalf("active instance wrong: %+v", active)
+	}
+	if failed := byKey["111111111111|eu-west-1"]; failed.State != StackSetStateFailed || failed.FailureReason != "Throttled" || failed.Attempts != 2 || !failed.Resumable {
+		t.Fatalf("failed instance wrong: %+v", failed)
+	}
+	if denied := byKey["222222222222|us-east-1"]; denied.State != StackSetStatePermissionDenied {
+		t.Fatalf("denied instance wrong: %+v", denied)
+	}
+	if plan.Summary.ActiveInstances != 1 || plan.Summary.FailedInstances != 1 || plan.Summary.PermissionDenied != 1 {
+		t.Fatalf("summary wrong: %+v", plan.Summary)
+	}
+}
+
+func TestPlanStackSetOnboardingRecoveryActionsCoverFailureModes(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.Targets.Accounts = append(config.Targets.Accounts, StackSetOnboardingTargetAccount{AccountID: "333333333333", Suspended: true})
+	config.Checkpoints = []StackSetOnboardingCheckpoint{
+		{AccountID: "111111111111", Region: "us-east-1", State: StackSetStateFailed, FailureReason: "Throttled"},
+		{AccountID: "222222222222", Region: "us-east-1", State: StackSetStatePermissionDenied},
+	}
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actionIDs := map[string]bool{}
+	for _, action := range plan.RecoveryActions {
+		actionIDs[action.ID] = true
+	}
+	for _, expected := range []string{"retry-failed-instances", "fix-permission-denied", "remove-suspended-accounts"} {
+		if !actionIDs[expected] {
+			t.Fatalf("missing recovery action %q in %v", expected, actionIDs)
+		}
+	}
+}
+
+func TestPlanStackSetOnboardingCoverageExpectationProjectsAcrossPlan(t *testing.T) {
+	now := time.Now().UTC()
+	coverageConfig := CoveragePlanConfig{
+		ConnectorID: "aws-conn-1",
+		Accounts: []CoverageAccount{
+			{AccountID: "111111111111", Enabled: true, Priority: CoveragePriorityCritical},
+			{AccountID: "222222222222", Enabled: true},
+		},
+		Regions: []CoverageRegion{
+			{Region: "us-east-1", Enabled: true},
+			{Region: "eu-west-1", Enabled: true},
+		},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true, Global: true},
+			{Service: "lambda", Enabled: true},
+		},
+		Checkpoints: []CoverageCheckpoint{
+			{AccountID: "111111111111", Region: "us-east-1", Service: "iam", State: CoverageStateCovered},
+		},
+	}
+	coveragePlan, err := PlanCoverage(coverageConfig, now)
+	if err != nil {
+		t.Fatalf("coverage plan err: %v", err)
+	}
+	stackConfig := sampleStackSetConfig()
+	stackConfig.CoveragePlan = &coveragePlan
+	plan, err := PlanStackSetOnboarding(stackConfig, now)
+	if err != nil {
+		t.Fatalf("stackset plan err: %v", err)
+	}
+	// Each account has 1 global iam target + 2 regional lambda targets = 3 enabled.
+	// With both accounts in the target set: 6 expected coverage targets.
+	if plan.CoverageExpectation.ExpectedCoverage != 6 {
+		t.Fatalf("expected 6 coverage targets, got %d", plan.CoverageExpectation.ExpectedCoverage)
+	}
+	if plan.CoverageExpectation.CoveragePercent <= 0 {
+		t.Fatalf("expected non-zero coverage percent, got %v", plan.CoverageExpectation.CoveragePercent)
+	}
+	// One instance must carry the global IAM count.
+	globalInstance := false
+	for _, instance := range plan.Instances {
+		if instance.AccountID == "111111111111" && instance.Region == "us-east-1" && instance.CoverageTargets >= 2 {
+			globalInstance = true
+		}
+	}
+	if !globalInstance {
+		t.Fatalf("expected home-region instance to carry global IAM count")
+	}
+}
+
+func TestPlanStackSetOnboardingDeduplicatesTargets(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.Targets.Accounts = append(config.Targets.Accounts, StackSetOnboardingTargetAccount{AccountID: " 111111111111 "})
+	config.Targets.Regions = append(config.Targets.Regions, StackSetOnboardingTargetRegion{Region: "US-EAST-1"})
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Instances) != 4 {
+		t.Fatalf("expected dedupe to keep 4 instances, got %d", len(plan.Instances))
+	}
+}
+
+func TestPlanStackSetOnboardingDeduplicatesAndMergesTargetMetadata(t *testing.T) {
+	now := time.Now().UTC()
+	config := sampleStackSetConfig()
+	config.Targets.Accounts = []StackSetOnboardingTargetAccount{
+		{AccountID: "111111111111", Name: "zzz-management", OUPath: "/Alt", Management: false, Suspended: false},
+		{AccountID: "111111111111", Name: "aaa-management", OUPath: "/Root", Management: true, Suspended: true},
+		{AccountID: "222222222222", Name: "member", OUPath: "/Root"},
+	}
+	plan, err := PlanStackSetOnboarding(config, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var deduped StackSetOnboardingTargetAccount
+	found := false
+	for _, account := range plan.Targets.Accounts {
+		if account.AccountID == "111111111111" {
+			deduped = account
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected merged account in targets")
+	}
+	if !deduped.Management || !deduped.Suspended {
+		t.Fatalf("expected merged metadata flags to retain true values, got %+v", deduped)
+	}
+	if deduped.Name != "aaa-management" {
+		t.Fatalf("expected deterministic name merge for metadata conflicts, got %q", deduped.Name)
+	}
+}
+
+func TestPlanStackSetCoverageExpectationDoesNotCountGlobalTargetsWithoutHomeRegion(t *testing.T) {
+	now := time.Now().UTC()
+	coverageConfig := CoveragePlanConfig{
+		ConnectorID: "aws-conn-1",
+		Accounts: []CoverageAccount{
+			{AccountID: "111111111111", Enabled: true},
+		},
+		Regions: []CoverageRegion{
+			{Region: "eu-west-1", Enabled: true},
+		},
+		Services: []CoverageService{
+			{Service: "iam", Enabled: true, Global: true},
+			{Service: "lambda", Enabled: true},
+		},
+	}
+	coveragePlan, err := PlanCoverage(coverageConfig, now)
+	if err != nil {
+		t.Fatalf("coverage plan err: %v", err)
+	}
+	planConfig := sampleStackSetConfig()
+	planConfig.CoveragePlan = &coveragePlan
+	planConfig.Targets.Regions = []StackSetOnboardingTargetRegion{{Region: "eu-west-1"}}
+	plan, err := PlanStackSetOnboarding(planConfig, now)
+	if err != nil {
+		t.Fatalf("stackset plan err: %v", err)
+	}
+	// Only regional lambda target is expected when global home region (us-east-1) is absent.
+	if plan.CoverageExpectation.ExpectedCoverage != 1 {
+		t.Fatalf("expected coverage 1 when global home region is not targeted, got %d", plan.CoverageExpectation.ExpectedCoverage)
+	}
+}
+
+func TestPlanStackSetOnboardingRejectsInvalidAccountID(t *testing.T) {
+	config := sampleStackSetConfig()
+	config.Targets.Accounts = []StackSetOnboardingTargetAccount{{AccountID: "abc", Name: "bad"}}
+	if _, err := PlanStackSetOnboarding(config, time.Now()); err == nil {
+		t.Fatalf("expected error for invalid account id")
+	}
+}
+
+func TestPlanStackSetOnboardingRejectsInvalidCheckpointState(t *testing.T) {
+	config := sampleStackSetConfig()
+	config.Checkpoints = []StackSetOnboardingCheckpoint{{AccountID: "111111111111", Region: "us-east-1", State: "bogus"}}
+	if _, err := PlanStackSetOnboarding(config, time.Now()); err == nil {
+		t.Fatalf("expected error for invalid checkpoint state")
+	}
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1102,6 +1102,44 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS StackSet onboarding with scoped headers, fixture state, and deployment mode', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        onboarding: {
+          status: 'ready',
+          summary: { total_instances: 6, active_instances: 2 },
+          instances: [],
+          validation: { status: 'ready' }
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectStackSetOnboarding(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { deploymentMode: 'self_managed' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/stackset-onboarding?connector_id=aws-prod&fixture_state=partial_failure&deployment_mode=self_managed'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3046,6 +3046,202 @@ export type AWSOrganizationsTopologyResult = {
   updated_at: string;
 };
 
+export type AWSStackSetOnboardingStatus = 'ready' | 'degraded' | 'blocked' | 'permission_denied' | 'partial_failure';
+export type AWSStackSetOnboardingFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSStackSetDeploymentMode = 'service_managed' | 'self_managed';
+export type AWSStackSetOnboardingValidationStatus = 'ready' | 'degraded' | 'blocked' | 'permission_denied';
+export type AWSStackSetOnboardingState =
+  | 'pending'
+  | 'validating'
+  | 'blocked'
+  | 'deploying'
+  | 'active'
+  | 'degraded'
+  | 'failed'
+  | 'permission_denied'
+  | 'unsupported'
+  | 'suspended'
+  | 'canceled';
+export type AWSStackSetOnboardingPrerequisiteSeverity = 'blocking' | 'advisory';
+
+export type AWSStackSetOnboardingPrerequisite = {
+  id: string;
+  title: string;
+  severity: AWSStackSetOnboardingPrerequisiteSeverity;
+  satisfied: boolean;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSStackSetOnboardingPermissionPreviewItem = {
+  service: string;
+  actions: string[];
+  resources: string[];
+  reason: string;
+};
+
+export type AWSStackSetOnboardingPermissionPreview = {
+  capability: string;
+  tier: string;
+  available: boolean;
+  summary: string;
+  permissions: AWSStackSetOnboardingPermissionPreviewItem[];
+};
+
+export type AWSStackSetOnboardingValidation = {
+  status: AWSStackSetOnboardingValidationStatus;
+  confidence: number;
+  blocking_count: number;
+  advisory_count: number;
+  prerequisites: AWSStackSetOnboardingPrerequisite[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+};
+
+export type AWSStackSetOnboardingTargetAccount = {
+  account_id: string;
+  name?: string;
+  ou_path?: string;
+  management?: boolean;
+  suspended?: boolean;
+};
+
+export type AWSStackSetOnboardingTargetRegion = {
+  region: string;
+  name?: string;
+  opt_in?: boolean;
+};
+
+export type AWSStackSetOnboardingOU = {
+  id: string;
+  name?: string;
+  parent_id?: string;
+  path?: string;
+  enabled: boolean;
+  reason?: string;
+};
+
+export type AWSStackSetOnboardingTargets = {
+  organization_id?: string;
+  organizational_units: AWSStackSetOnboardingOU[];
+  accounts: AWSStackSetOnboardingTargetAccount[];
+  regions: AWSStackSetOnboardingTargetRegion[];
+};
+
+export type AWSStackSetOnboardingInstance = {
+  key: string;
+  account_id: string;
+  account_name?: string;
+  ou_path?: string;
+  region: string;
+  region_name?: string;
+  state: AWSStackSetOnboardingState;
+  stack_id?: string;
+  operation_id?: string;
+  failure_reason?: string;
+  attempts?: number;
+  resumable: boolean;
+  suspended?: boolean;
+  opt_in_region?: boolean;
+  next_action: string;
+  coverage_targets: number;
+  evidence_ref: string;
+  observed_at?: string;
+};
+
+export type AWSStackSetOnboardingCoverageExpectation = {
+  expected_accounts: number;
+  expected_regions: number;
+  expected_instances: number;
+  expected_coverage_targets: number;
+  coverage_percent: number;
+  global_service_notes: string;
+};
+
+export type AWSStackSetOnboardingRecoveryAction = {
+  id: string;
+  title: string;
+  description: string;
+  targets: string[];
+};
+
+export type AWSStackSetOnboardingSummary = {
+  target_accounts: number;
+  target_regions: number;
+  total_instances: number;
+  pending_instances: number;
+  active_instances: number;
+  blocked_instances: number;
+  failed_instances: number;
+  degraded_instances: number;
+  suspended_instances: number;
+  permission_denied_instances: number;
+  unsupported_instances: number;
+  resumable_instances: number;
+  deployed_percent: number;
+  state_counts: Record<string, number>;
+};
+
+export type AWSStackSetOnboardingDiagnostic = {
+  source: string;
+  scope?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSStackSetOnboardingCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSStackSetOnboardingResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  organization_id?: string;
+  management_account_id?: string;
+  stack_set_name: string;
+  template_url?: string;
+  template_checksum?: string;
+  launch_url?: string;
+  deployment_mode: AWSStackSetDeploymentMode;
+  partition: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSStackSetOnboardingStatus;
+  fixture_state: AWSStackSetOnboardingFixtureState;
+  confidence: number;
+  validation: AWSStackSetOnboardingValidation;
+  permission_preview: AWSStackSetOnboardingPermissionPreview[];
+  targets: AWSStackSetOnboardingTargets;
+  instances: AWSStackSetOnboardingInstance[];
+  coverage_expectation: AWSStackSetOnboardingCoverageExpectation;
+  recovery_actions: AWSStackSetOnboardingRecoveryAction[];
+  summary: AWSStackSetOnboardingSummary;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSStackSetOnboardingCoverageGap[];
+  diagnostics: AWSStackSetOnboardingDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSDynamoDBRDSReachabilityInventoryResult = {
   tenant_id: string;
   workspace_id: string;
@@ -4863,6 +5059,23 @@ export const apiClient = {
         ou: filters?.ou,
         state: filters?.state,
         status: filters?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectStackSetOnboarding(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSStackSetOnboardingFixtureState,
+    options?: { deploymentMode?: AWSStackSetDeploymentMode },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ onboarding: AWSStackSetOnboardingResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/stackset-onboarding${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        deployment_mode: options?.deploymentMode
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -65,6 +65,8 @@ import {
   type AWSFanOutExecutionResult,
   type AWSOrganizationsTopologyAccount,
   type AWSOrganizationsTopologyResult,
+  type AWSStackSetOnboardingResult,
+  type AWSStackSetOnboardingInstance,
   type AWSSecretsManagerMetadataInventoryResult,
   type AWSSecretsManagerMetadataRecord,
   type AWSSQSSNSReachabilityInventoryResult,
@@ -3709,6 +3711,13 @@ type AWSInventoryOrganizationsTopologyState = {
   onRetry: () => void;
 };
 
+type AWSInventoryStackSetOnboardingState = {
+  onboarding: AWSStackSetOnboardingResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
@@ -4381,6 +4390,91 @@ function buildAWSOrganizationsTopologyRows(
   return [];
 }
 
+function buildAWSStackSetOnboardingRows(
+  onboarding: AWSStackSetOnboardingResult | null,
+  loading: boolean
+): AWSInventoryCoverageRow[] {
+  if (onboarding?.instances.length) {
+    return onboarding.instances.map((instance) => awsStackSetOnboardingInstanceRow(instance, onboarding.account_id ?? '', onboarding.region ?? ''));
+  }
+  if (onboarding) {
+    const validation = onboarding.validation;
+    const blocked = validation.status === 'blocked' || validation.status === 'permission_denied';
+    return [
+      {
+        id: 'stackset-onboarding-empty',
+        category: 'StackSet onboarding',
+        coverage: blocked ? 'missing' : 'planned',
+        source: onboarding.stack_set_name,
+        status: validation.status,
+        detail: blocked
+          ? validation.failure_reasons[0] ?? 'Resolve blocking prerequisites before launching the StackSet.'
+          : 'Configure target accounts/OUs and regions to populate the StackSet onboarding plan.',
+        filters: {
+          account: 'planned',
+          region: 'uncovered',
+          coverage: blocked ? 'missing' : 'planned',
+          search: ''
+        },
+        searchText: inventorySearchText(['stackset onboarding empty', validation.status])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'stackset-onboarding-loading',
+        category: 'AWS Organization StackSet onboarding',
+        coverage: 'planned',
+        source: 'StackSet onboarding planner',
+        status: 'loading',
+        detail: 'Loading StackSet target accounts, regions, prerequisites, and launch URL.',
+        filters: { account: 'planned', region: 'current,uncovered', coverage: 'planned', search: '' },
+        searchText: inventorySearchText(['stackset onboarding loading'])
+      }
+    ];
+  }
+  return [];
+}
+
+function awsStackSetOnboardingInstanceRow(
+  instance: AWSStackSetOnboardingInstance,
+  connectionAccountID: string,
+  connectionRegion: string
+): AWSInventoryCoverageRow {
+  const coverage = instance.state === 'active'
+    ? 'covered'
+    : instance.state === 'failed' || instance.state === 'permission_denied' || instance.state === 'suspended' || instance.state === 'blocked' || instance.state === 'unsupported'
+      ? 'missing'
+      : 'planned';
+  const coverageTokens = [coverage, instance.state];
+  return {
+    id: `stackset-instance-${instance.key}`,
+    category: `${instance.account_name || instance.account_id} / ${instance.region_name || instance.region}`,
+    coverage,
+    source: instance.evidence_ref,
+    status: instance.state,
+    detail: `${instance.next_action}${instance.failure_reason ? ` (${instance.failure_reason})` : ''}`,
+    filters: {
+      account: instance.account_id && instance.account_id === connectionAccountID ? 'connected,planned' : 'planned',
+      region: instance.region && instance.region === connectionRegion ? 'current' : 'uncovered',
+      coverage: [...new Set(coverageTokens)].join(','),
+      search: ''
+    },
+    searchText: inventorySearchText([
+      instance.account_id,
+      instance.account_name,
+      instance.ou_path,
+      instance.region,
+      instance.region_name,
+      instance.state,
+      instance.next_action,
+      instance.failure_reason,
+      instance.evidence_ref
+    ])
+  };
+}
+
 function AWSInventoryFilterSet({
   routeID,
   filters,
@@ -4559,6 +4653,7 @@ function AWSAccountsInventoryContent({
   accountRegionCoverageState,
   fanOutExecutionState,
   organizationsTopologyState,
+  stackSetOnboardingState,
   filters,
   onFiltersChange
 }: {
@@ -4568,6 +4663,7 @@ function AWSAccountsInventoryContent({
   accountRegionCoverageState: AWSInventoryAccountRegionCoverageState;
   fanOutExecutionState: AWSInventoryFanOutExecutionState;
   organizationsTopologyState: AWSInventoryOrganizationsTopologyState;
+  stackSetOnboardingState: AWSInventoryStackSetOnboardingState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
@@ -4580,6 +4676,8 @@ function AWSAccountsInventoryContent({
   const rows = buildAWSCoveragePlanRows(plan, coveragePlanState.loading, connection);
   const coverageAPIRows = buildAWSAccountRegionCoverageRows(coverageAPI, accountRegionCoverageState.loading, connection);
   const topologyRows = buildAWSOrganizationsTopologyRows(topology, organizationsTopologyState.loading, connection);
+  const stackSetOnboarding = stackSetOnboardingState.onboarding;
+  const stackSetRows = buildAWSStackSetOnboardingRows(stackSetOnboarding, stackSetOnboardingState.loading);
   const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
   const totalChecks = connection?.permission_checks.length ?? 0;
   const coveredAccounts = plan
@@ -4800,6 +4898,105 @@ function AWSAccountsInventoryContent({
           { key: 'coverage', header: 'Discovery', render: (row) => <AWSInventoryPill stage={awsCoveragePlanStage(row.coverage)} label={formatTokenLabel(row.coverage)} /> },
           { key: 'status', header: 'Account status', render: (row) => formatTokenLabel(row.status) },
           { key: 'detail', header: 'Detail', render: (row) => row.detail }
+        ]}
+      />
+      {stackSetOnboardingState.loading ? <DomainLoadingState label="Loading StackSet onboarding plan" /> : null}
+      {stackSetOnboardingState.error ? (
+        <DomainErrorState
+          title="StackSet onboarding could not load"
+          body={stackSetOnboardingState.error}
+          retryAction={{ label: 'Retry StackSet onboarding', onClick: stackSetOnboardingState.onRetry }}
+        />
+      ) : null}
+      {stackSetOnboarding ? (
+        <DomainStatusPanel
+          eyebrow="StackSet onboarding"
+          title="AWS Organization StackSet read-only deployment"
+          status={formatTokenLabel(stackSetOnboarding.validation.status)}
+              tone={
+                stackSetOnboarding.status === 'blocked' || stackSetOnboarding.status === 'permission_denied' || stackSetOnboarding.status === 'partial_failure'
+                  ? 'danger'
+                  : stackSetOnboarding.status === 'degraded'
+                    ? 'warning'
+                    : 'success'
+              }
+          actions={
+            stackSetOnboarding.launch_url
+              ? [{ label: 'Open StackSet launch URL', to: stackSetOnboarding.launch_url, variant: 'primary' }]
+              : undefined
+          }
+        >
+          <section className="idt-aws-inventory-coverage" aria-label="StackSet onboarding plan summary">
+            <DomainCoverageCard
+              label="Target accounts"
+              scanned={stackSetOnboarding.summary.target_accounts}
+              total={Math.max(stackSetOnboarding.summary.target_accounts, 1)}
+              detail={`${stackSetOnboarding.summary.target_regions} regions`}
+            />
+            <DomainCoverageCard
+              label="Active instances"
+              scanned={stackSetOnboarding.summary.active_instances}
+              total={Math.max(stackSetOnboarding.summary.total_instances, 1)}
+              detail={`${stackSetOnboarding.summary.deployed_percent}% deployed`}
+            />
+            <DomainCoverageCard
+              label="Failed or blocked"
+              scanned={stackSetOnboarding.summary.failed_instances + stackSetOnboarding.summary.blocked_instances}
+              total={Math.max(stackSetOnboarding.summary.total_instances, 1)}
+              detail={`${stackSetOnboarding.summary.permission_denied_instances} permission denied`}
+            />
+            <DomainCoverageCard
+              label="Expected coverage"
+              scanned={stackSetOnboarding.coverage_expectation.expected_coverage_targets}
+              total={Math.max(stackSetOnboarding.coverage_expectation.expected_coverage_targets, 1)}
+              detail={`${stackSetOnboarding.coverage_expectation.coverage_percent}% projected`}
+            />
+          </section>
+          {stackSetOnboarding.validation.prerequisites.length ? (
+            <ul className="idt-domain-charter-list" aria-label="StackSet onboarding prerequisites">
+              {stackSetOnboarding.validation.prerequisites.map((prereq) => (
+                <li key={prereq.id}>
+                  <strong>{prereq.satisfied ? '✓' : prereq.severity === 'blocking' ? '✗' : '!'} {prereq.title}</strong>
+                  {' — '}
+                  {prereq.reason}
+                  {prereq.remediation ? <small> {prereq.remediation}</small> : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {stackSetOnboarding.recovery_actions.length ? (
+            <ul className="idt-domain-charter-list" aria-label="StackSet onboarding recovery actions">
+              {stackSetOnboarding.recovery_actions.map((action) => (
+                <li key={action.id}>
+                  <strong>{action.title}</strong>
+                  {' — '}
+                  {action.description}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {stackSetOnboarding.diagnostics.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="StackSet onboarding diagnostics">
+              {stackSetOnboarding.diagnostics.map((diagnostic) => (
+                <article key={`${diagnostic.code}-${diagnostic.scope ?? diagnostic.source}`}>
+                  <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+        </DomainStatusPanel>
+      ) : null}
+      <DomainDataTable
+        label="StackSet onboarding instances"
+        rows={filterAWSInventoryRows(stackSetRows, filters)}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'category', header: 'Account / region', render: (row) => <strong>{row.category}</strong> },
+          { key: 'coverage', header: 'Stage', render: (row) => <AWSInventoryPill stage={awsCoveragePlanStage(row.coverage)} label={formatTokenLabel(row.coverage)} /> },
+          { key: 'status', header: 'Instance state', render: (row) => formatTokenLabel(row.status) },
+          { key: 'detail', header: 'Next action', render: (row) => row.detail }
         ]}
       />
       <DomainDataTable
@@ -7463,6 +7660,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [organizationsTopologyLoading, setOrganizationsTopologyLoading] = useState(false);
   const [organizationsTopologyError, setOrganizationsTopologyError] = useState('');
   const organizationsTopologyRequestRef = useRef(0);
+  const [stackSetOnboarding, setStackSetOnboarding] = useState<AWSStackSetOnboardingResult | null>(null);
+  const [stackSetOnboardingLoading, setStackSetOnboardingLoading] = useState(false);
+  const [stackSetOnboardingError, setStackSetOnboardingError] = useState('');
+  const stackSetOnboardingRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -8283,6 +8484,58 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     };
   }, [loadOrganizationsTopology]);
 
+  const loadStackSetOnboarding = useCallback(async () => {
+    const requestID = ++stackSetOnboardingRequestRef.current;
+    setStackSetOnboarding(null);
+    setStackSetOnboardingError('');
+    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setStackSetOnboardingLoading(false);
+      return;
+    }
+    setStackSetOnboardingLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectStackSetOnboarding(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== stackSetOnboardingRequestRef.current) {
+        return;
+      }
+      setStackSetOnboarding(response.onboarding);
+    } catch (error) {
+      if (requestID !== stackSetOnboardingRequestRef.current) {
+        return;
+      }
+      setStackSetOnboardingError(formatAPIError(error, 'Unable to load StackSet onboarding plan.'));
+    } finally {
+      if (requestID === stackSetOnboardingRequestRef.current) {
+        setStackSetOnboardingLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region,
+    connection?.status,
+    connection?.health_status,
+  ]);
+
+  useEffect(() => {
+    void loadStackSetOnboarding();
+    return () => {
+      stackSetOnboardingRequestRef.current += 1;
+    };
+  }, [loadStackSetOnboarding]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -8376,6 +8629,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: organizationsTopologyLoading,
             error: organizationsTopologyError,
             onRetry: () => void loadOrganizationsTopology()
+          }}
+          stackSetOnboardingState={{
+            onboarding: stackSetOnboarding,
+            loading: stackSetOnboardingLoading,
+            error: stackSetOnboardingError,
+            onRetry: () => void loadStackSetOnboarding()
           }}
           filters={activeFilters}
           onFiltersChange={onFiltersChange}


### PR DESCRIPTION
## Summary

Implements the Wave 3.08 read-only, metadata-only AWS Organization StackSet onboarding app flow: a deterministic planner, a project-scoped API, the CloudFormation StackSet console launch URL builder, and the operator-facing AWS app surface.

Closes #1504.

## Why

Operators onboarding many AWS accounts need an explicit, reproducible flow that previews what the StackSet will deploy, lists prerequisites (trusted access, external ID, template, delegated admin / administration role), shows per-instance state, projects post-launch coverage, and surfaces recovery actions for failures — without Identrail mutating AWS state. Without this, coverage gaps, partial failures, and retry behavior remain hard to diagnose at scale.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive: new API path, new web panel, new awscontract types)
- [x] Risk level assessed: low; read-only and metadata-only; the planner is a pure function; the launch URL embeds no secret values

## What's in the change

- `internal/providers/awscontract/stackset_onboarding.go` (+ tests): deterministic `PlanStackSetOnboarding` pure function. Lifecycle states are first-class (`pending`, `validating`, `blocked`, `deploying`, `active`, `degraded`, `failed`, `permission_denied`, `unsupported`, `suspended`, `canceled`), checkpoints replay so the plan is resumable, global services anchor once per account in the home region instead of being fanned out, and prerequisite severity (`blocking` / `advisory`) is explicit.
- `internal/api/aws_stackset_onboarding.go` (+ tests): `GET .../aws/stackset-onboarding` with `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` fixture states and a `deployment_mode` parameter (`service_managed` / `self_managed`). Response includes validation verdict, permission preview (read-only discovery tier + the unavailable write tiers), targets, instances, coverage expectation, recovery actions, diagnostics, evidence links, and the AWS console launch URL.
- `internal/connectors/aws/cfn.go` (+ tests): `BuildCloudFormationStackSetLaunchURL` console-URL builder that pins template URL, parameter set, permission model, OU ids, account ids, and target regions; returns empty when template URL is missing so callers can render a deterministic blocked state.
- `internal/api/router.go`, `internal/api/authz_policy_bundle_runtime.go`, `docs/openapi-v1.yaml`: route wiring, route policy entry, full OpenAPI path block + component schemas.
- `web/src/api/client.ts` (+ test), `web/src/productShell.tsx`: typed client getter and a new StackSet onboarding panel inside `AWS → Accounts` with loading / empty / error / blocked / degraded / permission-denied states, prerequisites list, target counts, expected coverage, instance table, diagnostics, and the StackSet launch button.
- `docs/aws-stackset-onboarding.md`, `CHANGELOG.md` updates.

## Safety / scope boundaries

- Identrail never executes the StackSet on the operator's behalf; the operator authorizes the AWS console launch URL.
- The planner reads no AWS state directly, never carries customer payloads, and never reads secret values, parameter values, database rows, object contents, prompts, completions, or environment values.
- The launch URL embeds no secret values — only the pinned template URL, parameter names, permission model, and target metadata.
- Only the read-only discovery permission tier is grantable through the bundled template. Write tiers stay advertised as *unavailable*.

## Validation

```bash
go test ./internal/providers/awscontract/ ./internal/connectors/aws/ ./internal/api/
make ci
npm run test:ci --prefix web
```

All passed locally (`make ci` ran fmt-check, vet, full Go tests, API example contract check, web route integrity check, web test, web build). API example contract check confirms the OpenAPI spec covers the registered route, scope headers, path parameters, and authorization metadata.

Manually verified the surface in the dev server by exercising the fixture states (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`) and confirming the validation verdict, instance table, recovery actions, and launch button behave as expected.

## Checklist

- [x] Tests added for the planner, API (multiple fixture states), router, and web client
- [x] Docs added (`docs/aws-stackset-onboarding.md`) and OpenAPI updated
- [x] `CHANGELOG.md` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a read-only, metadata-only AWS Organization StackSet onboarding flow with a deterministic planner, a project-scoped API, a StackSet console launch URL builder, and a new web panel. Supports service-managed and self-managed StackSets so operators can preview, launch, and recover org-wide deployments at scale without Identrail mutating AWS state. Closes #1504.

- New Features
  - Deterministic `PlanStackSetOnboarding` in `internal/providers/awscontract` with explicit lifecycle states, resumable checkpoints, home-region anchoring for global services, and prerequisite severity.
  - Project API `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/stackset-onboarding` with `connector_id`, `fixture_state` (`success`/`empty`/`degraded`/`partial_failure`/`permission_denied`), and `deployment_mode` (`service_managed`/`self_managed`). Returns validation verdict, permission preview (read-only; write tiers stay unavailable), targets, instances with resumable cursors and failure reasons, coverage expectations, recovery actions for failed/permission-denied/suspended instances, diagnostics, evidence links, and the AWS console launch URL.
  - `BuildCloudFormationStackSetLaunchURL` in `internal/connectors/aws` that pins template URL, parameters, permission model (`SERVICE_MANAGED`/`SELF_MANAGED`), OU/account IDs, and regions; returns empty when the template URL is missing.
  - Routing/policy/OpenAPI updates; typed client in `web/src/api/client.ts`; new StackSet onboarding panel under AWS → Accounts with loading/empty/error/blocked/degraded/permission-denied states; docs and `CHANGELOG.md`; tests across planner, API, connectors, and web.

<sup>Written for commit 94663dad3b74ae396f681900c4eb7675a7848328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

