### PR TITLE
Map AgentCore Memory, Browser, and Code Interpreter metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 ## Unreleased
+- Add **AgentCore Memory, Browser, and Code Interpreter metadata mapping** (#1509).
+  Extends the AWS AI agent identity model with a read-only, metadata-only
+  AgentCore capabilities adapter (`internal/providers/aws/sdk_agentcore_capabilities.go`)
+  that lists and describes AgentCore Memory, Browser, and Code Interpreter
+  resources and maps each into an `agentcore_capability` identity carrying its
+  `capability_kind` (`memory`/`browser`/`code_interpreter`), execution role
+  binding, storage references (browser recording `s3://` destination, memory
+  stream-delivery resource counts), customer encryption key ARN, network
+  posture (VPC/sandbox with subnet/security-group counts only), and lifecycle
+  status. The model gains `capability_kind`, `storage_reference_refs`, and
+  `encryption_key_arn` fields; the normalizer emits an `agentcore_capability`
+  resource node per surface linked to its agent identity and execution-role
+  identity. The inventory API exposes `capability_agent_count`,
+  `memory_store_count`, `browser_count`, and `code_interpreter_count`, and the
+  AWS Agents app surface shows an AgentCore capabilities coverage card and
+  per-capability rows. Per-resource describe failures degrade only that record
+  and emit a scoped diagnostic while surviving records stay visible. Memory
+  records, browser pages, code-interpreter output, conversations, and secret
+  values are never read. See
+  [docs/aws-ai-agent-identities.md](docs/aws-ai-agent-identities.md).
 - Add **AWS Bedrock Agents identity collector** (#1506). A bounded, retryable,
   read-only, metadata-only collector in `internal/providers/aws` that emits one
   `AIAgentIdentity` raw asset per Bedrock agent so the merged Wave 4.01 AI agent

--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -1,6 +1,6 @@
 # AWS AI Agent Identities
 
-Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping.
+Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping. Issue #1509 extends it again with AgentCore Memory, Browser, and Code Interpreter capability metadata mapping.
 
 ## What Is Collected
 
@@ -11,15 +11,28 @@ The model is metadata-only. Each `agent_identity` record can describe:
 - custom AWS-hosted agents
 - external-provider-backed agents
 - agent gateways
+- AgentCore capability surfaces (`agentcore_capability`) for Memory, Browser, and Code Interpreter resources, identified by `capability_kind` (`memory`, `browser`, `code_interpreter`)
 - runtime IAM role ARN/name/account
 - AgentCore runtime version, workload identity ARN, execution endpoints, observability links, network mode, and server protocol
 - provider and model identifiers
 - gateway auth mode, tool target references, allowed action names, tool names, and capability names
 - memory/browser/code-interpreter capability flags
+- per-capability execution role bindings, storage references (`storage_reference_refs` such as a browser recording `s3://bucket/prefix` destination or a memory stream-delivery resource count), customer encryption key ARN (`encryption_key_arn`), and network posture (`vpc`, `sandbox`, etc.)
 - credential-reference identifiers
 - agent-to-endpoint `invokes` relationships for AgentCore runtime execution surfaces
 - agent-to-tool `calls_tool` relationships for AgentCore Gateway and MCP tool surfaces
+- an `agentcore_capability` resource node per Memory/Browser/Code Interpreter surface, linked to its agent identity, carrying the kind, storage references, encryption key, network mode, and execution role — but never the capability's contents
 - evidence references, confidence, account, region, connector, scan, workspace, and project context
+
+### AgentCore Memory / Browser / Code Interpreter mapping (issue #1509)
+
+The capability adapter lists `ListMemories`, `ListBrowsers`, and `ListCodeInterpreters`, then describes each resource with `GetMemory` / `GetBrowser` / `GetCodeInterpreter`. It captures:
+
+- **Memory**: id/ARN/name, status, event-expiry days, strategy names and types, encryption key ARN, memory execution role ARN, and the presence/count of stream-delivery resources. Memory records (the stored conversation/event data) are never read.
+- **Browser**: id/ARN/name, status, execution role ARN, network mode and VPC posture (subnet/security-group counts only), recording enablement and the recording S3 destination reference, and enterprise-policy presence. Browser pages and recorded session content are never read.
+- **Code Interpreter**: id/ARN/name, status, execution role ARN, and network mode/VPC posture. Code, inputs, and execution output are never read.
+
+Inventory counts expose `capability_agent_count`, `memory_store_count`, `browser_count`, and `code_interpreter_count`. Per-resource describe failures degrade only that record (`coverage_status=degraded`) and emit a scoped `agentcore_memory_describe_failed` / `agentcore_browser_describe_failed` / `agentcore_code_interpreter_describe_failed` diagnostic without dropping the surviving capability records.
 
 The public API is:
 
@@ -46,7 +59,7 @@ External AI provider credentials are represented as credential references only. 
 
 ## Permissions
 
-Use metadata-only list and describe permissions for the relevant agent, runtime, gateway target, and IAM-role surfaces. Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue. Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
+Use metadata-only list and describe permissions for the relevant agent, runtime, gateway target, and IAM-role surfaces. For the AgentCore Memory/Browser/Code Interpreter capability mapping, grant the read-only control-plane actions `bedrock-agentcore:ListMemories`, `bedrock-agentcore:GetMemory`, `bedrock-agentcore:ListBrowsers`, `bedrock-agentcore:GetBrowser`, `bedrock-agentcore:ListCodeInterpreters`, and `bedrock-agentcore:GetCodeInterpreter` (control-plane metadata only). Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue. Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
 
 ## UI Surface
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10110,6 +10110,13 @@ components:
           items: { type: string }
         browser_enabled: { type: boolean }
         code_interpreter_enabled: { type: boolean }
+        capability_kind:
+          type: string
+          enum: [memory, browser, code_interpreter]
+        storage_reference_refs:
+          type: array
+          items: { type: string }
+        encryption_key_arn: { type: string }
         capability_names:
           type: array
           items: { type: string }
@@ -10224,6 +10231,10 @@ components:
         custom_agent_count: { type: integer }
         external_agent_count: { type: integer }
         gateway_count: { type: integer }
+        capability_agent_count: { type: integer }
+        memory_store_count: { type: integer }
+        browser_count: { type: integer }
+        code_interpreter_count: { type: integer }
         runtime_role_count: { type: integer }
         provider_count: { type: integer }
         model_count: { type: integer }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10084,6 +10084,7 @@ components:
             - custom_agent
             - external_provider_agent
             - agent_gateway
+            - agentcore_capability
         runtime_version: { type: string }
         provider: { type: string }
         model_id: { type: string }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.22
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.5
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.5
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0
@@ -65,9 +66,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.29 // indirect
-	github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,6 @@ github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.5 h1:F9+qleYIBE+8vTDc7ziud/
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.5/go.mod h1:7lvd8HgCk8mPW3LkZTpuc1r5xux1ZWi7cQ5wmORIdCA=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.5 h1:+bOiP++19XAWs3CRhFNkAhAe+DAGMF/eq7Q+4Ib5OlE=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.5/go.mod h1:H9zD0xL2LX2iF6XQAcvP1aJiMbIXTF2gVMoIG36mQTQ=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 h1:jZOg03lM41zl89h17avGr6AFqAb9g3s/rZytTQslz14=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0/go.mod h1:f0MnAznWRN75Dnezt6MBnHOKHEpAI/ztr4Q6Lo1IGDk=
-github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6 h1:4Z9EIZUF8dkVDYTEt7NxKhA3yE3S/x7iWYL/C+reRgw=
-github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.6/go.mod h1:GlwXK7c/0CMTSU4a0PAAp5jiYXH55DRYT3mliKlqf6M=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0 h1:LIu5UC4jQ1HktSVZTrj4YXNgnrE6zJ9ZFK+UX5HONDo=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0/go.mod h1:MQ3INaQ+EXhLY92cpengp85BSJcXyvl4ttfPniodC90=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.69.3 h1:bdJcqPbvkHSyG7N+5PDsBB6cWnWXHWkZ80SaY09R8qQ=
@@ -58,8 +54,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21 h1:FsZxbPiVgEHYof
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.21/go.mod h1:Mmm30OV+JLXYQUcbSd84THnv3P5JtjhVDujLwMqRG0U=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 h1:Bs2OwYq0HBgHYwfGmUwYIPtTNaGMGAHkRje4jmW2VoI=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6/go.mod h1:OTctu4cW8t7/TRlTKPLT6akzyOkfceMWhtEHqtYDIQQ=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.28 h1:axj4mEDletwKmTm/9jR+DkIMmCfcn5vE4jBMAAN+3Vg=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.28/go.mod h1:3Aaz69M0jqfSHLKqxgolgUBFT4hpwSNc7DzC95orEi8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29/go.mod h1:LfRkPCD8YHDM2E5eTkos2UpwYeZnBcVarTa8L59bJHA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 h1:hiME6pBzC7OTl9LMtlyTWBuEl1f4QBcUmFDKC7MLXtc=

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -786,9 +786,9 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 		return "Retry only the failed agent metadata call and keep successful normalized agent records visible."
 	case "agentcore_runtime_describe_failed", "agentcore_runtime_endpoint_list_failed", "agentcore_runtime_malformed":
 		return "Retry the failed AgentCore runtime metadata call and keep the surviving runtime records visible."
-	case "agentcore_memory_describe_failed", "agentcore_memory_malformed",
-		"agentcore_browser_describe_failed", "agentcore_browser_malformed",
-		"agentcore_code_interpreter_describe_failed", "agentcore_code_interpreter_malformed":
+	case "agentcore_memory_describe_failed", "agentcore_memory_malformed", "agentcore_memory_id_missing",
+		"agentcore_browser_describe_failed", "agentcore_browser_malformed", "agentcore_browser_id_missing",
+		"agentcore_code_interpreter_describe_failed", "agentcore_code_interpreter_malformed", "agentcore_code_interpreter_id_missing":
 		return "Retry the failed AgentCore Memory/Browser/Code Interpreter metadata call; never read memory records, browser pages, or code-interpreter output."
 	case "ai_agent_credential_reference_unresolved":
 		return "Join to credential-reference metadata for ownership and rotation without exposing provider key values."

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	awsAIAgentIdentityCurrentIssue = 1508
-	awsAIAgentIdentityVersion      = "aws-ai-agent-identity-normalized-model-v1"
-	awsAIAgentCredentialRefPrefix  = "aws:resource:credential-reference:"
-	awsAIAgentToolNodePrefix       = "tool:agent:"
+	awsAIAgentIdentityCurrentIssue  = 1509
+	awsAIAgentIdentityVersion       = "aws-ai-agent-identity-normalized-model-v1"
+	awsAIAgentCredentialRefPrefix   = "aws:resource:credential-reference:"
+	awsAIAgentToolNodePrefix        = "tool:agent:"
+	agentCoreCapabilityAgentTypeAPI = "agentcore_capability"
 )
 
 type AWSAIAgentIdentityInventoryRequest struct {
@@ -51,6 +52,10 @@ type AWSAIAgentIdentityInventoryResult struct {
 	CustomAgentCount      int                            `json:"custom_agent_count"`
 	ExternalAgentCount    int                            `json:"external_agent_count"`
 	GatewayCount          int                            `json:"gateway_count"`
+	CapabilityAgentCount  int                            `json:"capability_agent_count"`
+	MemoryStoreCount      int                            `json:"memory_store_count"`
+	BrowserCount          int                            `json:"browser_count"`
+	CodeInterpreterCount  int                            `json:"code_interpreter_count"`
 	RuntimeRoleCount      int                            `json:"runtime_role_count"`
 	ProviderCount         int                            `json:"provider_count"`
 	ModelCount            int                            `json:"model_count"`
@@ -95,6 +100,9 @@ type AWSAIAgentIdentityRecord struct {
 	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
 	BrowserEnabled            bool              `json:"browser_enabled"`
 	CodeInterpreterEnabled    bool              `json:"code_interpreter_enabled"`
+	CapabilityKind            string            `json:"capability_kind,omitempty"`
+	StorageReferenceRefs      []string          `json:"storage_reference_refs,omitempty"`
+	EncryptionKeyARN          string            `json:"encryption_key_arn,omitempty"`
 	CapabilityNames           []string          `json:"capability_names,omitempty"`
 	CredentialReferenceRefs   []string          `json:"credential_reference_refs,omitempty"`
 	ResourceReferenceRefs     []string          `json:"resource_reference_refs,omitempty"`
@@ -214,6 +222,10 @@ func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject,
 		CustomAgentCount:      awsAIAgentIdentityTypeCount(records, "custom_agent"),
 		ExternalAgentCount:    awsAIAgentIdentityTypeCount(records, "external_provider_agent"),
 		GatewayCount:          awsAIAgentIdentityTypeCount(records, "agent_gateway"),
+		CapabilityAgentCount:  awsAIAgentIdentityTypeCount(records, agentCoreCapabilityAgentTypeAPI),
+		MemoryStoreCount:      awsAIAgentIdentityCapabilityKindCount(records, "memory"),
+		BrowserCount:          awsAIAgentIdentityCapabilityKindCount(records, "browser"),
+		CodeInterpreterCount:  awsAIAgentIdentityCapabilityKindCount(records, "code_interpreter"),
 		RuntimeRoleCount:      awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.RuntimeRoleNodeID }),
 		ProviderCount:         awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.Provider }),
 		ModelCount:            awsAIAgentIdentityUniqueCount(records, func(r AWSAIAgentIdentityRecord) string { return r.ModelID }),
