### PR TITLE
Map AgentCore gateway MCP tools

### DIFF
--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -1,6 +1,6 @@
 # AWS AI Agent Identities
 
-Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance.
+Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping.
 
 ## What Is Collected
 
@@ -14,10 +14,11 @@ The model is metadata-only. Each `agent_identity` record can describe:
 - runtime IAM role ARN/name/account
 - AgentCore runtime version, workload identity ARN, execution endpoints, observability links, network mode, and server protocol
 - provider and model identifiers
-- tool names and capability names
+- gateway auth mode, tool target references, allowed action names, tool names, and capability names
 - memory/browser/code-interpreter capability flags
 - credential-reference identifiers
 - agent-to-endpoint `invokes` relationships for AgentCore runtime execution surfaces
+- agent-to-tool `calls_tool` relationships for AgentCore Gateway and MCP tool surfaces
 - evidence references, confidence, account, region, connector, scan, workspace, and project context
 
 The public API is:
@@ -45,11 +46,11 @@ External AI provider credentials are represented as credential references only. 
 
 ## Permissions
 
-Use metadata-only list and describe permissions for the relevant agent, runtime, gateway, and IAM-role surfaces. Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue.
+Use metadata-only list and describe permissions for the relevant agent, runtime, gateway target, and IAM-role surfaces. Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue. Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
 
 ## UI Surface
 
-The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, tools, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
+The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, Gateway/MCP tools, auth mode, allowed-action counts, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
 
 ## Troubleshooting
 
@@ -58,3 +59,4 @@ The AWS Agents inventory page shows normalized agent rows, runtime role anchors,
 - Unresolved credential reference: join to the credential-reference metadata surface for ownership and rotation, never to secret values.
 - Empty result: confirm that the selected connector account and region actually hosts Bedrock, AgentCore, custom, external-provider-backed, or gateway agent resources.
 - Missing runtime endpoints: confirm the runtime has published execution endpoints in the selected region and account.
+- Missing Gateway tools: confirm the gateway has targets, target describe permissions, and inline MCP/API tool metadata or schema references in the selected region and account.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10097,6 +10097,13 @@ components:
         tool_names:
           type: array
           items: { type: string }
+        tool_target_refs:
+          type: array
+          items: { type: string }
+        allowed_actions:
+          type: array
+          items: { type: string }
+        auth_mode: { type: string }
         memory_enabled: { type: boolean }
         memory_store_refs:
           type: array
@@ -10176,6 +10183,9 @@ components:
             - ai_agent_credential_reference_unresolved
             - ai_agent_gateway_describe_failed
             - ai_agent_gateway_list_failed
+            - ai_agent_gateway_malformed
+            - ai_agent_gateway_target_describe_failed
+            - ai_agent_gateway_target_list_failed
             - ai_agent_identity_page_failed
             - agentcore_runtime_describe_failed
             - agentcore_runtime_endpoint_list_failed

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	awsAIAgentIdentityCurrentIssue = 1505
+	awsAIAgentIdentityCurrentIssue = 1508
 	awsAIAgentIdentityVersion      = "aws-ai-agent-identity-normalized-model-v1"
 	awsAIAgentCredentialRefPrefix  = "aws:resource:credential-reference:"
 	awsAIAgentToolNodePrefix       = "tool:agent:"
@@ -88,6 +88,9 @@ type AWSAIAgentIdentityRecord struct {
 	GatewayARN                string            `json:"gateway_arn,omitempty"`
 	ExternalProvider          string            `json:"external_provider,omitempty"`
 	ToolNames                 []string          `json:"tool_names,omitempty"`
+	ToolTargetRefs            []string          `json:"tool_target_refs,omitempty"`
+	AllowedActions            []string          `json:"allowed_actions,omitempty"`
+	AuthMode                  string            `json:"auth_mode,omitempty"`
 	MemoryEnabled             bool              `json:"memory_enabled"`
 	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
 	BrowserEnabled            bool              `json:"browser_enabled"`
@@ -362,7 +365,10 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			r.GatewayID = "payments-gateway"
 			r.GatewayARN = gatewayARN
 			r.ToolNames = []string{"payments-case-search", "fraud-review-action-group", "support-search"}
-			r.CapabilityNames = []string{"gateway", "tool_routing"}
+			r.ToolTargetRefs = []string{"payments-search-target", "fraud-review-target", "support-search-target"}
+			r.AllowedActions = []string{"search_cases", "create_fraud_review", "search_support"}
+			r.AuthMode = "custom_jwt"
+			r.CapabilityNames = []string{"gateway", "tool_routing", "mcp", "gateway_auth_custom_jwt"}
 		}),
 	}
 	switch fixtureState {
@@ -435,13 +441,15 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 	record.AgentNodeID = awsAIAgentNodeID(accountID, region, agentType, firstNonEmptyAWSValue(record.AgentID, agentID), record.RuntimeVersion)
 	record.RuntimeRoleNodeID = awsIdentityNodeIDForAPI(roleARN)
 	record.ToolNames = dedupeStrings(record.ToolNames)
+	record.ToolTargetRefs = dedupeStrings(record.ToolTargetRefs)
+	record.AllowedActions = dedupeStrings(record.AllowedActions)
 	record.CapabilityNames = dedupeStrings(record.CapabilityNames)
 	record.CredentialReferenceRefs = dedupeStrings(record.CredentialReferenceRefs)
 	record.ExecutionEndpointARNs = normalizeOrderedStringList(record.ExecutionEndpointARNs)
 	record.ExecutionEndpointNames = normalizeOrderedStringList(record.ExecutionEndpointNames)
 	record.ExecutionEndpointStatuses = normalizeOrderedStringList(record.ExecutionEndpointStatuses)
 	record.ObservabilityLinks = normalizeOrderedStringList(record.ObservabilityLinks)
-	record.ResourceReferenceRefs = dedupeStrings(append(record.ResourceReferenceRefs, append(append([]string{}, record.ExecutionEndpointARNs...), record.WorkloadIdentityARN)...))
+	record.ResourceReferenceRefs = dedupeStrings(append(append(record.ResourceReferenceRefs, record.ToolTargetRefs...), append(append([]string{}, record.ExecutionEndpointARNs...), record.WorkloadIdentityARN)...))
 	if len(record.CredentialReferenceRefs) > 0 {
 		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_secret"))
 	}
@@ -714,7 +722,7 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 	switch code {
 	case "permission_denied":
 		return "Grant metadata-only AI agent list/describe permissions; do not add prompt, invoke, memory-content, browser-page, code-output, database-row, object-content, or secret-value reads."
-	case "ai_agent_gateway_list_failed", "ai_agent_gateway_describe_failed", "ai_agent_identity_page_failed":
+	case "ai_agent_gateway_list_failed", "ai_agent_gateway_describe_failed", "ai_agent_gateway_target_list_failed", "ai_agent_gateway_target_describe_failed", "ai_agent_gateway_malformed", "ai_agent_identity_page_failed":
 		return "Retry only the failed agent metadata call and keep successful normalized agent records visible."
 	case "agentcore_runtime_describe_failed", "agentcore_runtime_endpoint_list_failed", "agentcore_runtime_malformed":
 		return "Retry the failed AgentCore runtime metadata call and keep the surviving runtime records visible."

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -30,7 +30,7 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready inventory, got %+v", result)
 	}
-	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1505" || result.Version != awsAIAgentIdentityVersion {
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1508" || result.Version != awsAIAgentIdentityVersion {
 		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
 	}
 	if result.BedrockAgentCount != 1 || result.AgentCoreRuntimeCount != 1 || result.CustomAgentCount != 1 || result.ExternalAgentCount != 1 || result.GatewayCount != 1 {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -650,9 +650,9 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws secrets manager metadata collector: %w", err)
 			}
-			agentCoreAPI, err := awsprovider.NewSDKAgentCoreRuntimeAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			agentCoreAPI, err := awsprovider.NewSDKAgentCoreAIAgentIdentityAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if err != nil {
-				return app.Scanner{}, fmt.Errorf("initialize aws agentcore runtime collector: %w", err)
+				return app.Scanner{}, fmt.Errorf("initialize aws agentcore identity collector: %w", err)
 			}
 			ssmAPI, err := awsprovider.NewSDKSSMParameterMetadataAPI(cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if err != nil {

--- a/internal/providers/aws/ai_agent_identity_api.go
+++ b/internal/providers/aws/ai_agent_identity_api.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CompositeAIAgentIdentityAPI lets multiple metadata-only agent identity
+// adapters feed the same ai-agent collector without duplicating collector
+// service names in the AWS scanner.
+type CompositeAIAgentIdentityAPI struct {
+	apis []AIAgentIdentityAPI
+}
+
+var _ AIAgentIdentityAPI = (*CompositeAIAgentIdentityAPI)(nil)
+
+func NewCompositeAIAgentIdentityAPI(apis ...AIAgentIdentityAPI) AIAgentIdentityAPI {
+	filtered := make([]AIAgentIdentityAPI, 0, len(apis))
+	for _, api := range apis {
+		if api != nil {
+			filtered = append(filtered, api)
+		}
+	}
+	return &CompositeAIAgentIdentityAPI{apis: filtered}
+}
+
+func (a *CompositeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
+	if a == nil || len(a.apis) == 0 {
+		return AIAgentIdentityPage{}, nil
+	}
+	apiIndex, sourceToken, err := parseCompositeAIAgentIdentityToken(nextToken)
+	if err != nil {
+		return AIAgentIdentityPage{}, err
+	}
+	for apiIndex < len(a.apis) {
+		if err := ctx.Err(); err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		page, err := a.apis[apiIndex].ListAgentIdentities(ctx, sourceToken, pageSize)
+		if err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		if strings.TrimSpace(page.NextToken) != "" {
+			page.NextToken = formatCompositeAIAgentIdentityToken(apiIndex, page.NextToken)
+			return page, nil
+		}
+		if apiIndex+1 < len(a.apis) {
+			page.NextToken = formatCompositeAIAgentIdentityToken(apiIndex+1, "")
+		}
+		if len(page.Records) > 0 || len(page.Diagnostics) > 0 {
+			return page, nil
+		}
+		apiIndex++
+		sourceToken = ""
+	}
+	return AIAgentIdentityPage{}, nil
+}
+
+func parseCompositeAIAgentIdentityToken(token string) (int, string, error) {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
+		return 0, "", nil
+	}
+	index, sourceToken, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return 0, "", fmt.Errorf("invalid ai agent identity pagination token")
+	}
+	parsed, err := strconv.Atoi(index)
+	if err != nil || parsed < 0 {
+		return 0, "", fmt.Errorf("invalid ai agent identity pagination token")
+	}
+	return parsed, sourceToken, nil
+}
+
+func formatCompositeAIAgentIdentityToken(apiIndex int, sourceToken string) string {
+	return strconv.Itoa(apiIndex) + ":" + strings.TrimSpace(sourceToken)
+}

