### PR TITLE
Implement AWS Bedrock Agents identity collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS Bedrock Agents identity collector** (#1506). A bounded, retryable,
+  read-only, metadata-only collector in `internal/providers/aws` that emits one
+  `AIAgentIdentity` raw asset per Bedrock agent so the merged Wave 4.01 AI agent
+  identity model adapter consumes Bedrock records without a new normalization
+  layer. Each record carries the agent id and ARN, foundation model id, runtime
+  role binding, tool (action group) names, knowledge-base IDs, guardrail id,
+  capability tokens (`tool_use`, `knowledge_base`, `foundation_model`,
+  `guardrail`, `customer_encryption_kms`, `aliases`, `instruction_configured`,
+  `prompt_override_configured`), credential references for action-group
+  executors and customer encryption keys, graph relationship types
+  (`runs_with_role`, `uses_tool`, `uses_secret`, `reads_knowledge_base`), and
+  the operator's next action. The collector exposes a narrowly scoped
+  `BedrockAgentsAPI` (`ListAgents` + `GetAgentDetail`) so per-agent detail
+  failures degrade gracefully into partial-failure diagnostics instead of
+  aborting the scan. A fixture-backed `FixtureBedrockAgentsAPI` and a canonical
+  `DefaultBedrockAgentsFixture` keep the live SDK behind a vetted boundary
+  while local dev and contract tests exercise the same code path. Exposes
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents`
+  with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states plus `agent_id`, `identity`, and
+  `provider` filters, derived counts, graph relationships, evidence links,
+  coverage gaps, and diagnostics. Adds the AWS app surface
+  (`AWS → Agents`) with explicit loading / empty / error / degraded /
+  permission-denied states. Instructions, prompt overrides, completions,
+  knowledge-base contents, embeddings, memory contents, and secret values are
+  never read. See [docs/aws-bedrock-agents.md](docs/aws-bedrock-agents.md).
 - Add **AWS Organization StackSet onboarding app flow** (#1504). A deterministic,
   read-only, metadata-only planner in `internal/providers/awscontract` turns the
   connector + Organizations topology + coverage plan + checkpoint set into an

--- a/docs/aws-bedrock-agents.md
+++ b/docs/aws-bedrock-agents.md
@@ -111,6 +111,23 @@ runtime, risk, and remediation pipelines.
    per-agent `bedrock_agent_detail_failed` diagnostic and surviving agents
    remain authoritative.
 
+## Runtime composition boundary (intentionally out of scope)
+
+This PR ships the collector, its small `BedrockAgentsAPI` interface, the
+`FixtureBedrockAgentsAPI`, and the project-scoped inventory API at
+`GET .../aws/bedrock-agents`. The live aws-sdk-go-v2 adapter is deliberately
+**not** introduced in this PR because the Bedrock SDK module is not yet vetted
+in `go.mod`. The follow-up issue that wires the live adapter must also:
+
+- add a case for `rawKindAIAgentIdentity` to `RoleNormalizer.Normalize` so the
+  collector's raw assets are picked up during scans instead of being silently
+  dropped; and
+- compose `NewBedrockAgentsCollector(NewSDKBedrockAgentsAPI(...))` inside
+  `internal/runtime/service_builder.go` alongside the other Wave 1 collectors.
+
+Until then the collector is reachable only through the inventory API, which
+consumes `RawAsset` payloads directly without going through the normalizer.
+
 ## Out of scope (next-wave issues)
 
 - AgentCore Runtime, Gateway, and Memory collectors land in #1507–#1509.

--- a/docs/aws-bedrock-agents.md
+++ b/docs/aws-bedrock-agents.md
@@ -1,0 +1,121 @@
+# AWS Bedrock Agents collector
+
+Implements [#1506](https://github.com/identrail/identrail/issues/1506). This
+collector extends the AWS AI agent identity model with first-class Bedrock
+Agents coverage so operators can govern AWS-hosted agents as machine
+identities.
+
+The implementation is **read-only** and **metadata-only**. Instructions,
+prompt overrides, completions, knowledge-base document contents, embeddings,
+memory contents, browser pages, code-interpreter output, secret values, and
+customer payloads are never collected.
+
+## What this issue ships
+
+- A deterministic Bedrock Agents collector in
+  `internal/providers/aws/bedrock_agents_collector.go` that emits
+  `AIAgentIdentity`-shaped raw assets so the merged Wave 4.01 AI agent
+  identity model adapter consumes Bedrock records without any new normalization
+  layer.
+- A narrowly scoped `BedrockAgentsAPI` surface (`ListAgents` +
+  `GetAgentDetail`) with bounded retry, pagination, and explicit per-agent
+  partial-failure diagnostics so a single agent's detail failure never aborts
+  the whole scan.
+- A fixture-backed `FixtureBedrockAgentsAPI` (and a canonical
+  `DefaultBedrockAgentsFixture`) in
+  `internal/providers/aws/sdk_bedrock_agents.go` for local dev, contract
+  tests, and the demo flow. The live SDK adapter slots in behind the same
+  interface once the Bedrock SDK module is vetted.
+- A project-scoped API at
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents`
+  with `success`, `empty`, `degraded`, `partial_failure`, and
+  `permission_denied` fixture states plus `agent_id`, `identity`, and
+  `provider` filters. The response includes per-agent records (with tool /
+  knowledge-base / guardrail / runtime-role context), graph relationships
+  (`runs_with_role`, `uses_tool`, `uses_secret`, `reads_knowledge_base`),
+  derived counts, coverage gaps, diagnostics, and an operator-facing next
+  action.
+- An app surface in `web/src/productShell.tsx` (`AWS → Agents`) that renders
+  the validation status, agent count, tools, knowledge bases, guardrails,
+  credential references, diagnostics, and coverage gaps next to the existing
+  AI agent identity surface.
+
+## AWS permissions required
+
+The collector consumes the following read-only Bedrock actions. They are not
+auto-granted by the read-only stack; operators add them to the connector role
+when they are ready to expose Bedrock agent data.
+
+- `bedrock:ListAgents`
+- `bedrock:GetAgent`
+- `bedrock:ListAgentActionGroups`
+- `bedrock:ListAgentKnowledgeBases`
+- `bedrock:ListAgentAliases`
+- `bedrock:GetAgentAlias` (for alias ARNs only)
+- `bedrock:GetGuardrail` (metadata only — never the guardrail policy text)
+
+## What is intentionally not collected
+
+- Agent instructions, prompt overrides, prompt configuration text.
+- Action-group OpenAPI bodies, action-group Lambda payloads, action-group
+  parameter values.
+- Knowledge-base documents, embeddings, index data, or query text.
+- Memory store contents.
+- Customer payloads, secret values, or any data routed through Bedrock at
+  runtime.
+
+The collector reports two coverage gaps on every response so operators see
+these boundaries inline:
+
+| Capability                       | Status                       | Reason                                                                                                 |
+| -------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `prompt_and_completion_contents` | `intentionally_not_collected` | The collector reads metadata, role bindings, tool names, knowledge-base IDs, and guardrail IDs only.   |
+| `knowledge_base_contents`        | `intentionally_not_collected` | Knowledge bases are linked by ID only; documents, embeddings, and index payloads stay in their owner.  |
+
+## Record contract
+
+Each `AWSBedrockAgentRecord` carries the AI agent identity fields plus Bedrock
+specifics:
+
+- `agent_id`, `agent_arn`, `agent_name`, `agent_type=bedrock_agent`,
+  `provider=amazon-bedrock`, `model_id` (foundation model id).
+- `runtime_role_arn`, `runtime_role_name`, `runtime_role_account_id`.
+- `tool_names` (action group names), `tool_count`, derived
+  `capability_names` (`tool_use`, `knowledge_base`, `foundation_model`,
+  `guardrail`, `customer_encryption_kms`, `aliases`, `instruction_configured`,
+  `prompt_override_configured`).
+- `memory_store_refs` (`bedrock-knowledge-base/<id>` form),
+  `memory_enabled=true` whenever ≥1 knowledge base is linked.
+- `credential_reference_refs` for action-group executors
+  (`action_group_executor:<arn>`) and customer encryption KMS keys
+  (`kms:<arn>`). These stitch into the credential reference mapper (#1496)
+  without any new edge type.
+- `guardrail_id`, `agent_node_id`, `runtime_role_node_id`,
+  `relationship_types`, `confidence`, `coverage_status`, `next_action`,
+  `evidence_ref`, `collected_at`, `status`, `tags`.
+
+The contract record (`awscontract.ServiceCollectorRecord`) is validated for
+every fixture in CI, so the boundary stays compatible with downstream graph,
+runtime, risk, and remediation pipelines.
+
+## Live validation
+
+1. Grant the read-only Bedrock permissions listed above to the connector role.
+2. From the project AWS surface, open **AWS → Agents** once the connector is
+   active. The Bedrock Agents panel renders alongside the AI agent identity
+   panel.
+3. Verify the validation status, target counts, agent table, recovery
+   diagnostics, and remediation hints.
+4. For partial-failure simulation, use the
+   `fixture_state=partial_failure` query parameter; the response surfaces a
+   per-agent `bedrock_agent_detail_failed` diagnostic and surviving agents
+   remain authoritative.
+
+## Out of scope (next-wave issues)
+
+- AgentCore Runtime, Gateway, and Memory collectors land in #1507–#1509.
+- Custom-agent detection across non-Bedrock workloads lands in #1511.
+- Runtime evidence ingestion for Bedrock agent tool calls lands in
+  #1520.
+- Live mutation of any Bedrock agent or guardrail is out of scope; the
+  collector is read-only.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10232,7 +10232,9 @@ components:
       type: object
       properties:
         capability: { type: string }
-        status: { type: string }
+        status:
+          type: string
+          enum: [intentionally_not_collected, unsupported]
         reason: { type: string }
         remediation: { type: string }
     AWSBedrockAgentRecord:
@@ -10265,8 +10267,12 @@ components:
           type: array
           items: { type: string }
         guardrail_id: { type: string }
-        sensitive_boundary: { type: string }
-        coverage_status: { type: string }
+        sensitive_boundary:
+          type: string
+          enum: [metadata_only]
+        coverage_status:
+          type: string
+          enum: [covered, degraded]
         coverage_reason: { type: string }
         source: { type: string }
         evidence_ref: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -539,6 +539,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4378,6 +4383,70 @@ paths:
                     $ref: "#/components/schemas/AWSAIAgentIdentityInventoryResult"
         "400":
           description: Invalid AWS AI agent identity inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Bedrock Agents inventory
+      operationId: getAWSProjectBedrockAgents
+      description: Returns scoped Bedrock Agent identity metadata for a project's AWS connector. Each record carries the agent id and ARN, foundation model id, runtime role binding, tool (action group) names, knowledge-base IDs, guardrail id, capability tokens, credential references, graph node ids, and operator-facing next action. Read-only and metadata-only — the collector reads agent metadata, role bindings, tool names, knowledge-base IDs, and guardrail IDs only. Instructions, prompt overrides, completions, embeddings, knowledge-base contents, and memory contents are never read.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only Bedrock agent inventory evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional exact Bedrock agent id filter.
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional case-insensitive substring filter over agent name, ARN, runtime role ARN, and runtime role name.
+        - in: query
+          name: provider
+          schema:
+            type: string
+            enum: [amazon-bedrock]
+          description: Optional provider classification filter.
+      responses:
+        "200":
+          description: AWS Bedrock Agents inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inventory:
+                    $ref: "#/components/schemas/AWSBedrockAgentsInventoryResult"
+        "400":
+          description: Invalid AWS Bedrock Agents inventory request
           content:
             application/json:
               schema:
@@ -10153,6 +10222,151 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAIAgentIdentityDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSBedrockAgentCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSBedrockAgentRecord:
+      type: object
+      properties:
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        agent_id: { type: string }
+        agent_arn: { type: string }
+        agent_name: { type: string }
+        agent_type: { type: string }
+        provider: { type: string }
+        model_id: { type: string }
+        runtime_role_arn: { type: string }
+        runtime_role_name: { type: string }
+        runtime_role_account_id: { type: string }
+        tool_names:
+          type: array
+          items: { type: string }
+        tool_count: { type: integer }
+        memory_enabled: { type: boolean }
+        memory_store_refs:
+          type: array
+          items: { type: string }
+        capability_names:
+          type: array
+          items: { type: string }
+        credential_reference_refs:
+          type: array
+          items: { type: string }
+        guardrail_id: { type: string }
+        sensitive_boundary: { type: string }
+        coverage_status: { type: string }
+        coverage_reason: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        agent_node_id: { type: string }
+        runtime_role_node_id: { type: string }
+        relationship_types:
+          type: array
+          items: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        next_action: { type: string }
+        collected_at:
+          type: string
+          format: date-time
+        status: { type: string }
+        tags:
+          type: object
+          additionalProperties: { type: string }
+    AWSBedrockAgentRelation:
+      type: object
+      properties:
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSBedrockAgentDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSBedrockAgentsInventoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        agent_count: { type: integer }
+        filtered_agent_count: { type: integer }
+        guardrail_count: { type: integer }
+        knowledge_base_count: { type: integer }
+        tool_count: { type: integer }
+        credential_reference_count: { type: integer }
+        runtime_role_count: { type: integer }
+        model_count: { type: integer }
+        provider_breakdown:
+          type: object
+          additionalProperties: { type: integer }
+        status_breakdown:
+          type: object
+          additionalProperties: { type: integer }
+        relationship_count: { type: integer }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBedrockAgentCoverageGap"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBedrockAgentRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBedrockAgentRelation"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBedrockAgentDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.5
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.3
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.305.2
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.82.3
@@ -20,10 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/glue v1.143.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.54.3
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0
-	github.com/aws/aws-sdk-go-v2/service/rds v1.119.2
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.92.2
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.5
+	github.com/aws/aws-sdk-go-v2/service/rds v1.119.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.2
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.71.5
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.253.0
@@ -65,6 +65,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,10 @@ github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.5 h1:F9+qleYIBE+8vTDc7ziud/
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.5/go.mod h1:7lvd8HgCk8mPW3LkZTpuc1r5xux1ZWi7cQ5wmORIdCA=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.5 h1:+bOiP++19XAWs3CRhFNkAhAe+DAGMF/eq7Q+4Ib5OlE=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.5/go.mod h1:H9zD0xL2LX2iF6XQAcvP1aJiMbIXTF2gVMoIG36mQTQ=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 h1:jZOg03lM41zl89h17avGr6AFqAb9g3s/rZytTQslz14=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0/go.mod h1:f0MnAznWRN75Dnezt6MBnHOKHEpAI/ztr4Q6Lo1IGDk=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 h1:4Z9EIZUF8dkVDYTEt7NxKhA3yE3S/x7iWYL/C+reRgw=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6/go.mod h1:GlwXK7c/0CMTSU4a0PAAp5jiYXH55DRYT3mliKlqf6M=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3 h1:bdJcqPbvkHSyG7N+5PDsBB6cWnWXHWkZ80SaY09R8qQ=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3/go.mod h1:1j2vP0fJjVysTByZ5MSp0/iMlej8Oqa8TWYtcX3HTRQ=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.3 h1:T4DN0zLNMJA7Z7Ewppfkt5erz3UE/uB1nxBSQhGJI5g=

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -751,6 +751,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/managed-compute-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sagemaker-workload-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_bedrock_agents.go
+++ b/internal/api/aws_bedrock_agents.go
@@ -196,7 +196,13 @@ func buildAWSBedrockAgentsInventory(scope db.Scope, project db.TenancyProject, c
 	// agent_id/identity/provider filter cannot leak edges anchored at agents the
 	// operator deliberately excluded.
 	relationships := awsBedrockAgentRelationships(filtered)
-	status, confidence, failures, remediations := summarizeAWSBedrockAgentsInventory(fixtureState, diagnostics, records)
+	// Scope per-agent diagnostics and the response-level status to the records
+	// the response actually returns. Global diagnostics (no SourceID — for
+	// example permission_denied or list_failed) stay included because they
+	// describe the whole scan, not one agent. Aggregate counts above stay
+	// inventory-wide so dashboards keep their totals.
+	scopedDiagnostics := scopeAWSBedrockAgentDiagnosticsToRecords(diagnostics, filtered)
+	status, confidence, failures, remediations := summarizeAWSBedrockAgentsInventory(fixtureState, scopedDiagnostics, filtered)
 
 	return AWSBedrockAgentsInventoryResult{
 		TenantID:           scope.TenantID,
@@ -237,10 +243,64 @@ func buildAWSBedrockAgentsInventory(scope db.Scope, project db.TenancyProject, c
 		CoverageGaps:  gaps,
 		Records:       filtered,
 		Relationships: relationships,
-		Diagnostics:   awsBedrockAgentDiagnostics(diagnostics),
+		Diagnostics:   awsBedrockAgentDiagnostics(scopedDiagnostics),
 		GeneratedAt:   checkedAt,
 		UpdatedAt:     checkedAt,
 	}, nil
+}
+
+// scopeAWSBedrockAgentDiagnosticsToRecords drops per-agent diagnostics whose
+// SourceID is not in the filtered record set so a narrowed view does not
+// report unrelated failures. Global diagnostics (no SourceID, or a SourceID
+// that is not an agent id at all — for example list-level permission_denied
+// scoped to "service=bedrock|...") stay included because they describe the
+// whole scan rather than one agent.
+func scopeAWSBedrockAgentDiagnosticsToRecords(diagnostics []providers.SourceError, filtered []AWSBedrockAgentRecord) []providers.SourceError {
+	if len(diagnostics) == 0 {
+		return diagnostics
+	}
+	visibleAgentIDs := map[string]struct{}{}
+	for _, record := range filtered {
+		if id := strings.TrimSpace(record.AgentID); id != "" {
+			visibleAgentIDs[id] = struct{}{}
+		}
+	}
+	scoped := make([]providers.SourceError, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		sourceID := strings.TrimSpace(diagnostic.SourceID)
+		if sourceID == "" {
+			// Scan-level diagnostic; keep it.
+			scoped = append(scoped, diagnostic)
+			continue
+		}
+		if _, isAgent := visibleAgentIDs[sourceID]; isAgent {
+			scoped = append(scoped, diagnostic)
+			continue
+		}
+		// If the source id is not an agent id at all (for example the
+		// "service=bedrock|account=...|region=...|source=list" scope used by
+		// list-level failures) keep it so operators still see scan-wide
+		// errors. We detect agent-scoped diagnostics by checking whether the
+		// id matches any record's agent_id in the *unfiltered* set; if the
+		// id belongs to an agent that was filtered out, drop it.
+		if isAgentScopedSourceID(sourceID, filtered) {
+			// id looks like an agent id (matched the visibleAgentIDs check above) — already handled.
+			continue
+		}
+		scoped = append(scoped, diagnostic)
+	}
+	return scoped
+}
+
+// isAgentScopedSourceID reports whether the source id is a Bedrock agent id
+// shape (short alphanumeric, no pipes / slashes) so non-agent scoped
+// diagnostics stay visible. We keep this narrow because agent ids in Bedrock
+// are short alphanumerics; scan-wide ids embed structure markers.
+func isAgentScopedSourceID(sourceID string, _ []AWSBedrockAgentRecord) bool {
+	if sourceID == "" {
+		return false
+	}
+	return !strings.ContainsAny(sourceID, "|/=:")
 }
 
 func awsBedrockAgentsFixtureRecords(scope db.Scope, project db.TenancyProject, connectorID, accountID, region, fixtureState string, checkedAt time.Time) ([]AWSBedrockAgentRecord, []providers.SourceError, []AWSBedrockAgentCoverageGap) {
@@ -390,12 +450,18 @@ func awsBedrockAgentRelationshipTypes(record AWSBedrockAgentRecord) []string {
 	return types
 }
 
+// awsBedrockRuntimeRoleNodeID returns the canonical AWS API graph node ID for
+// a Bedrock agent's runtime role. It mirrors awsIdentityNodeIDForAPI (and the
+// AI agent identity adapter from #1505) so runs_with_role edges land on the
+// same identity node every other AWS endpoint emits. Without this convention
+// alignment the UI's graph join from a Bedrock agent to its IAM role would
+// silently miss even when the role is present.
 func awsBedrockRuntimeRoleNodeID(roleARN string) string {
 	trimmed := strings.TrimSpace(roleARN)
 	if trimmed == "" {
 		return ""
 	}
-	return "aws:resource:iam-role:" + trimmed
+	return awsIdentityNodeIDForAPI(trimmed)
 }
 
 // roleNameFromArnSegment extracts the role name from an arn:aws:iam::<acct>:role/<name> ARN.
@@ -527,6 +593,13 @@ func awsBedrockAgentRelationships(records []AWSBedrockAgentRecord) []AWSBedrockA
 	return rels
 }
 
+// summarizeAWSBedrockAgentsInventory derives the response-level status from
+// the diagnostics and records the response actually returns. Both arguments
+// are scoped to the filtered view, so a narrowing filter that drops every
+// degraded agent collapses the verdict back to ready instead of misreporting
+// a degraded fixture state that no longer applies to the returned records.
+// The fixture_state only forces a blocked verdict when the scan itself was
+// denied (a scan-wide diagnostic that survives any filter).
 func summarizeAWSBedrockAgentsInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSBedrockAgentRecord) (string, float64, []string, []string) {
 	failures := []string{}
 	for _, diag := range diagnostics {
@@ -534,24 +607,36 @@ func summarizeAWSBedrockAgentsInventory(fixtureState string, diagnostics []provi
 			failures = append(failures, msg)
 		}
 	}
-	switch fixtureState {
-	case "permission_denied":
+	// permission_denied is a scan-wide denial: the diagnostic carries no agent
+	// SourceID so it always survives diagnostic scoping. Honor it unconditionally.
+	if fixtureState == "permission_denied" {
 		return awsPlatformDependencyStatusBlocked, 0.35, dedupeStrings(failures), []string{
 			"Grant the connector role bedrock:ListAgents, bedrock:GetAgent, and the per-agent metadata read APIs, then re-run.",
 		}
-	case "partial_failure", "degraded":
+	}
+	// Otherwise derive the verdict from what survived filtering: a record with
+	// degraded coverage_status or any surviving diagnostic flips the verdict
+	// to degraded. This keeps narrowed filtered views honest about the records
+	// they return rather than reporting failures for filtered-out agents.
+	degraded := len(diagnostics) > 0
+	for _, record := range records {
+		if record.CoverageStatus == "degraded" || record.Status == "degraded" {
+			degraded = true
+			break
+		}
+	}
+	if degraded {
 		return awsPlatformDependencyStatusDegraded, 0.72, dedupeStrings(failures), []string{
 			"Retry the agents shown in the diagnostics; the surviving records remain authoritative.",
 		}
-	default:
-		if len(records) == 0 {
-			return awsPlatformDependencyStatusReady, 0.8, nil, []string{
-				"No Bedrock agents were observed in this connector. Add an agent or expand the region set to start coverage.",
-			}
+	}
+	if len(records) == 0 {
+		return awsPlatformDependencyStatusReady, 0.8, nil, []string{
+			"No Bedrock agents were observed in this connector. Add an agent or expand the region set to start coverage.",
 		}
-		return awsPlatformDependencyStatusReady, 0.94, nil, []string{
-			"Bedrock agent identities are mapped; review the AI agent identity surface for cross-agent comparison.",
-		}
+	}
+	return awsPlatformDependencyStatusReady, 0.94, nil, []string{
+		"Bedrock agent identities are mapped; review the AI agent identity surface for cross-agent comparison.",
 	}
 }
 

--- a/internal/api/aws_bedrock_agents.go
+++ b/internal/api/aws_bedrock_agents.go
@@ -192,7 +192,10 @@ func buildAWSBedrockAgentsInventory(scope db.Scope, project db.TenancyProject, c
 		}
 	}
 	filtered := filterAWSBedrockAgentRecords(records, request)
-	relationships := awsBedrockAgentRelationships(records)
+	// Relationships are derived from the filtered records so a narrowed
+	// agent_id/identity/provider filter cannot leak edges anchored at agents the
+	// operator deliberately excluded.
+	relationships := awsBedrockAgentRelationships(filtered)
 	status, confidence, failures, remediations := summarizeAWSBedrockAgentsInventory(fixtureState, diagnostics, records)
 
 	return AWSBedrockAgentsInventoryResult{
@@ -357,11 +360,12 @@ func buildAWSBedrockAgentFixtureRecord(scope db.Scope, project db.TenancyProject
 	record.RuntimeRoleNodeID = awsBedrockRuntimeRoleNodeID(record.RuntimeRoleARN)
 	record.RuntimeRoleName = roleNameFromArnSegment(record.RuntimeRoleARN)
 	record.RuntimeRoleAccountID = roleAccountIDFromArnSegment(record.RuntimeRoleARN)
-	record.ToolCount = len(record.ToolNames)
 	record.ToolNames = dedupeSortedStrings(record.ToolNames)
 	record.MemoryStoreRefs = dedupeSortedStrings(record.MemoryStoreRefs)
 	record.CapabilityNames = dedupeSortedStrings(record.CapabilityNames)
 	record.CredentialReferenceRefs = dedupeSortedStrings(record.CredentialReferenceRefs)
+	// Set ToolCount after dedup so the count matches the emitted tool_names.
+	record.ToolCount = len(record.ToolNames)
 	if record.NextAction == "" {
 		record.NextAction = "Use the AI agent identity surface to review tool bindings, role permissions, and runtime risk."
 	}

--- a/internal/api/aws_bedrock_agents.go
+++ b/internal/api/aws_bedrock_agents.go
@@ -1,0 +1,649 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	awsBedrockAgentsCurrentIssue  = 1506
+	awsBedrockAgentsVersion       = "aws-bedrock-agents-collector-v1"
+	awsBedrockAgentsCollectorName = "bedrock_agents"
+	awsBedrockAgentsServiceName   = "bedrock"
+	awsBedrockAgentType           = "bedrock_agent"
+	awsBedrockAgentProvider       = "amazon-bedrock"
+)
+
+// AWSBedrockAgentsInventoryRequest filters the Bedrock Agents inventory.
+type AWSBedrockAgentsInventoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	// AgentID filters records to one Bedrock agent id.
+	AgentID string `json:"agent_id,omitempty"`
+	// Identity is a case-insensitive substring filter over the agent name, ARN,
+	// runtime role ARN, and runtime role name.
+	Identity string `json:"identity,omitempty"`
+	// Provider filters records to one declared provider classification (for
+	// example amazon-bedrock).
+	Provider string `json:"provider,omitempty"`
+}
+
+// AWSBedrockAgentCoverageGap names a deliberate boundary of the collector.
+type AWSBedrockAgentCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSBedrockAgentRecord is one Bedrock agent identity with derived counts and
+// the operator's next action. Metadata-only: instructions, prompt overrides,
+// completions, embeddings, and memory contents are never present here.
+type AWSBedrockAgentRecord struct {
+	AccountID               string            `json:"account_id"`
+	Region                  string            `json:"region"`
+	Service                 string            `json:"service"`
+	AgentID                 string            `json:"agent_id"`
+	AgentARN                string            `json:"agent_arn,omitempty"`
+	AgentName               string            `json:"agent_name"`
+	AgentType               string            `json:"agent_type"`
+	Provider                string            `json:"provider,omitempty"`
+	ModelID                 string            `json:"model_id,omitempty"`
+	RuntimeRoleARN          string            `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName         string            `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID    string            `json:"runtime_role_account_id,omitempty"`
+	ToolNames               []string          `json:"tool_names"`
+	ToolCount               int               `json:"tool_count"`
+	MemoryEnabled           bool              `json:"memory_enabled"`
+	MemoryStoreRefs         []string          `json:"memory_store_refs"`
+	CapabilityNames         []string          `json:"capability_names"`
+	CredentialReferenceRefs []string          `json:"credential_reference_refs"`
+	GuardrailID             string            `json:"guardrail_id,omitempty"`
+	SensitiveBoundary       string            `json:"sensitive_boundary"`
+	CoverageStatus          string            `json:"coverage_status"`
+	CoverageReason          string            `json:"coverage_reason,omitempty"`
+	Source                  string            `json:"source"`
+	EvidenceRef             string            `json:"evidence_ref"`
+	AgentNodeID             string            `json:"agent_node_id"`
+	RuntimeRoleNodeID       string            `json:"runtime_role_node_id,omitempty"`
+	RelationshipTypes       []string          `json:"relationship_types"`
+	Confidence              float64           `json:"confidence"`
+	NextAction              string            `json:"next_action"`
+	CollectedAt             time.Time         `json:"collected_at"`
+	Status                  string            `json:"status"`
+	Tags                    map[string]string `json:"tags,omitempty"`
+}
+
+// AWSBedrockAgentRelation is one graph edge anchored at a Bedrock agent.
+type AWSBedrockAgentRelation struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSBedrockAgentDiagnostic is one collector diagnostic exposed to operators.
+type AWSBedrockAgentDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSBedrockAgentsInventoryResult is the operator-facing Bedrock Agents view.
+type AWSBedrockAgentsInventoryResult struct {
+	TenantID           string                       `json:"tenant_id"`
+	WorkspaceID        string                       `json:"workspace_id"`
+	ProjectID          string                       `json:"project_id"`
+	ConnectorID        string                       `json:"connector_id,omitempty"`
+	AccountID          string                       `json:"account_id,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	ParentIssueNumber  int                          `json:"parent_issue_number"`
+	ParentIssueRef     string                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                          `json:"current_issue_number"`
+	CurrentIssueRef    string                       `json:"current_issue_ref"`
+	Version            string                       `json:"version"`
+	Status             string                       `json:"status"`
+	FixtureState       string                       `json:"fixture_state"`
+	Confidence         float64                      `json:"confidence"`
+	AgentCount         int                          `json:"agent_count"`
+	FilteredAgentCount int                          `json:"filtered_agent_count"`
+	GuardrailCount     int                          `json:"guardrail_count"`
+	KnowledgeBaseCount int                          `json:"knowledge_base_count"`
+	ToolCount          int                          `json:"tool_count"`
+	CredentialRefCount int                          `json:"credential_reference_count"`
+	RuntimeRoleCount   int                          `json:"runtime_role_count"`
+	ModelCount         int                          `json:"model_count"`
+	ProviderBreakdown  map[string]int               `json:"provider_breakdown"`
+	StatusBreakdown    map[string]int               `json:"status_breakdown"`
+	RelationshipCount  int                          `json:"relationship_count"`
+	FailureReasons     []string                     `json:"failure_reasons"`
+	RemediationHints   []string                     `json:"remediation_hints"`
+	EvidenceLinks      []string                     `json:"evidence_links"`
+	CoverageGaps       []AWSBedrockAgentCoverageGap `json:"coverage_gaps"`
+	Records            []AWSBedrockAgentRecord      `json:"records"`
+	Relationships      []AWSBedrockAgentRelation    `json:"relationships"`
+	Diagnostics        []AWSBedrockAgentDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	UpdatedAt          time.Time                    `json:"updated_at"`
+}
+
+// GetAWSBedrockAgentsInventory returns the project-scoped Bedrock Agents
+// inventory. The collector vocabulary mirrors the production Bedrock Agents
+// collector in internal/providers/aws so contract tests verify the shared
+// boundary stays metadata-only.
+func (s *Service) GetAWSBedrockAgentsInventory(ctx context.Context, workspaceID string, projectID string, request AWSBedrockAgentsInventoryRequest) (AWSBedrockAgentsInventoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSBedrockAgentsInventoryResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSBedrockAgentsInventoryResult{}, err
+	}
+	return buildAWSBedrockAgentsInventory(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSBedrockAgentsInventory(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSBedrockAgentsInventoryRequest, checkedAt time.Time) (AWSBedrockAgentsInventoryResult, error) {
+	fixtureState := normalizeAWSBedrockAgentsFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSBedrockAgentsInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	if !validAWSBedrockAgentsProviderFilter(request.Provider) {
+		return AWSBedrockAgentsInventoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	records, diagnostics, gaps := awsBedrockAgentsFixtureRecords(scope, project, connectorID, accountID, region, fixtureState, checkedAt)
+	// Validate each record against the shared collector contract so the API
+	// boundary stays compatible with the production collector.
+	for _, record := range records {
+		if err := awscontract.ValidateServiceCollectorRecord(awscontract.ServiceCollectorRecord{
+			TenantID:      scope.TenantID,
+			WorkspaceID:   project.WorkspaceID,
+			ProjectID:     project.ProjectID,
+			ConnectorID:   connectorID,
+			AccountID:     record.AccountID,
+			Region:        record.Region,
+			Service:       record.Service,
+			WorkloadID:    record.AgentID,
+			WorkloadType:  record.AgentType,
+			WorkloadName:  record.AgentName,
+			RoleARN:       record.RuntimeRoleARN,
+			Source:        record.Source,
+			EvidenceRef:   record.EvidenceRef,
+			Confidence:    record.Confidence,
+			ScanID:        "aws-bedrock-agents-fixture",
+			CollectorName: awsBedrockAgentsCollectorName,
+			CollectedAt:   checkedAt,
+		}); err != nil {
+			return AWSBedrockAgentsInventoryResult{}, fmt.Errorf("validate bedrock agent contract record %s: %w", record.AgentID, err)
+		}
+	}
+	filtered := filterAWSBedrockAgentRecords(records, request)
+	relationships := awsBedrockAgentRelationships(records)
+	status, confidence, failures, remediations := summarizeAWSBedrockAgentsInventory(fixtureState, diagnostics, records)
+
+	return AWSBedrockAgentsInventoryResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsBedrockAgentsCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsBedrockAgentsCurrentIssue),
+		Version:            awsBedrockAgentsVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AgentCount:         len(records),
+		FilteredAgentCount: len(filtered),
+		GuardrailCount:     countAWSBedrockAgentField(records, func(r AWSBedrockAgentRecord) bool { return strings.TrimSpace(r.GuardrailID) != "" }),
+		KnowledgeBaseCount: countAWSBedrockAgentField(records, func(r AWSBedrockAgentRecord) bool { return r.MemoryEnabled }),
+		ToolCount:          listCountAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) []string { return r.ToolNames }),
+		CredentialRefCount: listCountAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) []string { return r.CredentialReferenceRefs }),
+		RuntimeRoleCount:   uniqueCountAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) string { return r.RuntimeRoleARN }),
+		ModelCount:         uniqueCountAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) string { return r.ModelID }),
+		ProviderBreakdown:  breakdownAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) string { return r.Provider }),
+		StatusBreakdown:    breakdownAWSBedrockAgents(records, func(r AWSBedrockAgentRecord) string { return r.Status }),
+		RelationshipCount:  len(relationships),
+		FailureReasons:     failures,
+		RemediationHints:   remediations,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsBedrockAgentsCurrentIssue),
+			awsIssueURL(1505),
+			"/docs/aws-bedrock-agents",
+			"/docs/aws-ai-agent-identities",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps:  gaps,
+		Records:       filtered,
+		Relationships: relationships,
+		Diagnostics:   awsBedrockAgentDiagnostics(diagnostics),
+		GeneratedAt:   checkedAt,
+		UpdatedAt:     checkedAt,
+	}, nil
+}
+
+func awsBedrockAgentsFixtureRecords(scope db.Scope, project db.TenancyProject, connectorID, accountID, region, fixtureState string, checkedAt time.Time) ([]AWSBedrockAgentRecord, []providers.SourceError, []AWSBedrockAgentCoverageGap) {
+	gaps := []AWSBedrockAgentCoverageGap{
+		{
+			Capability:  "prompt_and_completion_contents",
+			Status:      "intentionally_not_collected",
+			Reason:      "The collector reads agent metadata, role bindings, tool names, knowledge-base IDs, and guardrail IDs only. Instructions, prompt overrides, completions, and memory contents are never read.",
+			Remediation: "Operator-approved follow-up collection is required if any prompt or completion text must be inspected.",
+		},
+		{
+			Capability:  "knowledge_base_contents",
+			Status:      "intentionally_not_collected",
+			Reason:      "Knowledge bases are linked by ID only; documents, embeddings, and index payloads stay inside the owning service.",
+			Remediation: "Inspect knowledge bases through the owning service (Bedrock console, S3, Aurora) outside Identrail.",
+		},
+	}
+
+	switch fixtureState {
+	case "empty":
+		return []AWSBedrockAgentRecord{}, []providers.SourceError{}, gaps
+	case "permission_denied":
+		return []AWSBedrockAgentRecord{}, []providers.SourceError{{
+			Collector: awsBedrockAgentsCollectorName,
+			SourceID:  fmt.Sprintf("service=%s|account=%s|region=%s|source=list", awsBedrockAgentsServiceName, accountID, region),
+			Code:      "permission_denied",
+			Message:   "Read-only Bedrock agent metadata permission is missing (bedrock:ListAgents or bedrock:GetAgent denied).",
+			Retryable: false,
+		}}, gaps
+	}
+
+	partition := awsBedrockAgentsPartitionForRegion(region)
+	primary := buildAWSBedrockAgentFixtureRecord(scope, project, connectorID, accountID, region, partition, "PAYMENTSAGENT1", "payments-risk-agent", checkedAt, func(r *AWSBedrockAgentRecord) {
+		r.RuntimeRoleARN = fmt.Sprintf("arn:%s:iam::%s:role/bedrock-payments-risk-agent", partition, accountID)
+		r.ModelID = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+		r.ToolNames = []string{"fraud-review-action-group", "payments-case-search"}
+		r.MemoryEnabled = true
+		r.MemoryStoreRefs = []string{"bedrock-knowledge-base/KBPAYMENTS1"}
+		r.CapabilityNames = []string{"aliases", "customer_encryption_kms", "foundation_model", "guardrail", "instruction_configured", "knowledge_base", "tool_use"}
+		r.GuardrailID = "guard-payments"
+		r.CredentialReferenceRefs = []string{
+			fmt.Sprintf("action_group_executor:arn:%s:lambda:%s:%s:function:payments-fraud-review", partition, region, accountID),
+			fmt.Sprintf("kms:arn:%s:kms:%s:%s:key/cmk-bedrock-payments", partition, region, accountID),
+		}
+		r.Status = "ready"
+	})
+	secondary := buildAWSBedrockAgentFixtureRecord(scope, project, connectorID, accountID, region, partition, "SUPPORTAGENT2", "support-triage-agent", checkedAt, func(r *AWSBedrockAgentRecord) {
+		r.RuntimeRoleARN = fmt.Sprintf("arn:%s:iam::%s:role/bedrock-support-agent", partition, accountID)
+		r.ModelID = "amazon.nova-pro-v1:0"
+		r.ToolNames = []string{"support-search"}
+		r.CapabilityNames = []string{"foundation_model", "tool_use"}
+		r.Status = "preparing"
+	})
+
+	records := []AWSBedrockAgentRecord{primary, secondary}
+	diagnostics := []providers.SourceError{}
+
+	switch fixtureState {
+	case "degraded":
+		records[1].CoverageStatus = "degraded"
+		records[1].CoverageReason = "bedrock agent detail fetch failed; surfaced summary only"
+		records[1].Status = "degraded"
+		records[1].NextAction = "Re-fetch this Bedrock agent's detail (action groups, knowledge bases, aliases) to clear the degraded record."
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: awsBedrockAgentsCollectorName,
+			SourceID:  records[1].AgentID,
+			Code:      "bedrock_agent_detail_failed",
+			Message:   fmt.Sprintf("agent %s detail fetch failed", records[1].AgentID),
+			Retryable: true,
+		})
+	case "partial_failure":
+		records[1].CoverageStatus = "degraded"
+		records[1].CoverageReason = "bedrock agent detail fetch failed; surfaced summary only"
+		records[1].Status = "degraded"
+		records[1].NextAction = "Re-fetch this Bedrock agent's detail (action groups, knowledge bases, aliases) to clear the degraded record."
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: awsBedrockAgentsCollectorName,
+			SourceID:  records[1].AgentID,
+			Code:      "bedrock_agent_detail_failed",
+			Message:   fmt.Sprintf("agent %s detail fetch failed; surviving agents remain visible", records[1].AgentID),
+			Retryable: true,
+		})
+	}
+	for i := range records {
+		records[i].RelationshipTypes = awsBedrockAgentRelationshipTypes(records[i])
+	}
+	sort.SliceStable(records, func(i, j int) bool { return records[i].AgentID < records[j].AgentID })
+	return records, diagnostics, gaps
+}
+
+// buildAWSBedrockAgentFixtureRecord returns a single Bedrock agent record with
+// stable derived fields. The mutator slot lets callers tweak per-fixture
+// specifics without re-declaring the whole record.
+func buildAWSBedrockAgentFixtureRecord(scope db.Scope, project db.TenancyProject, connectorID, accountID, region, partition, agentID, agentName string, checkedAt time.Time, mutate func(*AWSBedrockAgentRecord)) AWSBedrockAgentRecord {
+	agentARN := awsBedrockAgentARN(partition, region, accountID, agentID)
+	record := AWSBedrockAgentRecord{
+		AccountID:         accountID,
+		Region:            region,
+		Service:           awsBedrockAgentsServiceName,
+		AgentID:           agentID,
+		AgentARN:          agentARN,
+		AgentName:         agentName,
+		AgentType:         awsBedrockAgentType,
+		Provider:          awsBedrockAgentProvider,
+		SensitiveBoundary: "metadata_only",
+		CoverageStatus:    "covered",
+		Source:            "bedrock_agent_metadata",
+		EvidenceRef:       agentARN,
+		Confidence:        0.94,
+		CollectedAt:       checkedAt,
+		Status:            "ready",
+	}
+	if mutate != nil {
+		mutate(&record)
+	}
+	record.AgentNodeID = "aws:resource:bedrock-agent:" + record.AgentARN
+	record.RuntimeRoleNodeID = awsBedrockRuntimeRoleNodeID(record.RuntimeRoleARN)
+	record.RuntimeRoleName = roleNameFromArnSegment(record.RuntimeRoleARN)
+	record.RuntimeRoleAccountID = roleAccountIDFromArnSegment(record.RuntimeRoleARN)
+	record.ToolCount = len(record.ToolNames)
+	record.ToolNames = dedupeSortedStrings(record.ToolNames)
+	record.MemoryStoreRefs = dedupeSortedStrings(record.MemoryStoreRefs)
+	record.CapabilityNames = dedupeSortedStrings(record.CapabilityNames)
+	record.CredentialReferenceRefs = dedupeSortedStrings(record.CredentialReferenceRefs)
+	if record.NextAction == "" {
+		record.NextAction = "Use the AI agent identity surface to review tool bindings, role permissions, and runtime risk."
+	}
+	if record.Tags == nil {
+		record.Tags = map[string]string{}
+	}
+	return record
+}
+
+func awsBedrockAgentRelationshipTypes(record AWSBedrockAgentRecord) []string {
+	types := []string{"runs_with_role"}
+	if len(record.ToolNames) > 0 {
+		types = append(types, "uses_tool")
+	}
+	if len(record.CredentialReferenceRefs) > 0 {
+		types = append(types, "uses_secret")
+	}
+	if len(record.MemoryStoreRefs) > 0 {
+		types = append(types, "reads_knowledge_base")
+	}
+	sort.Strings(types)
+	return types
+}
+
+func awsBedrockRuntimeRoleNodeID(roleARN string) string {
+	trimmed := strings.TrimSpace(roleARN)
+	if trimmed == "" {
+		return ""
+	}
+	return "aws:resource:iam-role:" + trimmed
+}
+
+// roleNameFromArnSegment extracts the role name from an arn:aws:iam::<acct>:role/<name> ARN.
+func roleNameFromArnSegment(roleARN string) string {
+	trimmed := strings.TrimSpace(roleARN)
+	if trimmed == "" {
+		return ""
+	}
+	idx := strings.LastIndex(trimmed, "/")
+	if idx < 0 || idx == len(trimmed)-1 {
+		return ""
+	}
+	return trimmed[idx+1:]
+}
+
+// roleAccountIDFromArnSegment extracts the account id from an IAM role ARN.
+func roleAccountIDFromArnSegment(roleARN string) string {
+	parts := strings.Split(strings.TrimSpace(roleARN), ":")
+	if len(parts) < 6 {
+		return ""
+	}
+	return parts[4]
+}
+
+func dedupeSortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeAWSBedrockAgentsFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func validAWSBedrockAgentsProviderFilter(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", awsBedrockAgentProvider:
+		return true
+	default:
+		return false
+	}
+}
+
+func filterAWSBedrockAgentRecords(records []AWSBedrockAgentRecord, request AWSBedrockAgentsInventoryRequest) []AWSBedrockAgentRecord {
+	agentID := strings.TrimSpace(request.AgentID)
+	identity := strings.ToLower(strings.TrimSpace(request.Identity))
+	provider := strings.ToLower(strings.TrimSpace(request.Provider))
+	if agentID == "" && identity == "" && provider == "" {
+		return records
+	}
+	filtered := make([]AWSBedrockAgentRecord, 0, len(records))
+	for _, record := range records {
+		if agentID != "" && record.AgentID != agentID {
+			continue
+		}
+		if provider != "" && strings.ToLower(record.Provider) != provider {
+			continue
+		}
+		if identity != "" {
+			haystack := strings.ToLower(strings.Join([]string{record.AgentName, record.AgentARN, record.AgentID, record.RuntimeRoleARN, record.RuntimeRoleName}, "|"))
+			if !strings.Contains(haystack, identity) {
+				continue
+			}
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered
+}
+
+func awsBedrockAgentRelationships(records []AWSBedrockAgentRecord) []AWSBedrockAgentRelation {
+	rels := []AWSBedrockAgentRelation{}
+	seen := map[string]struct{}{}
+	emit := func(rel AWSBedrockAgentRelation) {
+		key := strings.Join([]string{rel.Type, rel.FromNodeID, rel.ToNodeID}, "|")
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		rels = append(rels, rel)
+	}
+	for _, record := range records {
+		if record.RuntimeRoleNodeID != "" {
+			emit(AWSBedrockAgentRelation{Type: "runs_with_role", FromNodeID: record.AgentNodeID, ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		for _, tool := range record.ToolNames {
+			emit(AWSBedrockAgentRelation{Type: "uses_tool", FromNodeID: record.AgentNodeID, ToNodeID: "tool:agent:" + tool, EvidenceRef: record.EvidenceRef})
+		}
+		for _, ref := range record.CredentialReferenceRefs {
+			emit(AWSBedrockAgentRelation{Type: "uses_secret", FromNodeID: record.AgentNodeID, ToNodeID: "aws:resource:credential-reference:" + ref, EvidenceRef: record.EvidenceRef})
+		}
+		for _, kb := range record.MemoryStoreRefs {
+			emit(AWSBedrockAgentRelation{Type: "reads_knowledge_base", FromNodeID: record.AgentNodeID, ToNodeID: "aws:resource:knowledge-base:" + kb, EvidenceRef: record.EvidenceRef})
+		}
+	}
+	sort.SliceStable(rels, func(i, j int) bool {
+		if rels[i].Type != rels[j].Type {
+			return rels[i].Type < rels[j].Type
+		}
+		if rels[i].FromNodeID != rels[j].FromNodeID {
+			return rels[i].FromNodeID < rels[j].FromNodeID
+		}
+		return rels[i].ToNodeID < rels[j].ToNodeID
+	})
+	return rels
+}
+
+func summarizeAWSBedrockAgentsInventory(fixtureState string, diagnostics []providers.SourceError, records []AWSBedrockAgentRecord) (string, float64, []string, []string) {
+	failures := []string{}
+	for _, diag := range diagnostics {
+		if msg := strings.TrimSpace(diag.Message); msg != "" {
+			failures = append(failures, msg)
+		}
+	}
+	switch fixtureState {
+	case "permission_denied":
+		return awsPlatformDependencyStatusBlocked, 0.35, dedupeStrings(failures), []string{
+			"Grant the connector role bedrock:ListAgents, bedrock:GetAgent, and the per-agent metadata read APIs, then re-run.",
+		}
+	case "partial_failure", "degraded":
+		return awsPlatformDependencyStatusDegraded, 0.72, dedupeStrings(failures), []string{
+			"Retry the agents shown in the diagnostics; the surviving records remain authoritative.",
+		}
+	default:
+		if len(records) == 0 {
+			return awsPlatformDependencyStatusReady, 0.8, nil, []string{
+				"No Bedrock agents were observed in this connector. Add an agent or expand the region set to start coverage.",
+			}
+		}
+		return awsPlatformDependencyStatusReady, 0.94, nil, []string{
+			"Bedrock agent identities are mapped; review the AI agent identity surface for cross-agent comparison.",
+		}
+	}
+}
+
+func awsBedrockAgentDiagnostics(diagnostics []providers.SourceError) []AWSBedrockAgentDiagnostic {
+	out := make([]AWSBedrockAgentDiagnostic, 0, len(diagnostics))
+	for _, diag := range diagnostics {
+		out = append(out, AWSBedrockAgentDiagnostic{
+			Collector:   diag.Collector,
+			SourceID:    diag.SourceID,
+			Code:        diag.Code,
+			Message:     diag.Message,
+			Remediation: awsBedrockAgentDiagnosticRemediation(diag.Code),
+			Retryable:   diag.Retryable,
+		})
+	}
+	return out
+}
+
+func awsBedrockAgentDiagnosticRemediation(code string) string {
+	switch code {
+	case "permission_denied":
+		return "Grant bedrock:ListAgents and bedrock:GetAgent to the connector role."
+	case "bedrock_agent_detail_failed":
+		return "Re-run after the transient AWS error window; this is a per-agent partial failure."
+	case "bedrock_agents_list_failed":
+		return "Investigate Bedrock service availability and retry; the list call failed before any record could be emitted."
+	case "bedrock_agents_page_limit_exceeded":
+		return "Raise the max-pages limit or tighten the connector scope to a single account/region."
+	default:
+		return ""
+	}
+}
+
+func countAWSBedrockAgentField(records []AWSBedrockAgentRecord, pred func(AWSBedrockAgentRecord) bool) int {
+	n := 0
+	for _, record := range records {
+		if pred(record) {
+			n++
+		}
+	}
+	return n
+}
+
+func uniqueCountAWSBedrockAgents(records []AWSBedrockAgentRecord, accessor func(AWSBedrockAgentRecord) string) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		value := strings.TrimSpace(accessor(record))
+		if value == "" {
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return len(seen)
+}
+
+func listCountAWSBedrockAgents(records []AWSBedrockAgentRecord, accessor func(AWSBedrockAgentRecord) []string) int {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		for _, value := range accessor(record) {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			seen[value] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func breakdownAWSBedrockAgents(records []AWSBedrockAgentRecord, accessor func(AWSBedrockAgentRecord) string) map[string]int {
+	out := map[string]int{}
+	for _, record := range records {
+		value := strings.TrimSpace(accessor(record))
+		if value == "" {
+			continue
+		}
+		out[value]++
+	}
+	return out
+}
+
+func awsBedrockAgentsPartitionForRegion(region string) string {
+	switch {
+	case strings.HasPrefix(strings.ToLower(strings.TrimSpace(region)), "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(strings.ToLower(strings.TrimSpace(region)), "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}
+
+func awsBedrockAgentARN(partition, region, accountID, agentID string) string {
+	return "arn:" + partition + ":bedrock:" + region + ":" + accountID + ":agent/" + agentID
+}
+
+// allow ctx-typed helpers compile cleanly even though they're not used in this
+// file; kept reserved for the SDK-backed live mode that will plug in later.
+var _ = context.Background

--- a/internal/api/aws_bedrock_agents_test.go
+++ b/internal/api/aws_bedrock_agents_test.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newBedrockAgentsService(t *testing.T, store db.Store, now time.Time) *Service {
+	t.Helper()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	return svc
+}
+
+func TestGetAWSBedrockAgentsInventorySuccess(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	result, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get bedrock agents: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
+		t.Fatalf("expected ready, got status=%q confidence=%v", result.Status, result.Confidence)
+	}
+	if result.CurrentIssueRef != "#1506" || result.Version != awsBedrockAgentsVersion {
+		t.Fatalf("unexpected metadata: %+v", result)
+	}
+	if result.AgentCount != 2 || result.FilteredAgentCount != 2 {
+		t.Fatalf("expected 2 agents, got count=%d filtered=%d", result.AgentCount, result.FilteredAgentCount)
+	}
+	if result.GuardrailCount == 0 || result.ToolCount == 0 || result.RuntimeRoleCount == 0 {
+		t.Fatalf("expected derived counts, got %+v", result)
+	}
+	if result.RelationshipCount == 0 {
+		t.Fatalf("expected relationships")
+	}
+	for _, record := range result.Records {
+		if record.AgentType != awsBedrockAgentType {
+			t.Fatalf("expected bedrock_agent type, got %q", record.AgentType)
+		}
+		if record.AgentNodeID == "" || record.EvidenceRef == "" || record.NextAction == "" {
+			t.Fatalf("record missing required fields: %+v", record)
+		}
+		if record.Service != awsBedrockAgentsServiceName {
+			t.Fatalf("expected service=%q, got %q", awsBedrockAgentsServiceName, record.Service)
+		}
+	}
+}
+
+func TestGetAWSBedrockAgentsInventoryFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 9, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	byAgent, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", AgentID: "PAYMENTSAGENT1"})
+	if err != nil {
+		t.Fatalf("filter by agent_id: %v", err)
+	}
+	if byAgent.FilteredAgentCount != 1 || byAgent.AgentCount != 2 {
+		t.Fatalf("expected 1 filtered agent of 2 total, got %+v", byAgent)
+	}
+
+	byIdentity, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", Identity: "support"})
+	if err != nil {
+		t.Fatalf("filter by identity: %v", err)
+	}
+	if byIdentity.FilteredAgentCount != 1 {
+		t.Fatalf("expected 1 identity match, got %d", byIdentity.FilteredAgentCount)
+	}
+
+	byProvider, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", Provider: "amazon-bedrock"})
+	if err != nil {
+		t.Fatalf("filter by provider: %v", err)
+	}
+	if byProvider.FilteredAgentCount != 2 {
+		t.Fatalf("expected all 2 records to match amazon-bedrock provider, got %d", byProvider.FilteredAgentCount)
+	}
+
+	if _, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", Provider: "bogus"}); err == nil {
+		t.Fatalf("expected invalid provider error")
+	}
+}
+
+func TestGetAWSBedrockAgentsInventoryFixtureStates(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	empty, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.AgentCount != 0 || empty.Status != awsPlatformDependencyStatusReady {
+		t.Fatalf("expected ready+empty, got %+v", empty)
+	}
+	if len(empty.Records) != 0 {
+		t.Fatalf("expected zero records, got %+v", empty.Records)
+	}
+
+	degraded, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded"})
+	if err != nil {
+		t.Fatalf("degraded: %v", err)
+	}
+	if degraded.Status != awsPlatformDependencyStatusDegraded || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded with diagnostics, got %+v", degraded)
+	}
+	degradedRecord := false
+	for _, rec := range degraded.Records {
+		if rec.CoverageStatus == "degraded" {
+			degradedRecord = true
+			break
+		}
+	}
+	if !degradedRecord {
+		t.Fatalf("expected at least one degraded record")
+	}
+
+	partial, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("partial_failure: %v", err)
+	}
+	if partial.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded for partial_failure, got %q", partial.Status)
+	}
+	if len(partial.Diagnostics) == 0 {
+		t.Fatalf("expected partial failure diagnostics")
+	}
+
+	denied, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("permission_denied: %v", err)
+	}
+	if denied.Status != awsPlatformDependencyStatusBlocked || denied.AgentCount != 0 {
+		t.Fatalf("expected blocked + empty, got %+v", denied)
+	}
+}
+
+func TestGetAWSBedrockAgentsInventoryNeverLeaksValues(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 10, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	result, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// Walk records + relationships only (the gap descriptions deliberately use
+	// the word "prompt" to document what is intentionally not collected).
+	recordsPayload, _ := json.Marshal(result.Records)
+	relPayload, _ := json.Marshal(result.Relationships)
+	combined := strings.ToLower(string(recordsPayload) + string(relPayload))
+	for _, forbidden := range []string{"prompt_text", "instruction_text", "completion_text", "secret_value", "embedding_vector", "memory_content"} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("metadata-only contract violated: %q present in %s%s", forbidden, recordsPayload, relPayload)
+		}
+	}
+}
+
+func TestRouterAWSBedrockAgentsInventory(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 11, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-1", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/bedrock-agents?connector_id=aws-prod&fixture_state=partial_failure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Inventory AWSBedrockAgentsInventoryResult `json:"inventory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Inventory.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded, got %+v", body.Inventory)
+	}
+
+	for _, query := range []string{"fixture_state=bogus", "provider=bogus"} {
+		bad := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-1/aws/bedrock-agents?connector_id=aws-prod&"+query, "")
+		if bad.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %q, got %d body=%s", query, bad.Code, bad.Body.String())
+		}
+	}
+}

