### PR TITLE
Add AgentCore runtime collector

### DIFF
--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -12,10 +12,12 @@ The model is metadata-only. Each `agent_identity` record can describe:
 - external-provider-backed agents
 - agent gateways
 - runtime IAM role ARN/name/account
+- AgentCore runtime version, workload identity ARN, execution endpoints, observability links, network mode, and server protocol
 - provider and model identifiers
 - tool names and capability names
 - memory/browser/code-interpreter capability flags
 - credential-reference identifiers
+- agent-to-endpoint `invokes` relationships for AgentCore runtime execution surfaces
 - evidence references, confidence, account, region, connector, scan, workspace, and project context
 
 The public API is:
@@ -55,3 +57,4 @@ The AWS Agents inventory page shows normalized agent rows, runtime role anchors,
 - Partial failure: retry the failed sub-listing and keep successful records visible.
 - Unresolved credential reference: join to the credential-reference metadata surface for ownership and rotation, never to secret values.
 - Empty result: confirm that the selected connector account and region actually hosts Bedrock, AgentCore, custom, external-provider-backed, or gateway agent resources.
+- Missing runtime endpoints: confirm the runtime has published execution endpoints in the selected region and account.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10084,11 +10084,13 @@ components:
             - custom_agent
             - external_provider_agent
             - agent_gateway
+        runtime_version: { type: string }
         provider: { type: string }
         model_id: { type: string }
         runtime_role_arn: { type: string }
         runtime_role_name: { type: string }
         runtime_role_account_id: { type: string }
+        workload_identity_arn: { type: string }
         gateway_id: { type: string }
         gateway_arn: { type: string }
         external_provider: { type: string }
@@ -10107,6 +10109,23 @@ components:
         credential_reference_refs:
           type: array
           items: { type: string }
+        resource_reference_refs:
+          type: array
+          items: { type: string }
+        execution_endpoint_arns:
+          type: array
+          items: { type: string }
+        execution_endpoint_names:
+          type: array
+          items: { type: string }
+        execution_endpoint_statuses:
+          type: array
+          items: { type: string }
+        observability_links:
+          type: array
+          items: { type: string }
+        network_mode: { type: string }
+        server_protocol: { type: string }
         sensitive_boundary:
           type: string
           enum: [metadata_only]
@@ -10123,7 +10142,7 @@ components:
           type: array
           items:
             type: string
-            enum: [runs_as, calls_tool, uses_secret]
+            enum: [runs_as, calls_tool, uses_secret, invokes]
         confidence:
           type: number
           minimum: 0
@@ -10142,7 +10161,7 @@ components:
       properties:
         type:
           type: string
-          enum: [runs_as, calls_tool, uses_secret]
+          enum: [runs_as, calls_tool, uses_secret, invokes]
         from_node_id: { type: string }
         to_node_id: { type: string }
         evidence_ref: { type: string }
@@ -10155,7 +10174,12 @@ components:
           type: string
           enum:
             - ai_agent_credential_reference_unresolved
+            - ai_agent_gateway_describe_failed
             - ai_agent_gateway_list_failed
+            - ai_agent_identity_page_failed
+            - agentcore_runtime_describe_failed
+            - agentcore_runtime_endpoint_list_failed
+            - agentcore_runtime_malformed
             - permission_denied
         message: { type: string }
         remediation: { type: string }
@@ -10280,7 +10304,9 @@ components:
         runtime_role_node_id: { type: string }
         relationship_types:
           type: array
-          items: { type: string }
+          items:
+            type: string
+            enum: [runs_as, calls_tool, uses_secret, invokes]
         confidence:
           type: number
           minimum: 0

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 h1:jZOg03lM41zl89h17avGr6AF
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0/go.mod h1:f0MnAznWRN75Dnezt6MBnHOKHEpAI/ztr4Q6Lo1IGDk=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 h1:4Z9EIZUF8dkVDYTEt7NxKhA3yE3S/x7iWYL/C+reRgw=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6/go.mod h1:GlwXK7c/0CMTSU4a0PAAp5jiYXH55DRYT3mliKlqf6M=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0 h1:LIu5UC4jQ1HktSVZTrj4YXNgnrE6zJ9ZFK+UX5HONDo=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0/go.mod h1:MQ3INaQ+EXhLY92cpengp85BSJcXyvl4ttfPniodC90=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3 h1:bdJcqPbvkHSyG7N+5PDsBB6cWnWXHWkZ80SaY09R8qQ=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3/go.mod h1:1j2vP0fJjVysTByZ5MSp0/iMlej8Oqa8TWYtcX3HTRQ=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.3 h1:T4DN0zLNMJA7Z7Ewppfkt5erz3UE/uB1nxBSQhGJI5g=

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -70,41 +70,50 @@ type AWSAIAgentIdentityInventoryResult struct {
 }
 
 type AWSAIAgentIdentityRecord struct {
-	AccountID               string            `json:"account_id"`
-	Region                  string            `json:"region"`
-	Service                 string            `json:"service"`
-	AgentID                 string            `json:"agent_id"`
-	AgentARN                string            `json:"agent_arn,omitempty"`
-	AgentName               string            `json:"agent_name"`
-	AgentType               string            `json:"agent_type"`
-	Provider                string            `json:"provider,omitempty"`
-	ModelID                 string            `json:"model_id,omitempty"`
-	RuntimeRoleARN          string            `json:"runtime_role_arn,omitempty"`
-	RuntimeRoleName         string            `json:"runtime_role_name,omitempty"`
-	RuntimeRoleAccountID    string            `json:"runtime_role_account_id,omitempty"`
-	GatewayID               string            `json:"gateway_id,omitempty"`
-	GatewayARN              string            `json:"gateway_arn,omitempty"`
-	ExternalProvider        string            `json:"external_provider,omitempty"`
-	ToolNames               []string          `json:"tool_names,omitempty"`
-	MemoryEnabled           bool              `json:"memory_enabled"`
-	MemoryStoreRefs         []string          `json:"memory_store_refs,omitempty"`
-	BrowserEnabled          bool              `json:"browser_enabled"`
-	CodeInterpreterEnabled  bool              `json:"code_interpreter_enabled"`
-	CapabilityNames         []string          `json:"capability_names,omitempty"`
-	CredentialReferenceRefs []string          `json:"credential_reference_refs,omitempty"`
-	SensitiveBoundary       string            `json:"sensitive_boundary"`
-	CoverageStatus          string            `json:"coverage_status"`
-	CoverageReason          string            `json:"coverage_reason,omitempty"`
-	Source                  string            `json:"source"`
-	EvidenceRef             string            `json:"evidence_ref"`
-	AgentNodeID             string            `json:"agent_node_id"`
-	RuntimeRoleNodeID       string            `json:"runtime_role_node_id,omitempty"`
-	GatewayNodeID           string            `json:"gateway_node_id,omitempty"`
-	RelationshipTypes       []string          `json:"relationship_types"`
-	Confidence              float64           `json:"confidence"`
-	CollectedAt             time.Time         `json:"collected_at"`
-	Status                  string            `json:"status"`
-	Tags                    map[string]string `json:"tags,omitempty"`
+	AccountID                 string            `json:"account_id"`
+	Region                    string            `json:"region"`
+	Service                   string            `json:"service"`
+	AgentID                   string            `json:"agent_id"`
+	AgentARN                  string            `json:"agent_arn,omitempty"`
+	AgentName                 string            `json:"agent_name"`
+	AgentType                 string            `json:"agent_type"`
+	RuntimeVersion            string            `json:"runtime_version,omitempty"`
+	Provider                  string            `json:"provider,omitempty"`
+	ModelID                   string            `json:"model_id,omitempty"`
+	RuntimeRoleARN            string            `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName           string            `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID      string            `json:"runtime_role_account_id,omitempty"`
+	WorkloadIdentityARN       string            `json:"workload_identity_arn,omitempty"`
+	GatewayID                 string            `json:"gateway_id,omitempty"`
+	GatewayARN                string            `json:"gateway_arn,omitempty"`
+	ExternalProvider          string            `json:"external_provider,omitempty"`
+	ToolNames                 []string          `json:"tool_names,omitempty"`
+	MemoryEnabled             bool              `json:"memory_enabled"`
+	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
+	BrowserEnabled            bool              `json:"browser_enabled"`
+	CodeInterpreterEnabled    bool              `json:"code_interpreter_enabled"`
+	CapabilityNames           []string          `json:"capability_names,omitempty"`
+	CredentialReferenceRefs   []string          `json:"credential_reference_refs,omitempty"`
+	ResourceReferenceRefs     []string          `json:"resource_reference_refs,omitempty"`
+	ExecutionEndpointARNs     []string          `json:"execution_endpoint_arns,omitempty"`
+	ExecutionEndpointNames    []string          `json:"execution_endpoint_names,omitempty"`
+	ExecutionEndpointStatuses []string          `json:"execution_endpoint_statuses,omitempty"`
+	ObservabilityLinks        []string          `json:"observability_links,omitempty"`
+	NetworkMode               string            `json:"network_mode,omitempty"`
+	ServerProtocol            string            `json:"server_protocol,omitempty"`
+	SensitiveBoundary         string            `json:"sensitive_boundary"`
+	CoverageStatus            string            `json:"coverage_status"`
+	CoverageReason            string            `json:"coverage_reason,omitempty"`
+	Source                    string            `json:"source"`
+	EvidenceRef               string            `json:"evidence_ref"`
+	AgentNodeID               string            `json:"agent_node_id"`
+	RuntimeRoleNodeID         string            `json:"runtime_role_node_id,omitempty"`
+	GatewayNodeID             string            `json:"gateway_node_id,omitempty"`
+	RelationshipTypes         []string          `json:"relationship_types"`
+	Confidence                float64           `json:"confidence"`
+	CollectedAt               time.Time         `json:"collected_at"`
+	Status                    string            `json:"status"`
+	Tags                      map[string]string `json:"tags,omitempty"`
 }
 
 type AWSAIAgentIdentityRelation struct {
@@ -248,6 +257,21 @@ func emptyStrings(values []string) []string {
 	return values
 }
 
+func normalizeOrderedStringList(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		result = append(result, trimmed)
+	}
+	return result
+}
+
 func normalizeAWSAIAgentIdentityFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
 	switch strings.ToLower(strings.TrimSpace(requested)) {
 	case "":
@@ -293,8 +317,23 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 		awsAIAgentFixtureRecord(accountID, region, "agentcore_runtime", "case-triage-runtime", "runtime-case-triage", agentARN("bedrock-agentcore", "runtime-case-triage"), role("agentcore-case-triage-runtime"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
 			r.Service = "agentcore"
 			r.Provider = "amazon-bedrock-agentcore"
+			r.RuntimeVersion = "2026-06-01"
 			r.ModelID = "us.amazon.nova-pro-v1:0"
 			r.ToolNames = []string{"case-router", "policy-checker"}
+			r.WorkloadIdentityARN = fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:workload-identity/runtime-case-triage", partition, region, accountID)
+			r.ExecutionEndpointARNs = []string{
+				fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/blue", partition, region, accountID),
+				fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/green", partition, region, accountID),
+			}
+			r.ExecutionEndpointNames = []string{"blue", "green"}
+			r.ExecutionEndpointStatuses = []string{"READY", "READY"}
+			r.ObservabilityLinks = []string{
+				fmt.Sprintf("observability://agentcore/runtime/%s", "runtime-case-triage"),
+				fmt.Sprintf("observability://agentcore/runtime/%s/endpoints/blue", "runtime-case-triage"),
+				fmt.Sprintf("observability://agentcore/runtime/%s/endpoints/green", "runtime-case-triage"),
+			}
+			r.NetworkMode = "VPC"
+			r.ServerProtocol = "HTTP"
 			r.BrowserEnabled = true
 			r.CodeInterpreterEnabled = true
 			r.CapabilityNames = []string{"browser", "code_interpreter", "tool_use"}
@@ -378,7 +417,7 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 		CoverageStatus:          "covered",
 		Source:                  "ai_agent_metadata",
 		EvidenceRef:             agentARN,
-		AgentNodeID:             awsAIAgentNodeID(accountID, region, agentType, agentID),
+		AgentNodeID:             awsAIAgentNodeID(accountID, region, agentType, agentID, ""),
 		RuntimeRoleNodeID:       awsIdentityNodeIDForAPI(roleARN),
 		RelationshipTypes:       []string{"runs_as"},
 		Confidence:              0.9,
@@ -393,14 +432,24 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 	if mutate != nil {
 		mutate(&record)
 	}
+	record.AgentNodeID = awsAIAgentNodeID(accountID, region, agentType, firstNonEmptyAWSValue(record.AgentID, agentID), record.RuntimeVersion)
+	record.RuntimeRoleNodeID = awsIdentityNodeIDForAPI(roleARN)
 	record.ToolNames = dedupeStrings(record.ToolNames)
 	record.CapabilityNames = dedupeStrings(record.CapabilityNames)
 	record.CredentialReferenceRefs = dedupeStrings(record.CredentialReferenceRefs)
+	record.ExecutionEndpointARNs = normalizeOrderedStringList(record.ExecutionEndpointARNs)
+	record.ExecutionEndpointNames = normalizeOrderedStringList(record.ExecutionEndpointNames)
+	record.ExecutionEndpointStatuses = normalizeOrderedStringList(record.ExecutionEndpointStatuses)
+	record.ObservabilityLinks = normalizeOrderedStringList(record.ObservabilityLinks)
+	record.ResourceReferenceRefs = dedupeStrings(append(record.ResourceReferenceRefs, append(append([]string{}, record.ExecutionEndpointARNs...), record.WorkloadIdentityARN)...))
 	if len(record.CredentialReferenceRefs) > 0 {
 		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_secret"))
 	}
+	if len(record.ExecutionEndpointARNs) > 0 {
+		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "invokes"))
+	}
 	if record.GatewayARN != "" {
-		gatewayNodeID := awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN))
+		gatewayNodeID := awsAIAgentNodeID(accountID, region, "agent_gateway", firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN), "")
 		if record.AgentNodeID != gatewayNodeID {
 			record.GatewayNodeID = gatewayNodeID
 			record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "calls_tool"))
