### PR TITLE
Preserve model vendor provider filtering

### DIFF
--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -530,7 +530,7 @@ func awsAIAgentRecordMatchesProvider(record AWSAIAgentIdentityRecord, query stri
 			return true
 		}
 	}
-	if _, known := awsAIAgentKnownProviderFilterTokens()[normalizedQuery]; known {
+	if awsAIAgentProviderFilterRequiresExactProviderMatch(normalizedQuery) {
 		return false
 	}
 	return awsAIAgentRecordMatchesAny(record, query, record.ModelID)
@@ -551,15 +551,12 @@ func normalizeAWSAIAgentProviderToken(value string) string {
 	}
 }
 
-func awsAIAgentKnownProviderFilterTokens() map[string]struct{} {
-	return map[string]struct{}{
-		"amazon_bedrock":           {},
-		"amazon_bedrock_agentcore": {},
-		"external_provider":        {},
-		"openai":                   {},
-		"anthropic":                {},
-		"bedrock":                  {},
-		"custom":                   {},
+func awsAIAgentProviderFilterRequiresExactProviderMatch(normalizedQuery string) bool {
+	switch normalizedQuery {
+	case "amazon_bedrock", "amazon_bedrock_agentcore", "external_provider", "custom":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -273,6 +273,24 @@ func TestGetAWSAIAgentIdentityInventoryAppliesExplorerFilters(t *testing.T) {
 			t.Fatalf("expected exact amazon-bedrock provider filter to exclude %q record %+v", record.Provider, record)
 		}
 	}
+
+	anthropicResult, err := svc.GetAWSAIAgentIdentityInventory(ctx, "default", "project-a", AWSAIAgentIdentityInventoryRequest{
+		ConnectorID: "aws-prod",
+		Provider:    "anthropic",
+	})
+	if err != nil {
+		t.Fatalf("get anthropic-filtered ai agent identity inventory: %v", err)
+	}
+	foundClaudeBedrockModel := false
+	for _, record := range anthropicResult.Records {
+		if record.Provider == "amazon-bedrock" && strings.Contains(record.ModelID, "anthropic.claude") {
+			foundClaudeBedrockModel = true
+			break
+		}
+	}
+	if !foundClaudeBedrockModel {
+		t.Fatalf("expected anthropic provider filter to preserve Bedrock Claude model matches, got %+v", anthropicResult.Records)
+	}
 }
 
 func TestAWSAIAgentRiskClassifiesZeroConfidenceAsUnscored(t *testing.T) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7321,11 +7321,27 @@ function awsAIAgentProviderFilter(record: AWSAIAgentIdentityRecord): string {
   const providers = [
     record.provider,
     record.external_provider,
-    ...(record.provider_key_references?.map((ref) => ref.provider) ?? [])
+    ...(record.provider_key_references?.map((ref) => ref.provider) ?? []),
+    ...awsAIAgentModelProviderFilterTokens(record.model_id)
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => awsAIAgentProviderFilterToken(value));
   return providers.length ? Array.from(new Set(providers)).join(',') : 'custom';
+}
+
+function awsAIAgentModelProviderFilterTokens(modelID?: string): string[] {
+  const normalizedModel = normalizeFilterValue(modelID ?? '');
+  const tokens: string[] = [];
+  if (normalizedModel.includes('anthropic') || normalizedModel.includes('claude')) {
+    tokens.push('anthropic');
+  }
+  if (normalizedModel.includes('openai') || normalizedModel.includes('gpt')) {
+    tokens.push('openai');
+  }
+  if (normalizedModel.includes('bedrock')) {
+    tokens.push('bedrock');
+  }
+  return tokens;
 }
 
 function awsAIAgentProviderFilterToken(value: string): string {


### PR DESCRIPTION
## Summary
- Keep exact provider matching for category aliases like Amazon Bedrock, AgentCore, external provider, and custom
- Preserve model-vendor matching for provider tokens such as anthropic, so Bedrock Claude model records remain visible
- Add regression coverage for the resolved-but-unfixed #1623 review thread

## Follow-up
- Follows up #1623
- Refs #1512
- Addresses review thread: https://github.com/identrail/identrail/pull/1623#discussion_r3409935419

## Validation
- go test ./internal/api
- git diff --check

## AI disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider filtering so vendor tokens like `anthropic` still show Bedrock Claude models, while exact matching only applies to category aliases. Also updates the agent row filter to include vendor tokens from the model ID.

- **Bug Fixes**
  - Exact-match filtering now only for `amazon_bedrock`, `amazon_bedrock_agentcore`, `external_provider`, `custom`.
  - Agent row filters now add vendor tokens from `model_id` (e.g., `anthropic`, `openai`, `bedrock`) so Bedrock `anthropic.claude` records stay visible; regression test added.

<sup>Written for commit ea7335dc96f517445816c8cf3231d44640d70368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