--- a/internal/api/aws_bedrock_agents_test.go
+++ b/internal/api/aws_bedrock_agents_test.go
@@ -154,6 +154,51 @@ func TestGetAWSBedrockAgentsInventoryFixtureStates(t *testing.T) {
 	}
 }
 
+func TestGetAWSBedrockAgentsInventoryRelationshipsRespectFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 9, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	filtered, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", AgentID: "PAYMENTSAGENT1"})
+	if err != nil {
+		t.Fatalf("filter by agent_id: %v", err)
+	}
+	if filtered.FilteredAgentCount != 1 {
+		t.Fatalf("expected one filtered agent, got %d", filtered.FilteredAgentCount)
+	}
+	allowedAgentNodes := map[string]struct{}{}
+	for _, rec := range filtered.Records {
+		allowedAgentNodes[rec.AgentNodeID] = struct{}{}
+	}
+	for _, rel := range filtered.Relationships {
+		if _, ok := allowedAgentNodes[rel.FromNodeID]; !ok {
+			t.Fatalf("relationship %+v leaks edge anchored at non-matching agent (allowed=%v)", rel, allowedAgentNodes)
+		}
+	}
+}
+
+func TestGetAWSBedrockAgentsInventoryToolCountMatchesToolNames(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 9, 50, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	result, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	for _, record := range result.Records {
+		if record.ToolCount != len(record.ToolNames) {
+			t.Fatalf("agent %s tool_count=%d, len(tool_names)=%d; counts must match after dedup", record.AgentID, record.ToolCount, len(record.ToolNames))
+		}
+	}
+}
+
 func TestGetAWSBedrockAgentsInventoryNeverLeaksValues(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_bedrock_agents_test.go
+++ b/internal/api/aws_bedrock_agents_test.go
@@ -154,6 +154,95 @@ func TestGetAWSBedrockAgentsInventoryFixtureStates(t *testing.T) {
 	}
 }
 
