### PR TITLE
Add AWS AI agent identity model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Architecture overview: `architecture.md`
 - AWS collector details: `aws-collector.md`
 - AWS account/region fan-out worker: `aws-account-region-fanout-worker.md`
+- AWS AI agent identities: `aws-ai-agent-identities.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -1,0 +1,57 @@
+# AWS AI Agent Identities
+
+Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance.
+
+## What Is Collected
+
+The model is metadata-only. Each `agent_identity` record can describe:
+
+- Bedrock agents
+- AgentCore runtimes
+- custom AWS-hosted agents
+- external-provider-backed agents
+- agent gateways
+- runtime IAM role ARN/name/account
+- provider and model identifiers
+- tool names and capability names
+- memory/browser/code-interpreter capability flags
+- credential-reference identifiers
+- evidence references, confidence, account, region, connector, scan, workspace, and project context
+
+The public API is:
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-identities`
+
+Optional query parameters:
+
+- `connector_id`
+- `fixture_state=success|empty|degraded|partial_failure|permission_denied`
+
+## What Is Not Collected
+
+Identrail does not collect prompt text, completions, memory contents, browser pages, code-interpreter output, database rows, object contents, secret values, or customer payloads for this capability.
+
+External AI provider credentials are represented as credential references only. The secret value remains hidden.
+
+## Operator States
+
+- `ready`: normalized agent metadata is available.
+- `degraded`: some metadata is incomplete, but retained records remain visible.
+- `blocked`: read-only metadata permission is missing.
+- `empty`: the scan completed without AI agent records for the selected account and region.
+- `partial_failure`: at least one agent sub-listing failed while other records remain usable.
+
+## Permissions
+
+Use metadata-only list and describe permissions for the relevant agent, runtime, gateway, and IAM-role surfaces. Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue.
+
+## UI Surface
+
+The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, tools, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
+
+## Troubleshooting
+
+- Permission denied: grant the missing metadata-only list/describe actions, then retry the selected environment.
+- Partial failure: retry the failed sub-listing and keep successful records visible.
+- Unresolved credential reference: join to the credential-reference metadata surface for ownership and rotation, never to secret values.
+- Empty result: confirm that the selected connector account and region actually hosts Bedrock, AgentCore, custom, external-provider-backed, or gateway agent resources.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -534,6 +534,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-identities
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4323,6 +4328,56 @@ paths:
                     $ref: "#/components/schemas/AWSSageMakerWorkloadRoleInventoryResult"
         "400":
           description: Invalid AWS SageMaker workload role inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-identities:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS AI agent identity inventory
+      operationId: getAWSProjectAIAgentIdentities
+      description: Returns scoped AWS AI agent identity metadata for Bedrock agents, AgentCore runtimes, custom agents, external-provider agents, and agent gateways. The response includes runtime roles, providers, models, tool names, capability names, credential-reference metadata, graph relationships, coverage gaps, and diagnostics. It does not read prompt text, completions, memory contents, browser pages, code-interpreter output, object contents, database rows, or secret values.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only AI agent inventory evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+      responses:
+        "200":
+          description: AWS AI agent identity inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSAIAgentIdentityInventoryResult"
+        "400":
+          description: Invalid AWS AI agent identity inventory request
           content:
             application/json:
               schema:
@@ -9928,6 +9983,176 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSageMakerWorkloadRoleDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAIAgentCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status:
+          type: string
+          enum: [intentionally_not_collected, unsupported]
+        reason: { type: string }
+        remediation: { type: string }
+    AWSAIAgentIdentityRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        agent_id: { type: string }
+        agent_arn: { type: string }
+        agent_name: { type: string }
+        agent_type:
+          type: string
+          enum:
+            - bedrock_agent
+            - agentcore_runtime
+            - custom_agent
+            - external_provider_agent
+            - agent_gateway
+        provider: { type: string }
+        model_id: { type: string }
+        runtime_role_arn: { type: string }
+        runtime_role_name: { type: string }
+        runtime_role_account_id: { type: string }
+        gateway_id: { type: string }
+        gateway_arn: { type: string }
+        external_provider: { type: string }
+        tool_names:
+          type: array
+          items: { type: string }
+        memory_enabled: { type: boolean }
+        memory_store_refs:
+          type: array
+          items: { type: string }
+        browser_enabled: { type: boolean }
+        code_interpreter_enabled: { type: boolean }
+        capability_names:
+          type: array
+          items: { type: string }
+        credential_reference_refs:
+          type: array
+          items: { type: string }
+        sensitive_boundary:
+          type: string
+          enum: [metadata_only]
+        coverage_status:
+          type: string
+          enum: [covered, degraded]
+        coverage_reason: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        agent_node_id: { type: string }
+        runtime_role_node_id: { type: string }
+        gateway_node_id: { type: string }
+        relationship_types:
+          type: array
+          items:
+            type: string
+            enum: [runs_as, calls_tool, uses_credential]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ready, degraded]
+        tags:
+          type: object
+          additionalProperties: { type: string }
+    AWSAIAgentIdentityRelationship:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [runs_as, calls_tool, uses_credential]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAIAgentIdentityDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code:
+          type: string
+          enum:
+            - ai_agent_credential_reference_unresolved
+            - ai_agent_gateway_list_failed
+            - permission_denied
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSAIAgentIdentityInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        record_count: { type: integer }
+        bedrock_agent_count: { type: integer }
+        agentcore_runtime_count: { type: integer }
+        custom_agent_count: { type: integer }
+        external_agent_count: { type: integer }
+        gateway_count: { type: integer }
+        runtime_role_count: { type: integer }
+        provider_count: { type: integer }
+        model_count: { type: integer }
+        tool_count: { type: integer }
+        capability_count: { type: integer }
+        credential_reference_count: { type: integer }
+        relationship_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentIdentityRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentIdentityRelationship"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentIdentityDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10054,7 +10054,7 @@ components:
           type: array
           items:
             type: string
-            enum: [runs_as, calls_tool, uses_credential]
+            enum: [runs_as, calls_tool, uses_secret]
         confidence:
           type: number
           minimum: 0
@@ -10073,7 +10073,7 @@ components:
       properties:
         type:
           type: string
-          enum: [runs_as, calls_tool, uses_credential]
+          enum: [runs_as, calls_tool, uses_secret]
         from_node_id: { type: string }
         to_node_id: { type: string }
         evidence_ref: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -750,6 +750,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/event-driven-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/managed-compute-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sagemaker-workload-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -395,7 +395,7 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 	record.CapabilityNames = dedupeStrings(record.CapabilityNames)
 	record.CredentialReferenceRefs = dedupeStrings(record.CredentialReferenceRefs)
 	if len(record.CredentialReferenceRefs) > 0 {
-		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_credential"))
+		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_secret"))
 	}
 	if record.GatewayARN != "" {
 		gatewayNodeID := awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN))

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -15,6 +15,7 @@ const (
 	awsAIAgentIdentityCurrentIssue = 1505
 	awsAIAgentIdentityVersion      = "aws-ai-agent-identity-normalized-model-v1"
 	awsAIAgentCredentialRefPrefix  = "aws:resource:credential-reference:"
+	awsAIAgentToolNodePrefix       = "tool:agent:"
 )
 
 type AWSAIAgentIdentityInventoryRequest struct {
@@ -439,20 +440,120 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: record.AgentNodeID, ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
 		}
 		if record.AgentNodeID != "" && record.GatewayNodeID != "" && record.AgentNodeID != record.GatewayNodeID {
-			result = append(result, AWSAIAgentIdentityRelation{Type: "calls_tool", FromNodeID: record.GatewayNodeID, ToNodeID: record.AgentNodeID, EvidenceRef: record.EvidenceRef})
+			for _, tool := range dedupeStrings(record.ToolNames) {
+				tool = strings.TrimSpace(tool)
+				if tool == "" {
+					continue
+				}
+				result = append(result, AWSAIAgentIdentityRelation{
+					Type:        "calls_tool",
+					FromNodeID:  record.GatewayNodeID,
+					ToNodeID:    awsAIAgentToolNodeID(record.GatewayNodeID, tool),
+					EvidenceRef: record.EvidenceRef,
+				})
+			}
+			if len(dedupeStrings(record.ToolNames)) == 0 {
+				result = append(result, AWSAIAgentIdentityRelation{
+					Type:        "calls_tool",
+					FromNodeID:  record.GatewayNodeID,
+					ToNodeID:    awsAIAgentToolNodeID(record.GatewayNodeID, ""),
+					EvidenceRef: record.EvidenceRef,
+				})
+			}
 		}
 		for _, ref := range record.CredentialReferenceRefs {
 			ref = strings.TrimSpace(ref)
 			if record.AgentNodeID != "" && ref != "" {
-				result = append(result, AWSAIAgentIdentityRelation{Type: "uses_secret", FromNodeID: record.AgentNodeID, ToNodeID: awsCredentialReferenceNodeID(ref), EvidenceRef: record.EvidenceRef})
+				result = append(result, AWSAIAgentIdentityRelation{Type: "uses_secret", FromNodeID: record.AgentNodeID, ToNodeID: awsCredentialReferenceNodeID(record.AgentNodeID, ref), EvidenceRef: record.EvidenceRef})
 			}
 		}
 	}
 	return result
 }
 
-func awsCredentialReferenceNodeID(ref string) string {
-	return awsAIAgentCredentialRefPrefix + strings.ToLower(strings.NewReplacer(" ", "-", "/", ":", "|", ":", "#", "-").Replace(strings.TrimSpace(ref)))
+func awsAIAgentToolNodeID(gatewayNodeID string, tool string) string {
+	workload := strings.TrimSpace(strings.ToLower(gatewayNodeID))
+	if workload == "" {
+		workload = "gateway"
+	}
+	name := strings.TrimSpace(strings.ToLower(tool))
+	if name == "" {
+		name = "tool"
+	}
+	return awsAIAgentToolNodePrefix + strings.Join(normalizeStringList([]string{workload, name}), "|")
+}
+
+func awsCredentialReferenceNodeID(agentNodeID string, ref string) string {
+	name, source := awsAIAgentCredentialReferenceParts(ref)
+	agentNodeID = strings.TrimSpace(strings.ToLower(agentNodeID))
+	if agentNodeID == "" {
+		agentNodeID = "agent"
+	}
+	name = strings.TrimSpace(strings.ToLower(name))
+	source = strings.TrimSpace(strings.ToLower(source))
+	return awsAIAgentCredentialRefPrefix + strings.Join(normalizeStringList([]string{
+		agentNodeID,
+		awsAIAgentCredentialReferenceProvider(name, source),
+		name,
+		source,
+	}), "|")
+}
+
+func awsAIAgentCredentialReferenceProvider(name, source string) string {
+	probe := strings.ToLower(strings.TrimSpace(name + " " + source))
+	switch {
+	case containsAnyToken(probe, "openai", "open_ai", "gpt_"):
+		return "openai"
+	case containsAnyToken(probe, "anthropic", "claude"):
+		return "anthropic"
+	case containsAnyToken(probe, "bedrock"):
+		return "bedrock"
+	case strings.HasPrefix(probe, "secretsmanager:"):
+		return "secretsmanager"
+	case strings.HasPrefix(probe, "ssm:"):
+		return "ssm"
+	default:
+		return "generic"
+	}
+}
+
+func awsAIAgentCredentialReferenceParts(ref string) (string, string) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return "credential_reference", "unknown"
+	}
+	if idx := strings.Index(trimmed, "="); idx > 0 {
+		name := strings.TrimSpace(trimmed[:idx])
+		source := strings.TrimSpace(trimmed[idx+1:])
+		if source == "" {
+			source = "environment"
+		}
+		return sanitizeCredentialReferenceToken(name), sanitizeCredentialReferenceToken(source)
+	}
+
+	if !strings.Contains(trimmed, ":") && !strings.Contains(trimmed, "/") {
+		return sanitizeCredentialReferenceToken(trimmed), ""
+	}
+	name := trimmed
+	if lastSlash := strings.LastIndex(trimmed, "/"); lastSlash >= 0 && lastSlash < len(trimmed)-1 {
+		name = trimmed[lastSlash+1:]
+	} else if colonIndex := strings.LastIndex(trimmed, ":"); colonIndex >= 0 && colonIndex < len(trimmed)-1 {
+		name = trimmed[colonIndex+1:]
+	}
+	return sanitizeCredentialReferenceToken(name), sanitizeCredentialReferenceToken(trimmed)
+}
+
+func sanitizeCredentialReferenceToken(value string) string {
+	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "|", "-", ":", "-", "#", "-").Replace(strings.TrimSpace(value)))
+}
+
+func containsAnyToken(haystack string, tokens ...string) bool {
+	for _, token := range tokens {
+		if token != "" && strings.Contains(haystack, token) {
+			return true
+		}
+	}
+	return false
 }
 
 func awsAIAgentIdentityTypeCount(records []AWSAIAgentIdentityRecord, agentType string) int {

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -14,6 +14,7 @@ import (
 const (
 	awsAIAgentIdentityCurrentIssue = 1505
 	awsAIAgentIdentityVersion      = "aws-ai-agent-identity-normalized-model-v1"
+	awsAIAgentCredentialRefPrefix  = "aws:resource:credential-reference:"
 )
 
 type AWSAIAgentIdentityInventoryRequest struct {
@@ -451,7 +452,7 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 }
 
 func awsCredentialReferenceNodeID(ref string) string {
-	return "aws:credential-reference:" + strings.ToLower(strings.NewReplacer(" ", "-", "/", ":", "|", ":", "#", "-").Replace(strings.TrimSpace(ref)))
+	return awsAIAgentCredentialRefPrefix + strings.ToLower(strings.NewReplacer(" ", "-", "/", ":", "|", ":", "#", "-").Replace(strings.TrimSpace(ref)))
 }
 
 func awsAIAgentIdentityTypeCount(records []AWSAIAgentIdentityRecord, agentType string) int {

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -315,11 +315,11 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			Retryable: false,
 		}}, gaps
 	case "partial_failure":
-		return records[:3], []providers.SourceError{{
+		return records[:4], []providers.SourceError{{
 			Collector: "aws_ai-agent/ai_agent_identity",
 			SourceID:  fmt.Sprintf("service=ai-agent|account=%s|region=%s|source=agent_gateways", accountID, region),
 			Code:      "ai_agent_gateway_list_failed",
-			Message:   "agent gateway metadata could not be listed; retained Bedrock, AgentCore, and custom agent identities remain visible",
+			Message:   "agent gateway metadata could not be listed; retained Bedrock, AgentCore, custom, and external-provider-backed agent identities remain visible",
 			Retryable: true,
 		}}, gaps
 	case "permission_denied":
@@ -373,8 +373,11 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_credential"))
 	}
 	if record.GatewayARN != "" {
-		record.GatewayNodeID = awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN))
-		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "calls_tool"))
+		gatewayNodeID := awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN))
+		if record.AgentNodeID != gatewayNodeID {
+			record.GatewayNodeID = gatewayNodeID
+			record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "calls_tool"))
+		}
 	}
 	return record
 }

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -439,24 +439,24 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 		if record.AgentNodeID != "" && record.RuntimeRoleNodeID != "" {
 			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: record.AgentNodeID, ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
 		}