@@ -414,7 +463,7 @@ func summarizeAWSAIAgentIdentityInventory(fixtureState string, diagnostics []pro
 	case "permission_denied":
 		return awsPlatformDependencyStatusBlocked, 0.35,
 			[]string{"AI agent identity collection is blocked by missing read-only metadata permission"},
-			[]string{"Grant metadata-only agent, runtime, gateway, and role-list permissions; do not grant prompt, invocation, browser, memory-content, or code-output reads."}
+			[]string{"Grant metadata-only agent, runtime, gateway, and role-list permissions; do not grant prompt, invocation, browser, memory-content, code-output, or endpoint-content reads."}
 	case "degraded":
 		return awsPlatformDependencyStatusDegraded, 0.72,
 			[]string{"one or more agent credential references are unresolved"},
@@ -438,6 +487,17 @@ func awsAIAgentIdentityRelationships(records []AWSAIAgentIdentityRecord) []AWSAI
 	for _, record := range records {
 		if record.AgentNodeID != "" && record.RuntimeRoleNodeID != "" {
 			result = append(result, AWSAIAgentIdentityRelation{Type: "runs_as", FromNodeID: awsAIAgentWorkloadNodeID(record), ToNodeID: record.RuntimeRoleNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		for _, endpointARN := range record.ExecutionEndpointARNs {
+			endpointARN = strings.TrimSpace(endpointARN)
+			if record.AgentNodeID != "" && endpointARN != "" {
+				result = append(result, AWSAIAgentIdentityRelation{
+					Type:        "invokes",
+					FromNodeID:  record.AgentNodeID,
+					ToNodeID:    awsAIAgentExecutionEndpointNodeID(record.AgentNodeID, endpointARN),
+					EvidenceRef: record.EvidenceRef,
+				})
+			}
 		}
 		toolNames := dedupeStrings(record.ToolNames)
 		if record.AgentNodeID != "" && len(toolNames) > 0 {
@@ -481,6 +541,51 @@ func awsAIAgentToolNodeID(gatewayNodeID string, tool string) string {
 		name = "tool"
 	}
 	return awsAIAgentToolNodePrefix + strings.Join(normalizeStringList([]string{workload, name}), "|")
+}
+
+func awsAIAgentExecutionEndpointNodeID(agentNodeID string, endpointARN string) string {
+	workload := strings.TrimSpace(strings.ToLower(agentNodeID))
+	if workload == "" {
+		workload = "agent"
+	}
+	name, source := awsAIAgentResourceReferenceParts(endpointARN)
+	name = strings.TrimSpace(strings.ToLower(name))
+	source = strings.TrimSpace(strings.ToLower(source))
+	return "aws:resource:bedrock-agentcore:" + strings.Join(normalizeStringList([]string{
+		workload,
+		"endpoint",
+		source,
+		name,
+	}), "|")
+}
+
+func awsAIAgentResourceReferenceParts(ref string) (string, string) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return "resource", "unknown"
+	}
+	if idx := strings.Index(trimmed, "="); idx > 0 {
+		name := strings.TrimSpace(trimmed[:idx])
+		source := strings.TrimSpace(trimmed[idx+1:])
+		if source == "" {
+			source = "environment"
+		}
+		return sanitizeAIAgentReferenceToken(name), sanitizeAIAgentReferenceToken(source)
+	}
+	if !strings.Contains(trimmed, ":") && !strings.Contains(trimmed, "/") {
+		return sanitizeAIAgentReferenceToken(trimmed), ""
+	}
+	name := trimmed
+	if lastSlash := strings.LastIndex(trimmed, "/"); lastSlash >= 0 && lastSlash < len(trimmed)-1 {
+		name = trimmed[lastSlash+1:]
+	} else if colonIndex := strings.LastIndex(trimmed, ":"); colonIndex >= 0 && colonIndex < len(trimmed)-1 {
+		name = trimmed[colonIndex+1:]
+	}
+	return sanitizeAIAgentReferenceToken(name), sanitizeAIAgentReferenceToken(trimmed)
+}
+
+func sanitizeAIAgentReferenceToken(value string) string {
+	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "-", ":", "-", "#", "-").Replace(strings.TrimSpace(value)))
 }
 
 func awsCredentialReferenceNodeID(agentNodeID string, ref string) string {
@@ -611,6 +716,8 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 		return "Grant metadata-only AI agent list/describe permissions; do not add prompt, invoke, memory-content, browser-page, code-output, database-row, object-content, or secret-value reads."
 	case "ai_agent_gateway_list_failed", "ai_agent_gateway_describe_failed", "ai_agent_identity_page_failed":
 		return "Retry only the failed agent metadata call and keep successful normalized agent records visible."
+	case "agentcore_runtime_describe_failed", "agentcore_runtime_endpoint_list_failed", "agentcore_runtime_malformed":
+		return "Retry the failed AgentCore runtime metadata call and keep the surviving runtime records visible."
 	case "ai_agent_credential_reference_unresolved":
 		return "Join to credential-reference metadata for ownership and rotation without exposing provider key values."
 	default:
@@ -618,17 +725,37 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 	}
 }
 
