### PR TITLE
Fix Bedrock provider key follow-up

### DIFF
--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -394,7 +394,10 @@ func awsAIAgentIdentityFixtureRecords(accountID string, region string, fixtureSt
 			r.ModelID = "provider:model-redacted"
 			r.ToolNames = []string{"support-search"}
 			r.CapabilityNames = []string{"tool_use"}
-			r.CredentialReferenceRefs = []string{"ANTHROPIC_API_KEY=ssm:/prod/support/anthropic-key"}
+			r.CredentialReferenceRefs = []string{
+				"ANTHROPIC_API_KEY=ssm:/prod/support/anthropic-key",
+				"BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key",
+			}
 			r.ExternalProvider = "anthropic"
 		}),
 		awsAIAgentFixtureRecord(accountID, region, "agent_gateway", "payments-gateway", "payments-gateway", gatewayARN, role("bedrock-agent-gateway-payments"), checkedAt, func(r *AWSAIAgentIdentityRecord) {
@@ -690,6 +693,7 @@ func awsCredentialReferenceNodeID(agentNodeID string, ref string) string {
 }
 
 func awsAIAgentCredentialReferenceProvider(name, source string) string {
+	nameProbe := strings.ToLower(strings.TrimSpace(name))
 	probe := strings.ToLower(strings.TrimSpace(name + " " + source))
 	sourceProbe := strings.ToLower(strings.TrimSpace(source))
 	switch {
@@ -697,7 +701,7 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "openai"
 	case containsAnyToken(probe, "anthropic", "claude"):
 		return "anthropic"
-	case awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(probe):
+	case awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(nameProbe, probe):
 		return "bedrock"
 	case strings.HasPrefix(sourceProbe, "secretsmanager:") ||
 		strings.HasPrefix(sourceProbe, "secretsmanager-") ||
@@ -719,10 +723,14 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 	}
 }
 
-func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(probe string) bool {
-	if strings.Contains(probe, "bedrock-agentcore") || strings.Contains(probe, "bedrock_agentcore") {
+func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(nameProbe, probe string) bool {
+	if !awsAIAgentCredentialReferenceContainsBedrockKeyToken(nameProbe) && awsAIAgentCredentialReferenceLooksLikeAgentCoreOAuthSource(probe) {
 		return false
 	}
+	return awsAIAgentCredentialReferenceContainsBedrockKeyToken(probe)
+}
+
+func awsAIAgentCredentialReferenceContainsBedrockKeyToken(probe string) bool {
 	return containsAnyToken(probe,
 		"bedrock_api_key",
 		"bedrock-api-key",
@@ -734,6 +742,12 @@ func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(probe string) bool
 		"amazon-bedrock-api-key",
 		"amazonbedrockapikey",
 	)
+}
+
+func awsAIAgentCredentialReferenceLooksLikeAgentCoreOAuthSource(probe string) bool {
+	agentCore := strings.Contains(probe, "bedrock-agentcore") || strings.Contains(probe, "bedrock_agentcore")
+	oauth := strings.Contains(probe, "-oauth-") || strings.Contains(probe, "/oauth/") || strings.Contains(probe, ":oauth/")
+	return agentCore && oauth
 }
 
 func awsAIAgentProviderKeyReferences(record AWSAIAgentIdentityRecord) []AWSAIAgentProviderKeyReference {
@@ -806,7 +820,7 @@ func awsAIAgentCredentialReferenceConfidence(provider string) float64 {
 
 func awsAIAgentProviderIsExternalAI(provider string) bool {
 	switch provider {
-	case "openai", "anthropic":
+	case "openai", "anthropic", "bedrock":
 		return true
 	default:
 		return false

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -693,7 +693,6 @@ func awsCredentialReferenceNodeID(agentNodeID string, ref string) string {
 }
 
 func awsAIAgentCredentialReferenceProvider(name, source string) string {
-	nameProbe := strings.ToLower(strings.TrimSpace(name))
 	probe := strings.ToLower(strings.TrimSpace(name + " " + source))
 	sourceProbe := strings.ToLower(strings.TrimSpace(source))
 	switch {
@@ -701,7 +700,7 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 		return "openai"
 	case containsAnyToken(probe, "anthropic", "claude"):
 		return "anthropic"
-	case awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(nameProbe, probe):
+	case awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(sourceProbe, probe):
 		return "bedrock"
 	case strings.HasPrefix(sourceProbe, "secretsmanager:") ||
 		strings.HasPrefix(sourceProbe, "secretsmanager-") ||
@@ -723,8 +722,8 @@ func awsAIAgentCredentialReferenceProvider(name, source string) string {
 	}
 }
 
-func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(nameProbe, probe string) bool {
-	if !awsAIAgentCredentialReferenceContainsBedrockKeyToken(nameProbe) && awsAIAgentCredentialReferenceLooksLikeAgentCoreOAuthSource(probe) {
+func awsAIAgentCredentialReferenceLooksLikeBedrockProviderKey(sourceProbe, probe string) bool {
+	if sourceProbe != "" && awsAIAgentCredentialReferenceLooksLikeAgentCoreOAuthSource(sourceProbe) {
 		return false
 	}
 	return awsAIAgentCredentialReferenceContainsBedrockKeyToken(probe)

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -381,6 +381,7 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 			"BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key",
 			"BEDROCK_API_KEY=secretsmanager:prod/bedrock-agentcore/bedrock-api-key",
 			"arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments",
+			"arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/bedrock-api-key",
 		}
 	})
 
@@ -416,6 +417,9 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	if providersByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic" {
 		t.Fatalf("expected AgentCore OAuth ARN to classify as generic, got %+v", record.ProviderKeyReferences)
 	}
+	if providersByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/bedrock-api-key"] != "generic" {
+		t.Fatalf("expected AgentCore OAuth ARN with key-like tail to classify as generic, got %+v", record.ProviderKeyReferences)
+	}
 	if sensitivityByRef["ssm:/prod/support/ai-provider-key"] != "aws_managed_secret" ||
 		sensitivityByRef["secretsmanager:prod/provider-key"] != "aws_managed_secret" {
 		t.Fatalf("expected AWS store-backed references to use aws_managed_secret sensitivity, got %+v", record.ProviderKeyReferences)
@@ -428,6 +432,9 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	}
 	if sensitivityByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic_secret" {
 		t.Fatalf("expected AgentCore OAuth ARN to use generic_secret sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+	if sensitivityByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/bedrock-api-key"] != "generic_secret" {
+		t.Fatalf("expected AgentCore OAuth ARN with key-like tail to use generic_secret sensitivity, got %+v", record.ProviderKeyReferences)
 	}
 	if kindsByRef["OPENAI_API_KEY=SECRETS_MANAGER:arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/key-AbCdEf"] != "secrets_manager" {
 		t.Fatalf("expected SECRETS_MANAGER marker to classify as secrets_manager kind, got %+v", record.ProviderKeyReferences)

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -169,14 +169,14 @@ func TestGetAWSAIAgentIdentityInventoryBuildsScopedRecords(t *testing.T) {
 			}
 		}
 	}
-	if result.ExternalProviderKeyCount != 2 || result.AIProviderKeyCount != 2 {
-		t.Fatalf("expected two external AI provider key references, got external=%d ai=%d", result.ExternalProviderKeyCount, result.AIProviderKeyCount)
+	if result.ExternalProviderKeyCount != 3 || result.AIProviderKeyCount != 3 {
+		t.Fatalf("expected three external AI provider key references, got external=%d ai=%d", result.ExternalProviderKeyCount, result.AIProviderKeyCount)
 	}
-	if providerCounts["openai"] != 1 || providerCounts["anthropic"] != 1 {
-		t.Fatalf("expected openai and anthropic provider-key records, got %+v", providerCounts)
+	if providerCounts["openai"] != 1 || providerCounts["anthropic"] != 1 || providerCounts["bedrock"] != 1 {
+		t.Fatalf("expected openai, anthropic, and bedrock provider-key records, got %+v", providerCounts)
 	}
-	if result.ProviderKeyBreakdown["openai"] != 1 || result.ProviderKeyBreakdown["anthropic"] != 1 {
-		t.Fatalf("expected provider key breakdown for openai/anthropic, got %+v", result.ProviderKeyBreakdown)
+	if result.ProviderKeyBreakdown["openai"] != 1 || result.ProviderKeyBreakdown["anthropic"] != 1 || result.ProviderKeyBreakdown["bedrock"] != 1 {
+		t.Fatalf("expected provider key breakdown for openai/anthropic/bedrock, got %+v", result.ProviderKeyBreakdown)
 	}
 	if len(result.CoverageGaps) == 0 {
 		t.Fatalf("expected sensitive-boundary coverage gaps, got %+v", result.CoverageGaps)
@@ -379,6 +379,7 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 			"arn:aws:ssm:us-east-1:111111111111:parameter/provider/key",
 			"PARAMETER_STORE:/prod/provider-key",
 			"BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key",
+			"BEDROCK_API_KEY=secretsmanager:prod/bedrock-agentcore/bedrock-api-key",
 			"arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments",
 		}
 	})
@@ -409,6 +410,9 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	if providersByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key"] != "bedrock" {
 		t.Fatalf("expected Bedrock API key marker to classify as bedrock, got %+v", record.ProviderKeyReferences)
 	}
+	if providersByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock-agentcore/bedrock-api-key"] != "bedrock" {
+		t.Fatalf("expected explicit Bedrock API key marker with AgentCore path to classify as bedrock, got %+v", record.ProviderKeyReferences)
+	}
 	if providersByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic" {
 		t.Fatalf("expected AgentCore OAuth ARN to classify as generic, got %+v", record.ProviderKeyReferences)
 	}
@@ -418,6 +422,9 @@ func TestAIAgentProviderKeyReferencesClassifyStoreOnlySources(t *testing.T) {
 	}
 	if sensitivityByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock/api-key"] != "ai_provider_api_key" {
 		t.Fatalf("expected Bedrock API key marker to use ai_provider_api_key sensitivity, got %+v", record.ProviderKeyReferences)
+	}
+	if sensitivityByRef["BEDROCK_API_KEY=secretsmanager:prod/bedrock-agentcore/bedrock-api-key"] != "ai_provider_api_key" {
+		t.Fatalf("expected explicit Bedrock API key marker with AgentCore path to use ai_provider_api_key sensitivity, got %+v", record.ProviderKeyReferences)
 	}
 	if sensitivityByRef["arn:aws:bedrock-agentcore:us-east-1:111111111111:oauth/payments"] != "generic_secret" {
 		t.Fatalf("expected AgentCore OAuth ARN to use generic_secret sensitivity, got %+v", record.ProviderKeyReferences)


### PR DESCRIPTION
## Summary
- Count Bedrock provider keys as external AI provider keys in the AWS AI agent inventory aggregate
- Keep explicit Bedrock API key names classified as Bedrock even when the backing secret path contains bedrock-agentcore
- Add regression coverage for the unfixed review threads from #1620

## Follow-up
- Follows up #1620
- Refs #1510
- Fixes review threads:
  - https://github.com/identrail/identrail/pull/1620#discussion_r3409439937
  - https://github.com/identrail/identrail/pull/1620#discussion_r3409439938

## Tests
- go test ./internal/api ./internal/providers/aws
- git diff --check

## AI disclosure
No