### PR TITLE
Fix AI agent identity post-merge ChatGPT review findings

### DIFF
--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -437,7 +437,7 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 	result := []AWSAIAgentIdentityRelation{}
 	for _, record := range records {
 		if record.AgentNodeID != "" && record.RuntimeRoleNodeID != "" {
-			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: record.AgentNodeID, ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
+			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: awsAIAgentWorkloadNodeID(record), ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
 		}
 		toolNames := dedupeStrings(record.ToolNames)
 		if record.AgentNodeID != "" && len(toolNames) > 0 {
@@ -624,6 +624,21 @@ func awsAIAgentNodeID(accountID string, region string, agentType string, agentID
 		firstNonEmptyAWSValue(region, "region"),
 		firstNonEmptyAWSValue(agentType, "agent"),
 		firstNonEmptyAWSValue(agentID, "unknown"),
+	)
+}
+
+func awsAIAgentWorkloadNodeID(record AWSAIAgentIdentityRecord) string {
+	agentID := firstNonEmptyAWSValue(record.AgentID, record.AgentARN, record.AgentName)
+	if strings.TrimSpace(record.AgentNodeID) != "" {
+		if idx := strings.LastIndex(record.AgentNodeID, "/"); idx >= 0 && idx < len(record.AgentNodeID)-1 {
+			agentID = firstNonEmptyAWSValue(agentID, record.AgentNodeID[idx+1:])
+		}
+	}
+	return fmt.Sprintf("aws:workload:ai-agent:%s:%s:%s/%s",
+		firstNonEmptyAWSValue(record.AccountID, "account"),
+		firstNonEmptyAWSValue(record.Region, "region"),
+		firstNonEmptyAWSValue(record.AgentType, "agent"),
+		firstNonEmptyAWSValue(agentID, "workload"),
 	)
 }
 

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -251,6 +251,32 @@ func TestAIAgentRelationshipsEmitCallsToolForGatewayRecord(t *testing.T) {
 	}
 }
 
+func TestAIAgentRelationshipsEmitRunsAsFromWorkloadNode(t *testing.T) {
+	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "custom_agent", "invoice-reconciliation-agent", "custom-invoice-agent", "arn:aws:lambda:us-east-1:111111111111:function:invoice-reconciliation-agent", "arn:aws:iam::111111111111:role/invoice-agent", time.Now(), func(r *AWSAIAgentIdentityRecord) {
+		r.ToolNames = nil
+	})
+
+	relationships := awsAIAgentIdentityRelationships([]AWSAIAgentIdentityRecord{record})
+	var runsAs *AWSAIAgentIdentityRelation
+	for _, relationship := range relationships {
+		if relationship.Type == "runs_as" {
+			rel := relationship
+			runsAs = &rel
+			break
+		}
+	}
+	if runsAs == nil {
+		t.Fatalf("expected runs_as relationship, got %+v", relationships)
+	}
+	expected := awsAIAgentWorkloadNodeID(record)
+	if runsAs.FromNodeID != expected {
+		t.Fatalf("expected runs_as source %q, got %q", expected, runsAs.FromNodeID)
+	}
+	if runsAs.ToNodeID != record.RuntimeRoleNodeID {
+		t.Fatalf("expected runs_as target %q, got %q", record.RuntimeRoleNodeID, runsAs.ToNodeID)
+	}
+}
+
 func TestRouterAWSAIAgentIdentityInventoryPermissionDenied(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -241,7 +241,7 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.RuntimeRoleName = firstNonEmptyAWSValue(record.RuntimeRoleName, roleNameFromARN(record.RuntimeRoleARN), roleNameFromARN(record.RoleARN))
 	normalized.RuntimeRoleAccountID = firstNonEmptyAWSValue(record.RuntimeRoleAccountID, roleAccountIDFromARN(record.RuntimeRoleARN), roleAccountIDFromARN(record.RoleARN))
 	normalized.RoleARN = normalized.RuntimeRoleARN
-	normalized.WorkloadID = firstNonEmptyAWSValue(record.WorkloadID, normalized.AgentARN, normalized.AgentID)
+	normalized.WorkloadID = aiAgentIdentityWorkloadID(normalized)
 	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.AgentName)
 	normalized.WorkloadType = firstNonEmptyAWSValue(record.WorkloadType, normalized.AgentType)
 	normalized.Source = firstNonEmptyAWSValue(record.Source, "ai_agent_metadata")
@@ -276,8 +276,34 @@ func aiAgentIdentitySourceID(record AIAgentIdentity) string {
 		firstNonEmptyAWSValue(record.AccountID, "account"),
 		firstNonEmptyAWSValue(record.Region, "region"),
 		firstNonEmptyAWSValue(record.AgentType, "agent"),
-		firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName),
+		aiAgentIdentityWorkloadSourceID(record),
 	}, "|")
