### PR TITLE
Reduce PR check noise and mirror model aliases

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,5 +1,5 @@
 vulnerability-check: true
-comment-summary-in-pr: always
+comment-summary-in-pr: on-failure
 fail-on-severity: high
 license-check: true
 allow-dependencies-licenses:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - dev
-  pull_request:
   workflow_dispatch:
 
 permissions: read-all
@@ -17,7 +16,6 @@ jobs:
     name: Security Scorecard
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       id-token: write
       contents: read
       actions: read
@@ -30,11 +28,6 @@ jobs:
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
         with:
-          results_file: results.sarif
-          results_format: sarif
+          results_file: scorecard-results.json
+          results_format: json
           publish_results: true
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
-        with:
-          sarif_file: results.sarif

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-  pull_request:
   schedule:
     - cron: '31 2 * * *'
   workflow_dispatch:
@@ -13,20 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  osv-pr:
-    if: github.event_name == 'pull_request'
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2
-    with:
-      scan-args: |-
-        --recursive
-        .
-
   osv-default:
-    if: github.event_name != 'pull_request'
     permissions:
       actions: read
       contents: read

--- a/internal/api/aws_ai_agent_identities.go
+++ b/internal/api/aws_ai_agent_identities.go
@@ -530,10 +530,33 @@ func awsAIAgentRecordMatchesProvider(record AWSAIAgentIdentityRecord, query stri
 			return true
 		}
 	}
+	for _, value := range awsAIAgentModelProviderFilterAliases(record.ModelID) {
+		if normalizeAWSAIAgentProviderToken(value) == normalizedQuery {
+			return true
+		}
+	}
 	if awsAIAgentProviderFilterRequiresExactProviderMatch(normalizedQuery) {
 		return false
 	}
 	return awsAIAgentRecordMatchesAny(record, query, record.ModelID)
+}
+
+func awsAIAgentModelProviderFilterAliases(modelID string) []string {
+	normalizedModel := strings.ToLower(strings.TrimSpace(modelID))
+	if normalizedModel == "" {
+		return nil
+	}
+	aliases := []string{}
+	if strings.Contains(normalizedModel, "anthropic") || strings.Contains(normalizedModel, "claude") {
+		aliases = append(aliases, "anthropic")
+	}
+	if strings.Contains(normalizedModel, "openai") || strings.Contains(normalizedModel, "gpt") {
+		aliases = append(aliases, "openai")
+	}
+	if strings.Contains(normalizedModel, "bedrock") {
+		aliases = append(aliases, "bedrock")
+	}
+	return aliases
 }
 
 func normalizeAWSAIAgentProviderToken(value string) string {

--- a/internal/api/aws_ai_agent_identities_test.go
+++ b/internal/api/aws_ai_agent_identities_test.go
@@ -318,6 +318,48 @@ func TestAWSAIAgentIdentityExactDetailRecordDoesNotSubstringMatch(t *testing.T) 
 	}
 }
 
+func TestAWSAIAgentRecordMatchesProviderUsesModelProviderAliases(t *testing.T) {
+	tests := []struct {
+		name   string
+		record AWSAIAgentIdentityRecord
+		query  string
+		want   bool
+	}{
+		{
+			name:   "openai query matches gpt model ID",
+			record: AWSAIAgentIdentityRecord{ModelID: "gpt-4o"},
+			query:  "openai",
+			want:   true,
+		},
+		{
+			name:   "anthropic query matches claude model ID",
+			record: AWSAIAgentIdentityRecord{ModelID: "claude-3-opus"},
+			query:  "anthropic",
+			want:   true,
+		},
+		{
+			name:   "bedrock query matches bedrock model ID alias",
+			record: AWSAIAgentIdentityRecord{ModelID: "amazon.bedrock.meta.llama3"},
+			query:  "bedrock",
+			want:   true,
+		},
+		{
+			name:   "exact provider families still do not cross-match",
+			record: AWSAIAgentIdentityRecord{Provider: "amazon-bedrock-agentcore", ModelID: "claude-3-haiku"},
+			query:  "amazon-bedrock",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := awsAIAgentRecordMatchesProvider(tt.record, tt.query); got != tt.want {
+				t.Fatalf("awsAIAgentRecordMatchesProvider(%+v, %q) = %v, want %v", tt.record, tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRouterAWSAIAgentIdentityDetailReturnsOneRecord(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()


### PR DESCRIPTION
## Summary
- suppress Dependency Review success comments while keeping failure comments
- keep OpenSSF Scorecard on `dev`, branch-protection events, schedules, and manual runs only so it no longer creates PR check or code-scanning noise
- keep OSV scanning on `dev`, schedules, and manual runs only so ordinary PRs do not show skipped or neutral OSV noise
- mirror the UI provider alias mapping in the AWS AI agent API filter so `provider=openai` matches `gpt-*` model IDs and `provider=anthropic` matches `claude-*` model IDs

## Why
This removes the no-op PR noise shown on #1626 without weakening the required branch-protection checks. It also follows up the late review on merged PR #1625: https://github.com/identrail/identrail/pull/1625#discussion_r3409973750

Refs #1512

## Validation
- `go test ./internal/api`
- `git diff --check`
- `actionlint .github/workflows/dependency-review.yml .github/workflows/ossf-scorecard.yml .github/workflows/osv-scanner.yml`
- push hooks: merge conflict check, YAML check, EOF check, whitespace trim check, gofmt check, go vet, token hygiene, Vercel artifact hygiene

## AI disclosure
No
