### PR TITLE
Add AWS runtime event contract

### DIFF
--- a/docs/aws-runtime-events.md
+++ b/docs/aws-runtime-events.md
@@ -1,0 +1,51 @@
+# AWS runtime event contract
+
+Issue #1513 adds the metadata-only contract Identrail uses to show what AWS
+machine identities did at runtime. It covers API calls, STS sessions, Secrets
+Manager reads, KMS decrypt activity, S3 access metadata, and agent tool calls.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events`
+
+Supported filters:
+
+- `connector_id`
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
+- `account_id`
+- `region`
+- `event_type`: `sts-session`, `api-call`, `secret-read`, `kms-decrypt`, or `agent-tool`
+- `identity`
+- `agent_id`
+- `resource`
+- `evidence`: `cloudtrail` or `agent-runtime`
+- `owner`: `security`, `platform`, or `application`
+- `status`: `observed`, `delayed`, or `permission-denied`
+
+The response is returned as `{ "runtime": ... }` and includes:
+
+- scoped account, region, connector, issue, version, status, confidence, and applied filters
+- summary counts for event types, owners, identities, resources, sessions, and relationships
+- event records with actor, session, action, target resource metadata, agent context, timestamp, confidence, evidence, and next action
+- graph relationships from observed actors or agents to target resources
+- explicit diagnostics, coverage gaps, failure reasons, and remediation hints
+
+## Safety boundaries
+
+The runtime contract is read-only and metadata-only. It must not read, expose,
+log, or persist secret values, decrypted plaintext, object bodies, prompts,
+completions, browser pages, code-interpreter output, database rows, or customer
+payloads by default.
+
+The fixture contract uses redacted resource identifiers and the
+`metadata_only_no_payloads_no_secret_values` boundary so UI and API tests can
+prove the safe shape without requiring live AWS credentials.
+
+## Failure states
+
+- `empty`: no runtime events matched the scoped account and region.
+- `degraded`: runtime events were returned, but evidence is delayed or lower confidence.
+- `partial_failure`: one runtime source failed while retained events remain visible.
+- `permission_denied`: required metadata-only event lookup permissions are missing.
+
+These states are explicit and are not treated as successful runtime coverage.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -549,6 +549,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4511,6 +4516,94 @@ paths:
                     $ref: "#/components/schemas/AWSAIAgentIdentityInventoryResult"
         "400":
           description: Invalid AWS AI agent identity inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS runtime event contract
+      operationId: getAWSProjectRuntimeEvents
+      description: Returns scoped, metadata-only AWS runtime events for API calls, STS sessions, secret reads, KMS decrypts, S3 access, and agent tool calls. The response links actor identity, session, target resource, event source, timestamp, confidence, and evidence without reading or returning secret values, object bodies, prompts, completions, browser pages, code-interpreter output, database rows, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only runtime evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: event_type
+          schema:
+            type: string
+            enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool]
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional actor principal, role, session, or identity-node search.
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent ID or agent-node search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional target resource ARN, name, type, or node search.
+        - in: query
+          name: evidence
+          schema:
+            type: string
+            enum: [cloudtrail, agent-runtime]
+        - in: query
+          name: owner
+          schema:
+            type: string
+            enum: [security, platform, application]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [observed, delayed, permission-denied]
+      responses:
+        "200":
+          description: AWS runtime event contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runtime:
+                    $ref: "#/components/schemas/AWSRuntimeEventResult"
+        "400":
+          description: Invalid AWS runtime event request
           content:
             application/json:
               schema:
@@ -10601,6 +10694,185 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSBedrockAgentDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRuntimeEventSession:
+      type: object
+      properties:
+        session_id: { type: string }
+        principal_arn: { type: string }
+        principal_type: { type: string }
+        assumed_role_arn: { type: string }
+        session_issuer_arn: { type: string }
+        source_ip_address: { type: string }
+        user_agent: { type: string }
+        started_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    AWSRuntimeEventRecord:
+      type: object
+      properties:
+        event_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        event_type:
+          type: string
+          enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool]
+        event_source: { type: string }
+        event_name: { type: string }
+        action: { type: string }
+        actor_principal_arn: { type: string }
+        actor_principal_type: { type: string }
+        actor_identity_node_id: { type: string }
+        session:
+          $ref: "#/components/schemas/AWSRuntimeEventSession"
+        target_resource_arn: { type: string }
+        target_resource_type: { type: string }
+        target_resource_name: { type: string }
+        resource_node_id: { type: string }
+        agent_id: { type: string }
+        agent_node_id: { type: string }
+        tool_name: { type: string }
+        tool_target_ref: { type: string }
+        owner:
+          type: string
+          enum: [security, platform, application]
+        evidence_category:
+          type: string
+          enum: [cloudtrail, agent-runtime]
+        evidence_ref: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_at:
+          type: string
+          format: date-time
+        collected_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [observed, delayed, permission-denied]
+        next_action: { type: string }
+        redaction_boundary:
+          type: string
+          enum: [metadata_only_no_payloads_no_secret_values]
+    AWSRuntimeEventRelationship:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [observed_runtime_action, agent_invoked_runtime_action]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSRuntimeEventDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code:
+          type: string
+          enum: [runtime_event_delivery_delayed, agent_runtime_event_source_failed, permission_denied]
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSRuntimeEventCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status:
+          type: string
+          enum: [empty, partial_failure, permission_denied]
+        reason: { type: string }
+        remediation: { type: string }
+    AWSRuntimeEventSummary:
+      type: object
+      properties:
+        total_events: { type: integer }
+        filtered_events: { type: integer }
+        event_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        owner_counts:
+          type: object
+          additionalProperties: { type: integer }
+        account_count: { type: integer }
+        region_count: { type: integer }
+        identity_count: { type: integer }
+        resource_count: { type: integer }
+        agent_event_count: { type: integer }
+        secret_read_count: { type: integer }
+        kms_decrypt_count: { type: integer }
+        api_call_count: { type: integer }
+        sts_session_count: { type: integer }
+        relationship_count: { type: integer }
+        permission_denied_events: { type: integer }
+    AWSRuntimeEventResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSRuntimeEventSummary"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRuntimeEventRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRuntimeEventRelationship"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRuntimeEventCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRuntimeEventDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -753,6 +753,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities/:agent_id", Action: policyActionTenancyRead, ResourceType: "ai_agent_identity", ResourceIDParam: "agent_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -164,6 +164,7 @@ func buildAWSRuntimeEvents(scope db.Scope, project db.TenancyProject, connection
 	records, diagnostics, gaps := awsRuntimeEventFixtureRecords(accountID, region, fixtureState, checkedAt)
 	filtered, applied := filterAWSRuntimeEventRecords(records, request)
 	relationships := awsRuntimeEventRelationships(filtered)
+	diagnostics = scopeAWSRuntimeEventDiagnostics(diagnostics, filtered)
 	summary := summarizeAWSRuntimeEvents(records, len(filtered), len(relationships))
 	status, confidence, failures, remediations := summarizeAWSRuntimeEventStatus(fixtureState, diagnostics, filtered)
 
@@ -272,6 +273,28 @@ func filterAWSRuntimeEventRecords(records []AWSRuntimeEventRecord, request AWSRu
 
 func normalizeAWSRuntimeEventFilterToken(value string) string {
 	return strings.ToLower(strings.NewReplacer(" ", "-", "_", "-").Replace(strings.TrimSpace(value)))
+}
+
+func scopeAWSRuntimeEventDiagnostics(diagnostics []AWSRuntimeEventDiagnostic, records []AWSRuntimeEventRecord) []AWSRuntimeEventDiagnostic {
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	recordIDs := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		recordIDs[record.EventID] = struct{}{}
+	}
+	scoped := make([]AWSRuntimeEventDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		sourceID := strings.TrimSpace(diagnostic.SourceID)
+		if sourceID == "" {
+			scoped = append(scoped, diagnostic)
+			continue
+		}
+		if _, ok := recordIDs[sourceID]; ok {
+			scoped = append(scoped, diagnostic)
+		}
+	}
+	return scoped
 }
 
 func awsRuntimeEventMatchesAny(query string, values ...string) bool {

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1,0 +1,525 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+)
+
+const (
+	awsRuntimeEventsCurrentIssue = 1513
+	awsRuntimeEventsVersion      = "aws-runtime-events-contract-v1"
+)
+
+type AWSRuntimeEventRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	EventType    string `json:"event_type,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Evidence     string `json:"evidence,omitempty"`
+	Owner        string `json:"owner,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+type AWSRuntimeEventSession struct {
+	SessionID        string    `json:"session_id"`
+	PrincipalARN     string    `json:"principal_arn"`
+	PrincipalType    string    `json:"principal_type"`
+	AssumedRoleARN   string    `json:"assumed_role_arn,omitempty"`
+	SessionIssuerARN string    `json:"session_issuer_arn,omitempty"`
+	SourceIPAddress  string    `json:"source_ip_address,omitempty"`
+	UserAgent        string    `json:"user_agent,omitempty"`
+	StartedAt        time.Time `json:"started_at"`
+	ExpiresAt        time.Time `json:"expires_at,omitempty"`
+}
+
+type AWSRuntimeEventRecord struct {
+	EventID             string                 `json:"event_id"`
+	AccountID           string                 `json:"account_id"`
+	Region              string                 `json:"region"`
+	EventType           string                 `json:"event_type"`
+	EventSource         string                 `json:"event_source"`
+	EventName           string                 `json:"event_name"`
+	Action              string                 `json:"action"`
+	ActorPrincipalARN   string                 `json:"actor_principal_arn"`
+	ActorPrincipalType  string                 `json:"actor_principal_type"`
+	ActorIdentityNodeID string                 `json:"actor_identity_node_id"`
+	Session             AWSRuntimeEventSession `json:"session"`
+	TargetResourceARN   string                 `json:"target_resource_arn,omitempty"`
+	TargetResourceType  string                 `json:"target_resource_type,omitempty"`
+	TargetResourceName  string                 `json:"target_resource_name,omitempty"`
+	ResourceNodeID      string                 `json:"resource_node_id,omitempty"`
+	AgentID             string                 `json:"agent_id,omitempty"`
+	AgentNodeID         string                 `json:"agent_node_id,omitempty"`
+	ToolName            string                 `json:"tool_name,omitempty"`
+	ToolTargetRef       string                 `json:"tool_target_ref,omitempty"`
+	Owner               string                 `json:"owner"`
+	EvidenceCategory    string                 `json:"evidence_category"`
+	EvidenceRef         string                 `json:"evidence_ref"`
+	Confidence          float64                `json:"confidence"`
+	ObservedAt          time.Time              `json:"observed_at"`
+	CollectedAt         time.Time              `json:"collected_at"`
+	Status              string                 `json:"status"`
+	NextAction          string                 `json:"next_action"`
+	RedactionBoundary   string                 `json:"redaction_boundary"`
+}
+
+type AWSRuntimeEventRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+type AWSRuntimeEventDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+type AWSRuntimeEventCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSRuntimeEventSummary struct {
+	TotalEvents            int            `json:"total_events"`
+	FilteredEvents         int            `json:"filtered_events"`
+	EventTypeCounts        map[string]int `json:"event_type_counts"`
+	StatusCounts           map[string]int `json:"status_counts"`
+	OwnerCounts            map[string]int `json:"owner_counts"`
+	AccountCount           int            `json:"account_count"`
+	RegionCount            int            `json:"region_count"`
+	IdentityCount          int            `json:"identity_count"`
+	ResourceCount          int            `json:"resource_count"`
+	AgentEventCount        int            `json:"agent_event_count"`
+	SecretReadCount        int            `json:"secret_read_count"`
+	KMSDecryptCount        int            `json:"kms_decrypt_count"`
+	APICallCount           int            `json:"api_call_count"`
+	STSSessionCount        int            `json:"sts_session_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	PermissionDeniedEvents int            `json:"permission_denied_events"`
+}
+
+type AWSRuntimeEventResult struct {
+	TenantID           string                        `json:"tenant_id"`
+	WorkspaceID        string                        `json:"workspace_id"`
+	ProjectID          string                        `json:"project_id"`
+	ConnectorID        string                        `json:"connector_id,omitempty"`
+	AccountID          string                        `json:"account_id,omitempty"`
+	Region             string                        `json:"region,omitempty"`
+	ParentIssueNumber  int                           `json:"parent_issue_number"`
+	ParentIssueRef     string                        `json:"parent_issue_ref"`
+	CurrentIssueNumber int                           `json:"current_issue_number"`
+	CurrentIssueRef    string                        `json:"current_issue_ref"`
+	Version            string                        `json:"version"`
+	Status             string                        `json:"status"`
+	FixtureState       string                        `json:"fixture_state"`
+	Confidence         float64                       `json:"confidence"`
+	AppliedFilters     map[string]string             `json:"applied_filters"`
+	Summary            AWSRuntimeEventSummary        `json:"summary"`
+	Records            []AWSRuntimeEventRecord       `json:"records"`
+	Relationships      []AWSRuntimeEventRelationship `json:"relationships"`
+	FailureReasons     []string                      `json:"failure_reasons"`
+	RemediationHints   []string                      `json:"remediation_hints"`
+	EvidenceLinks      []string                      `json:"evidence_links"`
+	CoverageGaps       []AWSRuntimeEventCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSRuntimeEventDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                     `json:"generated_at"`
+	UpdatedAt          time.Time                     `json:"updated_at"`
+}
+
+func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, projectID string, request AWSRuntimeEventRequest) (AWSRuntimeEventResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRuntimeEventResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRuntimeEventResult{}, err
+	}
+	return buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSRuntimeEvents(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSRuntimeEventRequest, checkedAt time.Time) (AWSRuntimeEventResult, error) {
+	fixtureState := normalizeAWSRuntimeEventFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRuntimeEventResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, gaps := awsRuntimeEventFixtureRecords(accountID, region, fixtureState, checkedAt)
+	filtered, applied := filterAWSRuntimeEventRecords(records, request)
+	relationships := awsRuntimeEventRelationships(filtered)
+	summary := summarizeAWSRuntimeEvents(records, len(filtered), len(relationships))
+	status, confidence, failures, remediations := summarizeAWSRuntimeEventStatus(fixtureState, diagnostics, filtered)
+
+	return AWSRuntimeEventResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRuntimeEventsCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRuntimeEventsCurrentIssue),
+		Version:            awsRuntimeEventsVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Records:            filtered,
+		Relationships:      relationships,
+		FailureReasons:     emptyStrings(failures),
+		RemediationHints:   emptyStrings(remediations),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(1512),
+			awsIssueURL(1503),
+			"/docs/aws-runtime-events",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func normalizeAWSRuntimeEventFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func filterAWSRuntimeEventRecords(records []AWSRuntimeEventRecord, request AWSRuntimeEventRequest) ([]AWSRuntimeEventRecord, map[string]string) {
+	applied := map[string]string{}
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"event_type": normalizeAWSRuntimeEventFilterToken(request.EventType),
+		"identity":   strings.TrimSpace(request.Identity),
+		"agent_id":   strings.TrimSpace(request.AgentID),
+		"resource":   strings.TrimSpace(request.Resource),
+		"evidence":   normalizeAWSRuntimeEventFilterToken(request.Evidence),
+		"owner":      normalizeAWSRuntimeEventFilterToken(request.Owner),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		if value != "" && value != "all" {
+			applied[key] = value
+		}
+	}
+	filtered := make([]AWSRuntimeEventRecord, 0, len(records))
+	for _, record := range records {
+		if filters["account_id"] != "" && filters["account_id"] != record.AccountID {
+			continue
+		}
+		if filters["region"] != "" && filters["region"] != record.Region {
+			continue
+		}
+		if filters["event_type"] != "" && filters["event_type"] != "all" && filters["event_type"] != normalizeAWSRuntimeEventFilterToken(record.EventType) {
+			continue
+		}
+		if filters["evidence"] != "" && filters["evidence"] != "all" && filters["evidence"] != normalizeAWSRuntimeEventFilterToken(record.EvidenceCategory) {
+			continue
+		}
+		if filters["owner"] != "" && filters["owner"] != "all" && filters["owner"] != normalizeAWSRuntimeEventFilterToken(record.Owner) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != "all" && filters["status"] != normalizeAWSRuntimeEventFilterToken(record.Status) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], record.ActorPrincipalARN, record.ActorIdentityNodeID, record.Session.PrincipalARN, record.Session.AssumedRoleARN, record.Session.SessionIssuerARN, record.Session.SessionID) {
+			continue
+		}
+		if filters["agent_id"] != "" && !awsRuntimeEventMatchesAny(filters["agent_id"], record.AgentID, record.AgentNodeID) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], record.TargetResourceARN, record.TargetResourceName, record.TargetResourceType, record.ResourceNodeID, record.ToolTargetRef) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered, applied
+}
+
+func normalizeAWSRuntimeEventFilterToken(value string) string {
+	return strings.ToLower(strings.NewReplacer(" ", "-", "_", "-").Replace(strings.TrimSpace(value)))
+}
+
+func awsRuntimeEventMatchesAny(query string, values ...string) bool {
+	probe := strings.ToLower(strings.TrimSpace(query))
+	if probe == "" {
+		return true
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), probe) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSRuntimeEvents(records []AWSRuntimeEventRecord, filteredCount int, relationshipCount int) AWSRuntimeEventSummary {
+	summary := AWSRuntimeEventSummary{
+		TotalEvents:       len(records),
+		FilteredEvents:    filteredCount,
+		EventTypeCounts:   map[string]int{},
+		StatusCounts:      map[string]int{},
+		OwnerCounts:       map[string]int{},
+		RelationshipCount: relationshipCount,
+	}
+	accounts := map[string]struct{}{}
+	regions := map[string]struct{}{}
+	identities := map[string]struct{}{}
+	resources := map[string]struct{}{}
+	sessions := map[string]struct{}{}
+	for _, record := range records {
+		summary.EventTypeCounts[record.EventType]++
+		summary.StatusCounts[record.Status]++
+		summary.OwnerCounts[record.Owner]++
+		accounts[record.AccountID] = struct{}{}
+		regions[record.Region] = struct{}{}
+		identities[record.ActorIdentityNodeID] = struct{}{}
+		if record.ResourceNodeID != "" {
+			resources[record.ResourceNodeID] = struct{}{}
+		}
+		if record.Session.SessionID != "" {
+			sessions[record.Session.SessionID] = struct{}{}
+		}
+		switch record.EventType {
+		case "agent-tool":
+			summary.AgentEventCount++
+		case "secret-read":
+			summary.SecretReadCount++
+		case "kms-decrypt":
+			summary.KMSDecryptCount++
+		case "api-call":
+			summary.APICallCount++
+		case "sts-session":
+			summary.STSSessionCount++
+		}
+		if record.Status == "permission-denied" {
+			summary.PermissionDeniedEvents++
+		}
+	}
+	summary.AccountCount = len(accounts)
+	summary.RegionCount = len(regions)
+	summary.IdentityCount = len(identities)
+	summary.ResourceCount = len(resources)
+	if summary.STSSessionCount == 0 {
+		summary.STSSessionCount = len(sessions)
+	}
+	return summary
+}
+
+func summarizeAWSRuntimeEventStatus(fixtureState string, diagnostics []AWSRuntimeEventDiagnostic, records []AWSRuntimeEventRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return "blocked", 0,
+			[]string{"runtime event sources are not authorized for this connector"},
+			[]string{"Grant metadata-only CloudTrail LookupEvents and service audit permissions; do not grant payload, secret-value, decrypt, or object-body reads."}
+	case "empty":
+		return "degraded", 0.45,
+			[]string{"no runtime events matched the scoped account and region"},
+			[]string{"Confirm CloudTrail management events are enabled, then retry runtime event ingestion."}
+	case "partial_failure":
+		return "degraded", 0.74,
+			[]string{"one runtime event source failed while retained events remain visible"},
+			[]string{"Retry the failed runtime source without discarding successful runtime evidence."}
+	case "degraded":
+		return "degraded", 0.78,
+			[]string{"runtime events include low-confidence or delayed evidence"},
+			[]string{"Review delayed CloudTrail delivery before using runtime evidence for remediation decisions."}
+	default:
+		if len(records) == 0 {
+			return "degraded", 0.5, []string{"runtime event filters matched no records"}, []string{"Clear filters or broaden the time/resource scope."}
+		}
+		if len(diagnostics) > 0 {
+			return "degraded", 0.82, []string{"runtime event ingestion returned diagnostics"}, []string{"Review diagnostics before treating runtime coverage as complete."}
+		}
+		return "ready", 0.92, nil, nil
+	}
+}
+
+func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeEventRelationship {
+	out := []AWSRuntimeEventRelationship{}
+	for _, record := range records {
+		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" {
+			out = append(out, AWSRuntimeEventRelationship{Type: "observed_runtime_action", FromNodeID: record.ActorIdentityNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		if record.AgentNodeID != "" && record.ResourceNodeID != "" {
+			out = append(out, AWSRuntimeEventRelationship{Type: "agent_invoked_runtime_action", FromNodeID: record.AgentNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
+		}
+	}
+	return out
+}
+
+func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSRuntimeEventRecord, []AWSRuntimeEventDiagnostic, []AWSRuntimeEventCoverageGap) {
+	base := checkedAt.Add(-35 * time.Minute)
+	role := fmt.Sprintf("arn:aws:iam::%s:role/identrail-runtime-reader", accountID)
+	lambdaRole := fmt.Sprintf("arn:aws:iam::%s:role/lambda-invoice-agent", accountID)
+	agentRole := fmt.Sprintf("arn:aws:iam::%s:role/agentcore-case-triage-runtime", accountID)
+	session := func(id string, principal string, started time.Time) AWSRuntimeEventSession {
+		return AWSRuntimeEventSession{
+			SessionID:        id,
+			PrincipalARN:     principal,
+			PrincipalType:    "assumed_role",
+			AssumedRoleARN:   principal,
+			SessionIssuerARN: principal,
+			SourceIPAddress:  "AWS Internal",
+			UserAgent:        "identrail-runtime-fixture",
+			StartedAt:        started,
+			ExpiresAt:        started.Add(time.Hour),
+		}
+	}
+	records := []AWSRuntimeEventRecord{
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-sts-runtime-reader", "sts-session", "sts.amazonaws.com", "AssumeRole", "sts:AssumeRole", role, "", "", "security", "cloudtrail", base, session("sess-runtime-reader", role, base)),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-secret-invoice", "secret-read", "secretsmanager.amazonaws.com", "GetSecretValue", "secretsmanager:GetSecretValue", lambdaRole, fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/ai/openai-key", region, accountID), "secret", "application", "cloudtrail", base.Add(8*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-kms-decrypt", "kms-decrypt", "kms.amazonaws.com", "Decrypt", "kms:Decrypt", lambdaRole, fmt.Sprintf("arn:aws:kms:%s:%s:key/cmk-agent-secrets", region, accountID), "kms_key", "platform", "cloudtrail", base.Add(10*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-s3-access", "api-call", "s3.amazonaws.com", "GetObject", "s3:GetObject", lambdaRole, fmt.Sprintf("arn:aws:s3:::billing-artifacts-%s/reports/redacted", accountID), "s3_object_metadata", "application", "cloudtrail", base.Add(14*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-agent-tool", "agent-tool", "bedrock-agentcore.amazonaws.com", "InvokeTool", "bedrock-agentcore:InvokeTool", agentRole, fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/blue", region, accountID), "agent_tool_target", "security", "agent-runtime", base.Add(19*time.Minute), session("sess-agentcore-runtime", agentRole, base.Add(18*time.Minute))),
+	}
+	records[4].AgentID = "runtime-case-triage"
+	records[4].AgentNodeID = awsAIAgentNodeID(accountID, region, "agentcore_runtime", "runtime-case-triage", "2026-06-01")
+	records[4].ToolName = "case-router"
+	records[4].ToolTargetRef = "case-router-policy-checker"
+	switch fixtureState {
+	case "empty":
+		return []AWSRuntimeEventRecord{}, nil, []AWSRuntimeEventCoverageGap{{
+			Capability:  "cloudtrail_lookup_events",
+			Status:      "empty",
+			Reason:      "No runtime events were available in the fixture window.",
+			Remediation: "Confirm management events are enabled and widen the runtime event time range.",
+		}}
+	case "degraded":
+		records[3].Status = "delayed"
+		records[3].Confidence = 0.64
+		return records, []AWSRuntimeEventDiagnostic{{
+			Collector:   "aws_runtime_events",
+			SourceID:    records[3].EventID,
+			Code:        "runtime_event_delivery_delayed",
+			Message:     "CloudTrail delivered one runtime event after the expected collection window.",
+			Remediation: "Keep delayed evidence visible and avoid automated remediation until the event window catches up.",
+			Retryable:   true,
+		}}, nil
+	case "partial_failure":
+		return records[:3], []AWSRuntimeEventDiagnostic{{
+				Collector:   "aws_runtime_events",
+				SourceID:    "agent-runtime",
+				Code:        "agent_runtime_event_source_failed",
+				Message:     "Agent runtime event source failed; CloudTrail events remain visible.",
+				Remediation: "Retry only the agent runtime source and preserve retained CloudTrail evidence.",
+				Retryable:   true,
+			}}, []AWSRuntimeEventCoverageGap{{
+				Capability:  "agent_runtime_events",
+				Status:      "partial_failure",
+				Reason:      "Agent runtime events could not be listed in this fixture.",
+				Remediation: "Retry AgentCore runtime event collection without discarding CloudTrail events.",
+			}}
+	case "permission_denied":
+		return []AWSRuntimeEventRecord{}, []AWSRuntimeEventDiagnostic{{
+				Collector:   "aws_runtime_events",
+				SourceID:    "cloudtrail",
+				Code:        "permission_denied",
+				Message:     "CloudTrail LookupEvents permission is not available for runtime event ingestion.",
+				Remediation: "Grant metadata-only CloudTrail LookupEvents access. Do not grant payload, secret-value, decrypt, or object-body reads.",
+				Retryable:   true,
+			}}, []AWSRuntimeEventCoverageGap{{
+				Capability:  "cloudtrail_lookup_events",
+				Status:      "permission_denied",
+				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only event lookup permissions and retry.",
+			}}
+	default:
+		return records, nil, nil
+	}
+}
+
+func awsRuntimeEventFixtureRecord(accountID string, region string, id string, eventType string, source string, name string, action string, actorARN string, resourceARN string, resourceType string, owner string, evidence string, observedAt time.Time, session AWSRuntimeEventSession) AWSRuntimeEventRecord {
+	resourceName := ""
+	if resourceARN != "" {
+		resourceName = resourceARN
+		if slash := strings.LastIndex(resourceARN, "/"); slash >= 0 && slash < len(resourceARN)-1 {
+			resourceName = resourceARN[slash+1:]
+		} else if colon := strings.LastIndex(resourceARN, ":"); colon >= 0 && colon < len(resourceARN)-1 {
+			resourceName = resourceARN[colon+1:]
+		}
+	}
+	actorNode := awsIdentityNodeIDForAPI(actorARN)
+	return AWSRuntimeEventRecord{
+		EventID:             id,
+		AccountID:           accountID,
+		Region:              region,
+		EventType:           eventType,
+		EventSource:         source,
+		EventName:           name,
+		Action:              action,
+		ActorPrincipalARN:   actorARN,
+		ActorPrincipalType:  "assumed_role",
+		ActorIdentityNodeID: actorNode,
+		Session:             session,
+		TargetResourceARN:   resourceARN,
+		TargetResourceType:  resourceType,
+		TargetResourceName:  resourceName,
+		ResourceNodeID:      awsRuntimeEventResourceNodeID(resourceARN, resourceType),
+		Owner:               owner,
+		EvidenceCategory:    evidence,
+		EvidenceRef:         fmt.Sprintf("runtime-evidence://%s/%s/%s", accountID, region, id),
+		Confidence:          0.9,
+		ObservedAt:          observedAt,
+		CollectedAt:         observedAt.Add(2 * time.Minute),
+		Status:              "observed",
+		NextAction:          awsRuntimeEventNextAction(eventType),
+		RedactionBoundary:   "metadata_only_no_payloads_no_secret_values",
+	}
+}
+
+func awsRuntimeEventResourceNodeID(resourceARN string, resourceType string) string {
+	if strings.TrimSpace(resourceARN) == "" {
+		return ""
+	}
+	return "aws:runtime-resource:" + normalizeName(firstNonEmptyAWSValue(resourceType, "resource")) + ":" + sanitizeCredentialReferenceToken(resourceARN)
+}
+
+func awsRuntimeEventNextAction(eventType string) string {
+	switch eventType {
+	case "sts-session":
+		return "Correlate the session with downstream API calls."
+	case "secret-read":
+		return "Confirm the secret read matches an expected workload path."
+	case "kms-decrypt":
+		return "Join decrypt evidence with key reachability before remediation."
+	case "agent-tool":
+		return "Review the agent identity and tool target relationship."
+	default:
+		return "Correlate runtime evidence with identity and resource graph context."
+	}
+}

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1,0 +1,525 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+)
+
+const (
+	awsRuntimeEventsCurrentIssue = 1513
+	awsRuntimeEventsVersion      = "aws-runtime-events-contract-v1"
+)
+
+type AWSRuntimeEventRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	EventType    string `json:"event_type,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Evidence     string `json:"evidence,omitempty"`
+	Owner        string `json:"owner,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+type AWSRuntimeEventSession struct {
+	SessionID        string    `json:"session_id"`
+	PrincipalARN     string    `json:"principal_arn"`
+	PrincipalType    string    `json:"principal_type"`
+	AssumedRoleARN   string    `json:"assumed_role_arn,omitempty"`
+	SessionIssuerARN string    `json:"session_issuer_arn,omitempty"`
+	SourceIPAddress  string    `json:"source_ip_address,omitempty"`
+	UserAgent        string    `json:"user_agent,omitempty"`
+	StartedAt        time.Time `json:"started_at"`
+	ExpiresAt        time.Time `json:"expires_at,omitempty"`
+}
+
+type AWSRuntimeEventRecord struct {
+	EventID             string                 `json:"event_id"`
+	AccountID           string                 `json:"account_id"`
+	Region              string                 `json:"region"`
+	EventType           string                 `json:"event_type"`
+	EventSource         string                 `json:"event_source"`
+	EventName           string                 `json:"event_name"`
+	Action              string                 `json:"action"`
+	ActorPrincipalARN   string                 `json:"actor_principal_arn"`
+	ActorPrincipalType  string                 `json:"actor_principal_type"`
+	ActorIdentityNodeID string                 `json:"actor_identity_node_id"`
+	Session             AWSRuntimeEventSession `json:"session"`
+	TargetResourceARN   string                 `json:"target_resource_arn,omitempty"`
+	TargetResourceType  string                 `json:"target_resource_type,omitempty"`
+	TargetResourceName  string                 `json:"target_resource_name,omitempty"`
+	ResourceNodeID      string                 `json:"resource_node_id,omitempty"`
+	AgentID             string                 `json:"agent_id,omitempty"`
+	AgentNodeID         string                 `json:"agent_node_id,omitempty"`
+	ToolName            string                 `json:"tool_name,omitempty"`
+	ToolTargetRef       string                 `json:"tool_target_ref,omitempty"`
+	Owner               string                 `json:"owner"`
+	EvidenceCategory    string                 `json:"evidence_category"`
+	EvidenceRef         string                 `json:"evidence_ref"`
+	Confidence          float64                `json:"confidence"`
+	ObservedAt          time.Time              `json:"observed_at"`
+	CollectedAt         time.Time              `json:"collected_at"`
+	Status              string                 `json:"status"`
+	NextAction          string                 `json:"next_action"`
+	RedactionBoundary   string                 `json:"redaction_boundary"`
+}
+
+type AWSRuntimeEventRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+type AWSRuntimeEventDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+type AWSRuntimeEventCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSRuntimeEventSummary struct {
+	TotalEvents            int            `json:"total_events"`
+	FilteredEvents         int            `json:"filtered_events"`
+	EventTypeCounts        map[string]int `json:"event_type_counts"`
+	StatusCounts           map[string]int `json:"status_counts"`
+	OwnerCounts            map[string]int `json:"owner_counts"`
+	AccountCount           int            `json:"account_count"`
+	RegionCount            int            `json:"region_count"`
+	IdentityCount          int            `json:"identity_count"`
+	ResourceCount          int            `json:"resource_count"`
+	AgentEventCount        int            `json:"agent_event_count"`
+	SecretReadCount        int            `json:"secret_read_count"`
+	KMSDecryptCount        int            `json:"kms_decrypt_count"`
+	APICallCount           int            `json:"api_call_count"`
+	STSSessionCount        int            `json:"sts_session_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	PermissionDeniedEvents int            `json:"permission_denied_events"`
+}
+
+type AWSRuntimeEventResult struct {
+	TenantID           string                        `json:"tenant_id"`
+	WorkspaceID        string                        `json:"workspace_id"`
+	ProjectID          string                        `json:"project_id"`
+	ConnectorID        string                        `json:"connector_id,omitempty"`
+	AccountID          string                        `json:"account_id,omitempty"`
+	Region             string                        `json:"region,omitempty"`
+	ParentIssueNumber  int                           `json:"parent_issue_number"`
+	ParentIssueRef     string                        `json:"parent_issue_ref"`
+	CurrentIssueNumber int                           `json:"current_issue_number"`
+	CurrentIssueRef    string                        `json:"current_issue_ref"`
+	Version            string                        `json:"version"`
+	Status             string                        `json:"status"`
+	FixtureState       string                        `json:"fixture_state"`
+	Confidence         float64                       `json:"confidence"`
+	AppliedFilters     map[string]string             `json:"applied_filters"`
+	Summary            AWSRuntimeEventSummary        `json:"summary"`
+	Records            []AWSRuntimeEventRecord       `json:"records"`
+	Relationships      []AWSRuntimeEventRelationship `json:"relationships"`
+	FailureReasons     []string                      `json:"failure_reasons"`
+	RemediationHints   []string                      `json:"remediation_hints"`
+	EvidenceLinks      []string                      `json:"evidence_links"`
+	CoverageGaps       []AWSRuntimeEventCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSRuntimeEventDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                     `json:"generated_at"`
+	UpdatedAt          time.Time                     `json:"updated_at"`
+}
+
+func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, projectID string, request AWSRuntimeEventRequest) (AWSRuntimeEventResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRuntimeEventResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRuntimeEventResult{}, err
+	}
+	return buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, s.Now().UTC())
+}
+
+func buildAWSRuntimeEvents(scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, request AWSRuntimeEventRequest, checkedAt time.Time) (AWSRuntimeEventResult, error) {
+	fixtureState := normalizeAWSRuntimeEventFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRuntimeEventResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	records, diagnostics, gaps := awsRuntimeEventFixtureRecords(accountID, region, fixtureState, checkedAt)
+	filtered, applied := filterAWSRuntimeEventRecords(records, request)
+	relationships := awsRuntimeEventRelationships(filtered)
+	summary := summarizeAWSRuntimeEvents(records, len(filtered), len(relationships))
+	status, confidence, failures, remediations := summarizeAWSRuntimeEventStatus(fixtureState, diagnostics, filtered)
+
+	return AWSRuntimeEventResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRuntimeEventsCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRuntimeEventsCurrentIssue),
+		Version:            awsRuntimeEventsVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Records:            filtered,
+		Relationships:      relationships,
+		FailureReasons:     emptyStrings(failures),
+		RemediationHints:   emptyStrings(remediations),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(1512),
+			awsIssueURL(1503),
+			"/docs/aws-runtime-events",
+			"/docs/aws-service-collector-contract",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: gaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  checkedAt,
+		UpdatedAt:    checkedAt,
+	}, nil
+}
+
+func normalizeAWSRuntimeEventFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func filterAWSRuntimeEventRecords(records []AWSRuntimeEventRecord, request AWSRuntimeEventRequest) ([]AWSRuntimeEventRecord, map[string]string) {
+	applied := map[string]string{}
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"event_type": normalizeAWSRuntimeEventFilterToken(request.EventType),
+		"identity":   strings.TrimSpace(request.Identity),
+		"agent_id":   strings.TrimSpace(request.AgentID),
+		"resource":   strings.TrimSpace(request.Resource),
+		"evidence":   normalizeAWSRuntimeEventFilterToken(request.Evidence),
+		"owner":      normalizeAWSRuntimeEventFilterToken(request.Owner),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		if value != "" && value != "all" {
+			applied[key] = value
+		}
+	}
+	filtered := make([]AWSRuntimeEventRecord, 0, len(records))
+	for _, record := range records {
+		if filters["account_id"] != "" && filters["account_id"] != record.AccountID {
+			continue
+		}
+		if filters["region"] != "" && filters["region"] != record.Region {
+			continue
+		}
+		if filters["event_type"] != "" && filters["event_type"] != "all" && filters["event_type"] != normalizeAWSRuntimeEventFilterToken(record.EventType) {
+			continue
+		}
+		if filters["evidence"] != "" && filters["evidence"] != "all" && filters["evidence"] != normalizeAWSRuntimeEventFilterToken(record.EvidenceCategory) {
+			continue
+		}
+		if filters["owner"] != "" && filters["owner"] != "all" && filters["owner"] != normalizeAWSRuntimeEventFilterToken(record.Owner) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != "all" && filters["status"] != normalizeAWSRuntimeEventFilterToken(record.Status) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(record, filters["identity"], record.ActorPrincipalARN, record.ActorIdentityNodeID, record.Session.AssumedRoleARN, record.Session.SessionIssuerARN) {
+			continue
+		}
+		if filters["agent_id"] != "" && !awsRuntimeEventMatchesAny(record, filters["agent_id"], record.AgentID, record.AgentNodeID) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(record, filters["resource"], record.TargetResourceARN, record.TargetResourceName, record.ResourceNodeID, record.ToolTargetRef) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered, applied
+}
+
+func normalizeAWSRuntimeEventFilterToken(value string) string {
+	return strings.ToLower(strings.NewReplacer(" ", "-", "_", "-").Replace(strings.TrimSpace(value)))
+}
+
+func awsRuntimeEventMatchesAny(record AWSRuntimeEventRecord, query string, values ...string) bool {
+	probe := strings.ToLower(strings.TrimSpace(query))
+	if probe == "" {
+		return true
+	}
+	for _, value := range append(values, record.EventID, record.EventSource, record.EventName, record.Action, record.EvidenceRef) {
+		if strings.Contains(strings.ToLower(value), probe) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSRuntimeEvents(records []AWSRuntimeEventRecord, filteredCount int, relationshipCount int) AWSRuntimeEventSummary {
+	summary := AWSRuntimeEventSummary{
+		TotalEvents:       len(records),
+		FilteredEvents:    filteredCount,
+		EventTypeCounts:   map[string]int{},
+		StatusCounts:      map[string]int{},
+		OwnerCounts:       map[string]int{},
+		RelationshipCount: relationshipCount,
+	}
+	accounts := map[string]struct{}{}
+	regions := map[string]struct{}{}
+	identities := map[string]struct{}{}
+	resources := map[string]struct{}{}
+	sessions := map[string]struct{}{}
+	for _, record := range records {
+		summary.EventTypeCounts[record.EventType]++
+		summary.StatusCounts[record.Status]++
+		summary.OwnerCounts[record.Owner]++
+		accounts[record.AccountID] = struct{}{}
+		regions[record.Region] = struct{}{}
+		identities[record.ActorIdentityNodeID] = struct{}{}
+		if record.ResourceNodeID != "" {
+			resources[record.ResourceNodeID] = struct{}{}
+		}
+		if record.Session.SessionID != "" {
+			sessions[record.Session.SessionID] = struct{}{}
+		}
+		switch record.EventType {
+		case "agent-tool":
+			summary.AgentEventCount++
+		case "secret-read":
+			summary.SecretReadCount++
+		case "kms-decrypt":
+			summary.KMSDecryptCount++
+		case "api-call":
+			summary.APICallCount++
+		case "sts-session":
+			summary.STSSessionCount++
+		}
+		if record.Status == "permission-denied" {
+			summary.PermissionDeniedEvents++
+		}
+	}
+	summary.AccountCount = len(accounts)
+	summary.RegionCount = len(regions)
+	summary.IdentityCount = len(identities)
+	summary.ResourceCount = len(resources)
+	if summary.STSSessionCount == 0 {
+		summary.STSSessionCount = len(sessions)
+	}
+	return summary
+}
+
+func summarizeAWSRuntimeEventStatus(fixtureState string, diagnostics []AWSRuntimeEventDiagnostic, records []AWSRuntimeEventRecord) (string, float64, []string, []string) {
+	switch fixtureState {
+	case "permission_denied":
+		return "blocked", 0,
+			[]string{"runtime event sources are not authorized for this connector"},
+			[]string{"Grant metadata-only CloudTrail LookupEvents and service audit permissions; do not grant payload, secret-value, decrypt, or object-body reads."}
+	case "empty":
+		return "degraded", 0.45,
+			[]string{"no runtime events matched the scoped account and region"},
+			[]string{"Confirm CloudTrail management events are enabled, then retry runtime event ingestion."}
+	case "partial_failure":
+		return "degraded", 0.74,
+			[]string{"one runtime event source failed while retained events remain visible"},
+			[]string{"Retry the failed runtime source without discarding successful runtime evidence."}
+	case "degraded":
+		return "degraded", 0.78,
+			[]string{"runtime events include low-confidence or delayed evidence"},
+			[]string{"Review delayed CloudTrail delivery before using runtime evidence for remediation decisions."}
+	default:
+		if len(records) == 0 {
+			return "degraded", 0.5, []string{"runtime event filters matched no records"}, []string{"Clear filters or broaden the time/resource scope."}
+		}
+		if len(diagnostics) > 0 {
+			return "degraded", 0.82, []string{"runtime event ingestion returned diagnostics"}, []string{"Review diagnostics before treating runtime coverage as complete."}
+		}
+		return "ready", 0.92, nil, nil
+	}
+}
+
+func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeEventRelationship {
+	out := []AWSRuntimeEventRelationship{}
+	for _, record := range records {
+		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" {
+			out = append(out, AWSRuntimeEventRelationship{Type: "observed_runtime_action", FromNodeID: record.ActorIdentityNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
+		}
+		if record.AgentNodeID != "" && record.ResourceNodeID != "" {
+			out = append(out, AWSRuntimeEventRelationship{Type: "agent_invoked_runtime_action", FromNodeID: record.AgentNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
+		}
+	}
+	return out
+}
+
+func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSRuntimeEventRecord, []AWSRuntimeEventDiagnostic, []AWSRuntimeEventCoverageGap) {
+	base := checkedAt.Add(-35 * time.Minute)
+	role := fmt.Sprintf("arn:aws:iam::%s:role/identrail-runtime-reader", accountID)
+	lambdaRole := fmt.Sprintf("arn:aws:iam::%s:role/lambda-invoice-agent", accountID)
+	agentRole := fmt.Sprintf("arn:aws:iam::%s:role/agentcore-case-triage-runtime", accountID)
+	session := func(id string, principal string, started time.Time) AWSRuntimeEventSession {
+		return AWSRuntimeEventSession{
+			SessionID:        id,
+			PrincipalARN:     principal,
+			PrincipalType:    "assumed_role",
+			AssumedRoleARN:   principal,
+			SessionIssuerARN: principal,
+			SourceIPAddress:  "AWS Internal",
+			UserAgent:        "identrail-runtime-fixture",
+			StartedAt:        started,
+			ExpiresAt:        started.Add(time.Hour),
+		}
+	}
+	records := []AWSRuntimeEventRecord{
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-sts-runtime-reader", "sts-session", "sts.amazonaws.com", "AssumeRole", "sts:AssumeRole", role, "", "", "security", "cloudtrail", base, session("sess-runtime-reader", role, base)),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-secret-invoice", "secret-read", "secretsmanager.amazonaws.com", "GetSecretValue", "secretsmanager:GetSecretValue", lambdaRole, fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/ai/openai-key", region, accountID), "secret", "application", "cloudtrail", base.Add(8*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-kms-decrypt", "kms-decrypt", "kms.amazonaws.com", "Decrypt", "kms:Decrypt", lambdaRole, fmt.Sprintf("arn:aws:kms:%s:%s:key/cmk-agent-secrets", region, accountID), "kms_key", "platform", "cloudtrail", base.Add(10*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-s3-access", "api-call", "s3.amazonaws.com", "GetObject", "s3:GetObject", lambdaRole, fmt.Sprintf("arn:aws:s3:::billing-artifacts-%s/reports/redacted", accountID), "s3_object_metadata", "application", "cloudtrail", base.Add(14*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
+		awsRuntimeEventFixtureRecord(accountID, region, "evt-agent-tool", "agent-tool", "bedrock-agentcore.amazonaws.com", "InvokeTool", "bedrock-agentcore:InvokeTool", agentRole, fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/blue", region, accountID), "agent_tool_target", "security", "agent-runtime", base.Add(19*time.Minute), session("sess-agentcore-runtime", agentRole, base.Add(18*time.Minute))),
+	}
+	records[4].AgentID = "runtime-case-triage"
+	records[4].AgentNodeID = awsAIAgentNodeID(accountID, region, "agentcore_runtime", "runtime-case-triage", "2026-06-01")
+	records[4].ToolName = "case-router"
+	records[4].ToolTargetRef = "case-router-policy-checker"
+	switch fixtureState {
+	case "empty":
+		return []AWSRuntimeEventRecord{}, nil, []AWSRuntimeEventCoverageGap{{
+			Capability:  "cloudtrail_lookup_events",
+			Status:      "empty",
+			Reason:      "No runtime events were available in the fixture window.",
+			Remediation: "Confirm management events are enabled and widen the runtime event time range.",
+		}}
+	case "degraded":
+		records[3].Status = "delayed"
+		records[3].Confidence = 0.64
+		return records, []AWSRuntimeEventDiagnostic{{
+			Collector:   "aws_runtime_events",
+			SourceID:    records[3].EventID,
+			Code:        "runtime_event_delivery_delayed",
+			Message:     "CloudTrail delivered one runtime event after the expected collection window.",
+			Remediation: "Keep delayed evidence visible and avoid automated remediation until the event window catches up.",
+			Retryable:   true,
+		}}, nil
+	case "partial_failure":
+		return records[:3], []AWSRuntimeEventDiagnostic{{
+				Collector:   "aws_runtime_events",
+				SourceID:    "agent-runtime",
+				Code:        "agent_runtime_event_source_failed",
+				Message:     "Agent runtime event source failed; CloudTrail events remain visible.",
+				Remediation: "Retry only the agent runtime source and preserve retained CloudTrail evidence.",
+				Retryable:   true,
+			}}, []AWSRuntimeEventCoverageGap{{
+				Capability:  "agent_runtime_events",
+				Status:      "partial_failure",
+				Reason:      "Agent runtime events could not be listed in this fixture.",
+				Remediation: "Retry AgentCore runtime event collection without discarding CloudTrail events.",
+			}}
+	case "permission_denied":
+		return []AWSRuntimeEventRecord{}, []AWSRuntimeEventDiagnostic{{
+				Collector:   "aws_runtime_events",
+				SourceID:    "cloudtrail",
+				Code:        "permission_denied",
+				Message:     "CloudTrail LookupEvents permission is not available for runtime event ingestion.",
+				Remediation: "Grant metadata-only CloudTrail LookupEvents access. Do not grant payload, secret-value, decrypt, or object-body reads.",
+				Retryable:   true,
+			}}, []AWSRuntimeEventCoverageGap{{
+				Capability:  "cloudtrail_lookup_events",
+				Status:      "permission_denied",
+				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only event lookup permissions and retry.",
+			}}
+	default:
+		return records, nil, nil
+	}
+}
+
+func awsRuntimeEventFixtureRecord(accountID string, region string, id string, eventType string, source string, name string, action string, actorARN string, resourceARN string, resourceType string, owner string, evidence string, observedAt time.Time, session AWSRuntimeEventSession) AWSRuntimeEventRecord {
+	resourceName := ""
+	if resourceARN != "" {
+		resourceName = resourceARN
+		if slash := strings.LastIndex(resourceARN, "/"); slash >= 0 && slash < len(resourceARN)-1 {
+			resourceName = resourceARN[slash+1:]
+		} else if colon := strings.LastIndex(resourceARN, ":"); colon >= 0 && colon < len(resourceARN)-1 {
+			resourceName = resourceARN[colon+1:]
+		}
+	}
+	actorNode := awsIdentityNodeIDForAPI(actorARN)
+	return AWSRuntimeEventRecord{
+		EventID:             id,
+		AccountID:           accountID,
+		Region:              region,
+		EventType:           eventType,
+		EventSource:         source,
+		EventName:           name,
+		Action:              action,
+		ActorPrincipalARN:   actorARN,
+		ActorPrincipalType:  "assumed_role",
+		ActorIdentityNodeID: actorNode,
+		Session:             session,
+		TargetResourceARN:   resourceARN,
+		TargetResourceType:  resourceType,
+		TargetResourceName:  resourceName,
+		ResourceNodeID:      awsRuntimeEventResourceNodeID(resourceARN, resourceType),
+		Owner:               owner,
+		EvidenceCategory:    evidence,
+		EvidenceRef:         fmt.Sprintf("runtime-evidence://%s/%s/%s", accountID, region, id),
+		Confidence:          0.9,
+		ObservedAt:          observedAt,
+		CollectedAt:         observedAt.Add(2 * time.Minute),
+		Status:              "observed",
+		NextAction:          awsRuntimeEventNextAction(eventType),
+		RedactionBoundary:   "metadata_only_no_payloads_no_secret_values",
+	}
+}
+
+func awsRuntimeEventResourceNodeID(resourceARN string, resourceType string) string {
+	if strings.TrimSpace(resourceARN) == "" {
+		return ""
+	}
+	return "aws:runtime-resource:" + normalizeName(firstNonEmptyAWSValue(resourceType, "resource")) + ":" + sanitizeCredentialReferenceToken(resourceARN)
+}
+
+func awsRuntimeEventNextAction(eventType string) string {
+	switch eventType {
+	case "sts-session":
+		return "Correlate the session with downstream API calls."
+	case "secret-read":
+		return "Confirm the secret read matches an expected workload path."
+	case "kms-decrypt":
+		return "Join decrypt evidence with key reachability before remediation."
+	case "agent-tool":
+		return "Review the agent identity and tool target relationship."
+	default:
+		return "Correlate runtime evidence with identity and resource graph context."
+	}
+}

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -77,6 +77,9 @@ func TestGetAWSRuntimeEventsAppliesFiltersAndRelationships(t *testing.T) {
 	if result.AppliedFilters["event_type"] != "agent-tool" || result.AppliedFilters["agent_id"] != "runtime-case-triage" {
 		t.Fatalf("expected applied runtime filters, got %+v", result.AppliedFilters)
 	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("expected filtered agent-tool response to omit unrelated diagnostics, got %+v", result.Diagnostics)
+	}
 	for _, relationship := range result.Relationships {
 		if relationship.EvidenceRef != result.Records[0].EvidenceRef {
 			t.Fatalf("expected relationships scoped to filtered event, got %+v", relationship)
@@ -108,6 +111,49 @@ func TestGetAWSRuntimeEventsAppliesFiltersAndRelationships(t *testing.T) {
 				t.Fatalf("expected scoped filter to avoid metadata-only false positives, got summary=%+v records=%+v", result.Summary, result.Records)
 			}
 		})
+	}
+}
+
+func TestGetAWSRuntimeEventsScopesDiagnosticsToFilteredRecords(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-diagnostics")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-diagnostics", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-diagnostics", AWSRuntimeEventRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "degraded",
+		EventType:    "agent-tool",
+		Evidence:     "agent-runtime",
+		AgentID:      "runtime-case-triage",
+		Resource:     "runtime-case-triage",
+		Identity:     "agentcore-case-triage-runtime",
+		Owner:        "security",
+		Status:       "observed",
+	})
+	if err != nil {
+		t.Fatalf("get filtered degraded runtime events: %v", err)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-agent-tool" {
+		t.Fatalf("expected only the filtered agent event, got %+v", result.Records)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("expected delayed s3 diagnostic to be omitted from agent-only response, got %+v", result.Diagnostics)
+	}
+
+	unfiltered, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-diagnostics", AWSRuntimeEventRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "degraded",
+	})
+	if err != nil {
+		t.Fatalf("get unfiltered degraded runtime events: %v", err)
+	}
+	if len(unfiltered.Diagnostics) != 1 || unfiltered.Diagnostics[0].SourceID != "evt-s3-access" {
+		t.Fatalf("expected unfiltered degraded response to retain source diagnostic, got %+v", unfiltered.Diagnostics)
 	}
 }
 

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSRuntimeEventsBuildsMetadataOnlyContract(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime", AWSRuntimeEventRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.CurrentIssueRef != "#1513" || result.Version != awsRuntimeEventsVersion || result.Status != "ready" {
+		t.Fatalf("unexpected runtime event contract metadata: %+v", result)
+	}
+	if result.Summary.TotalEvents != 5 || result.Summary.FilteredEvents != 5 || result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("unexpected runtime event summary: %+v relationships=%d", result.Summary, len(result.Relationships))
+	}
+	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 {
+		t.Fatalf("expected runtime event type counts, got %+v", result.Summary)
+	}
+	for _, record := range result.Records {
+		if record.RedactionBoundary != "metadata_only_no_payloads_no_secret_values" {
+			t.Fatalf("runtime event leaked unsafe redaction boundary: %+v", record)
+		}
+		if record.EvidenceRef == "" || record.ActorIdentityNodeID == "" || record.Session.SessionID == "" || record.Confidence <= 0 {
+			t.Fatalf("runtime event missing evidence/session/identity/confidence: %+v", record)
+		}
+	}
+	if len(result.EvidenceLinks) == 0 || len(result.FailureReasons) != 0 {
+		t.Fatalf("expected evidence links and no failure reasons, got links=%v failures=%v", result.EvidenceLinks, result.FailureReasons)
+	}
+}
+
+func TestGetAWSRuntimeEventsAppliesFiltersAndRelationships(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-filter")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-filter", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-filter", AWSRuntimeEventRequest{
+		ConnectorID: "aws-prod",
+		EventType:   "agent-tool",
+		Owner:       "security",
+		Evidence:    "agent-runtime",
+		AgentID:     "runtime-case-triage",
+	})
+	if err != nil {
+		t.Fatalf("get filtered runtime events: %v", err)
+	}
+	if result.Summary.TotalEvents <= result.Summary.FilteredEvents || result.Summary.FilteredEvents != 1 || len(result.Records) != 1 {
+		t.Fatalf("expected one filtered runtime event with retained total count, got %+v records=%d", result.Summary, len(result.Records))
+	}
+	if result.Records[0].EventType != "agent-tool" || result.Records[0].AgentID != "runtime-case-triage" {
+		t.Fatalf("expected agent tool event, got %+v", result.Records[0])
+	}
+	if result.AppliedFilters["event_type"] != "agent-tool" || result.AppliedFilters["agent_id"] != "runtime-case-triage" {
+		t.Fatalf("expected applied runtime filters, got %+v", result.AppliedFilters)
+	}
+	for _, relationship := range result.Relationships {
+		if relationship.EvidenceRef != result.Records[0].EvidenceRef {
+			t.Fatalf("expected relationships scoped to filtered event, got %+v", relationship)
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		request AWSRuntimeEventRequest
+	}{
+		{
+			name:    "identity does not match event metadata",
+			request: AWSRuntimeEventRequest{ConnectorID: "aws-prod", Identity: "InvokeTool"},
+		},
+		{
+			name:    "agent id does not match event metadata",
+			request: AWSRuntimeEventRequest{ConnectorID: "aws-prod", AgentID: "bedrock-agentcore"},
+		},
+		{
+			name:    "resource does not match evidence metadata",
+			request: AWSRuntimeEventRequest{ConnectorID: "aws-prod", Resource: "runtime-evidence"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-filter", tc.request)
+			if err != nil {
+				t.Fatalf("get scoped filtered runtime events: %v", err)
+			}
+			if len(result.Records) != 0 || result.Summary.FilteredEvents != 0 {
+				t.Fatalf("expected scoped filter to avoid metadata-only false positives, got summary=%+v records=%+v", result.Summary, result.Records)
+			}
+		})
+	}
+}
+
+func TestRouterAWSRuntimeEventsHandlesFailureStates(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 19, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-router")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-router", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	for _, tc := range []struct {
+		state      string
+		wantStatus string
+		wantCode   int
+	}{
+		{state: "empty", wantStatus: "degraded", wantCode: http.StatusOK},
+		{state: "partial_failure", wantStatus: "degraded", wantCode: http.StatusOK},
+		{state: "permission_denied", wantStatus: "blocked", wantCode: http.StatusOK},
+		{state: "invalid_state", wantCode: http.StatusBadRequest},
+	} {
+		resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-runtime-router/aws/runtime-events?connector_id=aws-prod&fixture_state="+tc.state, "")
+		if resp.Code != tc.wantCode {
+			t.Fatalf("state %s expected HTTP %d, got %d body=%s", tc.state, tc.wantCode, resp.Code, resp.Body.String())
+		}
+		if tc.wantCode != http.StatusOK {
+			continue
+		}
+		var body struct {
+			Runtime AWSRuntimeEventResult `json:"runtime"`
+		}
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode runtime response for %s: %v", tc.state, err)
+		}
+		if body.Runtime.Status != tc.wantStatus {
+			t.Fatalf("state %s expected status %q, got %+v", tc.state, tc.wantStatus, body.Runtime)
+		}
+		if len(body.Runtime.Records) == 0 && tc.state == "partial_failure" {
+			t.Fatalf("partial failure should retain successful runtime events: %+v", body.Runtime)
+		}
+	}
+}

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestGetAWSRuntimeEventsBuildsMetadataOnlyContract(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime", AWSRuntimeEventRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.CurrentIssueRef != "#1513" || result.Version != awsRuntimeEventsVersion || result.Status != "ready" {
+		t.Fatalf("unexpected runtime event contract metadata: %+v", result)
+	}
+	if result.Summary.TotalEvents != 5 || result.Summary.FilteredEvents != 5 || result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("unexpected runtime event summary: %+v relationships=%d", result.Summary, len(result.Relationships))
+	}
+	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 {
+		t.Fatalf("expected runtime event type counts, got %+v", result.Summary)
+	}
+	for _, record := range result.Records {
+		if record.RedactionBoundary != "metadata_only_no_payloads_no_secret_values" {
+			t.Fatalf("runtime event leaked unsafe redaction boundary: %+v", record)
+		}
+		if record.EvidenceRef == "" || record.ActorIdentityNodeID == "" || record.Session.SessionID == "" || record.Confidence <= 0 {
+			t.Fatalf("runtime event missing evidence/session/identity/confidence: %+v", record)
+		}
+	}
+	if len(result.EvidenceLinks) == 0 || len(result.FailureReasons) != 0 {
+		t.Fatalf("expected evidence links and no failure reasons, got links=%v failures=%v", result.EvidenceLinks, result.FailureReasons)
+	}
+}
+
+func TestGetAWSRuntimeEventsAppliesFiltersAndRelationships(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-filter")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-filter", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-filter", AWSRuntimeEventRequest{
+		ConnectorID: "aws-prod",
+		EventType:   "agent-tool",
+		Owner:       "security",
+		Evidence:    "agent-runtime",
+		AgentID:     "runtime-case-triage",
+	})
+	if err != nil {
+		t.Fatalf("get filtered runtime events: %v", err)
+	}
+	if result.Summary.TotalEvents <= result.Summary.FilteredEvents || result.Summary.FilteredEvents != 1 || len(result.Records) != 1 {
+		t.Fatalf("expected one filtered runtime event with retained total count, got %+v records=%d", result.Summary, len(result.Records))
+	}
+	if result.Records[0].EventType != "agent-tool" || result.Records[0].AgentID != "runtime-case-triage" {
+		t.Fatalf("expected agent tool event, got %+v", result.Records[0])
+	}
+	if result.AppliedFilters["event_type"] != "agent-tool" || result.AppliedFilters["agent_id"] != "runtime-case-triage" {
+		t.Fatalf("expected applied runtime filters, got %+v", result.AppliedFilters)
+	}
+	for _, relationship := range result.Relationships {
+		if relationship.EvidenceRef != result.Records[0].EvidenceRef {
+			t.Fatalf("expected relationships scoped to filtered event, got %+v", relationship)
+		}
+	}
+}
+
+func TestRouterAWSRuntimeEventsHandlesFailureStates(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 19, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-router")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-router", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	for _, tc := range []struct {
+		state      string
+		wantStatus string
+		wantCode   int
+	}{
+		{state: "empty", wantStatus: "degraded", wantCode: http.StatusOK},
+		{state: "partial_failure", wantStatus: "degraded", wantCode: http.StatusOK},
+		{state: "permission_denied", wantStatus: "blocked", wantCode: http.StatusOK},
+		{state: "invalid_state", wantCode: http.StatusBadRequest},
+	} {
+		resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-runtime-router/aws/runtime-events?connector_id=aws-prod&fixture_state="+tc.state, "")
+		if resp.Code != tc.wantCode {
+			t.Fatalf("state %s expected HTTP %d, got %d body=%s", tc.state, tc.wantCode, resp.Code, resp.Body.String())
+		}
+		if tc.wantCode != http.StatusOK {
+			continue
+		}
+		var body struct {
+			Runtime AWSRuntimeEventResult `json:"runtime"`
+		}
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode runtime response for %s: %v", tc.state, err)
+		}
+		if body.Runtime.Status != tc.wantStatus {
+			t.Fatalf("state %s expected status %q, got %+v", tc.state, tc.wantStatus, body.Runtime)
+		}
+		if len(body.Runtime.Records) == 0 && tc.state == "partial_failure" {
+			t.Fatalf("partial failure should retain successful runtime events: %+v", body.Runtime)
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2869,6 +2869,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"inventory": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSRuntimeEvents(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRuntimeEventRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			EventType:    strings.TrimSpace(c.Query("event_type")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			AgentID:      strings.TrimSpace(c.Query("agent_id")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			Evidence:     strings.TrimSpace(c.Query("evidence")),
+			Owner:        strings.TrimSpace(c.Query("owner")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws runtime event request"})
+			default:
+				logger.Error("get aws runtime events",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws runtime events"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"runtime": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1178,6 +1178,52 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS runtime events with scoped headers, fixture state, and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        runtime: {
+          status: 'ready',
+          event_count: 2,
+          filtered_event_count: 2,
+          records: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectRuntimeEvents(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'partial_failure',
+        eventType: 'agent-tool',
+        identity: 'payments',
+        agentID: 'PAYMENTSAGENT1',
+        resource: 'arn:aws:s3:::payments-prod',
+        evidence: 'cloudtrail',
+        owner: 'security',
+        status: 'observed'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/runtime-events?connector_id=aws-prod&fixture_state=partial_failure&event_type=agent-tool&identity=payments&agent_id=PAYMENTSAGENT1&resource=arn%3Aaws%3As3%3A%3A%3Apayments-prod&evidence=cloudtrail&owner=security&status=observed'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2101,6 +2101,141 @@ export type AWSAIAgentIdentityQuery = {
   minConfidence?: string;
 };
 
+export type AWSRuntimeEventStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSRuntimeEventFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSRuntimeEventSession = {
+  session_id: string;
+  principal_arn: string;
+  principal_type: string;
+  assumed_role_arn?: string;
+  session_issuer_arn?: string;
+  source_ip_address?: string;
+  user_agent?: string;
+  started_at: string;
+  expires_at?: string;
+};
+
+export type AWSRuntimeEventRecord = {
+  event_id: string;
+  account_id: string;
+  region: string;
+  event_type: 'sts-session' | 'api-call' | 'secret-read' | 'kms-decrypt' | 'agent-tool' | string;
+  event_source: string;
+  event_name: string;
+  action: string;
+  actor_principal_arn: string;
+  actor_principal_type: string;
+  actor_identity_node_id: string;
+  session: AWSRuntimeEventSession;
+  target_resource_arn?: string;
+  target_resource_type?: string;
+  target_resource_name?: string;
+  resource_node_id?: string;
+  agent_id?: string;
+  agent_node_id?: string;
+  tool_name?: string;
+  tool_target_ref?: string;
+  owner: string;
+  evidence_category: string;
+  evidence_ref: string;
+  confidence: number;
+  observed_at: string;
+  collected_at: string;
+  status: string;
+  next_action: string;
+  redaction_boundary: string;
+};
+
+export type AWSRuntimeEventRelationship = {
+  type: 'observed_runtime_action' | 'agent_invoked_runtime_action' | string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSRuntimeEventDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: 'runtime_event_delivery_delayed' | 'agent_runtime_event_source_failed' | 'permission_denied' | string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSRuntimeEventCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSRuntimeEventSummary = {
+  total_events: number;
+  filtered_events: number;
+  event_type_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  owner_counts: Record<string, number>;
+  account_count: number;
+  region_count: number;
+  identity_count: number;
+  resource_count: number;
+  agent_event_count: number;
+  secret_read_count: number;
+  kms_decrypt_count: number;
+  api_call_count: number;
+  sts_session_count: number;
+  relationship_count: number;
+  permission_denied_events: number;
+};
+
+export type AWSRuntimeEventResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSRuntimeEventStatus;
+  fixture_state: AWSRuntimeEventFixtureState;
+  confidence: number;
+  applied_filters: Record<string, string>;
+  summary: AWSRuntimeEventSummary;
+  records: AWSRuntimeEventRecord[];
+  relationships: AWSRuntimeEventRelationship[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSRuntimeEventCoverageGap[];
+  diagnostics: AWSRuntimeEventDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSRuntimeEventQuery = {
+  connectorID?: string;
+  fixtureState?: AWSRuntimeEventFixtureState;
+  accountID?: string;
+  region?: string;
+  eventType?: string;
+  identity?: string;
+  agentID?: string;
+  resource?: string;
+  evidence?: string;
+  owner?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -5180,6 +5315,29 @@ export const apiClient = {
         agent_id: filters?.agentID,
         identity: filters?.identity,
         provider: filters?.provider
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectRuntimeEvents(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSRuntimeEventQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ runtime: AWSRuntimeEventResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/runtime-events${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        event_type: query?.eventType,
+        identity: query?.identity,
+        agent_id: query?.agentID,
+        resource: query?.resource,
+        evidence: query?.evidence,
+        owner: query?.owner,
+        status: query?.status
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -13,6 +13,7 @@ import type {
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
+  AWSRuntimeEventResult,
   AWSServiceCollectorContractResult,
   CurrentUserContext,
   Finding,
@@ -149,6 +150,118 @@ const connectedAWS: AWSConnectionStatus = {
   capabilities: { requested: ['discovery'], validated: ['discovery'], effective: ['discovery'], unavailable: [] },
   updated_at: '2026-05-17T10:00:00Z',
   last_validated_at: '2026-05-17T10:00:00Z'
+};
+
+const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1472,
+  parent_issue_ref: '#1472',
+  current_issue_number: 1513,
+  current_issue_ref: '#1513',
+  version: 'aws-runtime-events-contract-v1',
+  status: 'ready',
+  fixture_state: 'success',
+  confidence: 0.92,
+  applied_filters: {},
+  summary: {
+    total_events: 2,
+    filtered_events: 2,
+    event_type_counts: { 'api-call': 1, 'agent-tool': 1 },
+    status_counts: { observed: 2 },
+    owner_counts: { security: 2 },
+    account_count: 1,
+    region_count: 1,
+    identity_count: 1,
+    resource_count: 2,
+    agent_event_count: 1,
+    secret_read_count: 0,
+    kms_decrypt_count: 0,
+    api_call_count: 1,
+    sts_session_count: 0,
+    relationship_count: 2,
+    permission_denied_events: 0
+  },
+  records: [
+    {
+      event_id: 'evt-s3-access',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'api-call',
+      event_source: 's3.amazonaws.com',
+      event_name: 'GetObject',
+      action: 's3:GetObject',
+      actor_principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      actor_principal_type: 'assumed_role',
+      actor_identity_node_id: 'aws:identity:lambda-invoice-agent',
+      session: {
+        session_id: 'sess-invoice-agent',
+        principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        principal_type: 'assumed_role',
+        started_at: '2026-06-14T17:00:00Z'
+      },
+      target_resource_arn: 'arn:aws:s3:::billing-artifacts-123456789012/reports/redacted',
+      target_resource_type: 's3_object_metadata',
+      target_resource_name: 'redacted',
+      resource_node_id: 'aws:runtime-resource:s3_object_metadata:redacted',
+      owner: 'security',
+      evidence_category: 'cloudtrail',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-s3-access',
+      confidence: 0.9,
+      observed_at: '2026-06-14T17:15:00Z',
+      collected_at: '2026-06-14T17:17:00Z',
+      status: 'observed',
+      next_action: 'Correlate runtime evidence with identity and resource graph context.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    },
+    {
+      event_id: 'evt-agent-tool',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'agent-tool',
+      event_source: 'bedrock-agentcore.amazonaws.com',
+      event_name: 'InvokeTool',
+      action: 'bedrock-agentcore:InvokeTool',
+      actor_principal_arn: 'arn:aws:iam::123456789012:role/agentcore-case-triage-runtime',
+      actor_principal_type: 'assumed_role',
+      actor_identity_node_id: 'aws:identity:agentcore-case-triage-runtime',
+      session: {
+        session_id: 'sess-agentcore-runtime',
+        principal_arn: 'arn:aws:iam::123456789012:role/agentcore-case-triage-runtime',
+        principal_type: 'assumed_role',
+        started_at: '2026-06-14T17:18:00Z'
+      },
+      target_resource_arn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime-case-triage/blue',
+      target_resource_type: 'agent_tool_target',
+      target_resource_name: 'blue',
+      resource_node_id: 'aws:runtime-resource:agent_tool_target:blue',
+      agent_id: 'runtime-case-triage',
+      agent_node_id: 'aws:agent:runtime-case-triage',
+      tool_name: 'case-router',
+      tool_target_ref: 'case-router-policy-checker',
+      owner: 'security',
+      evidence_category: 'agent-runtime',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-agent-tool',
+      confidence: 0.9,
+      observed_at: '2026-06-14T17:19:00Z',
+      collected_at: '2026-06-14T17:21:00Z',
+      status: 'observed',
+      next_action: 'Review the agent identity and tool target relationship.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    }
+  ],
+  relationships: [],
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: ['/docs/aws-runtime-events'],
+  coverage_gaps: [],
+  diagnostics: [],
+  generated_at: '2026-06-14T17:30:00Z',
+  updated_at: '2026-06-14T17:30:00Z'
 };
 
 const readyAWSEC2InstanceProfileInventory: AWSEC2InstanceProfileInventoryResult = {
@@ -2635,6 +2748,69 @@ describe('Domain-first app routes', () => {
     expect(screen.getAllByText(/Bedrock agents/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/AgentCore runtime and gateway identity/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Secret metadata only, no value reads/i)).toBeInTheDocument();
+  });
+
+  it('translates AWS runtime filter aliases before querying runtime events', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getRuntimeEvents = vi
+      .spyOn(api.apiClient, 'getAWSProjectRuntimeEvents')
+      .mockResolvedValue({ runtime: readyAWSRuntimeEvents });
+
+    const { ProductAWSRuntimePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/runtime?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/runtime" element={<ProductAWSRuntimePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
+    expect(await screen.findByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Event type' }), {
+      target: { value: 'cloudtrail' }
+    });
+
+    await waitFor(() =>
+      expect(getRuntimeEvents).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', eventType: 'api-call' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(screen.getByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Agent tool: InvokeTool/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Evidence' }), {
+      target: { value: 'cloudtrail' }
+    });
+
+    await waitFor(() =>
+      expect(getRuntimeEvents).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', eventType: 'api-call', evidence: 'cloudtrail' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('keeps AWS resources inventory metadata-only when no environment exists', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -42,6 +42,8 @@ import {
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
+  type AWSRuntimeEventRecord,
+  type AWSRuntimeEventResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -9651,9 +9653,8 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
       label: 'Evidence',
       options: [
         { label: 'All evidence', value: 'all' },
-        { label: 'Current connector', value: 'current-connector' },
-        { label: 'Coming', value: 'coming' },
-        { label: 'Unavailable', value: 'unavailable' }
+        { label: 'CloudTrail', value: 'cloudtrail' },
+        { label: 'Agent runtime', value: 'agent-runtime' }
       ]
     },
     {
@@ -9970,90 +9971,42 @@ function AWSRiskOperationPrerequisites({
 }
 
 function AWSRuntimeEvidenceContent({
-  connection,
+  runtime,
+  loading,
+  error,
   filters,
-  onFiltersChange
+  onFiltersChange,
+  onRetry
 }: {
-  connection: AWSConnectionStatus | null;
+  runtime: AWSRuntimeEventResult | null;
+  loading: boolean;
+  error: string;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
+  onRetry: () => void;
 }) {
-  const rows: AWSRiskOperationTableRow[] = [
-    ...(connection?.role_arn
-      ? [
-          {
-            id: 'runtime-role-anchor',
-            title: awsConnectionRoleLabel(connection),
-            category: 'STS AssumeRole',
-            evidence: 'Connector',
-            owner: 'Security',
-            blastRadius: awsAccountRegionLabel(connection),
-            nextAction: 'Attach CloudTrail',
-            status: 'connector',
-            stage: 'wired' as AWSCapabilityStage,
-            filters: { event: 'sts-assume-role', evidence: 'current-connector', owner: 'security', search: '' },
-            searchText: inventorySearchText([connection.role_arn, connection.principal_arn, 'sts assume role current connector'])
-          }
-        ]
-      : []),
-    {
-      id: 'cloudtrail-management-events',
-      title: 'CloudTrail management events',
-      category: 'CloudTrail',
-      evidence: 'Planned',
-      owner: 'Security',
-      blastRadius: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
-      nextAction: 'Wire ingestion',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'cloudtrail', evidence: 'coming', owner: 'security', search: '' },
-      searchText: inventorySearchText(['cloudtrail', 'management events', 'runtime evidence'])
-    },
-    {
-      id: 'secret-read-events',
-      title: 'Secrets Manager GetSecretValue',
-      category: 'Secrets Manager',
-      evidence: 'Planned',
-      owner: 'Application',
-      blastRadius: 'Secret metadata only',
-      nextAction: 'Map metadata',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'secrets-manager', evidence: 'coming', owner: 'application', search: '' },
-      searchText: inventorySearchText(['secrets manager', 'getsecretvalue', 'secret reads'])
-    },
-    {
-      id: 'kms-decrypt-events',
-      title: 'KMS Decrypt activity',
-      category: 'KMS decrypt',
-      evidence: 'Planned',
-      owner: 'Platform',
-      blastRadius: 'Key reachability pending',
-      nextAction: 'Join key policy',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'kms-decrypt', evidence: 'coming', owner: 'platform', search: '' },
-      searchText: inventorySearchText(['kms', 'decrypt', 'runtime evidence'])
-    },
-    {
-      id: 'agent-tool-events',
-      title: 'Agent tool invocation',
-      category: 'Agent tool',
-      evidence: 'Unavailable',
-      owner: 'Security',
-      blastRadius: 'Agent graph pending',
-      nextAction: 'Map agent identity',
-      status: 'unavailable',
-      stage: 'not-available',
-      filters: { event: 'agent-tool', evidence: 'unavailable', owner: 'security', search: '' },
-      searchText: inventorySearchText(['agent', 'tool', 'mcp', 'agentcore'])
-    }
-  ];
-  const displayedRows = filterAWSInventoryRows(rows, filters);
+  const rows: AWSRiskOperationTableRow[] = runtime ? runtime.records.map((record) => awsRuntimeEventRow(record)) : [];
+  const displayFilters = awsRuntimeEventDisplayFilters(filters);
+  const displayedRows = filterAWSInventoryRows(rows, displayFilters);
 
   return (
     <>
       <AWSRiskOperationFilterSet routeID="runtime" filters={filters} onChange={onFiltersChange} />
+      {error ? <DomainErrorState title="Couldn't load runtime events" body={error} retryAction={{ label: 'Retry', onClick: onRetry }} /> : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Loading runtime events"
+          body="Identrail is loading metadata-only runtime events for this AWS environment."
+        />
+      ) : null}
+      {!error && !loading && runtime && runtime.records.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={runtime.status === 'blocked' ? 'Permission required' : 'No runtime events'}
+          title={runtime.status === 'blocked' ? 'Runtime events need read-only event access' : 'No runtime events matched'}
+          body={runtime.failure_reasons[0] ?? 'Runtime event ingestion returned no events for the current environment and filters.'}
+        />
+      ) : null}
       <DomainDataTable
         label="AWS runtime evidence surfaces"
         rows={displayedRows}
@@ -10073,6 +10026,125 @@ function AWSRuntimeEvidenceContent({
       />
     </>
   );
+}
+
+function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
+  const eventLabel = awsRuntimeEventLabel(record);
+  const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
+  const observed = formatShortDateLabel(record.observed_at);
+  return {
+    id: `runtime-${record.event_id}`,
+    title: `${eventLabel}: ${record.event_name}`,
+    category: eventLabel,
+    evidence: `${formatTokenLabel(record.evidence_category)} · ${formatConfidenceScore(record.confidence)}`,
+    owner: formatTokenLabel(record.owner),
+    blastRadius: `${awsAccountRegionInventoryLabel(record.account_id, record.region)} · ${resourceLabel}`,
+    nextAction: record.next_action,
+    status: record.status,
+    stage: record.status === 'observed' ? 'wired' : record.status === 'permission-denied' ? 'not-available' : 'coming',
+    filters: {
+      event: awsRuntimeEventUIEventFilterToken(record.event_type),
+      evidence: awsRuntimeEventFilterToken(record.evidence_category),
+      owner: awsRuntimeEventFilterToken(record.owner),
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.event_id,
+      record.event_type,
+      record.event_source,
+      record.event_name,
+      record.action,
+      record.actor_principal_arn,
+      record.session?.session_id,
+      record.target_resource_arn,
+      record.target_resource_type,
+      record.agent_id,
+      record.tool_name,
+      record.tool_target_ref,
+      record.evidence_ref,
+      observed,
+      'runtime event metadata only no payloads no secret values'
+    ])
+  };
+}
+
+function awsRuntimeEventLabel(record: AWSRuntimeEventRecord): string {
+  switch (record.event_type) {
+    case 'sts-session':
+      return 'STS AssumeRole';
+    case 'secret-read':
+      return 'Secrets Manager';
+    case 'kms-decrypt':
+      return 'KMS decrypt';
+    case 'agent-tool':
+      return 'Agent tool';
+    default:
+      return 'CloudTrail';
+  }
+}
+
+function awsRuntimeEventFilterToken(value: string): string {
+  return normalizeFilterValue(value).replace(/_/g, '-');
+}
+
+function awsRuntimeEventUIEventFilterToken(value: string): string {
+  switch (awsRuntimeEventFilterToken(value)) {
+    case 'sts-session':
+      return 'sts-assume-role';
+    case 'secret-read':
+      return 'secrets-manager';
+    case 'api-call':
+      return 'cloudtrail';
+    default:
+      return awsRuntimeEventFilterToken(value);
+  }
+}
+
+function awsRuntimeEventAPIEventFilterToken(value: string | undefined): string | undefined {
+  switch (awsRuntimeEventFilterToken(value ?? '')) {
+    case '':
+    case 'all':
+      return undefined;
+    case 'sts-assume-role':
+      return 'sts-session';
+    case 'secrets-manager':
+      return 'secret-read';
+    case 'cloudtrail':
+      return 'api-call';
+    default:
+      return awsRuntimeEventFilterToken(value ?? '');
+  }
+}
+
+function awsRuntimeEventAPIEvidenceFilterToken(value: string | undefined): string | undefined {
+  switch (awsRuntimeEventFilterToken(value ?? '')) {
+    case '':
+    case 'all':
+    case 'coming':
+    case 'unavailable':
+      return undefined;
+    case 'current-connector':
+      return 'cloudtrail';
+    default:
+      return awsRuntimeEventFilterToken(value ?? '');
+  }
+}
+
+function awsRuntimeEventDisplayFilters(filters: AWSInventoryFilterState): AWSInventoryFilterState {
+  const event = awsRuntimeEventFilterToken(filters.event ?? '');
+  const evidence = awsRuntimeEventFilterToken(filters.evidence ?? '');
+  return {
+    ...filters,
+    event:
+      event === 'api-call'
+        ? 'cloudtrail'
+        : event === 'sts-session'
+          ? 'sts-assume-role'
+          : event === 'secret-read'
+            ? 'secrets-manager'
+            : filters.event,
+    evidence: evidence === 'current-connector' ? 'cloudtrail' : evidence === 'coming' || evidence === 'unavailable' ? 'all' : filters.evidence
+  };
 }
 
 function AWSGraphExplorerContent({
@@ -10395,6 +10467,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [activeFilters, setActiveFilters] = useState<AWSInventoryFilterState>(() => ({
     ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID]
   }));
+  const [runtimeEvents, setRuntimeEvents] = useState<AWSRuntimeEventResult | null>(null);
+  const [runtimeEventsLoading, setRuntimeEventsLoading] = useState(false);
+  const [runtimeEventsError, setRuntimeEventsError] = useState('');
+  const runtimeEventsRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -10403,6 +10479,60 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   useEffect(() => {
     setActiveFilters({ ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID] });
   }, [routeID]);
+
+  const loadRuntimeEvents = useCallback(async () => {
+    const requestID = ++runtimeEventsRequestRef.current;
+    setRuntimeEvents(null);
+    setRuntimeEventsError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setRuntimeEventsLoading(false);
+      return;
+    }
+    setRuntimeEventsLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRuntimeEvents(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          eventType: awsRuntimeEventAPIEventFilterToken(activeFilters.event),
+          evidence: awsRuntimeEventAPIEvidenceFilterToken(activeFilters.evidence),
+          owner: activeFilters.owner && activeFilters.owner !== 'all' ? activeFilters.owner : undefined
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== runtimeEventsRequestRef.current) {
+        return;
+      }
+      setRuntimeEvents(response.runtime);
+    } catch (error) {
+      if (requestID !== runtimeEventsRequestRef.current) {
+        return;
+      }
+      setRuntimeEventsError(formatAPIError(error, 'Unable to load AWS runtime events.'));
+    } finally {
+      if (requestID === runtimeEventsRequestRef.current) {
+        setRuntimeEventsLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    activeFilters.event,
+    activeFilters.evidence,
+    activeFilters.owner
+  ]);
+
+  useEffect(() => {
+    void loadRuntimeEvents();
+    return () => {
+      runtimeEventsRequestRef.current += 1;
+    };
+  }, [loadRuntimeEvents]);
 
   if (!scope) {
     return (
@@ -10488,7 +10618,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         ) : null}
 
         {routeID === 'runtime' ? (
-          <AWSRuntimeEvidenceContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+          <AWSRuntimeEvidenceContent
+            runtime={runtimeEvents}
+            loading={runtimeEventsLoading}
+            error={runtimeEventsError}
+            filters={activeFilters}
+            onFiltersChange={onFiltersChange}
+            onRetry={loadRuntimeEvents}
+          />
         ) : null}
         {routeID === 'graph' ? (
           <AWSGraphExplorerContent

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -42,6 +42,8 @@ import {
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
+  type AWSRuntimeEventRecord,
+  type AWSRuntimeEventResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -9970,90 +9972,41 @@ function AWSRiskOperationPrerequisites({
 }
 
 function AWSRuntimeEvidenceContent({
-  connection,
+  runtime,
+  loading,
+  error,
   filters,
-  onFiltersChange
+  onFiltersChange,
+  onRetry
 }: {
-  connection: AWSConnectionStatus | null;
+  runtime: AWSRuntimeEventResult | null;
+  loading: boolean;
+  error: string;
   filters: AWSInventoryFilterState;
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
+  onRetry: () => void;
 }) {
-  const rows: AWSRiskOperationTableRow[] = [
-    ...(connection?.role_arn
-      ? [
-          {
-            id: 'runtime-role-anchor',
-            title: awsConnectionRoleLabel(connection),
-            category: 'STS AssumeRole',
-            evidence: 'Connector',
-            owner: 'Security',
-            blastRadius: awsAccountRegionLabel(connection),
-            nextAction: 'Attach CloudTrail',
-            status: 'connector',
-            stage: 'wired' as AWSCapabilityStage,
-            filters: { event: 'sts-assume-role', evidence: 'current-connector', owner: 'security', search: '' },
-            searchText: inventorySearchText([connection.role_arn, connection.principal_arn, 'sts assume role current connector'])
-          }
-        ]
-      : []),
-    {
-      id: 'cloudtrail-management-events',
-      title: 'CloudTrail management events',
-      category: 'CloudTrail',
-      evidence: 'Planned',
-      owner: 'Security',
-      blastRadius: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
-      nextAction: 'Wire ingestion',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'cloudtrail', evidence: 'coming', owner: 'security', search: '' },
-      searchText: inventorySearchText(['cloudtrail', 'management events', 'runtime evidence'])
-    },
-    {
-      id: 'secret-read-events',
-      title: 'Secrets Manager GetSecretValue',
-      category: 'Secrets Manager',
-      evidence: 'Planned',
-      owner: 'Application',
-      blastRadius: 'Secret metadata only',
-      nextAction: 'Map metadata',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'secrets-manager', evidence: 'coming', owner: 'application', search: '' },
-      searchText: inventorySearchText(['secrets manager', 'getsecretvalue', 'secret reads'])
-    },
-    {
-      id: 'kms-decrypt-events',
-      title: 'KMS Decrypt activity',
-      category: 'KMS decrypt',
-      evidence: 'Planned',
-      owner: 'Platform',
-      blastRadius: 'Key reachability pending',
-      nextAction: 'Join key policy',
-      status: 'planned',
-      stage: 'coming',
-      filters: { event: 'kms-decrypt', evidence: 'coming', owner: 'platform', search: '' },
-      searchText: inventorySearchText(['kms', 'decrypt', 'runtime evidence'])
-    },
-    {
-      id: 'agent-tool-events',
-      title: 'Agent tool invocation',
-      category: 'Agent tool',
-      evidence: 'Unavailable',
-      owner: 'Security',
-      blastRadius: 'Agent graph pending',
-      nextAction: 'Map agent identity',
-      status: 'unavailable',
-      stage: 'not-available',
-      filters: { event: 'agent-tool', evidence: 'unavailable', owner: 'security', search: '' },
-      searchText: inventorySearchText(['agent', 'tool', 'mcp', 'agentcore'])
-    }
-  ];
+  const rows: AWSRiskOperationTableRow[] = runtime ? runtime.records.map((record) => awsRuntimeEventRow(record)) : [];
   const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
       <AWSRiskOperationFilterSet routeID="runtime" filters={filters} onChange={onFiltersChange} />
+      {error ? <DomainErrorState title="Couldn't load runtime events" body={error} retryAction={{ label: 'Retry', onClick: onRetry }} /> : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Loading runtime events"
+          body="Identrail is loading metadata-only runtime events for this AWS environment."
+        />
+      ) : null}
+      {!error && !loading && runtime && runtime.records.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={runtime.status === 'blocked' ? 'Permission required' : 'No runtime events'}
+          title={runtime.status === 'blocked' ? 'Runtime events need read-only event access' : 'No runtime events matched'}
+          body={runtime.failure_reasons[0] ?? 'Runtime event ingestion returned no events for the current environment and filters.'}
+        />
+      ) : null}
       <DomainDataTable
         label="AWS runtime evidence surfaces"
         rows={displayedRows}
@@ -10073,6 +10026,72 @@ function AWSRuntimeEvidenceContent({
       />
     </>
   );
+}
+
+function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
+  const eventLabel = awsRuntimeEventLabel(record);
+  const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
+  const observed = formatShortDateLabel(record.observed_at);
+  return {
+    id: `runtime-${record.event_id}`,
+    title: `${eventLabel}: ${record.event_name}`,
+    category: eventLabel,
+    evidence: `${formatTokenLabel(record.evidence_category)} · ${formatConfidenceScore(record.confidence)}`,
+    owner: formatTokenLabel(record.owner),
+    blastRadius: `${awsAccountRegionInventoryLabel(record.account_id, record.region)} · ${resourceLabel}`,
+    nextAction: record.next_action,
+    status: record.status,
+    stage: record.status === 'observed' ? 'wired' : record.status === 'permission-denied' ? 'not-available' : 'coming',
+    filters: {
+      event: awsRuntimeEventFilterToken(record.event_type),
+      evidence: awsRuntimeEventFilterToken(record.evidence_category),
+      owner: awsRuntimeEventFilterToken(record.owner),
+      search: ''
+    },
+    searchText: inventorySearchText([
+      record.event_id,
+      record.event_type,
+      record.event_source,
+      record.event_name,
+      record.action,
+      record.actor_principal_arn,
+      record.session?.session_id,
+      record.target_resource_arn,
+      record.target_resource_type,
+      record.agent_id,
+      record.tool_name,
+      record.tool_target_ref,
+      record.evidence_ref,
+      observed,
+      'runtime event metadata only no payloads no secret values'
+    ])
+  };
+}
+
+function awsRuntimeEventLabel(record: AWSRuntimeEventRecord): string {
+  switch (record.event_type) {
+    case 'sts-session':
+      return 'STS AssumeRole';
+    case 'secret-read':
+      return 'Secrets Manager';
+    case 'kms-decrypt':
+      return 'KMS decrypt';
+    case 'agent-tool':
+      return 'Agent tool';
+    default:
+      return 'CloudTrail';
+  }
+}
+
+function awsRuntimeEventFilterToken(value: string): string {
+  switch (value) {
+    case 'sts-session':
+      return 'sts-assume-role';
+    case 'secret-read':
+      return 'secrets-manager';
+    default:
+      return normalizeFilterValue(value).replace(/_/g, '-');
+  }
 }
 
 function AWSGraphExplorerContent({
@@ -10395,6 +10414,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [activeFilters, setActiveFilters] = useState<AWSInventoryFilterState>(() => ({
     ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID]
   }));
+  const [runtimeEvents, setRuntimeEvents] = useState<AWSRuntimeEventResult | null>(null);
+  const [runtimeEventsLoading, setRuntimeEventsLoading] = useState(false);
+  const [runtimeEventsError, setRuntimeEventsError] = useState('');
+  const runtimeEventsRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -10403,6 +10426,60 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   useEffect(() => {
     setActiveFilters({ ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID] });
   }, [routeID]);
+
+  const loadRuntimeEvents = useCallback(async () => {
+    const requestID = ++runtimeEventsRequestRef.current;
+    setRuntimeEvents(null);
+    setRuntimeEventsError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setRuntimeEventsLoading(false);
+      return;
+    }
+    setRuntimeEventsLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRuntimeEvents(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          eventType: activeFilters.event && activeFilters.event !== 'all' ? activeFilters.event : undefined,
+          evidence: activeFilters.evidence && activeFilters.evidence !== 'all' ? activeFilters.evidence : undefined,
+          owner: activeFilters.owner && activeFilters.owner !== 'all' ? activeFilters.owner : undefined
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== runtimeEventsRequestRef.current) {
+        return;
+      }
+      setRuntimeEvents(response.runtime);
+    } catch (error) {
+      if (requestID !== runtimeEventsRequestRef.current) {
+        return;
+      }
+      setRuntimeEventsError(formatAPIError(error, 'Unable to load AWS runtime events.'));
+    } finally {
+      if (requestID === runtimeEventsRequestRef.current) {
+        setRuntimeEventsLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id,
+    activeFilters.event,
+    activeFilters.evidence,
+    activeFilters.owner
+  ]);
+
+  useEffect(() => {
+    void loadRuntimeEvents();
+    return () => {
+      runtimeEventsRequestRef.current += 1;
+    };
+  }, [loadRuntimeEvents]);
 
   if (!scope) {
     return (
@@ -10488,7 +10565,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         ) : null}
 
         {routeID === 'runtime' ? (
-          <AWSRuntimeEvidenceContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+          <AWSRuntimeEvidenceContent
+            runtime={runtimeEvents}
+            loading={runtimeEventsLoading}
+            error={runtimeEventsError}
+            filters={activeFilters}
+            onFiltersChange={onFiltersChange}
+            onRetry={loadRuntimeEvents}
+          />
         ) : null}
         {routeID === 'graph' ? (
           <AWSGraphExplorerContent


### PR DESCRIPTION
## Summary
- Add the AWS runtime event ingestion contract endpoint for API calls, STS sessions, secret reads, KMS decrypts, S3 access, and agent tool calls.
- Expose metadata-only runtime event records, graph relationships, summaries, confidence, diagnostics, coverage gaps, filters, and explicit failure states.
- Wire the AWS app runtime evidence surface to the new API with loading, empty, degraded, permission-denied, and error states.
- Document the route in OpenAPI with named schemas and add operator-facing docs for the metadata-only safety boundary.

## Safety
- Metadata only: no secret values, decrypted plaintext, object bodies, prompts, completions, browser pages, code-interpreter output, database rows, or customer payloads are read or returned.
- Uses scoped tenancy authz and existing AWS connector scoping.

## Validation
- `go test ./internal/api`
- `go test ./internal/api -run 'Test(GetAWSRuntimeEvents|RouterAWSRuntimeEvents|OpenAPIV1Spec)'`
- `npm run build --prefix web`
- `npm run test:ci --prefix web`
- `pre-commit run --files internal/api/aws_runtime_events.go internal/api/aws_runtime_events_test.go internal/api/router.go internal/api/authz_policy_bundle_runtime.go web/src/api/client.ts web/src/api/client.test.ts web/src/productShell.tsx docs/openapi-v1.yaml docs/aws-runtime-events.md`

Closes #1513

AI disclosure usage: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS runtime events API and wires the Risk Operations runtime page to show it, covering API calls, STS sessions, secret reads, KMS decrypts, S3 access metadata, and agent tool calls (per #1513). Diagnostics are now scoped to the applied filters so only relevant messages are returned.

- **New Features**
  - New GET route: `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events` with scoped tenancy auth and filters for connector/account/region/event_type/identity/agent_id/resource/evidence/owner/status/fixture_state.
  - Response returns `{ "runtime": AWSRuntimeEventResult }` with status (`ready`, `degraded`, `blocked`), fixture_state, summaries, records (actor/session/action/target/agent), graph relationships, applied filters, diagnostics (scoped to filtered records), coverage gaps, failure reasons, and evidence links.
  - Enforces a metadata-only boundary (no secret values, decrypted plaintext, object bodies, prompts, or customer payloads).
  - OpenAPI v1 updated with named schemas; docs added at `docs/aws-runtime-events.md`; router endpoint and auth policy included.
  - Backend tests cover contract shape, filtering, relationship building, explicit failure states (`empty`, `degraded`, `partial_failure`, `permission_denied`), and diagnostic scoping to filters.
  - Web: added `getAWSProjectRuntimeEvents` and TypeScript types; Risk Operations runtime page now shows live rows with loading/empty/blocked/degraded/error states, retry, and filter alias translation (UI “CloudTrail” → API `api-call`, “STS AssumeRole” → `sts-session`, Evidence: `cloudtrail`/`agent-runtime`); tests verify scoped headers, query mapping, and aliasing.

- **Migration**
  - No breaking changes.
  - To use, call the new route or `apiClient.getAWSProjectRuntimeEvents(workspaceID, projectID, query, auth)`.

<sup>Written for commit 7d789f9433408b987b5ce99c39c4d9a5fbbdbef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