--- a/internal/providers/aws/ai_agent_identity_api.go
+++ b/internal/providers/aws/ai_agent_identity_api.go
@@ -2,9 +2,12 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/identrail/identrail/internal/providers"
 )
 
 // CompositeAIAgentIdentityAPI lets multiple metadata-only agent identity
@@ -37,14 +40,28 @@ func (a *CompositeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, n
 	if apiIndex >= len(a.apis) {
 		return AIAgentIdentityPage{}, fmt.Errorf("invalid ai agent identity pagination token")
 	}
+	diagnostics := []providers.SourceError{}
 	for apiIndex < len(a.apis) {
 		if err := ctx.Err(); err != nil {
 			return AIAgentIdentityPage{}, err
 		}
 		page, err := a.apis[apiIndex].ListAgentIdentities(ctx, sourceToken, pageSize)
 		if err != nil {
-			return AIAgentIdentityPage{}, err
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return AIAgentIdentityPage{}, err
+			}
+			diagnostics = append(diagnostics, providers.SourceError{
+				Collector: aiAgentIdentityCollectorName,
+				SourceID:  fmt.Sprintf("adapter:%d", apiIndex),
+				Code:      "ai_agent_identity_adapter_failed",
+				Message:   fmt.Sprintf("ai agent identity adapter %d failed: %v", apiIndex, err),
+				Retryable: isRetryable(err),
+			})
+			apiIndex++
+			sourceToken = ""
+			continue
 		}
+		page.Diagnostics = append(diagnostics, page.Diagnostics...)
 		if strings.TrimSpace(page.NextToken) != "" {
 			page.NextToken = formatCompositeAIAgentIdentityToken(apiIndex, page.NextToken)
 			return page, nil
@@ -58,7 +75,7 @@ func (a *CompositeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, n
 		apiIndex++
 		sourceToken = ""
 	}
-	return AIAgentIdentityPage{}, nil
+	return AIAgentIdentityPage{Diagnostics: diagnostics}, nil
 }
 
 func parseCompositeAIAgentIdentityToken(token string) (int, string, error) {

--- a/internal/providers/aws/ai_agent_identity_api.go
+++ b/internal/providers/aws/ai_agent_identity_api.go
@@ -34,6 +34,9 @@ func (a *CompositeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, n
 	if err != nil {
 		return AIAgentIdentityPage{}, err
 	}
+	if apiIndex >= len(a.apis) {
+		return AIAgentIdentityPage{}, fmt.Errorf("invalid ai agent identity pagination token")
+	}
 	for apiIndex < len(a.apis) {
 		if err := ctx.Err(); err != nil {
 			return AIAgentIdentityPage{}, err

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -41,6 +41,9 @@ type AIAgentIdentity struct {
 	ExternalProvider          string            `json:"external_provider,omitempty"`
 	ToolNames                 []string          `json:"tool_names,omitempty"`
 	ToolCount                 int               `json:"tool_count"`
+	ToolTargetRefs            []string          `json:"tool_target_refs,omitempty"`
+	AllowedActions            []string          `json:"allowed_actions,omitempty"`
+	AuthMode                  string            `json:"auth_mode,omitempty"`
 	MemoryEnabled             bool              `json:"memory_enabled"`
 	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
 	BrowserEnabled            bool              `json:"browser_enabled"`
@@ -268,6 +271,9 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.ExternalProvider = strings.TrimSpace(record.ExternalProvider)
 	normalized.ToolNames = normalizeStringList(record.ToolNames)
 	normalized.ToolCount = len(normalized.ToolNames)
+	normalized.ToolTargetRefs = normalizeStringList(record.ToolTargetRefs)
+	normalized.AllowedActions = normalizeStringList(record.AllowedActions)
+	normalized.AuthMode = strings.TrimSpace(record.AuthMode)
 	normalized.MemoryStoreRefs = normalizeStringList(record.MemoryStoreRefs)
 	normalized.CapabilityNames = normalizeStringList(record.CapabilityNames)
 	normalized.CredentialReferenceRefs = normalizeStringList(record.CredentialReferenceRefs)
@@ -280,6 +286,9 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.ServerProtocol = strings.TrimSpace(record.ServerProtocol)
 	if len(normalized.ExecutionEndpointARNs) > 0 {
 		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.ExecutionEndpointARNs...))
+	}
+	if len(normalized.ToolTargetRefs) > 0 {
+		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.ToolTargetRefs...))
 	}
 	if normalized.WorkloadIdentityARN != "" {
 		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.WorkloadIdentityARN))
@@ -295,6 +304,9 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	}
 	if len(normalized.ExecutionEndpointARNs) > 0 {
 		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "execution_endpoint")
+	}
+	if normalized.AuthMode != "" {
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "auth_"+strings.ToLower(normalized.AuthMode))
 	}
 	if len(normalized.ObservabilityLinks) > 0 {
 		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "observability")

--- a/internal/providers/aws/ai_agent_identity_collector_test.go
+++ b/internal/providers/aws/ai_agent_identity_collector_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,11 +17,15 @@ type fakeAIAgentIdentityAPI struct {
 	pages     []AIAgentIdentityPage
 	tokens    []string
 	pageSizes []int32
+	err       error
 }
 
 func (f *fakeAIAgentIdentityAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
 	f.tokens = append(f.tokens, nextToken)
 	f.pageSizes = append(f.pageSizes, pageSize)
+	if f.err != nil {
+		return AIAgentIdentityPage{}, f.err
+	}
 	if len(f.pages) == 0 {
 		return AIAgentIdentityPage{}, nil
 	}
@@ -122,6 +127,32 @@ func TestCompositeAIAgentIdentityAPIRejectsOutOfRangeToken(t *testing.T) {
 	_, err := api.ListAgentIdentities(context.Background(), "4:", 10)
 	if err == nil || !strings.Contains(err.Error(), "invalid ai agent identity pagination token") {
 		t.Fatalf("expected invalid pagination token error, got %v", err)
+	}
+}
+
+func TestCompositeAIAgentIdentityAPIContinuesAfterAdapterFailure(t *testing.T) {
+	failing := &fakeAIAgentIdentityAPI{err: errors.New("access denied")}
+	successful := &fakeAIAgentIdentityAPI{pages: []AIAgentIdentityPage{{
+		Records: []AIAgentIdentity{{
+			AgentID:   "gateway-1",
+			AgentName: "payments-gateway",
+			AgentType: "agent_gateway",
+		}},
+	}}}
+	api := NewCompositeAIAgentIdentityAPI(failing, successful)
+
+	page, err := api.ListAgentIdentities(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("expected composite api to continue after adapter failure, got %v", err)
+	}
+	if len(page.Records) != 1 || page.Records[0].AgentID != "gateway-1" {
+		t.Fatalf("expected successful adapter records, got %+v", page.Records)
+	}
+	if len(page.Diagnostics) != 1 || page.Diagnostics[0].Code != "ai_agent_identity_adapter_failed" {
+		t.Fatalf("expected adapter failure diagnostic, got %+v", page.Diagnostics)
+	}
+	if got := strings.Join(successful.tokens, ","); got != "" {
+		t.Fatalf("expected next adapter to start with empty token, got %q", got)
 	}
 }
 

--- a/internal/providers/aws/ai_agent_identity_collector_test.go
+++ b/internal/providers/aws/ai_agent_identity_collector_test.go
@@ -116,6 +116,15 @@ func TestAIAgentIdentityCollectorEmitsNormalizedPayloadSafeAssets(t *testing.T) 
 	}
 }
 