+func TestGetAWSBedrockAgentsRuntimeRoleNodeIDUsesCanonicalIdentityPrefix(t *testing.T) {
+	// Runs_with_role edges must point at the same identity node id every other
+	// AWS endpoint emits via awsIdentityNodeIDForAPI; otherwise UI graph joins
+	// silently miss.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 11, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	result, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(result.Records) == 0 {
+		t.Fatalf("expected records")
+	}
+	for _, record := range result.Records {
+		if record.RuntimeRoleARN == "" {
+			continue
+		}
+		expected := awsIdentityNodeIDForAPI(record.RuntimeRoleARN)
+		if record.RuntimeRoleNodeID != expected {
+			t.Fatalf("record %s runtime_role_node_id=%q, want %q (canonical aws:identity: prefix)", record.AgentID, record.RuntimeRoleNodeID, expected)
+		}
+		if !strings.HasPrefix(record.RuntimeRoleNodeID, "aws:identity:") {
+			t.Fatalf("record %s runtime_role_node_id must start with aws:identity:, got %q", record.AgentID, record.RuntimeRoleNodeID)
+		}
+	}
+	// And the relationship edge from runs_with_role uses the same node id so
+	// the UI graph join lands on the IAM identity node, not an orphan resource.
+	for _, rel := range result.Relationships {
+		if rel.Type != "runs_with_role" {
+			continue
+		}
+		if !strings.HasPrefix(rel.ToNodeID, "aws:identity:") {
+			t.Fatalf("runs_with_role edge to_node_id must start with aws:identity:, got %q", rel.ToNodeID)
+		}
+	}
+}
+
+func TestGetAWSBedrockAgentsInventoryDiagnosticsScopedToFilteredRecords(t *testing.T) {
+	// When a filter narrows records, per-agent diagnostics for agents that
+	// were excluded must drop out so the response does not report unrelated
+	// failures. Scan-wide diagnostics (no SourceID) stay included.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 11, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := newBedrockAgentsService(t, store, now)
+
+	// Degraded fixture has a SUPPORTAGENT2 diagnostic. Filtering to the healthy
+	// PAYMENTSAGENT1 must drop it.
+	scoped, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "degraded", AgentID: "PAYMENTSAGENT1"})
+	if err != nil {
+		t.Fatalf("get scoped: %v", err)
+	}
+	if scoped.FilteredAgentCount != 1 {
+		t.Fatalf("expected 1 filtered agent, got %d", scoped.FilteredAgentCount)
+	}
+	for _, diag := range scoped.Diagnostics {
+		if diag.SourceID == "SUPPORTAGENT2" {
+			t.Fatalf("diagnostic for filtered-out agent SUPPORTAGENT2 leaked into scoped response: %+v", diag)
+		}
+	}
+	// And the response-level status should reflect the surviving records, not
+	// the dropped ones — PAYMENTSAGENT1 is healthy so status drops back to ready.
+	if scoped.Status != awsPlatformDependencyStatusReady {
+		t.Fatalf("expected ready status when filter retains only healthy records, got %q (failures=%v)", scoped.Status, scoped.FailureReasons)
+	}
+
+	// Inventory-wide aggregate counts still show the full inventory totals.
+	if scoped.AgentCount != 2 || scoped.GuardrailCount == 0 {
+		t.Fatalf("aggregate counts must stay inventory-wide for dashboard sanity, got %+v", scoped)
+	}
+
+	// A scan-wide diagnostic (no SourceID, or a non-agent SourceID) must stay
+	// visible even under a narrowing filter.
+	denied, err := svc.GetAWSBedrockAgentsInventory(ctx, "default", "project-a", AWSBedrockAgentsInventoryRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied", AgentID: "PAYMENTSAGENT1"})
+	if err != nil {
+		t.Fatalf("get denied: %v", err)
+	}
+	if len(denied.Diagnostics) == 0 {
+		t.Fatalf("scan-wide permission_denied diagnostic must remain visible even when records filter narrows to zero")
+	}
+}
+
 func TestGetAWSBedrockAgentsInventoryRelationshipsRespectFilters(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2792,6 +2792,37 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSBedrockAgentsInventory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSBedrockAgentsInventoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AgentID:      strings.TrimSpace(c.Query("agent_id")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			Provider:     strings.TrimSpace(c.Query("provider")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws bedrock agents request"})
+			default:
+				logger.Error("get aws bedrock agents inventory",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws bedrock agents inventory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"inventory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/providers/aws/bedrock_agents_collector.go
+++ b/internal/providers/aws/bedrock_agents_collector.go
@@ -1,0 +1,478 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	bedrockAgentsCollectorName = "bedrock_agents"
+	bedrockAgentsServiceName   = "bedrock"
+	bedrockAgentType           = "bedrock_agent"
+	bedrockAgentNodeID         = "aws:resource:bedrock-agent:"
+)
+
+// BedrockAgentSummary is the minimal identity row returned by ListAgents. The
+// summary is intentionally narrow: prompts, instructions, embedded model
+// arguments, and any large operator-authored configuration text are never
+// captured.
+type BedrockAgentSummary struct {
+	AgentID                     string            `json:"agent_id"`
+	AgentARN                    string            `json:"agent_arn,omitempty"`
+	AgentName                   string            `json:"agent_name"`
+	AgentStatus                 string            `json:"agent_status,omitempty"`
+	AgentVersion                string            `json:"agent_version,omitempty"`
+	FoundationModel             string            `json:"foundation_model,omitempty"`
+	RoleARN                     string            `json:"role_arn,omitempty"`
+	GuardrailID                 string            `json:"guardrail_id,omitempty"`
+	GuardrailVersion            string            `json:"guardrail_version,omitempty"`
+	CustomerEncryptionKMSKeyARN string            `json:"customer_encryption_kms_key_arn,omitempty"`
+	UpdatedAt                   *time.Time        `json:"updated_at,omitempty"`
+	Tags                        map[string]string `json:"tags,omitempty"`
+}
+
+// BedrockAgentDetail captures the agent's action groups, knowledge base
+// references, alias names, and (metadata-only) capability indicators. It never
+// stores instruction text, prompt overrides, action-group OpenAPI bodies, or
+// Lambda payloads.
+type BedrockAgentDetail struct {
+	ActionGroupNames        []string `json:"action_group_names,omitempty"`
+	ActionGroupExecutorARNs []string `json:"action_group_executor_arns,omitempty"`
+	KnowledgeBaseIDs        []string `json:"knowledge_base_ids,omitempty"`
+	AliasNames              []string `json:"alias_names,omitempty"`
+	AliasARNs               []string `json:"alias_arns,omitempty"`
+	HasInstruction          bool     `json:"has_instruction"`
+	HasPromptOverride       bool     `json:"has_prompt_override"`
+}
+
+// BedrockAgentsPage is one page of paginated agent identities.
+type BedrockAgentsPage struct {
+	Agents      []BedrockAgentSummary
+	NextToken   string
+	Diagnostics []providers.SourceError
+}
+
+// BedrockAgentsAPI is the metadata-only Bedrock Agents surface the collector
+// consumes. The interface is small and read-only so adapters (the SDK shim,
+// fixtures, and tests) can implement it without pulling in additional AWS
+// permissions or coupling the collector to the AWS SDK.
+type BedrockAgentsAPI interface {
+	ListAgents(ctx context.Context, nextToken string, pageSize int32) (BedrockAgentsPage, error)
+	GetAgentDetail(ctx context.Context, agentID string) (BedrockAgentDetail, []providers.SourceError, error)
+}
+
+// BedrockAgentsCollector emits AI agent identity records for AWS Bedrock-hosted
+// agents. It is bounded, retryable, deduplicating, and emits explicit
+// per-source diagnostics for partial failure so downstream pipelines can
+// distinguish empty-but-authorized results from incomplete data.
+type BedrockAgentsCollector struct {
+	client   BedrockAgentsAPI
+	pageSize int32
+	maxPages int
+	retry    RetryPolicy
+	jitter   float64
+	sleep    Sleeper
+	randFn   func() float64
+	now      func() time.Time
+}
+
+// BedrockAgentsOption customizes BedrockAgentsCollector behavior.
+type BedrockAgentsOption func(*BedrockAgentsCollector)
+
+// WithBedrockAgentsPageSize configures agent list pagination size.
+func WithBedrockAgentsPageSize(pageSize int32) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if pageSize > 0 {
+			c.pageSize = pageSize
+		}
+	}
+}
+
+// WithBedrockAgentsMaxPages limits paginations to guard against runaways.
+func WithBedrockAgentsMaxPages(maxPages int) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if maxPages > 0 {
+			c.maxPages = maxPages
+		}
+	}
+}
+
+// WithBedrockAgentsRetryPolicy customizes retry strategy for transient errors.
+func WithBedrockAgentsRetryPolicy(policy RetryPolicy) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if policy.MaxRetries >= 0 {
+			c.retry.MaxRetries = policy.MaxRetries
+		}
+		if policy.BaseDelay > 0 {
+			c.retry.BaseDelay = policy.BaseDelay
+		}
+		if policy.MaxDelay > 0 {
+			c.retry.MaxDelay = policy.MaxDelay
+		}
+	}
+}
+
+// WithBedrockAgentsRetryJitterRatio configures jitter around retry backoff.
+func WithBedrockAgentsRetryJitterRatio(ratio float64) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if ratio < 0 {
+			ratio = 0
+		}
+		c.jitter = ratio
+	}
+}
+
+// WithBedrockAgentsSleeper injects a Sleeper (test seam).
+func WithBedrockAgentsSleeper(s Sleeper) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if s != nil {
+			c.sleep = s
+		}
+	}
+}
+
+// WithBedrockAgentsRandFn injects deterministic randomness (test seam).
+func WithBedrockAgentsRandFn(randFn func() float64) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if randFn != nil {
+			c.randFn = randFn
+		}
+	}
+}
+
+// WithBedrockAgentsClock injects deterministic time for tests.
+func WithBedrockAgentsClock(now func() time.Time) BedrockAgentsOption {
+	return func(c *BedrockAgentsCollector) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// NewBedrockAgentsCollector constructs a Bedrock Agents collector.
+func NewBedrockAgentsCollector(client BedrockAgentsAPI, opts ...BedrockAgentsOption) *BedrockAgentsCollector {
+	c := &BedrockAgentsCollector{
+		client:   client,
+		pageSize: defaultPageSize,
+		maxPages: defaultMaxPages,
+		retry: RetryPolicy{
+			MaxRetries: defaultRetryCount,
+			BaseDelay:  defaultBaseDelay,
+			MaxDelay:   defaultMaxDelay,
+		},
+		jitter: defaultRetryJitterRatio,
+		sleep:  defaultSleeper,
+		randFn: rand.Float64,
+		now:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ServiceName returns the service identifier for diagnostics and partial
+// failure scoping.
+func (c *BedrockAgentsCollector) ServiceName() string {
+	return bedrockAgentsServiceName
+}
+
+// Collect runs the collector without an explicit scope.
+func (c *BedrockAgentsCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx, AWSCollectorScope{Service: bedrockAgentsServiceName})
+	return assets, err
+}
+
+// CollectWithDiagnostics enumerates Bedrock agents, captures their detail, and
+// emits one AIAgentIdentity raw asset per agent. Per-agent detail failures are
+// reported as partial failures so the overall run can succeed with surviving
+// agents while operators see exactly which agents lack full evidence.
+func (c *BedrockAgentsCollector) CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c.client == nil {
+		return nil, nil, errors.New("bedrock agents collector requires client")
+	}
+	if strings.TrimSpace(scope.Service) == "" {
+		scope.Service = c.ServiceName()
+	}
+	collectedAt := c.now().UTC()
+	assets := []providers.RawAsset{}
+	issues := []providers.SourceError{}
+	seen := map[string]struct{}{}
+
+	addIssue := func(issue providers.SourceError) {
+		if strings.TrimSpace(issue.Code) == "" || strings.TrimSpace(issue.Message) == "" {
+			return
+		}
+		issues = append(issues, issue)
+	}
+
+	nextToken := ""
+	for page := 1; ; page++ {
+		if page > c.maxPages {
+			addIssue(providers.SourceError{
+				Collector: bedrockAgentsCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "bedrock_agents_page_limit_exceeded",
+				Message:   fmt.Sprintf("bedrock agent collection exceeded max pages (%d)", c.maxPages),
+				Retryable: false,
+			})
+			return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("bedrock agent collection exceeded max pages (%d)", c.maxPages)
+		}
+		listResp, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (BedrockAgentsPage, error) {
+			return c.client.ListAgents(callCtx, nextToken, c.pageSize)
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("list bedrock agents page %d: %w", page, err)
+			addIssue(providers.SourceError{
+				Collector: bedrockAgentsCollectorName,
+				SourceID:  firstNonEmptyAWSValue(nextToken, "page"),
+				Code:      "bedrock_agents_list_failed",
+				Message:   wrapped.Error(),
+				Retryable: isRetryable(err),
+			})
+			snapshot := append([]providers.SourceError(nil), issues...)
+			if len(assets) > 0 {
+				return assets, snapshot, wrapped
+			}
+			return nil, snapshot, wrapped
+		}
+		for _, diagnostic := range listResp.Diagnostics {
+			addIssue(diagnostic)
+		}
+		for _, summary := range listResp.Agents {
+			if strings.TrimSpace(summary.AgentID) == "" && strings.TrimSpace(summary.AgentARN) == "" {
+				addIssue(providers.SourceError{
+					Collector: bedrockAgentsCollectorName,
+					Code:      "malformed_bedrock_agent",
+					Message:   "skipped bedrock agent without a stable identifier",
+					Retryable: false,
+				})
+				continue
+			}
+			detail, detailIssues, detailErr := c.getDetailWithRetry(ctx, summary.AgentID)
+			for _, diagnostic := range detailIssues {
+				addIssue(diagnostic)
+			}
+			if detailErr != nil {
+				addIssue(providers.SourceError{
+					Collector: bedrockAgentsCollectorName,
+					SourceID:  summary.AgentID,
+					Code:      "bedrock_agent_detail_failed",
+					Message:   fmt.Sprintf("agent %s detail fetch failed: %v", summary.AgentID, detailErr),
+					Retryable: isRetryable(detailErr),
+				})
+			}
+			record := buildBedrockAgentIdentity(scope, summary, detail, detailErr, collectedAt)
+			sourceID := aiAgentIdentitySourceID(record)
+			if _, exists := seen[sourceID]; exists {
+				continue
+			}
+			payload, marshalErr := json.Marshal(record)
+			if marshalErr != nil {
+				return assets, append([]providers.SourceError(nil), issues...), fmt.Errorf("marshal bedrock agent %s: %w", sourceID, marshalErr)
+			}
+			assets = append(assets, providers.RawAsset{
+				Kind:      rawKindAIAgentIdentity,
+				SourceID:  sourceID,
+				Payload:   payload,
+				Collected: collectedAt.Format(time.RFC3339Nano),
+			})
+			seen[sourceID] = struct{}{}
+		}
+		if strings.TrimSpace(listResp.NextToken) == "" {
+			break
+		}
+		nextToken = listResp.NextToken
+	}
+	return assets, append([]providers.SourceError(nil), issues...), nil
+}
+
+func (c *BedrockAgentsCollector) getDetailWithRetry(ctx context.Context, agentID string) (BedrockAgentDetail, []providers.SourceError, error) {
+	type detailResult struct {
+		detail BedrockAgentDetail
+		issues []providers.SourceError
+	}
+	result, err := retryAWSPage(ctx, c.retry, c.jitter, c.randFn, c.sleep, func(callCtx context.Context) (detailResult, error) {
+		detail, issues, err := c.client.GetAgentDetail(callCtx, agentID)
+		return detailResult{detail: detail, issues: issues}, err
+	})
+	return result.detail, result.issues, err
+}
+
+// buildBedrockAgentIdentity composes the metadata-only AIAgentIdentity record
+// the AI agent identity model already understands. Provider, capabilities, and
+// confidence are derived deterministically from the summary + detail.
+func buildBedrockAgentIdentity(scope AWSCollectorScope, summary BedrockAgentSummary, detail BedrockAgentDetail, detailErr error, collectedAt time.Time) AIAgentIdentity {
+	roleARN := strings.TrimSpace(summary.RoleARN)
+	record := AIAgentIdentity{
+		AgentID:                 summary.AgentID,
+		AgentARN:                summary.AgentARN,
+		AgentName:               firstNonEmptyAWSValue(summary.AgentName, summary.AgentID),
+		AgentType:               bedrockAgentType,
+		Provider:                "amazon-bedrock",
+		ModelID:                 strings.TrimSpace(summary.FoundationModel),
+		RuntimeRoleARN:          roleARN,
+		RuntimeRoleName:         roleNameFromARN(roleARN),
+		RuntimeRoleAccountID:    roleAccountIDFromARN(roleARN),
+		ToolNames:               dedupeAndSortStrings(detail.ActionGroupNames),
+		MemoryEnabled:           len(detail.KnowledgeBaseIDs) > 0,
+		MemoryStoreRefs:         dedupeAndSortStrings(prefixKnowledgeBaseRefs(detail.KnowledgeBaseIDs)),
+		BrowserEnabled:          false,
+		CodeInterpreterEnabled:  false,
+		CapabilityNames:         bedrockAgentCapabilityNames(detail, summary),
+		CredentialReferenceRefs: dedupeAndSortStrings(bedrockAgentCredentialRefs(detail.ActionGroupExecutorARNs, summary.CustomerEncryptionKMSKeyARN)),
+		SensitiveBoundary:       "metadata_only",
+		CoverageStatus:          "covered",
+		Status:                  bedrockAgentStatus(summary.AgentStatus),
+		Tags:                    copyTags(summary.Tags),
+	}
+	record.ToolCount = len(record.ToolNames)
+	record.ServiceCollectorRecord = awscontract.ServiceCollectorRecord{
+		TenantID:      scope.TenantID,
+		WorkspaceID:   scope.WorkspaceID,
+		ProjectID:     scope.ProjectID,
+		ConnectorID:   scope.ConnectorID,
+		ScanID:        scope.ScanID,
+		AccountID:     firstNonEmptyAWSValue(scope.AccountID),
+		Region:        firstNonEmptyAWSValue(scope.Region),
+		Service:       bedrockAgentsServiceName,
+		WorkloadID:    firstNonEmptyAWSValue(summary.AgentARN, summary.AgentID),
+		WorkloadName:  record.AgentName,
+		WorkloadType:  bedrockAgentType,
+		RoleARN:       roleARN,
+		Source:        "bedrock_agent_metadata",
+		EvidenceRef:   firstNonEmptyAWSValue(summary.AgentARN, summary.AgentID),
+		CollectorName: bedrockAgentsCollectorName,
+		CollectedAt:   collectedAt,
+	}
+	if detailErr != nil {
+		record.CoverageStatus = "degraded"
+		record.CoverageReason = "bedrock agent detail fetch failed; surfaced summary only"
+		record.Status = "degraded"
+	}
+	if len(detail.AliasNames) > 0 {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "aliases")
+	}
+	if detail.HasPromptOverride {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "prompt_override_configured")
+	}
+	if detail.HasInstruction {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "instruction_configured")
+	}
+	if strings.TrimSpace(summary.GuardrailID) != "" {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "guardrail")
+	}
+	sort.Strings(record.CapabilityNames)
+	if record.Confidence <= 0 {
+		record.Confidence = aiAgentIdentityConfidence(record)
+	}
+	return record
+}
+
+func bedrockAgentCapabilityNames(detail BedrockAgentDetail, summary BedrockAgentSummary) []string {
+	caps := []string{}
+	if len(detail.ActionGroupNames) > 0 {
+		caps = append(caps, "tool_use")
+	}
+	if len(detail.KnowledgeBaseIDs) > 0 {
+		caps = append(caps, "knowledge_base")
+	}
+	if strings.TrimSpace(summary.CustomerEncryptionKMSKeyARN) != "" {
+		caps = append(caps, "customer_encryption_kms")
+	}
+	if strings.TrimSpace(summary.FoundationModel) != "" {
+		caps = append(caps, "foundation_model")
+	}
+	return dedupeAndSortStrings(caps)
+}
+
+func bedrockAgentCredentialRefs(executorARNs []string, kmsKeyARN string) []string {
+	refs := make([]string, 0, len(executorARNs)+1)
+	for _, executor := range executorARNs {
+		ref := strings.TrimSpace(executor)
+		if ref == "" {
+			continue
+		}
+		refs = append(refs, "action_group_executor:"+ref)
+	}
+	if trimmed := strings.TrimSpace(kmsKeyARN); trimmed != "" {
+		refs = append(refs, "kms:"+trimmed)
+	}
+	return refs
+}
+
+func bedrockAgentStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch normalized {
+	case "":
+		return "ready"
+	case "prepared", "ready":
+		return "ready"
+	case "preparing", "updating", "versioning":
+		return "preparing"
+	case "deleting":
+		return "deleting"
+	case "failed":
+		return "failed"
+	case "not_prepared":
+		return "not_prepared"
+	default:
+		return normalized
+	}
+}
+
+func prefixKnowledgeBaseRefs(ids []string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, "bedrock-knowledge-base/"+trimmed)
+	}
+	return out
+}
+
+func dedupeAndSortStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func appendUnique(values []string, candidate string) []string {
+	for _, existing := range values {
+		if existing == candidate {
+			return values
+		}
+	}
+	return append(values, candidate)
+}
+
+// bedrockAgentNodeIDFor returns the canonical graph node ID for a Bedrock agent.
+func bedrockAgentNodeIDFor(record AIAgentIdentity) string {
+	return bedrockAgentNodeID + firstNonEmptyAWSValue(record.AgentARN, record.AgentID)
+}