-func awsAIAgentNodeID(accountID string, region string, agentType string, agentID string) string {
+func awsAIAgentNodeID(accountID string, region string, agentType string, agentID string, runtimeVersion string) string {
+	version := strings.TrimSpace(runtimeVersion)
+	if version != "" {
+		version = normalizeName(version)
+	}
+	suffix := firstNonEmptyAWSValue(agentID, "unknown")
+	if version != "" {
+		suffix = suffix + "/" + version
+	}
 	return fmt.Sprintf("aws:agent:%s:%s:%s/%s",
 		firstNonEmptyAWSValue(accountID, "account"),
 		firstNonEmptyAWSValue(region, "region"),
 		firstNonEmptyAWSValue(agentType, "agent"),
-		firstNonEmptyAWSValue(agentID, "unknown"),
+		suffix,
 	)
+}
+
+func normalizeName(input string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(input))
+	if trimmed == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-", ":", "-", "#", "-", ",", "-", ".", "-")
+	return strings.Trim(replacer.Replace(trimmed), "-")
 }
 
 func awsAIAgentWorkloadNodeID(record AWSAIAgentIdentityRecord) string {
 	agentID := firstNonEmptyAWSValue(record.AgentID, record.AgentARN, record.AgentName)
+	if strings.EqualFold(record.AgentType, "agentcore_runtime") && strings.TrimSpace(record.RuntimeVersion) != "" {
+		agentID = agentID + "/" + normalizeName(record.RuntimeVersion)
+	}
 	if strings.TrimSpace(record.AgentNodeID) != "" {
 		if idx := strings.LastIndex(record.AgentNodeID, "/"); idx >= 0 && idx < len(record.AgentNodeID)-1 {
 			agentID = firstNonEmptyAWSValue(agentID, record.AgentNodeID[idx+1:])

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -650,6 +650,10 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws secrets manager metadata collector: %w", err)
 			}
+			agentCoreAPI, err := awsprovider.NewSDKAgentCoreRuntimeAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if err != nil {
+				return app.Scanner{}, fmt.Errorf("initialize aws agentcore runtime collector: %w", err)
+			}
 			ssmAPI, err := awsprovider.NewSDKSSMParameterMetadataAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws ssm parameter metadata collector: %w", err)
@@ -674,6 +678,7 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 				awsprovider.NewKMSDecryptReachabilityCollector(kmsAPI),
 				awsprovider.NewSQSSNSReachabilityCollector(sqsSNSAPI),
 				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+				awsprovider.NewAIAgentIdentityCollector(agentCoreAPI),
 				awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 				awsprovider.NewECRRepositoryMetadataCollector(ecrAPI),
 			}, awsprovider.NewRuleSet(

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -493,7 +493,7 @@ func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
 	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
-	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "secretsmanager", "ssm", "ecr"})
+	assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "secretsmanager", "ai-agent", "ssm", "ecr"})
 }
 
 func assertAWSCompositeServiceNames(t *testing.T, composite *awsprovider.AWSCompositeCollector, want []string) {

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -25,31 +25,40 @@ const (
 // contents, browser pages, code output, object contents, and secret values.
 type AIAgentIdentity struct {
 	awscontract.ServiceCollectorRecord
-	AgentID                 string            `json:"agent_id"`
-	AgentARN                string            `json:"agent_arn,omitempty"`
-	AgentName               string            `json:"agent_name"`
-	AgentType               string            `json:"agent_type"`
-	Provider                string            `json:"provider,omitempty"`
-	ModelID                 string            `json:"model_id,omitempty"`
-	RuntimeRoleARN          string            `json:"runtime_role_arn,omitempty"`
-	RuntimeRoleName         string            `json:"runtime_role_name,omitempty"`
-	RuntimeRoleAccountID    string            `json:"runtime_role_account_id,omitempty"`
-	GatewayID               string            `json:"gateway_id,omitempty"`
-	GatewayARN              string            `json:"gateway_arn,omitempty"`
-	ExternalProvider        string            `json:"external_provider,omitempty"`
-	ToolNames               []string          `json:"tool_names,omitempty"`
-	ToolCount               int               `json:"tool_count"`
-	MemoryEnabled           bool              `json:"memory_enabled"`
-	MemoryStoreRefs         []string          `json:"memory_store_refs,omitempty"`
-	BrowserEnabled          bool              `json:"browser_enabled"`
-	CodeInterpreterEnabled  bool              `json:"code_interpreter_enabled"`
-	CapabilityNames         []string          `json:"capability_names,omitempty"`
-	CredentialReferenceRefs []string          `json:"credential_reference_refs,omitempty"`
-	SensitiveBoundary       string            `json:"sensitive_boundary"`
-	CoverageStatus          string            `json:"coverage_status"`
-	CoverageReason          string            `json:"coverage_reason,omitempty"`
-	Status                  string            `json:"status"`
-	Tags                    map[string]string `json:"tags,omitempty"`
+	AgentID                   string            `json:"agent_id"`
+	AgentARN                  string            `json:"agent_arn,omitempty"`
+	AgentName                 string            `json:"agent_name"`
+	AgentType                 string            `json:"agent_type"`
+	RuntimeVersion            string            `json:"runtime_version,omitempty"`
+	Provider                  string            `json:"provider,omitempty"`
+	ModelID                   string            `json:"model_id,omitempty"`
+	RuntimeRoleARN            string            `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName           string            `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID      string            `json:"runtime_role_account_id,omitempty"`
+	WorkloadIdentityARN       string            `json:"workload_identity_arn,omitempty"`
+	GatewayID                 string            `json:"gateway_id,omitempty"`
+	GatewayARN                string            `json:"gateway_arn,omitempty"`
+	ExternalProvider          string            `json:"external_provider,omitempty"`
+	ToolNames                 []string          `json:"tool_names,omitempty"`
+	ToolCount                 int               `json:"tool_count"`
+	MemoryEnabled             bool              `json:"memory_enabled"`
+	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
+	BrowserEnabled            bool              `json:"browser_enabled"`
+	CodeInterpreterEnabled    bool              `json:"code_interpreter_enabled"`
+	CapabilityNames           []string          `json:"capability_names,omitempty"`
+	CredentialReferenceRefs   []string          `json:"credential_reference_refs,omitempty"`
+	ResourceReferenceRefs     []string          `json:"resource_reference_refs,omitempty"`
+	ExecutionEndpointARNs     []string          `json:"execution_endpoint_arns,omitempty"`
+	ExecutionEndpointNames    []string          `json:"execution_endpoint_names,omitempty"`
+	ExecutionEndpointStatuses []string          `json:"execution_endpoint_statuses,omitempty"`
+	ObservabilityLinks        []string          `json:"observability_links,omitempty"`
+	NetworkMode               string            `json:"network_mode,omitempty"`
+	ServerProtocol            string            `json:"server_protocol,omitempty"`
+	SensitiveBoundary         string            `json:"sensitive_boundary"`
+	CoverageStatus            string            `json:"coverage_status"`
+	CoverageReason            string            `json:"coverage_reason,omitempty"`
+	Status                    string            `json:"status"`
+	Tags                      map[string]string `json:"tags,omitempty"`
 }
 
 type AIAgentIdentityPage struct {
@@ -235,11 +244,13 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.AgentARN = strings.TrimSpace(record.AgentARN)
 	normalized.AgentName = firstNonEmptyAWSValue(record.AgentName, normalized.AgentID)
 	normalized.AgentType = canonicalAIAgentType(record.AgentType, record.Service)
+	normalized.RuntimeVersion = strings.TrimSpace(record.RuntimeVersion)
 	normalized.Provider = strings.TrimSpace(record.Provider)
 	normalized.ModelID = strings.TrimSpace(record.ModelID)
 	normalized.RuntimeRoleARN = firstNonEmptyAWSValue(record.RuntimeRoleARN, record.RoleARN)
 	normalized.RuntimeRoleName = firstNonEmptyAWSValue(record.RuntimeRoleName, roleNameFromARN(record.RuntimeRoleARN), roleNameFromARN(record.RoleARN))
 	normalized.RuntimeRoleAccountID = firstNonEmptyAWSValue(record.RuntimeRoleAccountID, roleAccountIDFromARN(record.RuntimeRoleARN), roleAccountIDFromARN(record.RoleARN))
+	normalized.WorkloadIdentityARN = strings.TrimSpace(record.WorkloadIdentityARN)
 	normalized.RoleARN = normalized.RuntimeRoleARN
 	normalized.WorkloadID = aiAgentIdentityWorkloadID(normalized)
 	normalized.WorkloadName = firstNonEmptyAWSValue(record.WorkloadName, normalized.AgentName)
@@ -260,6 +271,34 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.MemoryStoreRefs = normalizeStringList(record.MemoryStoreRefs)
 	normalized.CapabilityNames = normalizeStringList(record.CapabilityNames)
 	normalized.CredentialReferenceRefs = normalizeStringList(record.CredentialReferenceRefs)
+	normalized.ResourceReferenceRefs = normalizeStringList(record.ResourceReferenceRefs)
+	normalized.ExecutionEndpointARNs = normalizeOrderedStringList(record.ExecutionEndpointARNs)
+	normalized.ExecutionEndpointNames = normalizeOrderedStringList(record.ExecutionEndpointNames)
+	normalized.ExecutionEndpointStatuses = normalizeOrderedStringList(record.ExecutionEndpointStatuses)
+	normalized.ObservabilityLinks = normalizeOrderedStringList(record.ObservabilityLinks)
+	normalized.NetworkMode = strings.TrimSpace(record.NetworkMode)
+	normalized.ServerProtocol = strings.TrimSpace(record.ServerProtocol)
+	if len(normalized.ExecutionEndpointARNs) > 0 {
+		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.ExecutionEndpointARNs...))
+	}
+	if normalized.WorkloadIdentityARN != "" {
+		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.WorkloadIdentityARN))
+	}
+	if normalized.NetworkMode != "" {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "runtime_network_"+strings.ToLower(normalized.NetworkMode))
+	}
+	if normalized.ServerProtocol != "" {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "runtime_protocol_"+strings.ToLower(normalized.ServerProtocol))
+	}
+	if normalized.WorkloadIdentityARN != "" {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "workload_identity")
+	}
+	if len(normalized.ExecutionEndpointARNs) > 0 {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "execution_endpoint")
+	}
+	if len(normalized.ObservabilityLinks) > 0 {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "observability")
+	}
 	normalized.SensitiveBoundary = firstNonEmptyAWSValue(record.SensitiveBoundary, "metadata_only")
 	normalized.CoverageStatus = firstNonEmptyAWSValue(record.CoverageStatus, "covered")
 	normalized.Status = firstNonEmptyAWSValue(record.Status, "ready")
@@ -280,22 +319,43 @@ func aiAgentIdentitySourceID(record AIAgentIdentity) string {
 	}, "|")
 }
 
-func aiAgentIdentityWorkloadSourceID(record AIAgentIdentity) string {
+func aiAgentIdentityAgentRef(record AIAgentIdentity) string {
+	agentType := canonicalAIAgentType(record.AgentType, record.Service)
 	agentRef := firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName)
-	if strings.EqualFold(firstNonEmptyAWSValue(record.AgentType, "agent"), "agent_gateway") {
+	if agentType == "agentcore_runtime" {
+		agentRef = firstNonEmptyAWSValue(record.AgentID, record.AgentARN, record.AgentName)
+		if version := strings.TrimSpace(record.RuntimeVersion); version != "" {
+			agentRef = agentRef + "/" + normalizeName(version)
+		}
+	}
+	return agentRef
+}
+
+func aiAgentIdentityNodeRef(record AIAgentIdentity) string {
+	agentRef := aiAgentIdentityAgentRef(record)
+	if canonicalAIAgentType(record.AgentType, record.Service) == "agent_gateway" {
 		return firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN, agentRef)
 	}
 	return firstNonEmptyAWSValue(agentRef, record.GatewayID, record.GatewayARN)
 }
 