-		if record.AgentNodeID != "" && record.GatewayNodeID != "" && record.AgentNodeID != record.GatewayNodeID {
-			for _, tool := range dedupeStrings(record.ToolNames) {
+		toolNames := dedupeStrings(record.ToolNames)
+		if record.AgentNodeID != "" && len(toolNames) > 0 {
+			callsToolSource := firstNonEmptyAWSValue(record.GatewayNodeID, record.AgentNodeID)
+			if strings.EqualFold(record.AgentType, "agent_gateway") {
+				callsToolSource = record.AgentNodeID
+			}
+			if callsToolSource == "" {
+				continue
+			}
+			for _, tool := range toolNames {
 				tool = strings.TrimSpace(tool)
 				if tool == "" {
 					continue
 				}
 				result = append(result, AWSAIAgentIdentityRelation{
 					Type:        "calls_tool",
-					FromNodeID:  record.GatewayNodeID,
-					ToNodeID:    awsAIAgentToolNodeID(record.GatewayNodeID, tool),
-					EvidenceRef: record.EvidenceRef,
-				})
-			}
-			if len(dedupeStrings(record.ToolNames)) == 0 {
-				result = append(result, AWSAIAgentIdentityRelation{
-					Type:        "calls_tool",
-					FromNodeID:  record.GatewayNodeID,
-					ToNodeID:    awsAIAgentToolNodeID(record.GatewayNodeID, ""),
+					FromNodeID:  callsToolSource,
+					ToNodeID:    awsAIAgentToolNodeID(callsToolSource, tool),
 					EvidenceRef: record.EvidenceRef,
 				})
 			}

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -150,6 +150,8 @@ func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject,
 	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
 	records, diagnostics, coverageGaps := awsAIAgentIdentityFixtureRecords(accountID, region, fixtureState, checkedAt)
+	records = emptyAWSAIAgentIdentityRecords(records)
+	coverageGaps = emptyAWSAIAgentCoverageGaps(coverageGaps)
 	for _, record := range records {
 		if _, err := awscontract.NormalizeServiceCollectorRecord(awscontract.ServiceCollectorRecord{
 			TenantID:      scope.TenantID,
@@ -175,6 +177,8 @@ func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject,
 	}
 	status, confidence, failures, remediations := summarizeAWSAIAgentIdentityInventory(fixtureState, diagnostics)
 	relationships := awsAIAgentIdentityRelationships(records)
+	failures = emptyStrings(failures)
+	remediations = emptyStrings(remediations)
 	return AWSAIAgentIdentityInventoryResult{
 		TenantID:              scope.TenantID,
 		WorkspaceID:           project.WorkspaceID,
@@ -219,6 +223,27 @@ func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject,
 		GeneratedAt:   checkedAt,
 		UpdatedAt:     checkedAt,
 	}, nil
+}
+
+func emptyAWSAIAgentIdentityRecords(records []AWSAIAgentIdentityRecord) []AWSAIAgentIdentityRecord {
+	if records == nil {
+		return []AWSAIAgentIdentityRecord{}
+	}
+	return records
+}
+
+func emptyAWSAIAgentCoverageGaps(gaps []AWSAIAgentCoverageGap) []AWSAIAgentCoverageGap {
+	if gaps == nil {
+		return []AWSAIAgentCoverageGap{}
+	}
+	return gaps
+}
+
+func emptyStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }
 
 func normalizeAWSAIAgentIdentityFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
@@ -301,7 +326,7 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 	}
 	switch fixtureState {
 	case "empty":
-		return nil, nil, gaps
+		return []AWSAIAgentIdentityRecord{}, nil, gaps
 	case "degraded":
 		records[2].Status = "degraded"
 		records[2].CoverageStatus = "degraded"
@@ -323,7 +348,7 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			Retryable: true,
 		}}, gaps
 	case "permission_denied":
-		return nil, []providers.SourceError{{
+		return []AWSAIAgentIdentityRecord{}, []providers.SourceError{{
 			Collector: "aws_ai-agent/ai_agent_identity",
 			SourceID:  fmt.Sprintf("service=ai-agent|account=%s|region=%s|source=list", accountID, region),
 			Code:      "permission_denied",

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -1,0 +1,510 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsAIAgentIdentityCurrentIssue = 1505
+	awsAIAgentIdentityVersion      = "aws-ai-agent-identity-normalized-model-v1"
+)
+
+type AWSAIAgentIdentityInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+}
+
+type AWSAIAgentCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSAIAgentIdentityInventoryResult struct {
+	TenantID              string                         `json:"tenant_id"`
+	WorkspaceID           string                         `json:"workspace_id"`
+	ProjectID             string                         `json:"project_id"`
+	ConnectorID           string                         `json:"connector_id,omitempty"`
+	AccountID             string                         `json:"account_id,omitempty"`
+	Region                string                         `json:"region,omitempty"`
+	ParentIssueNumber     int                            `json:"parent_issue_number"`
+	ParentIssueRef        string                         `json:"parent_issue_ref"`
+	CurrentIssueNumber    int                            `json:"current_issue_number"`
+	CurrentIssueRef       string                         `json:"current_issue_ref"`
+	Version               string                         `json:"version"`
+	Status                string                         `json:"status"`
+	FixtureState          string                         `json:"fixture_state"`
+	Confidence            float64                        `json:"confidence"`
+	RecordCount           int                            `json:"record_count"`
+	BedrockAgentCount     int                            `json:"bedrock_agent_count"`
+	AgentCoreRuntimeCount int                            `json:"agentcore_runtime_count"`
+	CustomAgentCount      int                            `json:"custom_agent_count"`
+	ExternalAgentCount    int                            `json:"external_agent_count"`
+	GatewayCount          int                            `json:"gateway_count"`
+	RuntimeRoleCount      int                            `json:"runtime_role_count"`
+	ProviderCount         int                            `json:"provider_count"`
+	ModelCount            int                            `json:"model_count"`
+	ToolCount             int                            `json:"tool_count"`
+	CapabilityCount       int                            `json:"capability_count"`
+	CredentialRefCount    int                            `json:"credential_reference_count"`
+	RelationshipCount     int                            `json:"relationship_count"`
+	FailureReasons        []string                       `json:"failure_reasons"`
+	RemediationHints      []string                       `json:"remediation_hints"`
+	EvidenceLinks         []string                       `json:"evidence_links"`
+	CoverageGaps          []AWSAIAgentCoverageGap        `json:"coverage_gaps"`
+	Records               []AWSAIAgentIdentityRecord     `json:"records"`
+	Relationships         []AWSAIAgentIdentityRelation   `json:"relationships"`
+	Diagnostics           []AWSAIAgentIdentityDiagnostic `json:"diagnostics"`
+	GeneratedAt           time.Time                      `json:"generated_at"`
+	UpdatedAt             time.Time                      `json:"updated_at"`
+}
+
+type AWSAIAgentIdentityRecord struct {
+	AccountID               string            `json:"account_id"`
+	Region                  string            `json:"region"`
+	Service                 string            `json:"service"`
+	AgentID                 string            `json:"agent_id"`
+	AgentARN                string            `json:"agent_arn,omitempty"`
+	AgentName               string            `json:"agent_name"`
+	AgentType               string            `json:"agent_type"`
+	Provider                string            `json:"provider,omitempty"`
+	ModelID                 string            `json:"model_id,omitempty"`
+	RuntimeRoleARN          string            `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName         string            `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID    string            `json:"runtime_role_account_id,omitempty"`
+	GatewayID               string            `json:"gateway_id,omitempty"`
+	GatewayARN              string            `json:"gateway_arn,omitempty"`
+	ExternalProvider        string            `json:"external_provider,omitempty"`
+	ToolNames               []string          `json:"tool_names,omitempty"`
+	MemoryEnabled           bool              `json:"memory_enabled"`
+	MemoryStoreRefs         []string          `json:"memory_store_refs,omitempty"`
+	BrowserEnabled          bool              `json:"browser_enabled"`
+	CodeInterpreterEnabled  bool              `json:"code_interpreter_enabled"`
+	CapabilityNames         []string          `json:"capability_names,omitempty"`
+	CredentialReferenceRefs []string          `json:"credential_reference_refs,omitempty"`
+	SensitiveBoundary       string            `json:"sensitive_boundary"`
+	CoverageStatus          string            `json:"coverage_status"`
+	CoverageReason          string            `json:"coverage_reason,omitempty"`
+	Source                  string            `json:"source"`
+	EvidenceRef             string            `json:"evidence_ref"`
+	AgentNodeID             string            `json:"agent_node_id"`
+	RuntimeRoleNodeID       string            `json:"runtime_role_node_id,omitempty"`
+	GatewayNodeID           string            `json:"gateway_node_id,omitempty"`
+	RelationshipTypes       []string          `json:"relationship_types"`
+	Confidence              float64           `json:"confidence"`
+	CollectedAt             time.Time         `json:"collected_at"`
+	Status                  string            `json:"status"`
+	Tags                    map[string]string `json:"tags,omitempty"`
+}
+
+type AWSAIAgentIdentityRelation struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+type AWSAIAgentIdentityDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+func (s *Service) GetAWSAIAgentIdentityInventory(ctx context.Context, workspaceID string, projectID string, request AWSAIAgentIdentityInventoryRequest) (AWSAIAgentIdentityInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAIAgentIdentityInventoryResult{}, err
+	}
+	var (
+		connection    AWSConnectionStatus
+		hasConnection bool
+	)
+	if strings.TrimSpace(request.ConnectorID) != "" {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, request.ConnectorID)
+	} else {
+		connection, hasConnection, err = s.awsBaselineConnection(ctx, project, "")
+	}
+	if err != nil {
+		return AWSAIAgentIdentityInventoryResult{}, err
+	}
+	return buildAWSAIAgentIdentityInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSAIAgentIdentityInventoryRequest, checkedAt time.Time) (AWSAIAgentIdentityInventoryResult, error) {
+	fixtureState := normalizeAWSAIAgentIdentityFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAIAgentIdentityInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, coverageGaps := awsAIAgentIdentityFixtureRecords(accountID, region, fixtureState, checkedAt)
+	for _, record := range records {
+		if _, err := awscontract.NormalizeServiceCollectorRecord(awscontract.ServiceCollectorRecord{
+			TenantID:      scope.TenantID,
+			WorkspaceID:   project.WorkspaceID,
+			ProjectID:     project.ProjectID,
+			ConnectorID:   connectorID,
+			AccountID:     record.AccountID,
+			Region:        record.Region,
+			Service:       record.Service,
+			WorkloadID:    record.AgentID,
+			WorkloadType:  record.AgentType,
+			WorkloadName:  record.AgentName,
+			RoleARN:       record.RuntimeRoleARN,
+			Source:        record.Source,
+			EvidenceRef:   record.EvidenceRef,
+			Confidence:    record.Confidence,
+			ScanID:        "aws-ai-agent-identity-fixture",
+			CollectorName: "ai_agent_identity",
+			CollectedAt:   checkedAt,
+		}); err != nil {
+			return AWSAIAgentIdentityInventoryResult{}, fmt.Errorf("validate ai agent identity contract record: %w", err)
+		}
+	}
+	status, confidence, failures, remediations := summarizeAWSAIAgentIdentityInventory(fixtureState, diagnostics)
+	relationships := awsAIAgentIdentityRelationships(records)
+	return AWSAIAgentIdentityInventoryResult{
+		TenantID:              scope.TenantID,
+		WorkspaceID:           project.WorkspaceID,
+		ProjectID:             project.ProjectID,
+		ConnectorID:           connectorID,
+		AccountID:             accountID,
+		Region:                region,
+		ParentIssueNumber:     awsPlatformDependencyParentIssue,
+		ParentIssueRef:        awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:    awsAIAgentIdentityCurrentIssue,
+		CurrentIssueRef:       awsIssueRef(awsAIAgentIdentityCurrentIssue),
+		Version:               awsAIAgentIdentityVersion,
+		Status:                status,
+		FixtureState:          fixtureState,
+		Confidence:            confidence,
+		RecordCount:           len(records),
+		BedrockAgentCount:     awsAIAgentIdentityTypeCount(records, "bedrock_agent"),
+		AgentCoreRuntimeCount: awsAIAgentIdentityTypeCount(records, "agentcore_runtime"),
+		CustomAgentCount:      awsAIAgentIdentityTypeCount(records, "custom_agent"),
+		ExternalAgentCount:    awsAIAgentIdentityTypeCount(records, "external_provider_agent"),
+		GatewayCount:          awsAIAgentIdentityTypeCount(records, "agent_gateway"),
+		RuntimeRoleCount:      awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.RuntimeRoleNodeID }),
+		ProviderCount:         awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.Provider }),
+		ModelCount:            awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.ModelID }),
+		ToolCount:             awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.ToolNames }),
+		CapabilityCount:       awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.CapabilityNames }),
+		CredentialRefCount:    awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.CredentialReferenceRefs }),
+		RelationshipCount:     len(relationships),
+		FailureReasons:        failures,
+		RemediationHints:      remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAIAgentIdentityCurrentIssue),
+			"/docs/aws-ai-agent-identities",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  coverageGaps,
+		Records:       records,
+		Relationships: relationships,
+		Diagnostics:   awsAIAgentIdentityDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func normalizeAWSAIAgentIdentityFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSAIAgentIdentityRecord, []providers.SourceError, []AWSAIAgentCoverageGap) {
+	partition := awsPartitionForAPIRegion(region)
+	role := func(name string) string { return fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, name) }
+	agentARN := func(service, id string) string {
+		return fmt.Sprintf("arn:%s:%s:%s:%s:agent/%s", partition, service, region, accountID, id)
+	}
+	gatewayARN := fmt.Sprintf("arn:%s:bedrock:%s:%s:agent-gateway/payments-gateway", partition, region, accountID)
+	gaps := []AWSAIAgentCoverageGap{{
+		Capability:  "prompt_and_completion_contents",
+		Status:      "intentionally_not_collected",
+		Reason:      "Prompt text, completions, memory content, browser pages, code-interpreter output, database rows, and object contents are outside this metadata-only model.",
+		Remediation: "Use runtime evidence references and operator-approved follow-up collection only when a future issue explicitly permits it.",
+	}, {
+		Capability:  "external_provider_secret_values",
+		Status:      "intentionally_not_collected",
+		Reason:      "External AI provider keys are represented as credential references only; secret values remain hidden.",
+		Remediation: "Join to credential-reference metadata for rotation and ownership, never to secret values.",
+	}}
+	records := []AWSAIAgentIdentityRecord{
+		awsAIAgentFixtureRecord(accountID, region, "bedrock_agent", "payments-risk-agent", "AGENTPAY1", agentARN("bedrock", "AGENTPAY1"), role("bedrock-payments-risk-agent"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "bedrock"
+			r.Provider = "amazon-bedrock"
+			r.ModelID = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+			r.ToolNames = []string{"payments-case-search", "fraud-review-action-group"}
+			r.MemoryEnabled = true
+			r.MemoryStoreRefs = []string{"bedrock-memory/payments-risk"}
+			r.CapabilityNames = []string{"tool_use", "memory", "knowledge_base"}
+		}),
+		awsAIAgentFixtureRecord(accountID, region, "agentcore_runtime", "case-triage-runtime", "runtime-case-triage", agentARN("bedrock-agentcore", "runtime-case-triage"), role("agentcore-case-triage-runtime"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "agentcore"
+			r.Provider = "amazon-bedrock-agentcore"
+			r.ModelID = "us.amazon.nova-pro-v1:0"
+			r.ToolNames = []string{"case-router", "policy-checker"}
+			r.BrowserEnabled = true
+			r.CodeInterpreterEnabled = true
+			r.CapabilityNames = []string{"browser", "code_interpreter", "tool_use"}
+		}),
+		awsAIAgentFixtureRecord(accountID, region, "custom_agent", "invoice-reconciliation-agent", "custom-invoice-agent", fmt.Sprintf("arn:%s:lambda:%s:%s:function:invoice-reconciliation-agent", partition, region, accountID), role("lambda-invoice-agent"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "lambda"
+			r.Provider = "custom"
+			r.ModelID = "external:model-class-hidden"
+			r.ToolNames = []string{"invoice-index", "ticket-writer"}
+			r.CapabilityNames = []string{"tool_use"}
+			r.CredentialReferenceRefs = []string{"secretsmanager:prod/ai/openai-key"}
+			r.ExternalProvider = "external_ai_provider"
+		}),
+		awsAIAgentFixtureRecord(accountID, region, "external_provider_agent", "support-assistant", "external-support-agent", fmt.Sprintf("arn:%s:ecs:%s:%s:service/support/support-assistant", partition, region, accountID), role("ecs-support-agent-task"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "ecs"
+			r.Provider = "external_provider"
+			r.ModelID = "provider:model-redacted"
+			r.ToolNames = []string{"support-search"}
+			r.CapabilityNames = []string{"tool_use"}
+			r.CredentialReferenceRefs = []string{"ssm:/prod/support/ai-provider-key"}
+			r.ExternalProvider = "provider_key_reference"
+		}),
+		awsAIAgentFixtureRecord(accountID, region, "agent_gateway", "payments-gateway", "payments-gateway", gatewayARN, role("bedrock-agent-gateway-payments"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "bedrock"
+			r.Provider = "amazon-bedrock"
+			r.GatewayID = "payments-gateway"
+			r.GatewayARN = gatewayARN
+			r.ToolNames = []string{"payments-case-search", "fraud-review-action-group", "support-search"}
+			r.CapabilityNames = []string{"gateway", "tool_routing"}
+		}),
+	}
+	switch fixtureState {
+	case "empty":
+		return nil, nil, gaps
+	case "degraded":
+		records[2].Status = "degraded"
+		records[2].CoverageStatus = "degraded"
+		records[2].CoverageReason = "custom agent provider key is an unresolved credential reference"
+		records[2].Confidence = 0.68
+		return records, []providers.SourceError{{
+			Collector: "aws_ai-agent/ai_agent_identity",
+			SourceID:  records[2].AgentID,
+			Code:      "ai_agent_credential_reference_unresolved",
+			Message:   "custom agent has an external provider credential reference that did not resolve to collected metadata",
+			Retryable: false,
+		}}, gaps
+	case "partial_failure":
+		return records[:3], []providers.SourceError{{
+			Collector: "aws_ai-agent/ai_agent_identity",
+			SourceID:  fmt.Sprintf("service=ai-agent|account=%s|region=%s|source=agent_gateways", accountID, region),
+			Code:      "ai_agent_gateway_list_failed",
+			Message:   "agent gateway metadata could not be listed; retained Bedrock, AgentCore, and custom agent identities remain visible",
+			Retryable: true,
+		}}, gaps
+	case "permission_denied":
+		return nil, []providers.SourceError{{
+			Collector: "aws_ai-agent/ai_agent_identity",
+			SourceID:  fmt.Sprintf("service=ai-agent|account=%s|region=%s|source=list", accountID, region),
+			Code:      "permission_denied",
+			Message:   "Read-only AI agent metadata permission is missing",
+			Retryable: false,
+		}}, gaps
+	default:
+		return records, nil, gaps
+	}
+}
+
+func awsAIAgentFixtureRecord(accountID string, region string, agentType string, agentName string, agentID string, agentARN string, roleARN string, checkedAt time.Time, mutate func(*AWSAIAgentIdentityRecord)) AWSAIAgentIdentityRecord {
+	record := AWSAIAgentIdentityRecord{
+		AccountID:               accountID,
+		Region:                  region,
+		Service:                 "ai-agent",
+		AgentID:                 agentID,
+		AgentARN:                agentARN,
+		AgentName:               agentName,
+		AgentType:               agentType,
+		RuntimeRoleARN:          roleARN,
+		RuntimeRoleName:         roleNameFromARNForAPI(roleARN),
+		RuntimeRoleAccountID:    roleAccountIDFromARNForAPI(roleARN),
+		SensitiveBoundary:       "metadata_only",
+		CoverageStatus:          "covered",
+		Source:                  "ai_agent_metadata",
+		EvidenceRef:             agentARN,
+		AgentNodeID:             awsAIAgentNodeID(accountID, region, agentType, agentID),
+		RuntimeRoleNodeID:       awsIdentityNodeIDForAPI(roleARN),
+		RelationshipTypes:       []string{"runs_as"},
+		Confidence:              0.9,
+		CollectedAt:             checkedAt,
+		Status:                  "ready",
+		Tags:                    map[string]string{"owner": "ai-platform", "classification": "metadata-only"},
+		CapabilityNames:         []string{"identity"},
+		ToolNames:               nil,
+		MemoryStoreRefs:         nil,
+		CredentialReferenceRefs: nil,
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	record.ToolNames = dedupeStrings(record.ToolNames)
+	record.CapabilityNames = dedupeStrings(record.CapabilityNames)
+	record.CredentialReferenceRefs = dedupeStrings(record.CredentialReferenceRefs)
+	if len(record.CredentialReferenceRefs) > 0 {
+		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_credential"))
+	}
+	if record.GatewayARN != "" {
+		record.GatewayNodeID = awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN))
+		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "calls_tool"))
+	}
+	return record
+}
+
+func summarizeAWSAIAgentIdentityInventory(fixtureState string, diagnostics []providers.SourceError) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35,
+			[]string{"AI agent identity collection is blocked by missing read-only metadata permission"},
+			[]string{"Grant metadata-only agent, runtime, gateway, and role-list permissions; do not grant prompt, invocation, browser, memory-content, or code-output reads."}
+	case "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72,
+			[]string{"one or more agent credential references are unresolved"},
+			[]string{"Join to credential-reference metadata for ownership and rotation; keep secret values hidden."}
+	case "partial_failure":
+		return awsPlatformDependencyStatusDegraded, 0.78,
+			[]string{"one agent sub-listing failed while successful agent identity records remain visible"},
+			[]string{"Retry the failed agent metadata call without discarding retained agent records."}
+	default:
+		if len(diagnostics) > 0 {
+			return awsPlatformDependencyStatusDegraded, 0.82,
+				[]string{"AI agent identity collection returned diagnostics"},
+				[]string{"Review diagnostics before treating AI agent coverage as complete."}
+		}
+		return awsPlatformDependencyStatusReady, 0.91, nil, nil
+	}
+}
+
+func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAIAgentIdentityRelation {
+	result := []AWSAIAgentIdentityRelation{}
+	for _, record := range records {
+		if record.AgentNodeID != "" && record.RuntimeRoleNodeID != "" {
+			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: record.AgentNodeID, ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		if record.AgentNodeID != "" && record.GatewayNodeID != "" && record.AgentNodeID != record.GatewayNodeID {
+			result = append(result, AWSAIAgentIdentityRelation{Type: "calls_tool", FromNodeID: record.GatewayNodeID, ToNodeID: record.AgentNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		for _, ref := range record.CredentialReferenceRefs {
+			ref = strings.TrimSpace(ref)
+			if record.AgentNodeID != "" && ref != "" {
+				result = append(result, AWSAIAgentIdentityRelation{Type: "uses_credential", FromNodeID: record.AgentNodeID, ToNodeID: awsCredentialReferenceNodeID(ref), EvidenceRef: record.EvidenceRef})
+			}
+		}
+	}
+	return result
+}
+
+func awsCredentialReferenceNodeID(ref string) string {
+	return "aws:credential-reference:" + strings.ToLower(strings.NewReplacer(" ", "-", "/", ":", "|", ":", "#", "-").Replace(strings.TrimSpace(ref)))
+}
+
+func awsAIAgentIdentityTypeCount(records []AWSAIAgentIdentityRecord, agentType string) int {
+	count := 0
+	for _, record := range records {
+		if record.AgentType == agentType {
+			count++
+		}
+	}
+	return count
+}
+
+func awsAIAgentIdentityUniqueCount(records []AWSAIAgentIdentityRecord, accessor func(AWSAIAgentIdentityRecord) string) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		value := strings.TrimSpace(accessor(record))
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func awsAIAgentIdentityListCount(records []AWSAIAgentIdentityRecord, accessor func(AWSAIAgentIdentityRecord) []string) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		for _, value := range accessor(record) {
+			trimmed := strings.TrimSpace(value)
+			if trimmed != "" {
+				seen[trimmed] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
+}
+
+func awsAIAgentIdentityDiagnostics(diagnostics []providers.SourceError) []AWSAIAgentIdentityDiagnostic {
+	result := make([]AWSAIAgentIdentityDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		result = append(result, AWSAIAgentIdentityDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: awsAIAgentIdentityDiagnosticRemediation(diagnostic.Code),
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	return result
+}
+
+func awsAIAgentIdentityDiagnosticRemediation(code string) string {
+	switch code {
+	case "permission_denied":
+		return "Grant metadata-only AI agent list/describe permissions; do not add prompt, invoke, memory-content, browser-page, code-output, database-row, object-content, or secret-value reads."
+	case "ai_agent_gateway_list_failed", "ai_agent_gateway_describe_failed", "ai_agent_identity_page_failed":
+		return "Retry only the failed agent metadata call and keep successful normalized agent records visible."
+	case "ai_agent_credential_reference_unresolved":
+		return "Join to credential-reference metadata for ownership and rotation without exposing provider key values."
+	default:
+		return "Review the AI agent metadata diagnostic and retry after the scoped read-only metadata issue is corrected."
+	}
+}
+
+func awsAIAgentNodeID(accountID string, region string, agentType string, agentID string) string {
+	return fmt.Sprintf("aws:agent:%s:%s:%s/%s",
+		firstNonEmptyAWSValue(accountID, "account"),
+		firstNonEmptyAWSValue(region, "region"),
+		firstNonEmptyAWSValue(agentType, "agent"),
+		firstNonEmptyAWSValue(agentID, "unknown"),
+	)
+}
+
+func awsPartitionForAPIRegion(region string) string {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	switch {
+	case strings.HasPrefix(normalized, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(normalized, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -443,7 +443,7 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 		for _, ref := range record.CredentialReferenceRefs {
 			ref = strings.TrimSpace(ref)
 			if record.AgentNodeID != "" && ref != "" {
-				result = append(result, AWSAIAgentIdentityRelation{Type: "uses_credential", FromNodeID: record.AgentNodeID, ToNodeID: awsCredentialReferenceNodeID(ref), EvidenceRef: record.EvidenceRef})
+				result = append(result, AWSAIAgentIdentityRelation{Type: "uses_secret", FromNodeID: record.AgentNodeID, ToNodeID: awsCredentialReferenceNodeID(ref), EvidenceRef: record.EvidenceRef})
 			}
 		}
 	}

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -544,7 +544,7 @@ func awsAIAgentCredentialReferenceParts(ref string) (string, string) {
 }
 
 func sanitizeCredentialReferenceToken(value string) string {
-	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "|", "-", ":", "-", "#", "-").Replace(strings.TrimSpace(value)))
+	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "-", ":", "-", "#", "-").Replace(strings.TrimSpace(value)))
 }
 
 func containsAnyToken(haystack string, tokens ...string) bool {

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -82,8 +82,8 @@ func TestRouterAWSAIAgentIdentityInventoryPartialFailure(t *testing.T) {
 	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
 		t.Fatalf("expected degraded partial_failure, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
 	}
-	if body.Inventory.RecordCount != 3 {
-		t.Fatalf("expected partial failure to retain three records, got %d", body.Inventory.RecordCount)
+	if body.Inventory.RecordCount != 4 {
+		t.Fatalf("expected partial failure to retain four records, got %d", body.Inventory.RecordCount)
 	}
 	foundGatewayDiag := false
 	for _, diag := range body.Inventory.Diagnostics {
@@ -93,6 +93,22 @@ func TestRouterAWSAIAgentIdentityInventoryPartialFailure(t *testing.T) {
 	}
 	if !foundGatewayDiag {
 		t.Fatalf("expected retryable gateway diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestAIAgentFixtureRecordCallsToolRelationshipTypeOnlyForTrueGatewayCalls(t *testing.T) {
+	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "agent_gateway", "payments-gateway", "payments-gateway", "arn:aws:bedrock:us-east-1:111111111111:agent-gateway/payments-gateway", "arn:aws:iam::111111111111:role/bedrock-agent-gateway-payments", time.Now(), func(r *AWSAIAgentIdentityRecord) {
+		r.GatewayID = "payments-gateway"
+		r.GatewayARN = "arn:aws:bedrock:us-east-1:111111111111:agent-gateway/payments-gateway"
+	})
+	found := false
+	for _, relationshipType := range record.RelationshipTypes {
+		if relationshipType == "calls_tool" {
+			found = true
+		}
+	}
+	if found {
+		t.Fatalf("expected gateway self-record to omit calls_tool relationship type, got %v", record.RelationshipTypes)
 	}
 }
 

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -60,6 +60,9 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 		}
 		if relationship.Type == "uses_secret" {
 			foundCredentialEdge = true
+			if !strings.HasPrefix(relationship.ToNodeID, awsAIAgentCredentialRefPrefix) {
+				t.Fatalf("expected uses_secret edge to target credential-reference resource node, got %+v", relationship)
+			}
 		}
 	}
 	if !foundCredentialEdge {

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -194,14 +194,20 @@ func TestAIAgentRelationshipsEmitCallsToolToToolNodes(t *testing.T) {
 	})
 
 	relationships := awsAIAgentIdentityRelationships([]AWSAIAgentIdentityRecord{record})
-	if len(relationships) != 2 {
-		t.Fatalf("expected one calls_tool relationship per tool, got %d", len(relationships))
+	callsToolRelationships := make([]AWSAIAgentIdentityRelation, 0, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.Type == "calls_tool" {
+			callsToolRelationships = append(callsToolRelationships, relationship)
+		}
+	}
+	if len(callsToolRelationships) != 2 {
+		t.Fatalf("expected one calls_tool relationship per tool, got %d", len(callsToolRelationships))
 	}
 	gatewayToolNodeIDs := map[string]struct{}{
 		awsAIAgentToolNodeID(record.GatewayNodeID, "payments-case-search"):      {},
 		awsAIAgentToolNodeID(record.GatewayNodeID, "fraud-review-action-group"): {},
 	}
-	for _, relationship := range relationships {
+	for _, relationship := range callsToolRelationships {
 		if relationship.Type != "calls_tool" {
 			t.Fatalf("expected calls_tool relationship, got %+v", relationship)
 		}

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -227,6 +227,30 @@ func TestAIAgentRelationshipsEmitCallsToolToToolNodes(t *testing.T) {
 	}
 }
 
+func TestAIAgentRelationshipsEmitCallsToolForGatewayRecord(t *testing.T) {
+	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "agent_gateway", "payments-gateway", "payments-gateway", "arn:aws:bedrock:us-east-1:111111111111:agent-gateway/payments-gateway", "arn:aws:iam::111111111111:role/bedrock-agent-gateway-payments", time.Now(), func(r *AWSAIAgentIdentityRecord) {
+		r.ToolNames = []string{"payments-case-search"}
+	})
+
+	relationships := awsAIAgentIdentityRelationships([]AWSAIAgentIdentityRecord{record})
+	found := false
+	for _, relationship := range relationships {
+		if relationship.Type != "calls_tool" {
+			continue
+		}
+		found = true
+		if relationship.FromNodeID != record.AgentNodeID {
+			t.Fatalf("expected calls_tool source %q, got %q", record.AgentNodeID, relationship.FromNodeID)
+		}
+		if relationship.ToNodeID != awsAIAgentToolNodeID(record.AgentNodeID, "payments-case-search") {
+			t.Fatalf("expected calls_tool to target %q, got %q", awsAIAgentToolNodeID(record.AgentNodeID, "payments-case-search"), relationship.ToNodeID)
+		}
+	}
+	if !found {
+		t.Fatalf("expected gateway record to emit calls_tool relationship when tool names are present, got %+v", relationships)
+	}
+}
+
 func TestRouterAWSAIAgentIdentityInventoryPermissionDenied(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -39,8 +39,15 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.RuntimeRoleCount == 0 || result.ToolCount == 0 || result.CapabilityCount == 0 || result.RelationshipCount == 0 {
 		t.Fatalf("expected populated counts, got %+v", result)
 	}
+	var customAgentNodeID, externalAgentNodeID string
 	foundRecordCredentialType := false
 	for _, record := range result.Records {
+		switch record.AgentType {
+		case "custom_agent":
+			customAgentNodeID = record.AgentNodeID
+		case "external_provider_agent":
+			externalAgentNodeID = record.AgentNodeID
+		}
 		for _, relationshipType := range record.RelationshipTypes {
 			if relationshipType == "uses_credential" {
 				t.Fatalf("expected supported graph relationship type uses_secret, got unsupported uses_credential in %+v", record)
@@ -53,6 +60,10 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if !foundRecordCredentialType {
 		t.Fatalf("expected credential records to advertise uses_secret relationship type, got %+v", result.Records)
 	}
+	expectedCustomCredentialRefTarget := awsCredentialReferenceNodeID(customAgentNodeID, "secretsmanager:prod/ai/openai-key")
+	expectedExternalCredentialRefTarget := awsCredentialReferenceNodeID(externalAgentNodeID, "ssm:/prod/support/ai-provider-key")
+	matchedCustomCredentialRef := false
+	matchedExternalCredentialRef := false
 	foundCredentialEdge := false
 	for _, relationship := range result.Relationships {
 		if relationship.Type == "uses_credential" {
@@ -60,13 +71,29 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 		}
 		if relationship.Type == "uses_secret" {
 			foundCredentialEdge = true
+			parts := strings.Split(strings.TrimPrefix(relationship.ToNodeID, awsAIAgentCredentialRefPrefix), "|")
+			if len(parts) != 4 {
+				t.Fatalf("expected uses_secret target to include workload/provider/name/source, got %+v", relationship)
+			}
 			if !strings.HasPrefix(relationship.ToNodeID, awsAIAgentCredentialRefPrefix) {
 				t.Fatalf("expected uses_secret edge to target credential-reference resource node, got %+v", relationship)
+			}
+			if relationship.ToNodeID == expectedCustomCredentialRefTarget {
+				matchedCustomCredentialRef = true
+			}
+			if relationship.ToNodeID == expectedExternalCredentialRefTarget {
+				matchedExternalCredentialRef = true
 			}
 		}
 	}
 	if !foundCredentialEdge {
 		t.Fatalf("expected credential references to emit uses_secret relationship, got %+v", result.Relationships)
+	}
+	if !matchedCustomCredentialRef {
+		t.Fatalf("expected custom agent unresolved credential reference to emit uses_secret edge to %q, got %+v", expectedCustomCredentialRefTarget, result.Relationships)
+	}
+	if !matchedExternalCredentialRef {
+		t.Fatalf("expected external-provider-agent unresolved credential reference to emit uses_secret edge to %q, got %+v", expectedExternalCredentialRefTarget, result.Relationships)
 	}
 	if len(result.CoverageGaps) == 0 {
 		t.Fatalf("expected sensitive-boundary coverage gaps, got %+v", result.CoverageGaps)
@@ -156,6 +183,41 @@ func TestAIAgentFixtureRecordCallsToolRelationshipTypeOnlyForTrueGatewayCalls(t 
 	}
 	if found {
 		t.Fatalf("expected gateway self-record to omit calls_tool relationship type, got %v", record.RelationshipTypes)
+	}
+}
+
+func TestAIAgentRelationshipsEmitCallsToolToToolNodes(t *testing.T) {
+	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "custom_agent", "agent-with-gateway", "agent-1", "arn:aws:bedrock:us-east-1:111111111111:agent/agent-1", "arn:aws:iam::111111111111:role/agent-1", time.Now(), func(r *AWSAIAgentIdentityRecord) {
+		r.GatewayID = "payments-gateway"
+		r.GatewayARN = "arn:aws:bedrock:us-east-1:111111111111:agent-gateway/payments-gateway"
+		r.ToolNames = []string{"payments-case-search", "fraud-review-action-group"}
+	})
+
+	relationships := awsAIAgentIdentityRelationships([]AWSAIAgentIdentityRecord{record})
+	if len(relationships) != 2 {
+		t.Fatalf("expected one calls_tool relationship per tool, got %d", len(relationships))
+	}
+	gatewayToolNodeIDs := map[string]struct{}{
+		awsAIAgentToolNodeID(record.GatewayNodeID, "payments-case-search"):      {},
+		awsAIAgentToolNodeID(record.GatewayNodeID, "fraud-review-action-group"): {},
+	}
+	for _, relationship := range relationships {
+		if relationship.Type != "calls_tool" {
+			t.Fatalf("expected calls_tool relationship, got %+v", relationship)
+		}
+		if relationship.FromNodeID != record.GatewayNodeID {
+			t.Fatalf("expected calls_tool source %q, got %q", record.GatewayNodeID, relationship.FromNodeID)
+		}
+		if !strings.HasPrefix(relationship.ToNodeID, awsAIAgentToolNodePrefix) {
+			t.Fatalf("expected tool node target with tool: prefix, got %q", relationship.ToNodeID)
+		}
+		if _, ok := gatewayToolNodeIDs[relationship.ToNodeID]; !ok {
+			t.Fatalf("unexpected tool node target %q", relationship.ToNodeID)
+		}
+		delete(gatewayToolNodeIDs, relationship.ToNodeID)
+	}
+	if len(gatewayToolNodeIDs) != 0 {
+		t.Fatalf("missing calls_tool edges for tools: %+v", gatewayToolNodeIDs)
 	}
 }
 

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -39,6 +39,20 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.RuntimeRoleCount == 0 || result.ToolCount == 0 || result.CapabilityCount == 0 || result.RelationshipCount == 0 {
 		t.Fatalf("expected populated counts, got %+v", result)
 	}
+	foundRecordCredentialType := false
+	for _, record := range result.Records {
+		for _, relationshipType := range record.RelationshipTypes {
+			if relationshipType == "uses_credential" {
+				t.Fatalf("expected supported graph relationship type uses_secret, got unsupported uses_credential in %+v", record)
+			}
+			if relationshipType == "uses_secret" {
+				foundRecordCredentialType = true
+			}
+		}
+	}
+	if !foundRecordCredentialType {
+		t.Fatalf("expected credential records to advertise uses_secret relationship type, got %+v", result.Records)
+	}
 	foundCredentialEdge := false
 	for _, relationship := range result.Relationships {
 		if relationship.Type == "uses_credential" {

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -39,6 +39,18 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.RuntimeRoleCount == 0 || result.ToolCount == 0 || result.CapabilityCount == 0 || result.RelationshipCount == 0 {
 		t.Fatalf("expected populated counts, got %+v", result)
 	}
+	foundCredentialEdge := false
+	for _, relationship := range result.Relationships {
+		if relationship.Type == "uses_credential" {
+			t.Fatalf("expected supported graph relationship type uses_secret, got unsupported uses_credential in %+v", relationship)
+		}
+		if relationship.Type == "uses_secret" {
+			foundCredentialEdge = true
+		}
+	}
+	if !foundCredentialEdge {
+		t.Fatalf("expected credential references to emit uses_secret relationship, got %+v", result.Relationships)
+	}
 	if len(result.CoverageGaps) == 0 {
 		t.Fatalf("expected sensitive-boundary coverage gaps, got %+v", result.CoverageGaps)
 	}

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 13, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSAIAgentIdentityInventory(ctx, "default", "project-a", AWSAIAgentIdentityInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get ai agent identity inventory: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready inventory, got %+v", result)
+	}
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1505" || result.Version != awsAIAgentIdentityVersion {
+		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
+	}
+	if result.BedrockAgentCount != 1 || result.AgentCoreRuntimeCount != 1 || result.CustomAgentCount != 1 || result.ExternalAgentCount != 1 || result.GatewayCount != 1 {
+		t.Fatalf("expected one record per agent type, got %+v", result)
+	}
+	if result.RuntimeRoleCount == 0 || result.ToolCount == 0 || result.CapabilityCount == 0 || result.RelationshipCount == 0 {
+		t.Fatalf("expected populated counts, got %+v", result)
+	}
+	if len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected sensitive-boundary coverage gaps, got %+v", result.CoverageGaps)
+	}
+	for _, record := range result.Records {
+		if record.SensitiveBoundary != "metadata_only" {
+			t.Fatalf("expected metadata_only sensitive boundary, got %+v", record)
+		}
+		evidence := strings.ToLower(record.EvidenceRef + " " + record.Source + " " + strings.Join(record.ToolNames, " "))
+		for _, forbidden := range []string{"prompt", "completion", "browser_page", "code_output", "secret_value", "payload_body"} {
+			if strings.Contains(evidence, forbidden) {
+				t.Fatalf("expected payload-safe evidence, got forbidden marker %q in %+v", forbidden, record)
+			}
+		}
+	}
+	if result.GeneratedAt != now || result.UpdatedAt != now {
+		t.Fatalf("expected deterministic timestamps %v, got %v/%v", now, result.GeneratedAt, result.UpdatedAt)
+	}
+}
+
+func TestRouterAWSAIAgentIdentityInventoryPartialFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 13, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/ai-agent-identities?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSAIAgentIdentityInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
+		t.Fatalf("expected degraded partial_failure, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
+	}
+	if body.Inventory.RecordCount != 3 {
+		t.Fatalf("expected partial failure to retain three records, got %d", body.Inventory.RecordCount)
+	}
+	foundGatewayDiag := false
+	for _, diag := range body.Inventory.Diagnostics {
+		if diag.Code == "ai_agent_gateway_list_failed" && diag.Retryable {
+			foundGatewayDiag = true
+		}
+	}
+	if !foundGatewayDiag {
+		t.Fatalf("expected retryable gateway diagnostic, got %+v", body.Inventory.Diagnostics)
+	}
+}
+
+func TestRouterAWSAIAgentIdentityInventoryPermissionDenied(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-2")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-2", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-2/aws/ai-agent-identities?connector_id=aws-prod&fixture_state=permission_denied", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSAIAgentIdentityInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusBlocked {
+		t.Fatalf("expected blocked status, got %q", body.Inventory.Status)
+	}
+	if len(body.Inventory.Records) != 0 {
+		t.Fatalf("expected no records on permission_denied, got %d", len(body.Inventory.Records))
+	}
+}
+
+func TestRouterAWSAIAgentIdentityInventoryInvalidFixtureState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 14, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-3")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-3", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-3/aws/ai-agent-identities?connector_id=aws-prod&fixture_state=invalid_state", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid fixture state, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -96,6 +96,24 @@ func TestRouterAWSAIAgentIdentityInventoryPartialFailure(t *testing.T) {
 	}
 }
 
+func TestRouterAWSAIAgentIdentityInventoryEmptyStateReturnsArrayFields(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 12, 13, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-empty")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-empty", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-empty/aws/ai-agent-identities?connector_id=aws-prod&fixture_state=empty", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	assertAWSAIAgentIdentityInventoryArrayFields(t, resp.Body.Bytes(), []string{"records", "relationships", "failure_reasons", "remediation_hints", "diagnostics"})
+}
+
 func TestAIAgentFixtureRecordCallsToolRelationshipTypeOnlyForTrueGatewayCalls(t *testing.T) {
 	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "agent_gateway", "payments-gateway", "payments-gateway", "arn:aws:bedrock:us-east-1:111111111111:agent-gateway/payments-gateway", "arn:aws:iam::111111111111:role/bedrock-agent-gateway-payments", time.Now(), func(r *AWSAIAgentIdentityRecord) {
 		r.GatewayID = "payments-gateway"
@@ -139,6 +157,7 @@ func TestRouterAWSAIAgentIdentityInventoryPermissionDenied(t *testing.T) {
 	if len(body.Inventory.Records) != 0 {
 		t.Fatalf("expected no records on permission_denied, got %d", len(body.Inventory.Records))
 	}
+	assertAWSAIAgentIdentityInventoryArrayFields(t, resp.Body.Bytes(), []string{"records", "relationships", "failure_reasons", "remediation_hints", "diagnostics"})
 }
 
 func TestRouterAWSAIAgentIdentityInventoryInvalidFixtureState(t *testing.T) {
@@ -155,5 +174,28 @@ func TestRouterAWSAIAgentIdentityInventoryInvalidFixtureState(t *testing.T) {
 	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-3/aws/ai-agent-identities?connector_id=aws-prod&fixture_state=invalid_state", "")
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid fixture state, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func assertAWSAIAgentIdentityInventoryArrayFields(t *testing.T, payload []byte, fields []string) {
+	t.Helper()
+	var body struct {
+		Inventory map[string]json.RawMessage `json:"inventory"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, field := range fields {
+		raw, ok := body.Inventory[field]
+		if !ok {
+			t.Fatalf("expected inventory.%s in response", field)
+		}
+		if string(raw) == "null" {
+			t.Fatalf("expected inventory.%s to be an array, got null", field)
+		}
+		var values []json.RawMessage
+		if err := json.Unmarshal(raw, &values); err != nil {
+			t.Fatalf("expected inventory.%s to be an array, got %s: %v", field, string(raw), err)
+		}
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2764,6 +2764,34 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAIAgentIdentityInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAIAgentIdentityInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws ai agent identity request"})
+			default:
+				logger.Error("get aws ai agent identity inventory",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws ai agent identity inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -1,0 +1,316 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	rawKindAIAgentIdentity       = "ai_agent_identity"
+	aiAgentIdentityCollectorName = "ai_agent_identity"
+	aiAgentIdentityServiceName   = "ai-agent"
+)
+
+// AIAgentIdentity is the payload-safe normalized model for AWS-hosted AI agents.
+// It records identity, role, provider/model, tool, memory, browser, and code
+// capability metadata while deliberately excluding prompts, completions, memory
+// contents, browser pages, code output, object contents, and secret values.
+type AIAgentIdentity struct {
+	awscontract.ServiceCollectorRecord
+	AgentID                 string            `json:"agent_id"`
+	AgentARN                string            `json:"agent_arn,omitempty"`
+	AgentName               string            `json:"agent_name"`
+	AgentType               string            `json:"agent_type"`
+	Provider                string            `json:"provider,omitempty"`
+	ModelID                 string            `json:"model_id,omitempty"`
+	RuntimeRoleARN          string            `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName         string            `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID    string            `json:"runtime_role_account_id,omitempty"`
+	GatewayID               string            `json:"gateway_id,omitempty"`
+	GatewayARN              string            `json:"gateway_arn,omitempty"`
+	ExternalProvider        string            `json:"external_provider,omitempty"`
+	ToolNames               []string          `json:"tool_names,omitempty"`
+	ToolCount               int               `json:"tool_count"`
+	MemoryEnabled           bool              `json:"memory_enabled"`
+	MemoryStoreRefs         []string          `json:"memory_store_refs,omitempty"`
+	BrowserEnabled          bool              `json:"browser_enabled"`
+	CodeInterpreterEnabled  bool              `json:"code_interpreter_enabled"`
+	CapabilityNames         []string          `json:"capability_names,omitempty"`
+	CredentialReferenceRefs []string          `json:"credential_reference_refs,omitempty"`
+	SensitiveBoundary       string            `json:"sensitive_boundary"`
+	CoverageStatus          string            `json:"coverage_status"`
+	CoverageReason          string            `json:"coverage_reason,omitempty"`
+	Status                  string            `json:"status"`
+	Tags                    map[string]string `json:"tags,omitempty"`
+}
+
+type AIAgentIdentityPage struct {
+	Records     []AIAgentIdentity
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+type AIAgentIdentityAPI interface {
+	ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error)
+}
+
+type AIAgentIdentityCollector struct {
+	client   AIAgentIdentityAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+type AIAgentIdentityOption func(*AIAgentIdentityCollector)
+
+func WithAIAgentIdentityPageSize(pageSize int32) AIAgentIdentityOption {
+	return func(c *AIAgentIdentityCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+func WithAIAgentIdentityMaxPages(maxPages int) AIAgentIdentityOption {
+	return func(c *AIAgentIdentityCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+func WithAIAgentIdentityClock(now func() time.Time) AIAgentIdentityOption {
+	return func(c *AIAgentIdentityCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+func WithAIAgentIdentitySleeper(s Sleeper) AIAgentIdentityOption {
+	return func(c *AIAgentIdentityCollector) {
+		if s != nil {
+			c.sleep = s
+		}
+	}
+}
+
+func NewAIAgentIdentityCollector(client AIAgentIdentityAPI, opts ...AIAgentIdentityOption) *AIAgentIdentityCollector {
+	c := &AIAgentIdentityCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *AIAgentIdentityCollector) ServiceName() string {
+	return aiAgentIdentityServiceName
+}
+
+func (c *AIAgentIdentityCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: aiAgentIdentityServiceName})
+	return assets, err
+}
+
+func (c *AIAgentIdentityCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("ai agent identity collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+	seen := map[string]struct{}{}
+	nextToken := ""
+	collectedAt := c.now().UTC()
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(providers.SourceError{
+				Collector: aiAgentIdentityCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "ai_agent_identity_page_limit_exceeded",
+				Message:   fmt.Sprintf("ai agent identity collection exceeded max pages (%d)", c.maxPages),
+				Retryable: false,
+			})
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("ai agent identity collection exceeded max pages (%d)", c.maxPages)
+		}
+		response, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (AIAgentIdentityPage, error) {
+			return c.client.ListAgentIdentities(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list ai agent identities page %d: %w", page, err)
+			addIssue(providers.SourceError{
+				Collector: aiAgentIdentityCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "ai_agent_identity_page_failed",
+				Message:   wrapped.Error(),
+				Retryable: isRetryable(err),
+			})
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, diagnostic := range response.Diagnostics {
+			addIssue(diagnostic)
+		}
+		for _, record := range response.Records {
+			normalized := normalizeAIAgentIdentityScope(scope, record, collectedAt)
+			if strings.TrimSpace(normalized.AgentID) == "" || strings.TrimSpace(normalized.AgentName) == "" {
+				addIssue(providers.SourceError{
+					Collector: aiAgentIdentityCollectorName,
+					Code:      "malformed_ai_agent_identity",
+					Message:   "skipped ai agent identity without an agent id and name",
+					Retryable: false,
+				})
+				continue
+			}
+			sourceID := aiAgentIdentitySourceID(normalized)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, err := json.Marshal(normalized)
+			if err != nil {
+				return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("marshal ai agent identity %s: %w", sourceID, err)
+			}
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindAIAgentIdentity,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+		if strings.TrimSpace(response.NextToken) == "" {
+			break
+		}
+		nextToken = response.NextToken
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdentity, collectedAt time.Time) AIAgentIdentity {
+	normalized := record
+	normalized.AccountID = firstNonEmptyAWSValue(record.AccountID, scope.AccountID)
+	normalized.Region = firstNonEmptyAWSValue(record.Region, scope.Region)
+	normalized.Service = firstNonEmptyAWSValue(record.Service, aiAgentIdentityServiceName)
+	normalized.AgentID = strings.TrimSpace(record.AgentID)
+	normalized.AgentARN = strings.TrimSpace(record.AgentARN)
+	normalized.AgentName = firstNonEmptyAWSValue(record.AgentName, normalized.AgentID)
+	normalized.AgentType = canonicalAIAgentType(record.AgentType, record.Service)
+	normalized.Provider = strings.TrimSpace(record.Provider)
+	normalized.ModelID = strings.TrimSpace(record.ModelID)
+	normalized.RuntimeRoleARN = firstNonEmptyAWSValue(record.RuntimeRoleARN, record.RoleARN)
+	normalized.RuntimeRoleName = firstNonEmptyAWSValue(record.RuntimeRoleName, roleNameFromARN(record.RuntimeRoleARN), roleNameFromARN(record.RoleARN))
+	normalized.RuntimeRoleAccountID = firstNonEmptyAWSValue(record.RuntimeRoleAccountID, roleAccountIDFromARN(record.RuntimeRoleARN), roleAccountIDFromARN(record.RoleARN))
+	normalized.RoleARN = normalized.RuntimeRoleARN
+	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.AgentARN, normalized.AgentID)
+	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.AgentName)
+	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, normalized.AgentType)
+	normalized.Source = firstNonEmptyAWSValue(record.Source, "ai_agent_metadata")
+	normalized.EvidenceRef = firstNonEmptyAWSValue(record.EvidenceRef, normalized.AgentARN, normalized.AgentID)
+	normalized.CollectorName = firstNonEmptyAWSValue(record.CollectorName, aiAgentIdentityCollectorName)
+	normalized.ScanID = firstNonEmptyAWSValue(record.ScanID, scope.ScanID, "aws-ai-agent-identity-fixture")
+	normalized.ConnectorID = firstNonEmptyAWSValue(record.ConnectorID, scope.ConnectorID, "aws-connector")
+	normalized.TenantID = firstNonEmptyAWSValue(record.TenantID, scope.TenantID, "tenant")
+	normalized.WorkspaceID = firstNonEmptyAWSValue(record.WorkspaceID, scope.WorkspaceID, "workspace")
+	normalized.ProjectID = firstNonEmptyAWSValue(record.ProjectID, scope.ProjectID, "project")
+	normalized.GatewayID = strings.TrimSpace(record.GatewayID)
+	normalized.GatewayARN = strings.TrimSpace(record.GatewayARN)
+	normalized.ExternalProvider = strings.TrimSpace(record.ExternalProvider)
+	normalized.ToolNames = normalizeStringList(record.ToolNames)
+	normalized.ToolCount = len(normalized.ToolNames)
+	normalized.MemoryStoreRefs = normalizeStringList(record.MemoryStoreRefs)
+	normalized.CapabilityNames = normalizeStringList(record.CapabilityNames)
+	normalized.CredentialReferenceRefs = normalizeStringList(record.CredentialReferenceRefs)
+	normalized.SensitiveBoundary = firstNonEmptyAWSValue(record.SensitiveBoundary, "metadata_only")
+	normalized.CoverageStatus = firstNonEmptyAWSValue(record.CoverageStatus, "covered")
+	normalized.Status = firstNonEmptyAWSValue(record.Status, "ready")
+	normalized.Tags = copyTags(record.Tags)
+	normalized.CollectedAt = collectedAt
+	if normalized.Confidence <= 0 {
+		normalized.Confidence = aiAgentIdentityConfidence(normalized)
+	}
+	return normalized
+}
+
+func aiAgentIdentitySourceID(record AIAgentIdentity) string {
+	return strings.Join([]string{
+		firstNonEmptyAWSValue(record.AccountID, "account"),
+		firstNonEmptyAWSValue(record.Region, "region"),
+		firstNonEmptyAWSValue(record.AgentType, "agent"),
+		firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName),
+	}, "|")
+}
+
+func canonicalAIAgentType(agentType string, service string) string {
+	switch strings.ToLower(strings.TrimSpace(agentType)) {
+	case "bedrock_agent", "bedrock":
+		return "bedrock_agent"
+	case "agentcore_runtime", "agentcore":
+		return "agentcore_runtime"
+	case "custom_agent", "custom":
+		return "custom_agent"
+	case "external_provider_agent", "external":
+		return "external_provider_agent"
+	case "agent_gateway", "gateway":
+		return "agent_gateway"
+	}
+	if strings.EqualFold(strings.TrimSpace(service), "bedrock") {
+		return "bedrock_agent"
+	}
+	return "custom_agent"
+}
+
+func aiAgentIdentityConfidence(record AIAgentIdentity) float64 {
+	confidence := 0.72
+	if strings.TrimSpace(record.RuntimeRoleARN) != "" {
+		confidence += 0.08
+	}
+	if strings.TrimSpace(record.AgentARN) != "" {
+		confidence += 0.06
+	}
+	if len(record.ToolNames) > 0 || len(record.CapabilityNames) > 0 {
+		confidence += 0.05
+	}
+	if len(record.CredentialReferenceRefs) > 0 {
+		confidence += 0.04
+	}
+	if confidence > 0.95 {
+		return 0.95
+	}
+	return confidence
+}

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -189,11 +189,15 @@ func (c *AIAgentIdentityCollector) CollectWithDiagnostics(ctx context.Context, s
 		}
 		for _, record := range response.Records {
 			normalized := normalizeAIAgentIdentityScope(scope, record, collectedAt)
-			if strings.TrimSpace(normalized.AgentID) == "" || strings.TrimSpace(normalized.AgentName) == "" {
+			if strings.TrimSpace(normalized.AgentName) == "" &&
+				strings.TrimSpace(normalized.AgentID) == "" &&
+				strings.TrimSpace(normalized.AgentARN) == "" &&
+				strings.TrimSpace(normalized.GatewayID) == "" &&
+				strings.TrimSpace(normalized.GatewayARN) == "" {
 				addIssue(providers.SourceError{
 					Collector: aiAgentIdentityCollectorName,
 					Code:      "malformed_ai_agent_identity",
-					Message:   "skipped ai agent identity without an agent id and name",
+					Message:   "skipped ai agent identity without a stable identity or gateway identifier",
 					Retryable: false,
 				})
 				continue

--- a/internal/providers/aws/ai_agent_identity_collector_test.go
+++ b/internal/providers/aws/ai_agent_identity_collector_test.go
@@ -1,0 +1,156 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+type fakeAIAgentIdentityAPI struct {
+	pages     []AIAgentIdentityPage
+	tokens    []string
+	pageSizes []int32
+}
+
+func (f *fakeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
+	f.tokens = append(f.tokens, nextToken)
+	f.pageSizes = append(f.pageSizes, pageSize)
+	if len(f.pages) == 0 {
+		return AIAgentIdentityPage{}, nil
+	}
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func TestAIAgentIdentityCollectorEmitsNormalizedPayloadSafeAssets(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/bedrock-payments-agent"
+	agentARN := "arn:aws:bedrock:us-east-1:123456789012:agent/AGENT123"
+	api := &fakeAIAgentIdentityAPI{pages: []AIAgentIdentityPage{{
+		Records: []AIAgentIdentity{{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+				AccountID:    "123456789012",
+				Region:       "us-east-1",
+				Service:      "bedrock",
+				WorkloadID:   agentARN,
+				WorkloadName: "payments-agent",
+				WorkloadType: "bedrock",
+				RoleARN:      roleARN,
+			},
+			AgentID:                 "AGENT123",
+			AgentARN:                agentARN,
+			AgentName:               "payments-agent",
+			AgentType:               "bedrock",
+			Provider:                "amazon-bedrock",
+			ModelID:                 "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			RuntimeRoleARN:          roleARN,
+			ToolNames:               []string{"payments-search", "case-router", "payments-search"},
+			MemoryEnabled:           true,
+			MemoryStoreRefs:         []string{"memory-store/payments"},
+			BrowserEnabled:          true,
+			CodeInterpreterEnabled:  true,
+			CapabilityNames:         []string{"tool_use", "memory", "browser", "code_interpreter"},
+			CredentialReferenceRefs: []string{"secretsmanager:prod/ai/provider-key"},
+			SensitiveBoundary:       "metadata_only",
+		}},
+		NextToken: "page-2",
+	}, {
+		Diagnostics: []providers.SourceError{{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  "gateway/payments",
+			Code:      "ai_agent_gateway_describe_failed",
+			Message:   "gateway metadata could not be described",
+			Retryable: true,
+		}},
+	}}}
+	collector := NewAIAgentIdentityCollector(api, WithAIAgentIdentityPageSize(50), WithAIAgentIdentityClock(func() time.Time { return collectedAt }))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		ConnectorID: "aws-prod",
+		ScanID:      "scan-1",
+	})
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one asset, got %d", len(assets))
+	}
+	if assets[0].Kind != rawKindAIAgentIdentity {
+		t.Fatalf("unexpected asset kind %q", assets[0].Kind)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Code != "ai_agent_gateway_describe_failed" {
+		t.Fatalf("expected retained diagnostic, got %+v", diagnostics)
+	}
+	if got, want := strings.Join(api.tokens, ","), ",page-2"; got != want {
+		t.Fatalf("expected pagination tokens %q, got %q", want, got)
+	}
+
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if record.AgentType != "bedrock_agent" || record.RuntimeRoleName != "bedrock-payments-agent" {
+		t.Fatalf("expected normalized agent type and role name, got %+v", record)
+	}
+	if record.TenantID != "tenant-a" || record.WorkspaceID != "workspace-a" || record.ProjectID != "project-a" {
+		t.Fatalf("expected scope inherited, got %+v", record)
+	}
+	if record.ToolCount != 2 || strings.Join(record.ToolNames, ",") != "payments-search,case-router" {
+		t.Fatalf("expected tool names deduped without sorting away fixture order, got %+v", record.ToolNames)
+	}
+	payload := strings.ToLower(string(assets[0].Payload))
+	for _, forbidden := range []string{"prompt", "completion", "browser_page", "code_output", "secret_value", "payload_body"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("payload leaked forbidden field marker %q: %s", forbidden, payload)
+		}
+	}
+}
+
+func TestAIAgentIdentityCollectorDedupesAndSkipsMalformedRecords(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Service:   "agentcore",
+		},
+		AgentID:        "runtime-1",
+		AgentName:      "payments-runtime",
+		AgentType:      "agentcore",
+		RuntimeRoleARN: "arn:aws:iam::123456789012:role/agentcore-payments-runtime",
+	}
+	api := &fakeAIAgentIdentityAPI{pages: []AIAgentIdentityPage{{
+		Records: []AIAgentIdentity{
+			record,
+			record,
+			{AgentType: "custom_agent"},
+		},
+	}}}
+	collector := NewAIAgentIdentityCollector(api, WithAIAgentIdentityClock(func() time.Time { return collectedAt }))
+
+	assets, diagnostics, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		ConnectorID: "aws-prod",
+		ScanID:      "scan-1",
+	})
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected duplicate and malformed records to collapse to one asset, got %d", len(assets))
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Code != "malformed_ai_agent_identity" {
+		t.Fatalf("expected malformed diagnostic, got %+v", diagnostics)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1995,7 +1995,7 @@ export type AWSAIAgentIdentityRecord = {
 };
 
 export type AWSAIAgentIdentityRelationship = {
-  type: 'runs_as' | 'calls_tool' | 'uses_credential' | string;
+  type: 'runs_as' | 'calls_tool' | 'uses_secret' | string;
   from_node_id: string;
   to_node_id: string;
   evidence_ref: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1941,6 +1941,114 @@ export type AWSSageMakerWorkloadRoleInventoryResult = {
   updated_at: string;
 };
 
+export type AWSAIAgentIdentityInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAIAgentIdentityFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSAIAgentCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSAIAgentIdentityRecord = {
+  account_id: string;
+  region: string;
+  service: string;
+  agent_id: string;
+  agent_arn?: string;
+  agent_name: string;
+  agent_type: 'bedrock_agent' | 'agentcore_runtime' | 'custom_agent' | 'external_provider_agent' | 'agent_gateway' | string;
+  provider?: string;
+  model_id?: string;
+  runtime_role_arn?: string;
+  runtime_role_name?: string;
+  runtime_role_account_id?: string;
+  gateway_id?: string;
+  gateway_arn?: string;
+  external_provider?: string;
+  tool_names?: string[];
+  memory_enabled: boolean;
+  memory_store_refs?: string[];
+  browser_enabled: boolean;
+  code_interpreter_enabled: boolean;
+  capability_names?: string[];
+  credential_reference_refs?: string[];
+  sensitive_boundary: string;
+  coverage_status: string;
+  coverage_reason?: string;
+  source: string;
+  evidence_ref: string;
+  agent_node_id: string;
+  runtime_role_node_id?: string;
+  gateway_node_id?: string;
+  relationship_types: string[];
+  confidence: number;
+  collected_at: string;
+  status: string;
+  tags?: Record<string, string>;
+};
+
+export type AWSAIAgentIdentityRelationship = {
+  type: 'runs_as' | 'calls_tool' | 'uses_credential' | string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSAIAgentIdentityDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSAIAgentIdentityInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAIAgentIdentityInventoryStatus;
+  fixture_state: AWSAIAgentIdentityFixtureState;
+  confidence: number;
+  record_count: number;
+  bedrock_agent_count: number;
+  agentcore_runtime_count: number;
+  custom_agent_count: number;
+  external_agent_count: number;
+  gateway_count: number;
+  runtime_role_count: number;
+  provider_count: number;
+  model_count: number;
+  tool_count: number;
+  capability_count: number;
+  credential_reference_count: number;
+  relationship_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSAIAgentCoverageGap[];
+  records: AWSAIAgentIdentityRecord[];
+  relationships: AWSAIAgentIdentityRelationship[];
+  diagnostics: AWSAIAgentIdentityDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSIAMPassRoleRelationshipInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSIAMPassRoleRelationshipFixtureState =
   | 'success'
@@ -4872,6 +4980,21 @@ export const apiClient = {
   ) {
     return request<{ inventory: AWSSageMakerWorkloadRoleInventoryResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/sagemaker-workload-roles${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAIAgentIdentities(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSAIAgentIdentityFixtureState,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSAIAgentIdentityInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/ai-agent-identities${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
       })}`,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6898,7 +6898,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
-      status: status === 'role anchor' ? 'role-anchor' : status === 'not yet available' ? 'not-yet-available' : 'coming,degraded',
+      status: status === 'role anchor' ? 'role-anchor' : status === 'not yet available' ? 'not-yet-available' : status === 'degraded' ? 'degraded' : 'coming',
       search: ''
     },
     searchText: inventorySearchText([

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -37,6 +37,8 @@ import {
   type AWSEventDrivenRoleRecord,
   type AWSManagedComputeRoleInventoryResult,
   type AWSManagedComputeRoleRecord,
+  type AWSAIAgentIdentityInventoryResult,
+  type AWSAIAgentIdentityRecord,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -3641,6 +3643,13 @@ type AWSInventoryEKSState = {
   onRetry: () => void;
 };
 
+type AWSInventoryAIAgentState = {
+  inventory: AWSAIAgentIdentityInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventorySecretsManagerState = {
   inventory: AWSSecretsManagerMetadataInventoryResult | null;
   loading: boolean;
@@ -3819,7 +3828,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
     {
       id: 'status',
       label: 'Status',
-      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
+      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Degraded', value: 'degraded' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
     }
   ],
   resources: [
@@ -6629,79 +6638,92 @@ function awsEC2IMDSLabel(inventory: AWSEC2InstanceProfileInventoryResult | null)
 
 function AWSAgentIdentitiesContent({
   connection,
+  aiAgentState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
+  aiAgentState: AWSInventoryAIAgentState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
-  const rows: AWSInventoryTableRow[] = [
-    {
-      id: 'role-anchor',
-      name: connection?.role_arn ?? 'AWS role anchor',
-      category: 'Agent-to-role anchor',
-      scope: awsAccountRegionLabel(connection),
-      status: connection?.connected ? 'role anchor' : 'not yet available',
-      stage: connection?.connected ? 'wired' : 'not-available',
-      detail: 'Future agent inventory can attach Bedrock or external agent execution back to this AWS role context.',
-      filters: {
-        surface: 'agentcore-runtime',
-        relationship: 'agent-to-role',
-        status: connection?.connected ? 'role-anchor' : 'not-yet-available',
-        search: ''
-      },
-      searchText: inventorySearchText(['agent to role', 'agent', 'role anchor', 'role relationship'])
-    },
-    {
-      id: 'bedrock-agents',
-      name: 'Bedrock agents',
-      category: 'AWS-native agent',
-      scope: 'Bedrock',
-      status: 'coming',
-      stage: 'coming',
-      detail: 'Agent identity, action groups, tool use, and role relationship slots are reserved here.',
-      filters: { surface: 'bedrock-agents', relationship: 'agent-to-tool', status: 'coming', search: '' },
-      searchText: inventorySearchText(['bedrock', 'agent surface', 'tools'])
-    },
-    {
-      id: 'agentcore',
-      name: 'AgentCore runtime and gateway identity',
-      category: 'AgentCore',
-      scope: 'Runtime / gateway',
-      status: 'coming',
-      stage: 'coming',
-      detail: 'Will map AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships.',
-      filters: { surface: 'agentcore-runtime,mcp-gateway', relationship: 'agent-to-tool', status: 'coming', search: '' },
-      searchText: inventorySearchText(['agentcore', 'runtime', 'gateway', 'identity'])
-    },
-    {
-      id: 'external-provider-keys',
-      name: 'External AI provider key metadata',
-      category: 'Safe metadata',
-      scope: 'Secrets metadata only',
-      status: 'not yet available',
-      stage: 'not-available',
-      detail: 'OpenAI, Anthropic, and Claude Platform usage mapping will use safe metadata, never secret values.',
-      filters: {
-        surface: 'external-provider-keys',
-        relationship: 'agent-to-secret',
-        status: 'not-yet-available',
-        search: ''
-      },
-      searchText: inventorySearchText(['external', 'provider', 'keys', 'agent'])
-    }
-  ];
+  const inventory = aiAgentState.inventory;
+  const rows = buildAWSAIAgentIdentityRows(inventory, aiAgentState.loading, connection);
   const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
       <AWSInventoryFilterSet routeID="agents" filters={filters} onChange={onFiltersChange} />
+      {aiAgentState.loading ? <DomainLoadingState label="Loading AWS AI agent identities" /> : null}
+      {aiAgentState.error ? (
+        <DomainErrorState
+          title="AI agent identities could not load"
+          body={aiAgentState.error}
+          retryAction={{ label: 'Retry AI agents', onClick: aiAgentState.onRetry }}
+        />
+      ) : null}
+      {inventory ? (
+        <DomainStatusPanel
+          eyebrow="Normalized agent model"
+          title="AI agent identities are metadata-only"
+          status={formatTokenLabel(inventory.status)}
+          tone={inventory.status === 'blocked' ? 'danger' : inventory.status === 'degraded' ? 'warning' : 'success'}
+        >
+          <section className="idt-aws-inventory-coverage" aria-label="AWS AI agent identity summary">
+            <DomainCoverageCard
+              label="Agent records"
+              scanned={inventory.record_count}
+              total={Math.max(inventory.record_count, 1)}
+              detail={`${inventory.runtime_role_count} runtime roles`}
+            />
+            <DomainCoverageCard
+              label="Native agents"
+              scanned={inventory.bedrock_agent_count + inventory.agentcore_runtime_count}
+              total={Math.max(inventory.record_count, 1)}
+              detail={`${inventory.gateway_count} gateways`}
+            />
+            <DomainCoverageCard
+              label="Tools"
+              scanned={inventory.tool_count}
+              total={Math.max(inventory.tool_count, 1)}
+              detail={`${inventory.capability_count} capabilities`}
+            />
+            <DomainCoverageCard
+              label="Credential refs"
+              scanned={inventory.credential_reference_count}
+              total={Math.max(inventory.credential_reference_count, 1)}
+              detail="Values hidden"
+            />
+          </section>
+          {inventory.diagnostics.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS AI agent identity diagnostics">
+              {inventory.diagnostics.map((diagnostic) => (
+                <article key={`${diagnostic.code}-${diagnostic.source_id ?? diagnostic.collector}`}>
+                  <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+          {inventory.coverage_gaps.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS AI agent identity sensitive boundaries">
+              {inventory.coverage_gaps.map((gap) => (
+                <article key={`${gap.capability}-${gap.status}`}>
+                  <strong>{formatTokenLabel(gap.capability)}</strong>
+                  <p>{gap.reason}</p>
+                  {gap.remediation ? <small>{gap.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+        </DomainStatusPanel>
+      ) : null}
       <section className="idt-aws-agent-relationship-grid" aria-label="AWS agent relationship slots">
         {[
-          ['Agent to role', connection?.role_arn ? 'Role anchor available' : 'Waiting for role validation'],
-          ['Agent to tool', 'Tool and MCP gateway coverage reserved'],
-          ['Agent to secret', 'Secret metadata only, no value reads'],
+          ['Agent to role', inventory ? `${inventory.runtime_role_count} runtime role anchors` : connection?.role_arn ? 'Role anchor available' : 'Waiting for role validation'],
+          ['Agent to tool', inventory ? `${inventory.tool_count} tool names` : 'Tool and gateway metadata pending'],
+          ['Agent to secret', inventory ? `${inventory.credential_reference_count} credential references, values hidden` : 'Secret metadata only, no value reads'],
           ['Agent to user', 'Human owner mapping reserved for governance waves']
         ].map(([label, detail]) => (
           <article key={label}>
@@ -6724,6 +6746,197 @@ function AWSAgentIdentitiesContent({
       />
     </>
   );
+}
+
+function buildAWSAIAgentIdentityRows(
+  inventory: AWSAIAgentIdentityInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsAIAgentIdentityRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'ai-agent-identities-blocked',
+        name: 'AI agent identities unavailable',
+        category: 'AI agent identity',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'AI agent identity collection is blocked.',
+        filters: { surface: 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys', relationship: 'agent-to-role,agent-to-tool,agent-to-secret', status: 'not-yet-available', search: '' },
+        searchText: inventorySearchText(['ai agent identity blocked', inventory.account_id, inventory.region])
+      }
+    ];
+  }
+  if (inventory) {
+    const degraded = inventory.status === 'degraded' || inventory.diagnostics.length > 0 || inventory.failure_reasons.length > 0;
+    return [
+      {
+        id: 'ai-agent-identities-empty',
+        name: degraded ? 'AI agent identities incomplete' : 'No AI agent identities found',
+        category: 'AI agent identity',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: degraded ? 'degraded' : 'role anchor',
+        stage: 'wired',
+        detail: degraded ? (inventory.failure_reasons[0] ?? 'AI agent identity collection completed with degraded evidence and no retained records.') : 'The collector completed without Bedrock, AgentCore, custom, external-provider-backed, or gateway agent records.',
+        filters: { surface: 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys', relationship: 'agent-to-role', status: degraded ? 'degraded' : 'role-anchor', search: '' },
+        searchText: inventorySearchText(['ai agent identity', inventory.account_id, inventory.region, degraded ? 'degraded empty' : 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'ai-agent-identities-loading',
+        name: 'AI agent identities',
+        category: 'AI agent identity',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading Bedrock, AgentCore, custom, external-provider-backed, and gateway metadata.',
+        filters: { surface: 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys', relationship: 'agent-to-role,agent-to-tool,agent-to-secret', status: 'coming', search: '' },
+        searchText: inventorySearchText(['ai agent identity loading'])
+      }
+    ];
+  }
+  return [
+    {
+      id: 'role-anchor',
+      name: connection?.role_arn ?? 'AWS role anchor',
+      category: 'Agent-to-role anchor',
+      scope: awsAccountRegionLabel(connection),
+      status: connection?.connected ? 'role anchor' : 'not yet available',
+      stage: connection?.connected ? 'wired' : 'not-available',
+      detail: 'AI agent inventory can attach Bedrock, AgentCore, custom, and external agent execution back to this AWS role context.',
+      filters: {
+        surface: 'agentcore-runtime',
+        relationship: 'agent-to-role',
+        status: connection?.connected ? 'role-anchor' : 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText(['agent to role', 'agent', 'role anchor', 'role relationship'])
+    },
+    {
+      id: 'bedrock-agents',
+      name: 'Bedrock agents',
+      category: 'AWS-native agent',
+      scope: 'Bedrock',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Agent identity, action groups, tool use, and runtime role relationships are normalized when AWS is connected.',
+      filters: { surface: 'bedrock-agents', relationship: 'agent-to-tool', status: 'coming', search: '' },
+      searchText: inventorySearchText(['bedrock', 'agent surface', 'tools'])
+    },
+    {
+      id: 'agentcore',
+      name: 'AgentCore runtime and gateway identity',
+      category: 'AgentCore',
+      scope: 'Runtime / gateway',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships are normalized when AWS is connected.',
+      filters: { surface: 'agentcore-runtime,mcp-gateway', relationship: 'agent-to-tool', status: 'coming', search: '' },
+      searchText: inventorySearchText(['agentcore', 'runtime', 'gateway', 'identity'])
+    },
+    {
+      id: 'external-provider-keys',
+      name: 'External AI provider key metadata',
+      category: 'Safe metadata',
+      scope: 'Secrets metadata only',
+      status: 'not yet available',
+      stage: 'not-available',
+      detail: 'External provider usage mapping uses safe credential-reference metadata, never secret values.',
+      filters: {
+        surface: 'external-provider-keys',
+        relationship: 'agent-to-secret',
+        status: 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText(['external', 'provider', 'keys', 'agent'])
+    },
+    {
+      id: 'ai-agent-identities',
+      name: 'AI agent identities',
+      category: 'AI agent identity',
+      scope: 'Account and region expansion',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Bedrock, AgentCore, custom, external-provider-backed, and gateway metadata will attach agents to runtime roles, tools, and credential references.',
+      filters: { surface: 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys', relationship: 'agent-to-role,agent-to-tool,agent-to-secret', status: 'coming', search: '' },
+      searchText: inventorySearchText(['bedrock agentcore custom external provider gateway ai agent'])
+    }
+  ];
+}
+
+function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTableRow {
+  const stage: AWSCapabilityStage = record.status === 'ready' && record.runtime_role_arn ? 'wired' : record.status === 'blocked' ? 'not-available' : 'coming';
+  const degraded = record.status !== 'ready' || record.coverage_status === 'degraded' || Boolean(record.coverage_reason);
+  const status = stage === 'not-available' ? 'not yet available' : degraded ? 'degraded' : 'role anchor';
+  const roleLabel = record.runtime_role_name || record.runtime_role_arn || 'runtime role unresolved';
+  const toolLabel = record.tool_names?.length ? `${record.tool_names.length} tools` : 'no tools reported';
+  const capabilityLabel = record.capability_names?.length ? `${record.capability_names.join(', ')} capabilities` : 'capabilities not reported';
+  const credentialLabel = record.credential_reference_refs?.length ? `${record.credential_reference_refs.length} credential refs, values hidden` : 'no credential refs reported';
+  const surface = awsAIAgentSurfaceFilter(record);
+  const relationships = new Set<string>(['agent-to-role']);
+  if (record.tool_names?.length || record.gateway_arn) {
+    relationships.add('agent-to-tool');
+  }
+  if (record.credential_reference_refs?.length) {
+    relationships.add('agent-to-secret');
+  }
+  return {
+    id: `ai-agent-identity-${record.agent_node_id || record.agent_id}`,
+    name: record.agent_name || record.agent_id,
+    category: formatTokenLabel(record.agent_type),
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage,
+    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${toolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
+    filters: {
+      surface,
+      relationship: Array.from(relationships).join(','),
+      status: status === 'role anchor' ? 'role-anchor' : status === 'not yet available' ? 'not-yet-available' : 'coming,degraded',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.agent_id,
+      record.agent_arn,
+      record.agent_name,
+      record.agent_type,
+      record.provider,
+      record.model_id,
+      record.runtime_role_arn,
+      record.runtime_role_name,
+      record.gateway_id,
+      record.gateway_arn,
+      record.external_provider,
+      ...(record.tool_names ?? []),
+      ...(record.capability_names ?? []),
+      ...(record.credential_reference_refs ?? []),
+      record.account_id,
+      record.region,
+      'ai agent identity metadata only values hidden'
+    ])
+  };
+}
+
+function awsAIAgentSurfaceFilter(record: AWSAIAgentIdentityRecord): string {
+  switch (record.agent_type) {
+    case 'bedrock_agent':
+      return 'bedrock-agents';
+    case 'agentcore_runtime':
+      return 'agentcore-runtime';
+    case 'agent_gateway':
+      return 'mcp-gateway';
+    case 'external_provider_agent':
+    case 'custom_agent':
+      return record.credential_reference_refs?.length ? 'external-provider-keys' : 'bedrock-agents';
+    default:
+      return 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys';
+  }
 }
 
 function AWSResourcesInventoryContent({
@@ -7620,6 +7833,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [eksInventoryLoading, setEKSInventoryLoading] = useState(false);
   const [eksInventoryError, setEKSInventoryError] = useState('');
   const eksInventoryRequestRef = useRef(0);
+  const [aiAgentInventory, setAIAgentInventory] = useState<AWSAIAgentIdentityInventoryResult | null>(null);
+  const [aiAgentInventoryLoading, setAIAgentInventoryLoading] = useState(false);
+  const [aiAgentInventoryError, setAIAgentInventoryError] = useState('');
+  const aiAgentInventoryRequestRef = useRef(0);
   const [secretsManagerInventory, setSecretsManagerInventory] = useState<AWSSecretsManagerMetadataInventoryResult | null>(null);
   const [secretsManagerInventoryLoading, setSecretsManagerInventoryLoading] = useState(false);
   const [secretsManagerInventoryError, setSecretsManagerInventoryError] = useState('');
@@ -8032,6 +8249,46 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       eksInventoryRequestRef.current += 1;
     };
   }, [loadEKSInventory]);
+
+  const loadAIAgentInventory = useCallback(async () => {
+    const requestID = ++aiAgentInventoryRequestRef.current;
+    setAIAgentInventory(null);
+    setAIAgentInventoryError('');
+    if (routeID !== 'agents' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAIAgentInventoryLoading(false);
+      return;
+    }
+    setAIAgentInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAIAgentIdentities(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== aiAgentInventoryRequestRef.current) {
+        return;
+      }
+      setAIAgentInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== aiAgentInventoryRequestRef.current) {
+        return;
+      }
+      setAIAgentInventoryError(formatAPIError(error, 'Unable to load AWS AI agent identities.'));
+    } finally {
+      if (requestID === aiAgentInventoryRequestRef.current) {
+        setAIAgentInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadAIAgentInventory();
+    return () => {
+      aiAgentInventoryRequestRef.current += 1;
+    };
+  }, [loadAIAgentInventory]);
 
   const loadSecretsManagerInventory = useCallback(async () => {
     const requestID = ++secretsManagerInventoryRequestRef.current;
@@ -8702,7 +8959,17 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         />
       ) : null}
       {routeID === 'agents' ? (
-        <AWSAgentIdentitiesContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+        <AWSAgentIdentitiesContent
+          connection={connection}
+          aiAgentState={{
+            inventory: aiAgentInventory,
+            loading: aiAgentInventoryLoading,
+            error: aiAgentInventoryError,
+            onRetry: () => void loadAIAgentInventory()
+          }}
+          filters={activeFilters}
+          onFiltersChange={onFiltersChange}
+        />
       ) : null}
       {routeID === 'resources' ? (
         <AWSResourcesInventoryContent


### PR DESCRIPTION
## Summary
- Add the AWS AI agent identity normalized model adapter for Bedrock agents, AgentCore runtimes, custom agents, external provider agents, and agent gateways.
- Expose a scoped API route with OpenAPI/authz coverage, deterministic fixture states, diagnostics, coverage gaps, and payload-safe graph relationships.
- Add the product-shell inventory surface and web API client types so the domain-first AWS UI can inspect agent identities without collecting prompts, completions, memory contents, browser pages, code output, object contents, database rows, or secret values.

## Tests
- go test ./internal/api
- go test ./internal/providers/aws
- npm test -- src/productShell.test.tsx
- npm run build --prefix web

## AI disclosure
No

Closes #1505

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #1505: adds a normalized AWS AI agent identity model and a scoped API to list Bedrock, AgentCore, custom/external agents, and gateways. Ships a metadata-only UI inventory with diagnostics and sensitive-boundary coverage; no prompts, completions, memory contents, browser pages, code output, object contents, database rows, or secret values are collected.

- **New Features**
  - API: GET `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-identities` with `connector_id` and `fixture_state` (success|empty|degraded|partial_failure|permission_denied); OpenAPI schemas, router, and project `tenancy.read` authz added.
  - Provider collector with paging/retry that emits payload-safe records (roles, providers/models, tools, capabilities, credential-reference refs), relationships, and diagnostics.
  - Deterministic fixtures for UI/contract tests; docs at `docs/aws-ai-agent-identities.md`; OpenAPI types included; tests for API, router, and collector.
  - Product shell inventory: AWS Agents surface now calls `apiClient.getAWSProjectAIAgentIdentities`, shows counts, role anchors, tools, credential-reference refs, coverage gaps, diagnostics, and status.

- **Bug Fixes**
  - Emit `calls_tool` for gateway agents when tools are present; removed false self-edge on gateway self-records.
  - Normalize degraded/permission_denied/partial_failure states: keep usable records, add retryable diagnostics, and return 400 for invalid `fixture_state`.
  - API: return arrays consistently for `records`, `relationships`, `failure_reasons`, `remediation_hints`, and `diagnostics` across all fixture states; router tests added.
  - Graph/UI: use `uses_secret` for credential-reference edges, align node IDs to `aws:resource:credential-reference:*`, fix sanitizer panic, and update UI enums (including Degraded filter), client/types, docs, and tests.

<sup>Written for commit 9dbfc6d97da6860f4c5ac8f57a59e2484236e9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