+func TestCompositeAIAgentIdentityAPIRejectsOutOfRangeToken(t *testing.T) {
+	api := NewCompositeAIAgentIdentityAPI(&fakeAIAgentIdentityAPI{})
+
+	_, err := api.ListAgentIdentities(context.Background(), "4:", 10)
+	if err == nil || !strings.Contains(err.Error(), "invalid ai agent identity pagination token") {
+		t.Fatalf("expected invalid pagination token error, got %v", err)
+	}
+}
+
 func TestAIAgentIdentityCollectorDedupesAndSkipsMalformedRecords(t *testing.T) {
 	collectedAt := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
 	record := AIAgentIdentity{

--- a/internal/providers/aws/graph.go
+++ b/internal/providers/aws/graph.go
@@ -114,6 +114,17 @@ func (b *RelationshipBuilder) ResolveRelationships(ctx context.Context, bundle p
 			}
 			appendRelationship(&relationships, seen, relationship)
 		}
+		if resource.Type == domain.ResourceTypeTool && strings.TrimSpace(resource.SourceEntityID) != "" {
+			relationship := domain.Relationship{
+				ID:           relationshipID(domain.RelationshipCallsTool, resource.SourceEntityID, resource.ID),
+				Type:         domain.RelationshipCallsTool,
+				FromNodeID:   resource.SourceEntityID,
+				ToNodeID:     resource.ID,
+				EvidenceRef:  resource.RawRef,
+				DiscoveredAt: timestamp,
+			}
+			appendRelationship(&relationships, seen, relationship)
+		}
 		refs := parseStringList(resource.Metadata["secret_refs"])
 		for _, ref := range refs {
 			secretID := matchSecretsManagerReference(ref, secretIndex)

--- a/internal/providers/aws/helpers.go
+++ b/internal/providers/aws/helpers.go
@@ -56,9 +56,9 @@ func awsAIAgentNodeID(accountID string, region string, agentType string, agentID
 }
 
 func awsAIAgentToolNodeID(agentNodeID string, tool string) string {
-	workload := strings.TrimSpace(agentNodeID)
+	workload := strings.TrimSpace(strings.ToLower(agentNodeID))
 	if workload == "" {
-		workload = "agent"
+		workload = "gateway"
 	}
 	name := strings.TrimSpace(strings.ToLower(tool))
 	if name == "" {

--- a/internal/providers/aws/helpers.go
+++ b/internal/providers/aws/helpers.go
@@ -55,6 +55,18 @@ func awsAIAgentNodeID(accountID string, region string, agentType string, agentID
 	)
 }
 
+func awsAIAgentToolNodeID(agentNodeID string, tool string) string {
+	workload := strings.TrimSpace(agentNodeID)
+	if workload == "" {
+		workload = "agent"
+	}
+	name := strings.TrimSpace(strings.ToLower(tool))
+	if name == "" {
+		name = "tool"
+	}
+	return "tool:agent:" + strings.Join(normalizeStringList([]string{workload, name}), "|")
+}
+
 func awsAIAgentExecutionEndpointNodeID(agentNodeID string, endpointARN string) string {
 	workload := strings.TrimSpace(agentNodeID)
 	if workload == "" {

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -374,6 +374,9 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 				"gateway_arn":                 strings.TrimSpace(record.GatewayARN),
 				"gateway_id":                  strings.TrimSpace(record.GatewayID),
 				"tool_names":                  normalizeStringList(record.ToolNames),
+				"tool_target_refs":            normalizeStringList(record.ToolTargetRefs),
+				"allowed_actions":             normalizeStringList(record.AllowedActions),
+				"auth_mode":                   strings.TrimSpace(record.AuthMode),
 				"capability_names":            normalizeStringList(record.CapabilityNames),
 				"credential_reference_refs":   normalizeStringList(record.CredentialReferenceRefs),
 				"resource_reference_refs":     normalizeStringList(record.ResourceReferenceRefs),
@@ -453,6 +456,38 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 		}
 		bundle.Resources = append(bundle.Resources, resource)
 		resourceSeen[endpointID] = struct{}{}
+	}
+
+	for _, toolName := range normalizeStringList(record.ToolNames) {
+		toolID := awsAIAgentToolNodeID(agentID, toolName)
+		if _, exists := resourceSeen[toolID]; exists {
+			continue
+		}
+		resource := domain.Resource{
+			ID:        toolID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.ResourceTypeTool,
+			Name:      toolName,
+			Region:    strings.TrimSpace(record.Region),
+			AccountID: strings.TrimSpace(record.AccountID),
+			Labels: map[string]string{
+				"resource_kind": "agentcore_gateway_tool",
+			},
+			Metadata: map[string]any{
+				"agent_id":         strings.TrimSpace(record.AgentID),
+				"agent_type":       strings.TrimSpace(record.AgentType),
+				"gateway_id":       strings.TrimSpace(record.GatewayID),
+				"gateway_arn":      strings.TrimSpace(record.GatewayARN),
+				"auth_mode":        strings.TrimSpace(record.AuthMode),
+				"allowed_actions":  normalizeStringList(record.AllowedActions),
+				"tool_target_refs": normalizeStringList(record.ToolTargetRefs),
+				"capability_names": normalizeStringList(record.CapabilityNames),
+			},
+			RawRef:         asset.SourceID,
+			SourceEntityID: agentID,
+		}
+		bundle.Resources = append(bundle.Resources, resource)
+		resourceSeen[toolID] = struct{}{}
 	}
 
 	return nil

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -482,6 +482,7 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 				"allowed_actions":  normalizeStringList(record.AllowedActions),
 				"tool_target_refs": normalizeStringList(record.ToolTargetRefs),
 				"capability_names": normalizeStringList(record.CapabilityNames),
+				"secret_refs":      normalizeStringList(record.CredentialReferenceRefs),
 			},
 			RawRef:         asset.SourceID,
 			SourceEntityID: agentID,

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -211,6 +211,7 @@ func TestRoleNormalizerKeepsDistinctGatewayOnlyAIAgents(t *testing.T) {
 
 func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 	normalizer := NewRoleNormalizer()
+	credentialRef := "arn:aws:bedrock-agentcore:us-east-1:123456789012:oauth/payments"
 	record := AIAgentIdentity{
 		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
 			AccountID: "123456789012",
@@ -225,6 +226,9 @@ func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 		RuntimeRoleARN: "arn:aws:iam::123456789012:role/agentcore-gateway-payments",
 		ToolNames:      []string{"payments-case-search"},
 		AuthMode:       "custom_jwt",
+		CredentialReferenceRefs: []string{
+			credentialRef,
+		},
 	}
 	payload, err := json.Marshal(record)
 	if err != nil {
@@ -240,27 +244,52 @@ func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 		t.Fatalf("normalize failed: %v", err)
 	}
 	var toolResourceID string
+	var toolSourceEntityID string
 	for _, resource := range bundle.Resources {
 		if resource.Type == domain.ResourceTypeTool {
 			toolResourceID = resource.ID
+			toolSourceEntityID = resource.SourceEntityID
 			if resource.SourceEntityID == "" {
 				t.Fatalf("expected tool source entity id, got %+v", resource)
+			}
+			if !containsString(parseStringList(resource.Metadata["secret_refs"]), credentialRef) {
+				t.Fatalf("expected gateway tool secret_refs to include %q, got %+v", credentialRef, resource.Metadata)
 			}
 		}
 	}
 	if toolResourceID == "" {
 		t.Fatalf("expected gateway tool resource, got %+v", bundle.Resources)
 	}
+
+	refs, _ := MapBundleCredentialReferences(bundle)
+	credential, ok := findCredentialReference(refs, credentialRef)
+	if !ok {
+		t.Fatalf("expected gateway tool credential reference %q, got %+v", credentialRef, refs)
+	}
+	if credential.WorkloadID != toolSourceEntityID {
+		t.Fatalf("expected credential reference workload %q, got %q", toolSourceEntityID, credential.WorkloadID)
+	}
+
 	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
 	if err != nil {
 		t.Fatalf("resolve relationships: %v", err)
 	}
+	foundCallsTool := false
+	foundUsesSecret := false
 	for _, relationship := range relationships {
 		if relationship.Type == domain.RelationshipCallsTool && relationship.ToNodeID == toolResourceID {
-			return
+			foundCallsTool = true
+		}
+		if relationship.Type == domain.RelationshipUsesSecret && relationship.FromNodeID == toolSourceEntityID && relationship.ToNodeID == credential.TargetNodeID {
+			foundUsesSecret = true
 		}
 	}
-	t.Fatalf("expected calls_tool relationship to %q, got %+v", toolResourceID, relationships)
+	if !foundCallsTool {
+		t.Fatalf("expected calls_tool relationship to %q, got %+v", toolResourceID, relationships)
+	}
+	if !foundUsesSecret {
+		t.Fatalf("expected uses_secret relationship from %q to %q, got %+v", toolSourceEntityID, credential.TargetNodeID, relationships)
+	}
 }
 
 func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -209,6 +209,60 @@ func TestRoleNormalizerKeepsDistinctGatewayOnlyAIAgents(t *testing.T) {
 	}
 }
 
+func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
+	normalizer := NewRoleNormalizer()
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Service:   "agentcore",
+		},
+		AgentType:      "agent_gateway",
+		AgentID:        "gw-payments",
+		AgentName:      "payments-gateway",
+		GatewayID:      "gw-payments",
+		GatewayARN:     "arn:aws:bedrock-agentcore:us-east-1:123456789012:gateway/gw-payments",
+		RuntimeRoleARN: "arn:aws:iam::123456789012:role/agentcore-gateway-payments",
+		ToolNames:      []string{"payments-case-search"},
+		AuthMode:       "custom_jwt",
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal ai agent: %v", err)
+	}
+
+	bundle, err := normalizer.Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     rawKindAIAgentIdentity,
+		SourceID: "gateway/gw-payments",
+		Payload:  payload,
+	}})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	var toolResourceID string
+	for _, resource := range bundle.Resources {
+		if resource.Type == domain.ResourceTypeTool {
+			toolResourceID = resource.ID
+			if resource.SourceEntityID == "" {
+				t.Fatalf("expected tool source entity id, got %+v", resource)
+			}
+		}
+	}
+	if toolResourceID == "" {
+		t.Fatalf("expected gateway tool resource, got %+v", bundle.Resources)
+	}
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("resolve relationships: %v", err)
+	}
+	for _, relationship := range relationships {
+		if relationship.Type == domain.RelationshipCallsTool && relationship.ToNodeID == toolResourceID {
+			return
+		}
+	}
+	t.Fatalf("expected calls_tool relationship to %q, got %+v", toolResourceID, relationships)
+}
+
 func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {
 	agentNodeID := "aws:agent:123456789012:us-east-1:custom_agent/CaseSensitiveGateway"
 	endpointARN := "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime/Blue"

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -273,7 +273,7 @@ func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {
 	}
 }
 
-func TestAIAgentToolNodeIDMatchesAPIGatewayFallbackBehavior(t *testing.T) {
+func TestAIAgentToolNodeIDGatewayFallbackBehavior(t *testing.T) {
 	nodeID := awsAIAgentToolNodeID("Aws:Agent:123456789012:Us-East-1:AgentCore/GatewayA", "Payments Search")
 	if nodeID != "tool:agent:aws:agent:123456789012:us-east-1:agentcore/gatewaya|payments search" {
 		t.Fatalf("expected lowercase provider tool node id, got %q", nodeID)

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -273,6 +273,18 @@ func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {
 	}
 }
 
+func TestAIAgentToolNodeIDMatchesAPIGatewayFallbackBehavior(t *testing.T) {
+	nodeID := awsAIAgentToolNodeID("Aws:Agent:123456789012:Us-East-1:AgentCore/GatewayA", "Payments Search")
+	if nodeID != "tool:agent:aws:agent:123456789012:us-east-1:agentcore/gatewaya|payments search" {
+		t.Fatalf("expected lowercase provider tool node id, got %q", nodeID)
+	}
+
+	fallbackNodeID := awsAIAgentToolNodeID("", "")
+	if fallbackNodeID != "tool:agent:gateway|tool" {
+		t.Fatalf("expected gateway/tool fallback node id, got %q", fallbackNodeID)
+	}
+}
+
 func TestRoleNormalizerInvalidPermissionPolicyDocument(t *testing.T) {
 	role := IAMRole{
 		ARN:                "arn:aws:iam::1:role/demo",

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -287,14 +287,12 @@ func (a *SDKAgentCoreGatewayAPI) gatewayTargets(ctx context.Context, gatewayID s
 					Retryable: isRetryable(err),
 				})
 				targets = append(targets, gatewayTargetMetadata{
-					targetID:       targetID,
-					targetName:     firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID),
-					status:         targetStatus(summary.Status),
-					toolNames:      []string{firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID)},
-					targetRefs:     []string{targetID},
-					capabilities:   []string{"gateway_target"},
-					allowedActions: []string{firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID)},
-					degraded:       true,
+					targetID:     targetID,
+					targetName:   firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID),
+					status:       targetStatus(summary.Status),
+					targetRefs:   []string{targetID},
+					capabilities: []string{"gateway_target"},
+					degraded:     true,
 				})
 				continue
 			}
