### PR TITLE
Detect custom AWS agent workloads

### DIFF
--- a/docs/aws-ai-agent-identities.md
+++ b/docs/aws-ai-agent-identities.md
@@ -1,6 +1,6 @@
 # AWS AI Agent Identities
 
-Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping. Issue #1509 extends it again with AgentCore Memory, Browser, and Code Interpreter capability metadata mapping. Issue #1510 maps external AI provider key metadata onto agent identities without reading credential values.
+Issue #1505 adds a normalized AI agent identity model for AWS machine-identity governance. Issue #1508 extends the same model with AgentCore Gateway and MCP tool mapping. Issue #1509 extends it again with AgentCore Memory, Browser, and Code Interpreter capability metadata mapping. Issue #1510 maps external AI provider key metadata onto agent identities without reading credential values. Issue #1511 detects custom AWS-hosted agents across existing workload metadata.
 
 ## What Is Collected
 
@@ -20,6 +20,7 @@ The model is metadata-only. Each `agent_identity` record can describe:
 - per-capability execution role bindings, storage references (`storage_reference_refs` such as a browser recording `s3://bucket/prefix` destination or a memory stream-delivery resource count), customer encryption key ARN (`encryption_key_arn`), and network posture (`vpc`, `sandbox`, etc.)
 - credential-reference identifiers
 - classified external provider key references (`provider_key_references`) for OpenAI, Anthropic/Claude, Bedrock, and generic credential metadata
+- custom-agent detector metadata (`custom-agent-detector-v1`) with candidate/confirmed confidence, detector signals, source workload family, and metadata-only evidence
 - agent-to-endpoint `invokes` relationships for AgentCore runtime execution surfaces
 - agent-to-tool `calls_tool` relationships for AgentCore Gateway and MCP tool surfaces
 - an `agentcore_capability` resource node per Memory/Browser/Code Interpreter surface, linked to its agent identity, carrying the kind, storage references, encryption key, network mode, and execution role — but never the capability's contents
@@ -55,6 +56,26 @@ Agent records expose `provider_key_references` derived from safe names, ARNs, so
 
 Inventory aggregates include `external_provider_key_count`, `ai_provider_key_count`, and `provider_key_breakdown`, alongside the existing `credential_reference_count` and `uses_secret` relationships. These fields let operators filter and drill into provider-key ownership from the AWS Agents surface while keeping values hidden.
 
+### Custom AWS-hosted agent detector (issue #1511)
+
+The custom-agent detector runs over existing workload metadata from ECS, EKS, Lambda, EC2, SageMaker, Step Functions, and CodeBuild. It does not add new payload-reading AWS calls. It uses only metadata already collected by the workload collectors:
+
+- workload names, ARNs, resource types, runtime names, handlers, descriptions, service-account names, and tags
+- container image URIs and SageMaker image URIs
+- environment variable names and secret/source reference names
+- Step Functions service-integration resource identifiers and SageMaker storage/KMS references
+- runtime role bindings, account, region, connector, scan, workspace, and project context
+
+Detected workloads emit `custom_agent` records with:
+
+- `status=ready` and `coverage_status=covered` when multiple strong signals confirm the custom agent
+- `status=candidate` and `coverage_status=candidate` when metadata is suggestive but not strong enough to call confirmed
+- `capability_names` including the detector version and safe signal categories such as `external_provider_key`, `container_image_signal`, `role_binding`, or `ai_runtime_metadata`
+- `credential_reference_refs` for AI-provider key references such as OpenAI, Anthropic/Claude, and Bedrock provider keys
+- graph `runs_as` edges to the runtime IAM role and `uses_secret` edges to credential-reference nodes when provider-key metadata is present
+
+The detector intentionally does not infer tool names from opaque commands, prompt text, source code, logs, execution history, or object contents. Tool names remain populated only when an upstream metadata source provides explicit tool identifiers.
+
 ## What Is Not Collected
 
 Identrail does not collect prompt text, completions, memory contents, browser pages, code-interpreter output, database rows, object contents, secret values, or customer payloads for this capability.
@@ -64,6 +85,7 @@ External AI provider credentials are represented as credential references only. 
 ## Operator States
 
 - `ready`: normalized agent metadata is available.
+- `candidate`: custom-agent metadata is suggestive but not strong enough to mark confirmed.
 - `degraded`: some metadata is incomplete, but retained records remain visible.
 - `blocked`: read-only metadata permission is missing.
 - `empty`: the scan completed without AI agent records for the selected account and region.
@@ -71,11 +93,11 @@ External AI provider credentials are represented as credential references only. 
 
 ## Permissions
 
-Use metadata-only list and describe permissions for the relevant agent, runtime, gateway target, and IAM-role surfaces. For the AgentCore Memory/Browser/Code Interpreter capability mapping, grant the read-only control-plane actions `bedrock-agentcore:ListMemories`, `bedrock-agentcore:GetMemory`, `bedrock-agentcore:ListBrowsers`, `bedrock-agentcore:GetBrowser`, `bedrock-agentcore:ListCodeInterpreters`, and `bedrock-agentcore:GetCodeInterpreter` (control-plane metadata only). Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, or secret-value reads for this issue. Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
+Use metadata-only list and describe permissions for the relevant agent, runtime, gateway target, IAM-role, and workload metadata surfaces. For the AgentCore Memory/Browser/Code Interpreter capability mapping, grant the read-only control-plane actions `bedrock-agentcore:ListMemories`, `bedrock-agentcore:GetMemory`, `bedrock-agentcore:ListBrowsers`, `bedrock-agentcore:GetBrowser`, `bedrock-agentcore:ListCodeInterpreters`, and `bedrock-agentcore:GetCodeInterpreter` (control-plane metadata only). Do not grant invoke, prompt/session reads, memory-content reads, browser-output reads, code-output reads, database-row reads, object-content reads, source-code reads, build-log reads, or secret-value reads for this issue. Inline MCP schemas are used only for declared tool names; S3-backed schemas are retained as references and are not fetched.
 
 ## UI Surface
 
-The AWS Agents inventory page shows normalized agent rows, runtime role anchors, provider/model metadata, Gateway/MCP tools, auth mode, allowed-action counts, external provider key counts, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
+The AWS Agents inventory page shows normalized agent rows, custom-agent candidates, runtime role anchors, provider/model metadata, Gateway/MCP tools, auth mode, allowed-action counts, external provider key counts, credential-reference counts, confidence, diagnostics, sensitive-boundary coverage gaps, account/region context, and retry guidance.
 
 ## Troubleshooting
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10146,7 +10146,7 @@ components:
           enum: [metadata_only]
         coverage_status:
           type: string
-          enum: [covered, degraded]
+          enum: [covered, degraded, candidate]
         coverage_reason: { type: string }
         source: { type: string }
         evidence_ref: { type: string }
@@ -10171,7 +10171,7 @@ components:
           format: date-time
         status:
           type: string
-          enum: [ready, degraded]
+          enum: [ready, degraded, candidate]
         tags:
           type: object
           additionalProperties: { type: string }

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	awsAIAgentIdentityCurrentIssue        = 1510
-	awsAIAgentIdentityVersion             = "aws-ai-agent-external-provider-keys-v1"
+	awsAIAgentIdentityCurrentIssue        = 1511
+	awsAIAgentIdentityVersion             = "aws-ai-agent-custom-agent-detector-v1"
 	awsAIAgentCredentialRefPrefix         = "aws:resource:credential-reference:"
 	awsAIAgentToolNodePrefix              = "tool:agent:"
 	agentCoreCapabilityAgentTypeAPI       = "agentcore_capability"

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -89,7 +89,7 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 	if result.Status != awsPlatformDependencyStatusReady || result.Confidence < 0.9 {
 		t.Fatalf("expected ready inventory, got %+v", result)
 	}
-	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1510" || result.Version != awsAIAgentIdentityVersion {
+	if result.ParentIssueRef != "#1472" || result.CurrentIssueRef != "#1511" || result.Version != awsAIAgentIdentityVersion {
 		t.Fatalf("unexpected parent/current/version metadata: %+v", result)
 	}
 	if result.BedrockAgentCount != 1 || result.AgentCoreRuntimeCount != 1 || result.CustomAgentCount != 1 || result.ExternalAgentCount != 1 || result.GatewayCount != 1 {

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -104,6 +104,9 @@ func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]Credent
 		fromNodeID := credentialWorkloadNodeID(resource)
 		workloadName := strings.TrimSpace(resource.Name)
 		for _, raw := range candidates {
+			if isAgentCoreCredentialProviderReference(raw) {
+				continue
+			}
 			ref := classifyCredentialReference(raw, resource, sourceService, secretIndex, parameterIndex)
 			if ref.Reference == "" {
 				continue
@@ -159,6 +162,9 @@ func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]Credent
 		fromNodeID := credentialWorkloadNodeID(resource)
 		workloadName := strings.TrimSpace(resource.Name)
 		for _, raw := range credentialCandidateRefs(resource) {
+			if isAgentCoreCredentialProviderReference(raw) {
+				continue
+			}
 			ref := classifyCredentialReference(raw, resource, sourceService, secretIndex, parameterIndex)
 			if ref.Reference == "" {
 				continue
@@ -390,6 +396,25 @@ func classifyCredentialReference(raw string, resource domain.Resource, sourceSer
 		}
 	}
 	return ref
+}
+
+func isAgentCoreCredentialProviderReference(raw string) bool {
+	name, source := splitCredentialReference(strings.TrimSpace(raw))
+	if strings.TrimSpace(name) != "" {
+		return false
+	}
+	probe := strings.ToLower(strings.TrimSpace(source))
+	if !strings.Contains(probe, "bedrock-agentcore") {
+		return false
+	}
+	return strings.Contains(probe, ":oauth/") ||
+		strings.Contains(probe, "/oauth/") ||
+		strings.Contains(probe, ":api-key/") ||
+		strings.Contains(probe, "/api-key/") ||
+		strings.Contains(probe, ":apikey/") ||
+		strings.Contains(probe, "/apikey/") ||
+		strings.Contains(probe, ":api_key/") ||
+		strings.Contains(probe, "/api_key/")
 }
 
 // splitCredentialReference separates a `NAME=SOURCE` reference into its env-var

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -169,6 +169,10 @@ func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]Credent
 			ref.Region = strings.TrimSpace(resource.Region)
 			ref.ResourceID = agent.ID
 			ref.ResourceType = string(agent.Type)