@@ -370,6 +382,32 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			r.AuthMode = "custom_jwt"
 			r.CapabilityNames = []string{"gateway", "tool_routing", "mcp", "gateway_auth_custom_jwt"}
 		}),
+		awsAIAgentFixtureRecord(accountID, region, agentCoreCapabilityAgentTypeAPI, "payments-agent-memory", "mem-payments", fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:memory/mem-payments", partition, region, accountID), role("agentcore-memory-payments"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "agentcore"
+			r.Provider = "amazon-bedrock-agentcore"
+			r.CapabilityKind = "memory"
+			r.MemoryEnabled = true
+			r.MemoryStoreRefs = []string{fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:memory/mem-payments", partition, region, accountID)}
+			r.EncryptionKeyARN = fmt.Sprintf("arn:%s:kms:%s:%s:key/cmk-agentcore-memory", partition, region, accountID)
+			r.CapabilityNames = []string{"agentcore_memory", "memory", "memory_strategy_semantic", "memory_event_expiry_days_30", "customer_encryption_kms"}
+		}),
+		awsAIAgentFixtureRecord(accountID, region, agentCoreCapabilityAgentTypeAPI, "research-browser", "br-research", fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:browser/br-research", partition, region, accountID), role("agentcore-browser-research"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "agentcore"
+			r.Provider = "amazon-bedrock-agentcore"
+			r.CapabilityKind = "browser"
+			r.BrowserEnabled = true
+			r.NetworkMode = "vpc"
+			r.StorageReferenceRefs = []string{"s3://agentcore-browser-recordings/research/"}
+			r.CapabilityNames = []string{"agentcore_browser", "browser", "browser_recording", "vpc_attached", "storage_reference"}
+		}),
+		awsAIAgentFixtureRecord(accountID, region, agentCoreCapabilityAgentTypeAPI, "python-sandbox", "ci-python", fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:code-interpreter/ci-python", partition, region, accountID), role("agentcore-code-python"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
+			r.Service = "agentcore"
+			r.Provider = "amazon-bedrock-agentcore"
+			r.CapabilityKind = "code_interpreter"
+			r.CodeInterpreterEnabled = true
+			r.NetworkMode = "sandbox"
+			r.CapabilityNames = []string{"agentcore_code_interpreter", "code_interpreter"}
+		}),
 	}
 	switch fixtureState {
 	case "empty":
@@ -387,11 +425,22 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			Retryable: false,
 		}}, gaps
 	case "partial_failure":
-		return records[:4], []providers.SourceError{{
+		// Simulate the gateway sub-listing failing while every other sub-listing
+		// (Bedrock, AgentCore runtime, custom, external-provider, and the
+		// AgentCore Memory/Browser/Code Interpreter capability surfaces) is
+		// retained. Drop only the gateway record so the diagnostic stays honest.
+		retained := make([]AWSAIAgentIdentityRecord, 0, len(records))
+		for _, record := range records {
+			if record.AgentType == "agent_gateway" {
+				continue
+			}
+			retained = append(retained, record)
+		}
+		return retained, []providers.SourceError{{
 			Collector: "aws_ai-agent/ai_agent_identity",
 			SourceID:  fmt.Sprintf("service=ai-agent|account=%s|region=%s|source=agent_gateways", accountID, region),
 			Code:      "ai_agent_gateway_list_failed",
-			Message:   "agent gateway metadata could not be listed; retained Bedrock, AgentCore, custom, and external-provider-backed agent identities remain visible",
+			Message:   "agent gateway metadata could not be listed; retained Bedrock, AgentCore runtime, custom, external-provider, and AgentCore capability identities remain visible",
 			Retryable: true,
 		}}, gaps
 	case "permission_denied":
@@ -449,7 +498,8 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 	record.ExecutionEndpointNames = normalizeOrderedStringList(record.ExecutionEndpointNames)
 	record.ExecutionEndpointStatuses = normalizeOrderedStringList(record.ExecutionEndpointStatuses)
 	record.ObservabilityLinks = normalizeOrderedStringList(record.ObservabilityLinks)
-	record.ResourceReferenceRefs = dedupeStrings(append(append(record.ResourceReferenceRefs, record.ToolTargetRefs...), append(append([]string{}, record.ExecutionEndpointARNs...), record.WorkloadIdentityARN)...))
+	record.StorageReferenceRefs = dedupeStrings(record.StorageReferenceRefs)
+	record.ResourceReferenceRefs = dedupeStrings(append(append(record.ResourceReferenceRefs, record.ToolTargetRefs...), append(append(append([]string{}, record.ExecutionEndpointARNs...), record.StorageReferenceRefs...), record.WorkloadIdentityARN, record.EncryptionKeyARN)...))
 	if len(record.CredentialReferenceRefs) > 0 {
 		record.RelationshipTypes = dedupeStrings(append(record.RelationshipTypes, "uses_secret"))
 	}
@@ -679,6 +729,16 @@ func awsAIAgentIdentityTypeCount(records []AWSAIAgentIdentityRecord, agentType s
 	return count
 }
 
+func awsAIAgentIdentityCapabilityKindCount(records []AWSAIAgentIdentityRecord, kind string) int {
+	count := 0
+	for _, record := range records {
+		if record.CapabilityKind == kind {
+			count++
+		}
+	}
+	return count
+}
+
 func awsAIAgentIdentityUniqueCount(records []AWSAIAgentIdentityRecord, accessor func(AWSAIAgentIdentityRecord) string) int {
 	seen := map[string]struct{}{}
 	for _, record := range records {
@@ -726,6 +786,10 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 		return "Retry only the failed agent metadata call and keep successful normalized agent records visible."
 	case "agentcore_runtime_describe_failed", "agentcore_runtime_endpoint_list_failed", "agentcore_runtime_malformed":
 		return "Retry the failed AgentCore runtime metadata call and keep the surviving runtime records visible."
+	case "agentcore_memory_describe_failed", "agentcore_memory_malformed",
+		"agentcore_browser_describe_failed", "agentcore_browser_malformed",
+		"agentcore_code_interpreter_describe_failed", "agentcore_code_interpreter_malformed":
+		return "Retry the failed AgentCore Memory/Browser/Code Interpreter metadata call; never read memory records, browser pages, or code-interpreter output."
 	case "ai_agent_credential_reference_unresolved":
 		return "Join to credential-reference metadata for ownership and rotation without exposing provider key values."
 	default:

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -788,8 +788,9 @@ func awsAIAgentIdentityDiagnosticRemediation(code string) string {
 		return "Retry the failed AgentCore runtime metadata call and keep the surviving runtime records visible."
 	case "agentcore_memory_describe_failed", "agentcore_memory_malformed", "agentcore_memory_id_missing",
 		"agentcore_browser_describe_failed", "agentcore_browser_malformed", "agentcore_browser_id_missing",
-		"agentcore_code_interpreter_describe_failed", "agentcore_code_interpreter_malformed", "agentcore_code_interpreter_id_missing":
-		return "Retry the failed AgentCore Memory/Browser/Code Interpreter metadata call; never read memory records, browser pages, or code-interpreter output."
+		"agentcore_code_interpreter_describe_failed", "agentcore_code_interpreter_malformed", "agentcore_code_interpreter_id_missing",
+		"agentcore_capability_list_failed":
+		return "Retry the failed AgentCore Memory/Browser/Code Interpreter metadata call; surviving capability sources remain visible. Never read memory records, browser pages, or code-interpreter output."
 	case "ai_agent_credential_reference_unresolved":
 		return "Join to credential-reference metadata for ownership and rotation without exposing provider key values."
 	default:

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -13,6 +13,65 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestGetAWSAIAgentIdentityInventoryMapsAgentCoreCapabilities(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 13, 13, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-a")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-a", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSAIAgentIdentityInventory(ctx, "default", "project-a", AWSAIAgentIdentityInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get ai agent identity inventory: %v", err)
+	}
+	byKind := map[string]AWSAIAgentIdentityRecord{}
+	for _, record := range result.Records {
+		if record.AgentType != agentCoreCapabilityAgentTypeAPI {
+			continue
+		}
+		byKind[record.CapabilityKind] = record
+	}
+	if len(byKind) != 3 {
+		t.Fatalf("expected memory/browser/code_interpreter capability records, got %v", byKind)
+	}
+
+	memory := byKind["memory"]
+	if !memory.MemoryEnabled || memory.EncryptionKeyARN == "" || memory.RuntimeRoleARN == "" {
+		t.Fatalf("memory capability missing role/encryption/flag: %+v", memory)
+	}
+	if !strings.HasPrefix(memory.RuntimeRoleNodeID, "aws:identity:") {
+		t.Fatalf("memory capability role node must use canonical identity prefix, got %q", memory.RuntimeRoleNodeID)
+	}
+	browser := byKind["browser"]
+	if !browser.BrowserEnabled || browser.NetworkMode != "vpc" {
+		t.Fatalf("browser capability missing network/flag: %+v", browser)
+	}
+	if !containsString(browser.StorageReferenceRefs, "s3://agentcore-browser-recordings/research/") {
+		t.Fatalf("browser capability missing storage reference: %+v", browser.StorageReferenceRefs)
+	}
+	code := byKind["code_interpreter"]
+	if !code.CodeInterpreterEnabled {
+		t.Fatalf("code interpreter capability flag not set: %+v", code)
+	}
+
+	// Counts must reflect the capability surfaces.
+	if result.CapabilityAgentCount != 3 || result.MemoryStoreCount != 1 || result.BrowserCount != 1 || result.CodeInterpreterCount != 1 {
+		t.Fatalf("unexpected capability counts: %+v", result)
+	}
+
+	// Metadata-only invariant: no capability contents leak.
+	payload, _ := json.Marshal(result.Records)
+	lower := strings.ToLower(string(payload))
+	for _, forbidden := range []string{"memory_record", "browser_page", "code_output", "conversation", "secret_value"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("metadata-only contract violated by %q in records", forbidden)
+		}
+	}
+}
+
 func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
@@ -30,11 +89,14 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready inventory, got %+v", result)
 	}
-	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1508" || result.Version != awsAIAgentIdentityVersion {
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1509" || result.Version != awsAIAgentIdentityVersion {
 		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
 	}
 	if result.BedrockAgentCount != 1 || result.AgentCoreRuntimeCount != 1 || result.CustomAgentCount != 1 || result.ExternalAgentCount != 1 || result.GatewayCount != 1 {
 		t.Fatalf("expected one record per agent type, got %+v", result)
+	}
+	if result.CapabilityAgentCount != 3 || result.MemoryStoreCount != 1 || result.BrowserCount != 1 || result.CodeInterpreterCount != 1 {
+		t.Fatalf("expected AgentCore Memory/Browser/Code Interpreter capability records, got %+v", result)
 	}
 	if result.RuntimeRoleCount == 0 || result.ToolCount == 0 || result.CapabilityCount == 0 || result.RelationshipCount == 0 {
 		t.Fatalf("expected populated counts, got %+v", result)
@@ -138,8 +200,17 @@ func TestRouterAWSAIAgentIdentityInventoryPartialFailure(t *testing.T) {
 	if body.Inventory.Status != awsPlatformDependencyStatusDegraded || body.Inventory.FixtureState != "partial_failure" {
 		t.Fatalf("expected degraded partial_failure, got status=%q fixture=%q", body.Inventory.Status, body.Inventory.FixtureState)
 	}
-	if body.Inventory.RecordCount != 4 {
-		t.Fatalf("expected partial failure to retain four records, got %d", body.Inventory.RecordCount)
+	// The gateway sub-listing fails; every non-gateway record (Bedrock,
+	// AgentCore runtime, custom, external-provider, and the three AgentCore
+	// capability surfaces) remains visible.
+	if body.Inventory.RecordCount != 7 {
+		t.Fatalf("expected partial failure to retain seven non-gateway records, got %d", body.Inventory.RecordCount)
+	}
+	if body.Inventory.GatewayCount != 0 {
+		t.Fatalf("expected gateway record to be dropped on gateway list failure, got %d", body.Inventory.GatewayCount)
+	}
+	if body.Inventory.CapabilityAgentCount != 3 {
+		t.Fatalf("expected AgentCore capability records to survive the gateway list failure, got %d", body.Inventory.CapabilityAgentCount)
 	}
 	foundGatewayDiag := false
 	for _, diag := range body.Inventory.Diagnostics {

--- a/internal/providers/aws/ai_agent_identity_collector.go
+++ b/internal/providers/aws/ai_agent_identity_collector.go
@@ -19,6 +19,17 @@ const (
 	aiAgentIdentityServiceName   = "ai-agent"
 )
 
+// AgentCore capability kinds describe the data/tool surface a capability record
+// represents. They are metadata-only: a memory store, browser, or code
+// interpreter is recorded by identity, role binding, storage references, and
+// network posture, never by its memory contents, browser pages, or code output.
+const (
+	agentCoreCapabilityKindMemory          = "memory"
+	agentCoreCapabilityKindBrowser         = "browser"
+	agentCoreCapabilityKindCodeInterpreter = "code_interpreter"
+	agentCoreCapabilityAgentType           = "agentcore_capability"
+)
+
 // AIAgentIdentity is the payload-safe normalized model for AWS-hosted AI agents.
 // It records identity, role, provider/model, tool, memory, browser, and code
 // capability metadata while deliberately excluding prompts, completions, memory
@@ -48,6 +59,9 @@ type AIAgentIdentity struct {
 	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
 	BrowserEnabled            bool              `json:"browser_enabled"`
 	CodeInterpreterEnabled    bool              `json:"code_interpreter_enabled"`
+	CapabilityKind            string            `json:"capability_kind,omitempty"`
+	StorageReferenceRefs      []string          `json:"storage_reference_refs,omitempty"`
+	EncryptionKeyARN          string            `json:"encryption_key_arn,omitempty"`
 	CapabilityNames           []string          `json:"capability_names,omitempty"`
 	CredentialReferenceRefs   []string          `json:"credential_reference_refs,omitempty"`
 	ResourceReferenceRefs     []string          `json:"resource_reference_refs,omitempty"`
@@ -275,6 +289,9 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	normalized.AllowedActions = normalizeStringList(record.AllowedActions)
 	normalized.AuthMode = strings.TrimSpace(record.AuthMode)
 	normalized.MemoryStoreRefs = normalizeStringList(record.MemoryStoreRefs)
+	normalized.CapabilityKind = canonicalAgentCoreCapabilityKind(record.CapabilityKind)
+	normalized.StorageReferenceRefs = normalizeStringList(record.StorageReferenceRefs)
+	normalized.EncryptionKeyARN = strings.TrimSpace(record.EncryptionKeyARN)
 	normalized.CapabilityNames = normalizeStringList(record.CapabilityNames)
 	normalized.CredentialReferenceRefs = normalizeStringList(record.CredentialReferenceRefs)
 	normalized.ResourceReferenceRefs = normalizeStringList(record.ResourceReferenceRefs)
@@ -310,6 +327,30 @@ func normalizeAIAgentIdentityScope(scope AWSCollectorScope, record AIAgentIdenti
 	}
 	if len(normalized.ObservabilityLinks) > 0 {
 		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "observability")
+	}
+	// AgentCore Memory / Browser / Code Interpreter capability surfaces. Storage
+	// references and the encryption key feed the resource-reference graph so the
+	// capability's persistent data surface is visible, while contents stay
+	// uncollected. The kind also flips the matching capability flag so downstream
+	// dashboards keep working without inspecting the agent_type.
+	switch normalized.CapabilityKind {
+	case agentCoreCapabilityKindMemory:
+		normalized.MemoryEnabled = true
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "memory")
+	case agentCoreCapabilityKindBrowser:
+		normalized.BrowserEnabled = true
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "browser")
+	case agentCoreCapabilityKindCodeInterpreter:
+		normalized.CodeInterpreterEnabled = true
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "code_interpreter")
+	}
+	if len(normalized.StorageReferenceRefs) > 0 {
+		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.StorageReferenceRefs...))
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "storage_reference")
+	}
+	if normalized.EncryptionKeyARN != "" {
+		normalized.ResourceReferenceRefs = normalizeStringList(append(normalized.ResourceReferenceRefs, normalized.EncryptionKeyARN))
+		normalized.CapabilityNames = appendUnique(normalized.CapabilityNames, "customer_encryption_kms")
 	}
 	normalized.SensitiveBoundary = firstNonEmptyAWSValue(record.SensitiveBoundary, "metadata_only")
 	normalized.CoverageStatus = firstNonEmptyAWSValue(record.CoverageStatus, "covered")