@@ -329,15 +327,13 @@ func gatewayTargetMetadataFromDetail(detail bedrockagentcorecontrol.GetGatewayTa
 	targetID := strings.TrimSpace(awsv2.ToString(detail.TargetId))
 	targetName := firstNonEmptyAWSValue(awsv2.ToString(detail.Name), targetID)
 	metadata := gatewayTargetMetadata{
-		targetID:       targetID,
-		targetName:     targetName,
-		status:         targetStatus(detail.Status),
-		toolNames:      []string{targetName},
-		targetRefs:     []string{targetID},
-		capabilities:   []string{"gateway_target", "target_protocol_" + strings.ToLower(string(detail.ProtocolType))},
-		resourceRefs:   []string{awsv2.ToString(detail.GatewayArn)},
-		allowedActions: []string{targetName},
-		degraded:       targetStatus(detail.Status) != "ready",
+		targetID:     targetID,
+		targetName:   targetName,
+		status:       targetStatus(detail.Status),
+		targetRefs:   []string{targetID},
+		capabilities: []string{"gateway_target", "target_protocol_" + strings.ToLower(string(detail.ProtocolType))},
+		resourceRefs: []string{awsv2.ToString(detail.GatewayArn)},
+		degraded:     targetStatus(detail.Status) != "ready",
 	}
 	metadata.credentialRefs = append(metadata.credentialRefs, gatewayCredentialRefs(detail.CredentialProviderConfigurations)...)
 	metadata.capabilities = append(metadata.capabilities, gatewayCredentialCapabilities(detail.CredentialProviderConfigurations)...)
@@ -346,6 +342,12 @@ func gatewayTargetMetadataFromDetail(detail bedrockagentcorecontrol.GetGatewayTa
 	metadata.resourceRefs = append(metadata.resourceRefs, refs...)
 	metadata.capabilities = append(metadata.capabilities, caps...)
 	metadata.allowedActions = append(metadata.allowedActions, actions...)
+	if len(normalizeOrderedStringList(metadata.toolNames)) == 0 {
+		metadata.toolNames = normalizeOrderedStringList([]string{targetName})
+	}
+	if len(normalizeOrderedStringList(metadata.allowedActions)) == 0 {
+		metadata.allowedActions = normalizeOrderedStringList([]string{targetName})
+	}
 	return metadata
 }
 

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -1,0 +1,578 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+type AgentCoreGatewaySDKClient interface {
+	ListGateways(ctx context.Context, params *bedrockagentcorecontrol.ListGatewaysInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListGatewaysOutput, error)
+	GetGateway(ctx context.Context, params *bedrockagentcorecontrol.GetGatewayInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetGatewayOutput, error)
+	ListGatewayTargets(ctx context.Context, params *bedrockagentcorecontrol.ListGatewayTargetsInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListGatewayTargetsOutput, error)
+	GetGatewayTarget(ctx context.Context, params *bedrockagentcorecontrol.GetGatewayTargetInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error)
+}
+
+type SDKAgentCoreGatewayAPI struct {
+	client    AgentCoreGatewaySDKClient
+	accountID string
+	region    string
+}
+
+var _ AIAgentIdentityAPI = (*SDKAgentCoreGatewayAPI)(nil)
+
+func NewSDKAgentCoreAIAgentIdentityAPI(region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	return NewSDKAgentCoreAIAgentIdentityAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+func NewSDKAgentCoreAIAgentIdentityAPIWithContext(ctx context.Context, region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	client := bedrockagentcorecontrol.NewFromConfig(cfg)
+	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKAgentCoreAIAgentIdentityAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	client := bedrockagentcorecontrol.NewFromConfig(cfg)
+	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, resolvedAccountID, resolvedRegion), nil
+}
+
+func NewSDKAgentCoreAIAgentIdentityAPIFromClient(runtimeClient AgentCoreRuntimeSDKClient, gatewayClient AgentCoreGatewaySDKClient, accountID string, region string) AIAgentIdentityAPI {
+	return NewCompositeAIAgentIdentityAPI(
+		NewSDKAgentCoreRuntimeAPIFromClient(runtimeClient, accountID, region),
+		NewSDKAgentCoreGatewayAPIFromClient(gatewayClient, accountID, region),
+	)
+}
+
+func NewSDKAgentCoreGatewayAPIFromClient(client AgentCoreGatewaySDKClient, accountID string, region string) AIAgentIdentityAPI {
+	return &SDKAgentCoreGatewayAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+func (a *SDKAgentCoreGatewayAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
+	if a.client == nil {
+		return AIAgentIdentityPage{}, fmt.Errorf("agentcore gateway sdk client is required")
+	}
+	input := &bedrockagentcorecontrol.ListGatewaysInput{
+		MaxResults: awsv2.Int32(agentCoreSDKPageSize(pageSize)),
+	}
+	if token := strings.TrimSpace(nextToken); token != "" {
+		input.NextToken = awsv2.String(token)
+	}
+	output, err := a.client.ListGateways(ctx, input)
+	if err != nil {
+		return AIAgentIdentityPage{}, err
+	}
+	records := make([]AIAgentIdentity, 0, len(output.Items))
+	diagnostics := []providers.SourceError{}
+	for _, summary := range output.Items {
+		if err := ctx.Err(); err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		record, gatewayDiagnostics, err := a.gatewayRecord(ctx, summary)
+		if err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		diagnostics = append(diagnostics, gatewayDiagnostics...)
+		if strings.TrimSpace(record.GatewayID) == "" && strings.TrimSpace(record.GatewayARN) == "" {
+			continue
+		}
+		records = append(records, record)
+	}
+	return AIAgentIdentityPage{
+		Records:     records,
+		NextToken:   strings.TrimSpace(awsv2.ToString(output.NextToken)),
+		Diagnostics: diagnostics,
+	}, nil
+}
+
+func (a *SDKAgentCoreGatewayAPI) gatewayRecord(ctx context.Context, summary agentcoretypes.GatewaySummary) (AIAgentIdentity, []providers.SourceError, error) {
+	diagnostics := []providers.SourceError{}
+	gatewayID := strings.TrimSpace(awsv2.ToString(summary.GatewayId))
+	gatewayName := firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.Name)), gatewayID)
+	if gatewayID == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			Code:      "ai_agent_gateway_malformed",
+			Message:   "skipped AgentCore gateway without a stable identifier",
+			Retryable: false,
+		})
+		return AIAgentIdentity{}, diagnostics, nil
+	}
+
+	detail, detailErr := a.describeGateway(ctx, gatewayID)
+	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, detailErr
+	}
+	if detailErr != nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  gatewayID,
+			Code:      "ai_agent_gateway_describe_failed",
+			Message:   fmt.Sprintf("AgentCore gateway %s could not be described: %v", gatewayID, detailErr),
+			Retryable: isRetryable(detailErr),
+		})
+	}
+
+	targets, targetDiagnostics, targetErr := a.gatewayTargets(ctx, gatewayID)
+	diagnostics = append(diagnostics, targetDiagnostics...)
+	if errors.Is(targetErr, context.Canceled) || errors.Is(targetErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, targetErr
+	}
+	if targetErr != nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  gatewayID,
+			Code:      "ai_agent_gateway_target_list_failed",
+			Message:   fmt.Sprintf("AgentCore gateway %s targets could not be listed: %v", gatewayID, targetErr),
+			Retryable: isRetryable(targetErr),
+		})
+	}
+
+	gatewayARN := strings.TrimSpace(awsv2.ToString(detail.GatewayArn))
+	roleARN := strings.TrimSpace(awsv2.ToString(detail.RoleArn))
+	workloadIdentityARN := ""
+	if detail.WorkloadIdentityDetails != nil {
+		workloadIdentityARN = strings.TrimSpace(awsv2.ToString(detail.WorkloadIdentityDetails.WorkloadIdentityArn))
+	}
+	targetMetadata := summarizeGatewayTargets(targets)
+	resourceRefs := normalizeStringList(append([]string{
+		gatewayARN,
+		strings.TrimSpace(awsv2.ToString(detail.GatewayUrl)),
+		strings.TrimSpace(awsv2.ToString(detail.KmsKeyArn)),
+		gatewayPolicyEngineARN(detail.PolicyEngineConfiguration),
+		workloadIdentityARN,
+	}, targetMetadata.resourceRefs...))
+	capabilities := normalizeStringList(append([]string{
+		"gateway",
+		"tool_routing",
+		gatewayProtocolCapability(firstNonEmptyAWSValue(string(detail.ProtocolType), string(summary.ProtocolType))),
+		gatewayAuthCapability(firstNonEmptyAWSValue(string(detail.AuthorizerType), string(summary.AuthorizerType))),
+		gatewayPolicyModeCapability(detail.PolicyEngineConfiguration),
+	}, targetMetadata.capabilities...))
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: strings.TrimSpace(a.accountID),
+			Region:    strings.TrimSpace(a.region),
+		},
+		AgentID:                 gatewayID,
+		AgentARN:                gatewayARN,
+		AgentName:               gatewayName,
+		AgentType:               "agent_gateway",
+		Provider:                "amazon-bedrock-agentcore",
+		RuntimeRoleARN:          roleARN,
+		RuntimeRoleName:         roleNameFromARN(roleARN),
+		RuntimeRoleAccountID:    roleAccountIDFromARN(roleARN),
+		WorkloadIdentityARN:     workloadIdentityARN,
+		GatewayID:               gatewayID,
+		GatewayARN:              gatewayARN,
+		ToolNames:               normalizeStringList(targetMetadata.toolNames),
+		CapabilityNames:         capabilities,
+		CredentialReferenceRefs: normalizeStringList(targetMetadata.credentialRefs),
+		ResourceReferenceRefs:   resourceRefs,
+		AuthMode:                strings.TrimSpace(strings.ToLower(firstNonEmptyAWSValue(string(detail.AuthorizerType), string(summary.AuthorizerType)))),
+		AllowedActions:          normalizeStringList(targetMetadata.allowedActions),
+		ToolTargetRefs:          normalizeStringList(targetMetadata.targetRefs),
+		ServerProtocol:          strings.TrimSpace(strings.ToLower(firstNonEmptyAWSValue(string(detail.ProtocolType), string(summary.ProtocolType)))),
+		SensitiveBoundary:       "metadata_only",
+		CoverageStatus:          "covered",
+		Status:                  gatewayStatus(firstNonEmptyAWSValue(string(detail.Status), string(summary.Status))),
+	}
+	if detailErr != nil || targetErr != nil || targetMetadata.degraded {
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = firstNonEmptyAWSValue(
+			strings.Join(normalizeStringList(detail.StatusReasons), "; "),
+			"AgentCore gateway metadata was partially collected",
+		)
+	}
+	record.Confidence = aiAgentIdentityConfidence(record)
+	record.Source = "agentcore_gateway_metadata"
+	record.Service = "agentcore"
+	record.EvidenceRef = firstNonEmptyAWSValue(record.GatewayARN, record.AgentARN, record.GatewayID, record.AgentID)
+	record.CollectorName = aiAgentIdentityCollectorName
+	return record, diagnostics, nil
+}
+
+func (a *SDKAgentCoreGatewayAPI) describeGateway(ctx context.Context, gatewayID string) (bedrockagentcorecontrol.GetGatewayOutput, error) {
+	output, err := a.client.GetGateway(ctx, &bedrockagentcorecontrol.GetGatewayInput{GatewayIdentifier: awsv2.String(gatewayID)})
+	if err != nil {
+		return bedrockagentcorecontrol.GetGatewayOutput{}, err
+	}
+	if output == nil {
+		return bedrockagentcorecontrol.GetGatewayOutput{}, fmt.Errorf("gateway %s returned no metadata", gatewayID)
+	}
+	return *output, nil
+}
+
+func (a *SDKAgentCoreGatewayAPI) gatewayTargets(ctx context.Context, gatewayID string) ([]gatewayTargetMetadata, []providers.SourceError, error) {
+	input := &bedrockagentcorecontrol.ListGatewayTargetsInput{
+		GatewayIdentifier: awsv2.String(gatewayID),
+		MaxResults:        awsv2.Int32(agentCoreSDKPageSize(defaultPageSize)),
+	}
+	targets := []gatewayTargetMetadata{}
+	diagnostics := []providers.SourceError{}
+	for {
+		if err := ctx.Err(); err != nil {
+			return targets, diagnostics, err
+		}
+		output, err := a.client.ListGatewayTargets(ctx, input)
+		if err != nil {
+			return targets, diagnostics, err
+		}
+		for _, summary := range output.Items {
+			targetID := strings.TrimSpace(awsv2.ToString(summary.TargetId))
+			if targetID == "" {
+				continue
+			}
+			detail, err := a.client.GetGatewayTarget(ctx, &bedrockagentcorecontrol.GetGatewayTargetInput{
+				GatewayIdentifier: awsv2.String(gatewayID),
+				TargetId:          awsv2.String(targetID),
+			})
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return targets, diagnostics, err
+			}
+			if err != nil {
+				diagnostics = append(diagnostics, providers.SourceError{
+					Collector: aiAgentIdentityCollectorName,
+					SourceID:  gatewayID + "/" + targetID,
+					Code:      "ai_agent_gateway_target_describe_failed",
+					Message:   fmt.Sprintf("AgentCore gateway target %s/%s could not be described: %v", gatewayID, targetID, err),
+					Retryable: isRetryable(err),
+				})
+				targets = append(targets, gatewayTargetMetadata{
+					targetID:       targetID,
+					targetName:     firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID),
+					status:         targetStatus(summary.Status),
+					toolNames:      []string{firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID)},
+					targetRefs:     []string{targetID},
+					capabilities:   []string{"gateway_target"},
+					allowedActions: []string{firstNonEmptyAWSValue(awsv2.ToString(summary.Name), targetID)},
+					degraded:       true,
+				})
+				continue
+			}
+			if detail == nil {
+				continue
+			}
+			targets = append(targets, gatewayTargetMetadataFromDetail(*detail))
+		}
+		nextToken := strings.TrimSpace(awsv2.ToString(output.NextToken))
+		if nextToken == "" {
+			break
+		}
+		input.NextToken = awsv2.String(nextToken)
+	}
+	return targets, diagnostics, nil
+}
+
+type gatewayTargetMetadata struct {
+	targetID       string
+	targetName     string
+	status         string
+	toolNames      []string
+	capabilities   []string
+	credentialRefs []string
+	resourceRefs   []string
+	allowedActions []string
+	targetRefs     []string
+	degraded       bool
+}
+
+func gatewayTargetMetadataFromDetail(detail bedrockagentcorecontrol.GetGatewayTargetOutput) gatewayTargetMetadata {
+	targetID := strings.TrimSpace(awsv2.ToString(detail.TargetId))
+	targetName := firstNonEmptyAWSValue(awsv2.ToString(detail.Name), targetID)
+	metadata := gatewayTargetMetadata{
+		targetID:       targetID,
+		targetName:     targetName,
+		status:         targetStatus(detail.Status),
+		toolNames:      []string{targetName},
+		targetRefs:     []string{targetID},
+		capabilities:   []string{"gateway_target", "target_protocol_" + strings.ToLower(string(detail.ProtocolType))},
+		resourceRefs:   []string{awsv2.ToString(detail.GatewayArn)},
+		allowedActions: []string{targetName},
+		degraded:       targetStatus(detail.Status) != "ready",
+	}
+	metadata.credentialRefs = append(metadata.credentialRefs, gatewayCredentialRefs(detail.CredentialProviderConfigurations)...)
+	metadata.capabilities = append(metadata.capabilities, gatewayCredentialCapabilities(detail.CredentialProviderConfigurations)...)
+	tools, refs, caps, actions := gatewayTargetConfigurationMetadata(detail.TargetConfiguration)
+	metadata.toolNames = append(metadata.toolNames, tools...)
+	metadata.resourceRefs = append(metadata.resourceRefs, refs...)
+	metadata.capabilities = append(metadata.capabilities, caps...)
+	metadata.allowedActions = append(metadata.allowedActions, actions...)
+	return metadata
+}
+
+func summarizeGatewayTargets(targets []gatewayTargetMetadata) gatewayTargetMetadata {
+	summary := gatewayTargetMetadata{}
+	for _, target := range targets {
+		summary.toolNames = append(summary.toolNames, target.toolNames...)
+		summary.capabilities = append(summary.capabilities, target.capabilities...)
+		summary.credentialRefs = append(summary.credentialRefs, target.credentialRefs...)
+		summary.resourceRefs = append(summary.resourceRefs, target.resourceRefs...)
+		summary.allowedActions = append(summary.allowedActions, target.allowedActions...)
+		summary.targetRefs = append(summary.targetRefs, target.targetRefs...)
+		summary.degraded = summary.degraded || target.degraded
+	}
+	return summary
+}
+
+func gatewayTargetConfigurationMetadata(config agentcoretypes.TargetConfiguration) ([]string, []string, []string, []string) {
+	switch typed := config.(type) {
+	case *agentcoretypes.TargetConfigurationMemberMcp:
+		tools, refs, caps, actions := mcpTargetConfigurationMetadata(typed.Value)
+		return tools, refs, append([]string{"mcp"}, caps...), actions
+	case *agentcoretypes.TargetConfigurationMemberHttp:
+		refs, caps := httpTargetConfigurationMetadata(typed.Value)
+		return nil, refs, append([]string{"http_target"}, caps...), nil
+	default:
+		return nil, nil, nil, nil
+	}
+}
+
+func mcpTargetConfigurationMetadata(config agentcoretypes.McpTargetConfiguration) ([]string, []string, []string, []string) {
+	switch typed := config.(type) {
+	case *agentcoretypes.McpTargetConfigurationMemberLambda:
+		tools, refs := toolSchemaMetadata(typed.Value.ToolSchema)
+		return tools, append(refs, awsv2.ToString(typed.Value.LambdaArn)), []string{"mcp_lambda"}, tools
+	case *agentcoretypes.McpTargetConfigurationMemberMcpServer:
+		tools, refs := mcpToolSchemaMetadata(typed.Value.McpToolSchema)
+		return tools, append(refs, awsv2.ToString(typed.Value.Endpoint)), []string{"mcp_server", "mcp_listing_" + strings.ToLower(string(typed.Value.ListingMode))}, tools
+	case *agentcoretypes.McpTargetConfigurationMemberApiGateway:
+		return apiGatewayTargetMetadata(typed.Value)
+	case *agentcoretypes.McpTargetConfigurationMemberOpenApiSchema:
+		return apiSchemaMetadata(typed.Value), apiSchemaRefs(typed.Value), []string{"mcp_openapi_schema"}, apiSchemaMetadata(typed.Value)
+	case *agentcoretypes.McpTargetConfigurationMemberSmithyModel:
+		return apiSchemaMetadata(typed.Value), apiSchemaRefs(typed.Value), []string{"mcp_smithy_model"}, apiSchemaMetadata(typed.Value)
+	default:
+		return nil, nil, nil, nil
+	}
+}
+
+func httpTargetConfigurationMetadata(config agentcoretypes.HttpTargetConfiguration) ([]string, []string) {
+	switch typed := config.(type) {
+	case *agentcoretypes.HttpTargetConfigurationMemberAgentcoreRuntime:
+		_ = typed
+		return nil, []string{"agentcore_runtime_target"}
+	default:
+		return nil, nil
+	}
+}
+
+func apiGatewayTargetMetadata(config agentcoretypes.ApiGatewayTargetConfiguration) ([]string, []string, []string, []string) {
+	refs := []string{awsv2.ToString(config.RestApiId), awsv2.ToString(config.Stage)}
+	tools := []string{}
+	actions := []string{}
+	if config.ApiGatewayToolConfiguration != nil {
+		for _, override := range config.ApiGatewayToolConfiguration.ToolOverrides {
+			name := firstNonEmptyAWSValue(awsv2.ToString(override.Name), string(override.Method)+" "+awsv2.ToString(override.Path))
+			tools = append(tools, name)
+			actions = append(actions, string(override.Method)+" "+awsv2.ToString(override.Path))
+		}
+		for _, filter := range config.ApiGatewayToolConfiguration.ToolFilters {
+			for _, method := range filter.Methods {
+				action := strings.TrimSpace(string(method) + " " + awsv2.ToString(filter.FilterPath))
+				tools = append(tools, action)
+				actions = append(actions, action)
+			}
+		}
+	}
+	return tools, refs, []string{"mcp_api_gateway"}, actions
+}
+
+func apiSchemaMetadata(config agentcoretypes.ApiSchemaConfiguration) []string {
+	switch typed := config.(type) {
+	case *agentcoretypes.ApiSchemaConfigurationMemberInlinePayload:
+		return toolNamesFromInlineJSON(awsv2.ToString(&typed.Value))
+	default:
+		return nil
+	}
+}
+
+func apiSchemaRefs(config agentcoretypes.ApiSchemaConfiguration) []string {
+	switch typed := config.(type) {
+	case *agentcoretypes.ApiSchemaConfigurationMemberS3:
+		return []string{s3ConfigurationRef(typed.Value)}
+	default:
+		return nil
+	}
+}
+
+func toolSchemaMetadata(schema agentcoretypes.ToolSchema) ([]string, []string) {
+	switch typed := schema.(type) {
+	case *agentcoretypes.ToolSchemaMemberInlinePayload:
+		tools := make([]string, 0, len(typed.Value))
+		for _, tool := range typed.Value {
+			tools = append(tools, awsv2.ToString(tool.Name))
+		}
+		return tools, nil
+	case *agentcoretypes.ToolSchemaMemberS3:
+		return nil, []string{s3ConfigurationRef(typed.Value)}
+	default:
+		return nil, nil
+	}
+}
+
+func mcpToolSchemaMetadata(schema agentcoretypes.McpToolSchemaConfiguration) ([]string, []string) {
+	switch typed := schema.(type) {
+	case *agentcoretypes.McpToolSchemaConfigurationMemberInlinePayload:
+		return toolNamesFromInlineJSON(typed.Value), nil
+	case *agentcoretypes.McpToolSchemaConfigurationMemberS3:
+		return nil, []string{s3ConfigurationRef(typed.Value)}
+	default:
+		return nil, nil
+	}
+}
+
+func toolNamesFromInlineJSON(raw string) []string {
+	var value any
+	if strings.TrimSpace(raw) == "" || json.Unmarshal([]byte(raw), &value) != nil {
+		return nil
+	}
+	names := []string{}
+	var visit func(any, string)
+	visit = func(node any, parent string) {
+		switch typed := node.(type) {
+		case map[string]any:
+			if strings.EqualFold(parent, "tools") {
+				if name, ok := typed["name"].(string); ok {
+					names = append(names, name)
+				}
+			}
+			for key, child := range typed {
+				visit(child, key)
+			}
+		case []any:
+			for _, child := range typed {
+				visit(child, parent)
+			}
+		}
+	}
+	visit(value, "")
+	return normalizeStringList(names)
+}
+
+func gatewayCredentialRefs(configs []agentcoretypes.CredentialProviderConfiguration) []string {
+	refs := []string{}
+	for _, config := range configs {
+		switch provider := config.CredentialProvider.(type) {
+		case *agentcoretypes.CredentialProviderMemberApiKeyCredentialProvider:
+			refs = append(refs, awsv2.ToString(provider.Value.ProviderArn))
+		case *agentcoretypes.CredentialProviderMemberOauthCredentialProvider:
+			refs = append(refs, awsv2.ToString(provider.Value.ProviderArn))
+		case *agentcoretypes.CredentialProviderMemberIamCredentialProvider:
+			refs = append(refs, "iam:"+firstNonEmptyAWSValue(awsv2.ToString(provider.Value.Service), "service")+":"+firstNonEmptyAWSValue(awsv2.ToString(provider.Value.Region), "region"))
+		}
+	}
+	return refs
+}
+
+func gatewayCredentialCapabilities(configs []agentcoretypes.CredentialProviderConfiguration) []string {
+	capabilities := []string{}
+	for _, config := range configs {
+		if credentialType := strings.TrimSpace(strings.ToLower(string(config.CredentialProviderType))); credentialType != "" {
+			capabilities = append(capabilities, "target_auth_"+credentialType)
+		}
+	}
+	return capabilities
+}
+
+func s3ConfigurationRef(config agentcoretypes.S3Configuration) string {
+	return firstNonEmptyAWSValue(awsv2.ToString(config.Uri), awsv2.ToString(config.BucketOwnerAccountId))
+}
+
+func gatewayPolicyEngineARN(config *agentcoretypes.GatewayPolicyEngineConfiguration) string {
+	if config == nil {
+		return ""
+	}
+	return awsv2.ToString(config.Arn)
+}
+
+func gatewayPolicyModeCapability(config *agentcoretypes.GatewayPolicyEngineConfiguration) string {
+	if config == nil {
+		return ""
+	}
+	mode := strings.TrimSpace(strings.ToLower(string(config.Mode)))
+	if mode == "" {
+		return ""
+	}
+	return "policy_engine_" + mode
+}
+
+func gatewayProtocolCapability(protocol string) string {
+	if strings.TrimSpace(protocol) == "" {
+		return ""
+	}
+	return "gateway_protocol_" + strings.ToLower(strings.TrimSpace(protocol))
+}
+
+func gatewayAuthCapability(authMode string) string {
+	if strings.TrimSpace(authMode) == "" {
+		return ""
+	}
+	return "gateway_auth_" + strings.ToLower(strings.TrimSpace(authMode))
+}
+
+func gatewayStatus(status string) string {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "", "READY":
+		return "ready"
+	default:
+		return "degraded"
+	}
+}
+
+func targetStatus(status agentcoretypes.TargetStatus) string {
+	switch strings.ToUpper(strings.TrimSpace(string(status))) {
+	case "", "READY":
+		return "ready"
+	default:
+		return "degraded"
+	}
+}

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -391,7 +391,7 @@ func mcpTargetConfigurationMetadata(config agentcoretypes.McpTargetConfiguration
 	case *agentcoretypes.McpTargetConfigurationMemberOpenApiSchema:
 		return apiSchemaMetadata(typed.Value), apiSchemaRefs(typed.Value), []string{"mcp_openapi_schema"}, apiSchemaMetadata(typed.Value)
 	case *agentcoretypes.McpTargetConfigurationMemberSmithyModel:
-		return apiSchemaMetadata(typed.Value), apiSchemaRefs(typed.Value), []string{"mcp_smithy_model"}, apiSchemaMetadata(typed.Value)
+		return smithyModelMetadata(typed.Value), apiSchemaRefs(typed.Value), []string{"mcp_smithy_model"}, smithyModelMetadata(typed.Value)
 	default:
 		return nil, nil, nil, nil
 	}