+			// classifyCredentialReference defaults WorkloadType to the synthesized
+			// credential-reference resource type; override it with the agent's own
+			// type so custom-agent attribution and workload_type filters are correct.
+			ref.WorkloadType = string(agent.Type)
 
 			refKey := strings.Join([]string{fromNodeID, ref.Reference}, "|")
 			if _, exists := seenRef[refKey]; !exists {

--- a/internal/providers/aws/credential_reference_mapper.go
+++ b/internal/providers/aws/credential_reference_mapper.go
@@ -139,6 +139,61 @@ func MapBundleCredentialReferences(bundle providers.NormalizedBundle) ([]Credent
 			})
 		}
 	}
+	for _, agent := range bundle.Agents {
+		candidates := parseStringList(agent.Metadata["credential_reference_refs"])
+		if len(candidates) == 0 {
+			continue
+		}
+		resource := domain.Resource{
+			ID:        agent.ID,
+			Provider:  domain.ProviderAWS,
+			Type:      domain.ResourceTypeCredentialReference,
+			Name:      agent.Name,
+			AccountID: stringMetadata(agent.Metadata, "account_id"),
+			Region:    stringMetadata(agent.Metadata, "region"),
+			Metadata: map[string]any{
+				"secret_refs": candidates,
+			},
+		}
+		sourceService := firstNonEmptyAWSValue(stringMetadata(agent.Metadata, "source"), "ai_agent")
+		fromNodeID := credentialWorkloadNodeID(resource)
+		workloadName := strings.TrimSpace(resource.Name)
+		for _, raw := range credentialCandidateRefs(resource) {
+			ref := classifyCredentialReference(raw, resource, sourceService, secretIndex, parameterIndex)
+			if ref.Reference == "" {
+				continue
+			}
+			ref.WorkloadID = fromNodeID
+			ref.WorkloadName = workloadName
+			ref.AccountID = strings.TrimSpace(resource.AccountID)
+			ref.Region = strings.TrimSpace(resource.Region)
+			ref.ResourceID = agent.ID
+			ref.ResourceType = string(agent.Type)
+
+			refKey := strings.Join([]string{fromNodeID, ref.Reference}, "|")
+			if _, exists := seenRef[refKey]; !exists {
+				seenRef[refKey] = struct{}{}
+				references = append(references, ref)
+			}
+
+			targetNode := ref.TargetNodeID
+			if targetNode == "" {
+				continue
+			}
+			edgeKey := strings.Join([]string{fromNodeID, targetNode}, "|")
+			if _, exists := seenEdge[edgeKey]; exists {
+				continue
+			}
+			seenEdge[edgeKey] = struct{}{}
+			relationships = append(relationships, domain.Relationship{
+				ID:          relationshipID(domain.RelationshipUsesSecret, fromNodeID, targetNode),
+				Type:        domain.RelationshipUsesSecret,
+				FromNodeID:  fromNodeID,
+				ToNodeID:    targetNode,
+				EvidenceRef: ref.Reference,
+			})
+		}
+	}
 
 	sort.SliceStable(references, func(i, j int) bool {
 		if references[i].WorkloadID == references[j].WorkloadID {
@@ -261,6 +316,16 @@ func credentialCandidateRefs(resource domain.Resource) []string {
 		out = append(out, key)
 	}
 	return out
+}
+
+func stringMetadata(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	if value, ok := metadata[key].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
 }
 
 // classifyCredentialReference parses one raw reference into a classified

--- a/internal/providers/aws/credential_reference_mapper_test.go
+++ b/internal/providers/aws/credential_reference_mapper_test.go
@@ -429,12 +429,12 @@ func TestNormalizerAndGraphEmitCredentialReferenceNodeAndEdge(t *testing.T) {
 			"region":"us-east-1",
 			"service":"ecs",
 			"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/prod",
-			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/agent",
-			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/agent",
+			"service_arn":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
+			"workload_id":"arn:aws:ecs:us-east-1:123456789012:service/prod/payments",
 			"workload_type":"ecs_service",
-			"workload_name":"agent",
-			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/agent:3",
-			"role_arn":"arn:aws:iam::123456789012:role/agent-task",
+			"workload_name":"payments",
+			"task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/payments:3",
+			"role_arn":"arn:aws:iam::123456789012:role/payments-task",
 			"environment_keys":["OPENAI_API_KEY","LOG_LEVEL"]
 		}`),
 	}})

--- a/internal/providers/aws/custom_agent_detector.go
+++ b/internal/providers/aws/custom_agent_detector.go
@@ -26,6 +26,7 @@ type customAgentWorkloadEvidence struct {
 	WorkloadARN     string
 	RuntimeRoleARN  string
 	RuntimeRoleName string
+	RoleKind        string
 	Status          string
 	Names           []string
 	Images          []string
@@ -51,6 +52,18 @@ func deriveCustomAIAgentIdentityAssets(raw []providers.RawAsset) []providers.Raw
 		}
 	}
 
+	// chosen tracks the derived asset already emitted for a sourceID together with
+	// the priority of the evidence that produced it. Multiple raw assets can map to
+	// the same detected agent (an ECS service exposes both an execution-role and a
+	// task-role asset, and the SDK adapter may visit the execution role first). A
+	// higher-priority detection must be able to replace a lower-priority one so the
+	// agent's runs_as edge points at the role the workload actually runs as rather
+	// than at whichever asset happened to be visited first.
+	type chosenDetection struct {
+		index    int
+		priority int
+	}
+	chosen := map[string]chosenDetection{}
 	derived := []providers.RawAsset{}
 	for _, asset := range raw {
 		evidence, ok := customAgentEvidenceFromRawAsset(asset)
@@ -76,15 +89,38 @@ func deriveCustomAIAgentIdentityAssets(raw []providers.RawAsset) []providers.Raw
 		if strings.TrimSpace(collected) == "" && !evidence.CollectedAt.IsZero() {
 			collected = evidence.CollectedAt.UTC().Format(time.RFC3339Nano)
 		}
-		derived = append(derived, providers.RawAsset{
+		newAsset := providers.RawAsset{
 			Kind:      rawKindAIAgentIdentity,
 			SourceID:  sourceID,
 			Payload:   payload,
 			Collected: collected,
-		})
-		existing[sourceID] = struct{}{}
+		}
+		priority := customAgentEvidencePriority(evidence)
+		if prev, exists := chosen[sourceID]; exists {
+			// Keep the higher-priority evidence; otherwise leave the earlier,
+			// deterministic first-wins detection in place.
+			if priority > prev.priority {
+				derived[prev.index] = newAsset
+				chosen[sourceID] = chosenDetection{index: prev.index, priority: priority}
+			}
+			continue
+		}
+		chosen[sourceID] = chosenDetection{index: len(derived), priority: priority}
+		derived = append(derived, newAsset)
 	}
 	return derived
+}
+
+// customAgentEvidencePriority ranks competing workload evidence for the same
+// detected agent so the role the workload actually runs as wins de-duplication.
+// An ECS task role (the identity the container code assumes) outranks an ECS
+// execution role, which is only used by the ECS agent to pull images and secrets.
+func customAgentEvidencePriority(evidence customAgentWorkloadEvidence) int {
+	if evidence.Kind == rawKindECSTaskRole &&
+		strings.EqualFold(strings.TrimSpace(evidence.RoleKind), ecsRoleKindExecution) {
+		return 0
+	}
+	return 1
 }
 
 func customAgentEvidenceFromRawAsset(asset providers.RawAsset) (customAgentWorkloadEvidence, bool) {
@@ -116,6 +152,7 @@ func customAgentEvidenceFromRawAsset(asset providers.RawAsset) (customAgentWorkl
 			mapString(payload, "pod_execution_role_arn"),
 		),
 		RuntimeRoleName: mapString(payload, "role_name"),
+		RoleKind:        mapString(payload, "role_kind"),
 		Status:          firstNonEmptyAWSValue(mapString(payload, "status"), mapString(payload, "resource_status"), mapString(payload, "function_state"), mapString(payload, "service_status"), mapString(payload, "state_machine_status"), mapString(payload, "instance_state")),
 		EnvironmentKeys: mapStringList(payload, "environment_keys"),
 		SecretRefs:      mapStringList(payload, "secret_refs"),

--- a/internal/providers/aws/custom_agent_detector.go
+++ b/internal/providers/aws/custom_agent_detector.go
@@ -70,6 +70,9 @@ func deriveCustomAIAgentIdentityAssets(raw []providers.RawAsset) []providers.Raw
 		if !ok {
 			continue
 		}
+		if customAgentEvidenceIsControlPlaneExecutionRole(evidence) {
+			continue
+		}
 		detection, ok := detectCustomAgentWorkload(evidence)
 		if !ok {
 			continue
@@ -116,11 +119,19 @@ func deriveCustomAIAgentIdentityAssets(raw []providers.RawAsset) []providers.Raw
 // An ECS task role (the identity the container code assumes) outranks an ECS
 // execution role, which is only used by the ECS agent to pull images and secrets.
 func customAgentEvidencePriority(evidence customAgentWorkloadEvidence) int {
-	if evidence.Kind == rawKindECSTaskRole &&
-		strings.EqualFold(strings.TrimSpace(evidence.RoleKind), ecsRoleKindExecution) {
+	if customAgentEvidenceIsControlPlaneExecutionRole(evidence) {
 		return 0
 	}
 	return 1
+}
+
+func customAgentEvidenceIsControlPlaneExecutionRole(evidence customAgentWorkloadEvidence) bool {
+	if evidence.Kind == rawKindECSTaskRole &&
+		strings.EqualFold(strings.TrimSpace(evidence.RoleKind), ecsRoleKindExecution) {
+		return true
+	}
+	return evidence.Kind == rawKindEKSWorkloadIdentity &&
+		strings.EqualFold(strings.TrimSpace(evidence.RoleKind), eksRoleKindFargatePodExecution)
 }
 
 func customAgentEvidenceFromRawAsset(asset providers.RawAsset) (customAgentWorkloadEvidence, bool) {

--- a/internal/providers/aws/custom_agent_detector.go
+++ b/internal/providers/aws/custom_agent_detector.go
@@ -300,6 +300,22 @@ func detectCustomAgentWorkload(evidence customAgentWorkloadEvidence) (customAgen
 }
 
 func customAgentProviderCredentialRefs(evidence customAgentWorkloadEvidence) ([]string, []string) {
+	// Collect the env-var names that are already backed by a sourced secret
+	// reference (for example a CodeBuild `OPENAI_API_KEY=PARAMETER_STORE:...`).
+	// CodeBuild records such variables in both SecretRefs and EnvironmentKeys, so
+	// a bare `OPENAI_API_KEY` env entry must be suppressed here — otherwise the
+	// downstream agent credential mapper (which sees this flattened list only as
+	// `secret_refs`, bypassing credentialCandidateRefs' env-key suppression)
+	// emits both a resolved secret reference and a spurious unresolved
+	// provider-key node/edge for the same variable.
+	sourcedNames := map[string]struct{}{}
+	for _, ref := range evidence.SecretRefs {
+		name, source := splitCredentialReference(strings.TrimSpace(ref))
+		if strings.TrimSpace(source) != "" && strings.TrimSpace(name) != "" {
+			sourcedNames[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+		}
+	}
+
 	refs := []string{}
 	providers := []string{}
 	for _, ref := range append(append([]string{}, evidence.SecretRefs...), evidence.EnvironmentKeys...) {
@@ -310,6 +326,12 @@ func customAgentProviderCredentialRefs(evidence customAgentWorkloadEvidence) ([]
 		name, source := splitCredentialReference(ref)
 		if source == "" && !credentialSuggestiveName(name) {
 			continue
+		}
+		// Skip a bare env key whose value is already sourced from a secret store.
+		if source == "" {
+			if _, sourced := sourcedNames[strings.ToLower(strings.TrimSpace(name))]; sourced {
+				continue
+			}
 		}
 		kind := classifyCredentialReferenceKind(name, source)
 		provider, sensitivity, _ := classifyCredentialProvider(name, source, kind)
@@ -356,9 +378,54 @@ func customAgentLooseAgentSignal(value string) bool {
 
 func customAgentAISignal(value string) bool {
 	probe := strings.ToLower(value)
-	return containsAnyToken(probe,
-		"openai", "anthropic", "claude", "bedrock", "llm", "gpt",
-		"agentcore", "rag", "vector", "embedding")
+	// Distinctive multi-character vendor/technique tokens are safe as substrings.
+	if containsAnyToken(probe,
+		"openai", "anthropic", "claude", "bedrock",
+		"agentcore", "vector", "embedding") {
+		return true
+	}
+	// Short, ambiguous tokens (rag/llm/gpt) only match at word boundaries so they
+	// do not fire on unrelated substrings such as "storage", "fragment",
+	// "allment", or "encryption".
+	return containsAnyWordToken(probe, "rag", "llm", "gpt")
+}
+
+// containsAnyWordToken reports whether any token appears in haystack delimited by
+// non-alphanumeric boundaries (or string ends), avoiding substring false
+// positives for short tokens.
+func containsAnyWordToken(haystack string, tokens ...string) bool {
+	isBoundary := func(r byte) bool {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return false
+		case r >= 'A' && r <= 'Z':
+			return false
+		case r >= '0' && r <= '9':
+			return false
+		default:
+			return true
+		}
+	}
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		for start := 0; ; {
+			idx := strings.Index(haystack[start:], token)
+			if idx < 0 {
+				break
+			}
+			pos := start + idx
+			before := pos == 0 || isBoundary(haystack[pos-1])
+			end := pos + len(token)
+			after := end == len(haystack) || isBoundary(haystack[end])
+			if before && after {
+				return true
+			}
+			start = pos + 1
+		}
+	}
+	return false
 }
 
 func customAgentToolSignal(value string) bool {

--- a/internal/providers/aws/custom_agent_detector.go
+++ b/internal/providers/aws/custom_agent_detector.go
@@ -1,0 +1,446 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+const (
+	customAgentDetectorVersion = "custom-agent-detector-v1"
+	customAgentDetectorSource  = "custom_agent_detector"
+)
+
+type customAgentWorkloadEvidence struct {
+	Kind            string
+	AccountID       string
+	Region          string
+	Service         string
+	WorkloadID      string
+	WorkloadName    string
+	WorkloadType    string
+	WorkloadARN     string
+	RuntimeRoleARN  string
+	RuntimeRoleName string
+	Status          string
+	Names           []string
+	Images          []string
+	EnvironmentKeys []string
+	SecretRefs      []string
+	ResourceRefs    []string
+	Tags            map[string]string
+	CollectedAt     time.Time
+	RawSourceID     string
+}
+
+type customAgentDetection struct {
+	Record  AIAgentIdentity
+	Score   float64
+	Signals []string
+}
+
+func deriveCustomAIAgentIdentityAssets(raw []providers.RawAsset) []providers.RawAsset {
+	existing := map[string]struct{}{}
+	for _, asset := range raw {
+		if asset.Kind == rawKindAIAgentIdentity {
+			existing[strings.TrimSpace(asset.SourceID)] = struct{}{}
+		}
+	}
+
+	derived := []providers.RawAsset{}
+	for _, asset := range raw {
+		evidence, ok := customAgentEvidenceFromRawAsset(asset)
+		if !ok {
+			continue
+		}
+		detection, ok := detectCustomAgentWorkload(evidence)
+		if !ok {
+			continue
+		}
+		sourceID := aiAgentIdentitySourceID(detection.Record)
+		if strings.TrimSpace(sourceID) == "" {
+			continue
+		}
+		if _, exists := existing[sourceID]; exists {
+			continue
+		}
+		payload, err := json.Marshal(detection.Record)
+		if err != nil {
+			continue
+		}
+		collected := asset.Collected
+		if strings.TrimSpace(collected) == "" && !evidence.CollectedAt.IsZero() {
+			collected = evidence.CollectedAt.UTC().Format(time.RFC3339Nano)
+		}
+		derived = append(derived, providers.RawAsset{
+			Kind:      rawKindAIAgentIdentity,
+			SourceID:  sourceID,
+			Payload:   payload,
+			Collected: collected,
+		})
+		existing[sourceID] = struct{}{}
+	}
+	return derived
+}
+
+func customAgentEvidenceFromRawAsset(asset providers.RawAsset) (customAgentWorkloadEvidence, bool) {
+	switch asset.Kind {
+	case rawKindECSTaskRole, rawKindLambdaExecutionRole, rawKindCodeBuildServiceRole,
+		rawKindEKSWorkloadIdentity, rawKindEC2InstanceProfile, rawKindSageMakerWorkloadRole,
+		rawKindStepFunctionsStateMachineRole:
+	default:
+		return customAgentWorkloadEvidence{}, false
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(asset.Payload, &payload); err != nil {
+		return customAgentWorkloadEvidence{}, false
+	}
+	evidence := customAgentWorkloadEvidence{
+		Kind:         asset.Kind,
+		AccountID:    mapString(payload, "account_id"),
+		Region:       mapString(payload, "region"),
+		Service:      firstNonEmptyAWSValue(mapString(payload, "service"), customAgentServiceFromKind(asset.Kind)),
+		WorkloadID:   mapString(payload, "workload_id"),
+		WorkloadName: mapString(payload, "workload_name"),
+		WorkloadType: mapString(payload, "workload_type"),
+		RuntimeRoleARN: firstNonEmptyAWSValue(
+			mapString(payload, "role_arn"),
+			mapString(payload, "task_role_arn"),
+			mapString(payload, "target_role_arn"),
+			mapString(payload, "node_role_arn"),
+			mapString(payload, "pod_execution_role_arn"),
+		),
+		RuntimeRoleName: mapString(payload, "role_name"),
+		Status:          firstNonEmptyAWSValue(mapString(payload, "status"), mapString(payload, "resource_status"), mapString(payload, "function_state"), mapString(payload, "service_status"), mapString(payload, "state_machine_status"), mapString(payload, "instance_state")),
+		EnvironmentKeys: mapStringList(payload, "environment_keys"),
+		SecretRefs:      mapStringList(payload, "secret_refs"),
+		Tags:            mapStringMap(payload, "tags"),
+		RawSourceID:     strings.TrimSpace(asset.SourceID),
+	}
+	evidence.CollectedAt = mapTime(payload, "collected_at")
+	if evidence.WorkloadID == "" {
+		evidence.WorkloadID = firstNonEmptyAWSValue(
+			mapString(payload, "service_arn"),
+			mapString(payload, "function_arn"),
+			mapString(payload, "project_arn"),
+			mapString(payload, "association_arn"),
+			mapString(payload, "kubernetes_subject"),
+			mapString(payload, "instance_arn"),
+			mapString(payload, "instance_id"),
+			mapString(payload, "workload_arn"),
+			mapString(payload, "state_machine_arn"),
+			evidence.RawSourceID,
+		)
+	}
+	evidence.WorkloadARN = firstNonEmptyAWSValue(
+		mapString(payload, "workload_arn"),
+		mapString(payload, "service_arn"),
+		mapString(payload, "function_arn"),
+		mapString(payload, "project_arn"),
+		mapString(payload, "association_arn"),
+		mapString(payload, "instance_arn"),
+		mapString(payload, "resource_arn"),
+		mapString(payload, "state_machine_arn"),
+	)
+	if evidence.WorkloadName == "" {
+		evidence.WorkloadName = firstNonEmptyAWSValue(
+			mapString(payload, "service_name"),
+			mapString(payload, "function_name"),
+			mapString(payload, "project_name"),
+			mapString(payload, "service_account"),
+			mapString(payload, "instance_name"),
+			mapString(payload, "resource_type"),
+			mapString(payload, "state_machine_name"),
+			evidence.WorkloadID,
+		)
+	}
+	if evidence.WorkloadType == "" {
+		evidence.WorkloadType = customAgentWorkloadTypeFromKind(asset.Kind)
+	}
+
+	evidence.Images = append(evidence.Images, mapStringList(payload, "container_images")...)
+	evidence.Images = append(evidence.Images, mapStringList(payload, "image_uris")...)
+	if image := mapString(payload, "image"); image != "" {
+		evidence.Images = append(evidence.Images, image)
+	}
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "task_resource_arns")...)
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "service_integration_resources")...)
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "s3_references")...)
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "kms_key_arns")...)
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "layer_arns")...)
+	evidence.ResourceRefs = append(evidence.ResourceRefs, mapStringList(payload, "selector_labels")...)
+	evidence.Names = append(evidence.Names,
+		evidence.WorkloadID,
+		evidence.WorkloadName,
+		evidence.WorkloadType,
+		evidence.RuntimeRoleName,
+		mapString(payload, "cluster_name"),
+		mapString(payload, "task_definition_family"),
+		mapString(payload, "handler"),
+		mapString(payload, "runtime"),
+		mapString(payload, "project_description"),
+		mapString(payload, "namespace"),
+		mapString(payload, "service_account"),
+		mapString(payload, "kubernetes_subject"),
+		mapString(payload, "nodegroup_name"),
+		mapString(payload, "fargate_profile_name"),
+		mapString(payload, "launch_template_name"),
+		mapString(payload, "resource_type"),
+		mapString(payload, "description"),
+	)
+	for key, value := range evidence.Tags {
+		evidence.Names = append(evidence.Names, key, value)
+	}
+	return evidence, evidence.WorkloadID != "" && evidence.RuntimeRoleARN != ""
+}
+
+func detectCustomAgentWorkload(evidence customAgentWorkloadEvidence) (customAgentDetection, bool) {
+	credentialRefs, providers := customAgentProviderCredentialRefs(evidence)
+	signals := []string{}
+	capabilities := []string{customAgentDetectorVersion}
+	score := 0.0
+
+	agentProbe := strings.Join(append(append([]string{}, evidence.Names...), evidence.Images...), " ")
+	agentProbe = strings.TrimSpace(agentProbe + " " + strings.Join(evidence.ResourceRefs, " "))
+	if customAgentExplicitAgentSignal(agentProbe) {
+		score += 0.45
+		signals = append(signals, "agent_name_or_runtime_metadata")
+		capabilities = appendUnique(capabilities, "custom_agent_metadata")
+	} else if customAgentLooseAgentSignal(agentProbe) {
+		score += 0.25
+		signals = append(signals, "agent_keyword")
+		capabilities = appendUnique(capabilities, "custom_agent_keyword")
+	}
+	if customAgentAISignal(agentProbe) {
+		score += 0.25
+		signals = append(signals, "ai_runtime_metadata")
+		capabilities = appendUnique(capabilities, "ai_runtime_metadata")
+	}
+	if len(credentialRefs) > 0 {
+		score += 0.30
+		signals = append(signals, "external_provider_key_reference")
+		capabilities = appendUnique(capabilities, "external_provider_key")
+	}
+	if len(evidence.Images) > 0 && customAgentAISignal(strings.Join(evidence.Images, " ")) {
+		score += 0.10
+		signals = append(signals, "container_image")
+		capabilities = appendUnique(capabilities, "container_image_signal")
+	}
+	if evidence.RuntimeRoleARN != "" {
+		score += 0.10
+		signals = append(signals, "runtime_role_binding")
+		capabilities = appendUnique(capabilities, "role_binding")
+	}
+	if customAgentToolSignal(agentProbe) {
+		score += 0.05
+		signals = append(signals, "tool_or_action_metadata")
+		capabilities = appendUnique(capabilities, "tool_use")
+	}
+	if score > 0.95 {
+		score = 0.95
+	}
+	if score < 0.55 {
+		return customAgentDetection{}, false
+	}
+
+	status := "candidate"
+	coverageStatus := "candidate"
+	coverageReason := fmt.Sprintf("custom agent detector matched %s", strings.Join(dedupeStrings(signals), ", "))
+	if score >= 0.75 {
+		status = "ready"
+		coverageStatus = "covered"
+		coverageReason = ""
+	}
+	externalProvider := "custom"
+	provider := "custom"
+	if len(providers) > 0 {
+		externalProvider = providers[0]
+		provider = "external_provider"
+	}
+
+	record := AIAgentIdentity{
+		ServiceCollectorRecord: awscontract.ServiceCollectorRecord{
+			AccountID:     evidence.AccountID,
+			Region:        evidence.Region,
+			Service:       evidence.Service,
+			WorkloadID:    evidence.WorkloadID,
+			WorkloadName:  evidence.WorkloadName,
+			WorkloadType:  evidence.WorkloadType,
+			RoleARN:       evidence.RuntimeRoleARN,
+			Source:        customAgentDetectorSource,
+			EvidenceRef:   firstNonEmptyAWSValue(evidence.WorkloadARN, evidence.WorkloadID, evidence.RawSourceID),
+			Confidence:    score,
+			CollectorName: aiAgentIdentityCollectorName,
+			CollectedAt:   evidence.CollectedAt,
+		},
+		AgentID:                 evidence.WorkloadID,
+		AgentARN:                evidence.WorkloadARN,
+		AgentName:               evidence.WorkloadName,
+		AgentType:               "custom_agent",
+		Provider:                provider,
+		RuntimeRoleARN:          evidence.RuntimeRoleARN,
+		RuntimeRoleName:         firstNonEmptyAWSValue(evidence.RuntimeRoleName, roleNameFromARN(evidence.RuntimeRoleARN)),
+		RuntimeRoleAccountID:    roleAccountIDFromARN(evidence.RuntimeRoleARN),
+		ExternalProvider:        externalProvider,
+		CapabilityNames:         dedupeStrings(capabilities),
+		CredentialReferenceRefs: credentialRefs,
+		ResourceReferenceRefs:   customAgentResourceRefs(evidence),
+		SensitiveBoundary:       "metadata_only",
+		CoverageStatus:          coverageStatus,
+		CoverageReason:          coverageReason,
+		Status:                  status,
+		Tags:                    customAgentDetectorTags(evidence, score, signals),
+	}
+	return customAgentDetection{Record: record, Score: score, Signals: dedupeStrings(signals)}, true
+}
+
+func customAgentProviderCredentialRefs(evidence customAgentWorkloadEvidence) ([]string, []string) {
+	refs := []string{}
+	providers := []string{}
+	for _, ref := range append(append([]string{}, evidence.SecretRefs...), evidence.EnvironmentKeys...) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		name, source := splitCredentialReference(ref)
+		if source == "" && !credentialSuggestiveName(name) {
+			continue
+		}
+		kind := classifyCredentialReferenceKind(name, source)
+		provider, sensitivity, _ := classifyCredentialProvider(name, source, kind)
+		if sensitivity != credentialSensitivityAIProviderKey {
+			continue
+		}
+		refs = append(refs, ref)
+		providers = appendUnique(providers, provider)
+	}
+	return dedupeStrings(refs), dedupeStrings(providers)
+}
+
+func customAgentResourceRefs(evidence customAgentWorkloadEvidence) []string {
+	refs := []string{evidence.WorkloadARN, evidence.WorkloadID}
+	refs = append(refs, evidence.Images...)
+	refs = append(refs, evidence.ResourceRefs...)
+	return dedupeStrings(refs)
+}
+
+func customAgentDetectorTags(evidence customAgentWorkloadEvidence, score float64, signals []string) map[string]string {
+	tags := copyTags(evidence.Tags)
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	tags["detector"] = customAgentDetectorVersion
+	tags["detector_score"] = fmt.Sprintf("%.2f", score)
+	tags["detector_signals"] = strings.Join(dedupeStrings(signals), ",")
+	tags["detector_source_kind"] = evidence.Kind
+	return tags
+}
+
+func customAgentExplicitAgentSignal(value string) bool {
+	probe := strings.ToLower(value)
+	return containsAnyToken(probe,
+		"ai-agent", "ai_agent", "agentic", "assistant", "copilot",
+		"langchain", "llm-agent", "llm_agent", "crewai", "autogen",
+		"semantic-kernel", "semantic_kernel", "bedrock-agent")
+}
+
+func customAgentLooseAgentSignal(value string) bool {
+	probe := strings.ToLower(value)
+	return containsAnyToken(probe, "agent", "planner", "orchestrator", "reasoner")
+}
+
+func customAgentAISignal(value string) bool {
+	probe := strings.ToLower(value)
+	return containsAnyToken(probe,
+		"openai", "anthropic", "claude", "bedrock", "llm", "gpt",
+		"agentcore", "rag", "vector", "embedding")
+}
+
+func customAgentToolSignal(value string) bool {
+	probe := strings.ToLower(value)
+	return containsAnyToken(probe, "tool", "mcp", "action", "function_call", "function-call")
+}
+
+func customAgentServiceFromKind(kind string) string {
+	switch kind {
+	case rawKindECSTaskRole:
+		return ecsServiceName
+	case rawKindLambdaExecutionRole:
+		return lambdaServiceName
+	case rawKindCodeBuildServiceRole:
+		return codeBuildServiceName
+	case rawKindEKSWorkloadIdentity:
+		return eksServiceName
+	case rawKindEC2InstanceProfile:
+		return ec2ServiceName
+	case rawKindSageMakerWorkloadRole:
+		return sageMakerServiceName
+	case rawKindStepFunctionsStateMachineRole:
+		return stepFunctionsServiceName
+	default:
+		return "aws"
+	}
+}
+
+func customAgentWorkloadTypeFromKind(kind string) string {
+	switch kind {
+	case rawKindECSTaskRole:
+		return "ecs_service"
+	case rawKindLambdaExecutionRole:
+		return "lambda_function"
+	case rawKindCodeBuildServiceRole:
+		return "codebuild_project"
+	case rawKindEKSWorkloadIdentity:
+		return "eks_workload"
+	case rawKindEC2InstanceProfile:
+		return "ec2_instance"
+	case rawKindSageMakerWorkloadRole:
+		return "sagemaker_workload"
+	case rawKindStepFunctionsStateMachineRole:
+		return "stepfunctions_state_machine"
+	default:
+		return "aws_workload"
+	}
+}
+
+func mapString(payload map[string]any, key string) string {
+	if value, ok := payload[key].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func mapStringList(payload map[string]any, key string) []string {
+	return normalizeStringList(parseStringList(payload[key]))
+}
+
+func mapStringMap(payload map[string]any, key string) map[string]string {
+	raw, ok := payload[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := map[string]string{}
+	for key, value := range raw {
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			out[strings.TrimSpace(key)] = strings.TrimSpace(s)
+		}
+	}
+	return out
+}
+
+func mapTime(payload map[string]any, key string) time.Time {
+	raw := mapString(payload, key)
+	if raw == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}

--- a/internal/providers/aws/custom_agent_detector_test.go
+++ b/internal/providers/aws/custom_agent_detector_test.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/providers/awscontract"
+)
+
+func TestCustomAgentDetectorFindsAWSWorkloadSignals(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	role := "arn:aws:iam::123456789012:role/custom-agent-runtime"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs", ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: role, WorkloadID: "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant", WorkloadName: "support-assistant", WorkloadType: "ecs_service", CollectedAt: now},
+			RoleKind:               ecsRoleKindTask,
+			ServiceARN:             "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant",
+			ServiceName:            "support-assistant",
+			ContainerImages:        []string{"123456789012.dkr.ecr.us-east-1.amazonaws.com/langchain-agent:prod"},
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+		}),
+		rawAsset(t, rawKindLambdaExecutionRole, "lambda", LambdaExecutionRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "lambda", RoleARN: role, WorkloadID: "arn:aws:lambda:us-east-1:123456789012:function:invoice-agent", WorkloadName: "invoice-agent", WorkloadType: "lambda_function", CollectedAt: now},
+			FunctionARN:            "arn:aws:lambda:us-east-1:123456789012:function:invoice-agent",
+			FunctionName:           "invoice-agent",
+			Runtime:                "python3.13",
+			Handler:                "agent.handler",
+			EnvironmentKeys:        []string{"ANTHROPIC_API_KEY"},
+		}),
+		rawAsset(t, rawKindCodeBuildServiceRole, "codebuild", CodeBuildServiceRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "codebuild", RoleARN: role, WorkloadID: "arn:aws:codebuild:us-east-1:123456789012:project/agent-eval-builder", WorkloadName: "agent-eval-builder", WorkloadType: "codebuild_project", CollectedAt: now},
+			ProjectARN:             "arn:aws:codebuild:us-east-1:123456789012:project/agent-eval-builder",
+			ProjectName:            "agent-eval-builder",
+			Image:                  "aws/codebuild/standard:llm-agent",
+			EnvironmentKeys:        []string{"BEDROCK_API_KEY"},
+		}),
+		rawAsset(t, rawKindEKSWorkloadIdentity, "eks", EKSWorkloadIdentity{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "eks", RoleARN: role, WorkloadID: "system:serviceaccount:ai:research-agent", WorkloadName: "research-agent", WorkloadType: "eks_workload", CollectedAt: now},
+			RoleKind:               eksRoleKindIRSA,
+			ClusterName:            "prod",
+			Namespace:              "ai",
+			ServiceAccount:         "research-agent",
+			KubernetesSubject:      "system:serviceaccount:ai:research-agent",
+			Tags:                   map[string]string{"app": "ai-agent"},
+		}),
+		rawAsset(t, rawKindEC2InstanceProfile, "ec2", EC2InstanceProfile{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ec2", RoleARN: role, WorkloadID: "i-1234567890abcdef0", WorkloadName: "langchain-agent-runner", WorkloadType: "ec2_instance", CollectedAt: now},
+			InstanceID:             "i-1234567890abcdef0",
+			InstanceName:           "langchain-agent-runner",
+			Tags:                   map[string]string{"workload": "ai-agent"},
+		}),
+		rawAsset(t, rawKindSageMakerWorkloadRole, "sagemaker", SageMakerWorkloadRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "sagemaker", RoleARN: role, WorkloadID: "arn:aws:sagemaker:us-east-1:123456789012:model/customer-llm-agent", WorkloadName: "customer-llm-agent", WorkloadType: "sagemaker_workload", CollectedAt: now},
+			WorkloadARN:            "arn:aws:sagemaker:us-east-1:123456789012:model/customer-llm-agent",
+			ResourceType:           "model",
+			ImageURIs:              []string{"123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-agent:prod"},
+		}),
+		rawAsset(t, rawKindStepFunctionsStateMachineRole, "stepfunctions", StepFunctionsStateMachineRole{
+			ServiceCollectorRecord:      awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "stepfunctions", RoleARN: role, WorkloadID: "arn:aws:states:us-east-1:123456789012:stateMachine:bedrock-agent-orchestrator", WorkloadName: "bedrock-agent-orchestrator", WorkloadType: "stepfunctions_state_machine", CollectedAt: now},
+			StateMachineARN:             "arn:aws:states:us-east-1:123456789012:stateMachine:bedrock-agent-orchestrator",
+			StateMachineName:            "bedrock-agent-orchestrator",
+			ServiceIntegrationResources: []string{"arn:aws:states:::bedrock:invokeModel"},
+		}),
+	}
+
+	derived := deriveCustomAIAgentIdentityAssets(raw)
+	if len(derived) != 7 {
+		t.Fatalf("expected seven custom agent detections, got %d: %+v", len(derived), derived)
+	}
+
+	services := map[string]AIAgentIdentity{}
+	for _, asset := range derived {
+		var record AIAgentIdentity
+		if err := json.Unmarshal(asset.Payload, &record); err != nil {
+			t.Fatalf("decode derived ai agent: %v", err)
+		}
+		services[record.Service] = record
+		if record.AgentType != "custom_agent" || record.AgentID == "" || record.RuntimeRoleARN == "" {
+			t.Fatalf("derived record missing custom identity fields: %+v", record)
+		}
+		if record.Tags["detector"] != customAgentDetectorVersion {
+			t.Fatalf("expected detector tag on %+v", record)
+		}
+		if record.SensitiveBoundary != "metadata_only" {
+			t.Fatalf("expected metadata-only boundary, got %+v", record)
+		}
+	}
+	for _, service := range []string{"ecs", "lambda", "codebuild", "eks", "ec2", "sagemaker", "stepfunctions"} {
+		if _, ok := services[service]; !ok {
+			t.Fatalf("missing custom agent detection for service %q in %+v", service, services)
+		}
+	}
+	if !containsString(services["ecs"].CredentialReferenceRefs, "OPENAI_API_KEY") {
+		t.Fatalf("expected ECS provider key ref, got %+v", services["ecs"].CredentialReferenceRefs)
+	}
+	if services["eks"].Status != "candidate" {
+		t.Fatalf("expected weak EKS metadata-only signal to stay candidate, got %+v", services["eks"])
+	}
+}
+
+func TestCustomAgentDetectorSkipsGenericCredentialWorkload(t *testing.T) {
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindLambdaExecutionRole, "lambda-generic", LambdaExecutionRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "lambda", RoleARN: "arn:aws:iam::123456789012:role/payments-api", WorkloadID: "arn:aws:lambda:us-east-1:123456789012:function:payments-api", WorkloadName: "payments-api", WorkloadType: "lambda_function"},
+			FunctionARN:            "arn:aws:lambda:us-east-1:123456789012:function:payments-api",
+			FunctionName:           "payments-api",
+			EnvironmentKeys:        []string{"DATABASE_URL"},
+		}),
+	}
+	if derived := deriveCustomAIAgentIdentityAssets(raw); len(derived) != 0 {
+		t.Fatalf("expected no generic workload detection, got %+v", derived)
+	}
+}
+
+func TestRoleNormalizerDerivesCustomAgentCredentialGraph(t *testing.T) {
+	role := "arn:aws:iam::123456789012:role/support-agent-task"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs-agent", ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: role, WorkloadID: "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant", WorkloadName: "support-assistant", WorkloadType: "ecs_service"},
+			RoleKind:               ecsRoleKindTask,
+			ServiceARN:             "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant",
+			ServiceName:            "support-assistant",
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+		}),
+	}
+
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("normalize custom agent workload: %v", err)
+	}
+	if len(bundle.Agents) != 1 {
+		t.Fatalf("expected one derived custom agent, got %+v", bundle.Agents)
+	}
+	agent := bundle.Agents[0]
+	if agent.Type != domain.AgentTypeAI || agent.Metadata["agent_type"] != "custom_agent" {
+		t.Fatalf("expected custom ai agent, got %+v", agent)
+	}
+	refs, _ := MapBundleCredentialReferences(bundle)
+	ref, ok := findCredentialReference(refs, "OPENAI_API_KEY")
+	if !ok {
+		t.Fatalf("expected mapped provider key reference, got %+v", refs)
+	}
+	if ref.WorkloadID != agent.ID || ref.TargetNodeID == "" {
+		t.Fatalf("expected credential ref anchored to agent %q, got %+v", agent.ID, ref)
+	}
+	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
+	if err != nil {
+		t.Fatalf("resolve relationships: %v", err)
+	}
+	foundRunsAs := false
+	foundUsesSecret := false
+	for _, relationship := range relationships {
+		if relationship.Type == domain.RelationshipRunsAs && relationship.FromNodeID == agent.ID {
+			foundRunsAs = true
+		}
+		if relationship.Type == domain.RelationshipUsesSecret && relationship.FromNodeID == agent.ID && relationship.ToNodeID == ref.TargetNodeID {
+			foundUsesSecret = true
+		}
+	}
+	if !foundRunsAs || !foundUsesSecret {
+		t.Fatalf("expected runs_as and uses_secret for derived agent, got %+v", relationships)
+	}
+}
+
+func rawAsset(t *testing.T, kind string, sourceID string, record any) providers.RawAsset {
+	t.Helper()
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal raw asset %s: %v", sourceID, err)
+	}
+	return providers.RawAsset{Kind: kind, SourceID: sourceID, Payload: payload}
+}

--- a/internal/providers/aws/custom_agent_detector_test.go
+++ b/internal/providers/aws/custom_agent_detector_test.go
@@ -303,6 +303,42 @@ func TestCustomAgentDetectorPrefersECSTaskRoleOverExecutionRole(t *testing.T) {
 	}
 }
 
+func TestCustomAgentDetectorSkipsECSExecutionRoleOnly(t *testing.T) {
+	executionRole := "arn:aws:iam::123456789012:role/support-assistant-exec"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs-exec", ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: executionRole, WorkloadID: "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant", WorkloadName: "support-assistant", WorkloadType: "ecs_service"},
+			RoleKind:               ecsRoleKindExecution,
+			ServiceARN:             "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant",
+			ServiceName:            "support-assistant",
+			ContainerImages:        []string{"123456789012.dkr.ecr.us-east-1.amazonaws.com/langchain-agent:prod"},
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+		}),
+	}
+	if derived := deriveCustomAIAgentIdentityAssets(raw); len(derived) != 0 {
+		t.Fatalf("expected execution-role-only ECS evidence to be skipped, got %+v", derived)
+	}
+}
+
+func TestCustomAgentDetectorSkipsEKSFargatePodExecutionRole(t *testing.T) {
+	podExecutionRole := "arn:aws:iam::123456789012:role/prod-fargate-pod-exec"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindEKSWorkloadIdentity, "eks-fargate", EKSWorkloadIdentity{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "eks", RoleARN: podExecutionRole, WorkloadID: "arn:aws:eks:us-east-1:123456789012:fargateprofile/prod/ai-agents", WorkloadName: "ai-agents", WorkloadType: "eks_fargate_pod_execution_role"},
+			RoleKind:               eksRoleKindFargatePodExecution,
+			ClusterName:            "prod",
+			FargateProfileARN:      "arn:aws:eks:us-east-1:123456789012:fargateprofile/prod/ai-agents",
+			FargateProfileName:     "ai-agents",
+			PodExecutionRoleARN:    podExecutionRole,
+			SelectorLabels:         []string{"workload=ai-agent"},
+			Tags:                   map[string]string{"workload": "ai-agent"},
+		}),
+	}
+	if derived := deriveCustomAIAgentIdentityAssets(raw); len(derived) != 0 {
+		t.Fatalf("expected EKS Fargate pod execution role evidence to be skipped, got %+v", derived)
+	}
+}
+
 func rawAsset(t *testing.T, kind string, sourceID string, record any) providers.RawAsset {
 	t.Helper()
 	payload, err := json.Marshal(record)

--- a/internal/providers/aws/custom_agent_detector_test.go
+++ b/internal/providers/aws/custom_agent_detector_test.go
@@ -166,6 +166,107 @@ func TestRoleNormalizerDerivesCustomAgentCredentialGraph(t *testing.T) {
 	}
 }
 
+func TestCustomAgentAISignalUsesWordBoundariesForShortTokens(t *testing.T) {
+	// Short, ambiguous tokens must only match at word boundaries so they do not
+	// fire on unrelated substrings.
+	for _, value := range []string{"storage-service", "fragment-cache", "gptable-store", "allment", "rage"} {
+		if customAgentAISignal(value) {
+			t.Fatalf("expected no AI signal for %q", value)
+		}
+	}
+	// Delimited short tokens and distinctive vendor substrings must still match.
+	for _, value := range []string{"rag-pipeline", "team_llm", "gpt.runner", "openai-proxy", "vector-index"} {
+		if !customAgentAISignal(value) {
+			t.Fatalf("expected AI signal for %q", value)
+		}
+	}
+}
+
+func TestCustomAgentProviderRefsDedupesSecretBackedEnvKeys(t *testing.T) {
+	// A CodeBuild project records OPENAI_API_KEY both as a sourced secret ref and
+	// as a bare environment key. The bare key must be suppressed so the downstream
+	// mapper does not emit a spurious unresolved provider-key node alongside the
+	// resolved secret reference.
+	evidence := customAgentWorkloadEvidence{
+		EnvironmentKeys: []string{"OPENAI_API_KEY"},
+		SecretRefs:      []string{"OPENAI_API_KEY=PARAMETER_STORE:arn:aws:ssm:us-east-1:123456789012:parameter/openai"},
+	}
+	refs, providers := customAgentProviderCredentialRefs(evidence)
+	if len(refs) != 1 {
+		t.Fatalf("expected single deduped provider ref, got %+v", refs)
+	}
+	if _, source := splitCredentialReference(refs[0]); source == "" {
+		t.Fatalf("expected the sourced secret ref to win, got bare key %q", refs[0])
+	}
+	if len(providers) != 1 || providers[0] != "openai" {
+		t.Fatalf("expected single openai provider, got %+v", providers)
+	}
+}
+
+func TestCustomAgentCredentialReferenceCarriesAgentWorkloadType(t *testing.T) {
+	role := "arn:aws:iam::123456789012:role/support-agent-task"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs-agent", ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: role, WorkloadID: "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant", WorkloadName: "support-assistant", WorkloadType: "ecs_service"},
+			RoleKind:               ecsRoleKindTask,
+			ServiceARN:             "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant",
+			ServiceName:            "support-assistant",
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+		}),
+	}
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("normalize custom agent workload: %v", err)
+	}
+	if len(bundle.Agents) != 1 {
+		t.Fatalf("expected one derived custom agent, got %+v", bundle.Agents)
+	}
+	agent := bundle.Agents[0]
+	refs, _ := MapBundleCredentialReferences(bundle)
+	ref, ok := findCredentialReference(refs, "OPENAI_API_KEY")
+	if !ok {
+		t.Fatalf("expected mapped provider key reference, got %+v", refs)
+	}
+	if ref.WorkloadType != string(agent.Type) {
+		t.Fatalf("expected credential ref workload_type %q, got %q", string(agent.Type), ref.WorkloadType)
+	}
+}
+
+func TestCustomAgentNormalizationPreservesWorkloadRoleIdentity(t *testing.T) {
+	// The agent's runtime role is only present as an ECS asset (never as a
+	// standalone iam_role asset). The richer workload-role identity (with tags) must
+	// survive AI-agent normalization rather than be shadowed by the agent's minimal
+	// runtime-role identity.
+	role := "arn:aws:iam::123456789012:role/support-agent-task"
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs-agent", ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: role, WorkloadID: "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant", WorkloadName: "support-assistant", WorkloadType: "ecs_service"},
+			RoleKind:               ecsRoleKindTask,
+			ServiceARN:             "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant",
+			ServiceName:            "support-assistant",
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+			Tags:                   map[string]string{"team": "support", "workload": "ai-agent"},
+		}),
+	}
+	bundle, err := NewRoleNormalizer().Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("normalize custom agent workload: %v", err)
+	}
+	var identity *domain.Identity
+	for i := range bundle.Identities {
+		if bundle.Identities[i].ARN == role {
+			identity = &bundle.Identities[i]
+			break
+		}
+	}
+	if identity == nil {
+		t.Fatalf("expected runtime-role identity for %q, got %+v", role, bundle.Identities)
+	}
+	if identity.Tags["team"] != "support" || identity.Tags["workload"] != "ai-agent" {
+		t.Fatalf("expected workload-role tags to win over agent runtime identity, got %+v", identity.Tags)
+	}
+}
+
 func rawAsset(t *testing.T, kind string, sourceID string, record any) providers.RawAsset {
 	t.Helper()
 	payload, err := json.Marshal(record)

--- a/internal/providers/aws/custom_agent_detector_test.go
+++ b/internal/providers/aws/custom_agent_detector_test.go
@@ -267,6 +267,42 @@ func TestCustomAgentNormalizationPreservesWorkloadRoleIdentity(t *testing.T) {
 	}
 }
 
+func TestCustomAgentDetectorPrefersECSTaskRoleOverExecutionRole(t *testing.T) {
+	// The ECS SDK adapter sorts assets so the execution-role record is visited
+	// before the task-role record for the same service. De-duplication must still
+	// attribute the agent to the task role (what the container code runs as) rather
+	// than the execution role (used only for image/secret retrieval).
+	taskRole := "arn:aws:iam::123456789012:role/support-assistant-task"
+	executionRole := "arn:aws:iam::123456789012:role/support-assistant-exec"
+	service := "arn:aws:ecs:us-east-1:123456789012:service/prod/support-assistant"
+	base := func(roleKind, roleARN string) ECSTaskRole {
+		return ECSTaskRole{
+			ServiceCollectorRecord: awscontract.ServiceCollectorRecord{AccountID: "123456789012", Region: "us-east-1", Service: "ecs", RoleARN: roleARN, WorkloadID: service, WorkloadName: "support-assistant", WorkloadType: "ecs_service"},
+			RoleKind:               roleKind,
+			ServiceARN:             service,
+			ServiceName:            "support-assistant",
+			ContainerImages:        []string{"123456789012.dkr.ecr.us-east-1.amazonaws.com/langchain-agent:prod"},
+			EnvironmentKeys:        []string{"OPENAI_API_KEY"},
+		}
+	}
+	// Execution role first, then task role — matching the SDK adapter ordering.
+	raw := []providers.RawAsset{
+		rawAsset(t, rawKindECSTaskRole, "ecs-exec", base(ecsRoleKindExecution, executionRole)),
+		rawAsset(t, rawKindECSTaskRole, "ecs-task", base(ecsRoleKindTask, taskRole)),
+	}
+	derived := deriveCustomAIAgentIdentityAssets(raw)
+	if len(derived) != 1 {
+		t.Fatalf("expected one deduped detection, got %d: %+v", len(derived), derived)
+	}
+	var record AIAgentIdentity
+	if err := json.Unmarshal(derived[0].Payload, &record); err != nil {
+		t.Fatalf("decode derived ai agent: %v", err)
+	}
+	if record.RuntimeRoleARN != taskRole {
+		t.Fatalf("expected agent to run as task role %q, got %q", taskRole, record.RuntimeRoleARN)
+	}
+}
+
 func rawAsset(t *testing.T, kind string, sourceID string, record any) providers.RawAsset {
 	t.Helper()
 	payload, err := json.Marshal(record)

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -31,6 +31,9 @@ func NewRoleNormalizer() *RoleNormalizer {
 
 // Normalize converts AWS role and workload assets to normalized entities.
 func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset) (providers.NormalizedBundle, error) {
+	if derived := deriveCustomAIAgentIdentityAssets(raw); len(derived) > 0 {
+		raw = append(append([]providers.RawAsset{}, raw...), derived...)
+	}
 	bundle := providers.NormalizedBundle{
 		Identities: make([]domain.Identity, 0, len(raw)),
 		Policies:   make([]domain.Policy, 0, len(raw)*2),
@@ -364,6 +367,8 @@ func normalizeAIAgentIdentityAsset(asset providers.RawAsset, index int, bundle *
 			RawRef:   asset.SourceID,
 			Metadata: map[string]any{
 				"agent_arn":                   strings.TrimSpace(record.AgentARN),
+				"account_id":                  strings.TrimSpace(record.AccountID),
+				"region":                      strings.TrimSpace(record.Region),
 				"agent_type":                  strings.TrimSpace(record.AgentType),
 				"provider":                    strings.TrimSpace(record.Provider),
 				"runtime_version":             strings.TrimSpace(record.RuntimeVersion),

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -99,18 +99,6 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 		if err := ctx.Err(); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
-		if asset.Kind != rawKindAIAgentIdentity {
-			continue
-		}
-		if err := normalizeAIAgentIdentityAsset(asset, i, &bundle, identitySeen, agentSeen, resourceSeen); err != nil {
-			return providers.NormalizedBundle{}, err
-		}
-	}
-
-	for i, asset := range raw {
-		if err := ctx.Err(); err != nil {
-			return providers.NormalizedBundle{}, err
-		}
 		if asset.Kind != rawKindEC2InstanceProfile {
 			continue
 		}
@@ -283,6 +271,23 @@ func (n *RoleNormalizer) Normalize(ctx context.Context, raw []providers.RawAsset
 			continue
 		}
 		if err := normalizeDynamoDBRDSReachabilityAsset(asset, i, &bundle, identitySeen, resourceSeen, policySeen); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+	}
+
+	// AI agent identities (including custom-agent detections derived from the
+	// workload assets above) are normalized last so the richer workload-role
+	// identities (with tags/owner) win in identitySeen. Running this earlier would
+	// let the agent's minimal runtime-role identity shadow a workload role that is
+	// only present as an ECS/Lambda/etc. asset and never as an iam_role asset.
+	for i, asset := range raw {
+		if err := ctx.Err(); err != nil {
+			return providers.NormalizedBundle{}, err
+		}
+		if asset.Kind != rawKindAIAgentIdentity {
+			continue
+		}
+		if err := normalizeAIAgentIdentityAsset(asset, i, &bundle, identitySeen, agentSeen, resourceSeen); err != nil {
 			return providers.NormalizedBundle{}, err
 		}
 	}

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -262,12 +262,8 @@ func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 	}
 
 	refs, _ := MapBundleCredentialReferences(bundle)
-	credential, ok := findCredentialReference(refs, credentialRef)
-	if !ok {
-		t.Fatalf("expected gateway tool credential reference %q, got %+v", credentialRef, refs)
-	}
-	if credential.WorkloadID != toolSourceEntityID {
-		t.Fatalf("expected credential reference workload %q, got %q", toolSourceEntityID, credential.WorkloadID)
+	if _, ok := findCredentialReference(refs, credentialRef); ok {
+		t.Fatalf("expected AgentCore credential-provider ARN to stay metadata-only, got %+v", refs)
 	}
 
 	relationships, err := NewRelationshipBuilder().ResolveRelationships(context.Background(), bundle, nil)
@@ -280,15 +276,15 @@ func TestRoleNormalizerEmitsGatewayToolResourcesAndRelationships(t *testing.T) {
 		if relationship.Type == domain.RelationshipCallsTool && relationship.ToNodeID == toolResourceID {
 			foundCallsTool = true
 		}
-		if relationship.Type == domain.RelationshipUsesSecret && relationship.FromNodeID == toolSourceEntityID && relationship.ToNodeID == credential.TargetNodeID {
+		if relationship.Type == domain.RelationshipUsesSecret && relationship.FromNodeID == toolSourceEntityID {
 			foundUsesSecret = true
 		}
 	}
 	if !foundCallsTool {
 		t.Fatalf("expected calls_tool relationship to %q, got %+v", toolResourceID, relationships)
 	}
-	if !foundUsesSecret {
-		t.Fatalf("expected uses_secret relationship from %q to %q, got %+v", toolSourceEntityID, credential.TargetNodeID, relationships)
+	if foundUsesSecret {
+		t.Fatalf("expected no uses_secret relationship for AgentCore credential-provider metadata from %q, got %+v", toolSourceEntityID, relationships)
 	}
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3821,6 +3821,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'Bedrock agents', value: 'bedrock-agents' },
         { label: 'AgentCore runtime', value: 'agentcore-runtime' },
         { label: 'AgentCore capabilities', value: 'agentcore-capabilities' },
+        { label: 'Custom agents', value: 'custom-agents' },
         { label: 'MCP gateway', value: 'mcp-gateway' },
         { label: 'External provider keys', value: 'external-provider-keys' }
       ]
@@ -3839,7 +3840,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
     {
       id: 'status',
       label: 'Status',
-      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Degraded', value: 'degraded' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
+      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Candidate', value: 'candidate' }, { label: 'Degraded', value: 'degraded' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
     }
   ],
   resources: [
@@ -6699,6 +6700,12 @@ function AWSAgentIdentitiesContent({
               detail={`${inventory.gateway_count} gateways`}
             />
             <DomainCoverageCard
+              label="Custom agents"
+              scanned={inventory.custom_agent_count}
+              total={Math.max(inventory.record_count, 1)}
+              detail={`${inventory.external_agent_count} external-provider agents`}
+            />
+            <DomainCoverageCard
               label="Tools"
               scanned={inventory.tool_count}
               total={Math.max(inventory.tool_count, 1)}
@@ -7100,9 +7107,10 @@ function buildAWSAIAgentIdentityRows(
 }
 
 function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTableRow {
+  const candidate = record.status === 'candidate' || record.coverage_status === 'candidate';
   const stage: AWSCapabilityStage = record.status === 'ready' && record.runtime_role_arn ? 'wired' : record.status === 'blocked' ? 'not-available' : 'coming';
-  const degraded = record.status !== 'ready' || record.coverage_status === 'degraded' || Boolean(record.coverage_reason);
-  const status = stage === 'not-available' ? 'not yet available' : degraded ? 'degraded' : 'role anchor';
+  const degraded = !candidate && (record.status !== 'ready' || record.coverage_status === 'degraded' || Boolean(record.coverage_reason));
+  const status = candidate ? 'candidate' : stage === 'not-available' ? 'not yet available' : degraded ? 'degraded' : 'role anchor';
   const roleLabel = record.runtime_role_name || record.runtime_role_arn || 'runtime role unresolved';
   const runtimeLabel = record.runtime_version || 'runtime version not reported';
   const toolLabel = record.tool_names?.length ? `${record.tool_names.length} tools` : 'no tools reported';
@@ -7155,7 +7163,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
     filters: {
       surface,
       relationship: Array.from(relationships).join(','),
-      status: status === 'role anchor' ? 'role-anchor' : status === 'not yet available' ? 'not-yet-available' : status === 'degraded' ? 'degraded' : 'coming',
+      status: status === 'role anchor' ? 'role-anchor' : status === 'not yet available' ? 'not-yet-available' : status === 'candidate' ? 'candidate' : status === 'degraded' ? 'degraded' : 'coming',
       search: ''
     },
     searchText: inventorySearchText([
@@ -7205,10 +7213,11 @@ function awsAIAgentSurfaceFilter(record: AWSAIAgentIdentityRecord): string {
     case 'agentcore_capability':
       return 'agentcore-capabilities';
     case 'external_provider_agent':
+      return 'external-provider-keys';
     case 'custom_agent':
-      return record.credential_reference_refs?.length ? 'external-provider-keys' : 'bedrock-agents';
+      return record.credential_reference_refs?.length ? 'custom-agents,external-provider-keys' : 'custom-agents';
     default:
-      return 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys';
+      return 'bedrock-agents,agentcore-runtime,agentcore-capabilities,custom-agents,mcp-gateway,external-provider-keys';
   }
 }
 


### PR DESCRIPTION
## Summary
- add a metadata-only custom AWS agent detector across ECS, EKS, Lambda, EC2, SageMaker, Step Functions, and CodeBuild workloads
- emit candidate or ready custom agent identities with detector version, confidence signals, workload provenance, and external provider credential references where present
- surface custom agent and candidate states in the API contract, docs, and web AWS agent inventory filters

## Why
Issue #1511 extends AWS AI agent identity coverage beyond managed AgentCore and foundation-model services. Custom agents often run inside ordinary AWS compute workloads, so the normalizer now derives agent identities from workload metadata without reading customer payloads, source code, build logs, or secret values.

## Implementation
- derive custom AIAgentIdentity raw assets from workload names, ARNs, tags, image names, handlers, environment key names, secret reference names, and role bindings
- keep uncertain matches as candidate and promote stronger matches to covered/ready identities
- map agent credential references into the existing credential-reference graph so custom agents can show uses_secret edges
- update the AWS AI agent identities endpoint version/current issue, OpenAPI enums, documentation, and web filters/cards

## Risk
- read-only and metadata-only; no new AWS calls or secret-value reads are introduced here
- scoring is intentionally conservative, with generic credential-only workloads skipped
- UI changes are additive: custom agents and candidates appear as new filter/status states

## Validation
- go test ./internal/providers/aws ./internal/api
- go test ./internal/providers/aws ./internal/api ./internal/runtime ./internal/cli
- go test ./...
- npm run test:ci --prefix web
- npm run build --prefix web
- git diff --check
- pre-commit run --files docs/aws-ai-agent-identities.md docs/openapi-v1.yaml internal/api/aws_ai_agent_identities.go internal/api/aws_ai_agent_identities_test.go internal/providers/aws/custom_agent_detector.go internal/providers/aws/custom_agent_detector_test.go internal/providers/aws/credential_reference_mapper.go internal/providers/aws/credential_reference_mapper_test.go internal/providers/aws/normalizer.go web/src/productShell.tsx

## AI Assistance Disclosure
No

Closes #1511

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a metadata‑only detector to find custom AWS‑hosted agents in ECS, EKS, Lambda, EC2, SageMaker, Step Functions, and CodeBuild. Implements #1511 by surfacing confirmed and candidate agents with provider‑key links in the API and UI.

- **New Features**
  - Detect custom agents from workload metadata (names, ARNs, tags, images, handlers, env/secret refs, role bindings) without reading payloads, code, logs, or secret values.
  - Emit `custom_agent` identities with `status=ready|candidate`, `coverage_status=covered|candidate`, detector version/signals, and resource references; map provider‑key references and add `uses_secret` edges.
  - Update API to accept `candidate` for `status` and `coverage_status`, bump identity version to `aws-ai-agent-custom-agent-detector-v1`, and extend docs with detector details.
  - Update web: add “Custom agents” filter and “Candidate” status; show custom‑agent coverage.

- **Bug Fixes**
  - Prefer ECS task roles over execution roles when de‑duping detections so the runtime role is correct.
  - Match short AI tokens (`rag`, `llm`, `gpt`) at word boundaries to reduce false positives.
  - Suppress bare env keys when a sourced secret ref exists to avoid duplicate unresolved provider‑key nodes.
  - Set credential‑reference `WorkloadType` to the agent’s type for accurate attribution and filters.
  - Normalize agent identities after workload roles so richer workload‑role identities (tags/owner) win.
  - Ignore AgentCore credential‑provider ARNs for `uses_secret` graph edges; keep them metadata‑only.

<sup>Written for commit 01f4ca2e1971959bbafc9afae8565a11917c4081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