@@ -390,11 +431,28 @@ func canonicalAIAgentType(agentType string, service string) string {
 		return "external_provider_agent"
 	case "agent_gateway", "gateway":
 		return "agent_gateway"
+	case agentCoreCapabilityAgentType, "agentcore_memory", "agentcore_browser", "agentcore_code_interpreter":
+		return agentCoreCapabilityAgentType
 	}
 	if strings.EqualFold(strings.TrimSpace(service), "bedrock") {
 		return "bedrock_agent"
 	}
 	return "custom_agent"
+}
+
+// canonicalAgentCoreCapabilityKind normalizes a capability kind onto the
+// supported set, returning "" for non-capability records.
+func canonicalAgentCoreCapabilityKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case agentCoreCapabilityKindMemory, "agentcore_memory", "memory_store":
+		return agentCoreCapabilityKindMemory
+	case agentCoreCapabilityKindBrowser, "agentcore_browser", "browser_tool":
+		return agentCoreCapabilityKindBrowser
+	case agentCoreCapabilityKindCodeInterpreter, "agentcore_code_interpreter", "code-interpreter", "codeinterpreter":
+		return agentCoreCapabilityKindCodeInterpreter
+	default:
+		return ""
+	}
 }
 
 func aiAgentIdentityConfidence(record AIAgentIdentity) float64 {
@@ -424,6 +482,15 @@ func aiAgentIdentityConfidence(record AIAgentIdentity) float64 {
 		confidence += 0.02
 	}
 	if strings.TrimSpace(record.NetworkMode) != "" || strings.TrimSpace(record.ServerProtocol) != "" {
+		confidence += 0.02
+	}
+	if strings.TrimSpace(record.CapabilityKind) != "" {
+		confidence += 0.04
+	}
+	if len(record.StorageReferenceRefs) > 0 {
+		confidence += 0.03
+	}
+	if strings.TrimSpace(record.EncryptionKeyARN) != "" {
 		confidence += 0.02
 	}
 	if confidence > 0.95 {

--- a/internal/providers/aws/helpers.go
+++ b/internal/providers/aws/helpers.go
@@ -83,6 +83,18 @@ func awsAIAgentExecutionEndpointNodeID(agentNodeID string, endpointARN string) s
 	}), "|")
 }
 
+func awsAIAgentCapabilityNodeID(agentNodeID string, capabilityKind string) string {
+	workload := strings.TrimSpace(agentNodeID)
+	if workload == "" {
+		workload = "agent"
+	}
+	kind := strings.TrimSpace(strings.ToLower(capabilityKind))
+	if kind == "" {
+		kind = "capability"
+	}
+	return "aws:resource:agentcore-capability:" + strings.Join(normalizeStringList([]string{workload, kind}), "|")
+}
+
 func awsAIAgentResourceReferenceParts(ref string) (string, string) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -377,6 +377,13 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 				"tool_target_refs":            normalizeStringList(record.ToolTargetRefs),
 				"allowed_actions":             normalizeStringList(record.AllowedActions),
 				"auth_mode":                   strings.TrimSpace(record.AuthMode),
+				"capability_kind":             strings.TrimSpace(record.CapabilityKind),
+				"storage_reference_refs":      normalizeStringList(record.StorageReferenceRefs),
+				"encryption_key_arn":          strings.TrimSpace(record.EncryptionKeyARN),
+				"memory_enabled":              record.MemoryEnabled,
+				"browser_enabled":             record.BrowserEnabled,
+				"code_interpreter_enabled":    record.CodeInterpreterEnabled,
+				"memory_store_refs":           normalizeStringList(record.MemoryStoreRefs),
 				"capability_names":            normalizeStringList(record.CapabilityNames),
 				"credential_reference_refs":   normalizeStringList(record.CredentialReferenceRefs),
 				"resource_reference_refs":     normalizeStringList(record.ResourceReferenceRefs),
@@ -489,6 +496,47 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 		}
 		bundle.Resources = append(bundle.Resources, resource)
 		resourceSeen[toolID] = struct{}{}
+	}
+
+	// AgentCore Memory / Browser / Code Interpreter capability surface. Each
+	// capability record emits one capability resource node carrying its kind,
+	// storage references, encryption key, and network posture so the graph shows
+	// the agent's persistent data/tool surface without any capability contents.
+	if capabilityKind := canonicalAgentCoreCapabilityKind(record.CapabilityKind); capabilityKind != "" {
+		capabilityID := awsAIAgentCapabilityNodeID(agentID, capabilityKind)
+		if _, exists := resourceSeen[capabilityID]; !exists {
+			resource := domain.Resource{
+				ID:        capabilityID,
+				Provider:  domain.ProviderAWS,
+				Type:      domain.ResourceTypeBedrockAgentCore,
+				Name:      firstNonEmptyAWSValue(record.AgentName, record.AgentID),
+				ARN:       strings.TrimSpace(record.AgentARN),
+				Region:    strings.TrimSpace(record.Region),
+				AccountID: strings.TrimSpace(record.AccountID),
+				Labels: map[string]string{
+					"resource_kind":   "agentcore_capability",
+					"capability_kind": capabilityKind,
+				},
+				Metadata: map[string]any{
+					"capability_kind":          capabilityKind,
+					"capability_agent_id":      agentID,
+					"memory_enabled":           record.MemoryEnabled,
+					"browser_enabled":          record.BrowserEnabled,
+					"code_interpreter_enabled": record.CodeInterpreterEnabled,
+					"storage_reference_refs":   normalizeStringList(record.StorageReferenceRefs),
+					"resource_reference_refs":  normalizeStringList(record.ResourceReferenceRefs),
+					"encryption_key_arn":       strings.TrimSpace(record.EncryptionKeyARN),
+					"execution_role_arn":       strings.TrimSpace(record.RuntimeRoleARN),
+					"network_mode":             strings.TrimSpace(record.NetworkMode),
+					"capability_names":         normalizeStringList(record.CapabilityNames),
+					"coverage_status":          strings.TrimSpace(record.CoverageStatus),
+				},
+				RawRef:         asset.SourceID,
+				SourceEntityID: agentID,
+			}
+			bundle.Resources = append(bundle.Resources, resource)
+			resourceSeen[capabilityID] = struct{}{}
+		}
 	}
 
 	return nil

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -292,6 +292,81 @@ func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 	}
 }
 