@@ -444,6 +444,15 @@ func apiSchemaRefs(config agentcoretypes.ApiSchemaConfiguration) []string {
 	switch typed := config.(type) {
 	case *agentcoretypes.ApiSchemaConfigurationMemberS3:
 		return []string{s3ConfigurationRef(typed.Value)}
+	default:
+		return nil
+	}
+}
+
+func smithyModelMetadata(config agentcoretypes.ApiSchemaConfiguration) []string {
+	switch typed := config.(type) {
+	case *agentcoretypes.ApiSchemaConfigurationMemberInlinePayload:
+		return smithyOperationNamesFromInlineJSON(awsv2.ToString(&typed.Value))
 	default:
 		return nil
 	}
@@ -502,6 +511,45 @@ func toolNamesFromInlineJSON(raw string) []string {
 	}
 	visit(value, "")
 	return normalizeStringList(names)
+}
+
+func smithyOperationNamesFromInlineJSON(raw string) []string {
+	var value any
+	if strings.TrimSpace(raw) == "" || json.Unmarshal([]byte(raw), &value) != nil {
+		return nil
+	}
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	shapes, ok := root["shapes"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	names := []string{}
+	for shapeID, rawShape := range shapes {
+		shape, ok := rawShape.(map[string]any)
+		if !ok {
+			continue
+		}
+		shapeType, _ := shape["type"].(string)
+		if !strings.EqualFold(strings.TrimSpace(shapeType), "operation") {
+			continue
+		}
+		names = append(names, smithyShapeName(shapeID))
+	}
+	return normalizeStringList(names)
+}
+
+func smithyShapeName(shapeID string) string {
+	trimmed := strings.TrimSpace(shapeID)
+	if trimmed == "" {
+		return ""
+	}
+	if hash := strings.LastIndex(trimmed, "#"); hash >= 0 && hash < len(trimmed)-1 {
+		return strings.TrimSpace(trimmed[hash+1:])
+	}
+	return trimmed
 }
 
 func openAPIOperationIDs(value any) []string {

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -413,14 +413,14 @@ func apiGatewayTargetMetadata(config agentcoretypes.ApiGatewayTargetConfiguratio
 	actions := []string{}
 	if config.ApiGatewayToolConfiguration != nil {
 		for _, override := range config.ApiGatewayToolConfiguration.ToolOverrides {
-			name := firstNonEmptyAWSValue(awsv2.ToString(override.Name), string(override.Method)+" "+awsv2.ToString(override.Path))
-			tools = append(tools, name)
-			actions = append(actions, string(override.Method)+" "+awsv2.ToString(override.Path))
+			if name := strings.TrimSpace(awsv2.ToString(override.Name)); name != "" {
+				tools = append(tools, name)
+			}
+			actions = append(actions, strings.TrimSpace(string(override.Method)+" "+awsv2.ToString(override.Path)))
 		}
 		for _, filter := range config.ApiGatewayToolConfiguration.ToolFilters {
 			for _, method := range filter.Methods {
 				action := strings.TrimSpace(string(method) + " " + awsv2.ToString(filter.FilterPath))
-				tools = append(tools, action)
 				actions = append(actions, action)
 			}
 		}
@@ -478,6 +478,7 @@ func toolNamesFromInlineJSON(raw string) []string {
 		return nil
 	}
 	names := []string{}
+	names = append(names, openAPIOperationIDs(value)...)
 	var visit func(any, string)
 	visit = func(node any, parent string) {
 		switch typed := node.(type) {
@@ -498,6 +499,46 @@ func toolNamesFromInlineJSON(raw string) []string {
 	}
 	visit(value, "")
 	return normalizeStringList(names)
+}
+
+func openAPIOperationIDs(value any) []string {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	paths, ok := root["paths"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	names := []string{}
+	for _, rawPathItem := range paths {
+		pathItem, ok := rawPathItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		for method, rawOperation := range pathItem {
+			if !isOpenAPIOperationMethod(method) {
+				continue
+			}
+			operation, ok := rawOperation.(map[string]any)
+			if !ok {
+				continue
+			}
+			if operationID, ok := operation["operationId"].(string); ok {
+				names = append(names, operationID)
+			}
+		}
+	}
+	return names
+}
+
+func isOpenAPIOperationMethod(method string) bool {
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "get", "put", "post", "delete", "options", "head", "patch", "trace":
+		return true
+	default:
+		return false
+	}
 }
 
 func gatewayCredentialRefs(configs []agentcoretypes.CredentialProviderConfiguration) []string {

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -413,10 +413,13 @@ func apiGatewayTargetMetadata(config agentcoretypes.ApiGatewayTargetConfiguratio
 	actions := []string{}
 	if config.ApiGatewayToolConfiguration != nil {
 		for _, override := range config.ApiGatewayToolConfiguration.ToolOverrides {
+			action := strings.TrimSpace(string(override.Method) + " " + awsv2.ToString(override.Path))
 			if name := strings.TrimSpace(awsv2.ToString(override.Name)); name != "" {
 				tools = append(tools, name)
+			} else if action != "" {
+				tools = append(tools, action)
 			}
-			actions = append(actions, strings.TrimSpace(string(override.Method)+" "+awsv2.ToString(override.Path)))
+			actions = append(actions, action)
 		}
 		for _, filter := range config.ApiGatewayToolConfiguration.ToolFilters {
 			for _, method := range filter.Methods {

--- a/internal/providers/aws/sdk_agentcore_gateway_test.go
+++ b/internal/providers/aws/sdk_agentcore_gateway_test.go
@@ -1,0 +1,202 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+)
+
+type fakeAgentCoreGatewaySDKClient struct {
+	listOutput    *bedrockagentcorecontrol.ListGatewaysOutput
+	listErr       error
+	detailOutput  *bedrockagentcorecontrol.GetGatewayOutput
+	detailErr     error
+	targetsOutput *bedrockagentcorecontrol.ListGatewayTargetsOutput
+	targetsErr    error
+	targetOutput  *bedrockagentcorecontrol.GetGatewayTargetOutput
+	targetErr     error
+}
+
+func (f *fakeAgentCoreGatewaySDKClient) ListGateways(_ context.Context, _ *bedrockagentcorecontrol.ListGatewaysInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListGatewaysOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listOutput == nil {
+		return &bedrockagentcorecontrol.ListGatewaysOutput{}, nil
+	}
+	return f.listOutput, nil
+}
+
+func (f *fakeAgentCoreGatewaySDKClient) GetGateway(_ context.Context, _ *bedrockagentcorecontrol.GetGatewayInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetGatewayOutput, error) {
+	if f.detailErr != nil {
+		return nil, f.detailErr
+	}
+	if f.detailOutput == nil {
+		return &bedrockagentcorecontrol.GetGatewayOutput{}, nil
+	}
+	return f.detailOutput, nil
+}
+
+func (f *fakeAgentCoreGatewaySDKClient) ListGatewayTargets(_ context.Context, _ *bedrockagentcorecontrol.ListGatewayTargetsInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListGatewayTargetsOutput, error) {
+	if f.targetsErr != nil {
+		return nil, f.targetsErr
+	}
+	if f.targetsOutput == nil {
+		return &bedrockagentcorecontrol.ListGatewayTargetsOutput{}, nil
+	}
+	return f.targetsOutput, nil
+}
+
+func (f *fakeAgentCoreGatewaySDKClient) GetGatewayTarget(_ context.Context, _ *bedrockagentcorecontrol.GetGatewayTargetInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
+	if f.targetErr != nil {
+		return nil, f.targetErr
+	}
+	if f.targetOutput == nil {
+		return &bedrockagentcorecontrol.GetGatewayTargetOutput{}, nil
+	}
+	return f.targetOutput, nil
+}
+
+func TestSDKAgentCoreGatewayAPIMapsMCPToolsAndAuthMetadata(t *testing.T) {
+	client := &fakeAgentCoreGatewaySDKClient{
+		listOutput: &bedrockagentcorecontrol.ListGatewaysOutput{
+			Items: []agentcoretypes.GatewaySummary{{
+				GatewayId:      awsv2.String("gw-payments"),
+				Name:           awsv2.String("payments-gateway"),
+				AuthorizerType: agentcoretypes.AuthorizerTypeCustomJwt,
+				ProtocolType:   agentcoretypes.GatewayProtocolTypeMcp,
+				Status:         agentcoretypes.GatewayStatusReady,
+			}},
+		},
+		detailOutput: &bedrockagentcorecontrol.GetGatewayOutput{
+			GatewayId:      awsv2.String("gw-payments"),
+			GatewayArn:     awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:gateway/gw-payments"),
+			Name:           awsv2.String("payments-gateway"),
+			RoleArn:        awsv2.String("arn:aws:iam::123456789012:role/agentcore-gateway-payments"),
+			AuthorizerType: agentcoretypes.AuthorizerTypeCustomJwt,
+			ProtocolType:   agentcoretypes.GatewayProtocolTypeMcp,
+			Status:         agentcoretypes.GatewayStatusReady,
+			GatewayUrl:     awsv2.String("https://gateway.example.test/mcp"),
+			PolicyEngineConfiguration: &agentcoretypes.GatewayPolicyEngineConfiguration{
+				Arn:  awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:policy-engine/payments"),
+				Mode: agentcoretypes.GatewayPolicyEngineModeEnforce,
+			},
+			WorkloadIdentityDetails: &agentcoretypes.WorkloadIdentityDetails{
+				WorkloadIdentityArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:workload-identity/gw-payments"),
+			},
+		},
+		targetsOutput: &bedrockagentcorecontrol.ListGatewayTargetsOutput{
+			Items: []agentcoretypes.TargetSummary{{
+				TargetId: awsv2.String("target-payments"),
+				Name:     awsv2.String("payments-mcp"),
+				Status:   agentcoretypes.TargetStatusReady,
+			}},
+		},
+		targetOutput: &bedrockagentcorecontrol.GetGatewayTargetOutput{
+			TargetId:     awsv2.String("target-payments"),
+			Name:         awsv2.String("payments-mcp"),
+			GatewayArn:   awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:gateway/gw-payments"),
+			Status:       agentcoretypes.TargetStatusReady,
+			ProtocolType: agentcoretypes.TargetProtocolTypeMcp,
+			CredentialProviderConfigurations: []agentcoretypes.CredentialProviderConfiguration{{
+				CredentialProviderType: agentcoretypes.CredentialProviderTypeOauth,
+				CredentialProvider: &agentcoretypes.CredentialProviderMemberOauthCredentialProvider{
+					Value: agentcoretypes.OAuthCredentialProvider{ProviderArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:oauth/payments")},
+				},
+			}},
+			TargetConfiguration: &agentcoretypes.TargetConfigurationMemberMcp{
+				Value: &agentcoretypes.McpTargetConfigurationMemberLambda{
+					Value: agentcoretypes.McpLambdaTargetConfiguration{
+						LambdaArn: awsv2.String("arn:aws:lambda:us-east-1:123456789012:function:payments-tools"),
+						ToolSchema: &agentcoretypes.ToolSchemaMemberInlinePayload{Value: []agentcoretypes.ToolDefinition{
+							{Name: awsv2.String("payments-case-search")},
+							{Name: awsv2.String("fraud-review-action-group")},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	page, err := NewSDKAgentCoreGatewayAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("ListAgentIdentities: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected one gateway record, got %+v", page.Records)
+	}
+	record := page.Records[0]
+	if record.AgentType != "agent_gateway" || record.GatewayID != "gw-payments" {
+		t.Fatalf("expected gateway identity record, got %+v", record)
+	}
+	if record.AuthMode != "custom_jwt" {
+		t.Fatalf("expected custom_jwt auth mode, got %q", record.AuthMode)
+	}
+	if !containsGatewayTestString(record.ToolNames, "payments-case-search") || !containsGatewayTestString(record.ToolNames, "fraud-review-action-group") {
+		t.Fatalf("expected MCP tool names from inline schema, got %+v", record.ToolNames)
+	}
+	if !containsGatewayTestString(record.CredentialReferenceRefs, "arn:aws:bedrock-agentcore:us-east-1:123456789012:oauth/payments") {
+		t.Fatalf("expected credential provider ARN reference, got %+v", record.CredentialReferenceRefs)
+	}
+	if !containsGatewayTestString(record.AllowedActions, "payments-case-search") {
+		t.Fatalf("expected allowed actions derived from tool names, got %+v", record.AllowedActions)
+	}
+	if record.Status != "ready" || record.CoverageStatus != "covered" {
+		t.Fatalf("expected covered ready gateway record, got status=%q coverage=%q", record.Status, record.CoverageStatus)
+	}
+}
+
+func TestSDKAgentCoreGatewayAPIDegradesOnTargetDescribeFailure(t *testing.T) {
+	client := &fakeAgentCoreGatewaySDKClient{
+		listOutput: &bedrockagentcorecontrol.ListGatewaysOutput{
+			Items: []agentcoretypes.GatewaySummary{{
+				GatewayId: awsv2.String("gw-payments"),
+				Name:      awsv2.String("payments-gateway"),
+				Status:    agentcoretypes.GatewayStatusReady,
+			}},
+		},
+		detailOutput: &bedrockagentcorecontrol.GetGatewayOutput{
+			GatewayId:  awsv2.String("gw-payments"),
+			GatewayArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:gateway/gw-payments"),
+			Name:       awsv2.String("payments-gateway"),
+			RoleArn:    awsv2.String("arn:aws:iam::123456789012:role/agentcore-gateway-payments"),
+			Status:     agentcoretypes.GatewayStatusReady,
+		},
+		targetsOutput: &bedrockagentcorecontrol.ListGatewayTargetsOutput{
+			Items: []agentcoretypes.TargetSummary{{
+				TargetId: awsv2.String("target-payments"),
+				Name:     awsv2.String("payments-mcp"),
+				Status:   agentcoretypes.TargetStatusReady,
+			}},
+		},
+		targetErr: errors.New("throttled"),
+	}
+
+	page, err := NewSDKAgentCoreGatewayAPIFromClient(client, "123456789012", "us-east-1").ListAgentIdentities(context.Background(), "", 10)
+	if err != nil {
+		t.Fatalf("ListAgentIdentities: %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("expected retained degraded gateway record, got %+v", page.Records)
+	}
+	if page.Records[0].Status != "degraded" || page.Records[0].CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded gateway record, got %+v", page.Records[0])
+	}
+	if len(page.Diagnostics) != 1 || page.Diagnostics[0].Code != "ai_agent_gateway_target_describe_failed" {
+		t.Fatalf("expected target describe diagnostic, got %+v", page.Diagnostics)
+	}
+}
+
+func containsGatewayTestString(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/aws/sdk_agentcore_gateway_test.go
+++ b/internal/providers/aws/sdk_agentcore_gateway_test.go
@@ -198,6 +198,65 @@ func TestSDKAgentCoreGatewayAPIDegradesOnTargetDescribeFailure(t *testing.T) {
 	}
 }
 
+func TestAPIGatewayTargetMetadataKeepsFiltersOutOfToolNames(t *testing.T) {
+	tools, refs, caps, actions := apiGatewayTargetMetadata(agentcoretypes.ApiGatewayTargetConfiguration{
+		RestApiId: awsv2.String("api-123"),
+		Stage:     awsv2.String("prod"),
+		ApiGatewayToolConfiguration: &agentcoretypes.ApiGatewayToolConfiguration{
+			ToolOverrides: []agentcoretypes.ApiGatewayToolOverride{{
+				Name:   awsv2.String("getOrder"),
+				Method: agentcoretypes.RestApiMethodGet,
+				Path:   awsv2.String("/orders/{id}"),
+			}},
+			ToolFilters: []agentcoretypes.ApiGatewayToolFilter{{
+				Methods:    []agentcoretypes.RestApiMethod{agentcoretypes.RestApiMethodPost},
+				FilterPath: awsv2.String("/orders"),
+			}},
+		},
+	})
+
+	if !containsGatewayTestString(tools, "getOrder") {
+		t.Fatalf("expected override name as tool, got %+v", tools)
+	}
+	if containsGatewayTestString(tools, "POST /orders") {
+		t.Fatalf("expected filter actions to stay out of tool names, got %+v", tools)
+	}
+	if !containsGatewayTestString(actions, "GET /orders/{id}") || !containsGatewayTestString(actions, "POST /orders") {
+		t.Fatalf("expected override and filter actions, got %+v", actions)
+	}
+	if !containsGatewayTestString(refs, "api-123") || !containsGatewayTestString(refs, "prod") {
+		t.Fatalf("expected API Gateway refs, got %+v", refs)
+	}
+	if !containsGatewayTestString(caps, "mcp_api_gateway") {
+		t.Fatalf("expected API Gateway capability, got %+v", caps)
+	}
+}
+
+func TestToolNamesFromInlineJSONExtractsOpenAPIOperationIDs(t *testing.T) {
+	tools := toolNamesFromInlineJSON(`{
+		"openapi": "3.0.1",
+		"paths": {
+			"/orders": {
+				"get": {"operationId": "listOrders"},
+				"post": {"operationId": "createOrder"},
+				"parameters": [{"name": "tenant_id", "in": "header"}]
+			},
+			"/orders/{id}": {
+				"get": {"operationId": "getOrder"}
+			}
+		}
+	}`)
+
+	for _, want := range []string{"listOrders", "createOrder", "getOrder"} {
+		if !containsGatewayTestString(tools, want) {
+			t.Fatalf("expected OpenAPI operationId %q in tools, got %+v", want, tools)
+		}
+	}
+	if containsGatewayTestString(tools, "tenant_id") {
+		t.Fatalf("expected non-operation schema names to stay out of tools, got %+v", tools)
+	}
+}
+
 func containsGatewayTestString(values []string, want string) bool {
 	for _, value := range values {
 		if strings.TrimSpace(value) == want {

--- a/internal/providers/aws/sdk_agentcore_gateway_test.go
+++ b/internal/providers/aws/sdk_agentcore_gateway_test.go
@@ -140,6 +140,9 @@ func TestSDKAgentCoreGatewayAPIMapsMCPToolsAndAuthMetadata(t *testing.T) {
 	if !containsGatewayTestString(record.ToolNames, "payments-case-search") || !containsGatewayTestString(record.ToolNames, "fraud-review-action-group") {
 		t.Fatalf("expected MCP tool names from inline schema, got %+v", record.ToolNames)
 	}
+	if len(record.ToolNames) != 2 || containsGatewayTestString(record.ToolNames, "payments-mcp") {
+		t.Fatalf("expected only schema-derived MCP tool names, got %+v", record.ToolNames)
+	}
 	if !containsGatewayTestString(record.CredentialReferenceRefs, "arn:aws:bedrock-agentcore:us-east-1:123456789012:oauth/payments") {
 		t.Fatalf("expected credential provider ARN reference, got %+v", record.CredentialReferenceRefs)
 	}
@@ -189,6 +192,9 @@ func TestSDKAgentCoreGatewayAPIDegradesOnTargetDescribeFailure(t *testing.T) {
 	}
 	if len(page.Diagnostics) != 1 || page.Diagnostics[0].Code != "ai_agent_gateway_target_describe_failed" {
 		t.Fatalf("expected target describe diagnostic, got %+v", page.Diagnostics)
+	}
+	if len(page.Records[0].ToolNames) != 0 || len(page.Records[0].AllowedActions) != 0 {
+		t.Fatalf("expected no synthetic tools for undescribed target, got tools=%+v actions=%+v", page.Records[0].ToolNames, page.Records[0].AllowedActions)
 	}
 }
 

--- a/internal/providers/aws/sdk_agentcore_gateway_test.go
+++ b/internal/providers/aws/sdk_agentcore_gateway_test.go
@@ -207,6 +207,9 @@ func TestAPIGatewayTargetMetadataKeepsFiltersOutOfToolNames(t *testing.T) {
 				Name:   awsv2.String("getOrder"),
 				Method: agentcoretypes.RestApiMethodGet,
 				Path:   awsv2.String("/orders/{id}"),
+			}, {
+				Method: agentcoretypes.RestApiMethodDelete,
+				Path:   awsv2.String("/orders/{id}"),
 			}},
 			ToolFilters: []agentcoretypes.ApiGatewayToolFilter{{
 				Methods:    []agentcoretypes.RestApiMethod{agentcoretypes.RestApiMethodPost},
@@ -218,10 +221,15 @@ func TestAPIGatewayTargetMetadataKeepsFiltersOutOfToolNames(t *testing.T) {
 	if !containsGatewayTestString(tools, "getOrder") {
 		t.Fatalf("expected override name as tool, got %+v", tools)
 	}
+	if !containsGatewayTestString(tools, "DELETE /orders/{id}") {
+		t.Fatalf("expected unnamed override method/path fallback as tool, got %+v", tools)
+	}
 	if containsGatewayTestString(tools, "POST /orders") {
 		t.Fatalf("expected filter actions to stay out of tool names, got %+v", tools)
 	}
-	if !containsGatewayTestString(actions, "GET /orders/{id}") || !containsGatewayTestString(actions, "POST /orders") {
+	if !containsGatewayTestString(actions, "GET /orders/{id}") ||
+		!containsGatewayTestString(actions, "DELETE /orders/{id}") ||
+		!containsGatewayTestString(actions, "POST /orders") {
 		t.Fatalf("expected override and filter actions, got %+v", actions)
 	}
 	if !containsGatewayTestString(refs, "api-123") || !containsGatewayTestString(refs, "prod") {

--- a/internal/providers/aws/sdk_agentcore_gateway_test.go
+++ b/internal/providers/aws/sdk_agentcore_gateway_test.go
@@ -265,6 +265,24 @@ func TestToolNamesFromInlineJSONExtractsOpenAPIOperationIDs(t *testing.T) {
 	}
 }
 
+func TestSmithyModelMetadataExtractsOperationShapes(t *testing.T) {
+	tools := smithyModelMetadata(&agentcoretypes.ApiSchemaConfigurationMemberInlinePayload{Value: `{
+		"smithy": "2.0",
+		"shapes": {
+			"com.example#ListOrders": {"type": "operation"},
+			"com.example#CreateOrder": {"type": "operation"},
+			"com.example#Order": {"type": "structure"}
+		}
+	}`})
+
+	if !containsGatewayTestString(tools, "ListOrders") || !containsGatewayTestString(tools, "CreateOrder") {
+		t.Fatalf("expected Smithy operation shapes as tools, got %+v", tools)
+	}
+	if containsGatewayTestString(tools, "Order") || containsGatewayTestString(tools, "com.example#ListOrders") {
+		t.Fatalf("expected only local operation shape names, got %+v", tools)
+	}
+}
+
 func containsGatewayTestString(values []string, want string) bool {
 	for _, value := range values {
 		if strings.TrimSpace(value) == want {

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -148,10 +148,10 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws secrets manager metadata collector: %w", secretsErr)
 			}
-			agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreRuntimeAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
+			agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreAIAgentIdentityAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if agentCoreErr != nil {
 				_ = store.Close()
-				return nil, nil, fmt.Errorf("initialize aws agentcore runtime collector: %w", agentCoreErr)
+				return nil, nil, fmt.Errorf("initialize aws agentcore identity collector: %w", agentCoreErr)
 			}
 			ssmAPI, ssmErr := awsprovider.NewSDKSSMParameterMetadataAPIWithContext(ctx, cfg.AWSRegion, cfg.AWSProfile, cfg.AWSAccountID)
 			if ssmErr != nil {
@@ -334,7 +334,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if secretsErr != nil {
 			return nil, secretsErr
 		}
-		agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreRuntimeAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
+		agentCoreAPI, agentCoreErr := awsprovider.NewSDKAgentCoreAIAgentIdentityAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan", connection.AccountID)
 		if agentCoreErr != nil {
 			return nil, agentCoreErr
 		}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1975,6 +1975,9 @@ export type AWSAIAgentIdentityRecord = {
   gateway_arn?: string;
   external_provider?: string;
   tool_names?: string[];
+  tool_target_refs?: string[];
+  allowed_actions?: string[];
+  auth_mode?: string;
   memory_enabled: boolean;
   memory_store_refs?: string[];
   browser_enabled: boolean;
@@ -2013,7 +2016,7 @@ export type AWSAIAgentIdentityRelationship = {
 export type AWSAIAgentIdentityDiagnostic = {
   collector: string;
   source_id?: string;
-  code: 'ai_agent_credential_reference_unresolved' | 'ai_agent_gateway_list_failed' | 'ai_agent_gateway_describe_failed' | 'ai_agent_identity_page_failed' | 'agentcore_runtime_describe_failed' | 'agentcore_runtime_endpoint_list_failed' | 'agentcore_runtime_malformed' | 'permission_denied' | string;
+  code: 'ai_agent_credential_reference_unresolved' | 'ai_agent_gateway_list_failed' | 'ai_agent_gateway_describe_failed' | 'ai_agent_gateway_malformed' | 'ai_agent_gateway_target_describe_failed' | 'ai_agent_gateway_target_list_failed' | 'ai_agent_identity_page_failed' | 'agentcore_runtime_describe_failed' | 'agentcore_runtime_endpoint_list_failed' | 'agentcore_runtime_malformed' | 'permission_denied' | string;
   message: string;
   remediation?: string;
   retryable: boolean;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7100,6 +7100,8 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   const toolLabel = record.tool_names?.length ? `${record.tool_names.length} tools` : 'no tools reported';
   const capabilityLabel = record.capability_names?.length ? `${record.capability_names.join(', ')} capabilities` : 'capabilities not reported';
   const credentialLabel = record.credential_reference_refs?.length ? `${record.credential_reference_refs.length} credential refs, values hidden` : 'no credential refs reported';
+  const authLabel = record.auth_mode ? `${formatTokenLabel(record.auth_mode)} auth` : 'auth mode not reported';
+  const actionLabel = record.allowed_actions?.length ? `${record.allowed_actions.length} allowed actions` : 'allowed actions not reported';
   const endpointLabel = record.execution_endpoint_names?.length ? `${record.execution_endpoint_names.length} execution endpoints` : 'no execution endpoints reported';
   const protocolLabel = record.server_protocol || 'protocol not reported';
   const networkLabel = record.network_mode || 'network mode not reported';
@@ -7121,7 +7123,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
     stage,
-    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
+    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${authLabel}; ${actionLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
@@ -7141,7 +7143,10 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
       record.gateway_id,
       record.gateway_arn,
       record.external_provider,
+      record.auth_mode,
       ...(record.tool_names ?? []),
+      ...(record.tool_target_refs ?? []),
+      ...(record.allowed_actions ?? []),
       ...(record.execution_endpoint_names ?? []),
       ...(record.execution_endpoint_arns ?? []),
       ...(record.observability_links ?? []),


### PR DESCRIPTION
## What changed
- Added an AgentCore Gateway SDK adapter that maps gateways, gateway targets, MCP tool schemas, auth mode, allowed actions, credential references, and target refs into the existing AWS AI agent identity stream.
- Composed AgentCore Runtime and Gateway collection behind the existing `ai-agent` collector so CLI scans, worker scans, normalization, and graph resolution stay on one model.
- Added normalized tool resources plus `calls_tool` graph edges for Gateway/MCP tools.
- Extended API schema, frontend client types, AWS Agents row details, and docs for gateway auth/action/tool metadata.

## Why
Issue #1508 requires AgentCore Gateway and MCP tool mapping so AWS-hosted agents can be governed as machine identities with visible tool access, identity binding, evidence, and degraded-state handling.

## Safety
- Metadata-only collection: no prompts, completions, browser pages, code output, memory contents, database rows, object contents, customer payloads, or secret values are read.
- Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
- Gateway/target describe failures degrade retained records instead of hiding successful metadata.

## Validation
- `go test ./internal/providers/aws ./internal/api ./internal/runtime ./internal/cli`
- `go test ./...`
- `npm run build` in `web/`
- `npm test -- --run src/productShell.test.tsx` in `web/`

Closes #1508

AI disclosure: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AgentCore Gateway to the AWS AI agent inventory and unifies Runtime + Gateway behind a single composite identity API. Maps MCP tools (OpenAPI, Smithy, API Gateway, Lambda, MCP server), captures auth mode, allowed actions, target/credential refs, and emits tool resources with calls_tool edges. Closes #1508.

- **New Features**
  - Introduced `CompositeAIAgentIdentityAPI`; CLI/runtime now use `NewSDKAgentCoreAIAgentIdentityAPI` to scan Runtime + Gateway in one stream.
  - Gateway mapping: parses inline OpenAPI/Smithy/MCP schemas and keeps S3 schemas as refs; preserves unnamed API Gateway override tools (method/path); filters only add `allowed_actions`; records `auth_mode`, `allowed_actions`, `tool_target_refs`, and credential-provider refs; adds `gateway_auth_*`, `target_auth_*`, protocol, and policy-engine capabilities; includes target refs in `resource_reference_refs`.
  - Normalizer/graph: creates tool resources with `secret_refs`, links them to the source agent, and builds `calls_tool` and `uses_secret` edges.
  - API/UI/docs: added `auth_mode`, `allowed_actions`, and `tool_target_refs`; new diagnostics for malformed/list/describe failures (gateway and targets); UI shows Gateway/MCP tools, auth mode, and allowed-action counts.

<sup>Written for commit baf7a0fc0811956250efb26aa5252dd874da70af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