+func aiAgentIdentityNodeIdentity(record AIAgentIdentity) string {
+	if canonicalAIAgentType(record.AgentType, record.Service) == "agent_gateway" {
+		return firstNonEmptyAWSValue(record.GatewayID, record.GatewayARN, record.AgentID, record.AgentARN, record.AgentName)
+	}
+	return firstNonEmptyAWSValue(record.AgentID, record.AgentARN, record.AgentName)
+}
+
+func aiAgentIdentityWorkloadSourceID(record AIAgentIdentity) string {
+	return aiAgentIdentityNodeRef(record)
+}
+
 func aiAgentIdentityWorkloadID(record AIAgentIdentity) string {
-	agentRef := firstNonEmptyAWSValue(record.AgentARN, record.AgentID, record.AgentName)
-	if strings.EqualFold(firstNonEmptyAWSValue(record.AgentType, "agent"), "agent_gateway") {
+	agentRef := aiAgentIdentityAgentRef(record)
+	if canonicalAIAgentType(record.AgentType, record.Service) == "agent_gateway" {
 		return firstNonEmptyAWSValue(
 			record.WorkloadID,
-			record.GatewayID,
-			record.GatewayARN,
-			agentRef,
+			aiAgentIdentityNodeRef(record),
 		)
 	}
 	return firstNonEmptyAWSValue(
@@ -330,6 +390,9 @@ func aiAgentIdentityConfidence(record AIAgentIdentity) float64 {
 	if strings.TrimSpace(record.RuntimeRoleARN) != "" {
 		confidence += 0.08
 	}
+	if strings.TrimSpace(record.RuntimeVersion) != "" {
+		confidence += 0.03
+	}
 	if strings.TrimSpace(record.AgentARN) != "" {
 		confidence += 0.06
 	}
@@ -338,6 +401,18 @@ func aiAgentIdentityConfidence(record AIAgentIdentity) float64 {
 	}
 	if len(record.CredentialReferenceRefs) > 0 {
 		confidence += 0.04
+	}
+	if strings.TrimSpace(record.WorkloadIdentityARN) != "" {
+		confidence += 0.03
+	}
+	if len(record.ExecutionEndpointARNs) > 0 {
+		confidence += 0.04
+	}
+	if len(record.ObservabilityLinks) > 0 {
+		confidence += 0.02
+	}
+	if strings.TrimSpace(record.NetworkMode) != "" || strings.TrimSpace(record.ServerProtocol) != "" {
+		confidence += 0.02
 	}
 	if confidence > 0.95 {
 		return 0.95

--- a/internal/providers/aws/bedrock_agents_collector.go
+++ b/internal/providers/aws/bedrock_agents_collector.go
@@ -382,11 +382,11 @@ func buildBedrockAgentIdentity(scope AWSCollectorScope, summary BedrockAgentSumm
 	}
 	record.ToolCount = len(record.ToolNames)
 	record.ServiceCollectorRecord = awscontract.ServiceCollectorRecord{
-		TenantID:      scope.TenantID,
-		WorkspaceID:   scope.WorkspaceID,
-		ProjectID:     scope.ProjectID,
-		ConnectorID:   scope.ConnectorID,
-		ScanID:        scope.ScanID,
+		TenantID:      firstNonEmptyAWSValue(scope.TenantID, "tenant"),
+		WorkspaceID:   firstNonEmptyAWSValue(scope.WorkspaceID, "workspace"),
+		ProjectID:     firstNonEmptyAWSValue(scope.ProjectID, "project"),
+		ConnectorID:   firstNonEmptyAWSValue(scope.ConnectorID, "aws-connector"),
+		ScanID:        firstNonEmptyAWSValue(scope.ScanID, "aws-ai-agent-identity-fixture"),
 		AccountID:     firstNonEmptyAWSValue(scope.AccountID),
 		Region:        firstNonEmptyAWSValue(scope.Region),
 		Service:       bedrockAgentsServiceName,

--- a/internal/providers/aws/bedrock_agents_collector_test.go
+++ b/internal/providers/aws/bedrock_agents_collector_test.go
@@ -164,6 +164,34 @@ func TestBedrockAgentsCollectorMetadataOnlyPayload(t *testing.T) {
 	}
 }
 
+func TestBedrockAgentsCollectorDefaultsScopeFieldsOnCollect(t *testing.T) {
+	api := &fakeBedrockAgentsAPI{
+		pages: []BedrockAgentsPage{{
+			Agents: []BedrockAgentSummary{
+				{AgentID: "AG1", AgentARN: "arn:aws:bedrock:us-east-1:123456789012:agent/AG1", AgentName: "agent", RoleARN: "arn:aws:iam::123456789012:role/r"},
+			},
+		}},
+		details: map[string]BedrockAgentDetail{"AG1": {}},
+	}
+	collector := NewBedrockAgentsCollector(api)
+	assets, err := collector.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one asset, got %d", len(assets))
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(assets[0].Payload, &record); err != nil {
+		t.Fatalf("unmarshal asset: %v", err)
+	}
+	if record.TenantID != "tenant" || record.WorkspaceID != "workspace" || record.ProjectID != "project" {
+		t.Fatalf("expected default tenant/workspace/project scope, got %+v", record.ServiceCollectorRecord)
+	}
+	if record.ConnectorID != "aws-connector" || record.ScanID != "aws-ai-agent-identity-fixture" {
+		t.Fatalf("expected default connector/scan scope, got %+v", record.ServiceCollectorRecord)
+	}
+}
 func TestBedrockAgentsCollectorPartialFailureWhenDetailFails(t *testing.T) {
 	api := &fakeBedrockAgentsAPI{
 		pages: []BedrockAgentsPage{{

--- a/internal/providers/aws/fixture_collector.go
+++ b/internal/providers/aws/fixture_collector.go
@@ -101,6 +101,15 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 		}
 	}
 
+	var aiAgentIdentity AIAgentIdentity
+	if err := json.Unmarshal(payload, &aiAgentIdentity); err == nil {
+		if isAIAgentIdentityFixture(aiAgentIdentity) {
+			if sourceID := strings.TrimSpace(aiAgentIdentitySourceID(aiAgentIdentity)); sourceID != "" {
+				return rawKindAIAgentIdentity, sourceID
+			}
+		}
+	}
+
 	var eksIdentity EKSWorkloadIdentity
 	if err := json.Unmarshal(payload, &eksIdentity); err == nil {
 		sourceID := eksWorkloadIdentitySourceID(eksIdentity)
@@ -253,6 +262,20 @@ func fixtureAssetKindAndSourceID(payload []byte) (string, string) {
 	}
 
 	return "", ""
+}
+
+func isAIAgentIdentityFixture(record AIAgentIdentity) bool {
+	if strings.TrimSpace(record.AgentType) == "" {
+		return false
+	}
+	if strings.TrimSpace(record.AgentID) == "" &&
+		strings.TrimSpace(record.AgentARN) == "" &&
+		strings.TrimSpace(record.GatewayID) == "" &&
+		strings.TrimSpace(record.GatewayARN) == "" &&
+		strings.TrimSpace(record.WorkloadID) == "" {
+		return false
+	}
+	return true
 }
 
 func isECRRepositoryMetadataFixture(record ECRRepositoryMetadata) bool {

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -51,6 +51,28 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 		identityIDs[identity.ID] = struct{}{}
 	}
 
+	for _, agent := range bundle.Agents {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		identityID := strings.TrimSpace(agent.OwnerID)
+		if identityID == "" {
+			continue
+		}
+		if _, exists := identityIDs[identityID]; !exists {
+			continue
+		}
+		relationship := domain.Relationship{
+			ID:           relationshipID(domain.RelationshipRunsAs, agent.ID, identityID),
+			Type:         domain.RelationshipRunsAs,
+			FromNodeID:   agent.ID,
+			ToNodeID:     identityID,
+			EvidenceRef:  agent.RawRef,
+			DiscoveredAt: timestamp,
+		}
+		appendRelationship(&relationships, seen, relationship)
+	}
+
 	for _, workload := range bundle.Workloads {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -80,6 +102,17 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 	for _, resource := range bundle.Resources {
 		if err := ctx.Err(); err != nil {
 			return nil, err
+		}
+		if resource.Type == domain.ResourceTypeBedrockAgentCore && strings.TrimSpace(resource.SourceEntityID) != "" {
+			relationship := domain.Relationship{
+				ID:           relationshipID(domain.RelationshipInvokes, resource.SourceEntityID, resource.ID),
+				Type:         domain.RelationshipInvokes,
+				FromNodeID:   resource.SourceEntityID,
+				ToNodeID:     resource.ID,
+				EvidenceRef:  resource.RawRef,
+				DiscoveredAt: timestamp,
+			}
+			appendRelationship(&relationships, seen, relationship)
 		}
 		refs := parseStringList(resource.Metadata["secret_refs"])
 		for _, ref := range refs {

--- a/internal/providers/aws/helpers.go
+++ b/internal/providers/aws/helpers.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -19,4 +20,82 @@ func firstNonEmptyAWSValue(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func normalizeOrderedStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func awsAIAgentNodeID(accountID string, region string, agentType string, agentID string, runtimeVersion string) string {
+	version := strings.TrimSpace(runtimeVersion)
+	if version != "" {
+		version = normalizeName(version)
+	}
+	suffix := firstNonEmptyAWSValue(agentID, "unknown")
+	if version != "" {
+		suffix = suffix + "/" + version
+	}
+	return fmt.Sprintf("aws:agent:%s:%s:%s/%s",
+		firstNonEmptyAWSValue(accountID, "account"),
+		firstNonEmptyAWSValue(region, "region"),
+		firstNonEmptyAWSValue(agentType, "agent"),
+		suffix,
+	)
+}
+
+func awsAIAgentExecutionEndpointNodeID(agentNodeID string, endpointARN string) string {
+	workload := strings.TrimSpace(agentNodeID)
+	if workload == "" {
+		workload = "agent"
+	}
+	name, source := awsAIAgentResourceReferenceParts(endpointARN)
+	name = strings.TrimSpace(strings.ToLower(name))
+	source = strings.TrimSpace(strings.ToLower(source))
+	return "aws:resource:bedrock-agentcore:" + strings.Join(normalizeStringList([]string{
+		workload,
+		"endpoint",
+		source,
+		name,
+	}), "|")
+}
+
+func awsAIAgentResourceReferenceParts(ref string) (string, string) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return "resource", "unknown"
+	}
+	if idx := strings.Index(trimmed, "="); idx > 0 {
+		name := strings.TrimSpace(trimmed[:idx])
+		source := strings.TrimSpace(trimmed[idx+1:])
+		if source == "" {
+			source = "environment"
+		}
+		return sanitizeAIAgentReferenceToken(name), sanitizeAIAgentReferenceToken(source)
+	}
+	if !strings.Contains(trimmed, ":") && !strings.Contains(trimmed, "/") {
+		return sanitizeAIAgentReferenceToken(trimmed), ""
+	}
+	name := trimmed
+	if lastSlash := strings.LastIndex(trimmed, "/"); lastSlash >= 0 && lastSlash < len(trimmed)-1 {
+		name = trimmed[lastSlash+1:]
+	} else if colonIndex := strings.LastIndex(trimmed, ":"); colonIndex >= 0 && colonIndex < len(trimmed)-1 {
+		name = trimmed[colonIndex+1:]
+	}
+	return sanitizeAIAgentReferenceToken(name), sanitizeAIAgentReferenceToken(trimmed)
+}
+
+func sanitizeAIAgentReferenceToken(value string) string {
+	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "-", ":", "-", "#", "-").Replace(strings.TrimSpace(value)))
 }

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -41,6 +41,7 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 	identitySeen := map[string]struct{}{}
 	policySeen := map[string]struct{}{}
 	workloadSeen := map[string]struct{}{}
+	agentSeen := map[string]struct{}{}
 	resourceSeen := map[string]struct{}{}
 
 	for i, asset := range raw {
@@ -87,6 +88,18 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 			continue
 		}
 		if err := normalizeIAMRoleAsset(asset, i, &bundle, identitySeen, policySeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+		if asset.Kind != rawKindAIAgentIdentity {
+			continue
+		}
+		if err := normalizeAIAgentIdentityAsset(asset, i, &bundle, identitySeen, agentSeen, resourceSeen); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
 	}
@@ -326,6 +339,154 @@ func normalizeIAMRoleAsset(asset providers.RawAsset, index int, bundle *provider
 		}
 	}
 	return nil
+}
+
+func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, identitySeen map[string]struct{}, agentSeen map[string]struct{}, resourceSeen map[string]struct{}) error {
+	var record AIAgentIdentity
+	if err := json.Unmarshal(asset.Payload, &record); err != nil {
+		return fmt.Errorf("decode ai agent identity %s: %w", asset.SourceID, err)
+	}
+	if strings.TrimSpace(record.AgentID) == "" && strings.TrimSpace(record.AgentARN) == "" && strings.TrimSpace(record.GatewayID) == "" && strings.TrimSpace(record.GatewayARN) == "" {
+		return fmt.Errorf("ai agent identity %s missing stable identifier", asset.SourceID)
+	}
+
+	agentID := awsAIAgentNodeID(record.AccountID, record.Region, canonicalAIAgentType(record.AgentType, record.Service), aiAgentIdentityNodeIdentity(record), record.RuntimeVersion)
+	agentIndex := -1
+	if _, exists := agentSeen[agentID]; !exists {
+		agent := domain.Agent{
+			ID:       agentID,
+			Provider: domain.ProviderAWS,
+			Type:     domain.AgentTypeAI,
+			Name:     firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.GatewayID, record.GatewayARN),
+			Model:    strings.TrimSpace(record.ModelID),
+			Runtime:  firstNonEmptyAWSValue(record.RuntimeVersion, record.AgentType, record.Service),
+			OwnerID:  "",
+			RawRef:   asset.SourceID,
+			Metadata: map[string]any{
+				"agent_arn":                   strings.TrimSpace(record.AgentARN),
+				"agent_type":                  strings.TrimSpace(record.AgentType),
+				"provider":                    strings.TrimSpace(record.Provider),
+				"runtime_version":             strings.TrimSpace(record.RuntimeVersion),
+				"runtime_role_arn":            strings.TrimSpace(record.RuntimeRoleARN),
+				"runtime_role_name":           strings.TrimSpace(record.RuntimeRoleName),
+				"runtime_role_account_id":     strings.TrimSpace(record.RuntimeRoleAccountID),
+				"workload_identity_arn":       strings.TrimSpace(record.WorkloadIdentityARN),
+				"gateway_arn":                 strings.TrimSpace(record.GatewayARN),
+				"gateway_id":                  strings.TrimSpace(record.GatewayID),
+				"tool_names":                  normalizeStringList(record.ToolNames),
+				"capability_names":            normalizeStringList(record.CapabilityNames),
+				"credential_reference_refs":   normalizeStringList(record.CredentialReferenceRefs),
+				"resource_reference_refs":     normalizeStringList(record.ResourceReferenceRefs),
+				"execution_endpoint_arns":     normalizeOrderedStringList(record.ExecutionEndpointARNs),
+				"execution_endpoint_names":    normalizeOrderedStringList(record.ExecutionEndpointNames),
+				"execution_endpoint_statuses": normalizeOrderedStringList(record.ExecutionEndpointStatuses),
+				"observability_links":         normalizeOrderedStringList(record.ObservabilityLinks),
+				"network_mode":                strings.TrimSpace(record.NetworkMode),
+				"server_protocol":             strings.TrimSpace(record.ServerProtocol),
+				"source":                      strings.TrimSpace(record.Source),
+				"evidence_ref":                strings.TrimSpace(record.EvidenceRef),
+				"coverage_status":             strings.TrimSpace(record.CoverageStatus),
+				"coverage_reason":             strings.TrimSpace(record.CoverageReason),
+				"sensitive_boundary":          strings.TrimSpace(record.SensitiveBoundary),
+				"status":                      strings.TrimSpace(record.Status),
+			},
+			Tags: copyTags(record.Tags),
+		}
+		bundle.Agents = append(bundle.Agents, agent)
+		agentSeen[agentID] = struct{}{}
+		agentIndex = len(bundle.Agents) - 1
+	}
+
+	if runtimeRoleARN := strings.TrimSpace(record.RuntimeRoleARN); runtimeRoleARN != "" {
+		runtimeRoleID := identityIDFromARN(runtimeRoleARN)
+		if _, exists := identitySeen[runtimeRoleID]; !exists {
+			identity := domain.Identity{
+				ID:        runtimeRoleID,
+				Provider:  domain.ProviderAWS,
+				Type:      domain.IdentityTypeRole,
+				Name:      firstNonEmptyAWSValue(record.RuntimeRoleName, roleNameFromARN(runtimeRoleARN), runtimeRoleARN),
+				ARN:       runtimeRoleARN,
+				OwnerHint: firstNonEmptyAWSValue(record.RuntimeRoleAccountID, record.AccountID),
+				CreatedAt: record.CollectedAt,
+				Tags:      map[string]string{},
+				RawRef:    asset.SourceID,
+			}
+			bundle.Identities = append(bundle.Identities, identity)
+			identitySeen[runtimeRoleID] = struct{}{}
+		}
+		if agentIndex >= 0 && agentIndex < len(bundle.Agents) {
+			bundle.Agents[agentIndex].OwnerID = runtimeRoleID
+		}
+	}
+
+	for _, endpointARN := range normalizeStringList(record.ExecutionEndpointARNs) {
+		endpointID := awsAIAgentExecutionEndpointNodeID(agentID, endpointARN)
+		if _, exists := resourceSeen[endpointID]; exists {
+			continue
+		}
+		resource := domain.Resource{
+			ID:        endpointID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.ResourceTypeBedrockAgentCore,
+			Name:      endpointNameFromARN(endpointARN),
+			ARN:       endpointARN,
+			Region:    strings.TrimSpace(record.Region),
+			AccountID: strings.TrimSpace(record.AccountID),
+			Labels: map[string]string{
+				"resource_kind": "agentcore_runtime_endpoint",
+			},
+			Metadata: map[string]any{
+				"runtime_agent_id":          agentID,
+				"runtime_version":           strings.TrimSpace(record.RuntimeVersion),
+				"runtime_role_arn":          strings.TrimSpace(record.RuntimeRoleARN),
+				"endpoint_name":             endpointNameFromARN(endpointARN),
+				"endpoint_status":           endpointStatusByIndex(record, endpointARN),
+				"endpoint_arn":              endpointARN,
+				"observability_links":       normalizeOrderedStringList(record.ObservabilityLinks),
+				"resource_reference_refs":   normalizeStringList(record.ResourceReferenceRefs),
+				"workload_identity_arn":     strings.TrimSpace(record.WorkloadIdentityARN),
+				"execution_endpoint_names":  normalizeOrderedStringList(record.ExecutionEndpointNames),
+				"execution_endpoint_status": endpointStatusByIndex(record, endpointARN),
+			},
+			RawRef:         asset.SourceID,
+			SourceEntityID: agentID,
+		}
+		bundle.Resources = append(bundle.Resources, resource)
+		resourceSeen[endpointID] = struct{}{}
+	}
+
+	return nil
+}
+
+func endpointNameFromARN(arn string) string {
+	trimmed := strings.TrimSpace(arn)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 && idx < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	if idx := strings.LastIndex(trimmed, ":"); idx >= 0 && idx < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	return trimmed
+}
+
+func endpointStatusByIndex(record AIAgentIdentity, endpointARN string) string {
+	normalizedARN := strings.TrimSpace(endpointARN)
+	if normalizedARN == "" {
+		return ""
+	}
+	for i, arn := range record.ExecutionEndpointARNs {
+		if strings.TrimSpace(arn) != normalizedARN {
+			continue
+		}
+		if i < len(record.ExecutionEndpointStatuses) {
+			return strings.TrimSpace(record.ExecutionEndpointStatuses[i])
+		}
+		break
+	}
+	return ""
 }
 
 func normalizeECRRepositoryMetadataAsset(asset providers.RawAsset, index int, bundle *providers.NormalizedBundle, resourceSeen map[string]struct{}) error {

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -158,6 +158,67 @@ func TestRoleNormalizerInvalidPayload(t *testing.T) {
 	}
 }
 
+func TestRoleNormalizerKeepsDistinctGatewayOnlyAIAgents(t *testing.T) {
+	normalizer := NewRoleNormalizer()
+	recordA := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Service:   "bedrock",
+		},
+		AgentType:  "agent_gateway",
+		AgentName:  "payments gateway a",
+		GatewayID:  "payments-gateway-a",
+		GatewayARN: "arn:aws:bedrock:us-east-1:123456789012:agent-gateway/payments-gateway-a",
+	}
+	recordB := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Service:   "bedrock",
+		},
+		AgentType:  "agent_gateway",
+		AgentName:  "payments gateway b",
+		GatewayID:  "payments-gateway-b",
+		GatewayARN: "arn:aws:bedrock:us-east-1:123456789012:agent-gateway/payments-gateway-b",
+	}
+	payloadA, err := json.Marshal(recordA)
+	if err != nil {
+		t.Fatalf("marshal record A: %v", err)
+	}
+	payloadB, err := json.Marshal(recordB)
+	if err != nil {
+		t.Fatalf("marshal record B: %v", err)
+	}
+
+	bundle, err := normalizer.Normalize(context.Background(), []providers.RawAsset{
+		{Kind: rawKindAIAgentIdentity, SourceID: "gateway-a", Payload: payloadA},
+		{Kind: rawKindAIAgentIdentity, SourceID: "gateway-b", Payload: payloadB},
+	})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if len(bundle.Agents) != 2 {
+		t.Fatalf("expected two gateway agents, got %+v", bundle.Agents)
+	}
+	if bundle.Agents[0].ID == bundle.Agents[1].ID {
+		t.Fatalf("expected distinct gateway agent IDs, got %q", bundle.Agents[0].ID)
+	}
+	if strings.Contains(bundle.Agents[0].ID, "/unknown") || strings.Contains(bundle.Agents[1].ID, "/unknown") {
+		t.Fatalf("gateway-only agents should not collapse to unknown IDs: %+v", bundle.Agents)
+	}
+}
+
+func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {
+	agentNodeID := "aws:agent:123456789012:us-east-1:custom_agent/CaseSensitiveGateway"
+	endpointARN := "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime/Blue"
+
+	nodeID := awsAIAgentExecutionEndpointNodeID(agentNodeID, endpointARN)
+	if !strings.Contains(nodeID, agentNodeID) {
+		t.Fatalf("expected endpoint node id to preserve agent node case, got %q", nodeID)
+	}
+}
+
 func TestRoleNormalizerInvalidPermissionPolicyDocument(t *testing.T) {
 	role := IAMRole{
 		ARN:                "arn:aws:iam::1:role/demo",

--- a/internal/providers/aws/sdk_agentcore_runtime.go
+++ b/internal/providers/aws/sdk_agentcore_runtime.go
@@ -1,0 +1,407 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+// AgentCoreRuntimeSDKClient defines the AgentCore Control API calls required by
+// the live runtime identity adapter.
+type AgentCoreRuntimeSDKClient interface {
+	ListAgentRuntimes(ctx context.Context, params *bedrockagentcorecontrol.ListAgentRuntimesInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListAgentRuntimesOutput, error)
+	GetAgentRuntime(ctx context.Context, params *bedrockagentcorecontrol.GetAgentRuntimeInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetAgentRuntimeOutput, error)
+	ListAgentRuntimeEndpoints(ctx context.Context, params *bedrockagentcorecontrol.ListAgentRuntimeEndpointsInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput, error)
+}
+
+// SDKAgentCoreRuntimeAPI adapts the AgentCore control plane into the generic
+// AIAgentIdentity API contract.
+type SDKAgentCoreRuntimeAPI struct {
+	client    AgentCoreRuntimeSDKClient
+	accountID string
+	region    string
+}
+
+var _ AIAgentIdentityAPI = (*SDKAgentCoreRuntimeAPI)(nil)
+
+// NewSDKAgentCoreRuntimeAPI constructs the runtime API using ambient AWS
+// credentials.
+func NewSDKAgentCoreRuntimeAPI(region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	return NewSDKAgentCoreRuntimeAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+// NewSDKAgentCoreRuntimeAPIWithContext constructs the runtime API using the
+// caller-provided context for AWS configuration loading.
+func NewSDKAgentCoreRuntimeAPIWithContext(ctx context.Context, region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKAgentCoreRuntimeAPIFromClient(bedrockagentcorecontrol.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+// NewSDKAgentCoreRuntimeAPIFromAssumeRole constructs the runtime API after
+// assuming the connector role.
+func NewSDKAgentCoreRuntimeAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKAgentCoreRuntimeAPIFromClient(bedrockagentcorecontrol.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+// NewSDKAgentCoreRuntimeAPIFromClient creates a test seam around a provided
+// AgentCore client.
+func NewSDKAgentCoreRuntimeAPIFromClient(client AgentCoreRuntimeSDKClient, accountID string, region string) AIAgentIdentityAPI {
+	return &SDKAgentCoreRuntimeAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+// ListAgentIdentities lists AgentCore runtimes and enriches each runtime with
+// endpoint and workload-identity metadata while preserving partial-failure
+// diagnostics for incomplete sub-calls.
+func (a *SDKAgentCoreRuntimeAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
+	if a.client == nil {
+		return AIAgentIdentityPage{}, fmt.Errorf("agentcore runtime sdk client is required")
+	}
+	input := &bedrockagentcorecontrol.ListAgentRuntimesInput{
+		MaxResults: awsv2.Int32(agentCoreSDKPageSize(pageSize)),
+	}
+	if token := strings.TrimSpace(nextToken); token != "" {
+		input.NextToken = awsv2.String(token)
+	}
+	output, err := a.client.ListAgentRuntimes(ctx, input)
+	if err != nil {
+		return AIAgentIdentityPage{}, err
+	}
+
+	records := make([]AIAgentIdentity, 0, len(output.AgentRuntimes))
+	diagnostics := []providers.SourceError{}
+	for _, summary := range output.AgentRuntimes {
+		if err := ctx.Err(); err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		record, runtimeDiagnostics, err := a.runtimeRecord(ctx, summary)
+		if err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		diagnostics = append(diagnostics, runtimeDiagnostics...)
+		if strings.TrimSpace(record.AgentID) == "" && strings.TrimSpace(record.AgentARN) == "" {
+			continue
+		}
+		records = append(records, record)
+	}
+
+	return AIAgentIdentityPage{
+		Records:     records,
+		NextToken:   strings.TrimSpace(awsv2.ToString(output.NextToken)),
+		Diagnostics: diagnostics,
+	}, nil
+}
+
+func (a *SDKAgentCoreRuntimeAPI) runtimeRecord(ctx context.Context, summary agentcoretypes.AgentRuntime) (AIAgentIdentity, []providers.SourceError, error) {
+	diagnostics := []providers.SourceError{}
+	runtimeID := strings.TrimSpace(awsv2.ToString(summary.AgentRuntimeId))
+	runtimeARN := strings.TrimSpace(awsv2.ToString(summary.AgentRuntimeArn))
+	runtimeName := firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.AgentRuntimeName)), runtimeID, runtimeARN)
+	runtimeVersion := strings.TrimSpace(awsv2.ToString(summary.AgentRuntimeVersion))
+	if runtimeID == "" && runtimeARN != "" {
+		runtimeID = agentCoreRuntimeIDFromARN(runtimeARN)
+	}
+	if runtimeID == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			Code:      "agentcore_runtime_malformed",
+			Message:   "skipped AgentCore runtime without a stable identifier",
+			Retryable: false,
+		})
+		return AIAgentIdentity{}, diagnostics, nil
+	}
+
+	detail, detailErr := a.describeRuntime(ctx, runtimeID, runtimeVersion)
+	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, detailErr
+	}
+	if runtimeID != "" {
+		// Keep the summary record visible even when a per-runtime describe
+		// call fails. The record will be marked degraded below.
+		if detailErr != nil {
+			diagnostics = append(diagnostics, providers.SourceError{
+				Collector: aiAgentIdentityCollectorName,
+				SourceID:  runtimeID,
+				Code:      "agentcore_runtime_describe_failed",
+				Message:   fmt.Sprintf("AgentCore runtime %s could not be described: %v", runtimeID, detailErr),
+				Retryable: isRetryable(detailErr),
+			})
+		}
+	}
+
+	endpointARNs, endpointNames, endpointStatuses, observabilityLinks, resourceRefs, endpointDiagnostics, endpointErr := a.listRuntimeEndpoints(ctx, runtimeID)
+	diagnostics = append(diagnostics, endpointDiagnostics...)
+	if errors.Is(endpointErr, context.Canceled) || errors.Is(endpointErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, endpointErr
+	}
+	if endpointErr != nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  runtimeID,
+			Code:      "agentcore_runtime_endpoint_list_failed",
+			Message:   fmt.Sprintf("AgentCore runtime %s endpoints could not be listed: %v", runtimeID, endpointErr),
+			Retryable: isRetryable(endpointErr),
+		})
+	}
+
+	workloadIdentityARN := ""
+	if detail.WorkloadIdentityDetails != nil {
+		workloadIdentityARN = strings.TrimSpace(awsv2.ToString(detail.WorkloadIdentityDetails.WorkloadIdentityArn))
+	}
+	if workloadIdentityARN != "" {
+		resourceRefs = append(resourceRefs, workloadIdentityARN)
+	}
+
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: strings.TrimSpace(a.accountID),
+			Region:    strings.TrimSpace(a.region),
+		},
+		AgentID:                   runtimeID,
+		AgentARN:                  firstNonEmptyAWSValue(runtimeARN, awsv2.ToString(detail.AgentRuntimeArn)),
+		AgentName:                 runtimeName,
+		AgentType:                 "agentcore_runtime",
+		RuntimeVersion:            firstNonEmptyAWSValue(runtimeVersion, awsv2.ToString(detail.AgentRuntimeVersion)),
+		Provider:                  "amazon-bedrock-agentcore",
+		RuntimeRoleARN:            strings.TrimSpace(awsv2.ToString(detail.RoleArn)),
+		RuntimeRoleName:           roleNameFromARN(strings.TrimSpace(awsv2.ToString(detail.RoleArn))),
+		RuntimeRoleAccountID:      roleAccountIDFromARN(strings.TrimSpace(awsv2.ToString(detail.RoleArn))),
+		WorkloadIdentityARN:       workloadIdentityARN,
+		ToolNames:                 nil,
+		BrowserEnabled:            false,
+		CodeInterpreterEnabled:    false,
+		CapabilityNames:           agentCoreRuntimeCapabilities(workloadIdentityARN, endpointARNs),
+		CredentialReferenceRefs:   nil,
+		ResourceReferenceRefs:     dedupeStrings(resourceRefs),
+		ExecutionEndpointARNs:     endpointARNs,
+		ExecutionEndpointNames:    endpointNames,
+		ExecutionEndpointStatuses: endpointStatuses,
+		ObservabilityLinks:        observabilityLinks,
+		NetworkMode:               runtimeNetworkMode(detail.NetworkConfiguration),
+		ServerProtocol:            runtimeServerProtocol(detail.ProtocolConfiguration),
+		SensitiveBoundary:         "metadata_only",
+		CoverageStatus:            "covered",
+		Status:                    agentCoreRuntimeStatus(detail.Status),
+	}
+	if strings.TrimSpace(record.RuntimeVersion) == "" {
+		record.RuntimeVersion = runtimeVersion
+	}
+	if strings.TrimSpace(record.AgentARN) == "" {
+		record.AgentARN = runtimeARN
+	}
+	if strings.TrimSpace(record.RuntimeRoleARN) == "" {
+		record.RuntimeRoleARN = strings.TrimSpace(awsv2.ToString(detail.RoleArn))
+		record.RuntimeRoleName = roleNameFromARN(record.RuntimeRoleARN)
+		record.RuntimeRoleAccountID = roleAccountIDFromARN(record.RuntimeRoleARN)
+	}
+	if detailErr != nil || endpointErr != nil {
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = firstNonEmptyAWSValue(
+			strings.TrimSpace(awsv2.ToString(detail.FailureReason)),
+			"AgentCore runtime metadata was partially collected",
+		)
+	}
+	record.Confidence = aiAgentIdentityConfidence(record)
+	record.Source = "agentcore_runtime_metadata"
+	record.Service = "agentcore"
+	record.EvidenceRef = firstNonEmptyAWSValue(record.AgentARN, record.AgentID)
+	record.CollectorName = aiAgentIdentityCollectorName
+	record.SensitiveBoundary = firstNonEmptyAWSValue(record.SensitiveBoundary, "metadata_only")
+	return record, diagnostics, nil
+}
+
+func agentCoreRuntimeCapabilities(workloadIdentityARN string, endpointARNs []string) []string {
+	capabilities := []string{"runtime"}
+	if strings.TrimSpace(workloadIdentityARN) != "" {
+		capabilities = append(capabilities, "workload_identity")
+	}
+	if len(endpointARNs) > 0 {
+		capabilities = append(capabilities, "execution_endpoint")
+	}
+	return capabilities
+}
+
+func (a *SDKAgentCoreRuntimeAPI) describeRuntime(ctx context.Context, runtimeID string, runtimeVersion string) (bedrockagentcorecontrol.GetAgentRuntimeOutput, error) {
+	if strings.TrimSpace(runtimeID) == "" {
+		return bedrockagentcorecontrol.GetAgentRuntimeOutput{}, fmt.Errorf("runtime id is required")
+	}
+	output, err := a.client.GetAgentRuntime(ctx, &bedrockagentcorecontrol.GetAgentRuntimeInput{
+		AgentRuntimeId:      awsv2.String(runtimeID),
+		AgentRuntimeVersion: stringPtrOrNil(strings.TrimSpace(runtimeVersion)),
+	})
+	if err != nil {
+		return bedrockagentcorecontrol.GetAgentRuntimeOutput{}, err
+	}
+	if output == nil {
+		return bedrockagentcorecontrol.GetAgentRuntimeOutput{}, fmt.Errorf("runtime %s returned no metadata", runtimeID)
+	}
+	return *output, nil
+}
+
+func (a *SDKAgentCoreRuntimeAPI) listRuntimeEndpoints(ctx context.Context, runtimeID string) ([]string, []string, []string, []string, []string, []providers.SourceError, error) {
+	if strings.TrimSpace(runtimeID) == "" {
+		return nil, nil, nil, nil, nil, nil, nil
+	}
+	input := &bedrockagentcorecontrol.ListAgentRuntimeEndpointsInput{
+		AgentRuntimeId: awsv2.String(runtimeID),
+		MaxResults:     awsv2.Int32(agentCoreSDKPageSize(defaultPageSize)),
+	}
+	endpointARNs := []string{}
+	endpointNames := []string{}
+	endpointStatuses := []string{}
+	observabilityLinks := []string{}
+	resourceRefs := []string{}
+	for {
+		if err := ctx.Err(); err != nil {
+			return endpointARNs, endpointNames, endpointStatuses, observabilityLinks, resourceRefs, nil, err
+		}
+		output, err := a.client.ListAgentRuntimeEndpoints(ctx, input)
+		if err != nil {
+			return endpointARNs, endpointNames, endpointStatuses, observabilityLinks, resourceRefs, nil, err
+		}
+		if output != nil {
+			for _, endpoint := range output.RuntimeEndpoints {
+				endpointARN := strings.TrimSpace(awsv2.ToString(endpoint.AgentRuntimeEndpointArn))
+				if endpointARN == "" {
+					continue
+				}
+				endpointARNs = append(endpointARNs, endpointARN)
+				endpointNames = append(endpointNames, firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(endpoint.Name)), agentCoreRuntimeEndpointNameFromARN(endpointARN)))
+				endpointStatuses = append(endpointStatuses, agentCoreRuntimeEndpointStatus(endpoint.Status))
+				observabilityLinks = append(observabilityLinks, agentCoreRuntimeObservabilityLink(runtimeID, endpoint))
+				resourceRefs = append(resourceRefs, endpointARN)
+			}
+		}
+		nextToken := ""
+		if output != nil {
+			nextToken = strings.TrimSpace(awsv2.ToString(output.NextToken))
+		}
+		if nextToken == "" {
+			break
+		}
+		input.NextToken = awsv2.String(nextToken)
+	}
+	return normalizeOrderedStringList(endpointARNs), normalizeOrderedStringList(endpointNames), normalizeOrderedStringList(endpointStatuses), normalizeOrderedStringList(observabilityLinks), normalizeStringList(resourceRefs), nil, nil
+}
+
+func agentCoreSDKPageSize(pageSize int32) int32 {
+	if pageSize <= 0 {
+		return defaultPageSize
+	}
+	if pageSize > 100 {
+		return 100
+	}
+	return pageSize
+}
+
+func agentCoreRuntimeIDFromARN(arn string) string {
+	trimmed := strings.TrimSpace(arn)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 && idx < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	if idx := strings.LastIndex(trimmed, ":"); idx >= 0 && idx < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	return trimmed
+}
+
+func agentCoreRuntimeEndpointNameFromARN(arn string) string {
+	trimmed := strings.TrimSpace(arn)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 && idx < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	return trimmed
+}
+
+func agentCoreRuntimeEndpointStatus(status agentcoretypes.AgentRuntimeEndpointStatus) string {
+	switch strings.ToUpper(strings.TrimSpace(string(status))) {
+	case "", "READY", "AVAILABLE", "ACTIVE":
+		return "ready"
+	default:
+		return "degraded"
+	}
+}
+
+func runtimeNetworkMode(network *agentcoretypes.NetworkConfiguration) string {
+	if network == nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.ToLower(string(network.NetworkMode)))
+}
+
+func runtimeServerProtocol(protocol *agentcoretypes.ProtocolConfiguration) string {
+	if protocol == nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.ToLower(string(protocol.ServerProtocol)))
+}
+
+func agentCoreRuntimeStatus(status agentcoretypes.AgentRuntimeStatus) string {
+	switch strings.ToUpper(strings.TrimSpace(string(status))) {
+	case "", "ACTIVE", "READY":
+		return "ready"
+	default:
+		return "degraded"
+	}
+}
+
+func agentCoreRuntimeObservabilityLink(runtimeID string, endpoint agentcoretypes.AgentRuntimeEndpoint) string {
+	endpointName := firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(endpoint.Name)), agentCoreRuntimeEndpointNameFromARN(strings.TrimSpace(awsv2.ToString(endpoint.AgentRuntimeEndpointArn))))
+	if endpointName == "" {
+		endpointName = "endpoint"
+	}
+	return fmt.Sprintf("observability://agentcore/runtime/%s/endpoints/%s", normalizeName(runtimeID), normalizeName(endpointName))
+}