+func TestRoleNormalizerEmitsAgentCoreCapabilityResource(t *testing.T) {
+	normalizer := NewRoleNormalizer()
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Service:   "agentcore",
+		},
+		AgentType:            agentCoreCapabilityAgentType,
+		CapabilityKind:       agentCoreCapabilityKindBrowser,
+		AgentID:              "br-research",
+		AgentName:            "research-browser",
+		AgentARN:             "arn:aws:bedrock-agentcore:us-east-1:123456789012:browser/br-research",
+		RuntimeRoleARN:       "arn:aws:iam::123456789012:role/agentcore-browser",
+		NetworkMode:          "vpc",
+		StorageReferenceRefs: []string{"s3://agent-recordings/browser/"},
+		EncryptionKeyARN:     "arn:aws:kms:us-east-1:123456789012:key/cmk-browser",
+	}
+	// Normalize the record the way the collector would before marshalling.
+	enriched := normalizeAIAgentIdentityScope(AWSCollectorScope{AccountID: "123456789012", Region: "us-east-1"}, record, record.CollectedAt)
+	payload, err := json.Marshal(enriched)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	bundle, err := normalizer.Normalize(context.Background(), []providers.RawAsset{{
+		Kind:     rawKindAIAgentIdentity,
+		SourceID: "capability/br-research",
+		Payload:  payload,
+	}})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+
+	// One agent node, one runtime-role identity, and one capability resource.
+	if len(bundle.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(bundle.Agents))
+	}
+	var capabilityResource *domain.Resource
+	for i := range bundle.Resources {
+		if bundle.Resources[i].Labels["resource_kind"] == "agentcore_capability" {
+			capabilityResource = &bundle.Resources[i]
+		}
+	}
+	if capabilityResource == nil {
+		t.Fatalf("expected agentcore_capability resource, got %+v", bundle.Resources)
+	}
+	if capabilityResource.Labels["capability_kind"] != agentCoreCapabilityKindBrowser {
+		t.Fatalf("expected browser capability kind, got %+v", capabilityResource.Labels)
+	}
+	if capabilityResource.SourceEntityID == "" {
+		t.Fatalf("capability resource must link to its agent node")
+	}
+	if !containsString(parseStringList(capabilityResource.Metadata["storage_reference_refs"]), "s3://agent-recordings/browser/") {
+		t.Fatalf("expected storage reference, got %+v", capabilityResource.Metadata)
+	}
+	if got, _ := capabilityResource.Metadata["encryption_key_arn"].(string); strings.TrimSpace(got) == "" {
+		t.Fatalf("expected encryption key arn metadata, got %+v", capabilityResource.Metadata)
+	}
+	if enabled, _ := capabilityResource.Metadata["browser_enabled"].(bool); !enabled {
+		t.Fatalf("expected browser_enabled true, got %+v", capabilityResource.Metadata)
+	}
+
+	// The capability's execution role must surface as an identity.
+	foundRole := false
+	for _, identity := range bundle.Identities {
+		if identity.ARN == "arn:aws:iam::123456789012:role/agentcore-browser" {
+			foundRole = true
+		}
+	}
+	if !foundRole {
+		t.Fatalf("expected capability execution role identity, got %+v", bundle.Identities)
+	}
+}
+
 func TestAIAgentExecutionEndpointNodeIDPreservesAgentNodeCase(t *testing.T) {
 	agentNodeID := "aws:agent:123456789012:us-east-1:custom_agent/CaseSensitiveGateway"
 	endpointARN := "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime/Blue"

--- a/internal/providers/aws/sdk_agentcore_capabilities.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities.go
@@ -1,0 +1,549 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+	"github.com/identrail/identrail/internal/textutil"
+)
+
+// AgentCoreCapabilitiesSDKClient defines the AgentCore Control API calls the
+// capability adapter uses to map Memory, Browser, and Code Interpreter
+// resources. Every call is read-only metadata: the adapter never reads memory
+// records, browser pages, or code-interpreter output.
+type AgentCoreCapabilitiesSDKClient interface {
+	ListMemories(ctx context.Context, params *bedrockagentcorecontrol.ListMemoriesInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListMemoriesOutput, error)
+	GetMemory(ctx context.Context, params *bedrockagentcorecontrol.GetMemoryInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetMemoryOutput, error)
+	ListBrowsers(ctx context.Context, params *bedrockagentcorecontrol.ListBrowsersInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListBrowsersOutput, error)
+	GetBrowser(ctx context.Context, params *bedrockagentcorecontrol.GetBrowserInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetBrowserOutput, error)
+	ListCodeInterpreters(ctx context.Context, params *bedrockagentcorecontrol.ListCodeInterpretersInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListCodeInterpretersOutput, error)
+	GetCodeInterpreter(ctx context.Context, params *bedrockagentcorecontrol.GetCodeInterpreterInput, optFns ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetCodeInterpreterOutput, error)
+}
+
+// SDKAgentCoreCapabilitiesAPI adapts AgentCore Memory/Browser/Code Interpreter
+// resources into the generic AIAgentIdentity API contract as data/tool surfaces.
+type SDKAgentCoreCapabilitiesAPI struct {
+	client    AgentCoreCapabilitiesSDKClient
+	accountID string
+	region    string
+}
+
+var _ AIAgentIdentityAPI = (*SDKAgentCoreCapabilitiesAPI)(nil)
+
+// NewSDKAgentCoreCapabilitiesAPI constructs the capability adapter using ambient
+// AWS credentials.
+func NewSDKAgentCoreCapabilitiesAPI(region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	return NewSDKAgentCoreCapabilitiesAPIWithContext(context.Background(), region, profile, accountID)
+}
+
+// NewSDKAgentCoreCapabilitiesAPIWithContext constructs the capability adapter
+// using the caller-provided context for AWS configuration loading.
+func NewSDKAgentCoreCapabilitiesAPIWithContext(ctx context.Context, region string, profile string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKAgentCoreCapabilitiesAPIFromClient(bedrockagentcorecontrol.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+// NewSDKAgentCoreCapabilitiesAPIFromAssumeRole constructs the capability adapter
+// after assuming the connector role.
+func NewSDKAgentCoreCapabilitiesAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (AIAgentIdentityAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, fmt.Errorf("aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(options *stscreds.AssumeRoleOptions) {
+			options.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	resolvedAccountID, err := awsCallerAccountID(ctx, cfg, accountID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
+	return NewSDKAgentCoreCapabilitiesAPIFromClient(bedrockagentcorecontrol.NewFromConfig(cfg), resolvedAccountID, resolvedRegion), nil
+}
+
+// NewSDKAgentCoreCapabilitiesAPIFromClient creates a test seam around a provided
+// AgentCore client.
+func NewSDKAgentCoreCapabilitiesAPIFromClient(client AgentCoreCapabilitiesSDKClient, accountID string, region string) AIAgentIdentityAPI {
+	return &SDKAgentCoreCapabilitiesAPI{
+		client:    client,
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+	}
+}
+
+// agentCoreCapabilitySource indexes the three capability surfaces so pagination
+// walks them deterministically (memory, then browser, then code interpreter).
+type agentCoreCapabilitySource int
+
+const (
+	agentCoreCapabilitySourceMemory agentCoreCapabilitySource = iota
+	agentCoreCapabilitySourceBrowser
+	agentCoreCapabilitySourceCodeInterpreter
+	agentCoreCapabilitySourceCount
+)
+
+// ListAgentIdentities lists AgentCore Memory, Browser, and Code Interpreter
+// resources and maps each into a metadata-only capability identity. It walks the
+// three surfaces in order using a composite "<source>:<token>" pagination token
+// so a single agent collector can fan across all three without losing position.
+func (a *SDKAgentCoreCapabilitiesAPI) ListAgentIdentities(ctx context.Context, nextToken string, pageSize int32) (AIAgentIdentityPage, error) {
+	if a.client == nil {
+		return AIAgentIdentityPage{}, fmt.Errorf("agentcore capabilities sdk client is required")
+	}
+	source, sourceToken, err := parseAgentCoreCapabilityToken(nextToken)
+	if err != nil {
+		return AIAgentIdentityPage{}, err
+	}
+	for source < agentCoreCapabilitySourceCount {
+		if err := ctx.Err(); err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		var (
+			records     []AIAgentIdentity
+			diagnostics []providers.SourceError
+			next        string
+		)
+		switch source {
+		case agentCoreCapabilitySourceMemory:
+			records, next, diagnostics, err = a.listMemories(ctx, sourceToken, pageSize)
+		case agentCoreCapabilitySourceBrowser:
+			records, next, diagnostics, err = a.listBrowsers(ctx, sourceToken, pageSize)
+		case agentCoreCapabilitySourceCodeInterpreter:
+			records, next, diagnostics, err = a.listCodeInterpreters(ctx, sourceToken, pageSize)
+		}
+		if err != nil {
+			return AIAgentIdentityPage{}, err
+		}
+		page := AIAgentIdentityPage{Records: records, Diagnostics: diagnostics}
+		if strings.TrimSpace(next) != "" {
+			page.NextToken = formatAgentCoreCapabilityToken(source, next)
+			return page, nil
+		}
+		if source+1 < agentCoreCapabilitySourceCount {
+			page.NextToken = formatAgentCoreCapabilityToken(source+1, "")
+		}
+		if len(page.Records) > 0 || len(page.Diagnostics) > 0 {
+			return page, nil
+		}
+		source++
+		sourceToken = ""
+	}
+	return AIAgentIdentityPage{}, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) listMemories(ctx context.Context, token string, pageSize int32) ([]AIAgentIdentity, string, []providers.SourceError, error) {
+	input := &bedrockagentcorecontrol.ListMemoriesInput{MaxResults: awsv2.Int32(agentCoreSDKPageSize(pageSize))}
+	if trimmed := strings.TrimSpace(token); trimmed != "" {
+		input.NextToken = awsv2.String(trimmed)
+	}
+	output, err := a.client.ListMemories(ctx, input)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	records := make([]AIAgentIdentity, 0, len(output.Memories))
+	diagnostics := []providers.SourceError{}
+	for _, summary := range output.Memories {
+		if err := ctx.Err(); err != nil {
+			return records, "", diagnostics, err
+		}
+		record, recordDiagnostics, recordErr := a.memoryRecord(ctx, summary)
+		if errors.Is(recordErr, context.Canceled) || errors.Is(recordErr, context.DeadlineExceeded) {
+			return records, "", diagnostics, recordErr
+		}
+		diagnostics = append(diagnostics, recordDiagnostics...)
+		if strings.TrimSpace(record.AgentID) == "" && strings.TrimSpace(record.AgentARN) == "" {
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, strings.TrimSpace(awsv2.ToString(output.NextToken)), diagnostics, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) memoryRecord(ctx context.Context, summary agentcoretypes.MemorySummary) (AIAgentIdentity, []providers.SourceError, error) {
+	diagnostics := []providers.SourceError{}
+	memoryID := strings.TrimSpace(awsv2.ToString(summary.Id))
+	memoryARN := strings.TrimSpace(awsv2.ToString(summary.Arn))
+	if memoryID == "" && memoryARN == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			Code:      "agentcore_memory_malformed",
+			Message:   "skipped AgentCore memory without a stable identifier",
+			Retryable: false,
+		})
+		return AIAgentIdentity{}, diagnostics, nil
+	}
+
+	record := a.baseCapabilityRecord(agentCoreCapabilityKindMemory, memoryID, memoryARN, "")
+	record.Status = agentCoreCapabilityStatus(string(summary.Status))
+
+	detail, detailErr := a.client.GetMemory(ctx, &bedrockagentcorecontrol.GetMemoryInput{MemoryId: awsv2.String(memoryID)})
+	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, detailErr
+	}
+	if detailErr != nil || detail == nil || detail.Memory == nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  firstNonEmptyAWSValue(memoryID, memoryARN),
+			Code:      "agentcore_memory_describe_failed",
+			Message:   fmt.Sprintf("AgentCore memory %s could not be described: %v", firstNonEmptyAWSValue(memoryID, memoryARN), detailErr),
+			Retryable: isRetryable(detailErr),
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore memory metadata was partially collected"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
+
+	memory := detail.Memory
+	record.AgentARN = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(memory.Arn)), memoryARN)
+	record.AgentName = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(memory.Name)), record.AgentName)
+	roleARN := strings.TrimSpace(awsv2.ToString(memory.MemoryExecutionRoleArn))
+	record.RuntimeRoleARN = roleARN
+	record.RuntimeRoleName = roleNameFromARN(roleARN)
+	record.RuntimeRoleAccountID = roleAccountIDFromARN(roleARN)
+	record.EncryptionKeyARN = strings.TrimSpace(awsv2.ToString(memory.EncryptionKeyArn))
+	record.Status = agentCoreCapabilityStatus(string(memory.Status))
+	storageRefs := []string{}
+	for _, strategy := range memory.Strategies {
+		if name := strings.TrimSpace(awsv2.ToString(strategy.Name)); name != "" {
+			record.CapabilityNames = appendUnique(record.CapabilityNames, "memory_strategy_"+normalizeName(name))
+		}
+		if kind := strings.TrimSpace(string(strategy.Type)); kind != "" {
+			record.CapabilityNames = appendUnique(record.CapabilityNames, "memory_strategy_type_"+strings.ToLower(kind))
+		}
+	}
+	if memory.EventExpiryDuration != nil {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, fmt.Sprintf("memory_event_expiry_days_%d", awsv2.ToInt32(memory.EventExpiryDuration)))
+	}
+	if memory.StreamDeliveryResources != nil {
+		storageRefs = append(storageRefs, fmt.Sprintf("memory_stream_delivery_resources_%d", len(memory.StreamDeliveryResources.Resources)))
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "memory_stream_delivery")
+	}
+	record.StorageReferenceRefs = normalizeStringList(storageRefs)
+	record.MemoryStoreRefs = normalizeStringList([]string{firstNonEmptyAWSValue(record.AgentARN, record.AgentID)})
+	if reason := strings.TrimSpace(awsv2.ToString(memory.FailureReason)); reason != "" && record.CoverageStatus != "covered" {
+		record.CoverageReason = reason
+	}
+	a.finalizeCapabilityRecord(&record)
+	return record, diagnostics, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) listBrowsers(ctx context.Context, token string, pageSize int32) ([]AIAgentIdentity, string, []providers.SourceError, error) {
+	input := &bedrockagentcorecontrol.ListBrowsersInput{MaxResults: awsv2.Int32(agentCoreSDKPageSize(pageSize))}
+	if trimmed := strings.TrimSpace(token); trimmed != "" {
+		input.NextToken = awsv2.String(trimmed)
+	}
+	output, err := a.client.ListBrowsers(ctx, input)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	records := make([]AIAgentIdentity, 0, len(output.BrowserSummaries))
+	diagnostics := []providers.SourceError{}
+	for _, summary := range output.BrowserSummaries {
+		if err := ctx.Err(); err != nil {
+			return records, "", diagnostics, err
+		}
+		record, recordDiagnostics, recordErr := a.browserRecord(ctx, summary)
+		if errors.Is(recordErr, context.Canceled) || errors.Is(recordErr, context.DeadlineExceeded) {
+			return records, "", diagnostics, recordErr
+		}
+		diagnostics = append(diagnostics, recordDiagnostics...)
+		if strings.TrimSpace(record.AgentID) == "" && strings.TrimSpace(record.AgentARN) == "" {
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, strings.TrimSpace(awsv2.ToString(output.NextToken)), diagnostics, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) browserRecord(ctx context.Context, summary agentcoretypes.BrowserSummary) (AIAgentIdentity, []providers.SourceError, error) {
+	diagnostics := []providers.SourceError{}
+	browserID := strings.TrimSpace(awsv2.ToString(summary.BrowserId))
+	browserARN := strings.TrimSpace(awsv2.ToString(summary.BrowserArn))
+	if browserID == "" && browserARN == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			Code:      "agentcore_browser_malformed",
+			Message:   "skipped AgentCore browser without a stable identifier",
+			Retryable: false,
+		})
+		return AIAgentIdentity{}, diagnostics, nil
+	}
+
+	record := a.baseCapabilityRecord(agentCoreCapabilityKindBrowser, browserID, browserARN, firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.Name)), browserID))
+	record.Status = agentCoreCapabilityStatus(string(summary.Status))
+
+	detail, detailErr := a.client.GetBrowser(ctx, &bedrockagentcorecontrol.GetBrowserInput{BrowserId: awsv2.String(browserID)})
+	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, detailErr
+	}
+	if detailErr != nil || detail == nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  firstNonEmptyAWSValue(browserID, browserARN),
+			Code:      "agentcore_browser_describe_failed",
+			Message:   fmt.Sprintf("AgentCore browser %s could not be described: %v", firstNonEmptyAWSValue(browserID, browserARN), detailErr),
+			Retryable: isRetryable(detailErr),
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore browser metadata was partially collected"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
+
+	record.AgentARN = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(detail.BrowserArn)), browserARN)
+	record.AgentName = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(detail.Name)), record.AgentName)
+	roleARN := strings.TrimSpace(awsv2.ToString(detail.ExecutionRoleArn))
+	record.RuntimeRoleARN = roleARN
+	record.RuntimeRoleName = roleNameFromARN(roleARN)
+	record.RuntimeRoleAccountID = roleAccountIDFromARN(roleARN)
+	record.Status = agentCoreCapabilityStatus(string(detail.Status))
+	if detail.NetworkConfiguration != nil {
+		record.NetworkMode = strings.ToLower(strings.TrimSpace(string(detail.NetworkConfiguration.NetworkMode)))
+		record.CapabilityNames = append(record.CapabilityNames, vpcConfigCapabilities(detail.NetworkConfiguration.VpcConfig)...)
+	}
+	storageRefs := []string{}
+	if detail.Recording != nil && detail.Recording.Enabled {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "browser_recording")
+		if ref := s3LocationRef(detail.Recording.S3Location); ref != "" {
+			storageRefs = append(storageRefs, ref)
+		}
+	}
+	if len(detail.EnterprisePolicies) > 0 {
+		record.CapabilityNames = appendUnique(record.CapabilityNames, "browser_enterprise_policy")
+	}
+	record.StorageReferenceRefs = normalizeStringList(storageRefs)
+	if reason := strings.TrimSpace(awsv2.ToString(detail.FailureReason)); reason != "" && record.CoverageStatus != "covered" {
+		record.CoverageReason = reason
+	}
+	a.finalizeCapabilityRecord(&record)
+	return record, diagnostics, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) listCodeInterpreters(ctx context.Context, token string, pageSize int32) ([]AIAgentIdentity, string, []providers.SourceError, error) {
+	input := &bedrockagentcorecontrol.ListCodeInterpretersInput{MaxResults: awsv2.Int32(agentCoreSDKPageSize(pageSize))}
+	if trimmed := strings.TrimSpace(token); trimmed != "" {
+		input.NextToken = awsv2.String(trimmed)
+	}
+	output, err := a.client.ListCodeInterpreters(ctx, input)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	records := make([]AIAgentIdentity, 0, len(output.CodeInterpreterSummaries))
+	diagnostics := []providers.SourceError{}
+	for _, summary := range output.CodeInterpreterSummaries {
+		if err := ctx.Err(); err != nil {
+			return records, "", diagnostics, err
+		}
+		record, recordDiagnostics, recordErr := a.codeInterpreterRecord(ctx, summary)
+		if errors.Is(recordErr, context.Canceled) || errors.Is(recordErr, context.DeadlineExceeded) {
+			return records, "", diagnostics, recordErr
+		}
+		diagnostics = append(diagnostics, recordDiagnostics...)
+		if strings.TrimSpace(record.AgentID) == "" && strings.TrimSpace(record.AgentARN) == "" {
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, strings.TrimSpace(awsv2.ToString(output.NextToken)), diagnostics, nil
+}
+
+func (a *SDKAgentCoreCapabilitiesAPI) codeInterpreterRecord(ctx context.Context, summary agentcoretypes.CodeInterpreterSummary) (AIAgentIdentity, []providers.SourceError, error) {
+	diagnostics := []providers.SourceError{}
+	interpreterID := strings.TrimSpace(awsv2.ToString(summary.CodeInterpreterId))
+	interpreterARN := strings.TrimSpace(awsv2.ToString(summary.CodeInterpreterArn))
+	if interpreterID == "" && interpreterARN == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			Code:      "agentcore_code_interpreter_malformed",
+			Message:   "skipped AgentCore code interpreter without a stable identifier",
+			Retryable: false,
+		})
+		return AIAgentIdentity{}, diagnostics, nil
+	}
+
+	record := a.baseCapabilityRecord(agentCoreCapabilityKindCodeInterpreter, interpreterID, interpreterARN, firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.Name)), interpreterID))
+	record.Status = agentCoreCapabilityStatus(string(summary.Status))
+
+	detail, detailErr := a.client.GetCodeInterpreter(ctx, &bedrockagentcorecontrol.GetCodeInterpreterInput{CodeInterpreterId: awsv2.String(interpreterID)})
+	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
+		return AIAgentIdentity{}, diagnostics, detailErr
+	}
+	if detailErr != nil || detail == nil {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  firstNonEmptyAWSValue(interpreterID, interpreterARN),
+			Code:      "agentcore_code_interpreter_describe_failed",
+			Message:   fmt.Sprintf("AgentCore code interpreter %s could not be described: %v", firstNonEmptyAWSValue(interpreterID, interpreterARN), detailErr),
+			Retryable: isRetryable(detailErr),
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore code interpreter metadata was partially collected"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
+
+	record.AgentARN = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(detail.CodeInterpreterArn)), interpreterARN)
+	record.AgentName = firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(detail.Name)), record.AgentName)
+	roleARN := strings.TrimSpace(awsv2.ToString(detail.ExecutionRoleArn))
+	record.RuntimeRoleARN = roleARN
+	record.RuntimeRoleName = roleNameFromARN(roleARN)
+	record.RuntimeRoleAccountID = roleAccountIDFromARN(roleARN)
+	record.Status = agentCoreCapabilityStatus(string(detail.Status))
+	if detail.NetworkConfiguration != nil {
+		record.NetworkMode = strings.ToLower(strings.TrimSpace(string(detail.NetworkConfiguration.NetworkMode)))
+		record.CapabilityNames = append(record.CapabilityNames, vpcConfigCapabilities(detail.NetworkConfiguration.VpcConfig)...)
+	}
+	if reason := strings.TrimSpace(awsv2.ToString(detail.FailureReason)); reason != "" && record.CoverageStatus != "covered" {
+		record.CoverageReason = reason
+	}
+	a.finalizeCapabilityRecord(&record)
+	return record, diagnostics, nil
+}
+
+// baseCapabilityRecord seeds the common metadata-only fields shared by every
+// capability surface.
+func (a *SDKAgentCoreCapabilitiesAPI) baseCapabilityRecord(kind, id, arn, name string) AIAgentIdentity {
+	return AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID: strings.TrimSpace(a.accountID),
+			Region:    strings.TrimSpace(a.region),
+		},
+		AgentID:           id,
+		AgentARN:          arn,
+		AgentName:         firstNonEmptyAWSValue(name, id, arn),
+		AgentType:         agentCoreCapabilityAgentType,
+		CapabilityKind:    kind,
+		Provider:          "amazon-bedrock-agentcore",
+		CapabilityNames:   []string{"agentcore_" + kind},
+		SensitiveBoundary: "metadata_only",
+		CoverageStatus:    "covered",
+		Status:            "ready",
+	}
+}
+
+// finalizeCapabilityRecord fills in the derived collector envelope fields so the
+// capability record validates against the shared service collector contract.
+func (a *SDKAgentCoreCapabilitiesAPI) finalizeCapabilityRecord(record *AIAgentIdentity) {
+	record.CapabilityNames = normalizeStringList(record.CapabilityNames)
+	record.StorageReferenceRefs = normalizeStringList(record.StorageReferenceRefs)
+	record.Service = "agentcore"
+	record.Source = "agentcore_" + record.CapabilityKind + "_metadata"
+	record.EvidenceRef = firstNonEmptyAWSValue(record.AgentARN, record.AgentID)
+	record.CollectorName = aiAgentIdentityCollectorName
+	record.Confidence = aiAgentIdentityConfidence(*record)
+}
+
+// agentCoreCapabilityStatus maps the AgentCore lifecycle status strings onto the
+// constrained vocabulary used by every AI agent identity record.
+func agentCoreCapabilityStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch normalized {
+	case "", "active", "ready", "available":
+		if normalized == "" {
+			return "ready"
+		}
+		return "ready"
+	case "creating", "create_in_progress", "updating", "update_in_progress":
+		return "creating"
+	case "deleting", "delete_in_progress":
+		return "deleting"
+	case "create_failed", "update_failed", "delete_failed", "failed":
+		return "failed"
+	default:
+		return normalized
+	}
+}
+
+// vpcConfigCapabilities returns metadata-only network posture tokens for a VPC
+// configuration. It records only counts and the presence of the S3 endpoint
+// requirement, never security-group or subnet identifiers as data.
+func vpcConfigCapabilities(vpc *agentcoretypes.VpcConfig) []string {
+	if vpc == nil {
+		return nil
+	}
+	caps := []string{"vpc_attached"}
+	if len(vpc.Subnets) > 0 {
+		caps = append(caps, fmt.Sprintf("vpc_subnets_%d", len(vpc.Subnets)))
+	}
+	if len(vpc.SecurityGroups) > 0 {
+		caps = append(caps, fmt.Sprintf("vpc_security_groups_%d", len(vpc.SecurityGroups)))
+	}
+	if awsv2.ToBool(vpc.RequireServiceS3Endpoint) {
+		caps = append(caps, "vpc_require_s3_endpoint")
+	}
+	return caps
+}
+
+// s3LocationRef renders a metadata-only s3://bucket/prefix reference for a
+// recording or storage destination, never the object contents.
+func s3LocationRef(loc *agentcoretypes.S3Location) string {
+	if loc == nil {
+		return ""
+	}
+	bucket := strings.TrimSpace(awsv2.ToString(loc.Bucket))
+	if bucket == "" {
+		return ""
+	}
+	ref := "s3://" + bucket
+	if prefix := strings.TrimSpace(awsv2.ToString(loc.Prefix)); prefix != "" {
+		ref = ref + "/" + strings.TrimPrefix(prefix, "/")
+	}
+	return ref
+}
+
+func parseAgentCoreCapabilityToken(token string) (agentCoreCapabilitySource, string, error) {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
+		return agentCoreCapabilitySourceMemory, "", nil
+	}
+	indexPart, sourceToken, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return 0, "", fmt.Errorf("invalid agentcore capability pagination token")
+	}
+	var index int
+	if _, err := fmt.Sscanf(indexPart, "%d", &index); err != nil {
+		return 0, "", fmt.Errorf("invalid agentcore capability pagination token")
+	}
+	if index < 0 || agentCoreCapabilitySource(index) >= agentCoreCapabilitySourceCount {
+		return 0, "", fmt.Errorf("invalid agentcore capability pagination token")
+	}
+	return agentCoreCapabilitySource(index), sourceToken, nil
+}
+
+func formatAgentCoreCapabilityToken(source agentCoreCapabilitySource, sourceToken string) string {
+	return fmt.Sprintf("%d:%s", int(source), strings.TrimSpace(sourceToken))
+}