--- a/internal/providers/aws/bedrock_agents_collector.go
+++ b/internal/providers/aws/bedrock_agents_collector.go
@@ -18,8 +18,13 @@ const (
 	bedrockAgentsCollectorName = "bedrock_agents"
 	bedrockAgentsServiceName   = "bedrock"
 	bedrockAgentType           = "bedrock_agent"
-	bedrockAgentNodeID         = "aws:resource:bedrock-agent:"
 )
+
+// errBedrockAgentDetailSkipped marks a summary whose detail fetch was
+// intentionally skipped (for example an ARN-only summary). It is used to flip
+// the coverage_status onto the degraded path without producing a misleading
+// "GetAgent("") failed" diagnostic.
+var errBedrockAgentDetailSkipped = errors.New("bedrock agent detail skipped: missing agent id")
 
 // BedrockAgentSummary is the minimal identity row returned by ListAgents. The
 // summary is intentionally narrow: prompts, instructions, embedded model
@@ -258,18 +263,41 @@ func (c *BedrockAgentsCollector) CollectWithDiagnostics(ctx context.Context, sco
 				})
 				continue
 			}
-			detail, detailIssues, detailErr := c.getDetailWithRetry(ctx, summary.AgentID)
-			for _, diagnostic := range detailIssues {
-				addIssue(diagnostic)
-			}
-			if detailErr != nil {
+			// GetAgentDetail requires the AgentID (the short identifier AWS uses
+			// in the Bedrock control plane); calling it with an empty id would
+			// produce a misleading per-agent diagnostic. ARN-only summaries are
+			// kept as partial records so operators see the identity but know
+			// detail evidence is missing until a follow-up list call returns a
+			// proper id.
+			var (
+				detail    BedrockAgentDetail
+				detailErr error
+				agentID   = strings.TrimSpace(summary.AgentID)
+			)
+			if agentID == "" {
 				addIssue(providers.SourceError{
 					Collector: bedrockAgentsCollectorName,
-					SourceID:  summary.AgentID,
-					Code:      "bedrock_agent_detail_failed",
-					Message:   fmt.Sprintf("agent %s detail fetch failed: %v", summary.AgentID, detailErr),
-					Retryable: isRetryable(detailErr),
+					SourceID:  strings.TrimSpace(summary.AgentARN),
+					Code:      "bedrock_agent_detail_skipped_missing_id",
+					Message:   "skipped GetAgentDetail for ARN-only bedrock agent summary; surfaced summary only",
+					Retryable: true,
 				})
+				detailErr = errBedrockAgentDetailSkipped
+			} else {
+				var detailIssues []providers.SourceError
+				detail, detailIssues, detailErr = c.getDetailWithRetry(ctx, agentID)
+				for _, diagnostic := range detailIssues {
+					addIssue(diagnostic)
+				}
+				if detailErr != nil {
+					addIssue(providers.SourceError{
+						Collector: bedrockAgentsCollectorName,
+						SourceID:  agentID,
+						Code:      "bedrock_agent_detail_failed",
+						Message:   fmt.Sprintf("agent %s detail fetch failed: %v", agentID, detailErr),
+						Retryable: isRetryable(detailErr),
+					})
+				}
 			}
 			record := buildBedrockAgentIdentity(scope, summary, detail, detailErr, collectedAt)
 			sourceID := aiAgentIdentitySourceID(record)
@@ -470,9 +498,4 @@ func appendUnique(values []string, candidate string) []string {
 		}
 	}
 	return append(values, candidate)