--- a/internal/providers/aws/sdk_agentcore_runtime_test.go
+++ b/internal/providers/aws/sdk_agentcore_runtime_test.go
@@ -1,0 +1,178 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+)
+
+type fakeAgentCoreRuntimeSDKClient struct {
+	listOutput      *bedrockagentcorecontrol.ListAgentRuntimesOutput
+	listErr         error
+	detailOutput    *bedrockagentcorecontrol.GetAgentRuntimeOutput
+	detailErr       error
+	endpointsOutput *bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput
+	endpointsErr    error
+	onGetRuntime    func()
+	onListEndpoints func()
+}
+
+func (f *fakeAgentCoreRuntimeSDKClient) ListAgentRuntimes(_ context.Context, _ *bedrockagentcorecontrol.ListAgentRuntimesInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListAgentRuntimesOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listOutput == nil {
+		return &bedrockagentcorecontrol.ListAgentRuntimesOutput{}, nil
+	}
+	return f.listOutput, nil
+}
+
+func (f *fakeAgentCoreRuntimeSDKClient) GetAgentRuntime(_ context.Context, _ *bedrockagentcorecontrol.GetAgentRuntimeInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetAgentRuntimeOutput, error) {
+	if f.onGetRuntime != nil {
+		f.onGetRuntime()
+	}
+	if f.detailErr != nil {
+		return nil, f.detailErr
+	}
+	if f.detailOutput == nil {
+		return &bedrockagentcorecontrol.GetAgentRuntimeOutput{}, nil
+	}
+	return f.detailOutput, nil
+}
+
+func (f *fakeAgentCoreRuntimeSDKClient) ListAgentRuntimeEndpoints(_ context.Context, _ *bedrockagentcorecontrol.ListAgentRuntimeEndpointsInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput, error) {
+	if f.onListEndpoints != nil {
+		f.onListEndpoints()
+	}
+	if f.endpointsErr != nil {
+		return nil, f.endpointsErr
+	}
+	if f.endpointsOutput == nil {
+		return &bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput{}, nil
+	}
+	return f.endpointsOutput, nil
+}
+
+func TestSDKAgentCoreRuntimeAPIIncludesAccountRegionAndObservedCapabilities(t *testing.T) {
+	client := &fakeAgentCoreRuntimeSDKClient{
+		listOutput: &bedrockagentcorecontrol.ListAgentRuntimesOutput{
+			AgentRuntimes: []agentcoretypes.AgentRuntime{{
+				AgentRuntimeId:      awsv2.String("runtime-1"),
+				AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+				AgentRuntimeName:    awsv2.String("runtime-1"),
+				AgentRuntimeVersion: awsv2.String("2026-06-01"),
+				Status:              agentcoretypes.AgentRuntimeStatusReady,
+			}},
+		},
+		detailOutput: &bedrockagentcorecontrol.GetAgentRuntimeOutput{
+			AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+			AgentRuntimeVersion: awsv2.String("2026-06-01"),
+			RoleArn:             awsv2.String("arn:aws:iam::123456789012:role/agentcore-runtime"),
+			Status:              agentcoretypes.AgentRuntimeStatusReady,
+			WorkloadIdentityDetails: &agentcoretypes.WorkloadIdentityDetails{
+				WorkloadIdentityArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:workload-identity/runtime-1"),
+			},
+			NetworkConfiguration:  &agentcoretypes.NetworkConfiguration{NetworkMode: agentcoretypes.NetworkModeVpc},
+			ProtocolConfiguration: &agentcoretypes.ProtocolConfiguration{ServerProtocol: agentcoretypes.ServerProtocolHttp},
+		},
+		endpointsOutput: &bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput{
+			RuntimeEndpoints: []agentcoretypes.AgentRuntimeEndpoint{{
+				AgentRuntimeEndpointArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime-1/blue"),
+				Name:                    awsv2.String("blue"),
+				Status:                  agentcoretypes.AgentRuntimeEndpointStatusReady,
+			}},
+		},
+	}
+
+	page, err := NewSDKAgentCoreRuntimeAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("ListAgentIdentities: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected one runtime record, got %+v", page.Records)
+	}
+	record := page.Records[0]
+	if record.AccountID != "123456789012" || record.Region != "us-east-1" {
+		t.Fatalf("expected account/region context on runtime record, got %+v", record)
+	}
+	if got := record.CapabilityNames; len(got) != 3 || got[0] != "runtime" || got[1] != "workload_identity" || got[2] != "execution_endpoint" {
+		t.Fatalf("expected observed runtime capabilities, got %+v", got)
+	}
+}
+
+func TestSDKAgentCoreRuntimeAPIDoesNotReportMissingCapabilities(t *testing.T) {
+	client := &fakeAgentCoreRuntimeSDKClient{
+		listOutput: &bedrockagentcorecontrol.ListAgentRuntimesOutput{
+			AgentRuntimes: []agentcoretypes.AgentRuntime{{
+				AgentRuntimeId:      awsv2.String("runtime-1"),
+				AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+				AgentRuntimeName:    awsv2.String("runtime-1"),
+				AgentRuntimeVersion: awsv2.String("2026-06-01"),
+				Status:              agentcoretypes.AgentRuntimeStatusReady,
+			}},
+		},
+		detailOutput: &bedrockagentcorecontrol.GetAgentRuntimeOutput{
+			AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+			AgentRuntimeVersion: awsv2.String("2026-06-01"),
+			RoleArn:             awsv2.String("arn:aws:iam::123456789012:role/agentcore-runtime"),
+			Status:              agentcoretypes.AgentRuntimeStatusReady,
+		},
+		endpointsOutput: &bedrockagentcorecontrol.ListAgentRuntimeEndpointsOutput{},
+	}
+
+	page, err := NewSDKAgentCoreRuntimeAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("ListAgentIdentities: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected one runtime record, got %+v", page.Records)
+	}
+	if got := page.Records[0].CapabilityNames; len(got) != 1 || got[0] != "runtime" {
+		t.Fatalf("expected only runtime capability when metadata is absent, got %+v", got)
+	}
+}
+
+func TestSDKAgentCoreRuntimeAPIPropagatesContextCancellation(t *testing.T) {
+	baseList := &bedrockagentcorecontrol.ListAgentRuntimesOutput{
+		AgentRuntimes: []agentcoretypes.AgentRuntime{{
+			AgentRuntimeId:      awsv2.String("runtime-1"),
+			AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+			AgentRuntimeName:    awsv2.String("runtime-1"),
+			AgentRuntimeVersion: awsv2.String("2026-06-01"),
+			Status:              agentcoretypes.AgentRuntimeStatusReady,
+		}},
+	}
+
+	t.Run("describe runtime", func(t *testing.T) {
+		client := &fakeAgentCoreRuntimeSDKClient{
+			listOutput:   baseList,
+			detailErr:    context.Canceled,
+			onGetRuntime: func() {},
+		}
+		_, err := NewSDKAgentCoreRuntimeAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation from describe, got %v", err)
+		}
+	})
+
+	t.Run("list endpoints", func(t *testing.T) {
+		client := &fakeAgentCoreRuntimeSDKClient{
+			listOutput: baseList,
+			detailOutput: &bedrockagentcorecontrol.GetAgentRuntimeOutput{
+				AgentRuntimeArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1"),
+				AgentRuntimeVersion: awsv2.String("2026-06-01"),
+				RoleArn:             awsv2.String("arn:aws:iam::123456789012:role/agentcore-runtime"),
+				Status:              agentcoretypes.AgentRuntimeStatusReady,
+			},
+			endpointsErr: context.Canceled,
+		}
+		_, err := NewSDKAgentCoreRuntimeAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation from endpoint listing, got %v", err)
+		}
+	})
+}