--- a/internal/providers/aws/sdk_agentcore_capabilities.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
@@ -206,6 +207,24 @@ func (a *SDKAgentCoreCapabilitiesAPI) memoryRecord(ctx context.Context, summary 
 	record := a.baseCapabilityRecord(agentCoreCapabilityKindMemory, memoryID, memoryARN, "")
 	record.Status = agentCoreCapabilityStatus(string(summary.Status))
 
+	// GetMemory keys on the short memory id. If the summary is ARN-only, skip the
+	// describe call (it would query an empty id) and surface the summary as
+	// degraded with an explicit reason instead of an avoidable describe failure.
+	if memoryID == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  memoryARN,
+			Code:      "agentcore_memory_id_missing",
+			Message:   "AgentCore memory summary did not include an id; surfaced summary only",
+			Retryable: true,
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore memory summary did not include an id"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
+
 	detail, detailErr := a.client.GetMemory(ctx, &bedrockagentcorecontrol.GetMemoryInput{MemoryId: awsv2.String(memoryID)})
 	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
 		return AIAgentIdentity{}, diagnostics, detailErr
@@ -304,6 +323,24 @@ func (a *SDKAgentCoreCapabilitiesAPI) browserRecord(ctx context.Context, summary
 	record := a.baseCapabilityRecord(agentCoreCapabilityKindBrowser, browserID, browserARN, firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.Name)), browserID))
 	record.Status = agentCoreCapabilityStatus(string(summary.Status))
 