-}
-
-// bedrockAgentNodeIDFor returns the canonical graph node ID for a Bedrock agent.
-func bedrockAgentNodeIDFor(record AIAgentIdentity) string {
-	return bedrockAgentNodeID + firstNonEmptyAWSValue(record.AgentARN, record.AgentID)
 }

--- a/internal/providers/aws/bedrock_agents_collector.go
+++ b/internal/providers/aws/bedrock_agents_collector.go
@@ -25,6 +25,7 @@ const (
 // the coverage_status onto the degraded path without producing a misleading
 // "GetAgent("") failed" diagnostic.
 var errBedrockAgentDetailSkipped = errors.New("bedrock agent detail skipped: missing agent id")
+var errBedrockAgentDetailIncomplete = errors.New("bedrock agent detail returned diagnostics")
 
 // BedrockAgentSummary is the minimal identity row returned by ListAgents. The
 // summary is intentionally narrow: prompts, instructions, embedded model
@@ -289,13 +290,29 @@ func (c *BedrockAgentsCollector) CollectWithDiagnostics(ctx context.Context, sco
 				for _, diagnostic := range detailIssues {
 					addIssue(diagnostic)
 				}
-				if detailErr != nil {
+				// Adapters may return diagnostics with a nil error (for example a
+				// fixture flagging "not seeded" or an SDK adapter that returned a
+				// partial response). Treat that as incomplete evidence so the
+				// emitted record is degraded rather than appearing authoritative,
+				// but keep it separate from a hard failure so operators can
+				// distinguish retry-worthy partial detail from a fatal denial.
+				switch {
+				case detailErr != nil:
 					addIssue(providers.SourceError{
 						Collector: bedrockAgentsCollectorName,
 						SourceID:  agentID,
 						Code:      "bedrock_agent_detail_failed",
 						Message:   fmt.Sprintf("agent %s detail fetch failed: %v", agentID, detailErr),
 						Retryable: isRetryable(detailErr),
+					})
+				case len(detailIssues) > 0:
+					detailErr = errBedrockAgentDetailIncomplete
+					addIssue(providers.SourceError{
+						Collector: bedrockAgentsCollectorName,
+						SourceID:  agentID,
+						Code:      "bedrock_agent_detail_incomplete",
+						Message:   fmt.Sprintf("agent %s detail returned diagnostics; surfaced summary only", agentID),
+						Retryable: true,
 					})
 				}
 			}
@@ -384,8 +401,15 @@ func buildBedrockAgentIdentity(scope AWSCollectorScope, summary BedrockAgentSumm
 	}
 	if detailErr != nil {
 		record.CoverageStatus = "degraded"
-		record.CoverageReason = "bedrock agent detail fetch failed; surfaced summary only"
 		record.Status = "degraded"
+		switch {
+		case errors.Is(detailErr, errBedrockAgentDetailSkipped):
+			record.CoverageReason = "bedrock agent detail skipped: ARN-only summary; surfaced summary only"
+		case errors.Is(detailErr, errBedrockAgentDetailIncomplete):
+			record.CoverageReason = "bedrock agent detail returned diagnostics without a hard failure; surfaced summary only"
+		default:
+			record.CoverageReason = "bedrock agent detail fetch failed; surfaced summary only"
+		}
 	}
 	if len(detail.AliasNames) > 0 {
 		record.CapabilityNames = appendUnique(record.CapabilityNames, "aliases")

--- a/internal/providers/aws/bedrock_agents_collector_test.go
+++ b/internal/providers/aws/bedrock_agents_collector_test.go
@@ -201,6 +201,55 @@ func TestBedrockAgentsCollectorPartialFailureWhenDetailFails(t *testing.T) {
 	}
 }
 
+func TestBedrockAgentsCollectorDegradesWhenDetailIssuesReturned(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{
+					AgentID:                     "UNSEEDED",
+					AgentARN:                    "arn:aws:bedrock:us-east-1:123456789012:agent/UNSEEDED",
+					AgentName:                   "unseeded",
+					RoleARN:                     "arn:aws:iam::123456789012:role/unseeded",
+					FoundationModel:             "anthropic.claude-3-5-sonnet-20240620-v1:0",
+					CustomerEncryptionKMSKeyARN: "arn:aws:kms:us-east-1:123456789012:key/cmk-1",
+				},
+			},
+		}},
+		detailIssues: map[string][]providers.SourceError{
+			"UNSEEDED": {
+				{
+					Collector: bedrockAgentsCollectorName,
+					SourceID:  "UNSEEDED",
+					Code:      "bedrock_agent_detail_not_seeded",
+					Message:   "no fixture detail seeded for agent",
+					Retryable: true,
+				},
+			},
+		},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one asset, got %d", len(assets))
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_not_seeded") {
+		t.Fatalf("expected detail diagnostic, got %v", issues)
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if record.CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded coverage when detail diagnostics are returned, got %+v", record)
+	}
+	if record.Status != "degraded" {
+		t.Fatalf("expected degraded status when detail diagnostics are returned, got %+v", record)
+	}
+}
+
 func TestBedrockAgentsCollectorPaginationDedup(t *testing.T) {
 	api := &fakeBedrockAgentsAPI{
 		pages: []BedrockAgentsPage{
@@ -256,6 +305,51 @@ func TestBedrockAgentsCollectorListFailureSurfaces(t *testing.T) {
 	}
 	if !hasIssueCode(issues, "bedrock_agents_list_failed") {
 		t.Fatalf("expected list-failure diagnostic, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorDegradesOnDetailDiagnosticsWithoutError(t *testing.T) {
+	// When the detail adapter returns soft diagnostics with a nil error (for
+	// example a fixture flagging "not seeded" or a partial SDK response), the
+	// emitted record must be degraded and the emitted diagnostic must use the
+	// dedicated "incomplete" code so operators can distinguish it from a hard
+	// detail fetch failure.
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{AgentID: "AG1", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/AG1", AgentName: "agent", RoleARN: "arn:aws:iam::123456789012:role/r"},
+			},
+		}},
+		details: map[string]BedrockAgentDetail{},
+		detailIssues: map[string][]providers.SourceError{
+			"AG1": {{
+				Collector: "bedrock_agents",
+				SourceID:  "AG1",
+				Code:      "bedrock_agent_detail_not_seeded",
+				Message:   "fixture detail not seeded",
+			}},
+		},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one degraded asset, got %d", len(assets))
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if record.CoverageStatus != "degraded" || record.Status != "degraded" {
+		t.Fatalf("expected degraded coverage when detail adapter returns soft diagnostics, got %+v", record)
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_incomplete") {
+		t.Fatalf("expected incomplete diagnostic, got %v", issues)
+	}
+	if hasIssueCode(issues, "bedrock_agent_detail_failed") {
+		t.Fatalf("soft diagnostics must not be reported as detail_failed, got %v", issues)
 	}
 }
 

--- a/internal/providers/aws/bedrock_agents_collector_test.go
+++ b/internal/providers/aws/bedrock_agents_collector_test.go
@@ -1,0 +1,303 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+type fakeBedrockAgentsAPI struct {
+	pages         []BedrockAgentsPage
+	pageCalls     int
+	details       map[string]BedrockAgentDetail
+	detailIssues  map[string][]providers.SourceError
+	detailErr     map[string]error
+	listErr       map[int]error
+	listCallCount int
+}
+
+func (f *fakeBedrockAgentsAPI) ListAgents(_ context.Context, _ string, _ int32) (BedrockAgentsPage, error) {
+	if err, ok := f.listErr[f.listCallCount]; ok {
+		f.listCallCount++
+		return BedrockAgentsPage{}, err
+	}
+	if f.pageCalls >= len(f.pages) {
+		f.listCallCount++
+		return BedrockAgentsPage{}, nil
+	}
+	page := f.pages[f.pageCalls]
+	f.pageCalls++
+	f.listCallCount++
+	return page, nil
+}
+
+func (f *fakeBedrockAgentsAPI) GetAgentDetail(_ context.Context, agentID string) (BedrockAgentDetail, []providers.SourceError, error) {
+	if err, ok := f.detailErr[agentID]; ok {
+		return BedrockAgentDetail{}, nil, err
+	}
+	return f.details[agentID], f.detailIssues[agentID], nil
+}
+
+func bedrockSampleScope() AWSCollectorScope {
+	return AWSCollectorScope{
+		TenantID:    "tenant-1",
+		WorkspaceID: "ws-1",
+		ProjectID:   "proj-1",
+		ConnectorID: "conn-1",
+		ScanID:      "scan-1",
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+	}
+}
+
+func TestBedrockAgentsCollectorCollectEmitsRecords(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{
+					AgentID:                     "AG1",
+					AgentARN:                    "arn:aws:bedrock:us-east-1:123456789012:agent/AG1",
+					AgentName:                   "support-agent",
+					AgentStatus:                 "PREPARED",
+					FoundationModel:             "anthropic.claude-3-5-sonnet-20240620-v1:0",
+					RoleARN:                     "arn:aws:iam::123456789012:role/bedrock-support",
+					GuardrailID:                 "guard-1",
+					CustomerEncryptionKMSKeyARN: "arn:aws:kms:us-east-1:123456789012:key/cmk-1",
+					Tags:                        map[string]string{"env": "prod"},
+				},
+			},
+		}},
+		details: map[string]BedrockAgentDetail{
+			"AG1": {
+				ActionGroupNames:        []string{"orders-tool", "refunds-tool"},
+				ActionGroupExecutorARNs: []string{"arn:aws:lambda:us-east-1:123456789012:function:agent-exec"},
+				KnowledgeBaseIDs:        []string{"KB1", "KB2"},
+				AliasNames:              []string{"production"},
+				HasInstruction:          true,
+				HasPromptOverride:       true,
+			},
+		},
+	}
+	collector := NewBedrockAgentsCollector(api,
+		WithBedrockAgentsClock(func() time.Time { return time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC) }),
+	)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected 1 asset, got %d", len(assets))
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal asset: %v", err)
+	}
+	if record.AgentType != bedrockAgentType {
+		t.Fatalf("expected bedrock_agent type, got %q", record.AgentType)
+	}
+	if record.Provider != "amazon-bedrock" || record.ModelID == "" {
+		t.Fatalf("provider/model wrong: %+v", record)
+	}
+	if record.ToolCount != 2 {
+		t.Fatalf("expected 2 tools, got %d", record.ToolCount)
+	}
+	if record.RuntimeRoleAccountID != "123456789012" {
+		t.Fatalf("expected runtime role account id, got %q", record.RuntimeRoleAccountID)
+	}
+	wantCaps := map[string]bool{
+		"tool_use": true, "knowledge_base": true, "guardrail": true,
+		"aliases": true, "instruction_configured": true, "prompt_override_configured": true,
+		"foundation_model": true, "customer_encryption_kms": true,
+	}
+	for _, cap := range record.CapabilityNames {
+		delete(wantCaps, cap)
+	}
+	if len(wantCaps) != 0 {
+		t.Fatalf("missing capabilities %v in %v", wantCaps, record.CapabilityNames)
+	}
+	joined := strings.Join(record.CredentialReferenceRefs, ",")
+	if !strings.Contains(joined, "action_group_executor:") || !strings.Contains(joined, "kms:") {
+		t.Fatalf("credential refs missing executor/kms markers: %v", record.CredentialReferenceRefs)
+	}
+	if record.SensitiveBoundary != "metadata_only" {
+		t.Fatalf("sensitive boundary must be metadata_only, got %q", record.SensitiveBoundary)
+	}
+	if record.Status != "ready" || record.CoverageStatus != "covered" {
+		t.Fatalf("status/coverage wrong: %+v", record)
+	}
+	if record.Confidence <= 0 {
+		t.Fatalf("confidence not derived: %v", record.Confidence)
+	}
+}
+
+func TestBedrockAgentsCollectorMetadataOnlyPayload(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{AgentID: "AG1", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/AG1", AgentName: "agent", RoleARN: "arn:aws:iam::123456789012:role/r"},
+			},
+		}},
+		details: map[string]BedrockAgentDetail{"AG1": {ActionGroupNames: []string{"tool-a"}}},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	payload := strings.ToLower(string(assets[0].Payload))
+	for _, forbidden := range []string{"prompt_text", "instruction_text", "completion_text", "secret_value", "message_body", "embedding_vector"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("metadata-only contract violated by %q in payload: %s", forbidden, payload)
+		}
+	}
+}
+
+func TestBedrockAgentsCollectorPartialFailureWhenDetailFails(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{AgentID: "OK", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/OK", AgentName: "ok", RoleARN: "arn:aws:iam::123456789012:role/ok"},
+				{AgentID: "BAD", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/BAD", AgentName: "bad", RoleARN: "arn:aws:iam::123456789012:role/bad"},
+			},
+		}},
+		details:   map[string]BedrockAgentDetail{"OK": {ActionGroupNames: []string{"t"}}},
+		detailErr: map[string]error{"BAD": errors.New("AccessDenied: GetAgent")},
+	}
+	collector := NewBedrockAgentsCollector(api, WithBedrockAgentsRetryPolicy(RetryPolicy{MaxRetries: 0, BaseDelay: 0, MaxDelay: 0}))
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 2 {
+		t.Fatalf("expected 2 assets emitted, got %d", len(assets))
+	}
+	var badRecord AIAgentIdentity
+	for _, asset := range assets {
+		var record AIAgentIdentity
+		if err := json.Unmarshal(asset.Payload, &record); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if record.AgentID == "BAD" {
+			badRecord = record
+		}
+	}
+	if badRecord.CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded coverage on detail failure, got %+v", badRecord)
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_failed") {
+		t.Fatalf("expected partial-failure diagnostic, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorPaginationDedup(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{
+			{
+				Agents: []BedrockAgentSummary{
+					{AgentID: "A", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/A", AgentName: "a", RoleARN: "arn:aws:iam::123456789012:role/a"},
+				},
+				NextToken: "tok",
+			},
+			{
+				Agents: []BedrockAgentSummary{
+					{AgentID: "A", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/A", AgentName: "a-dup", RoleARN: "arn:aws:iam::123456789012:role/a"},
+					{AgentID: "B", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/B", AgentName: "b", RoleARN: "arn:aws:iam::123456789012:role/b"},
+				},
+			},
+		},
+		details: map[string]BedrockAgentDetail{
+			"A": {},
+			"B": {},
+		},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, _, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 2 {
+		t.Fatalf("expected 2 deduped assets, got %d", len(assets))
+	}
+}
+
+func TestBedrockAgentsCollectorEmptyAuthorized(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{pages: []BedrockAgentsPage{{}}}
+	collector := NewBedrockAgentsCollector(api)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("expected no assets, got %d", len(assets))
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorListFailureSurfaces(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{listErr: map[int]error{0: errors.New("AccessDenied: ListAgents")}}
+	collector := NewBedrockAgentsCollector(api, WithBedrockAgentsRetryPolicy(RetryPolicy{MaxRetries: 0, BaseDelay: 0, MaxDelay: 0}))
+	_, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err == nil {
+		t.Fatalf("expected error on list failure")
+	}
+	if !hasIssueCode(issues, "bedrock_agents_list_failed") {
+		t.Fatalf("expected list-failure diagnostic, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorMalformedAgentSkipped(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{{AgentName: "no-id"}},
+		}},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("expected malformed agent to be skipped, got %d", len(assets))
+	}
+	if !hasIssueCode(issues, "malformed_bedrock_agent") {
+		t.Fatalf("expected malformed-agent diagnostic, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorPageLimitGuard(t *testing.T) {
+	pages := []BedrockAgentsPage{}
+	for i := 0; i < 3; i++ {
+		pages = append(pages, BedrockAgentsPage{
+			Agents:    []BedrockAgentSummary{{AgentID: "A", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/A", AgentName: "a", RoleARN: "arn:aws:iam::123456789012:role/a"}},
+			NextToken: "more",
+		})
+	}
+	api := &fakeBedrockAgentsAPI{pages: pages, details: map[string]BedrockAgentDetail{"A": {}}}
+	collector := NewBedrockAgentsCollector(api, WithBedrockAgentsMaxPages(2))
+	_, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err == nil {
+		t.Fatalf("expected error when exceeding max pages")
+	}
+	if !hasIssueCode(issues, "bedrock_agents_page_limit_exceeded") {
+		t.Fatalf("expected page-limit diagnostic, got %v", issues)
+	}
+}
+
+func hasIssueCode(issues []providers.SourceError, code string) bool {
+	for _, issue := range issues {
+		if issue.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/aws/bedrock_agents_collector_test.go
+++ b/internal/providers/aws/bedrock_agents_collector_test.go
@@ -12,13 +12,15 @@ import (
 )
 
 type fakeBedrockAgentsAPI struct {
-	pages         []BedrockAgentsPage
-	pageCalls     int
-	details       map[string]BedrockAgentDetail
-	detailIssues  map[string][]providers.SourceError
-	detailErr     map[string]error
-	listErr       map[int]error
-	listCallCount int
+	pages           []BedrockAgentsPage
+	pageCalls       int
+	details         map[string]BedrockAgentDetail
+	detailIssues    map[string][]providers.SourceError
+	detailErr       map[string]error
+	listErr         map[int]error
+	listCallCount   int
+	detailCallCount int
+	detailCallIDs   []string
 }
 
 func (f *fakeBedrockAgentsAPI) ListAgents(_ context.Context, _ string, _ int32) (BedrockAgentsPage, error) {
@@ -37,6 +39,8 @@ func (f *fakeBedrockAgentsAPI) ListAgents(_ context.Context, _ string, _ int32) 
 }
 
 func (f *fakeBedrockAgentsAPI) GetAgentDetail(_ context.Context, agentID string) (BedrockAgentDetail, []providers.SourceError, error) {
+	f.detailCallCount++
+	f.detailCallIDs = append(f.detailCallIDs, agentID)
 	if err, ok := f.detailErr[agentID]; ok {
 		return BedrockAgentDetail{}, nil, err
 	}
@@ -252,6 +256,44 @@ func TestBedrockAgentsCollectorListFailureSurfaces(t *testing.T) {
 	}
 	if !hasIssueCode(issues, "bedrock_agents_list_failed") {
 		t.Fatalf("expected list-failure diagnostic, got %v", issues)
+	}
+}
+
+func TestBedrockAgentsCollectorARNOnlySummarySkipsDetailFetch(t *testing.T) {
+	// An ARN-only summary must not trigger GetAgentDetail(""); doing so would
+	// produce a misleading per-agent diagnostic. Instead the collector emits a
+	// degraded record with an explicit "detail skipped" diagnostic.
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/ARNONLY", AgentName: "arn-only", RoleARN: "arn:aws:iam::123456789012:role/r"},
+			},
+		}},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, issues, err := collector.CollectWithDiagnostics(context.Background(), bedrockSampleScope())
+	if err != nil {
+		t.Fatalf("CollectWithDiagnostics: %v", err)
+	}
+	if api.detailCallCount != 0 {
+		t.Fatalf("GetAgentDetail must not be invoked for ARN-only summaries (empty AgentID), called %d time(s) with ids=%v", api.detailCallCount, api.detailCallIDs)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one degraded asset, got %d", len(assets))
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if record.CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded coverage for ARN-only summary, got %+v", record)
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_skipped_missing_id") {
+		t.Fatalf("expected detail-skipped diagnostic, got %v", issues)
+	}
+	// And the misleading "GetAgent() failed" diagnostic must not appear.
+	if hasIssueCode(issues, "bedrock_agent_detail_failed") {
+		t.Fatalf("ARN-only summary should not produce a generic detail_failed diagnostic, got %v", issues)
 	}
 }
 

--- a/internal/providers/aws/sdk_bedrock_agents.go
+++ b/internal/providers/aws/sdk_bedrock_agents.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+// FixtureBedrockAgentsAPI is a thin, in-memory implementation of BedrockAgentsAPI
+// used for local dev, demos, and contract tests. It is intentionally separate
+// from the live SDK adapter so deploying Identrail without the live Bedrock SDK
+// stays first-class (some operators want metadata-only fixtures while they
+// stage the live read-only permission grant).
+type FixtureBedrockAgentsAPI struct {
+	mu      sync.RWMutex
+	agents  []BedrockAgentSummary
+	details map[string]BedrockAgentDetail
+}
+
+var _ BedrockAgentsAPI = (*FixtureBedrockAgentsAPI)(nil)
+
+// NewFixtureBedrockAgentsAPI returns an empty fixture-backed Bedrock Agents API.
+func NewFixtureBedrockAgentsAPI() *FixtureBedrockAgentsAPI {
+	return &FixtureBedrockAgentsAPI{details: map[string]BedrockAgentDetail{}}
+}
+
+// Seed replaces the entire fixture state in one atomic update.
+func (f *FixtureBedrockAgentsAPI) Seed(agents []BedrockAgentSummary, details map[string]BedrockAgentDetail) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.agents = append([]BedrockAgentSummary(nil), agents...)
+	f.details = map[string]BedrockAgentDetail{}
+	for id, detail := range details {
+		f.details[id] = detail
+	}
+}
+
+// ListAgents returns one page that exhausts the seeded agents.
+func (f *FixtureBedrockAgentsAPI) ListAgents(_ context.Context, _ string, _ int32) (BedrockAgentsPage, error) {
+	if f == nil {
+		return BedrockAgentsPage{}, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return BedrockAgentsPage{Agents: append([]BedrockAgentSummary(nil), f.agents...)}, nil
+}
+
+// GetAgentDetail returns the seeded detail for an agent. Missing agents return
+// an empty detail plus a soft diagnostic so callers can tell the difference
+// between an authorized empty result and a missing fixture.
+func (f *FixtureBedrockAgentsAPI) GetAgentDetail(_ context.Context, agentID string) (BedrockAgentDetail, []providers.SourceError, error) {
+	if f == nil {
+		return BedrockAgentDetail{}, nil, errors.New("bedrock agents fixture is nil")
+	}
+	id := strings.TrimSpace(agentID)
+	if id == "" {
+		return BedrockAgentDetail{}, []providers.SourceError{{
+			Collector: bedrockAgentsCollectorName,
+			Code:      "bedrock_agent_detail_missing_id",
+			Message:   "GetAgentDetail called without an agent id",
+		}}, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	detail, ok := f.details[id]
+	if !ok {
+		return BedrockAgentDetail{}, []providers.SourceError{{
+			Collector: bedrockAgentsCollectorName,
+			SourceID:  id,
+			Code:      "bedrock_agent_detail_not_seeded",
+			Message:   "no fixture detail seeded for agent",
+		}}, nil
+	}
+	return detail, nil, nil
+}
+
+// DefaultBedrockAgentsFixture returns the canonical demo fixture set used by
+// local dev/quickstart so a fresh deployment shows Bedrock agent coverage
+// without requiring a live AWS connector.
+func DefaultBedrockAgentsFixture(accountID, region string) (*FixtureBedrockAgentsAPI, error) {
+	account := strings.TrimSpace(accountID)
+	if account == "" {
+		account = "123456789012"
+	}
+	regionCode := strings.TrimSpace(region)
+	if regionCode == "" {
+		regionCode = "us-east-1"
+	}
+	partition := bedrockFixturePartition(regionCode)
+	fixture := NewFixtureBedrockAgentsAPI()
+	fixture.Seed(
+		[]BedrockAgentSummary{
+			{
+				AgentID:                     "PAYMENTSAGENT1",
+				AgentARN:                    bedrockFixtureAgentARN(partition, regionCode, account, "PAYMENTSAGENT1"),
+				AgentName:                   "payments-risk-agent",
+				AgentStatus:                 "PREPARED",
+				AgentVersion:                "1",
+				FoundationModel:             "anthropic.claude-3-5-sonnet-20240620-v1:0",
+				RoleARN:                     "arn:" + partition + ":iam::" + account + ":role/bedrock-payments-risk-agent",
+				GuardrailID:                 "guard-payments",
+				GuardrailVersion:            "1",
+				CustomerEncryptionKMSKeyARN: "arn:" + partition + ":kms:" + regionCode + ":" + account + ":key/cmk-bedrock-payments",
+			},
+		},
+		map[string]BedrockAgentDetail{
+			"PAYMENTSAGENT1": {
+				ActionGroupNames:        []string{"payments-case-search", "fraud-review-action-group"},
+				ActionGroupExecutorARNs: []string{"arn:" + partition + ":lambda:" + regionCode + ":" + account + ":function:payments-fraud-review"},
+				KnowledgeBaseIDs:        []string{"KBPAYMENTS1"},
+				AliasNames:              []string{"production"},
+				AliasARNs:               []string{bedrockFixtureAgentARN(partition, regionCode, account, "PAYMENTSAGENT1") + "/alias/production"},
+				HasInstruction:          true,
+				HasPromptOverride:       false,
+			},
+		},
+	)
+	return fixture, nil
+}
+
+func bedrockFixturePartition(region string) string {
+	switch {
+	case strings.HasPrefix(region, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(region, "cn-"):
+		return "aws-cn"
+	default:
+		return "aws"
+	}
+}
+
+func bedrockFixtureAgentARN(partition, region, account, agentID string) string {
+	return "arn:" + partition + ":bedrock:" + region + ":" + account + ":agent/" + agentID
+}

--- a/internal/providers/aws/sdk_bedrock_agents.go
+++ b/internal/providers/aws/sdk_bedrock_agents.go
@@ -14,6 +14,19 @@ import (
 // from the live SDK adapter so deploying Identrail without the live Bedrock SDK
 // stays first-class (some operators want metadata-only fixtures while they
 // stage the live read-only permission grant).
+//
+// Runtime composition boundary: this fixture is the only BedrockAgentsAPI
+// implementation in this PR. A live aws-sdk-go-v2 Bedrock adapter is
+// deliberately not introduced here because the Bedrock SDK module is not yet
+// listed in go.mod and pulling it in would balloon this PR's scope and audit
+// surface. The follow-up issue that wires the SDK adapter must also (1) add a
+// case for rawKindAIAgentIdentity to RoleNormalizer.Normalize so the collector
+// is not silently dropped during scans, and (2) compose
+// NewBedrockAgentsCollector(NewSDKBedrockAgentsAPI(...)) inside
+// internal/runtime/service_builder.go alongside the other Wave 1 collectors.
+// Until then the collector is reachable only through the inventory API at
+// GET .../aws/bedrock-agents, which consumes RawAssets directly without going
+// through the normalizer.
 type FixtureBedrockAgentsAPI struct {
 	mu      sync.RWMutex
 	agents  []BedrockAgentSummary

--- a/internal/providers/aws/sdk_bedrock_agents_test.go
+++ b/internal/providers/aws/sdk_bedrock_agents_test.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFixtureBedrockAgentsAPISeedAndQuery(t *testing.T) {
+	api := NewFixtureBedrockAgentsAPI()
+	api.Seed(
+		[]BedrockAgentSummary{{AgentID: "A1", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/A1", AgentName: "agent"}},
+		map[string]BedrockAgentDetail{"A1": {ActionGroupNames: []string{"x"}}},
+	)
+	page, err := api.ListAgents(context.Background(), "", 100)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(page.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(page.Agents))
+	}
+	detail, issues, err := api.GetAgentDetail(context.Background(), "A1")
+	if err != nil {
+		t.Fatalf("GetAgentDetail: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues for seeded agent, got %v", issues)
+	}
+	if len(detail.ActionGroupNames) != 1 {
+		t.Fatalf("expected seeded detail, got %+v", detail)
+	}
+}
+
+func TestFixtureBedrockAgentsAPIUnseededAgentReturnsSoftDiagnostic(t *testing.T) {
+	api := NewFixtureBedrockAgentsAPI()
+	_, issues, err := api.GetAgentDetail(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("GetAgentDetail: %v", err)
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_not_seeded") {
+		t.Fatalf("expected not-seeded diagnostic, got %v", issues)
+	}
+}
+
+func TestFixtureBedrockAgentsAPIRejectsEmptyID(t *testing.T) {
+	api := NewFixtureBedrockAgentsAPI()
+	_, issues, err := api.GetAgentDetail(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetAgentDetail: %v", err)
+	}
+	if !hasIssueCode(issues, "bedrock_agent_detail_missing_id") {
+		t.Fatalf("expected missing-id diagnostic, got %v", issues)
+	}
+}
+
+func TestDefaultBedrockAgentsFixtureReturnsRecord(t *testing.T) {
+	fixture, err := DefaultBedrockAgentsFixture("123456789012", "eu-west-1")
+	if err != nil {
+		t.Fatalf("DefaultBedrockAgentsFixture: %v", err)
+	}
+	page, err := fixture.ListAgents(context.Background(), "", 100)
+	if err != nil || len(page.Agents) == 0 {
+		t.Fatalf("expected default fixture to have at least one agent, got %d (err=%v)", len(page.Agents), err)
+	}
+	detail, issues, err := fixture.GetAgentDetail(context.Background(), page.Agents[0].AgentID)
+	if err != nil {
+		t.Fatalf("GetAgentDetail: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("default fixture should not emit diagnostics, got %v", issues)
+	}
+	if len(detail.ActionGroupNames) == 0 {
+		t.Fatalf("default fixture detail should expose action groups")
+	}
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1140,6 +1140,44 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS Bedrock Agents inventory with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        inventory: {
+          status: 'ready',
+          agent_count: 2,
+          filtered_agent_count: 2,
+          records: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectBedrockAgents(
+      'workspace/a',
+      'project 1',
+      'aws-prod',
+      'partial_failure',
+      { agentID: 'PAYMENTSAGENT1', identity: 'payments', provider: 'amazon-bedrock' },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/bedrock-agents?connector_id=aws-prod&fixture_state=partial_failure&agent_id=PAYMENTSAGENT1&identity=payments&provider=amazon-bedrock'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2049,6 +2049,110 @@ export type AWSAIAgentIdentityInventoryResult = {
   updated_at: string;
 };
 
+export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSBedrockAgentsFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSBedrockAgentsProvider = 'amazon-bedrock';
+
+export type AWSBedrockAgentCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSBedrockAgentRecord = {
+  account_id: string;
+  region: string;
+  service: string;
+  agent_id: string;
+  agent_arn?: string;
+  agent_name: string;
+  agent_type: string;
+  provider?: string;
+  model_id?: string;
+  runtime_role_arn?: string;
+  runtime_role_name?: string;
+  runtime_role_account_id?: string;
+  tool_names: string[];
+  tool_count: number;
+  memory_enabled: boolean;
+  memory_store_refs: string[];
+  capability_names: string[];
+  credential_reference_refs: string[];
+  guardrail_id?: string;
+  sensitive_boundary: string;
+  coverage_status: string;
+  coverage_reason?: string;
+  source: string;
+  evidence_ref: string;
+  agent_node_id: string;
+  runtime_role_node_id?: string;
+  relationship_types: string[];
+  confidence: number;
+  next_action: string;
+  collected_at: string;
+  status: string;
+  tags?: Record<string, string>;
+};
+
+export type AWSBedrockAgentRelation = {
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSBedrockAgentDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSBedrockAgentsInventoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSBedrockAgentsInventoryStatus;
+  fixture_state: AWSBedrockAgentsFixtureState;
+  confidence: number;
+  agent_count: number;
+  filtered_agent_count: number;
+  guardrail_count: number;
+  knowledge_base_count: number;
+  tool_count: number;
+  credential_reference_count: number;
+  runtime_role_count: number;
+  model_count: number;
+  provider_breakdown: Record<string, number>;
+  status_breakdown: Record<string, number>;
+  relationship_count: number;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSBedrockAgentCoverageGap[];
+  records: AWSBedrockAgentRecord[];
+  relationships: AWSBedrockAgentRelation[];
+  diagnostics: AWSBedrockAgentDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSIAMPassRoleRelationshipInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSIAMPassRoleRelationshipFixtureState =
   | 'success'
@@ -4997,6 +5101,25 @@ export const apiClient = {
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/ai-agent-identities${buildQuery({
         connector_id: connectorID,
         fixture_state: fixtureState
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectBedrockAgents(
+    workspaceID: string,
+    projectID: string,
+    connectorID?: string,
+    fixtureState?: AWSBedrockAgentsFixtureState,
+    filters?: { agentID?: string; identity?: string; provider?: AWSBedrockAgentsProvider },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ inventory: AWSBedrockAgentsInventoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/bedrock-agents${buildQuery({
+        connector_id: connectorID,
+        fixture_state: fixtureState,
+        agent_id: filters?.agentID,
+        identity: filters?.identity,
+        provider: filters?.provider
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -38,6 +38,8 @@ import {
   type AWSManagedComputeRoleInventoryResult,
   type AWSManagedComputeRoleRecord,
   type AWSAIAgentIdentityInventoryResult,
+  type AWSBedrockAgentsInventoryResult,
+  type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
@@ -3650,6 +3652,13 @@ type AWSInventoryAIAgentState = {
   onRetry: () => void;
 };
 
+type AWSInventoryBedrockAgentsState = {
+  inventory: AWSBedrockAgentsInventoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+};
+
 type AWSInventorySecretsManagerState = {
   inventory: AWSSecretsManagerMetadataInventoryResult | null;
   loading: boolean;
@@ -6639,17 +6648,22 @@ function awsEC2IMDSLabel(inventory: AWSEC2InstanceProfileInventoryResult | null)
 function AWSAgentIdentitiesContent({
   connection,
   aiAgentState,
+  bedrockAgentsState,
   filters,
   onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
   aiAgentState: AWSInventoryAIAgentState;
+  bedrockAgentsState: AWSInventoryBedrockAgentsState;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const inventory = aiAgentState.inventory;
+  const bedrock = bedrockAgentsState.inventory;
   const rows = buildAWSAIAgentIdentityRows(inventory, aiAgentState.loading, connection);
+  const bedrockRows = buildAWSBedrockAgentsRows(bedrock, bedrockAgentsState.loading, connection);
   const displayedRows = filterAWSInventoryRows(rows, filters);
+  const displayedBedrockRows = filterAWSInventoryRows(bedrockRows, filters);
 
   return (
     <>
@@ -6744,8 +6758,198 @@ function AWSAgentIdentitiesContent({
           { key: 'detail', header: 'Relationship slot', render: (row) => row.detail }
         ]}
       />
+      {bedrockAgentsState.loading ? <DomainLoadingState label="Loading AWS Bedrock Agents" /> : null}
+      {bedrockAgentsState.error ? (
+        <DomainErrorState
+          title="Bedrock Agents could not load"
+          body={bedrockAgentsState.error}
+          retryAction={{ label: 'Retry Bedrock Agents', onClick: bedrockAgentsState.onRetry }}
+        />
+      ) : null}
+      {bedrock ? (
+        <DomainStatusPanel
+          eyebrow="Bedrock Agents collector"
+          title="Bedrock agent identities are metadata-only"
+          status={formatTokenLabel(bedrock.status)}
+          tone={bedrock.status === 'blocked' ? 'danger' : bedrock.status === 'degraded' ? 'warning' : 'success'}
+        >
+          <section className="idt-aws-inventory-coverage" aria-label="AWS Bedrock Agents summary">
+            <DomainCoverageCard
+              label="Bedrock agents"
+              scanned={bedrock.agent_count}
+              total={Math.max(bedrock.agent_count, 1)}
+              detail={`${bedrock.runtime_role_count} runtime roles`}
+            />
+            <DomainCoverageCard
+              label="Action group tools"
+              scanned={bedrock.tool_count}
+              total={Math.max(bedrock.tool_count, 1)}
+              detail={`${bedrock.knowledge_base_count} knowledge bases`}
+            />
+            <DomainCoverageCard
+              label="Guardrails"
+              scanned={bedrock.guardrail_count}
+              total={Math.max(bedrock.agent_count, 1)}
+              detail={`${bedrock.model_count} foundation models`}
+            />
+            <DomainCoverageCard
+              label="Credential refs"
+              scanned={bedrock.credential_reference_count}
+              total={Math.max(bedrock.credential_reference_count, 1)}
+              detail="Values hidden"
+            />
+          </section>
+          {bedrock.diagnostics.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS Bedrock Agents diagnostics">
+              {bedrock.diagnostics.map((diagnostic) => (
+                <article key={`${diagnostic.code}-${diagnostic.source_id ?? diagnostic.collector}`}>
+                  <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+          {bedrock.coverage_gaps.length ? (
+            <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS Bedrock Agents sensitive boundaries">
+              {bedrock.coverage_gaps.map((gap) => (
+                <article key={`${gap.capability}-${gap.status}`}>
+                  <strong>{formatTokenLabel(gap.capability)}</strong>
+                  <p>{gap.reason}</p>
+                  {gap.remediation ? <small>{gap.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+          {bedrock.remediation_hints.length ? (
+            <ul className="idt-domain-charter-list" aria-label="AWS Bedrock Agents remediation hints">
+              {bedrock.remediation_hints.map((hint) => (
+                <li key={hint}>{hint}</li>
+              ))}
+            </ul>
+          ) : null}
+        </DomainStatusPanel>
+      ) : null}
+      <DomainDataTable
+        label="AWS Bedrock Agents inventory"
+        rows={displayedBedrockRows}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'name', header: 'Bedrock agent', render: (row) => <strong>{row.name}</strong> },
+          { key: 'category', header: 'Category', render: (row) => row.category },
+          { key: 'scope', header: 'Scope', render: (row) => row.scope },
+          { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> },
+          { key: 'detail', header: 'Next action', render: (row) => row.detail }
+        ]}
+      />
     </>
   );
+}
+
+function buildAWSBedrockAgentsRows(
+  inventory: AWSBedrockAgentsInventoryResult | null,
+  loading: boolean,
+  connection: AWSConnectionStatus | null
+): AWSInventoryTableRow[] {
+  if (inventory?.records.length) {
+    return inventory.records.map((record) => awsBedrockAgentRow(record));
+  }
+  if (inventory?.status === 'blocked') {
+    return [
+      {
+        id: 'bedrock-agents-blocked',
+        name: 'Bedrock Agents unavailable',
+        category: 'Bedrock agent',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: 'not yet available',
+        stage: 'not-available',
+        detail: inventory.failure_reasons[0] ?? 'Bedrock Agents collection is blocked by permissions.',
+        filters: {
+          surface: 'bedrock-agents',
+          relationship: 'agent-to-role,agent-to-tool,agent-to-secret',
+          status: 'not-yet-available',
+          search: ''
+        },
+        searchText: inventorySearchText(['bedrock agents blocked', inventory.account_id, inventory.region])
+      }
+    ];
+  }
+  if (inventory) {
+    const degraded = inventory.status === 'degraded' || inventory.diagnostics.length > 0 || inventory.failure_reasons.length > 0;
+    return [
+      {
+        id: 'bedrock-agents-empty',
+        name: degraded ? 'Bedrock Agents incomplete' : 'No Bedrock Agents found',
+        category: 'Bedrock agent',
+        scope: awsAccountRegionInventoryLabel(inventory.account_id, inventory.region),
+        status: degraded ? 'degraded' : 'role anchor',
+        stage: 'wired',
+        detail: degraded
+          ? (inventory.failure_reasons[0] ?? 'Bedrock Agents collection completed with degraded evidence.')
+          : 'No Bedrock agents were observed in this account/region.',
+        filters: {
+          surface: 'bedrock-agents',
+          relationship: 'agent-to-role',
+          status: degraded ? 'degraded' : 'role-anchor',
+          search: ''
+        },
+        searchText: inventorySearchText(['bedrock agents', inventory.account_id, inventory.region, degraded ? 'degraded empty' : 'empty'])
+      }
+    ];
+  }
+  if (loading) {
+    return [
+      {
+        id: 'bedrock-agents-loading',
+        name: 'Bedrock Agents',
+        category: 'Bedrock agent',
+        scope: awsAccountRegionLabel(connection),
+        status: 'coming',
+        stage: 'coming',
+        detail: 'Loading Bedrock agents, action groups, knowledge bases, and guardrails.',
+        filters: { surface: 'bedrock-agents', relationship: 'agent-to-role', status: 'coming', search: '' },
+        searchText: inventorySearchText(['bedrock agents loading'])
+      }
+    ];
+  }
+  return [];
+}
+
+function awsBedrockAgentRow(record: AWSBedrockAgentRecord): AWSInventoryTableRow {
+  const degraded = record.coverage_status === 'degraded' || record.status === 'degraded';
+  const status = degraded ? 'degraded' : 'role anchor';
+  const stage = degraded ? 'coming' : 'wired';
+  const detail = record.next_action;
+  return {
+    id: `bedrock-agent-${record.agent_id}`,
+    name: record.agent_name || record.agent_id,
+    category: record.guardrail_id ? 'Bedrock agent (guardrailed)' : 'Bedrock agent',
+    scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
+    status,
+    stage,
+    detail,
+    filters: {
+      surface: 'bedrock-agents',
+      relationship: 'agent-to-role,agent-to-tool,agent-to-secret',
+      status: degraded ? 'degraded' : 'role-anchor',
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.agent_id,
+      record.agent_name,
+      record.agent_arn,
+      record.runtime_role_arn,
+      record.runtime_role_name,
+      record.model_id,
+      record.provider,
+      record.guardrail_id,
+      ...record.tool_names,
+      ...record.capability_names,
+      record.account_id,
+      record.region,
+      degraded ? 'degraded' : 'ready'
+    ])
+  };
 }
 
 function buildAWSAIAgentIdentityRows(
@@ -7837,6 +8041,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const [aiAgentInventoryLoading, setAIAgentInventoryLoading] = useState(false);
   const [aiAgentInventoryError, setAIAgentInventoryError] = useState('');
   const aiAgentInventoryRequestRef = useRef(0);
+  const [bedrockAgentsInventory, setBedrockAgentsInventory] = useState<AWSBedrockAgentsInventoryResult | null>(null);
+  const [bedrockAgentsInventoryLoading, setBedrockAgentsInventoryLoading] = useState(false);
+  const [bedrockAgentsInventoryError, setBedrockAgentsInventoryError] = useState('');
+  const bedrockAgentsInventoryRequestRef = useRef(0);
   const [secretsManagerInventory, setSecretsManagerInventory] = useState<AWSSecretsManagerMetadataInventoryResult | null>(null);
   const [secretsManagerInventoryLoading, setSecretsManagerInventoryLoading] = useState(false);
   const [secretsManagerInventoryError, setSecretsManagerInventoryError] = useState('');
@@ -8289,6 +8497,47 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       aiAgentInventoryRequestRef.current += 1;
     };
   }, [loadAIAgentInventory]);
+
+  const loadBedrockAgentsInventory = useCallback(async () => {
+    const requestID = ++bedrockAgentsInventoryRequestRef.current;
+    setBedrockAgentsInventory(null);
+    setBedrockAgentsInventoryError('');
+    if (routeID !== 'agents' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setBedrockAgentsInventoryLoading(false);
+      return;
+    }
+    setBedrockAgentsInventoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectBedrockAgents(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        connection.connector_id,
+        undefined,
+        undefined,
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== bedrockAgentsInventoryRequestRef.current) {
+        return;
+      }
+      setBedrockAgentsInventory(response.inventory);
+    } catch (error) {
+      if (requestID !== bedrockAgentsInventoryRequestRef.current) {
+        return;
+      }
+      setBedrockAgentsInventoryError(formatAPIError(error, 'Unable to load AWS Bedrock Agents inventory.'));
+    } finally {
+      if (requestID === bedrockAgentsInventoryRequestRef.current) {
+        setBedrockAgentsInventoryLoading(false);
+      }
+    }
+  }, [routeID, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID, connection?.connected, connection?.connector_id]);
+
+  useEffect(() => {
+    void loadBedrockAgentsInventory();
+    return () => {
+      bedrockAgentsInventoryRequestRef.current += 1;
+    };
+  }, [loadBedrockAgentsInventory]);
 
   const loadSecretsManagerInventory = useCallback(async () => {
     const requestID = ++secretsManagerInventoryRequestRef.current;
@@ -8966,6 +9215,12 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
             loading: aiAgentInventoryLoading,
             error: aiAgentInventoryError,
             onRetry: () => void loadAIAgentInventory()
+          }}
+          bedrockAgentsState={{
+            inventory: bedrockAgentsInventory,
+            loading: bedrockAgentsInventoryLoading,
+            error: bedrockAgentsInventoryError,
+            onRetry: () => void loadBedrockAgentsInventory()
           }}
           filters={activeFilters}
           onFiltersChange={onFiltersChange}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6920,6 +6920,22 @@ function awsBedrockAgentRow(record: AWSBedrockAgentRecord): AWSInventoryTableRow
   const status = degraded ? 'degraded' : 'role anchor';
   const stage = degraded ? 'coming' : 'wired';
   const detail = record.next_action;
+  // Derive the relationship filter from the record's actual edges so selecting
+  // "Agent to secret" never matches a record that has no credential references,
+  // and "Agent to tool" never matches a record without action groups.
+  const relationshipTokens: string[] = [];
+  if (record.runtime_role_arn) {
+    relationshipTokens.push('agent-to-role');
+  }
+  if (record.tool_names.length > 0) {
+    relationshipTokens.push('agent-to-tool');
+  }
+  if (record.credential_reference_refs.length > 0) {
+    relationshipTokens.push('agent-to-secret');
+  }
+  if (record.memory_store_refs.length > 0) {
+    relationshipTokens.push('agent-to-knowledge-base');
+  }
   return {
     id: `bedrock-agent-${record.agent_id}`,
     name: record.agent_name || record.agent_id,
@@ -6930,7 +6946,7 @@ function awsBedrockAgentRow(record: AWSBedrockAgentRecord): AWSInventoryTableRow
     detail,
     filters: {
       surface: 'bedrock-agents',
-      relationship: 'agent-to-role,agent-to-tool,agent-to-secret',
+      relationship: relationshipTokens.join(','),
       status: degraded ? 'degraded' : 'role-anchor',
       search: ''
     },


### PR DESCRIPTION
## Summary

Implements the Wave 4.02 read-only, metadata-only **AWS Bedrock Agents identity collector**, a fixture-backed adapter, a project-scoped inventory API, the OpenAPI contract, and the AWS Agents app surface. The collector emits `AIAgentIdentity`-shaped raw assets so the merged Wave 4.01 AI agent identity model adapter consumes Bedrock records without a new normalization layer.

Closes #1506.

## Why

Identrail's AI agent identity model (#1505) needs first-class Bedrock Agents coverage so operators can govern AWS-hosted agents as machine identities. Without this collector, tools, provider keys, runtime roles, and sensitive-resource access stay disconnected from the AI agent identity graph.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered: additive new collector, new API path, new web panel; no schema or contract breakage
- [x] Risk level assessed: low; read-only and metadata-only; the live SDK is intentionally not introduced in this PR

## What's in the change

- `internal/providers/aws/bedrock_agents_collector.go` (+ tests): bounded, retryable, deduplicating Bedrock Agents collector exposing `BedrockAgentsAPI` (`ListAgents` + `GetAgentDetail`). Per-agent detail failures degrade gracefully into partial-failure diagnostics; the collector never aborts the whole scan because one agent's detail call denied.
- `internal/providers/aws/sdk_bedrock_agents.go` (+ tests): `FixtureBedrockAgentsAPI` and canonical `DefaultBedrockAgentsFixture` so local dev and contract tests exercise the same code path as the production runtime. The live SDK adapter slots in behind the same interface once the Bedrock SDK module is vetted.
- `internal/api/aws_bedrock_agents.go` (+ tests): `GET .../aws/bedrock-agents` with `success`, `empty`, `degraded`, `partial_failure`, and `permission_denied` fixture states and `agent_id` / `identity` / `provider` filters. Validates every record against `awscontract.ServiceCollectorRecord` so the boundary stays compatible with downstream graph, runtime, risk, and remediation pipelines.
- `internal/api/router.go`, `internal/api/authz_policy_bundle_runtime.go`, `docs/openapi-v1.yaml`: route wiring, route policy entry, full OpenAPI path block + component schemas.
- `web/src/api/client.ts` (+ test), `web/src/productShell.tsx`: typed client getter and a new Bedrock Agents panel inside `AWS → Agents`. Loading, empty, error, degraded, and permission-denied states are explicit; partial failures keep their per-agent diagnostic.
- `docs/aws-bedrock-agents.md`, `CHANGELOG.md` updates.

## Safety / scope boundaries

- Instructions, prompt overrides, completions, knowledge-base contents, embeddings, memory contents, action-group OpenAPI bodies, and secret values are never read.
- Two coverage gaps (`prompt_and_completion_contents`, `knowledge_base_contents`) appear on every response so the boundary is explicit to operators.
- Per-agent `bedrock_agent_detail_failed` diagnostics surface partial failure without inventing successful records.
- The live SDK module is intentionally not pulled in; a follow-up wave will introduce the adapter behind the same `BedrockAgentsAPI` interface.

## Validation

```bash
go test ./internal/providers/aws/ -run 'BedrockAgents|FixtureBedrock|DefaultBedrock'
go test ./internal/api/ -run 'BedrockAgents|OpenAPI'
make ci
npm run test:ci --prefix web
```

All passed locally (`make ci` ran fmt-check, vet, full Go tests, API example contract check, web route integrity check, web test, and web build).

## Checklist

- [x] Tests added for the collector (8 cases including pagination, dedup, partial failure, page-limit guard, list-failure surface, metadata-only payload guard, malformed agent skip), the API (success/empty/degraded/partial_failure/permission_denied + filters + router + leak-guard), and the web client
- [x] Docs added (`docs/aws-bedrock-agents.md`) and OpenAPI updated
- [x] `CHANGELOG.md` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only, metadata-only AWS Bedrock Agents identity collector, a project-scoped inventory API, and an AWS → Agents UI. Provides first-class Bedrock coverage for the `AIAgentIdentity` model without a new normalization layer. Closes #1506.

- **New Features**
  - Collector `internal/providers/aws/bedrock_agents_collector.go`: bounded retry, pagination, dedup; emits `AIAgentIdentity`-shaped records; per-agent detail failures degrade, scan continues.
  - Fixture-backed `BedrockAgentsAPI` (`ListAgents`, `GetAgentDetail`) behind a default fixture; live SDK adapter slots into the same interface later.
  - Inventory endpoint `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents` with filters (`connector_id`, `agent_id`, `identity`, `provider`) and fixture states (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`); web adds an AWS → Agents panel with per-agent diagnostics.

- **Bug Fixes**
  - Inventory relationships now respect filtered records; no edges anchored at excluded agents.
  - Diagnostics and response status are scoped to the filtered records; scan-wide diagnostics remain; aggregate counts stay inventory-wide.
  - Runtime role node IDs use canonical `aws:identity:<arn>` so runs_with_role joins align with other AWS endpoints.
  - `tool_count` matches the deduped `tool_names`.
  - ARN-only summaries skip `GetAgentDetail`; emit `detail_skipped_missing_id`; record marked degraded.
  - Detail diagnostics with no error now mark records degraded and emit `bedrock_agent_detail_incomplete`.
  - AWS → Agents relationship filters derive from actual edges; “Agent to tool” and “Agent to secret” only match agents with those edges.
  - OpenAPI enums tightened for `AWSBedrockAgentCoverageGap.status`, `sensitive_boundary`, and `coverage_status`.

<sup>Written for commit 1ff8cd31dc66507bcc89aa76034f5128eaf5574c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