--- a/internal/providers/graph_contract.go
+++ b/internal/providers/graph_contract.go
@@ -208,8 +208,8 @@ func validateRelationshipEndpoints(
 		}
 		return fmt.Errorf("can_access relationship %q has invalid access node %q", relationship.ID, relationship.ToNodeID)
 	case domain.RelationshipRunsAs:
-		if !hasWorkload(relationship.FromNodeID) {
-			return fmt.Errorf("runs_as relationship %q has unknown workload %q", relationship.ID, relationship.FromNodeID)
+		if !hasWorkload(relationship.FromNodeID) && !hasAgent(relationship.FromNodeID) {
+			return fmt.Errorf("runs_as relationship %q has unknown workload or agent %q", relationship.ID, relationship.FromNodeID)
 		}
 		if !hasIdentity(relationship.ToNodeID) {
 			return fmt.Errorf("runs_as relationship %q has unknown target identity %q", relationship.ID, relationship.ToNodeID)

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -148,6 +148,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws secrets manager metadata collector: %w", secretsErr)
 			}
+			agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreRuntimeAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			if agentCoreErr != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("initialize aws agentcore runtime collector: %w", agentCoreErr)
+			}
 			ssmAPI, ssmErr := awsprovider.NewSDKSSMParameterMetadataAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if ssmErr != nil {
 				_ = store.Close()
@@ -178,6 +183,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				awsprovider.NewSQSSNSReachabilityCollector(sqsSNSAPI),
 				awsprovider.NewDynamoDBRDSReachabilityCollector(dynamoDBRDSAPI),
 				awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+				awsprovider.NewAIAgentIdentityCollector(agentCoreAPI),
 				awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 				awsprovider.NewECRRepositoryMetadataCollector(ecrAPI),
 			)