+}
+
+func aiAgentIdentityWorkloadSourceID(record AIAgentIdentity) string {
+	agentRef := firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName)
+	if strings.EqualFold(firstNonEmptyAWSValue(record.AgentType, "agent"), "agent_gateway") {
+		return firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN, agentRef)
+	}
+	return firstNonEmptyAWSValue(agentRef, record.GatewayID, record.GatewayARN)
+}
+
+func aiAgentIdentityWorkloadID(record AIAgentIdentity) string {
+	agentRef := firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName)
+	if strings.EqualFold(firstNonEmptyAWSValue(record.AgentType, "agent"), "agent_gateway") {
+		return firstNonEmptyAWSValue(
+			record.WorkloadID,
+			record.GatewayID,
+			record.GatewayARN,
+			agentRef,
+		)
+	}
+	return firstNonEmptyAWSValue(
+		agentRef,
+		record.WorkloadID,
+		record.GatewayID,
+		record.GatewayARN,
+	)
 }
 
 func canonicalAIAgentType(agentType string, service string) string {

--- a/internal/providers/aws/ai_agent_identity_collector_test.go
+++ b/internal/providers/aws/ai_agent_identity_collector_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -152,5 +153,116 @@ func TestAIAgentIdentityCollectorDedupesAndSkipsMalformedRecords(t *testing.T) {
 	}
 	if len(diagnostics) != 1 || diagnostics[0].Code != "malformed_ai_agent_identity" {
 		t.Fatalf("expected malformed diagnostic, got %+v", diagnostics)
+	}
+}
+
+func TestAIAgentIdentityCollectorPreservesGatewayIdentifiersForSourceID(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 12, 12, 30, 0, 0, time.UTC)
+	gatewayRecord := func(gatewayID string) AIAgentIdentity {
+		return AIAgentIdentity{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+				AccountID:     "123456789012",
+				Region:        "us-east-1",
+				Service:       "bedrock",
+				Source:        "ai_agent_metadata",
+				EvidenceRef:   "gateway:" + gatewayID,
+				ScanID:        "scan-gateway",
+				CollectorName: aiAgentIdentityCollectorName,
+				CollectedAt:   collectedAt,
+			},
+			GatewayID:  gatewayID,
+			GatewayARN: fmt.Sprintf("arn:aws:bedrock:us-east-1:123456789012:agent-gateway/%s", gatewayID),
+			AgentType:  "agent_gateway",
+			AgentName:  "",
+			AgentID:    "",
+			AgentARN:   "",
+		}
+	}
+
+	api := &fakeAIAgentIdentityAPI{pages: []AIAgentIdentityPage{{
+		Records: []AIAgentIdentity{
+			gatewayRecord("payments-gateway-a"),
+			gatewayRecord("payments-gateway-b"),
+		},
+	}}}
+	collector := NewAIAgentIdentityCollector(api, WithAIAgentIdentityClock(func() time.Time { return collectedAt }))
+
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-a", ConnectorID: "aws-prod", ScanID: "scan-1"})
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if len(assets) != 2 {
+		t.Fatalf("expected two unique gateway identities, got %d", len(assets))
+	}
+
+	seenWorkloads := map[string]struct{}{}
+	for _, raw := range assets {
+		var record AIAgentIdentity
+		if err := json.Unmarshal(raw.Payload, &record); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if strings.TrimSpace(record.WorkloadID) == "" {
+			t.Fatalf("expected workload ID from gateway identifier, got %+v", record)
+		}
+		seenWorkloads[record.WorkloadID] = struct{}{}
+	}
+	if len(seenWorkloads) != 2 {
+		t.Fatalf("expected two preserved gateway workload IDs, got %d (%+v)", len(seenWorkloads), seenWorkloads)
+	}
+}
+
+func TestAIAgentIdentityCollectorPreservesAgentIDsInSourceIDForNonGatewayRecords(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 12, 12, 45, 0, 0, time.UTC)
+	agentRecord := func(agentID string) AIAgentIdentity {
+		return AIAgentIdentity{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+				AccountID:     "123456789012",
+				Region:        "us-east-1",
+				Service:       "bedrock",
+				Source:        "ai_agent_metadata",
+				EvidenceRef:   "agent:" + agentID,
+				WorkloadID:    "gateway-workload-shared-gateway",
+				ScanID:        "scan-agent",
+				CollectorName: aiAgentIdentityCollectorName,
+				CollectedAt:   collectedAt,
+			},
+			GatewayID:  "shared-gateway",
+			GatewayARN: "arn:aws:bedrock:us-east-1:123456789012:agent-gateway/shared-gateway",
+			AgentType:  "custom_agent",
+			AgentID:    agentID,
+			AgentARN:   "arn:aws:bedrock:us-east-1:123456789012:agent/" + agentID,
+			AgentName:  "agent-" + agentID,
+		}
+	}
+
+	api := &fakeAIAgentIdentityAPI{pages: []AIAgentIdentityPage{{
+		Records: []AIAgentIdentity{
+			agentRecord("agent-a"),
+			agentRecord("agent-b"),
+		},
+	}}}
+	collector := NewAIAgentIdentityCollector(api, WithAIAgentIdentityClock(func() time.Time { return collectedAt }))
+
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), AWSCollectorScope{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-a", ConnectorID: "aws-prod", ScanID: "scan-1"})
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if len(assets) != 2 {
+		t.Fatalf("expected two unique non-gateway agents, got %d", len(assets))
+	}
+
+	seen := map[string]struct{}{}
+	for _, raw := range assets {
+		var record AIAgentIdentity
+		if err := json.Unmarshal(raw.Payload, &record); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		seen[record.WorkloadID] = struct{}{}
+		if strings.Contains(record.WorkloadID, "shared-gateway") {
+			t.Fatalf("expected non-gateway agent workload to preserve agent identity, got gateway-derived workload ID %q", record.WorkloadID)
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("expected two unique workload IDs, got %d (%+v)", len(seen), seen)
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve gateway identifiers in AI agent collector identity derivation so gateway-only records are not collapsed.
- Emit `runs_as` from an AI-workload node to satisfy workload->identity relationship expectations.
- Add tests for gateway source stability and workload-based `runs_as` edge source.

## Related issues
Closes #1505

## AI disclosure
No
