### PR TITLE
Map external AI provider key metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Add **external AI provider key metadata mapping for AWS agents** (#1510).
+  Extends the AWS AI agent identity inventory with classified
+  `provider_key_references` derived from safe names, ARNs, source markers, and
+  workload credential references for OpenAI, Anthropic/Claude, Bedrock, and
+  generic provider keys. The API now reports `external_provider_key_count`,
+  `ai_provider_key_count`, and `provider_key_breakdown`, keeps `uses_secret`
+  edges pointed at credential-reference nodes, and the AWS Agents app surface
+  shows external provider key counts and per-agent provider labels. The mapper
+  remains metadata-only: it never reads, logs, persists, or exposes secret
+  values, prompts, completions, browser pages, code output, database rows,
+  object contents, or customer payloads. See
+  [docs/aws-ai-agent-identities.md](docs/aws-ai-agent-identities.md).
 - Add **AgentCore Memory, Browser, and Code Interpreter metadata mapping** (#1509).
   Extends the AWS AI agent identity model with a read-only, metadata-only
   AgentCore capabilities adapter (`internal/providers/aws/sdk_agentcore_capabilities.go`)

--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -1,6 +1,6 @@
 # AWS AI Agent Identities
 
-Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping. Issue #1509 extends it again with AgentCore Memory, Browser, and Code Interpreter capability metadata mapping.
+Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping. Issue #1509 extends it again with AgentCore Memory, Browser, and Code Interpreter capability metadata mapping. Issue #1510 maps external AI provider key metadata onto agent identities without reading credential values.
 
 ## What Is Collected
 
@@ -19,6 +19,7 @@ The model is metadata-only. Each `agent_identity` record can describe:
 - memory/browser/code-interpreter capability flags
 - per-capability execution role bindings, storage references (`storage_reference_refs` such as a browser recording `s3://bucket/prefix` destination or a memory stream-delivery resource count), customer encryption key ARN (`encryption_key_arn`), and network posture (`vpc`, `sandbox`, etc.)
 - credential-reference identifiers
+- classified external provider key references (`provider_key_references`) for OpenAI, Anthropic/Claude, Bedrock, and generic credential metadata
 - agent-to-endpoint `invokes` relationships for AgentCore runtime execution surfaces
 - agent-to-tool `calls_tool` relationships for AgentCore Gateway and MCP tool surfaces
 - an `agentcore_capability` resource node per Memory/Browser/Code Interpreter surface, linked to its agent identity, carrying the kind, storage references, encryption key, network mode, and execution role — but never the capability's contents
@@ -43,6 +44,17 @@ Optional query parameters:
 - `connector_id`
 - `fixture_state=success|empty|degraded|partial_failure|permission_denied`
 
+### External AI provider key metadata mapping (issue #1510)
+
+Agent records expose `provider_key_references` derived from safe names, ARNs, source markers, and workload references such as `OPENAI_API_KEY=secretsmanager:...` or `ANTHROPIC_API_KEY=ssm:...`. Each reference includes:
+
+- provider classification (`openai`, `anthropic`, `bedrock`, `secretsmanager`, `ssm`, or `generic`)
+- reference kind (`secrets_manager`, `ssm_parameter`, `environment_variable`, or `credential_reference`)
+- sensitivity (`ai_provider_api_key`, `aws_managed_secret`, or `generic_secret`)
+- evidence reference, target credential-reference node id, and confidence
+
+Inventory aggregates include `external_provider_key_count`, `ai_provider_key_count`, and `provider_key_breakdown`, alongside the existing `credential_reference_count` and `uses_secret` relationships. These fields let operators filter and drill into provider-key ownership from the AWS Agents surface while keeping values hidden.
+
 ## What Is Not Collected
 
 Identrail does not collect prompt text, completions, memory contents, browser pages, code-interpreter output, database rows, object contents, secret values, or customer payloads for this capability.
@@ -63,7 +75,7 @@ Use metadata-only list and describe permissions for the relevant agent, runtime,
 
 ## UI Surface
 
-The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, Gateway/MCP tools, auth mode, allowed-action counts, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
+The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, Gateway/MCP tools, auth mode, allowed-action counts, external provider key counts, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
 
 ## Troubleshooting
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10158,6 +10158,10 @@ components:
           items:
             type: string
             enum: [runs_as, calls_tool, uses_secret, invokes]
+        provider_key_references:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentProviderKeyReference"
         confidence:
           type: number
           minimum: 0
@@ -10171,6 +10175,27 @@ components:
         tags:
           type: object
           additionalProperties: { type: string }
+    AWSAIAgentProviderKeyReference:
+      type: object
+      properties:
+        reference: { type: string }
+        reference_name: { type: string }
+        reference_kind:
+          type: string
+          enum: [secrets_manager, ssm_parameter, environment_variable, credential_reference]
+        provider:
+          type: string
+          enum: [openai, anthropic, bedrock, secretsmanager, ssm, generic]
+        sensitivity:
+          type: string
+          enum: [ai_provider_api_key, aws_managed_secret, generic_secret]
+        resolved: { type: boolean }
+        target_node_id: { type: string }
+        evidence_ref: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
     AWSAIAgentIdentityRelationship:
       type: object
       properties:
@@ -10242,6 +10267,11 @@ components:
         tool_count: { type: integer }
         capability_count: { type: integer }
         credential_reference_count: { type: integer }
+        external_provider_key_count: { type: integer }
+        ai_provider_key_count: { type: integer }
+        provider_key_breakdown:
+          type: object
+          additionalProperties: { type: integer }
         relationship_count: { type: integer }
         failure_reasons:
           type: array

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -691,6 +691,7 @@ func awsCredentialReferenceNodeID(agentNodeID string, ref string) string {
 
 func awsAIAgentCredentialReferenceProvider(name, source string) string {
 	probe := strings.ToLower(strings.TrimSpace(name + " " + source))
+	sourceProbe := strings.ToLower(strings.TrimSpace(source))
 	switch {
 	case containsAnyToken(probe, "openai", "open_ai", "gpt_"):
 		return "openai"
@@ -698,9 +699,9 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "anthropic"
 	case containsAnyToken(probe, "bedrock"):
 		return "bedrock"
-	case strings.HasPrefix(probe, "secretsmanager:"):
+	case strings.HasPrefix(sourceProbe, "secretsmanager:") || strings.HasPrefix(sourceProbe, "secretsmanager-") || strings.HasPrefix(sourceProbe, "secrets_manager-"):
 		return "secretsmanager"
-	case strings.HasPrefix(probe, "ssm:"):
+	case strings.HasPrefix(sourceProbe, "ssm:") || strings.HasPrefix(sourceProbe, "ssm-"):
 		return "ssm"
 	default:
 		return "generic"

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -12,11 +12,14 @@ import (
 )
 
 const (
-	awsAIAgentIdentityCurrentIssue  = 1509
-	awsAIAgentIdentityVersion       = "aws-ai-agent-identity-normalized-model-v1"
-	awsAIAgentCredentialRefPrefix   = "aws:resource:credential-reference:"
-	awsAIAgentToolNodePrefix        = "tool:agent:"
-	agentCoreCapabilityAgentTypeAPI = "agentcore_capability"
+	awsAIAgentIdentityCurrentIssue        = 1510
+	awsAIAgentIdentityVersion             = "aws-ai-agent-external-provider-keys-v1"
+	awsAIAgentCredentialRefPrefix         = "aws:resource:credential-reference:"
+	awsAIAgentToolNodePrefix              = "tool:agent:"
+	agentCoreCapabilityAgentTypeAPI       = "agentcore_capability"
+	awsAIAgentProviderSensitivityAIKey    = "ai_provider_api_key"
+	awsAIAgentProviderSensitivityAWSStore = "aws_managed_secret"
+	awsAIAgentProviderSensitivityGeneric  = "generic_secret"
 )
 
 type AWSAIAgentIdentityInventoryRequest struct {
@@ -32,99 +35,115 @@ type AWSAIAgentCoverageGap struct {
 }
 
 type AWSAIAgentIdentityInventoryResult struct {
-	TenantID              string                         `json:"tenant_id"`
-	WorkspaceID           string                         `json:"workspace_id"`
-	ProjectID             string                         `json:"project_id"`
-	ConnectorID           string                         `json:"connector_id,omitempty"`
-	AccountID             string                         `json:"account_id,omitempty"`
-	Region                string                         `json:"region,omitempty"`
-	ParentIssueNumber     int                            `json:"parent_issue_number"`
-	ParentIssueRef        string                         `json:"parent_issue_ref"`
-	CurrentIssueNumber    int                            `json:"current_issue_number"`
-	CurrentIssueRef       string                         `json:"current_issue_ref"`
-	Version               string                         `json:"version"`
-	Status                string                         `json:"status"`
-	FixtureState          string                         `json:"fixture_state"`
-	Confidence            float64                        `json:"confidence"`
-	RecordCount           int                            `json:"record_count"`
-	BedrockAgentCount     int                            `json:"bedrock_agent_count"`
-	AgentCoreRuntimeCount int                            `json:"agentcore_runtime_count"`
-	CustomAgentCount      int                            `json:"custom_agent_count"`
-	ExternalAgentCount    int                            `json:"external_agent_count"`
-	GatewayCount          int                            `json:"gateway_count"`
-	CapabilityAgentCount  int                            `json:"capability_agent_count"`
-	MemoryStoreCount      int                            `json:"memory_store_count"`
-	BrowserCount          int                            `json:"browser_count"`
-	CodeInterpreterCount  int                            `json:"code_interpreter_count"`
-	RuntimeRoleCount      int                            `json:"runtime_role_count"`
-	ProviderCount         int                            `json:"provider_count"`
-	ModelCount            int                            `json:"model_count"`
-	ToolCount             int                            `json:"tool_count"`
-	CapabilityCount       int                            `json:"capability_count"`
-	CredentialRefCount    int                            `json:"credential_reference_count"`
-	RelationshipCount     int                            `json:"relationship_count"`
-	FailureReasons        []string                       `json:"failure_reasons"`
-	RemediationHints      []string                       `json:"remediation_hints"`
-	EvidenceLinks         []string                       `json:"evidence_links"`
-	CoverageGaps          []AWSAIAgentCoverageGap        `json:"coverage_gaps"`
-	Records               []AWSAIAgentIdentityRecord     `json:"records"`
-	Relationships         []AWSAIAgentIdentityRelation   `json:"relationships"`
-	Diagnostics           []AWSAIAgentIdentityDiagnostic `json:"diagnostics"`
-	GeneratedAt           time.Time                      `json:"generated_at"`
-	UpdatedAt             time.Time                      `json:"updated_at"`
+	TenantID                 string                         `json:"tenant_id"`
+	WorkspaceID              string                         `json:"workspace_id"`
+	ProjectID                string                         `json:"project_id"`
+	ConnectorID              string                         `json:"connector_id,omitempty"`
+	AccountID                string                         `json:"account_id,omitempty"`
+	Region                   string                         `json:"region,omitempty"`
+	ParentIssueNumber        int                            `json:"parent_issue_number"`
+	ParentIssueRef           string                         `json:"parent_issue_ref"`
+	CurrentIssueNumber       int                            `json:"current_issue_number"`
+	CurrentIssueRef          string                         `json:"current_issue_ref"`
+	Version                  string                         `json:"version"`
+	Status                   string                         `json:"status"`
+	FixtureState             string                         `json:"fixture_state"`
+	Confidence               float64                        `json:"confidence"`
+	RecordCount              int                            `json:"record_count"`
+	BedrockAgentCount        int                            `json:"bedrock_agent_count"`
+	AgentCoreRuntimeCount    int                            `json:"agentcore_runtime_count"`
+	CustomAgentCount         int                            `json:"custom_agent_count"`
+	ExternalAgentCount       int                            `json:"external_agent_count"`
+	GatewayCount             int                            `json:"gateway_count"`
+	CapabilityAgentCount     int                            `json:"capability_agent_count"`
+	MemoryStoreCount         int                            `json:"memory_store_count"`
+	BrowserCount             int                            `json:"browser_count"`
+	CodeInterpreterCount     int                            `json:"code_interpreter_count"`
+	RuntimeRoleCount         int                            `json:"runtime_role_count"`
+	ProviderCount            int                            `json:"provider_count"`
+	ModelCount               int                            `json:"model_count"`
+	ToolCount                int                            `json:"tool_count"`
+	CapabilityCount          int                            `json:"capability_count"`
+	CredentialRefCount       int                            `json:"credential_reference_count"`
+	ExternalProviderKeyCount int                            `json:"external_provider_key_count"`
+	AIProviderKeyCount       int                            `json:"ai_provider_key_count"`
+	ProviderKeyBreakdown     map[string]int                 `json:"provider_key_breakdown"`
+	RelationshipCount        int                            `json:"relationship_count"`
+	FailureReasons           []string                       `json:"failure_reasons"`
+	RemediationHints         []string                       `json:"remediation_hints"`
+	EvidenceLinks            []string                       `json:"evidence_links"`
+	CoverageGaps             []AWSAIAgentCoverageGap        `json:"coverage_gaps"`
+	Records                  []AWSAIAgentIdentityRecord     `json:"records"`
+	Relationships            []AWSAIAgentIdentityRelation   `json:"relationships"`
+	Diagnostics              []AWSAIAgentIdentityDiagnostic `json:"diagnostics"`
+	GeneratedAt              time.Time                      `json:"generated_at"`
+	UpdatedAt                time.Time                      `json:"updated_at"`
 }
 
 type AWSAIAgentIdentityRecord struct {
-	AccountID                 string            `json:"account_id"`
-	Region                    string            `json:"region"`
-	Service                   string            `json:"service"`
-	AgentID                   string            `json:"agent_id"`
-	AgentARN                  string            `json:"agent_arn,omitempty"`
-	AgentName                 string            `json:"agent_name"`
-	AgentType                 string            `json:"agent_type"`
-	RuntimeVersion            string            `json:"runtime_version,omitempty"`
-	Provider                  string            `json:"provider,omitempty"`
-	ModelID                   string            `json:"model_id,omitempty"`
-	RuntimeRoleARN            string            `json:"runtime_role_arn,omitempty"`
-	RuntimeRoleName           string            `json:"runtime_role_name,omitempty"`
-	RuntimeRoleAccountID      string            `json:"runtime_role_account_id,omitempty"`
-	WorkloadIdentityARN       string            `json:"workload_identity_arn,omitempty"`
-	GatewayID                 string            `json:"gateway_id,omitempty"`
-	GatewayARN                string            `json:"gateway_arn,omitempty"`
-	ExternalProvider          string            `json:"external_provider,omitempty"`
-	ToolNames                 []string          `json:"tool_names,omitempty"`
-	ToolTargetRefs            []string          `json:"tool_target_refs,omitempty"`
-	AllowedActions            []string          `json:"allowed_actions,omitempty"`
-	AuthMode                  string            `json:"auth_mode,omitempty"`
-	MemoryEnabled             bool              `json:"memory_enabled"`
-	MemoryStoreRefs           []string          `json:"memory_store_refs,omitempty"`
-	BrowserEnabled            bool              `json:"browser_enabled"`
-	CodeInterpreterEnabled    bool              `json:"code_interpreter_enabled"`
-	CapabilityKind            string            `json:"capability_kind,omitempty"`
-	StorageReferenceRefs      []string          `json:"storage_reference_refs,omitempty"`
-	EncryptionKeyARN          string            `json:"encryption_key_arn,omitempty"`
-	CapabilityNames           []string          `json:"capability_names,omitempty"`
-	CredentialReferenceRefs   []string          `json:"credential_reference_refs,omitempty"`
-	ResourceReferenceRefs     []string          `json:"resource_reference_refs,omitempty"`
-	ExecutionEndpointARNs     []string          `json:"execution_endpoint_arns,omitempty"`
-	ExecutionEndpointNames    []string          `json:"execution_endpoint_names,omitempty"`
-	ExecutionEndpointStatuses []string          `json:"execution_endpoint_statuses,omitempty"`
-	ObservabilityLinks        []string          `json:"observability_links,omitempty"`
-	NetworkMode               string            `json:"network_mode,omitempty"`
-	ServerProtocol            string            `json:"server_protocol,omitempty"`
-	SensitiveBoundary         string            `json:"sensitive_boundary"`
-	CoverageStatus            string            `json:"coverage_status"`
-	CoverageReason            string            `json:"coverage_reason,omitempty"`
-	Source                    string            `json:"source"`
-	EvidenceRef               string            `json:"evidence_ref"`
-	AgentNodeID               string            `json:"agent_node_id"`
-	RuntimeRoleNodeID         string            `json:"runtime_role_node_id,omitempty"`
-	GatewayNodeID             string            `json:"gateway_node_id,omitempty"`
-	RelationshipTypes         []string          `json:"relationship_types"`
-	Confidence                float64           `json:"confidence"`
-	CollectedAt               time.Time         `json:"collected_at"`
-	Status                    string            `json:"status"`
-	Tags                      map[string]string `json:"tags,omitempty"`
+	AccountID                 string                           `json:"account_id"`
+	Region                    string                           `json:"region"`
+	Service                   string                           `json:"service"`
+	AgentID                   string                           `json:"agent_id"`
+	AgentARN                  string                           `json:"agent_arn,omitempty"`
+	AgentName                 string                           `json:"agent_name"`
+	AgentType                 string                           `json:"agent_type"`
+	RuntimeVersion            string                           `json:"runtime_version,omitempty"`
+	Provider                  string                           `json:"provider,omitempty"`
+	ModelID                   string                           `json:"model_id,omitempty"`
+	RuntimeRoleARN            string                           `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName           string                           `json:"runtime_role_name,omitempty"`
+	RuntimeRoleAccountID      string                           `json:"runtime_role_account_id,omitempty"`
+	WorkloadIdentityARN       string                           `json:"workload_identity_arn,omitempty"`
+	GatewayID                 string                           `json:"gateway_id,omitempty"`
+	GatewayARN                string                           `json:"gateway_arn,omitempty"`
+	ExternalProvider          string                           `json:"external_provider,omitempty"`
+	ToolNames                 []string                         `json:"tool_names,omitempty"`
+	ToolTargetRefs            []string                         `json:"tool_target_refs,omitempty"`
+	AllowedActions            []string                         `json:"allowed_actions,omitempty"`
+	AuthMode                  string                           `json:"auth_mode,omitempty"`
+	MemoryEnabled             bool                             `json:"memory_enabled"`
+	MemoryStoreRefs           []string                         `json:"memory_store_refs,omitempty"`
+	BrowserEnabled            bool                             `json:"browser_enabled"`
+	CodeInterpreterEnabled    bool                             `json:"code_interpreter_enabled"`
+	CapabilityKind            string                           `json:"capability_kind,omitempty"`
+	StorageReferenceRefs      []string                         `json:"storage_reference_refs,omitempty"`
+	EncryptionKeyARN          string                           `json:"encryption_key_arn,omitempty"`
+	CapabilityNames           []string                         `json:"capability_names,omitempty"`
+	CredentialReferenceRefs   []string                         `json:"credential_reference_refs,omitempty"`
+	ResourceReferenceRefs     []string                         `json:"resource_reference_refs,omitempty"`
+	ExecutionEndpointARNs     []string                         `json:"execution_endpoint_arns,omitempty"`
+	ExecutionEndpointNames    []string                         `json:"execution_endpoint_names,omitempty"`
+	ExecutionEndpointStatuses []string                         `json:"execution_endpoint_statuses,omitempty"`
+	ObservabilityLinks        []string                         `json:"observability_links,omitempty"`
+	NetworkMode               string                           `json:"network_mode,omitempty"`
+	ServerProtocol            string                           `json:"server_protocol,omitempty"`
+	SensitiveBoundary         string                           `json:"sensitive_boundary"`
+	CoverageStatus            string                           `json:"coverage_status"`
+	CoverageReason            string                           `json:"coverage_reason,omitempty"`
+	Source                    string                           `json:"source"`
+	EvidenceRef               string                           `json:"evidence_ref"`
+	AgentNodeID               string                           `json:"agent_node_id"`
+	RuntimeRoleNodeID         string                           `json:"runtime_role_node_id,omitempty"`
+	GatewayNodeID             string                           `json:"gateway_node_id,omitempty"`
+	RelationshipTypes         []string                         `json:"relationship_types"`
+	ProviderKeyReferences     []AWSAIAgentProviderKeyReference `json:"provider_key_references,omitempty"`
+	Confidence                float64                          `json:"confidence"`
+	CollectedAt               time.Time                        `json:"collected_at"`
+	Status                    string                           `json:"status"`
+	Tags                      map[string]string                `json:"tags,omitempty"`
+}
+
+type AWSAIAgentProviderKeyReference struct {
+	Reference     string  `json:"reference"`
+	ReferenceName string  `json:"reference_name,omitempty"`
+	ReferenceKind string  `json:"reference_kind"`
+	Provider      string  `json:"provider"`
+	Sensitivity   string  `json:"sensitivity"`
+	Resolved      bool    `json:"resolved"`
+	TargetNodeID  string  `json:"target_node_id,omitempty"`
+	EvidenceRef   string  `json:"evidence_ref"`
+	Confidence    float64 `json:"confidence"`
 }
 
 type AWSAIAgentIdentityRelation struct {
@@ -232,9 +251,16 @@ func buildAWSAIAgentIdentityInventory(scope db.Scope, project db.TenancyProject,
 		ToolCount:             awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.ToolNames }),
 		CapabilityCount:       awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.CapabilityNames }),
 		CredentialRefCount:    awsAIAgentIdentityListCount(records, func(r AWSAIAgentIdentityRecord) []string { return r.CredentialReferenceRefs }),
-		RelationshipCount:     len(relationships),
-		FailureReasons:        failures,
-		RemediationHints:      remediations,
+		ExternalProviderKeyCount: awsAIAgentProviderKeyCount(records, func(ref AWSAIAgentProviderKeyReference) bool {
+			return awsAIAgentProviderIsExternalAI(ref.Provider)
+		}),
+		AIProviderKeyCount: awsAIAgentProviderKeyCount(records, func(ref AWSAIAgentProviderKeyReference) bool {
+			return ref.Sensitivity == awsAIAgentProviderSensitivityAIKey
+		}),
+		ProviderKeyBreakdown: awsAIAgentProviderKeyBreakdown(records),
+		RelationshipCount:    len(relationships),
+		FailureReasons:       failures,
+		RemediationHints:     remediations,
 		EvidenceLinks: dedupeStrings([]string{
 			awsIssueURL(awsPlatformDependencyParentIssue),
 			awsIssueURL(awsAIAgentIdentityCurrentIssue),
@@ -368,8 +394,8 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			r.ModelID = "provider:model-redacted"
 			r.ToolNames = []string{"support-search"}
 			r.CapabilityNames = []string{"tool_use"}
-			r.CredentialReferenceRefs = []string{"ssm:/prod/support/ai-provider-key"}
-			r.ExternalProvider = "provider_key_reference"
+			r.CredentialReferenceRefs = []string{"ANTHROPIC_API_KEY=ssm:/prod/support/anthropic-key"}
+			r.ExternalProvider = "anthropic"
 		}),
 		awsAIAgentFixtureRecord(accountID, region, "agent_gateway", "payments-gateway", "payments-gateway", gatewayARN, role("bedrock-agent-gateway-payments"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
 			r.Service = "bedrock"
@@ -494,6 +520,7 @@ func awsAIAgentFixtureRecord(accountID string, region string, agentType string, 
 	record.AllowedActions = dedupeStrings(record.AllowedActions)
 	record.CapabilityNames = dedupeStrings(record.CapabilityNames)
 	record.CredentialReferenceRefs = dedupeStrings(record.CredentialReferenceRefs)
+	record.ProviderKeyReferences = awsAIAgentProviderKeyReferences(record)
 	record.ExecutionEndpointARNs = normalizeOrderedStringList(record.ExecutionEndpointARNs)
 	record.ExecutionEndpointNames = normalizeOrderedStringList(record.ExecutionEndpointNames)
 	record.ExecutionEndpointStatuses = normalizeOrderedStringList(record.ExecutionEndpointStatuses)
@@ -680,6 +707,83 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 	}
 }
 
+func awsAIAgentProviderKeyReferences(record AWSAIAgentIdentityRecord) []AWSAIAgentProviderKeyReference {
+	refs := []AWSAIAgentProviderKeyReference{}
+	seen := map[string]struct{}{}
+	for _, raw := range record.CredentialReferenceRefs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		name, source := awsAIAgentCredentialReferenceParts(trimmed)
+		provider := awsAIAgentCredentialReferenceProvider(name, source)
+		ref := AWSAIAgentProviderKeyReference{
+			Reference:     trimmed,
+			ReferenceName: name,
+			ReferenceKind: awsAIAgentCredentialReferenceKind(source),
+			Provider:      provider,
+			Sensitivity:   awsAIAgentCredentialReferenceSensitivity(provider),
+			Resolved:      false,
+			TargetNodeID:  awsCredentialReferenceNodeID(record.AgentNodeID, trimmed),
+			EvidenceRef:   firstNonEmptyAWSValue(record.EvidenceRef, trimmed),
+			Confidence:    awsAIAgentCredentialReferenceConfidence(provider),
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func awsAIAgentCredentialReferenceKind(source string) string {
+	probe := strings.ToLower(strings.TrimSpace(source))
+	switch {
+	case strings.Contains(probe, "secretsmanager") || strings.HasPrefix(probe, "secretsmanager-"):
+		return "secrets_manager"
+	case strings.HasPrefix(probe, "ssm-") || strings.Contains(probe, "parameter"):
+		return "ssm_parameter"
+	case probe == "":
+		return "environment_variable"
+	default:
+		return "credential_reference"
+	}
+}
+
+func awsAIAgentCredentialReferenceSensitivity(provider string) string {
+	switch provider {
+	case "openai", "anthropic", "bedrock":
+		return awsAIAgentProviderSensitivityAIKey
+	case "secretsmanager", "ssm":
+		return awsAIAgentProviderSensitivityAWSStore
+	default:
+		return awsAIAgentProviderSensitivityGeneric
+	}
+}
+
+func awsAIAgentCredentialReferenceConfidence(provider string) float64 {
+	switch provider {
+	case "openai", "anthropic":
+		return 0.9
+	case "bedrock":
+		return 0.85
+	case "secretsmanager", "ssm":
+		return 0.72
+	default:
+		return 0.62
+	}
+}
+
+func awsAIAgentProviderIsExternalAI(provider string) bool {
+	switch provider {
+	case "openai", "anthropic":
+		return true
+	default:
+		return false
+	}
+}
+
 func awsAIAgentCredentialReferenceParts(ref string) (string, string) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
@@ -704,6 +808,31 @@ func awsAIAgentCredentialReferenceParts(ref string) (string, string) {
 		name = trimmed[colonIndex+1:]
 	}
 	return sanitizeCredentialReferenceToken(name), sanitizeCredentialReferenceToken(trimmed)
+}
+
+func awsAIAgentProviderKeyCount(records []AWSAIAgentIdentityRecord, match func(AWSAIAgentProviderKeyReference) bool) int {
+	count := 0
+	for _, record := range records {
+		for _, ref := range record.ProviderKeyReferences {
+			if match(ref) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func awsAIAgentProviderKeyBreakdown(records []AWSAIAgentIdentityRecord) map[string]int {
+	breakdown := map[string]int{}
+	for _, record := range records {
+		for _, ref := range record.ProviderKeyReferences {
+			if ref.Provider == "" {
+				continue
+			}
+			breakdown[ref.Provider]++
+		}
+	}
+	return breakdown
 }
 
 func sanitizeCredentialReferenceToken(value string) string {

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -708,6 +708,8 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "secretsmanager"
 	case strings.HasPrefix(sourceProbe, "ssm:") ||
 		strings.HasPrefix(sourceProbe, "ssm-") ||
+		strings.HasPrefix(sourceProbe, "parameter_store:") ||
+		strings.HasPrefix(sourceProbe, "parameter_store-") ||
 		strings.Contains(sourceProbe, "arn-aws-ssm-") ||
 		strings.Contains(sourceProbe, "arn-aws-us-gov-ssm-") ||
 		strings.Contains(sourceProbe, "arn-aws-cn-ssm-"):

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -697,7 +697,7 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "openai"
 	case containsAnyToken(probe, "anthropic", "claude"):
 		return "anthropic"
-	case containsAnyToken(probe, "bedrock"):
+	case awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(probe):
 		return "bedrock"
 	case strings.HasPrefix(sourceProbe, "secretsmanager:") ||
 		strings.HasPrefix(sourceProbe, "secretsmanager-") ||
@@ -717,6 +717,23 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 	default:
 		return "generic"
 	}
+}
+
+func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(probe string) bool {
+	if strings.Contains(probe, "bedrock-agentcore") || strings.Contains(probe, "bedrock_agentcore") {
+		return false
+	}
+	return containsAnyToken(probe,
+		"bedrock_api_key",
+		"bedrock-api-key",
+		"bedrockapikey",
+		"bedrock_provider_key",
+		"bedrock-provider-key",
+		"bedrockproviderkey",
+		"amazon_bedrock_api_key",
+		"amazon-bedrock-api-key",
+		"amazonbedrockapikey",
+	)
 }
 
 func awsAIAgentProviderKeyReferences(record AWSAIAgentIdentityRecord) []AWSAIAgentProviderKeyReference {

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -699,9 +699,18 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "anthropic"
 	case containsAnyToken(probe, "bedrock"):
 		return "bedrock"
-	case strings.HasPrefix(sourceProbe, "secretsmanager:") || strings.HasPrefix(sourceProbe, "secretsmanager-") || strings.HasPrefix(sourceProbe, "secrets_manager-"):
+	case strings.HasPrefix(sourceProbe, "secretsmanager:") ||
+		strings.HasPrefix(sourceProbe, "secretsmanager-") ||
+		strings.HasPrefix(sourceProbe, "secrets_manager-") ||
+		strings.Contains(sourceProbe, "arn-aws-secretsmanager-") ||
+		strings.Contains(sourceProbe, "arn-aws-us-gov-secretsmanager-") ||
+		strings.Contains(sourceProbe, "arn-aws-cn-secretsmanager-"):
 		return "secretsmanager"
-	case strings.HasPrefix(sourceProbe, "ssm:") || strings.HasPrefix(sourceProbe, "ssm-"):
+	case strings.HasPrefix(sourceProbe, "ssm:") ||
+		strings.HasPrefix(sourceProbe, "ssm-") ||
+		strings.Contains(sourceProbe, "arn-aws-ssm-") ||
+		strings.Contains(sourceProbe, "arn-aws-us-gov-ssm-") ||
+		strings.Contains(sourceProbe, "arn-aws-cn-ssm-"):
 		return "ssm"
 	default:
 		return "generic"

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -741,7 +741,7 @@ func awsAIAgentProviderKeyReferences(record AWSAIAgentIdentityRecord) []AWSAIAge
 func awsAIAgentCredentialReferenceKind(source string) string {
 	probe := strings.ToLower(strings.TrimSpace(source))
 	switch {
-	case strings.Contains(probe, "secretsmanager") || strings.HasPrefix(probe, "secretsmanager-"):
+	case strings.Contains(probe, "secretsmanager") || strings.HasPrefix(probe, "secretsmanager-") || strings.HasPrefix(probe, "secrets_manager-"):
 		return "secrets_manager"
 	case strings.HasPrefix(probe, "ssm-") || strings.Contains(probe, "parameter"):
 		return "ssm_parameter"

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -369,6 +369,32 @@ func TestAIAgentRelationshipsEmitRunsAsFromWorkloadNode(t *testing.T) {
 	}
 }
 
+func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
+	record := awsAIAgentFixtureRecord("111111111111", "us-east-1", "external_provider_agent", "store-backed-agent", "agent-1", "arn:aws:ecs:us-east-1:111111111111:service/prod/agent-1", "arn:aws:iam::111111111111:role/agent-1", time.Now(), func(r *AWSAIAgentIdentityRecord) {
+		r.CredentialReferenceRefs = []string{
+			"ssm:/prod/support/ai-provider-key",
+			"secretsmanager:prod/provider-key",
+		}
+	})
+
+	providersByRef := map[string]string{}
+	sensitivityByRef := map[string]string{}
+	for _, ref := range record.ProviderKeyReferences {
+		providersByRef[ref.Reference] = ref.Provider
+		sensitivityByRef[ref.Reference] = ref.Sensitivity
+	}
+	if providersByRef["ssm:/prod/support/ai-provider-key"] != "ssm" {
+		t.Fatalf("expected SSM store-only reference to classify as ssm, got %+v", record.ProviderKeyReferences)
+	}
+	if providersByRef["secretsmanager:prod/provider-key"] != "secretsmanager" {
+		t.Fatalf("expected Secrets Manager store-only reference to classify as secretsmanager, got %+v", record.ProviderKeyReferences)
+	}
+	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
+		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {
+		t.Fatalf("expected AWS store-backed references to use aws_managed_secret sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+}
+
 func TestRouterAWSAIAgentIdentityInventoryPermissionDenied(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -375,6 +375,8 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 			"ssm:/prod/support/ai-provider-key",
 			"secretsmanager:prod/provider-key",
 			"OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf",
+			"arn:aws:secretsmanager:us-east-1:111111111111:secret:provider/key-AbCdEf",
+			"arn:aws:ssm:us-east-1:111111111111:parameter/provider/key",
 		}
 	})
 
@@ -391,6 +393,12 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	}
 	if providersByRef["secretsmanager:prod/provider-key"] != "secretsmanager" {
 		t.Fatalf("expected Secrets Manager store-only reference to classify as secretsmanager, got %+v", record.ProviderKeyReferences)
+	}
+	if providersByRef["arn:aws:secretsmanager:us-east-1:111111111111:secret:provider/key-AbCdEf"] != "secretsmanager" {
+		t.Fatalf("expected full Secrets Manager ARN to classify as secretsmanager, got %+v", record.ProviderKeyReferences)
+	}
+	if providersByRef["arn:aws:ssm:us-east-1:111111111111:parameter/provider/key"] != "ssm" {
+		t.Fatalf("expected full SSM ARN to classify as ssm, got %+v", record.ProviderKeyReferences)
 	}
 	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
 		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -378,6 +378,8 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 			"arn:aws:secretsmanager:us-east-1:111111111111:secret:provider/key-AbCdEf",
 			"arn:aws:ssm:us-east-1:111111111111:parameter/provider/key",
 			"PARAMETER_STORE:/prod/provider-key",
+			"BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key",
+			"arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments",
 		}
 	})
 
@@ -404,9 +406,21 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	if providersByRef["PARAMETER_STORE:/prod/provider-key"] != "ssm" {
 		t.Fatalf("expected PARAMETER_STORE marker to classify as ssm, got %+v", record.ProviderKeyReferences)
 	}
+	if providersByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key"] != "bedrock" {
+		t.Fatalf("expected Bedrock API key marker to classify as bedrock, got %+v", record.ProviderKeyReferences)
+	}
+	if providersByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic" {
+		t.Fatalf("expected AgentCore OAuth ARN to classify as generic, got %+v", record.ProviderKeyReferences)
+	}
 	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
 		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {
 		t.Fatalf("expected AWS store-backed references to use aws_managed_secret sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+	if sensitivityByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key"] != "ai_provider_api_key" {
+		t.Fatalf("expected Bedrock API key marker to use ai_provider_api_key sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+	if sensitivityByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic_secret" {
+		t.Fatalf("expected AgentCore OAuth ARN to use generic_secret sensitivity, got %+v", record.ProviderKeyReferences)
 	}
 	if kindsByRef["OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf"] != "secrets_manager" {
 		t.Fatalf("expected SECRETS_MANAGER marker to classify as secrets_manager kind, got %+v", record.ProviderKeyReferences)

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -89,7 +89,7 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready inventory, got %+v", result)
 	}
-	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1509" || result.Version != awsAIAgentIdentityVersion {
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1510" || result.Version != awsAIAgentIdentityVersion {
 		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
 	}
 	if result.BedrockAgentCount != 1 || result.AgentCoreRuntimeCount != 1 || result.CustomAgentCount != 1 || result.ExternalAgentCount != 1 || result.GatewayCount != 1 {
@@ -123,10 +123,11 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 		t.Fatalf("expected credential records to advertise uses_secret relationship type, got %+v", result.Records)
 	}
 	expectedCustomCredentialRefTarget := awsCredentialReferenceNodeID(customAgentNodeID, "secretsmanager:prod/ai/openai-key")
-	expectedExternalCredentialRefTarget := awsCredentialReferenceNodeID(externalAgentNodeID, "ssm:/prod/support/ai-provider-key")
+	expectedExternalCredentialRefTarget := awsCredentialReferenceNodeID(externalAgentNodeID, "ANTHROPIC_API_KEY=ssm:/prod/support/anthropic-key")
 	matchedCustomCredentialRef := false
 	matchedExternalCredentialRef := false
 	foundCredentialEdge := false
+	providerCounts := map[string]int{}
 	for _, relationship := range result.Relationships {
 		if relationship.Type == "uses_credential" {
 			t.Fatalf("expected supported graph relationship type uses_secret, got unsupported uses_credential in %+v", relationship)
@@ -156,6 +157,26 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	}
 	if !matchedExternalCredentialRef {
 		t.Fatalf("expected external-provider-agent unresolved credential reference to emit uses_secret edge to %q, got %+v", expectedExternalCredentialRefTarget, result.Relationships)
+	}
+	for _, record := range result.Records {
+		for _, ref := range record.ProviderKeyReferences {
+			providerCounts[ref.Provider]++
+			if ref.Sensitivity == "ai_provider_api_key" && ref.ReferenceKind == "" {
+				t.Fatalf("expected provider key reference kind for %+v", ref)
+			}
+			if strings.Contains(strings.ToLower(ref.Reference+" "+ref.EvidenceRef), "secret_value") {
+				t.Fatalf("provider key reference leaked forbidden value marker: %+v", ref)
+			}
+		}
+	}
+	if result.ExternalProviderKeyCount != 2 || result.AIProviderKeyCount != 2 {
+		t.Fatalf("expected two external AI provider key references, got external=%d ai=%d", result.ExternalProviderKeyCount, result.AIProviderKeyCount)
+	}
+	if providerCounts["openai"] != 1 || providerCounts["anthropic"] != 1 {
+		t.Fatalf("expected openai and anthropic provider-key records, got %+v", providerCounts)
+	}
+	if result.ProviderKeyBreakdown["openai"] != 1 || result.ProviderKeyBreakdown["anthropic"] != 1 {
+		t.Fatalf("expected provider key breakdown for openai/anthropic, got %+v", result.ProviderKeyBreakdown)
 	}
 	if len(result.CoverageGaps) == 0 {
 		t.Fatalf("expected sensitive-boundary coverage gaps, got %+v", result.CoverageGaps)

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -377,6 +377,7 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 			"OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf",
 			"arn:aws:secretsmanager:us-east-1:111111111111:secret:provider/key-AbCdEf",
 			"arn:aws:ssm:us-east-1:111111111111:parameter/provider/key",
+			"PARAMETER_STORE:/prod/provider-key",
 		}
 	})
 
@@ -400,12 +401,18 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	if providersByRef["arn:aws:ssm:us-east-1:111111111111:parameter/provider/key"] != "ssm" {
 		t.Fatalf("expected full SSM ARN to classify as ssm, got %+v", record.ProviderKeyReferences)
 	}
+	if providersByRef["PARAMETER_STORE:/prod/provider-key"] != "ssm" {
+		t.Fatalf("expected PARAMETER_STORE marker to classify as ssm, got %+v", record.ProviderKeyReferences)
+	}
 	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
 		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {
 		t.Fatalf("expected AWS store-backed references to use aws_managed_secret sensitivity, got %+v", record.ProviderKeyReferences)
 	}
 	if kindsByRef["OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf"] != "secrets_manager" {
 		t.Fatalf("expected SECRETS_MANAGER marker to classify as secrets_manager kind, got %+v", record.ProviderKeyReferences)
+	}
+	if kindsByRef["PARAMETER_STORE:/prod/provider-key"] != "ssm_parameter" {
+		t.Fatalf("expected PARAMETER_STORE marker to classify as ssm_parameter kind, got %+v", record.ProviderKeyReferences)
 	}
 }
 

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -374,13 +374,16 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 		r.CredentialReferenceRefs = []string{
 			"ssm:/prod/support/ai-provider-key",
 			"secretsmanager:prod/provider-key",
+			"OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf",
 		}
 	})
 
 	providersByRef := map[string]string{}
+	kindsByRef := map[string]string{}
 	sensitivityByRef := map[string]string{}
 	for _, ref := range record.ProviderKeyReferences {
 		providersByRef[ref.Reference] = ref.Provider
+		kindsByRef[ref.Reference] = ref.ReferenceKind
 		sensitivityByRef[ref.Reference] = ref.Sensitivity
 	}
 	if providersByRef["ssm:/prod/support/ai-provider-key"] != "ssm" {
@@ -392,6 +395,9 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
 		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {
 		t.Fatalf("expected AWS store-backed references to use aws_managed_secret sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+	if kindsByRef["OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf"] != "secrets_manager" {
+		t.Fatalf("expected SECRETS_MANAGER marker to classify as secrets_manager kind, got %+v", record.ProviderKeyReferences)
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2003,10 +2003,23 @@ export type AWSAIAgentIdentityRecord = {
   runtime_role_node_id?: string;
   gateway_node_id?: string;
   relationship_types: string[];
+  provider_key_references?: AWSAIAgentProviderKeyReference[];
   confidence: number;
   collected_at: string;
   status: string;
   tags?: Record<string, string>;
+};
+
+export type AWSAIAgentProviderKeyReference = {
+  reference: string;
+  reference_name?: string;
+  reference_kind: string;
+  provider: string;
+  sensitivity: string;
+  resolved: boolean;
+  target_node_id?: string;
+  evidence_ref: string;
+  confidence: number;
 };
 
 export type AWSAIAgentIdentityRelationship = {
@@ -2056,6 +2069,9 @@ export type AWSAIAgentIdentityInventoryResult = {
   tool_count: number;
   capability_count: number;
   credential_reference_count: number;
+  external_provider_key_count: number;
+  ai_provider_key_count: number;
+  provider_key_breakdown: Record<string, number>;
   relationship_count: number;
   failure_reasons: string[];
   remediation_hints: string[];

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6711,10 +6711,10 @@ function AWSAgentIdentitiesContent({
               detail={`${inventory.memory_store_count} memory · ${inventory.browser_count} browser · ${inventory.code_interpreter_count} code`}
             />
             <DomainCoverageCard
-              label="Credential refs"
-              scanned={inventory.credential_reference_count}
+              label="External provider keys"
+              scanned={inventory.external_provider_key_count}
               total={Math.max(inventory.credential_reference_count, 1)}
-              detail="Values hidden"
+              detail={`${inventory.ai_provider_key_count} AI keys, values hidden`}
             />
           </section>
           {inventory.diagnostics.length ? (
@@ -6745,7 +6745,7 @@ function AWSAgentIdentitiesContent({
         {[
           ['Agent to role', inventory ? `${inventory.runtime_role_count} runtime role anchors` : connection?.role_arn ? 'Role anchor available' : 'Waiting for role validation'],
           ['Agent to tool', inventory ? `${inventory.tool_count} tool names` : 'Tool and gateway metadata pending'],
-          ['Agent to secret', inventory ? `${inventory.credential_reference_count} credential references, values hidden` : 'Secret metadata only, no value reads'],
+          ['Agent to secret', inventory ? `${inventory.external_provider_key_count} external provider keys, ${inventory.credential_reference_count} credential references; values hidden` : 'Secret metadata only, no value reads'],
           ['Agent to user', 'Human owner mapping reserved for governance waves']
         ].map(([label, detail]) => (
           <article key={label}>
@@ -7113,6 +7113,9 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   const endpointLabel = record.execution_endpoint_names?.length ? `${record.execution_endpoint_names.length} execution endpoints` : 'no execution endpoints reported';
   const protocolLabel = record.server_protocol || 'protocol not reported';
   const networkLabel = record.network_mode || 'network mode not reported';
+  const providerKeyLabel = record.provider_key_references?.length
+    ? `${record.provider_key_references.map((ref) => formatTokenLabel(ref.provider)).join(', ')} provider keys, values hidden`
+    : credentialLabel;
   const surface = awsAIAgentSurfaceFilter(record);
   const relationships = new Set<string>(['agent-to-role']);
   if (record.tool_names?.length || record.gateway_arn) {
@@ -7148,7 +7151,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
     stage,
     detail: record.capability_kind
       ? `${capabilityDetail}; runs as ${roleLabel}; ${capabilityLabel}. Contents never collected.`
-      : `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${authLabel}; ${actionLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${credentialLabel}.`,
+      : `${record.provider || 'provider not reported'} ${record.model_id || 'model not reported'}; runs as ${roleLabel}; ${runtimeLabel}; ${toolLabel}; ${authLabel}; ${actionLabel}; ${endpointLabel}; ${networkLabel}; ${protocolLabel}; ${capabilityLabel}; ${providerKeyLabel}.`,
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
@@ -7177,6 +7180,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
       ...(record.observability_links ?? []),
       ...(record.capability_names ?? []),
       ...(record.credential_reference_refs ?? []),
+      ...(record.provider_key_references?.flatMap((ref) => [ref.provider, ref.sensitivity, ref.reference_kind, ref.reference]) ?? []),
       ...(record.storage_reference_refs ?? []),
       ...(record.memory_store_refs ?? []),
       record.capability_kind,


### PR DESCRIPTION
Closes #1510

## Summary
- Adds classified provider-key references to the AWS AI agent identity inventory for OpenAI, Anthropic/Claude, Bedrock, and generic credential metadata.
- Exposes external provider key counts, AI provider key counts, and provider breakdowns in the API, OpenAPI schema, and AWS Agents app surface.
- Updates fixtures, tests, docs, and changelog while preserving the metadata-only boundary: no secret values, prompts, completions, browser pages, code output, database rows, object contents, or customer payloads are read or exposed.

## Validation
- `go test ./internal/api ./internal/providers/aws`
- `npm run test --prefix web -- --run src/api/client.test.ts src/productShell.test.tsx`
- `npm run build --prefix web`
- pre-push hooks: merge conflict check, YAML check, EOF/trailing whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps external AI provider key metadata onto AWS agent identities and exposes per-agent references plus provider counts and breakdowns in the API and UI. Implements #1510 with a strict metadata-only boundary (no secret values).

- New Features
  - Adds per-agent `provider_key_references` from env vars, `secretsmanager`, and `ssm`; classifies as `openai`, `anthropic`, `bedrock`, `secretsmanager`, `ssm`, or `generic` with `reference_kind` (`environment_variable`, `secrets_manager`, `ssm_parameter`, `credential_reference`), sensitivity (`ai_provider_api_key`, `aws_managed_secret`, `generic_secret`), confidence, target node, and evidence; preserves `uses_secret` edges.
  - Adds `external_provider_key_count`, `ai_provider_key_count`, and `provider_key_breakdown` to inventory; updates OpenAPI with `AWSAIAgentProviderKeyReference` and `records.provider_key_references`; bumps inventory version to `aws-ai-agent-external-provider-keys-v1`; updates `web` types and UI to show external provider key counts and per-agent provider labels.

- Bug Fixes
  - Correctly classifies store-only references and ARNs for provider-key stores: `ssm:/...`, `PARAMETER_STORE:/...`, and `arn:aws:ssm:...` as `ssm`; `secretsmanager:...`, `SECRETS_MANAGER:arn:...`, and `arn:aws:secretsmanager:...` (including Gov/China) as `secretsmanager`; sets `reference_kind` (`ssm_parameter`/`secrets_manager`) and `aws_managed_secret` sensitivity.
  - Avoids misclassifying Bedrock AgentCore OAuth ARNs as Bedrock API keys; treats them as `generic` with `generic_secret` sensitivity.

<sup>Written for commit 7bc97a21818dc292cbf0ec6fe6e0634f55248507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