@@ -328,6 +334,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if secretsErr != nil {
 			return nil, secretsErr
 		}
+		agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreRuntimeAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		if agentCoreErr != nil {
+			return nil, agentCoreErr
+		}
 		ssmAPI, ssmErr := awsprovider.NewSDKSSMParameterMetadataAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
 		if ssmErr != nil {
 			return nil, ssmErr
@@ -356,6 +366,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			awsprovider.NewSQSSNSReachabilityCollector(sqsSNSAPI),
 			awsprovider.NewDynamoDBRDSReachabilityCollector(dynamoDBRDSAPI),
 			awsprovider.NewSecretsManagerMetadataCollector(secretsAPI),
+			awsprovider.NewAIAgentIdentityCollector(agentCoreAPI),
 			awsprovider.NewSSMParameterMetadataCollector(ssmAPI),
 			awsprovider.NewECRRepositoryMetadataCollector(ecrAPI),
 		)

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -287,7 +287,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
 		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	} else {
-		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "dynamodb_rds", "secretsmanager", "ssm", "ecr"})
+		assertAWSCompositeServiceNames(t, composite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "dynamodb_rds", "secretsmanager", "ai-agent", "ssm", "ecr"})
 	}
 	connectorScanner, err := svc.AWSScannerFactory(context.Background(), api.AWSConnectionStatus{
 		AccountID:  cfg.AWSAccountID,
@@ -305,7 +305,7 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 	if connectorComposite, ok := connectorAppScanner.Collector.(*aws.AWSCompositeCollector); !ok {
 		t.Fatalf("expected connector composite collector, got %T", connectorAppScanner.Collector)
 	} else {
-		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "dynamodb_rds", "secretsmanager", "ssm", "ecr"})
+		assertAWSCompositeServiceNames(t, connectorComposite, []string{"iam", "ec2", "ecs", "lambda", "codebuild", "codepipeline", "stepfunctions", "eventbridge", "managed-compute", "sagemaker", "iam-passrole", "eks", "s3", "kms", "sqs_sns", "dynamodb_rds", "secretsmanager", "ai-agent", "ssm", "ecr"})
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1964,11 +1964,13 @@ export type AWSAIAgentIdentityRecord = {
   agent_arn?: string;
   agent_name: string;
   agent_type: 'bedrock_agent' | 'agentcore_runtime' | 'custom_agent' | 'external_provider_agent' | 'agent_gateway' | string;
+  runtime_version?: string;
   provider?: string;
   model_id?: string;
   runtime_role_arn?: string;
   runtime_role_name?: string;
   runtime_role_account_id?: string;
+  workload_identity_arn?: string;
   gateway_id?: string;
   gateway_arn?: string;
   external_provider?: string;
@@ -1979,6 +1981,13 @@ export type AWSAIAgentIdentityRecord = {
   code_interpreter_enabled: boolean;
   capability_names?: string[];
   credential_reference_refs?: string[];
+  resource_reference_refs?: string[];
+  execution_endpoint_arns?: string[];
+  execution_endpoint_names?: string[];
+  execution_endpoint_statuses?: string[];
+  observability_links?: string[];
+  network_mode?: string;
+  server_protocol?: string;
   sensitive_boundary: string;
   coverage_status: string;
   coverage_reason?: string;
@@ -1995,7 +2004,7 @@ export type AWSAIAgentIdentityRecord = {
 };
 
 export type AWSAIAgentIdentityRelationship = {
-  type: 'runs_as' | 'calls_tool' | 'uses_secret' | string;
+  type: 'runs_as' | 'calls_tool' | 'uses_secret' | 'invokes' | string;
   from_node_id: string;
   to_node_id: string;
   evidence_ref: string;
@@ -2004,7 +2013,7 @@ export type AWSAIAgentIdentityRelationship = {
 export type AWSAIAgentIdentityDiagnostic = {
   collector: string;
   source_id?: string;
-  code: string;
+  code: 'ai_agent_credential_reference_unresolved' | 'ai_agent_gateway_list_failed' | 'ai_agent_gateway_describe_failed' | 'ai_agent_identity_page_failed' | 'agentcore_runtime_describe_failed' | 'agentcore_runtime_endpoint_list_failed' | 'agentcore_runtime_malformed' | 'permission_denied' | string;
   message: string;
   remediation?: string;
   retryable: boolean;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7096,9 +7096,13 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   const degraded = record.status !== 'ready' || record.coverage_status === 'degraded' || Boolean(record.coverage_reason);
   const status = stage === 'not-available' ? 'not yet available' : degraded ? 'degraded' : 'role anchor';
   const roleLabel = record.runtime_role_name || record.runtime_role_arn || 'runtime role unresolved';
+  const runtimeLabel = record.runtime_version || 'runtime version not reported';
   const toolLabel = record.tool_names?.length ? `${record.tool_names.length} tools` : 'no tools reported';
   const capabilityLabel = record.capability_names?.length ? `${record.capability_names.join(', ')} capabilities` : 'capabilities not reported';
   const credentialLabel = record.credential_reference_refs?.length ? `${record.credential_reference_refs.length} credential refs, values hidden` : 'no credential refs reported';
+  const endpointLabel = record.execution_endpoint_names?.length ? `${record.execution_endpoint_names.length} execution endpoints` : 'no execution endpoints reported';
+  const protocolLabel = record.server_protocol || 'protocol not reported';
+  const networkLabel = record.network_mode || 'network mode not reported';
   const surface = awsAIAgentSurfaceFilter(record);
   const relationships = new Set<string>(['agent-to-role']);
   if (record.tool_names?.length || record.gateway_arn) {
@@ -7107,6 +7111,9 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   if (record.credential_reference_refs?.length) {
     relationships.add('agent-to-secret');
   }
+  if (record.execution_endpoint_arns?.length) {
+    relationships.add('agent-to-endpoint');
+  }
   return {
     id: `ai-agent-identity-${record.agent_node_id || record.agent_id}`,
     name: record.agent_name || record.agent_id,
@@ -7114,7 +7121,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
     stage,
-    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${toolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
+    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
@@ -7130,12 +7137,18 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
       record.model_id,
       record.runtime_role_arn,
       record.runtime_role_name,
+      record.runtime_version,
       record.gateway_id,
       record.gateway_arn,
       record.external_provider,
       ...(record.tool_names ?? []),
+      ...(record.execution_endpoint_names ?? []),
+      ...(record.execution_endpoint_arns ?? []),
+      ...(record.observability_links ?? []),
       ...(record.capability_names ?? []),
       ...(record.credential_reference_refs ?? []),
+      record.network_mode,
+      record.server_protocol,
       record.account_id,
       record.region,
       'ai agent identity metadata only values hidden'


### PR DESCRIPTION
## What changed
- Added an AgentCore runtime SDK collector and wired it into both AWS scan modes.
- Normalized AgentCore runtimes with runtime version, workload identity, execution endpoints, observability links, and network/protocol metadata.
- Added `invokes` relationships for runtime-to-endpoint edges and kept the fixture classifier from claiming unrelated AWS payloads.
- Updated the API schema, frontend types, and product inventory row details to surface the new runtime fields.

## Why
Issue #1507 asks for AgentCore Runtime identity collection with graph wiring and metadata that lets the UI and API describe the runtime surface clearly.

## Validation
- `go test ./internal/providers/aws ./internal/api ./internal/runtime`
- `npm run build` in `web/`

AI disclosure: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AgentCore runtime collector and extends the AI agent identity model with runtime version scoping, workload identity, execution endpoints, and `invokes` edges across API, graph, and UI. Delivers AgentCore runtime identity per #1507 and introduces a project‑scoped Bedrock Agents inventory.

- **New Features**
  - SDK-backed AgentCore runtime collector integrated into both AWS scan modes; captures `runtime_version`, `workload_identity_arn`, execution endpoint ARNs/names/statuses, `observability_links`, `network_mode`, and `server_protocol`; indexes endpoints as resources and adds agent‑to‑endpoint `invokes` edges.
  - Normalizer builds AI agent nodes (runtime version in node ID) and AgentCore endpoint resources; sets agent owner to the IAM role; relationship builder resolves `runs_as` from agents and `invokes` from endpoint `SourceEntityID`; validator accepts agent origins for `runs_as`.
  - API/OpenAPI adds new runtime and endpoint fields (`resource_reference_refs`, execution endpoint arrays, `observability_links`, `network_mode`, `server_protocol`), the `invokes` relationship type, and diagnostics for AgentCore (`agentcore_runtime_*`) plus gateway/identity paging (`ai_agent_gateway_describe_failed`, `ai_agent_identity_page_failed`); filters and diagnostics scope to returned records.
  - Fixtures/classifier accept `AIAgentIdentity` assets and avoid claiming unrelated payloads; docs add guidance for missing runtime endpoints.
  - Web types and client updated for new fields and `invokes`; inventory rows show runtime version, endpoint count, network mode, and protocol.

- **Dependencies**
  - Adds `github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol`.
  - Metadata-only collection; no prompts, invocations, documents, secret values, or endpoint content are read.

<sup>Written for commit 945ef8b595e6d49c9b2bfbf2fb790382f92830cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Refs #1507
