### PR TITLE
Speed up deploy portability builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+
       - name: Validate Docker Compose Config
         shell: bash
         run: |
@@ -224,16 +227,43 @@ jobs:
           docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config > /tmp/identrail-compose.yml
 
       - name: Build API Image
-        run: docker build -f deploy/docker/Dockerfile.backend --build-arg TARGET=server -t identrail/api:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.backend
+          build-args: |
+            TARGET=server
+          tags: identrail/api:ci
+          load: true
+          cache-from: type=gha,scope=deploy-portability-backend
+          cache-to: type=gha,mode=max,scope=deploy-portability-backend,ignore-error=true
 
       - name: Build Worker Image
-        run: docker build -f deploy/docker/Dockerfile.backend --build-arg TARGET=worker -t identrail/worker:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.backend
+          build-args: |
+            TARGET=worker
+          tags: identrail/worker:ci
+          load: true
+          cache-from: type=gha,scope=deploy-portability-backend
+          cache-to: type=gha,mode=max,scope=deploy-portability-backend,ignore-error=true
 
       - name: Verify Worker Repo Scan Runtime
         run: docker run --rm --entrypoint /usr/bin/git identrail/worker:ci --version
 
       - name: Build Web Image
-        run: docker build -f deploy/docker/Dockerfile.web --build-arg VITE_IDENTRAIL_API_URL=http://localhost:8080 -t identrail/web:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.web
+          build-args: |
+            VITE_IDENTRAIL_API_URL=http://localhost:8080
+          tags: identrail/web:ci
+          load: true
+          cache-from: type=gha,scope=deploy-portability-web
+          cache-to: type=gha,mode=max,scope=deploy-portability-web,ignore-error=true
 
       - name: Compose API Smoke (Postgres + API)
         shell: bash
@@ -269,7 +299,7 @@ jobs:
           docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d postgres api
 
           healthy=false
-          for i in $(seq 1 30); do
+          for _attempt in $(seq 1 30); do
             if curl -fsS http://localhost:8080/healthz >/dev/null; then
               healthy=true
               break


### PR DESCRIPTION
## Summary

- Replaces the Deploy Portability raw `docker build` calls with Docker Buildx builds.
- Adds GitHub Actions Docker layer caching for backend and web images.
- Keeps the existing Compose smoke test and local image tags unchanged.
- Cleans up the health-check loop variable so local `actionlint` + `shellcheck` passes.

## Why

Deploy Portability spends most of its time rebuilding Docker layers for the API, worker, and web images. Caching those layers should make repeated PR runs faster without weakening the deployment smoke coverage.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is low: this only changes the CI build mechanism. The job still builds the same Dockerfiles, loads the same image tags, boots Postgres + API, and runs the same health and API smoke checks.

## Validation

```bash
actionlint .github/workflows/ci.yml
pre-commit run --files .github/workflows/ci.yml
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'
git diff --check
pre-commit hooks during commit and push: check yaml, gofmt check, go vet, token hygiene, vercel artifact hygiene
```

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

Notes: no product behavior changes, docs, or changelog entry are needed for this CI-only workflow update.

## AI Assistance Disclosure

- AI-assisted: No

## Related Issues

No issue: CI-only follow-up to reduce Deploy Portability runtime while preserving the existing smoke coverage.