+	// GetBrowser keys on the short browser id. Skip the describe call for an
+	// ARN-only summary and surface it as degraded with an explicit reason
+	// instead of an avoidable describe failure on an empty id.
+	if browserID == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  browserARN,
+			Code:      "agentcore_browser_id_missing",
+			Message:   "AgentCore browser summary did not include an id; surfaced summary only",
+			Retryable: true,
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore browser summary did not include an id"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
+
 	detail, detailErr := a.client.GetBrowser(ctx, &bedrockagentcorecontrol.GetBrowserInput{BrowserId: awsv2.String(browserID)})
 	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
 		return AIAgentIdentity{}, diagnostics, detailErr
@@ -396,6 +433,24 @@ func (a *SDKAgentCoreCapabilitiesAPI) codeInterpreterRecord(ctx context.Context,
 
 	record := a.baseCapabilityRecord(agentCoreCapabilityKindCodeInterpreter, interpreterID, interpreterARN, firstNonEmptyAWSValue(strings.TrimSpace(awsv2.ToString(summary.Name)), interpreterID))
 	record.Status = agentCoreCapabilityStatus(string(summary.Status))
+
+	// GetCodeInterpreter keys on the short id. Skip the describe call for an
+	// ARN-only summary and surface it as degraded with an explicit reason
+	// instead of an avoidable describe failure on an empty id.
+	if interpreterID == "" {
+		diagnostics = append(diagnostics, providers.SourceError{
+			Collector: aiAgentIdentityCollectorName,
+			SourceID:  interpreterARN,
+			Code:      "agentcore_code_interpreter_id_missing",
+			Message:   "AgentCore code interpreter summary did not include an id; surfaced summary only",
+			Retryable: true,
+		})
+		record.CoverageStatus = "degraded"
+		record.Status = "degraded"
+		record.CoverageReason = "AgentCore code interpreter summary did not include an id"
+		a.finalizeCapabilityRecord(&record)
+		return record, diagnostics, nil
+	}
 
 	detail, detailErr := a.client.GetCodeInterpreter(ctx, &bedrockagentcorecontrol.GetCodeInterpreterInput{CodeInterpreterId: awsv2.String(interpreterID)})
 	if errors.Is(detailErr, context.Canceled) || errors.Is(detailErr, context.DeadlineExceeded) {
@@ -534,8 +589,10 @@ func parseAgentCoreCapabilityToken(token string) (agentCoreCapabilitySource, str
 	if !ok {
 		return 0, "", fmt.Errorf("invalid agentcore capability pagination token")
 	}
-	var index int
-	if _, err := fmt.Sscanf(indexPart, "%d", &index); err != nil {
+	// strconv.Atoi rejects malformed prefixes like "1abc" that fmt.Sscanf("%d")
+	// would silently accept by stopping at the first non-digit.
+	index, err := strconv.Atoi(indexPart)
+	if err != nil {
 		return 0, "", fmt.Errorf("invalid agentcore capability pagination token")
 	}
 	if index < 0 || agentCoreCapabilitySource(index) >= agentCoreCapabilitySourceCount {

--- a/internal/providers/aws/sdk_agentcore_capabilities.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities.go
@@ -143,7 +143,26 @@ func (a *SDKAgentCoreCapabilitiesAPI) ListAgentIdentities(ctx context.Context, n
 			records, next, diagnostics, err = a.listCodeInterpreters(ctx, sourceToken, pageSize)
 		}
 		if err != nil {
-			return AIAgentIdentityPage{}, err
+			// Cancellation/deadline aborts the whole adapter; any other list
+			// failure (denied/throttled on one capability source) is recorded as
+			// a diagnostic and we advance to the next source so an account that
+			// still has ListBrowsers/ListCodeInterpreters permission does not
+			// lose those records to a single ListMemories denial.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return AIAgentIdentityPage{}, err
+			}
+			diagnostic := providers.SourceError{
+				Collector: aiAgentIdentityCollectorName,
+				SourceID:  agentCoreCapabilitySourceName(source),
+				Code:      "agentcore_capability_list_failed",
+				Message:   fmt.Sprintf("AgentCore %s list failed: %v", agentCoreCapabilitySourceName(source), err),
+				Retryable: isRetryable(err),
+			}
+			page := AIAgentIdentityPage{Diagnostics: []providers.SourceError{diagnostic}}
+			if source+1 < agentCoreCapabilitySourceCount {
+				page.NextToken = formatAgentCoreCapabilityToken(source+1, "")
+			}
+			return page, nil
 		}
 		page := AIAgentIdentityPage{Records: records, Diagnostics: diagnostics}
 		if strings.TrimSpace(next) != "" {
@@ -603,4 +622,17 @@ func parseAgentCoreCapabilityToken(token string) (agentCoreCapabilitySource, str
 
 func formatAgentCoreCapabilityToken(source agentCoreCapabilitySource, sourceToken string) string {
 	return fmt.Sprintf("%d:%s", int(source), strings.TrimSpace(sourceToken))
+}
+
+func agentCoreCapabilitySourceName(source agentCoreCapabilitySource) string {
+	switch source {
+	case agentCoreCapabilitySourceMemory:
+		return "memory"
+	case agentCoreCapabilitySourceBrowser:
+		return "browser"
+	case agentCoreCapabilitySourceCodeInterpreter:
+		return "code_interpreter"
+	default:
+		return "capability"
+	}
 }

--- a/internal/providers/aws/sdk_agentcore_capabilities.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities.go
@@ -148,7 +148,7 @@ func (a *SDKAgentCoreCapabilitiesAPI) ListAgentIdentities(ctx context.Context, n
 			// a diagnostic and we advance to the next source so an account that
 			// still has ListBrowsers/ListCodeInterpreters permission does not
 			// lose those records to a single ListMemories denial.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || isRetryable(err) {
 				return AIAgentIdentityPage{}, err
 			}
 			diagnostic := providers.SourceError{

--- a/internal/providers/aws/sdk_agentcore_capabilities_test.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities_test.go
@@ -231,12 +231,54 @@ func TestSDKAgentCoreCapabilitiesDegradesOnDescribeFailure(t *testing.T) {
 	}
 }
 
-func TestSDKAgentCoreCapabilitiesListFailureSurfaces(t *testing.T) {
-	client := &fakeAgentCoreCapabilitiesSDKClient{memoriesErr: errors.New("AccessDenied: ListMemories")}
+func TestSDKAgentCoreCapabilitiesListFailureAdvancesToNextSource(t *testing.T) {
+	// ListMemories is denied, but the account still has ListBrowsers /
+	// ListCodeInterpreters permission. The adapter must record a diagnostic for
+	// the failed memory source and still surface the browser record instead of
+	// aborting the whole capabilities adapter.
+	client := &fakeAgentCoreCapabilitiesSDKClient{
+		memoriesErr: errors.New("AccessDenied: ListMemories"),
+		browsersOutput: &bedrockagentcorecontrol.ListBrowsersOutput{
+			BrowserSummaries: []agentcoretypes.BrowserSummary{{BrowserId: awsv2.String("br-1"), BrowserArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:browser/br-1"), Name: awsv2.String("research-browser"), Status: agentcoretypes.BrowserStatusReady}},
+		},
+		browserDetail: map[string]*bedrockagentcorecontrol.GetBrowserOutput{
+			"br-1": {
+				BrowserId:        awsv2.String("br-1"),
+				BrowserArn:       awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:browser/br-1"),
+				Name:             awsv2.String("research-browser"),
+				Status:           agentcoretypes.BrowserStatusReady,
+				ExecutionRoleArn: awsv2.String("arn:aws:iam::123456789012:role/agentcore-browser"),
+			},
+		},
+	}
 	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
-	_, err := api.ListAgentIdentities(context.Background(), "", 50)
-	if err == nil {
-		t.Fatalf("expected list error to surface")
+	records, diagnostics := collectAllCapabilityRecords(t, api)
+
+	foundBrowser := false
+	for _, r := range records {
+		if r.CapabilityKind == agentCoreCapabilityKindBrowser {
+			foundBrowser = true
+		}
+	}
+	if !foundBrowser {
+		t.Fatalf("expected browser record to survive a ListMemories denial, got %+v", records)
+	}
+	foundDiag := false
+	for _, d := range diagnostics {
+		if d.Code == "agentcore_capability_list_failed" && d.SourceID == "memory" {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected agentcore_capability_list_failed diagnostic for memory, got %v", diagnostics)
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesListFailureAbortsOnCancellation(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{memoriesErr: context.Canceled}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	if _, err := api.ListAgentIdentities(context.Background(), "", 50); err == nil {
+		t.Fatalf("expected cancellation to abort the adapter")
 	}
 }
 

--- a/internal/providers/aws/sdk_agentcore_capabilities_test.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities_test.go
@@ -1,0 +1,258 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	agentcoretypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+type fakeAgentCoreCapabilitiesSDKClient struct {
+	memoriesOutput       *bedrockagentcorecontrol.ListMemoriesOutput
+	memoriesErr          error
+	memoryDetail         map[string]*bedrockagentcorecontrol.GetMemoryOutput
+	memoryDetailErr      map[string]error
+	browsersOutput       *bedrockagentcorecontrol.ListBrowsersOutput
+	browsersErr          error
+	browserDetail        map[string]*bedrockagentcorecontrol.GetBrowserOutput
+	browserDetailErr     map[string]error
+	interpretersOutput   *bedrockagentcorecontrol.ListCodeInterpretersOutput
+	interpretersErr      error
+	interpreterDetail    map[string]*bedrockagentcorecontrol.GetCodeInterpreterOutput
+	interpreterDetailErr map[string]error
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) ListMemories(_ context.Context, _ *bedrockagentcorecontrol.ListMemoriesInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListMemoriesOutput, error) {
+	if f.memoriesErr != nil {
+		return nil, f.memoriesErr
+	}
+	if f.memoriesOutput == nil {
+		return &bedrockagentcorecontrol.ListMemoriesOutput{}, nil
+	}
+	return f.memoriesOutput, nil
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) GetMemory(_ context.Context, params *bedrockagentcorecontrol.GetMemoryInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetMemoryOutput, error) {
+	id := awsv2.ToString(params.MemoryId)
+	if err := f.memoryDetailErr[id]; err != nil {
+		return nil, err
+	}
+	return f.memoryDetail[id], nil
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) ListBrowsers(_ context.Context, _ *bedrockagentcorecontrol.ListBrowsersInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListBrowsersOutput, error) {
+	if f.browsersErr != nil {
+		return nil, f.browsersErr
+	}
+	if f.browsersOutput == nil {
+		return &bedrockagentcorecontrol.ListBrowsersOutput{}, nil
+	}
+	return f.browsersOutput, nil
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) GetBrowser(_ context.Context, params *bedrockagentcorecontrol.GetBrowserInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetBrowserOutput, error) {
+	id := awsv2.ToString(params.BrowserId)
+	if err := f.browserDetailErr[id]; err != nil {
+		return nil, err
+	}
+	return f.browserDetail[id], nil
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) ListCodeInterpreters(_ context.Context, _ *bedrockagentcorecontrol.ListCodeInterpretersInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.ListCodeInterpretersOutput, error) {
+	if f.interpretersErr != nil {
+		return nil, f.interpretersErr
+	}
+	if f.interpretersOutput == nil {
+		return &bedrockagentcorecontrol.ListCodeInterpretersOutput{}, nil
+	}
+	return f.interpretersOutput, nil
+}
+
+func (f *fakeAgentCoreCapabilitiesSDKClient) GetCodeInterpreter(_ context.Context, params *bedrockagentcorecontrol.GetCodeInterpreterInput, _ ...func(*bedrockagentcorecontrol.Options)) (*bedrockagentcorecontrol.GetCodeInterpreterOutput, error) {
+	id := awsv2.ToString(params.CodeInterpreterId)
+	if err := f.interpreterDetailErr[id]; err != nil {
+		return nil, err
+	}
+	return f.interpreterDetail[id], nil
+}
+
+func collectAllCapabilityRecords(t *testing.T, api AIAgentIdentityAPI) ([]AIAgentIdentity, []providers.SourceError) {
+	t.Helper()
+	records := []AIAgentIdentity{}
+	diagnostics := []providers.SourceError{}
+	token := ""
+	for i := 0; i < 16; i++ {
+		page, err := api.ListAgentIdentities(context.Background(), token, 50)
+		if err != nil {
+			t.Fatalf("ListAgentIdentities: %v", err)
+		}
+		records = append(records, page.Records...)
+		diagnostics = append(diagnostics, page.Diagnostics...)
+		if strings.TrimSpace(page.NextToken) == "" {
+			return records, diagnostics
+		}
+		token = page.NextToken
+	}
+	t.Fatalf("pagination did not terminate")
+	return nil, nil
+}
+
+func TestSDKAgentCoreCapabilitiesMapsAllSurfaces(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{
+		memoriesOutput: &bedrockagentcorecontrol.ListMemoriesOutput{
+			Memories: []agentcoretypes.MemorySummary{{Id: awsv2.String("mem-1"), Arn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-1"), Status: agentcoretypes.MemoryStatusActive}},
+		},
+		memoryDetail: map[string]*bedrockagentcorecontrol.GetMemoryOutput{
+			"mem-1": {Memory: &agentcoretypes.Memory{
+				Id:                     awsv2.String("mem-1"),
+				Arn:                    awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-1"),
+				Name:                   awsv2.String("payments-memory"),
+				Status:                 agentcoretypes.MemoryStatusActive,
+				EventExpiryDuration:    awsv2.Int32(30),
+				EncryptionKeyArn:       awsv2.String("arn:aws:kms:us-east-1:123456789012:key/cmk-mem"),
+				MemoryExecutionRoleArn: awsv2.String("arn:aws:iam::123456789012:role/agentcore-memory"),
+				Strategies:             []agentcoretypes.MemoryStrategy{{Name: awsv2.String("semantic"), Type: agentcoretypes.MemoryStrategyTypeSemantic}},
+			}},
+		},
+		browsersOutput: &bedrockagentcorecontrol.ListBrowsersOutput{
+			BrowserSummaries: []agentcoretypes.BrowserSummary{{BrowserId: awsv2.String("br-1"), BrowserArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:browser/br-1"), Name: awsv2.String("research-browser"), Status: agentcoretypes.BrowserStatusReady}},
+		},
+		browserDetail: map[string]*bedrockagentcorecontrol.GetBrowserOutput{
+			"br-1": {
+				BrowserId:        awsv2.String("br-1"),
+				BrowserArn:       awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:browser/br-1"),
+				Name:             awsv2.String("research-browser"),
+				Status:           agentcoretypes.BrowserStatusReady,
+				ExecutionRoleArn: awsv2.String("arn:aws:iam::123456789012:role/agentcore-browser"),
+				NetworkConfiguration: &agentcoretypes.BrowserNetworkConfiguration{
+					NetworkMode: agentcoretypes.BrowserNetworkModeVpc,
+					VpcConfig:   &agentcoretypes.VpcConfig{Subnets: []string{"subnet-a", "subnet-b"}, SecurityGroups: []string{"sg-1"}},
+				},
+				Recording: &agentcoretypes.RecordingConfig{Enabled: true, S3Location: &agentcoretypes.S3Location{Bucket: awsv2.String("agent-recordings"), Prefix: awsv2.String("browser/")}},
+			},
+		},
+		interpretersOutput: &bedrockagentcorecontrol.ListCodeInterpretersOutput{
+			CodeInterpreterSummaries: []agentcoretypes.CodeInterpreterSummary{{CodeInterpreterId: awsv2.String("ci-1"), CodeInterpreterArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:code-interpreter/ci-1"), Name: awsv2.String("python-sandbox"), Status: agentcoretypes.CodeInterpreterStatusReady}},
+		},
+		interpreterDetail: map[string]*bedrockagentcorecontrol.GetCodeInterpreterOutput{
+			"ci-1": {
+				CodeInterpreterId:  awsv2.String("ci-1"),
+				CodeInterpreterArn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:code-interpreter/ci-1"),
+				Name:               awsv2.String("python-sandbox"),
+				Status:             agentcoretypes.CodeInterpreterStatusReady,
+				ExecutionRoleArn:   awsv2.String("arn:aws:iam::123456789012:role/agentcore-code"),
+				NetworkConfiguration: &agentcoretypes.CodeInterpreterNetworkConfiguration{
+					NetworkMode: agentcoretypes.CodeInterpreterNetworkModeSandbox,
+				},
+			},
+		},
+	}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	records, diagnostics := collectAllCapabilityRecords(t, api)
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", diagnostics)
+	}
+	if len(records) != 3 {
+		t.Fatalf("expected 3 capability records, got %d", len(records))
+	}
+	byKind := map[string]AIAgentIdentity{}
+	for _, r := range records {
+		if r.AgentType != agentCoreCapabilityAgentType {
+			t.Fatalf("expected agentcore_capability type, got %q", r.AgentType)
+		}
+		byKind[r.CapabilityKind] = r
+	}
+
+	memory := byKind[agentCoreCapabilityKindMemory]
+	if memory.RuntimeRoleARN == "" || memory.EncryptionKeyARN == "" {
+		t.Fatalf("memory capability missing role/encryption: %+v", memory)
+	}
+	browser := byKind[agentCoreCapabilityKindBrowser]
+	if browser.NetworkMode != "vpc" {
+		t.Fatalf("browser network mode wrong: %+v", browser)
+	}
+	storage := strings.Join(browser.StorageReferenceRefs, ",")
+	if !strings.Contains(storage, "s3://agent-recordings/browser/") {
+		t.Fatalf("browser recording storage ref missing: %v", browser.StorageReferenceRefs)
+	}
+	code := byKind[agentCoreCapabilityKindCodeInterpreter]
+	if code.RuntimeRoleARN == "" || code.NetworkMode == "" {
+		t.Fatalf("code interpreter missing role/network: %+v", code)
+	}
+
+	// Every record must validate against the shared contract once enriched.
+	for _, r := range records {
+		enriched := normalizeAIAgentIdentityScope(AWSCollectorScope{
+			TenantID: "t", WorkspaceID: "w", ProjectID: "p", ConnectorID: "c", ScanID: "s", AccountID: "123456789012", Region: "us-east-1",
+		}, r, r.CollectedAt)
+		payload, err := json.Marshal(enriched)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		lower := strings.ToLower(string(payload))
+		for _, forbidden := range []string{"memory_record", "browser_page", "code_output", "conversation", "secret_value"} {
+			if strings.Contains(lower, forbidden) {
+				t.Fatalf("metadata-only contract violated by %q: %s", forbidden, payload)
+			}
+		}
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesDegradesOnDescribeFailure(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{
+		memoriesOutput: &bedrockagentcorecontrol.ListMemoriesOutput{
+			Memories: []agentcoretypes.MemorySummary{{Id: awsv2.String("mem-bad"), Arn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-bad"), Status: agentcoretypes.MemoryStatusActive}},
+		},
+		memoryDetailErr: map[string]error{"mem-bad": errors.New("AccessDenied: GetMemory")},
+	}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	records, diagnostics := collectAllCapabilityRecords(t, api)
+	if len(records) != 1 {
+		t.Fatalf("expected one degraded record, got %d", len(records))
+	}
+	if records[0].CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded coverage, got %+v", records[0])
+	}
+	found := false
+	for _, d := range diagnostics {
+		if d.Code == "agentcore_memory_describe_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected describe-failed diagnostic, got %v", diagnostics)
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesListFailureSurfaces(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{memoriesErr: errors.New("AccessDenied: ListMemories")}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	_, err := api.ListAgentIdentities(context.Background(), "", 50)
+	if err == nil {
+		t.Fatalf("expected list error to surface")
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesEmptyAuthorized(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	records, diagnostics := collectAllCapabilityRecords(t, api)
+	if len(records) != 0 || len(diagnostics) != 0 {
+		t.Fatalf("expected empty authorized result, got %d records %d diagnostics", len(records), len(diagnostics))
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesRejectsBadToken(t *testing.T) {
+	client := &fakeAgentCoreCapabilitiesSDKClient{}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	if _, err := api.ListAgentIdentities(context.Background(), "9:tok", 50); err == nil {
+		t.Fatalf("expected invalid token error")
+	}
+}

--- a/internal/providers/aws/sdk_agentcore_capabilities_test.go
+++ b/internal/providers/aws/sdk_agentcore_capabilities_test.go
@@ -252,7 +252,42 @@ func TestSDKAgentCoreCapabilitiesEmptyAuthorized(t *testing.T) {
 func TestSDKAgentCoreCapabilitiesRejectsBadToken(t *testing.T) {
 	client := &fakeAgentCoreCapabilitiesSDKClient{}
 	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
-	if _, err := api.ListAgentIdentities(context.Background(), "9:tok", 50); err == nil {
-		t.Fatalf("expected invalid token error")
+	// Out-of-range source index, non-numeric prefix, and a malformed prefix that
+	// a lenient %d scan would otherwise accept must all be rejected.
+	for _, badToken := range []string{"9:tok", "x:tok", "1abc:tok", "nodelim"} {
+		if _, err := api.ListAgentIdentities(context.Background(), badToken, 50); err == nil {
+			t.Fatalf("expected invalid token error for %q", badToken)
+		}
+	}
+}
+
+func TestSDKAgentCoreCapabilitiesSkipsDescribeForArnOnlySummary(t *testing.T) {
+	// An ARN-only memory summary (no short id) must not trigger GetMemory with an
+	// empty id; instead it surfaces a degraded record with an explicit reason.
+	client := &fakeAgentCoreCapabilitiesSDKClient{
+		memoriesOutput: &bedrockagentcorecontrol.ListMemoriesOutput{
+			Memories: []agentcoretypes.MemorySummary{{Arn: awsv2.String("arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-arn-only"), Status: agentcoretypes.MemoryStatusActive}},
+		},
+		memoryDetailErr: map[string]error{"": errors.New("GetMemory should not be called with an empty id")},
+	}
+	api := NewSDKAgentCoreCapabilitiesAPIFromClient(client, "123456789012", "us-east-1")
+	records, diagnostics := collectAllCapabilityRecords(t, api)
+	if len(records) != 1 {
+		t.Fatalf("expected one degraded record, got %d", len(records))
+	}
+	if records[0].CoverageStatus != "degraded" {
+		t.Fatalf("expected degraded coverage for ARN-only summary, got %+v", records[0])
+	}
+	found := false
+	for _, d := range diagnostics {
+		if d.Code == "agentcore_memory_id_missing" {
+			found = true
+		}
+		if d.Code == "agentcore_memory_describe_failed" {
+			t.Fatalf("ARN-only summary must not emit a describe-failed diagnostic, got %+v", d)
+		}
+	}
+	if !found {
+		t.Fatalf("expected agentcore_memory_id_missing diagnostic, got %v", diagnostics)
 	}
 }

--- a/internal/providers/aws/sdk_agentcore_gateway.go
+++ b/internal/providers/aws/sdk_agentcore_gateway.go
@@ -48,7 +48,7 @@ func NewSDKAgentCoreAIAgentIdentityAPIWithContext(ctx context.Context, region st
 	}
 	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
 	client := bedrockagentcorecontrol.NewFromConfig(cfg)
-	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, resolvedAccountID, resolvedRegion), nil
+	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, client, resolvedAccountID, resolvedRegion), nil
 }
 
 func NewSDKAgentCoreAIAgentIdentityAPIFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string, accountID string) (AIAgentIdentityAPI, error) {
@@ -77,13 +77,14 @@ func NewSDKAgentCoreAIAgentIdentityAPIFromAssumeRole(ctx context.Context, region
 	}
 	resolvedRegion := firstNonEmptyAWSValue(strings.TrimSpace(region), strings.TrimSpace(cfg.Region))
 	client := bedrockagentcorecontrol.NewFromConfig(cfg)
-	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, resolvedAccountID, resolvedRegion), nil
+	return NewSDKAgentCoreAIAgentIdentityAPIFromClient(client, client, client, resolvedAccountID, resolvedRegion), nil
 }
 
-func NewSDKAgentCoreAIAgentIdentityAPIFromClient(runtimeClient AgentCoreRuntimeSDKClient, gatewayClient AgentCoreGatewaySDKClient, accountID string, region string) AIAgentIdentityAPI {
+func NewSDKAgentCoreAIAgentIdentityAPIFromClient(runtimeClient AgentCoreRuntimeSDKClient, gatewayClient AgentCoreGatewaySDKClient, capabilitiesClient AgentCoreCapabilitiesSDKClient, accountID string, region string) AIAgentIdentityAPI {
 	return NewCompositeAIAgentIdentityAPI(
 		NewSDKAgentCoreRuntimeAPIFromClient(runtimeClient, accountID, region),
 		NewSDKAgentCoreGatewayAPIFromClient(gatewayClient, accountID, region),
+		NewSDKAgentCoreCapabilitiesAPIFromClient(capabilitiesClient, accountID, region),
 	)
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1982,6 +1982,9 @@ export type AWSAIAgentIdentityRecord = {
   memory_store_refs?: string[];
   browser_enabled: boolean;
   code_interpreter_enabled: boolean;
+  capability_kind?: 'memory' | 'browser' | 'code_interpreter';
+  storage_reference_refs?: string[];
+  encryption_key_arn?: string;
   capability_names?: string[];
   credential_reference_refs?: string[];
   resource_reference_refs?: string[];
@@ -2043,6 +2046,10 @@ export type AWSAIAgentIdentityInventoryResult = {
   custom_agent_count: number;
   external_agent_count: number;
   gateway_count: number;
+  capability_agent_count: number;
+  memory_store_count: number;
+  browser_count: number;
+  code_interpreter_count: number;
   runtime_role_count: number;
   provider_count: number;
   model_count: number;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3820,6 +3820,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'All surfaces', value: 'all' },
         { label: 'Bedrock agents', value: 'bedrock-agents' },
         { label: 'AgentCore runtime', value: 'agentcore-runtime' },
+        { label: 'AgentCore capabilities', value: 'agentcore-capabilities' },
         { label: 'MCP gateway', value: 'mcp-gateway' },
         { label: 'External provider keys', value: 'external-provider-keys' }
       ]
@@ -3831,7 +3832,8 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'All relationships', value: 'all' },
         { label: 'Agent to role', value: 'agent-to-role' },
         { label: 'Agent to tool', value: 'agent-to-tool' },
-        { label: 'Agent to secret', value: 'agent-to-secret' }
+        { label: 'Agent to secret', value: 'agent-to-secret' },
+        { label: 'Agent to storage', value: 'agent-to-storage' }
       ]
     },
     {
@@ -7175,6 +7177,10 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
       ...(record.observability_links ?? []),
       ...(record.capability_names ?? []),
       ...(record.credential_reference_refs ?? []),
+      ...(record.storage_reference_refs ?? []),
+      ...(record.memory_store_refs ?? []),
+      record.capability_kind,
+      record.encryption_key_arn,
       record.network_mode,
       record.server_protocol,
       record.account_id,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6703,6 +6703,12 @@ function AWSAgentIdentitiesContent({
               detail={`${inventory.capability_count} capabilities`}
             />
             <DomainCoverageCard
+              label="AgentCore capabilities"
+              scanned={inventory.capability_agent_count}
+              total={Math.max(inventory.record_count, 1)}
+              detail={`${inventory.memory_store_count} memory · ${inventory.browser_count} browser · ${inventory.code_interpreter_count} code`}
+            />
+            <DomainCoverageCard
               label="Credential refs"
               scanned={inventory.credential_reference_count}
               total={Math.max(inventory.credential_reference_count, 1)}
@@ -7116,14 +7122,31 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   if (record.execution_endpoint_arns?.length) {
     relationships.add('agent-to-endpoint');
   }
+  if (record.storage_reference_refs?.length || record.memory_store_refs?.length || record.encryption_key_arn) {
+    relationships.add('agent-to-storage');
+  }
+  // AgentCore Memory / Browser / Code Interpreter capability surface detail.
+  const capabilityDetail =
+    record.capability_kind === 'memory'
+      ? `memory store; ${record.encryption_key_arn ? 'customer-encrypted; ' : ''}${(record.storage_reference_refs?.length || record.memory_store_refs?.length || 0)} storage refs`
+      : record.capability_kind === 'browser'
+        ? `browser tool; ${record.network_mode || 'network mode not reported'}; ${(record.storage_reference_refs?.length || 0)} recording refs`
+        : record.capability_kind === 'code_interpreter'
+          ? `code interpreter; ${record.network_mode || 'network mode not reported'}`
+          : '';
+  const category = record.capability_kind
+    ? `AgentCore ${formatTokenLabel(record.capability_kind)}`
+    : formatTokenLabel(record.agent_type);
   return {
     id: `ai-agent-identity-${record.agent_node_id || record.agent_id}`,
     name: record.agent_name || record.agent_id,
-    category: formatTokenLabel(record.agent_type),
+    category,
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
     stage,
-    detail: `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${authLabel}; ${actionLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
+    detail: record.capability_kind
+      ? `${capabilityDetail}; runs as ${roleLabel}; ${capabilityLabel}. Contents never collected.`
+      : `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${authLabel}; ${actionLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
@@ -7169,6 +7192,8 @@ function awsAIAgentSurfaceFilter(record: AWSAIAgentIdentityRecord): string {
       return 'agentcore-runtime';
     case 'agent_gateway':
       return 'mcp-gateway';
+    case 'agentcore_capability':
+      return 'agentcore-capabilities';
     case 'external_provider_agent':
     case 'custom_agent':
       return record.credential_reference_refs?.length ? 'external-provider-keys' : 'bedrock-agents';


### PR DESCRIPTION
## Summary

Implements Wave 4.05 (#1509): extends the AWS AI agent identity model with a **read-only, metadata-only** AgentCore capabilities adapter that lists and describes AgentCore **Memory**, **Browser**, and **Code Interpreter** resources and maps each as a data/tool surface attached to an agent identity.

Closes #1509. Blocker #1507 (AgentCore Runtime identity collector) is closed and merged.

## Why

The AI agent identity model (#1505, #1508) needs AgentCore Memory/Browser/Code Interpreter coverage so Identrail can govern AWS-hosted agents' persistent data and tool surfaces — their execution roles, storage references, encryption, and network posture — as machine identities, without ever reading the capability contents.

## What's in the change

- **`internal/providers/aws/sdk_agentcore_capabilities.go`** (+ test): new `AgentCoreCapabilitiesSDKClient` adapter implementing `AIAgentIdentityAPI`. It walks `ListMemories` / `ListBrowsers` / `ListCodeInterpreters` with a composite `<source>:<token>` pagination cursor, describes each resource, and emits `agentcore_capability` records carrying `capability_kind`, execution-role binding, storage references (browser recording `s3://` destination, memory stream-delivery resource counts), customer encryption key ARN, and network posture (VPC/sandbox — subnet/security-group **counts only**). Per-resource describe failures degrade only that record (`coverage_status=degraded`) and emit a scoped `agentcore_{memory,browser,code_interpreter}_describe_failed` diagnostic while surviving records stay visible. Composed into `NewSDKAgentCoreAIAgentIdentityAPIFromClient` alongside the runtime and gateway adapters, so the CLI and recurring-scan wiring pick it up with no further change.
- **Model**: `AIAgentIdentity` gains `capability_kind`, `storage_reference_refs`, and `encryption_key_arn`; normalize derives capability flags/tokens and feeds storage refs + encryption key into the resource-reference graph; confidence credits the new fields.
- **Normalizer / graph**: emits an `agentcore_capability` resource node per surface, linked to its agent node and execution-role identity, carrying the kind, storage refs, encryption key, network mode, and execution role.
- **API**: `aws/ai-agent-identities` exposes `capability_agent_count`, `memory_store_count`, `browser_count`, `code_interpreter_count`; adds three capability fixtures; keeps capability records visible under the gateway `partial_failure` fixture (only the gateway record drops); adds capability diagnostic remediations; bumps the inventory current-issue ref to `#1509`.
- **Web**: client types + an AgentCore capabilities coverage card + per-capability rows with `agentcore-capabilities` surface filter and `agent-to-storage` relationship token.
- **OpenAPI**, **docs/aws-ai-agent-identities.md**, **CHANGELOG**.

## Safety / scope boundaries

- Memory records, browser pages, code-interpreter output, conversations, and secret values are **never** read — only control-plane metadata (ids, ARNs, roles, storage destination references, encryption key ARN, network mode, status).
- Required read-only permissions are documented (`bedrock-agentcore:ListMemories`/`GetMemory`/`ListBrowsers`/`GetBrowser`/`ListCodeInterpreters`/`GetCodeInterpreter`); consistent with the runtime/gateway PRs they are not auto-granted by the connector policy.
- `go.mod`: `bedrockagentcorecontrol` promoted to a direct dependency (now used directly) via `go mod tidy`; no new third-party modules.

## Validation

```bash
go test ./internal/providers/aws/ ./internal/api/ -run 'AgentCore|AIAgent|Capabilit'
make ci
npm run test:ci --prefix web
```

All green locally (`make ci` = fmt-check, vet, full Go tests + integration, API example contract check, web route integrity, web test, web build).

## Checklist

- [x] Tests added: capabilities SDK adapter (all-surfaces mapping, describe-failure degrade, list-failure, empty, bad-token), normalizer capability-resource emission, and API capability mapping + counts + metadata-only leak guard
- [x] Docs + OpenAPI updated
- [x] `CHANGELOG.md` updated
- [x] No secrets, credentials, or capability contents collected

## AI Assistance Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AgentCore capabilities adapter that maps Memory, Browser, and Code Interpreter metadata into the AI agent identity model and UI. Exposes execution role, storage refs, encryption key, and network posture without collecting any capability contents. Addresses #1509.

- **New Features**
  - Added `internal/providers/aws/sdk_agentcore_capabilities.go` implementing `AIAgentIdentityAPI`; emits `agentcore_capability` records with `capability_kind`, `storage_reference_refs`, `encryption_key_arn`, and network posture; composed with runtime and gateway in `NewSDKAgentCoreAIAgentIdentityAPIFromClient`.
  - Model/API/OpenAPI: added `capability_kind`, `storage_reference_refs`, `encryption_key_arn`; inventory counts for `capability_agent_count`, `memory_store_count`, `browser_count`, `code_interpreter_count`; normalizer emits an `agentcore_capability` resource node linked to the agent and execution role; OpenAPI `agent_type` enum includes `agentcore_capability`; added remediation for `agentcore_capability_list_failed`; partial-failure fixture retains capability records when gateway list fails; current issue ref is `#1509`.
  - Pagination and error handling: composite "<source>:<token>" cursor across Memories/Browsers/Code Interpreters; strict token parsing rejects malformed prefixes; per-resource describe failures degrade only that record; skip `Get*` for ARN-only summaries and emit `*_id_missing`; if one source list fails, emit `agentcore_capability_list_failed` and continue to the next source (cancellation/deadline still aborts).
  - Web: new capabilities coverage card and per-capability rows; added `agentcore-capabilities` surface and `agent-to-storage` relationship filters; search indexes `storage_reference_refs`, `memory_store_refs`, `capability_kind`, and `encryption_key_arn`; row detail clarifies contents are never collected.
  - Metadata-only: uses `bedrock-agentcore:{List,Get}{Memories,Browsers,CodeInterpreters}`; never reads memory records, browser pages, or code output.

- **Dependencies**
  - Promoted `github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol` to a direct dependency.

<sup>Written for commit f256b6b645b728393b056b4fcf5889e26a36a2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

