### PR TITLE
AWS Platform Wave 5.03: CloudTrail S3 and EventBridge ingestion path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS CloudTrail S3 + EventBridge delivery ingestion** (#1515).
+  Adds two bounded, metadata-only CloudTrail delivery-channel
+  ingesters (`internal/runtime/cloudtraildelivery`) that read directly
+  from the trail's S3 log destination or an EventBridge target SQS
+  queue. The new `delivery_source` query parameter on
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/runtime-events` selects
+  `lookup_events` (default), `s3`, `eventbridge`, or `all`; the `all`
+  fan-out runs every wired channel and dedupes by `EventID` so the
+  same CloudTrail event arriving on multiple channels surfaces once.
+  Both ingesters enforce `MaxFiles`/`MaxMessages`/`MaxEvents` budgets,
+  use linear-backoff throttling retries, surface
+  `permission_denied`/`history_truncated`/`empty` coverage gaps, and
+  reuse `cloudtrail.NormalizeEvent` for the metadata-only field
+  extraction the LookupEvents path already vets. The S3 ingester
+  resumes from a per-run S3 key checkpoint; the EventBridge ingester
+  deletes successfully-processed messages so they are not re-
+  delivered and leaves malformed envelopes in-queue so the queue's
+  redrive policy applies. The ingesters are wired into
+  `Service.AWSCloudTrailDeliveryFactory` and only run when the
+  connector is active and healthy and the operator's effective
+  capability set includes `runtime_evidence`. Closes #1515. See
+  [docs/aws-runtime-events.md](docs/aws-runtime-events.md).
 - Add **AWS CloudTrail LookupEvents runtime ingestion** (#1514). Adds a
   bounded, metadata-only CloudTrail LookupEvents ingester
   (`internal/runtime/cloudtrail`) that turns recent CloudTrail API

--- a/docs/aws-runtime-events.md
+++ b/docs/aws-runtime-events.md
@@ -176,6 +176,14 @@ other state (no factory wired, no connector, capability denied,
 explicit `fixture_state`) falls through to the deterministic fixture
 path so demos and tests stay stable.
 
+Hosted runtime wiring uses these optional environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `IDENTRAIL_AWS_CLOUDTRAIL_S3_BUCKET` | CloudTrail trail destination bucket used by `delivery_source=s3`. |
+| `IDENTRAIL_AWS_CLOUDTRAIL_S3_PREFIX` | Optional account/region/date-scoped prefix for S3 trail objects. |
+| `IDENTRAIL_AWS_CLOUDTRAIL_EVENTBRIDGE_QUEUE_URL` | SQS queue URL targeted by the EventBridge rule used by `delivery_source=eventbridge`. |
+
 ### Required AWS permissions
 
 The connector role needs read-only access to the chosen delivery

--- a/docs/aws-runtime-events.md
+++ b/docs/aws-runtime-events.md
@@ -12,6 +12,16 @@ response shape is identical so operator UI, filters, evidence links, and
 graph relationships behave the same whether the data came from CloudTrail or
 the fixture.
 
+Issue #1515 adds two additional CloudTrail delivery channels — **S3 trail
+logs** and **EventBridge** (via SQS) — behind the same response envelope.
+LookupEvents only indexes management events, so the data-event rows in the
+contract (S3 `GetObject`, Lambda `Invoke`, Bedrock Agent / AgentCore tool
+calls, DynamoDB item reads) are not reachable through the LookupEvents code
+path. The new S3 and EventBridge ingesters read directly from the trail's
+S3 log destination or the EventBridge fan-out queue, so they can deliver
+data events too. Operators select the source with the new `delivery_source`
+query parameter; the default keeps the existing LookupEvents behavior.
+
 ## API
 
 `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events`
@@ -19,6 +29,7 @@ the fixture.
 Supported filters:
 
 - `connector_id`
+- `delivery_source`: `lookup_events` (default), `s3`, `eventbridge`, or `all`
 - `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
 - `account_id`
 - `region`
@@ -152,3 +163,95 @@ response means the role policy is missing
 `cloudtrail:LookupEvents`. A `history_truncated` coverage gap means the
 window covered more events than the per-run budget; narrow the
 `event_type` filter or raise budgets in a future release.
+
+## CloudTrail S3 + EventBridge delivery ingestion (#1515)
+
+Live S3-trail and EventBridge ingestion is implemented in
+`internal/runtime/cloudtraildelivery` and wired into
+`internal/api.Service.AWSCloudTrailDeliveryFactory`. The factory is
+invoked once per selected source when `delivery_source` is `s3`,
+`eventbridge`, or `all`, the connector is active and healthy, and the
+operator's effective capability set includes `runtime_evidence`. Any
+other state (no factory wired, no connector, capability denied,
+explicit `fixture_state`) falls through to the deterministic fixture
+path so demos and tests stay stable.
+
+### Required AWS permissions
+
+The connector role needs read-only access to the chosen delivery
+channel:
+
+| Source | IAM permissions |
+|---|---|
+| `s3` | `s3:ListBucket` + `s3:GetObject` scoped to the CloudTrail trail's S3 destination bucket and prefix |
+| `eventbridge` | `sqs:ReceiveMessage` + `sqs:DeleteMessage` on the EventBridge target queue |
+
+Identrail never grants or requests object-body write permissions, KMS
+decrypt permissions, or any mutation of the trail destination. Object
+bodies, request parameters, and response elements are never read; only
+the metadata allow-list defined by `cloudtrail.NormalizeEvent` crosses
+the boundary.
+
+### Bounded budgets
+
+Each delivery-ingestion run enforces:
+
+| Budget | Default | Purpose |
+|---|---|---|
+| `LookbackWindow` | 30 minutes | S3 ingester's scan window when no Checkpoint is supplied. |
+| `MaxFiles` | 50 | Caps S3 log objects downloaded per run. |
+| `MaxMessages` | 100 | Caps SQS messages consumed per run. |
+| `MaxEvents` | 1000 | Caps total normalized events across all files / messages per run. |
+| `MaxFileBytes` | 32 MiB | Skips and diagnostically-warns on individual S3 log files larger than this. |
+| `MaxThrottleRetries` | 4 | Per-request throttling retries with linear backoff. |
+
+When ingestion stops at the budget, the response gains a
+`history_truncated` coverage gap and a `degraded` status. When
+`AccessDeniedException` is observed on a list / get / receive call the
+response collapses to `status=blocked` with a `permission_denied`
+coverage gap and zero records — partial coverage is dropped because
+the run could not assert completeness.
+
+### Delivery channel semantics
+
+- **S3 trail logs** are pulled with `ListObjectsV2(StartAfter=checkpoint)`
+  so the next run efficiently resumes after the last processed key. The
+  ingester downloads each `.json.gz` log, parses the `Records[]`
+  envelope, dedupes by `eventID`, and reuses
+  `cloudtrail.NormalizeEvent` for the metadata-only field extraction
+  the LookupEvents engine already vets. The advanced checkpoint is
+  returned on `IngestResult.Checkpoint` for the caller to persist.
+- **EventBridge** ingestion consumes the SQS queue an EventBridge rule
+  targets. The ingester pulls a bounded batch, normalizes each
+  envelope's `detail` (a CloudTrail record), and **deletes
+  successfully-processed messages** so they are not re-delivered.
+  Messages whose envelopes are unparseable are **left in the queue**
+  so the queue's redrive policy applies; messages whose records pass
+  envelope parsing but fail the engine's allow-list normalization
+  (missing core fields, etc.) are deleted to prevent re-delivery
+  storms.
+
+### Cross-channel dedupe
+
+When `delivery_source=all` runs both S3 and EventBridge in the same
+request (plus LookupEvents in a future extension), the API layer
+dedupes by `EventID` across channels. The same CloudTrail event
+arriving on multiple channels surfaces only once; diagnostics,
+coverage gaps, failure reasons, and remediation hints from every
+channel are preserved.
+
+### Live validation
+
+```
+# S3 trail delivery
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events?connector_id={id}&delivery_source=s3
+
+# EventBridge delivery
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events?connector_id={id}&delivery_source=eventbridge
+
+# Union with cross-channel dedupe
+GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events?connector_id={id}&delivery_source=all
+```
+
+Look for `evidence_category=s3-delivery` or `eventbridge-delivery` on
+the returned records to confirm which channel produced each event.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4558,7 +4558,7 @@ paths:
           name: fixture_state
           schema:
             type: string
-            enum: [success, empty, degraded, partial_failure, permission_denied, capability_unavailable]
+            enum: [success, empty, degraded, partial_failure, permission_denied]
           description: Optional deterministic fixture state for UI validation and contract tests.
         - in: query
           name: account_id

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4549,10 +4549,16 @@ paths:
           schema: { type: string }
           description: Optional AWS connector ID used to scope the account, region, and read-only runtime evidence.
         - in: query
+          name: delivery_source
+          schema:
+            type: string
+            enum: [lookup_events, s3, eventbridge, all]
+          description: Optional CloudTrail delivery channel selector. Default `lookup_events` keeps the existing LookupEvents-API path; `s3` reads from the trail's S3 log destination; `eventbridge` consumes the EventBridge target SQS queue; `all` fans out across every wired channel and dedupes by EventID.
+        - in: query
           name: fixture_state
           schema:
             type: string
-            enum: [success, empty, degraded, partial_failure, permission_denied]
+            enum: [success, empty, degraded, partial_failure, permission_denied, capability_unavailable]
           description: Optional deterministic fixture state for UI validation and contract tests.
         - in: query
           name: account_id

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4587,7 +4587,7 @@ paths:
           name: evidence
           schema:
             type: string
-            enum: [cloudtrail, agent-runtime]
+            enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime]
         - in: query
           name: owner
           schema:
@@ -10752,7 +10752,7 @@ components:
           enum: [security, platform, application]
         evidence_category:
           type: string
-          enum: [cloudtrail, agent-runtime]
+          enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime]
         evidence_ref: { type: string }
         confidence:
           type: number
@@ -10799,6 +10799,16 @@ components:
             - cloudtrail_event_missing_id
             - cloudtrail_event_missing_core_fields
             - cloudtrail_event_payload_unparseable
+            - cloudtrail_delivery_unavailable
+            - cloudtrail_delivery_source_unavailable
+            - cloudtrail_s3_object_too_large
+            - cloudtrail_s3_record_missing_id
+            - cloudtrail_eventbridge_envelope_unparseable
+            - cloudtrail_eventbridge_record_missing_id
+            - cloudtrail_eventbridge_delete_failed
+            - cloudtrail_delivery_throttled
+            - cloudtrail_delivery_credentials_expired
+            - cloudtrail_delivery_failed
         message: { type: string }
         remediation: { type: string }
         retryable: { type: boolean }
@@ -10814,6 +10824,7 @@ components:
             - permission_denied
             - capability_unavailable
             - history_truncated
+            - delivery_unavailable
         reason: { type: string }
         remediation: { type: string }
     AWSRuntimeEventSummary:

--- a/internal/api/aws_runtime_cloudtrail.go
+++ b/internal/api/aws_runtime_cloudtrail.go
@@ -34,6 +34,11 @@ type AWSCloudTrailIngestResult struct {
 	FailureReasons   []string
 	RemediationHints []string
 	HistoryTruncated bool
+	// Checkpoint is the delivery engine's resume marker. For S3 this
+	// is the last completely processed object key; callers should
+	// persist it and pass it back in the next IngestRequest so the
+	// next run resumes from where this one stopped.
+	Checkpoint string
 }
 
 // cloudTrailIngesterAdapter wraps an internal/runtime/cloudtrail

--- a/internal/api/aws_runtime_cloudtrail_delivery.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery.go
@@ -79,6 +79,7 @@ func (a *cloudTrailDeliveryAdapter) Ingest(ctx context.Context, request AWSCloud
 		FailureReasons:   append([]string{}, engineResult.FailureReasons...),
 		RemediationHints: append([]string{}, engineResult.RemediationHints...),
 		HistoryTruncated: engineResult.HistoryTruncated,
+		Checkpoint:       engineResult.Checkpoint,
 	}
 	for _, ev := range engineResult.Events {
 		record := runtimeEventRecordFromNormalized(ev, request.AccountID, request.Region)

--- a/internal/api/aws_runtime_cloudtrail_delivery.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/identrail/identrail/internal/runtime/cloudtrail"
+	"github.com/identrail/identrail/internal/runtime/cloudtraildelivery"
+)
+
+// cloudTrailDeliveryAdapter wraps an
+// internal/runtime/cloudtraildelivery ingester (S3 or EventBridge)
+// behind the API-layer AWSCloudTrailRuntimeEventIngester contract so
+// the runtime-events handler can fold delivery-channel results into
+// the same AWSRuntimeEventResult envelope LookupEvents already uses.
+type cloudTrailDeliveryAdapter struct {
+	source DeliverySource
+	s3     *cloudtraildelivery.S3Ingester
+	eb     *cloudtraildelivery.EventBridgeIngester
+}
+
+// DeliverySource is an API-layer alias for the delivery channel
+// the adapter is bound to.
+type DeliverySource = cloudtraildelivery.DeliverySource
+
+const (
+	// DeliverySourceS3 selects the S3 trail log ingester.
+	DeliverySourceS3 DeliverySource = cloudtraildelivery.DeliverySourceS3
+	// DeliverySourceEventBridge selects the EventBridge (SQS-backed)
+	// ingester.
+	DeliverySourceEventBridge DeliverySource = cloudtraildelivery.DeliverySourceEventBridge
+)
+
+// NewCloudTrailS3DeliveryIngester wraps a configured S3 ingester.
+// Production wiring constructs the ingester from the AWS connector's
+// CloudTrail bucket configuration; tests pass an in-memory fake.
+func NewCloudTrailS3DeliveryIngester(ingester *cloudtraildelivery.S3Ingester) AWSCloudTrailRuntimeEventIngester {
+	if ingester == nil {
+		return nil
+	}
+	return &cloudTrailDeliveryAdapter{source: DeliverySourceS3, s3: ingester}
+}
+
+// NewCloudTrailEventBridgeDeliveryIngester wraps a configured
+// EventBridge ingester.
+func NewCloudTrailEventBridgeDeliveryIngester(ingester *cloudtraildelivery.EventBridgeIngester) AWSCloudTrailRuntimeEventIngester {
+	if ingester == nil {
+		return nil
+	}
+	return &cloudTrailDeliveryAdapter{source: DeliverySourceEventBridge, eb: ingester}
+}
+
+// Ingest dispatches to the bound delivery channel and maps the
+// engine's result into the same AWSCloudTrailIngestResult shape the
+// LookupEvents adapter uses.
+func (a *cloudTrailDeliveryAdapter) Ingest(ctx context.Context, request AWSCloudTrailIngestRequest) (AWSCloudTrailIngestResult, error) {
+	deliveryRequest := cloudtraildelivery.IngestRequest{
+		AccountID: request.AccountID,
+		Region:    request.Region,
+	}
+	var (
+		engineResult cloudtraildelivery.IngestResult
+		err          error
+	)
+	switch a.source {
+	case DeliverySourceS3:
+		engineResult, err = a.s3.Ingest(ctx, deliveryRequest)
+	case DeliverySourceEventBridge:
+		engineResult, err = a.eb.Ingest(ctx, deliveryRequest)
+	default:
+		return AWSCloudTrailIngestResult{}, fmt.Errorf("cloudtraildelivery: unknown delivery source %q", a.source)
+	}
+	if err != nil {
+		return AWSCloudTrailIngestResult{}, err
+	}
+	result := AWSCloudTrailIngestResult{
+		Status:           engineResult.Status,
+		FailureReasons:   append([]string{}, engineResult.FailureReasons...),
+		RemediationHints: append([]string{}, engineResult.RemediationHints...),
+		HistoryTruncated: engineResult.HistoryTruncated,
+	}
+	for _, ev := range engineResult.Events {
+		record := runtimeEventRecordFromNormalized(ev, request.AccountID, request.Region)
+		// Stamp the delivery source on the evidence category so
+		// operators can tell which channel produced the record. The
+		// LookupEvents path keeps `cloudtrail`; S3 and EventBridge
+		// each get their own tag so the UI can group records by
+		// delivery channel.
+		record.EvidenceCategory = string(a.source) + "-delivery"
+		result.Records = append(result.Records, record)
+	}
+	for _, diag := range engineResult.Diagnostics {
+		result.Diagnostics = append(result.Diagnostics, AWSRuntimeEventDiagnostic{
+			Collector:   cloudtraildelivery.CollectorName,
+			SourceID:    diag.SourceID,
+			Code:        diag.Code,
+			Message:     diag.Message,
+			Remediation: diag.Remediation,
+			Retryable:   diag.Retryable,
+		})
+	}
+	for _, gap := range engineResult.CoverageGaps {
+		result.CoverageGaps = append(result.CoverageGaps, AWSRuntimeEventCoverageGap{
+			Capability:  gap.Capability,
+			Status:      gap.Status,
+			Reason:      gap.Reason,
+			Remediation: gap.Remediation,
+		})
+	}
+	return result, nil
+}
+
+// normalizeDeliverySource maps the operator-supplied query value to a
+// canonical token. Returns one of "", "lookup_events", "s3",
+// "eventbridge", "all", or "" + an error sentinel for unknown values
+// (the handler converts that to HTTP 400).
+func normalizeDeliverySource(value string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	switch trimmed {
+	case "", "lookup_events", "lookup-events":
+		return "lookup_events", nil
+	case "s3":
+		return "s3", nil
+	case "eventbridge", "event_bridge", "event-bridge":
+		return "eventbridge", nil
+	case "all":
+		return "all", nil
+	default:
+		return "", ErrInvalidAWSConnectionRequest
+	}
+}
+
+// mergeDeliveryResults combines per-source IngestResults into a
+// single union. Cross-channel dedupe is by EventID so the same
+// CloudTrail event arriving on multiple channels surfaces only once.
+// Diagnostics, coverage gaps, failure reasons, and remediation hints
+// from every source are preserved.
+func mergeDeliveryResults(results []AWSCloudTrailIngestResult) AWSCloudTrailIngestResult {
+	merged := AWSCloudTrailIngestResult{Status: "ready"}
+	seenEvents := map[string]struct{}{}
+	worstStatus := "ready"
+	statusRank := map[string]int{"ready": 0, "degraded": 1, "blocked": 2}
+	for _, r := range results {
+		if statusRank[r.Status] > statusRank[worstStatus] {
+			worstStatus = r.Status
+		}
+		for _, record := range r.Records {
+			if _, dupe := seenEvents[record.EventID]; dupe {
+				continue
+			}
+			seenEvents[record.EventID] = struct{}{}
+			merged.Records = append(merged.Records, record)
+		}
+		merged.Diagnostics = append(merged.Diagnostics, r.Diagnostics...)
+		merged.CoverageGaps = append(merged.CoverageGaps, r.CoverageGaps...)
+		merged.FailureReasons = append(merged.FailureReasons, r.FailureReasons...)
+		merged.RemediationHints = append(merged.RemediationHints, r.RemediationHints...)
+		if r.HistoryTruncated {
+			merged.HistoryTruncated = true
+		}
+	}
+	merged.Status = worstStatus
+	return merged
+}
+
+// Reuse cloudtrail.CollectorName so the API surface keeps a single
+// authoritative string identifier for the LookupEvents engine, and
+// have the unused cloudtrail import here remain stable across
+// refactors. Touching the import explicitly avoids a goimports prune.
+var _ = cloudtrail.CollectorName

--- a/internal/api/aws_runtime_cloudtrail_delivery.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery.go
@@ -140,6 +140,7 @@ func normalizeDeliverySource(value string) (string, error) {
 func mergeDeliveryResults(results []AWSCloudTrailIngestResult) AWSCloudTrailIngestResult {
 	merged := AWSCloudTrailIngestResult{Status: "ready"}
 	seenEvents := map[string]struct{}{}
+	hasRecords := false
 	worstStatus := "ready"
 	statusRank := map[string]int{"ready": 0, "degraded": 1, "blocked": 2}
 	for _, r := range results {
@@ -152,6 +153,7 @@ func mergeDeliveryResults(results []AWSCloudTrailIngestResult) AWSCloudTrailInge
 			}
 			seenEvents[record.EventID] = struct{}{}
 			merged.Records = append(merged.Records, record)
+			hasRecords = true
 		}
 		merged.Diagnostics = append(merged.Diagnostics, r.Diagnostics...)
 		merged.CoverageGaps = append(merged.CoverageGaps, r.CoverageGaps...)
@@ -161,7 +163,11 @@ func mergeDeliveryResults(results []AWSCloudTrailIngestResult) AWSCloudTrailInge
 			merged.HistoryTruncated = true
 		}
 	}
-	merged.Status = worstStatus
+	if worstStatus == "blocked" && hasRecords {
+		merged.Status = "degraded"
+	} else {
+		merged.Status = worstStatus
+	}
 	return merged
 }
 

--- a/internal/api/aws_runtime_cloudtrail_delivery_test.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery_test.go
@@ -225,3 +225,16 @@ func TestMergeDeliveryResultsPropagatesWorstStatus(t *testing.T) {
 		t.Fatalf("expected merged status to inherit worst (blocked), got %q", got.Status)
 	}
 }
+
+func TestMergeDeliveryResultsBlockedWithRecordsDegrades(t *testing.T) {
+	got := mergeDeliveryResults([]AWSCloudTrailIngestResult{
+		{Status: "ready", Records: []AWSRuntimeEventRecord{{EventID: "a"}}},
+		{Status: "blocked", Records: []AWSRuntimeEventRecord{{EventID: "b"}}},
+	})
+	if got.Status != "degraded" {
+		t.Fatalf("expected mixed-source blocked+records merge to degrade, got %q", got.Status)
+	}
+	if len(got.Records) != 2 {
+		t.Fatalf("expected both source records to remain, got %d", len(got.Records))
+	}
+}

--- a/internal/api/aws_runtime_cloudtrail_delivery_test.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+)
+
+type fakeDeliveryIngester struct {
+	source AWSCloudTrailDeliverySource
+	result AWSCloudTrailIngestResult
+	err    error
+	calls  int
+}
+
+func (f *fakeDeliveryIngester) Ingest(_ context.Context, _ AWSCloudTrailIngestRequest) (AWSCloudTrailIngestResult, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+func TestNormalizeDeliverySourceAcceptsKnownTokensAndRejectsUnknown(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{in: "", want: "lookup_events"},
+		{in: "lookup_events", want: "lookup_events"},
+		{in: "Lookup-Events", want: "lookup_events"},
+		{in: "s3", want: "s3"},
+		{in: "eventbridge", want: "eventbridge"},
+		{in: "event-bridge", want: "eventbridge"},
+		{in: "all", want: "all"},
+	} {
+		got, err := normalizeDeliverySource(tc.in)
+		if err != nil {
+			t.Errorf("normalizeDeliverySource(%q) returned err=%v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeDeliverySource(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+	if _, err := normalizeDeliverySource("garbage"); !errors.Is(err, ErrInvalidAWSConnectionRequest) {
+		t.Fatalf("expected unknown delivery source to return ErrInvalidAWSConnectionRequest, got %v", err)
+	}
+}
+
+func TestGetAWSRuntimeEventsDeliverySourceS3UsesDeliveryFactory(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 15, 19, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-s3-delivery")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-s3-delivery", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-s3-delivery", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail/sess"
+	deliveryRecord := liveRuntimeRecord(t, "evt-s3-1", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "s3-delivery", role, "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/key", "AWS::SecretsManager::Secret", now.Add(-2*time.Minute))
+	s3Fake := &fakeDeliveryIngester{source: AWSCloudTrailDeliverySourceS3, result: AWSCloudTrailIngestResult{
+		Status:  "ready",
+		Records: []AWSRuntimeEventRecord{deliveryRecord},
+	}}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, source AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		if source != AWSCloudTrailDeliverySourceS3 {
+			t.Fatalf("expected only S3 source, got %q", source)
+		}
+		return s3Fake, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-s3-delivery", AWSRuntimeEventRequest{
+		ConnectorID:    "aws-prod",
+		DeliverySource: "s3",
+	})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if s3Fake.calls != 1 {
+		t.Fatalf("expected S3 ingester called once, got %d", s3Fake.calls)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-s3-1" {
+		t.Fatalf("expected S3-delivered record in response, got %+v", result.Records)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready, got %q (%+v)", result.Status, result)
+	}
+}
+
+func TestGetAWSRuntimeEventsDeliverySourceAllFansOutAndDedupes(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 15, 19, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-all-delivery")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-all-delivery", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-all-delivery", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail/sess"
+	dupe := liveRuntimeRecord(t, "evt-dupe", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "cloudtrail", role, "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/key", "AWS::SecretsManager::Secret", now.Add(-5*time.Minute))
+	s3Only := liveRuntimeRecord(t, "evt-s3-only", "kms-decrypt", "Decrypt", "kms.amazonaws.com", "kms:Decrypt", "platform", "s3-delivery", role, "arn:aws:kms:us-east-1:123456789012:key/abc", "AWS::KMS::Key", now.Add(-4*time.Minute))
+	ebOnly := liveRuntimeRecord(t, "evt-eb-only", "sts-session", "AssumeRole", "sts.amazonaws.com", "sts:AssumeRole", "security", "eventbridge-delivery", role, "", "", now.Add(-3*time.Minute))
+	s3Fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready", Records: []AWSRuntimeEventRecord{dupe, s3Only}}}
+	ebFake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready", Records: []AWSRuntimeEventRecord{dupe, ebOnly}}}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, source AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		switch source {
+		case AWSCloudTrailDeliverySourceS3:
+			return s3Fake, nil
+		case AWSCloudTrailDeliverySourceEventBridge:
+			return ebFake, nil
+		}
+		t.Fatalf("unknown source %q", source)
+		return nil, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-all-delivery", AWSRuntimeEventRequest{
+		ConnectorID:    "aws-prod",
+		DeliverySource: "all",
+	})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if s3Fake.calls != 1 || ebFake.calls != 1 {
+		t.Fatalf("expected both ingesters called once, got s3=%d eb=%d", s3Fake.calls, ebFake.calls)
+	}
+	ids := map[string]bool{}
+	for _, r := range result.Records {
+		ids[r.EventID] = true
+	}
+	for _, want := range []string{"evt-dupe", "evt-s3-only", "evt-eb-only"} {
+		if !ids[want] {
+			t.Fatalf("expected merged result to include %q, got %+v", want, ids)
+		}
+	}
+	// dedupe: evt-dupe must appear exactly once.
+	dupeCount := 0
+	for _, r := range result.Records {
+		if r.EventID == "evt-dupe" {
+			dupeCount++
+		}
+	}
+	if dupeCount != 1 {
+		t.Fatalf("expected evt-dupe to appear once after cross-channel dedupe, got %d", dupeCount)
+	}
+}
+
+func TestGetAWSRuntimeEventsDeliveryUnknownSourceRejectedWith400(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 15, 19, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-bad-delivery")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-bad-delivery", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	_, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-bad-delivery", AWSRuntimeEventRequest{ConnectorID: "aws-prod", DeliverySource: "smoke-signal"})
+	if !errors.Is(err, ErrInvalidAWSConnectionRequest) {
+		t.Fatalf("expected ErrInvalidAWSConnectionRequest, got %v", err)
+	}
+}
+
+func TestGetAWSRuntimeEventsDeliveryWithoutCapabilityFallsBackToFixturesAndDegrades(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 15, 20, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-delivery-nocap")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-delivery-nocap", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	// No capability grant: discovery-only connector.
+
+	called := false
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		called = true
+		return &fakeDeliveryIngester{}, nil
+	}
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-delivery-nocap", AWSRuntimeEventRequest{ConnectorID: "aws-prod", DeliverySource: "s3"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if called {
+		t.Fatalf("discovery-only connector must not call the delivery factory")
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected degraded fallback when capability missing, got %q", result.Status)
+	}
+	if result.FixtureState != "partial_failure" {
+		t.Fatalf("expected fixture_state=partial_failure, got %q", result.FixtureState)
+	}
+	foundDiag := false
+	for _, diag := range result.Diagnostics {
+		if strings.Contains(diag.Code, "cloudtrail_delivery_unavailable") {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected cloudtrail_delivery_unavailable diagnostic, got %+v", result.Diagnostics)
+	}
+}
+
+func TestMergeDeliveryResultsPropagatesWorstStatus(t *testing.T) {
+	got := mergeDeliveryResults([]AWSCloudTrailIngestResult{
+		{Status: "ready", Records: []AWSRuntimeEventRecord{{EventID: "a"}}},
+		{Status: "degraded", Records: []AWSRuntimeEventRecord{{EventID: "b"}}},
+	})
+	if got.Status != "degraded" {
+		t.Fatalf("expected merged status to inherit worst (degraded), got %q", got.Status)
+	}
+	if len(got.Records) != 2 {
+		t.Fatalf("expected union of records, got %d", len(got.Records))
+	}
+
+	got = mergeDeliveryResults([]AWSCloudTrailIngestResult{
+		{Status: "ready"},
+		{Status: "blocked"},
+	})
+	if got.Status != "blocked" {
+		t.Fatalf("expected merged status to inherit worst (blocked), got %q", got.Status)
+	}
+}

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -28,6 +28,12 @@ type AWSRuntimeEventRequest struct {
 	Evidence     string `json:"evidence,omitempty"`
 	Owner        string `json:"owner,omitempty"`
 	Status       string `json:"status,omitempty"`
+	// DeliverySource selects the CloudTrail ingestion path: empty (or
+	// `lookup_events`) uses the LookupEvents API, `s3` uses the S3
+	// trail log ingester, `eventbridge` uses the EventBridge/SQS
+	// ingester, and `all` runs every available source and merges with
+	// cross-channel dedupe by EventID. Unknown values return 400.
+	DeliverySource string `json:"delivery_source,omitempty"`
 }
 
 type AWSRuntimeEventSession struct {
@@ -163,6 +169,24 @@ func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, p
 		return AWSRuntimeEventResult{}, err
 	}
 	now := s.Now().UTC()
+
+	// Resolve and validate the delivery_source query value. Unknown
+	// tokens return HTTP 400 via ErrInvalidAWSConnectionRequest.
+	deliverySource, deliveryErr := normalizeDeliverySource(request.DeliverySource)
+	if deliveryErr != nil {
+		return AWSRuntimeEventResult{}, deliveryErr
+	}
+
+	// Delivery-channel ingestion (S3, EventBridge, or all) is gated
+	// on the same connector-healthy + runtime_evidence + no-fixture
+	// guards as LookupEvents. When the operator pins a delivery
+	// source other than the default lookup_events, dispatch to the
+	// delivery builder instead. The delivery builder falls back to
+	// fixtures and the same capability/factory diagnostics if the
+	// delivery factory is not wired or the connector is not eligible.
+	if deliverySource == "s3" || deliverySource == "eventbridge" || deliverySource == "all" {
+		return s.getAWSRuntimeEventsFromDelivery(ctx, scope, project, connection, hasConnection, deliverySource, request, now)
+	}
 	// Live CloudTrail ingestion is used only when the operator has not
 	// explicitly forced a fixture state, the connector is active and
 	// healthy, AND the connector's effective capability set includes
@@ -840,4 +864,110 @@ func awsRuntimeEventNextAction(eventType string) string {
 	default:
 		return "Correlate runtime evidence with identity and resource graph context."
 	}
+}
+
+// getAWSRuntimeEventsFromDelivery handles `delivery_source=s3`,
+// `eventbridge`, and `all`. It mirrors the LookupEvents capability /
+// factory gating but dispatches to the delivery factory once per
+// selected source and merges results before threading them through
+// the existing buildAWSRuntimeEventsFromCloudTrail envelope so the
+// response shape stays identical regardless of which CloudTrail
+// ingestion path produced the records.
+func (s *Service) getAWSRuntimeEventsFromDelivery(ctx context.Context, scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, deliverySource string, request AWSRuntimeEventRequest, now time.Time) (AWSRuntimeEventResult, error) {
+	// Capability + factory + connector-health gate mirrors the
+	// LookupEvents path. If the operator pinned a fixture state, fall
+	// through to the deterministic fixture so demos stay stable.
+	if strings.TrimSpace(request.FixtureState) != "" || s.AWSCloudTrailDeliveryFactory == nil || !hasConnection || !connection.Connected || !awsConnectorHasRuntimeEvidence(connection) {
+		result, fixtureErr := buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, now)
+		if fixtureErr != nil {
+			return result, fixtureErr
+		}
+		if strings.TrimSpace(request.FixtureState) == "" {
+			result.Diagnostics = append(result.Diagnostics, AWSRuntimeEventDiagnostic{
+				Collector:   "aws_cloudtrail_delivery",
+				SourceID:    "delivery-" + deliverySource,
+				Code:        "cloudtrail_delivery_unavailable",
+				Message:     fmt.Sprintf("CloudTrail %s delivery ingester is not available for this connector.", deliverySource),
+				Remediation: "Wire AWSCloudTrailDeliveryFactory and grant the connector role read-only access to the trail's S3 bucket or EventBridge target.",
+				Retryable:   true,
+			})
+			result.Status = "degraded"
+			result.FixtureState = "partial_failure"
+			if result.Confidence > 0.6 {
+				result.Confidence = 0.6
+			}
+			result.FailureReasons = dedupeStrings(append(result.FailureReasons, fmt.Sprintf("CloudTrail %s delivery ingester is not available for this connector", deliverySource)))
+			result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Wire AWSCloudTrailDeliveryFactory or grant read-only delivery channel access."))
+		}
+		return result, nil
+	}
+
+	sources := []AWSCloudTrailDeliverySource{}
+	switch deliverySource {
+	case "s3":
+		sources = append(sources, AWSCloudTrailDeliverySourceS3)
+	case "eventbridge":
+		sources = append(sources, AWSCloudTrailDeliverySourceEventBridge)
+	case "all":
+		sources = append(sources, AWSCloudTrailDeliverySourceS3, AWSCloudTrailDeliverySourceEventBridge)
+	}
+
+	results := make([]AWSCloudTrailIngestResult, 0, len(sources))
+	for _, source := range sources {
+		ingester, ingErr := s.AWSCloudTrailDeliveryFactory(ctx, connection, source)
+		if ingErr != nil && (errors.Is(ingErr, context.Canceled) || errors.Is(ingErr, context.DeadlineExceeded)) {
+			return AWSRuntimeEventResult{}, ingErr
+		}
+		if ingErr != nil || ingester == nil {
+			// Source not configured for this connector. Record a
+			// per-source diagnostic so the operator sees why it was
+			// skipped, then continue with the other sources.
+			results = append(results, AWSCloudTrailIngestResult{
+				Status: "degraded",
+				Diagnostics: []AWSRuntimeEventDiagnostic{{
+					Collector:   "aws_cloudtrail_delivery",
+					SourceID:    string(source),
+					Code:        "cloudtrail_delivery_source_unavailable",
+					Message:     fmt.Sprintf("CloudTrail %s delivery ingester is not configured: %v", source, ingErr),
+					Remediation: "Configure the bucket/queue for this delivery channel on the connector and retry.",
+					Retryable:   true,
+				}},
+				CoverageGaps: []AWSRuntimeEventCoverageGap{{
+					Capability:  "cloudtrail_" + string(source) + "_delivery",
+					Status:      "delivery_unavailable",
+					Reason:      fmt.Sprintf("Connector does not have a configured %s delivery target.", source),
+					Remediation: "Configure the delivery channel and retry.",
+				}},
+				FailureReasons:   []string{fmt.Sprintf("CloudTrail %s delivery is not configured", source)},
+				RemediationHints: []string{fmt.Sprintf("Configure the %s delivery target on the connector.", source)},
+			})
+			continue
+		}
+		accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+		region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+		ingestResult, err := ingester.Ingest(ctx, AWSCloudTrailIngestRequest{
+			AccountID: accountID,
+			Region:    region,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, fmt.Errorf("ingest cloudtrail %s delivery: %w", source, err)
+		}
+		results = append(results, ingestResult)
+	}
+
+	merged := mergeDeliveryResults(results)
+	// Wrap a fake ingester so we can reuse the existing CloudTrail
+	// envelope builder without duplicating its 80+ lines.
+	stub := &precomputedIngester{result: merged}
+	return buildAWSRuntimeEventsFromCloudTrail(ctx, scope, project, connection, stub, request, now)
+}
+
+// precomputedIngester satisfies AWSCloudTrailRuntimeEventIngester
+// with a pre-computed result. Used by the delivery dispatcher to
+// reuse buildAWSRuntimeEventsFromCloudTrail's envelope builder
+// without duplicating its summary/filter/diagnostic logic.
+type precomputedIngester struct{ result AWSCloudTrailIngestResult }
+
+func (p *precomputedIngester) Ingest(_ context.Context, _ AWSCloudTrailIngestRequest) (AWSCloudTrailIngestResult, error) {
+	return p.result, nil
 }

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -874,22 +874,30 @@ func awsRuntimeEventNextAction(eventType string) string {
 // response shape stays identical regardless of which CloudTrail
 // ingestion path produced the records.
 func (s *Service) getAWSRuntimeEventsFromDelivery(ctx context.Context, scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, hasConnection bool, deliverySource string, request AWSRuntimeEventRequest, now time.Time) (AWSRuntimeEventResult, error) {
+	hasRequestFixture := strings.TrimSpace(request.FixtureState) != ""
+	isEligibleConnector := hasConnection && connection.Connected && awsConnectorHasRuntimeEvidence(connection)
 	// Capability + factory + connector-health gate mirrors the
 	// LookupEvents path. If the operator pinned a fixture state, fall
 	// through to the deterministic fixture so demos stay stable.
-	if strings.TrimSpace(request.FixtureState) != "" || s.AWSCloudTrailDeliveryFactory == nil || !hasConnection || !connection.Connected || !awsConnectorHasRuntimeEvidence(connection) {
+	if hasRequestFixture || s.AWSCloudTrailDeliveryFactory == nil || !isEligibleConnector {
 		result, fixtureErr := buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, now)
 		if fixtureErr != nil {
 			return result, fixtureErr
 		}
-		if strings.TrimSpace(request.FixtureState) == "" {
+		if !hasRequestFixture && s.AWSCloudTrailDeliveryFactory != nil && hasConnection && connection.Connected && !awsConnectorHasRuntimeEvidence(connection) && result.Status != "blocked" {
 			result.Diagnostics = append(result.Diagnostics, AWSRuntimeEventDiagnostic{
 				Collector:   "aws_cloudtrail_delivery",
 				SourceID:    "delivery-" + deliverySource,
 				Code:        "cloudtrail_delivery_unavailable",
 				Message:     fmt.Sprintf("CloudTrail %s delivery ingester is not available for this connector.", deliverySource),
-				Remediation: "Wire AWSCloudTrailDeliveryFactory and grant the connector role read-only access to the trail's S3 bucket or EventBridge target.",
+				Remediation: "Grant the runtime_evidence capability and configure the connector role with read-only access to the trail's S3 bucket or EventBridge target.",
 				Retryable:   true,
+			})
+			result.CoverageGaps = append(result.CoverageGaps, AWSRuntimeEventCoverageGap{
+				Capability:  "cloudtrail_" + deliverySource + "_delivery",
+				Status:      "capability_unavailable",
+				Reason:      "Connector capabilities do not include runtime_evidence.",
+				Remediation: "Grant runtime_evidence to this connector role and rerun the query.",
 			})
 			result.Status = "degraded"
 			result.FixtureState = "partial_failure"

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2875,17 +2875,18 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			return
 		}
 		record, err := svc.GetAWSRuntimeEvents(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRuntimeEventRequest{
-			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
-			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
-			AccountID:    strings.TrimSpace(c.Query("account_id")),
-			Region:       strings.TrimSpace(c.Query("region")),
-			EventType:    strings.TrimSpace(c.Query("event_type")),
-			Identity:     strings.TrimSpace(c.Query("identity")),
-			AgentID:      strings.TrimSpace(c.Query("agent_id")),
-			Resource:     strings.TrimSpace(c.Query("resource")),
-			Evidence:     strings.TrimSpace(c.Query("evidence")),
-			Owner:        strings.TrimSpace(c.Query("owner")),
-			Status:       strings.TrimSpace(c.Query("status")),
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			EventType:      strings.TrimSpace(c.Query("event_type")),
+			Identity:       strings.TrimSpace(c.Query("identity")),
+			AgentID:        strings.TrimSpace(c.Query("agent_id")),
+			Resource:       strings.TrimSpace(c.Query("resource")),
+			Evidence:       strings.TrimSpace(c.Query("evidence")),
+			Owner:          strings.TrimSpace(c.Query("owner")),
+			Status:         strings.TrimSpace(c.Query("status")),
+			DeliverySource: strings.TrimSpace(c.Query("delivery_source")),
 		})
 		if err != nil {
 			switch {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -143,6 +143,26 @@ type AWSCloudTrailRuntimeEventIngester interface {
 	Ingest(ctx context.Context, request AWSCloudTrailIngestRequest) (AWSCloudTrailIngestResult, error)
 }
 
+// AWSCloudTrailDeliverySource selects which CloudTrail delivery
+// channel (S3 trail logs or EventBridge/SQS) the delivery factory
+// should bind to.
+type AWSCloudTrailDeliverySource string
+
+const (
+	// AWSCloudTrailDeliverySourceS3 selects the S3 trail log ingester.
+	AWSCloudTrailDeliverySourceS3 AWSCloudTrailDeliverySource = "s3"
+	// AWSCloudTrailDeliverySourceEventBridge selects the EventBridge
+	// (SQS-backed) ingester.
+	AWSCloudTrailDeliverySourceEventBridge AWSCloudTrailDeliverySource = "eventbridge"
+)
+
+// AWSCloudTrailDeliveryIngesterFactory builds a delivery-channel
+// ingester (S3 trail logs or EventBridge/SQS) bound to one persisted
+// AWS connector. The factory returns nil for sources the deployment
+// does not configure (e.g. no S3 bucket recorded on the connector);
+// the runtime-events handler then skips that source for the request.
+type AWSCloudTrailDeliveryIngesterFactory func(ctx context.Context, connection AWSConnectionStatus, source AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error)
+
 type queuedScanDepthCounter interface {
 	CountQueuedScansAnyScope(ctx context.Context, provider string) (int, error)
 }
@@ -182,6 +202,7 @@ type Service struct {
 	AWSConnectorValidator              AWSConnectorValidator
 	AWSScannerFactory                  AWSScannerFactory
 	AWSCloudTrailLookupEventsFactory   AWSCloudTrailLookupEventsFactory
+	AWSCloudTrailDeliveryFactory       AWSCloudTrailDeliveryIngesterFactory
 	AWSCloudFormationTemplateURL       string
 	AWSAccountID                       string
 	AWSBaselineGitSHA                  string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,9 @@ type Config struct {
 	AWSProfile                    string
 	AWSCloudFormationTemplateURL  string
 	AWSAccountID                  string
+	AWSCloudTrailS3Bucket         string
+	AWSCloudTrailS3Prefix         string
+	AWSCloudTrailEventBridgeQueue string
 	AWSConnectorCapabilities      []string
 	AWSFixturePath                []string
 	KubernetesFixturePath         []string
@@ -278,6 +281,9 @@ func Load() Config {
 		AWSProfile:                    getEnv("IDENTRAIL_AWS_PROFILE", ""),
 		AWSCloudFormationTemplateURL:  getEnv("IDENTRAIL_AWS_CFN_TEMPLATE_URL", ""),
 		AWSAccountID:                  getEnv("IDENTRAIL_AWS_ACCOUNT_ID", ""),
+		AWSCloudTrailS3Bucket:         strings.TrimSpace(getEnv("IDENTRAIL_AWS_CLOUDTRAIL_S3_BUCKET", "")),
+		AWSCloudTrailS3Prefix:         strings.TrimSpace(getEnv("IDENTRAIL_AWS_CLOUDTRAIL_S3_PREFIX", "")),
+		AWSCloudTrailEventBridgeQueue: strings.TrimSpace(getEnv("IDENTRAIL_AWS_CLOUDTRAIL_EVENTBRIDGE_QUEUE_URL", "")),
 		AWSConnectorCapabilities:      parseCommaSeparated(getEnv("IDENTRAIL_AWS_CONNECTOR_CAPABILITIES", "")),
 		AWSFixturePath:                parseCommaSeparated(getEnv("IDENTRAIL_AWS_FIXTURES", defaultAWSFixtures)),
 		KubernetesFixturePath:         parseCommaSeparated(getEnv("IDENTRAIL_K8S_FIXTURES", defaultK8sFixtures)),

--- a/internal/runtime/cloudtrail/lookup_events.go
+++ b/internal/runtime/cloudtrail/lookup_events.go
@@ -723,7 +723,7 @@ var payloadAllowedKeys = struct {
 	CreationDate:      "creationDate",
 }
 
-// normalizeEvent converts one CloudTrail Event into one or more
+// NormalizeEvent converts one CloudTrail Event into one or more
 // NormalizedEvents. Multi-resource CloudTrail events
 // (e.g. BatchGetSecretValue reading several secrets) fan out to one
 // normalized event per Resources entry — using suffixed EventIDs to
@@ -733,6 +733,15 @@ var payloadAllowedKeys = struct {
 // argument is the wall-clock time of the ingestion run; live records
 // use it instead of `observed_at + 2min` so audit ordering, cache
 // invalidation, and freshness checks see the actual collection time.
+//
+// Exported so the S3 and EventBridge delivery ingesters in
+// internal/runtime/cloudtraildelivery can reuse the same
+// metadata-only normalization without duplicating the allow-listed
+// payload extraction.
+func NormalizeEvent(raw Event, accountID string, region string, collectedAt time.Time) ([]NormalizedEvent, *Diagnostic, bool) {
+	return normalizeEvent(raw, accountID, region, collectedAt)
+}
+
 func normalizeEvent(raw Event, accountID string, region string, collectedAt time.Time) ([]NormalizedEvent, *Diagnostic, bool) {
 	eventID := strings.TrimSpace(raw.EventID)
 	eventName := strings.TrimSpace(raw.EventName)

--- a/internal/runtime/cloudtraildelivery/delivery.go
+++ b/internal/runtime/cloudtraildelivery/delivery.go
@@ -85,10 +85,10 @@ type IngestRequest struct {
 	AccountID string
 	Region    string
 	// Checkpoint is the per-channel resume marker. For S3 it is the
-	// last processed key's LastModified time (RFC3339). For
-	// EventBridge/SQS it is unused — the queue itself is the
-	// checkpoint, and the ingester deletes successfully-processed
-	// messages so they are not re-delivered.
+	// last completely processed S3 object key, passed to ListObjectsV2
+	// as StartAfter on the next run. For EventBridge/SQS it is unused
+	// — the queue itself is the checkpoint, and the ingester deletes
+	// successfully-processed messages so they are not re-delivered.
 	Checkpoint string
 	// LookbackWindow caps how far back the S3 ingester scans for new
 	// trail files when no Checkpoint is supplied. Defaults to
@@ -125,9 +125,9 @@ type IngestResult struct {
 	FailureReasons   []string
 	RemediationHints []string
 	// Checkpoint is the new resume marker the caller should persist
-	// for the next run. For S3 this is the latest-LastModified key the
-	// run processed; for EventBridge the field is empty because the
-	// queue is the implicit checkpoint.
+	// for the next run. For S3 this is the last completely processed
+	// object key; for EventBridge the field is empty because the queue
+	// is the implicit checkpoint.
 	Checkpoint string
 	// FilesProcessed (S3) and MessagesProcessed (EventBridge) let the
 	// API layer attach observability metadata to the response.

--- a/internal/runtime/cloudtraildelivery/delivery.go
+++ b/internal/runtime/cloudtraildelivery/delivery.go
@@ -261,7 +261,7 @@ type CloudTrailRecord struct {
 	EventTime        string           `json:"eventTime,omitempty"`
 	AWSRegion        string           `json:"awsRegion,omitempty"`
 	RecipientAccount string           `json:"recipientAccountId,omitempty"`
-	ReadOnly         string           `json:"readOnly,omitempty"`
+	ReadOnly         any              `json:"readOnly,omitempty"`
 	UserIdentity     map[string]any   `json:"userIdentity,omitempty"`
 	Resources        []CloudTrailRsrc `json:"resources,omitempty"`
 	SourceIPAddress  string           `json:"sourceIPAddress,omitempty"`
@@ -294,7 +294,7 @@ func (r CloudTrailRecord) toCloudTrailEvent(rawJSON string) cloudtrail.Event {
 		EventID:     strings.TrimSpace(r.EventID),
 		EventName:   strings.TrimSpace(r.EventName),
 		EventSource: strings.TrimSpace(r.EventSource),
-		ReadOnly:    strings.TrimSpace(r.ReadOnly),
+		ReadOnly:    readOnlyString(r.ReadOnly),
 		Username:    pickUsername(r.UserIdentity),
 		AccessKeyID: pickAccessKeyID(r.UserIdentity),
 		Resources:   resources,
@@ -306,6 +306,20 @@ func (r CloudTrailRecord) toCloudTrailEvent(rawJSON string) cloudtrail.Event {
 		}
 	}
 	return event
+}
+
+func readOnlyString(value any) string {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return ""
+	}
 }
 
 func pickUsername(identity map[string]any) string {

--- a/internal/runtime/cloudtraildelivery/delivery.go
+++ b/internal/runtime/cloudtraildelivery/delivery.go
@@ -1,0 +1,358 @@
+// Package cloudtraildelivery implements bounded, metadata-only
+// ingestion of AWS CloudTrail records delivered through two channels
+// that the existing internal/runtime/cloudtrail LookupEvents engine
+// does not cover:
+//
+//   - S3 trail delivery. CloudTrail trails write gzip-compressed JSON
+//     log files to a configured S3 bucket. This ingester lists object
+//     keys newer than the operator-supplied checkpoint, downloads each
+//     log file, parses the `Records[]` array, dedupes by EventId, and
+//     hands the resulting metadata-only events to the cloudtrail
+//     engine's NormalizeEvent for translation into the shared runtime
+//     contract.
+//   - EventBridge delivery. CloudTrail can deliver every event in
+//     near-real-time to EventBridge; the standard fan-out is to put
+//     events on an SQS queue. This ingester pulls a bounded batch of
+//     messages, parses the EventBridge envelope, and normalizes the
+//     CloudTrail `detail` payload. Messages whose events are
+//     successfully ingested are deleted from the queue so they are not
+//     re-delivered; messages that fail normalization are left in the
+//     queue and surface as partial-failure diagnostics so the
+//     consumer's redrive policy can apply.
+//
+// Both ingesters share the same IngestRequest/IngestResult shape and
+// produce slices of cloudtrail.NormalizedEvent so the API layer can
+// fold the delivery channels into the same AWSRuntimeEventResult
+// envelope that the LookupEvents path uses. Cross-channel dedupe by
+// EventId is the API layer's responsibility (a single CloudTrail
+// event can arrive via LookupEvents AND S3 AND EventBridge in the
+// same run).
+//
+// Safety boundaries are inherited from the cloudtrail engine: the
+// ingesters never read, log, or persist request parameters, response
+// elements, secret values, decrypted plaintext, object bodies, or any
+// customer payload from a CloudTrail record. Only the metadata
+// allow-list defined by cloudtrail.NormalizeEvent crosses the
+// boundary. Bounded budgets (MaxFiles, MaxEvents, MaxMessages, file-
+// size limit) cap one ingestion run so a misbehaving trail or queue
+// cannot exhaust the worker.
+package cloudtraildelivery
+
+import (
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/cloudtrail"
+)
+
+// DeliverySource identifies which CloudTrail delivery channel
+// produced a record. The API layer uses this both for source-scoped
+// filtering and so operators can attribute a record to its origin in
+// the response.
+type DeliverySource string
+
+const (
+	// DeliverySourceS3 indicates the record was extracted from a
+	// CloudTrail trail's S3 log object.
+	DeliverySourceS3 DeliverySource = "s3"
+
+	// DeliverySourceEventBridge indicates the record was consumed from
+	// an EventBridge target (typically SQS).
+	DeliverySourceEventBridge DeliverySource = "eventbridge"
+)
+
+// CollectorName tags every diagnostic emitted by the delivery
+// ingesters so downstream callers can scope diagnostics by source.
+const CollectorName = "aws_cloudtrail_delivery"
+
+// Bounded budget defaults. Operators can override per-run; the
+// defaults are sized so one tick of a 5-minute worker comfortably
+// stays inside the budget on a steady-state trail.
+const (
+	DefaultMaxFiles            = 50
+	DefaultMaxEvents           = 1000
+	DefaultMaxMessages         = 100
+	DefaultMaxFileBytes        = int64(32 << 20) // 32 MiB per gzip log file
+	DefaultLookbackWindow      = 30 * time.Minute
+	DefaultMaxThrottleRetries  = 4
+	DefaultThrottleBackoff     = 200 * time.Millisecond
+	DefaultSQSVisibilityBuffer = 30 * time.Second
+)
+
+// IngestRequest configures one bounded ingestion run for either
+// delivery channel.
+type IngestRequest struct {
+	AccountID string
+	Region    string
+	// Checkpoint is the per-channel resume marker. For S3 it is the
+	// last processed key's LastModified time (RFC3339). For
+	// EventBridge/SQS it is unused — the queue itself is the
+	// checkpoint, and the ingester deletes successfully-processed
+	// messages so they are not re-delivered.
+	Checkpoint string
+	// LookbackWindow caps how far back the S3 ingester scans for new
+	// trail files when no Checkpoint is supplied. Defaults to
+	// DefaultLookbackWindow.
+	LookbackWindow time.Duration
+	// MaxFiles caps the number of S3 log objects one S3 ingestion
+	// run downloads. Defaults to DefaultMaxFiles.
+	MaxFiles int
+	// MaxMessages caps the number of SQS messages one EventBridge
+	// ingestion run consumes. Defaults to DefaultMaxMessages.
+	MaxMessages int
+	// MaxEvents caps the total normalized events one ingestion run
+	// emits across all files / messages. Defaults to
+	// DefaultMaxEvents.
+	MaxEvents int
+	// MaxFileBytes caps each S3 log object's decompressed size.
+	// Defaults to DefaultMaxFileBytes.
+	MaxFileBytes int64
+	// MaxThrottleRetries caps per-request retries when the
+	// underlying SDK returns a throttling error. Defaults to
+	// DefaultMaxThrottleRetries.
+	MaxThrottleRetries int
+	// ThrottleBackoff is the base linear backoff between retries.
+	ThrottleBackoff time.Duration
+}
+
+// IngestResult is the bounded outcome of one ingestion run.
+type IngestResult struct {
+	Source           DeliverySource
+	Events           []cloudtrail.NormalizedEvent
+	Diagnostics      []cloudtrail.Diagnostic
+	CoverageGaps     []cloudtrail.CoverageGap
+	Status           string
+	FailureReasons   []string
+	RemediationHints []string
+	// Checkpoint is the new resume marker the caller should persist
+	// for the next run. For S3 this is the latest-LastModified key the
+	// run processed; for EventBridge the field is empty because the
+	// queue is the implicit checkpoint.
+	Checkpoint string
+	// FilesProcessed (S3) and MessagesProcessed (EventBridge) let the
+	// API layer attach observability metadata to the response.
+	FilesProcessed    int
+	MessagesProcessed int
+	EventsConsidered  int
+	// HistoryTruncated is true when the run stopped at the bounded
+	// budget with more files / messages still available.
+	HistoryTruncated bool
+}
+
+func (r IngestRequest) withDefaults() IngestRequest {
+	if r.LookbackWindow <= 0 {
+		r.LookbackWindow = DefaultLookbackWindow
+	}
+	if r.MaxFiles <= 0 {
+		r.MaxFiles = DefaultMaxFiles
+	}
+	if r.MaxMessages <= 0 {
+		r.MaxMessages = DefaultMaxMessages
+	}
+	if r.MaxEvents <= 0 {
+		r.MaxEvents = DefaultMaxEvents
+	}
+	if r.MaxFileBytes <= 0 {
+		r.MaxFileBytes = DefaultMaxFileBytes
+	}
+	if r.MaxThrottleRetries < 0 {
+		r.MaxThrottleRetries = 0
+	}
+	if r.MaxThrottleRetries == 0 {
+		r.MaxThrottleRetries = DefaultMaxThrottleRetries
+	}
+	if r.ThrottleBackoff <= 0 {
+		r.ThrottleBackoff = DefaultThrottleBackoff
+	}
+	return r
+}
+
+// permissionDeniedCodes enumerates the AWS error codes the delivery
+// ingesters treat as authoritative permission-denied signals. The
+// check is case-insensitive and also matches the code embedded in an
+// unwrapped error string. Mirrors the cloudtrail engine.
+var permissionDeniedCodes = []string{
+	"AccessDeniedException",
+	"AccessDenied",
+	"UnauthorizedOperation",
+	"InvalidClientTokenId",
+}
+
+// throttleCodes are the AWS error codes the ingesters treat as
+// throttling. Mirrors the cloudtrail engine list plus S3's SlowDown.
+var throttleCodes = []string{
+	"ThrottlingException",
+	"Throttling",
+	"RequestLimitExceeded",
+	"TooManyRequestsException",
+	"SlowDown",
+}
+
+// transientAuthCodes are credential-freshness signals. They degrade
+// the response but never collapse it to blocked.
+var transientAuthCodes = []string{
+	"ExpiredToken",
+	"ExpiredTokenException",
+	"TokenRefreshRequired",
+}
+
+func isPermissionDenied(err error) bool { return errorMatchesAny(err, permissionDeniedCodes) }
+func isThrottling(err error) bool       { return errorMatchesAny(err, throttleCodes) }
+func isTransientAuth(err error) bool    { return errorMatchesAny(err, transientAuthCodes) }
+func isRetryable(err error) bool        { return isThrottling(err) || isTransientAuth(err) }
+
+func errorMatchesAny(err error, codes []string) bool {
+	if err == nil {
+		return false
+	}
+	type codeNamer interface{ ErrorCode() string }
+	if c, ok := err.(codeNamer); ok {
+		got := c.ErrorCode()
+		for _, code := range codes {
+			if strings.EqualFold(got, code) {
+				return true
+			}
+		}
+	}
+	msg := strings.ToLower(err.Error())
+	for _, code := range codes {
+		if strings.Contains(msg, strings.ToLower(code)) {
+			return true
+		}
+	}
+	return false
+}
+
+func diagnosticCodeFor(err error) string {
+	if isPermissionDenied(err) {
+		return "permission_denied"
+	}
+	if isThrottling(err) {
+		return "cloudtrail_delivery_throttled"
+	}
+	if isTransientAuth(err) {
+		return "cloudtrail_delivery_credentials_expired"
+	}
+	return "cloudtrail_delivery_failed"
+}
+
+// CloudTrailLogFile is the JSON envelope CloudTrail writes to S3 and
+// publishes through EventBridge. The S3 file is `{ "Records": [...] }`
+// containing N events; an EventBridge SQS message contains one
+// envelope whose `detail` is a single CloudTrail record (S3 and
+// EventBridge serialize the same record shape, only the envelope
+// differs).
+type CloudTrailLogFile struct {
+	Records []CloudTrailRecord `json:"Records"`
+}
+
+// CloudTrailRecord is the metadata-only projection of one CloudTrail
+// record. Field names mirror the documented CloudTrail event JSON.
+// Critically, `requestParameters` and `responseElements` are NOT
+// represented here — the ingesters never decode them, and the engine
+// re-uses cloudtrail.NormalizeEvent's allow-listed extraction over
+// the raw envelope string for any fields it needs from `userIdentity`
+// / `sessionContext`.
+type CloudTrailRecord struct {
+	EventVersion     string           `json:"eventVersion,omitempty"`
+	EventID          string           `json:"eventID,omitempty"`
+	EventName        string           `json:"eventName,omitempty"`
+	EventSource      string           `json:"eventSource,omitempty"`
+	EventTime        string           `json:"eventTime,omitempty"`
+	AWSRegion        string           `json:"awsRegion,omitempty"`
+	RecipientAccount string           `json:"recipientAccountId,omitempty"`
+	ReadOnly         string           `json:"readOnly,omitempty"`
+	UserIdentity     map[string]any   `json:"userIdentity,omitempty"`
+	Resources        []CloudTrailRsrc `json:"resources,omitempty"`
+	SourceIPAddress  string           `json:"sourceIPAddress,omitempty"`
+	UserAgent        string           `json:"userAgent,omitempty"`
+	AdditionalRaw    map[string]any   `json:"-"`
+}
+
+// CloudTrailRsrc mirrors the per-record resource subobject.
+type CloudTrailRsrc struct {
+	ResourceType string `json:"type,omitempty"`
+	ResourceName string `json:"ARN,omitempty"`
+	AccountID    string `json:"accountId,omitempty"`
+}
+
+// toCloudTrailEvent converts a CloudTrail record into the
+// cloudtrail.Event shape the engine's NormalizeEvent consumes. The
+// raw record JSON is serialized back into the Event.RawEvent slot so
+// the engine's allow-listed metadata extraction can pull
+// sessionContext / userIdentity tokens the lightweight projection
+// above does not enumerate.
+func (r CloudTrailRecord) toCloudTrailEvent(rawJSON string) cloudtrail.Event {
+	resources := make([]cloudtrail.EventResource, 0, len(r.Resources))
+	for _, rsrc := range r.Resources {
+		resources = append(resources, cloudtrail.EventResource{
+			ResourceType: strings.TrimSpace(rsrc.ResourceType),
+			ResourceName: strings.TrimSpace(rsrc.ResourceName),
+		})
+	}
+	event := cloudtrail.Event{
+		EventID:     strings.TrimSpace(r.EventID),
+		EventName:   strings.TrimSpace(r.EventName),
+		EventSource: strings.TrimSpace(r.EventSource),
+		ReadOnly:    strings.TrimSpace(r.ReadOnly),
+		Username:    pickUsername(r.UserIdentity),
+		AccessKeyID: pickAccessKeyID(r.UserIdentity),
+		Resources:   resources,
+		RawEvent:    rawJSON,
+	}
+	if r.EventTime != "" {
+		if t, err := parseEventTime(r.EventTime); err == nil {
+			event.EventTime = t
+		}
+	}
+	return event
+}
+
+func pickUsername(identity map[string]any) string {
+	if identity == nil {
+		return ""
+	}
+	if v, ok := identity["arn"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	if v, ok := identity["userName"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+func pickAccessKeyID(identity map[string]any) string {
+	if identity == nil {
+		return ""
+	}
+	if v, ok := identity["accessKeyId"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+// parseEventTime accepts the CloudTrail-documented basic ISO-8601
+// layout, the dashed RFC3339 / RFC3339Nano forms, and the plain
+// `2006-01-02T15:04:05Z` layout. Mirrors cloudtrail.parseSessionTime.
+func parseEventTime(value string) (time.Time, error) {
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05Z",
+		"20060102T150405Z",
+		"20060102T150405.000Z",
+	} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, errUnrecognizedEventTime
+}
+
+var errUnrecognizedEventTime = newConstError("unrecognized CloudTrail eventTime")
+
+type constError string
+
+func (e constError) Error() string { return string(e) }
+
+func newConstError(msg string) error { return constError(msg) }

--- a/internal/runtime/cloudtraildelivery/eventbridge.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge.go
@@ -1,0 +1,328 @@
+package cloudtraildelivery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/cloudtrail"
+)
+
+// SQSAPI is the narrow seam for the EventBridge → SQS delivery
+// channel. EventBridge fans CloudTrail events out to subscribers; the
+// most common fan-out target in production is an SQS queue, and the
+// ingester pulls a bounded batch of messages, normalizes the
+// CloudTrail `detail` payload, and deletes successfully-ingested
+// messages so they are not re-delivered. Messages whose normalization
+// fails are left in the queue so the queue's redrive policy applies.
+type SQSAPI interface {
+	ReceiveMessage(ctx context.Context, input ReceiveMessageInput) (ReceiveMessageOutput, error)
+	DeleteMessageBatch(ctx context.Context, input DeleteMessageBatchInput) (DeleteMessageBatchOutput, error)
+}
+
+// ReceiveMessageInput mirrors the SDK input.
+type ReceiveMessageInput struct {
+	QueueURL            string
+	MaxNumberOfMessages int32
+	WaitTimeSeconds     int32
+	VisibilityTimeout   int32
+}
+
+// ReceiveMessageOutput holds the messages pulled from the queue.
+type ReceiveMessageOutput struct {
+	Messages []SQSMessage
+}
+
+// SQSMessage is the trimmed SDK message shape.
+type SQSMessage struct {
+	MessageID     string
+	ReceiptHandle string
+	Body          string
+}
+
+// DeleteMessageBatchInput requests deletion of one or more processed
+// messages.
+type DeleteMessageBatchInput struct {
+	QueueURL string
+	Entries  []DeleteMessageBatchEntry
+}
+
+// DeleteMessageBatchEntry pairs a message id with its receipt handle.
+type DeleteMessageBatchEntry struct {
+	ID            string
+	ReceiptHandle string
+}
+
+// DeleteMessageBatchOutput surfaces the partial-failure structure
+// SQS uses (some deletes can succeed while others fail in one
+// request).
+type DeleteMessageBatchOutput struct {
+	Successful []string
+	Failed     []DeleteMessageBatchFailure
+}
+
+// DeleteMessageBatchFailure carries the SQS error code per failed
+// entry so the ingester can attach a per-message diagnostic.
+type DeleteMessageBatchFailure struct {
+	ID      string
+	Code    string
+	Message string
+}
+
+// EventBridgeIngester drives one bounded EventBridge ingestion run by
+// consuming the SQS queue an EventBridge rule targets.
+type EventBridgeIngester struct {
+	API      SQSAPI
+	QueueURL string
+	Now      func() time.Time
+	Sleep    func(time.Duration)
+}
+
+// NewEventBridgeIngester returns an EventBridgeIngester with sensible
+// defaults for the Now and Sleep hooks.
+func NewEventBridgeIngester(api SQSAPI, queueURL string) *EventBridgeIngester {
+	return &EventBridgeIngester{
+		API:      api,
+		QueueURL: strings.TrimSpace(queueURL),
+		Now:      func() time.Time { return time.Now().UTC() },
+		Sleep:    time.Sleep,
+	}
+}
+
+// eventBridgeEnvelope is the metadata-only projection of the
+// EventBridge event envelope CloudTrail publishes. The `detail` field
+// is the CloudTrail record itself; everything outside `detail` is
+// envelope metadata the ingester does not need.
+type eventBridgeEnvelope struct {
+	ID         string          `json:"id"`
+	Source     string          `json:"source"`
+	DetailType string          `json:"detail-type"`
+	Account    string          `json:"account"`
+	Region     string          `json:"region"`
+	Time       string          `json:"time"`
+	Detail     json.RawMessage `json:"detail"`
+}
+
+// Ingest runs one bounded EventBridge ingestion pass.
+func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest) (IngestResult, error) {
+	if i == nil {
+		return IngestResult{}, errors.New("cloudtraildelivery: EventBridgeIngester is nil")
+	}
+	if i.API == nil {
+		return IngestResult{}, errors.New("cloudtraildelivery: SQS API is required")
+	}
+	if strings.TrimSpace(i.QueueURL) == "" {
+		return IngestResult{}, errors.New("cloudtraildelivery: queue url is required")
+	}
+	now := i.callerNow()
+	request = request.withDefaults()
+	result := IngestResult{Source: DeliverySourceEventBridge, Status: "ready"}
+
+	receiveOut, recvErr := i.receiveWithRetry(ctx, request)
+	if recvErr != nil {
+		if errors.Is(recvErr, context.Canceled) || errors.Is(recvErr, context.DeadlineExceeded) {
+			return IngestResult{}, recvErr
+		}
+		if isPermissionDenied(recvErr) {
+			return finalizeBlocked(result, recvErr, "CloudTrail EventBridge SQS receive is not authorized."), nil
+		}
+		result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+			SourceID:    "sqs-receive",
+			Code:        diagnosticCodeFor(recvErr),
+			Message:     fmt.Sprintf("SQS ReceiveMessage failed: %v", recvErr),
+			Remediation: "Retry SQS receive; no messages were consumed.",
+			Retryable:   isRetryable(recvErr),
+		})
+		result.Status = "degraded"
+		result.FailureReasons = append(result.FailureReasons, "CloudTrail EventBridge SQS receive failed")
+		result.RemediationHints = append(result.RemediationHints, "Confirm the connector role can sqs:ReceiveMessage on the configured queue.")
+		finalizeEmptyOrTruncated(&result)
+		return result, nil
+	}
+
+	seen := map[string]struct{}{}
+	toDelete := make([]DeleteMessageBatchEntry, 0, len(receiveOut.Messages))
+	for _, msg := range receiveOut.Messages {
+		result.MessagesProcessed++
+		if result.MessagesProcessed > request.MaxMessages {
+			result.HistoryTruncated = true
+			break
+		}
+		record, raw, parseErr := decodeEventBridgeMessage(msg.Body)
+		if parseErr != nil {
+			// Malformed envelope: emit a diagnostic and leave the
+			// message in-queue so the queue's redrive policy applies.
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:    msg.MessageID,
+				Code:        "cloudtrail_eventbridge_envelope_unparseable",
+				Message:     fmt.Sprintf("EventBridge envelope unparseable for message %s: %v", msg.MessageID, parseErr),
+				Remediation: "Inspect the dead-letter queue; the message is preserved for redelivery.",
+				Retryable:   false,
+			})
+			continue
+		}
+		eventID := strings.TrimSpace(record.EventID)
+		if eventID == "" {
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:  msg.MessageID,
+				Code:      "cloudtrail_eventbridge_record_missing_id",
+				Message:   fmt.Sprintf("EventBridge message %s has no eventID; skipping.", msg.MessageID),
+				Retryable: false,
+			})
+			// Even without an event id we can safely delete: the
+			// message has no future value.
+			toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
+			continue
+		}
+		if _, dupe := seen[eventID]; dupe {
+			toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
+			continue
+		}
+		seen[eventID] = struct{}{}
+		event := record.toCloudTrailEvent(raw)
+		normalized, mapDiag, ok := cloudtrail.NormalizeEvent(event, request.AccountID, request.Region, now)
+		if mapDiag != nil {
+			mapDiag.SourceID = eventID
+			result.Diagnostics = append(result.Diagnostics, *mapDiag)
+		}
+		if !ok {
+			// Engine rejected the record (missing core fields, etc.).
+			// Delete so the queue does not keep re-delivering it.
+			toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
+			continue
+		}
+		remaining := request.MaxEvents - len(result.Events)
+		if remaining <= 0 {
+			result.HistoryTruncated = true
+			break
+		}
+		if len(normalized) > remaining {
+			normalized = normalized[:remaining]
+			result.HistoryTruncated = true
+		}
+		result.Events = append(result.Events, normalized...)
+		toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
+		result.EventsConsidered++
+	}
+
+	if len(toDelete) > 0 {
+		i.deleteBatch(ctx, toDelete, &result)
+	}
+	finalizeEmptyOrTruncated(&result)
+	finalizeDiagnosticDegrade(&result)
+	return result, nil
+}
+
+func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request IngestRequest) (ReceiveMessageOutput, error) {
+	max := request.MaxMessages
+	// SQS caps ReceiveMessage at 10 entries per request — let the
+	// caller batch beyond that by sizing MaxMessages but cap each
+	// receive at 10 to match SDK semantics.
+	if max > 10 {
+		max = 10
+	}
+	input := ReceiveMessageInput{
+		QueueURL:            i.QueueURL,
+		MaxNumberOfMessages: int32(max),
+		// Long-poll with a 5-second wait so the ingester does not hot-
+		// loop on an empty queue, but stays well below typical worker
+		// tick budgets.
+		WaitTimeSeconds:   5,
+		VisibilityTimeout: int32(DefaultSQSVisibilityBuffer / time.Second),
+	}
+	var lastErr error
+	for attempt := 0; attempt <= request.MaxThrottleRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return ReceiveMessageOutput{}, err
+		}
+		out, err := i.API.ReceiveMessage(ctx, input)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		if !isThrottling(err) {
+			return ReceiveMessageOutput{}, err
+		}
+		if attempt == request.MaxThrottleRetries {
+			break
+		}
+		i.sleep(request.ThrottleBackoff * time.Duration(attempt+1))
+	}
+	return ReceiveMessageOutput{}, lastErr
+}
+
+func (i *EventBridgeIngester) deleteBatch(ctx context.Context, entries []DeleteMessageBatchEntry, result *IngestResult) {
+	// SQS DeleteMessageBatch caps at 10 entries per request. Chunk to
+	// stay within the cap and accumulate per-failure diagnostics.
+	const batchCap = 10
+	for start := 0; start < len(entries); start += batchCap {
+		end := start + batchCap
+		if end > len(entries) {
+			end = len(entries)
+		}
+		out, err := i.API.DeleteMessageBatch(ctx, DeleteMessageBatchInput{
+			QueueURL: i.QueueURL,
+			Entries:  entries[start:end],
+		})
+		if err != nil {
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:    "sqs-delete-batch",
+				Code:        diagnosticCodeFor(err),
+				Message:     fmt.Sprintf("SQS DeleteMessageBatch failed: %v", err),
+				Remediation: "Retry: messages re-appear after the visibility timeout and the next run will reprocess them.",
+				Retryable:   isRetryable(err),
+			})
+			continue
+		}
+		for _, failure := range out.Failed {
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:    failure.ID,
+				Code:        "cloudtrail_eventbridge_delete_failed",
+				Message:     fmt.Sprintf("SQS DeleteMessageBatch failed for message %s: %s (%s)", failure.ID, failure.Message, failure.Code),
+				Remediation: "Message re-appears after the visibility timeout; the next run dedupes by eventID and re-deletes.",
+				Retryable:   true,
+			})
+		}
+	}
+}
+
+// decodeEventBridgeMessage parses an SQS message body produced by an
+// EventBridge rule targeting an SQS queue. The body is the
+// EventBridge envelope JSON; `detail` is the CloudTrail record. The
+// raw `detail` JSON is returned so cloudtrail.NormalizeEvent can use
+// its allow-listed metadata extraction on the full payload.
+func decodeEventBridgeMessage(body string) (CloudTrailRecord, string, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return CloudTrailRecord{}, "", errors.New("empty SQS body")
+	}
+	var envelope eventBridgeEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return CloudTrailRecord{}, "", fmt.Errorf("decode EventBridge envelope: %w", err)
+	}
+	if len(envelope.Detail) == 0 {
+		return CloudTrailRecord{}, "", errors.New("EventBridge envelope has empty detail")
+	}
+	var record CloudTrailRecord
+	if err := json.Unmarshal(envelope.Detail, &record); err != nil {
+		return CloudTrailRecord{}, "", fmt.Errorf("decode CloudTrail detail: %w", err)
+	}
+	return record, string(envelope.Detail), nil
+}
+
+func (i *EventBridgeIngester) callerNow() time.Time {
+	if i == nil || i.Now == nil {
+		return time.Now().UTC()
+	}
+	return i.Now().UTC()
+}
+
+func (i *EventBridgeIngester) sleep(d time.Duration) {
+	if i == nil || i.Sleep == nil || d <= 0 {
+		return
+	}
+	i.Sleep(d)
+}

--- a/internal/runtime/cloudtraildelivery/eventbridge.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge.go
@@ -197,6 +197,9 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 			toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
 			continue
 		}
+		if !isWithinScope(request.AccountID, request.Region, record.RecipientAccount, record.AWSRegion) {
+			continue
+		}
 		remaining := request.MaxEvents - len(result.Events)
 		if remaining <= 0 {
 			result.HistoryTruncated = true
@@ -222,6 +225,18 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 	finalizeEmptyOrTruncated(&result)
 	finalizeDiagnosticDegrade(&result)
 	return result, nil
+}
+
+func isWithinScope(requestedAccount string, requestedRegion string, recordAccount string, recordRegion string) bool {
+	account := strings.TrimSpace(requestedAccount)
+	region := strings.TrimSpace(requestedRegion)
+	if account != "" && strings.TrimSpace(recordAccount) != account {
+		return false
+	}
+	if region != "" && strings.TrimSpace(recordRegion) != region {
+		return false
+	}
+	return true
 }
 
 func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request IngestRequest) (ReceiveMessageOutput, bool, error) {

--- a/internal/runtime/cloudtraildelivery/eventbridge.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge.go
@@ -209,7 +209,9 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 	}
 
 	if len(toDelete) > 0 {
-		i.deleteBatch(ctx, toDelete, &result)
+		if err := i.deleteBatch(ctx, toDelete, &result); err != nil {
+			return IngestResult{}, err
+		}
 	}
 	finalizeEmptyOrTruncated(&result)
 	finalizeDiagnosticDegrade(&result)
@@ -254,11 +256,14 @@ func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request Inge
 	return ReceiveMessageOutput{}, lastErr
 }
 
-func (i *EventBridgeIngester) deleteBatch(ctx context.Context, entries []DeleteMessageBatchEntry, result *IngestResult) {
+func (i *EventBridgeIngester) deleteBatch(ctx context.Context, entries []DeleteMessageBatchEntry, result *IngestResult) error {
 	// SQS DeleteMessageBatch caps at 10 entries per request. Chunk to
 	// stay within the cap and accumulate per-failure diagnostics.
 	const batchCap = 10
 	for start := 0; start < len(entries); start += batchCap {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		end := start + batchCap
 		if end > len(entries) {
 			end = len(entries)
@@ -268,6 +273,9 @@ func (i *EventBridgeIngester) deleteBatch(ctx context.Context, entries []DeleteM
 			Entries:  entries[start:end],
 		})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
 			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
 				SourceID:    "sqs-delete-batch",
 				Code:        diagnosticCodeFor(err),
@@ -287,6 +295,7 @@ func (i *EventBridgeIngester) deleteBatch(ctx context.Context, entries []DeleteM
 			})
 		}
 	}
+	return nil
 }
 
 // decodeEventBridgeMessage parses an SQS message body produced by an

--- a/internal/runtime/cloudtraildelivery/eventbridge.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge.go
@@ -202,6 +202,9 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 		if len(normalized) > remaining {
 			normalized = normalized[:remaining]
 			result.HistoryTruncated = true
+			result.Events = append(result.Events, normalized...)
+			result.EventsConsidered++
+			break
 		}
 		result.Events = append(result.Events, normalized...)
 		toDelete = append(toDelete, DeleteMessageBatchEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle})
@@ -219,13 +222,30 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 }
 
 func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request IngestRequest) (ReceiveMessageOutput, error) {
-	max := request.MaxMessages
-	// SQS caps ReceiveMessage at 10 entries per request — let the
-	// caller batch beyond that by sizing MaxMessages but cap each
-	// receive at 10 to match SDK semantics.
-	if max > 10 {
-		max = 10
+	var combined ReceiveMessageOutput
+	for len(combined.Messages) < request.MaxMessages {
+		max := request.MaxMessages - len(combined.Messages)
+		// SQS caps ReceiveMessage at 10 entries per request; loop so
+		// one ingestion run can consume the caller's MaxMessages budget.
+		if max > 10 {
+			max = 10
+		}
+		out, err := i.receiveOneWithRetry(ctx, request, max)
+		if err != nil {
+			return ReceiveMessageOutput{}, err
+		}
+		if len(out.Messages) == 0 {
+			break
+		}
+		combined.Messages = append(combined.Messages, out.Messages...)
+		if len(out.Messages) < max {
+			break
+		}
 	}
+	return combined, nil
+}
+
+func (i *EventBridgeIngester) receiveOneWithRetry(ctx context.Context, request IngestRequest, max int) (ReceiveMessageOutput, error) {
 	input := ReceiveMessageInput{
 		QueueURL:            i.QueueURL,
 		MaxNumberOfMessages: int32(max),

--- a/internal/runtime/cloudtraildelivery/eventbridge.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge.go
@@ -121,7 +121,7 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 	request = request.withDefaults()
 	result := IngestResult{Source: DeliverySourceEventBridge, Status: "ready"}
 
-	receiveOut, recvErr := i.receiveWithRetry(ctx, request)
+	receiveOut, moreAvailable, recvErr := i.receiveWithRetry(ctx, request)
 	if recvErr != nil {
 		if errors.Is(recvErr, context.Canceled) || errors.Is(recvErr, context.DeadlineExceeded) {
 			return IngestResult{}, recvErr
@@ -141,6 +141,9 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 		result.RemediationHints = append(result.RemediationHints, "Confirm the connector role can sqs:ReceiveMessage on the configured queue.")
 		finalizeEmptyOrTruncated(&result)
 		return result, nil
+	}
+	if moreAvailable {
+		result.HistoryTruncated = true
 	}
 
 	seen := map[string]struct{}{}
@@ -221,8 +224,9 @@ func (i *EventBridgeIngester) Ingest(ctx context.Context, request IngestRequest)
 	return result, nil
 }
 
-func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request IngestRequest) (ReceiveMessageOutput, error) {
+func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request IngestRequest) (ReceiveMessageOutput, bool, error) {
 	var combined ReceiveMessageOutput
+	lastBatchFull := false
 	for len(combined.Messages) < request.MaxMessages {
 		max := request.MaxMessages - len(combined.Messages)
 		// SQS caps ReceiveMessage at 10 entries per request; loop so
@@ -232,17 +236,22 @@ func (i *EventBridgeIngester) receiveWithRetry(ctx context.Context, request Inge
 		}
 		out, err := i.receiveOneWithRetry(ctx, request, max)
 		if err != nil {
-			return ReceiveMessageOutput{}, err
+			return ReceiveMessageOutput{}, false, err
 		}
 		if len(out.Messages) == 0 {
+			lastBatchFull = false
 			break
 		}
 		combined.Messages = append(combined.Messages, out.Messages...)
+		lastBatchFull = len(out.Messages) >= max
 		if len(out.Messages) < max {
 			break
 		}
 	}
-	return combined, nil
+	// If the budget is filled and the last batch was full, the queue
+	// likely has more messages the caller could not consume.
+	moreAvailable := lastBatchFull && len(combined.Messages) >= request.MaxMessages
+	return combined, moreAvailable, nil
 }
 
 func (i *EventBridgeIngester) receiveOneWithRetry(ctx context.Context, request IngestRequest, max int) (ReceiveMessageOutput, error) {

--- a/internal/runtime/cloudtraildelivery/eventbridge_test.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge_test.go
@@ -4,21 +4,32 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
 
 type fakeSQS struct {
 	receiveOut    ReceiveMessageOutput
+	receivePages  []ReceiveMessageOutput
 	receiveErr    error
+	receiveInputs []ReceiveMessageInput
 	deletedIDs    []string
 	deleteFailure []DeleteMessageBatchFailure
 	deleteErr     error
 }
 
-func (f *fakeSQS) ReceiveMessage(ctx context.Context, _ ReceiveMessageInput) (ReceiveMessageOutput, error) {
+func (f *fakeSQS) ReceiveMessage(ctx context.Context, input ReceiveMessageInput) (ReceiveMessageOutput, error) {
 	if err := ctx.Err(); err != nil {
 		return ReceiveMessageOutput{}, err
+	}
+	f.receiveInputs = append(f.receiveInputs, input)
+	if len(f.receivePages) > 0 {
+		idx := len(f.receiveInputs) - 1
+		if idx >= len(f.receivePages) {
+			return ReceiveMessageOutput{}, nil
+		}
+		return f.receivePages[idx], f.receiveErr
 	}
 	return f.receiveOut, f.receiveErr
 }
@@ -47,6 +58,37 @@ func eventBridgeMessageBody(t *testing.T, eventID, eventName, eventSource string
 		"eventTime":          eventTime.UTC().Format(time.RFC3339),
 		"awsRegion":          "us-east-1",
 		"recipientAccountId": "123456789012",
+		"userIdentity": map[string]any{
+			"type": "AssumedRole",
+			"arn":  "arn:aws:sts::123456789012:assumed-role/role/sess",
+		},
+	}
+	envelope := map[string]any{
+		"id":          "eb-id-" + eventID,
+		"source":      "aws.cloudtrail",
+		"detail-type": "AWS API Call via CloudTrail",
+		"account":     "123456789012",
+		"region":      "us-east-1",
+		"time":        eventTime.UTC().Format(time.RFC3339),
+		"detail":      detail,
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	return string(body)
+}
+
+func eventBridgeMessageBodyWithResources(t *testing.T, eventID, eventName, eventSource string, eventTime time.Time, resources []map[string]any) string {
+	t.Helper()
+	detail := map[string]any{
+		"eventID":            eventID,
+		"eventName":          eventName,
+		"eventSource":        eventSource,
+		"eventTime":          eventTime.UTC().Format(time.RFC3339),
+		"awsRegion":          "us-east-1",
+		"recipientAccountId": "123456789012",
+		"resources":          resources,
 		"userIdentity": map[string]any{
 			"type": "AssumedRole",
 			"arn":  "arn:aws:sts::123456789012:assumed-role/role/sess",
@@ -193,5 +235,57 @@ func TestEventBridgeIngesterRespectsMaxEventsBudget(t *testing.T) {
 	}
 	if !result.HistoryTruncated {
 		t.Fatalf("expected HistoryTruncated when budget capped")
+	}
+}
+
+func TestEventBridgeIngesterReceivesBatchesUpToMaxMessages(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	page := func(start int) ReceiveMessageOutput {
+		out := ReceiveMessageOutput{}
+		for idx := 0; idx < 10; idx++ {
+			n := start + idx
+			out.Messages = append(out.Messages, SQSMessage{
+				MessageID:     fmt.Sprintf("msg-%02d", n),
+				ReceiptHandle: fmt.Sprintf("rh-%02d", n),
+				Body:          eventBridgeMessageBody(t, fmt.Sprintf("evt-%02d", n), "AssumeRole", "sts.amazonaws.com", now),
+			})
+		}
+		return out
+	}
+	fake := &fakeSQS{receivePages: []ReceiveMessageOutput{page(0), page(10), ReceiveMessageOutput{}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxMessages: 20})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 20 || len(fake.deletedIDs) != 20 {
+		t.Fatalf("expected 20 events/deletes, got events=%d deletes=%d", len(result.Events), len(fake.deletedIDs))
+	}
+	if len(fake.receiveInputs) != 2 || fake.receiveInputs[0].MaxNumberOfMessages != 10 || fake.receiveInputs[1].MaxNumberOfMessages != 10 {
+		t.Fatalf("expected two 10-message receives, got %+v", fake.receiveInputs)
+	}
+}
+
+func TestEventBridgeIngesterDoesNotDeleteMessageTruncatedMidFanout(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	body := eventBridgeMessageBodyWithResources(t, "evt-many", "BatchGetSecretValue", "secretsmanager.amazonaws.com", now, []map[string]any{
+		{"type": "AWS::SecretsManager::Secret", "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/one"},
+		{"type": "AWS::SecretsManager::Secret", "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/two"},
+	})
+	fake := &fakeSQS{receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+		{MessageID: "msg-many", ReceiptHandle: "rh-many", Body: body},
+	}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxEvents: 1})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if !result.HistoryTruncated || len(result.Events) != 1 {
+		t.Fatalf("expected one truncated event, got %+v", result)
+	}
+	if len(fake.deletedIDs) != 0 {
+		t.Fatalf("truncated message must remain for redelivery, deleted=%+v", fake.deletedIDs)
 	}
 }

--- a/internal/runtime/cloudtraildelivery/eventbridge_test.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge_test.go
@@ -16,11 +16,17 @@ type fakeSQS struct {
 	deleteErr     error
 }
 
-func (f *fakeSQS) ReceiveMessage(_ context.Context, _ ReceiveMessageInput) (ReceiveMessageOutput, error) {
+func (f *fakeSQS) ReceiveMessage(ctx context.Context, _ ReceiveMessageInput) (ReceiveMessageOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return ReceiveMessageOutput{}, err
+	}
 	return f.receiveOut, f.receiveErr
 }
 
-func (f *fakeSQS) DeleteMessageBatch(_ context.Context, input DeleteMessageBatchInput) (DeleteMessageBatchOutput, error) {
+func (f *fakeSQS) DeleteMessageBatch(ctx context.Context, input DeleteMessageBatchInput) (DeleteMessageBatchOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return DeleteMessageBatchOutput{}, err
+	}
 	if f.deleteErr != nil {
 		return DeleteMessageBatchOutput{}, f.deleteErr
 	}
@@ -151,6 +157,21 @@ func TestEventBridgeIngesterPropagatesContextCancellation(t *testing.T) {
 	ing.Now = func() time.Time { return time.Now().UTC() }
 	if _, err := ing.Ingest(context.Background(), IngestRequest{}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled propagation, got %v", err)
+	}
+}
+
+func TestEventBridgeIngesterPropagatesDeleteContextCancellation(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeSQS{
+		receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+			{MessageID: "msg-1", ReceiptHandle: "rh-1", Body: eventBridgeMessageBody(t, "evt-1", "AssumeRole", "sts.amazonaws.com", now)},
+		}},
+		deleteErr: context.Canceled,
+	}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	if _, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled propagation from delete, got %v", err)
 	}
 }
 

--- a/internal/runtime/cloudtraildelivery/eventbridge_test.go
+++ b/internal/runtime/cloudtraildelivery/eventbridge_test.go
@@ -1,0 +1,176 @@
+package cloudtraildelivery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeSQS struct {
+	receiveOut    ReceiveMessageOutput
+	receiveErr    error
+	deletedIDs    []string
+	deleteFailure []DeleteMessageBatchFailure
+	deleteErr     error
+}
+
+func (f *fakeSQS) ReceiveMessage(_ context.Context, _ ReceiveMessageInput) (ReceiveMessageOutput, error) {
+	return f.receiveOut, f.receiveErr
+}
+
+func (f *fakeSQS) DeleteMessageBatch(_ context.Context, input DeleteMessageBatchInput) (DeleteMessageBatchOutput, error) {
+	if f.deleteErr != nil {
+		return DeleteMessageBatchOutput{}, f.deleteErr
+	}
+	out := DeleteMessageBatchOutput{Failed: f.deleteFailure}
+	for _, e := range input.Entries {
+		out.Successful = append(out.Successful, e.ID)
+		f.deletedIDs = append(f.deletedIDs, e.ID)
+	}
+	return out, nil
+}
+
+func eventBridgeMessageBody(t *testing.T, eventID, eventName, eventSource string, eventTime time.Time) string {
+	t.Helper()
+	detail := map[string]any{
+		"eventID":            eventID,
+		"eventName":          eventName,
+		"eventSource":        eventSource,
+		"eventTime":          eventTime.UTC().Format(time.RFC3339),
+		"awsRegion":          "us-east-1",
+		"recipientAccountId": "123456789012",
+		"userIdentity": map[string]any{
+			"type": "AssumedRole",
+			"arn":  "arn:aws:sts::123456789012:assumed-role/role/sess",
+		},
+	}
+	envelope := map[string]any{
+		"id":          "eb-id-" + eventID,
+		"source":      "aws.cloudtrail",
+		"detail-type": "AWS API Call via CloudTrail",
+		"account":     "123456789012",
+		"region":      "us-east-1",
+		"time":        eventTime.UTC().Format(time.RFC3339),
+		"detail":      detail,
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	return string(body)
+}
+
+func TestEventBridgeIngesterNormalizesAndDeletesProcessedMessages(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeSQS{receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+		{MessageID: "msg-1", ReceiptHandle: "rh-1", Body: eventBridgeMessageBody(t, "evt-secret", "GetSecretValue", "secretsmanager.amazonaws.com", now.Add(-2*time.Minute))},
+		{MessageID: "msg-2", ReceiptHandle: "rh-2", Body: eventBridgeMessageBody(t, "evt-kms", "Decrypt", "kms.amazonaws.com", now.Add(-1*time.Minute))},
+	}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs.us-east-1.amazonaws.com/123456789012/cloudtrail-events")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Source != DeliverySourceEventBridge || result.Status != "ready" {
+		t.Fatalf("expected source=eventbridge ready, got %+v", result)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+	if len(fake.deletedIDs) != 2 {
+		t.Fatalf("expected both messages deleted, got %+v", fake.deletedIDs)
+	}
+}
+
+func TestEventBridgeIngesterDedupesAndStillDeletesDuplicates(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	body := eventBridgeMessageBody(t, "evt-dupe", "AssumeRole", "sts.amazonaws.com", now)
+	fake := &fakeSQS{receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+		{MessageID: "msg-1", ReceiptHandle: "rh-1", Body: body},
+		{MessageID: "msg-2", ReceiptHandle: "rh-2", Body: body},
+	}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected one event after dedupe, got %d", len(result.Events))
+	}
+	if len(fake.deletedIDs) != 2 {
+		t.Fatalf("expected both duplicate messages deleted, got %+v", fake.deletedIDs)
+	}
+}
+
+func TestEventBridgeIngesterLeavesUnparseableMessagesInQueueForRedrive(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeSQS{receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+		{MessageID: "msg-bad", ReceiptHandle: "rh-bad", Body: "{not-json"},
+		{MessageID: "msg-good", ReceiptHandle: "rh-good", Body: eventBridgeMessageBody(t, "evt-good", "AssumeRole", "sts.amazonaws.com", now)},
+	}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 1 || result.Events[0].EventID != "evt-good" {
+		t.Fatalf("expected the good event preserved, got %+v", result.Events)
+	}
+	if len(fake.deletedIDs) != 1 || fake.deletedIDs[0] != "msg-good" {
+		t.Fatalf("malformed message must remain in queue for redrive, got deleted=%+v", fake.deletedIDs)
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected degraded status when an envelope is unparseable, got %q", result.Status)
+	}
+}
+
+func TestEventBridgeIngesterReportsPermissionDeniedAsBlocked(t *testing.T) {
+	fake := &fakeSQS{receiveErr: codedErr{code: "AccessDeniedException", msg: "User is not authorized (AccessDeniedException)"}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return time.Now().UTC() }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected blocked, got %q", result.Status)
+	}
+	if len(result.CoverageGaps) == 0 || result.CoverageGaps[0].Status != "permission_denied" {
+		t.Fatalf("expected permission_denied coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
+func TestEventBridgeIngesterPropagatesContextCancellation(t *testing.T) {
+	fake := &fakeSQS{receiveErr: context.Canceled}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return time.Now().UTC() }
+	if _, err := ing.Ingest(context.Background(), IngestRequest{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled propagation, got %v", err)
+	}
+}
+
+func TestEventBridgeIngesterRespectsMaxEventsBudget(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeSQS{receiveOut: ReceiveMessageOutput{Messages: []SQSMessage{
+		{MessageID: "msg-1", ReceiptHandle: "rh-1", Body: eventBridgeMessageBody(t, "evt-1", "AssumeRole", "sts.amazonaws.com", now.Add(-3*time.Minute))},
+		{MessageID: "msg-2", ReceiptHandle: "rh-2", Body: eventBridgeMessageBody(t, "evt-2", "AssumeRole", "sts.amazonaws.com", now.Add(-2*time.Minute))},
+		{MessageID: "msg-3", ReceiptHandle: "rh-3", Body: eventBridgeMessageBody(t, "evt-3", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute))},
+	}}}
+	ing := NewEventBridgeIngester(fake, "https://sqs/queue")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxEvents: 2})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected MaxEvents=2 cap, got %d", len(result.Events))
+	}
+	if !result.HistoryTruncated {
+		t.Fatalf("expected HistoryTruncated when budget capped")
+	}
+}

--- a/internal/runtime/cloudtraildelivery/s3.go
+++ b/internal/runtime/cloudtraildelivery/s3.go
@@ -1,0 +1,399 @@
+package cloudtraildelivery
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/cloudtrail"
+)
+
+// S3API is the narrow seam every S3 backend implements. The SDK
+// adapter wraps s3.Client; tests use a fake to exercise the ingester
+// deterministically without network access.
+type S3API interface {
+	ListObjectsV2(ctx context.Context, input ListObjectsV2Input) (ListObjectsV2Output, error)
+	GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error)
+}
+
+// ListObjectsV2Input is the S3 ListObjectsV2 request, expressed
+// independently of the SDK so the ingester layer never imports the
+// SDK types directly.
+type ListObjectsV2Input struct {
+	Bucket            string
+	Prefix            string
+	ContinuationToken string
+	MaxKeys           int32
+	// StartAfter scopes the listing to keys strictly greater than the
+	// supplied key. CloudTrail object keys embed an ISO-8601 timestamp,
+	// so passing the last processed key gives the next run an
+	// efficient resume marker without re-listing the entire window.
+	StartAfter string
+}
+
+// ListObjectsV2Output is the trimmed S3 response shape.
+type ListObjectsV2Output struct {
+	Objects     []S3Object
+	NextToken   string
+	IsTruncated bool
+}
+
+// S3Object is the per-object metadata the ingester needs from
+// ListObjectsV2.
+type S3Object struct {
+	Key          string
+	Size         int64
+	LastModified time.Time
+}
+
+// GetObjectInput is the S3 GetObject request shape.
+type GetObjectInput struct {
+	Bucket string
+	Key    string
+}
+
+// GetObjectOutput is the trimmed S3 response shape. The Body field is
+// the caller's responsibility to close.
+type GetObjectOutput struct {
+	Body          io.ReadCloser
+	ContentLength int64
+}
+
+// S3Ingester drives one bounded CloudTrail S3 ingestion run.
+type S3Ingester struct {
+	API S3API
+	// Bucket and Prefix locate the CloudTrail trail's S3 destination.
+	// CloudTrail keys look like
+	// AWSLogs/<account>/CloudTrail/<region>/YYYY/MM/DD/<account>_CloudTrail_<region>_<timestamp>_<uuid>.json.gz
+	// so a prefix scoped to one account+region greatly reduces the
+	// number of objects listed per run.
+	Bucket string
+	Prefix string
+	Now    func() time.Time
+	Sleep  func(time.Duration)
+}
+
+// NewS3Ingester returns an S3Ingester with sensible defaults for the
+// Now and Sleep hooks.
+func NewS3Ingester(api S3API, bucket, prefix string) *S3Ingester {
+	return &S3Ingester{
+		API:    api,
+		Bucket: strings.TrimSpace(bucket),
+		Prefix: strings.TrimSpace(prefix),
+		Now:    func() time.Time { return time.Now().UTC() },
+		Sleep:  time.Sleep,
+	}
+}
+
+// Ingest runs one bounded S3 ingestion pass. Documented failure modes
+// (permission denied, throttling exhaustion, partial-file failures,
+// empty window) are surfaced through IngestResult.Status and
+// Diagnostics rather than the error return so the API layer can serve
+// a stable 200 response. A returned error means a programmer bug or
+// context cancellation.
+func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestResult, error) {
+	if i == nil {
+		return IngestResult{}, errors.New("cloudtraildelivery: S3Ingester is nil")
+	}
+	if i.API == nil {
+		return IngestResult{}, errors.New("cloudtraildelivery: S3 API is required")
+	}
+	if strings.TrimSpace(i.Bucket) == "" {
+		return IngestResult{}, errors.New("cloudtraildelivery: bucket is required")
+	}
+	now := i.callerNow()
+	request = request.withDefaults()
+	result := IngestResult{Source: DeliverySourceS3, Status: "ready"}
+
+	objects, listErr := i.listObjects(ctx, request, now)
+	if listErr != nil {
+		if errors.Is(listErr, context.Canceled) || errors.Is(listErr, context.DeadlineExceeded) {
+			return IngestResult{}, listErr
+		}
+		if isPermissionDenied(listErr) {
+			return finalizeBlocked(result, listErr, "CloudTrail S3 log listing is not authorized."), nil
+		}
+		result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+			SourceID:    "s3-list",
+			Code:        diagnosticCodeFor(listErr),
+			Message:     fmt.Sprintf("CloudTrail S3 ListObjectsV2 failed: %v", listErr),
+			Remediation: "Retry CloudTrail S3 listing; partial coverage from any objects already downloaded is preserved.",
+			Retryable:   isRetryable(listErr),
+		})
+		result.Status = "degraded"
+		result.FailureReasons = append(result.FailureReasons, "CloudTrail S3 trail listing failed")
+		result.RemediationHints = append(result.RemediationHints, "Confirm the connector role can s3:ListBucket on the CloudTrail bucket and retry.")
+		finalizeEmptyOrTruncated(&result)
+		return result, nil
+	}
+
+	// Objects are returned key-sorted; sort by LastModified for
+	// deterministic checkpoint advancement even if S3 returns them in
+	// list-key order.
+	sort.SliceStable(objects, func(a, b int) bool {
+		return objects[a].LastModified.Before(objects[b].LastModified)
+	})
+
+	seen := map[string]struct{}{}
+	checkpoint := strings.TrimSpace(request.Checkpoint)
+	for idx, obj := range objects {
+		result.FilesProcessed++
+		if result.FilesProcessed > request.MaxFiles {
+			result.HistoryTruncated = true
+			break
+		}
+		if obj.Size > request.MaxFileBytes {
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:    obj.Key,
+				Code:        "cloudtrail_s3_object_too_large",
+				Message:     fmt.Sprintf("CloudTrail S3 object %q is %d bytes; exceeds MaxFileBytes=%d and was skipped.", obj.Key, obj.Size, request.MaxFileBytes),
+				Remediation: "Raise the MaxFileBytes budget or split the trail's destination so each file is smaller.",
+				Retryable:   false,
+			})
+			continue
+		}
+		records, recordErr := i.downloadAndParse(ctx, obj.Key)
+		if recordErr != nil {
+			if errors.Is(recordErr, context.Canceled) || errors.Is(recordErr, context.DeadlineExceeded) {
+				return IngestResult{}, recordErr
+			}
+			if isPermissionDenied(recordErr) {
+				return finalizeBlocked(result, recordErr, "CloudTrail S3 object read is not authorized."), nil
+			}
+			result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+				SourceID:    obj.Key,
+				Code:        diagnosticCodeFor(recordErr),
+				Message:     fmt.Sprintf("CloudTrail S3 object %q failed to parse: %v", obj.Key, recordErr),
+				Remediation: "Retry the failed object; events from other objects in this run are preserved.",
+				Retryable:   isRetryable(recordErr),
+			})
+			result.Status = "degraded"
+			continue
+		}
+		for _, raw := range records {
+			result.EventsConsidered++
+			eventID := strings.TrimSpace(raw.Event.EventID)
+			if eventID == "" {
+				result.Diagnostics = append(result.Diagnostics, cloudtrail.Diagnostic{
+					SourceID:  obj.Key,
+					Code:      "cloudtrail_s3_record_missing_id",
+					Message:   "CloudTrail S3 record had no eventID; skipping.",
+					Retryable: false,
+				})
+				continue
+			}
+			if _, dupe := seen[eventID]; dupe {
+				continue
+			}
+			seen[eventID] = struct{}{}
+			normalized, mapDiag, ok := cloudtrail.NormalizeEvent(raw.Event, request.AccountID, request.Region, now)
+			if mapDiag != nil {
+				mapDiag.SourceID = eventID
+				result.Diagnostics = append(result.Diagnostics, *mapDiag)
+			}
+			if !ok {
+				continue
+			}
+			remaining := request.MaxEvents - len(result.Events)
+			if remaining <= 0 {
+				result.HistoryTruncated = true
+				break
+			}
+			if len(normalized) > remaining {
+				normalized = normalized[:remaining]
+				result.HistoryTruncated = true
+			}
+			result.Events = append(result.Events, normalized...)
+		}
+		if len(result.Events) >= request.MaxEvents {
+			// More files may exist past the current index → truncated.
+			if idx+1 < len(objects) {
+				result.HistoryTruncated = true
+			}
+			checkpoint = obj.Key
+			break
+		}
+		checkpoint = obj.Key
+	}
+	result.Checkpoint = checkpoint
+	finalizeEmptyOrTruncated(&result)
+	finalizeDiagnosticDegrade(&result)
+	return result, nil
+}
+
+// listObjects pulls one page worth of CloudTrail trail files. The
+// caller-supplied Checkpoint is the previous run's last-processed key
+// (already strictly greater than any earlier key for the same trail).
+// When the checkpoint is empty the lookback window scopes the listing
+// to the last LookbackWindow worth of activity.
+func (i *S3Ingester) listObjects(ctx context.Context, request IngestRequest, now time.Time) ([]S3Object, error) {
+	startAfter := strings.TrimSpace(request.Checkpoint)
+	prefix := strings.TrimSpace(i.Prefix)
+	out, err := i.listWithRetry(ctx, ListObjectsV2Input{
+		Bucket:     i.Bucket,
+		Prefix:     prefix,
+		MaxKeys:    int32(request.MaxFiles),
+		StartAfter: startAfter,
+	}, request)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]S3Object, 0, len(out.Objects))
+	cutoff := now.Add(-request.LookbackWindow)
+	for _, obj := range out.Objects {
+		if startAfter == "" && !obj.LastModified.IsZero() && obj.LastModified.Before(cutoff) {
+			continue
+		}
+		filtered = append(filtered, obj)
+	}
+	return filtered, nil
+}
+
+func (i *S3Ingester) listWithRetry(ctx context.Context, input ListObjectsV2Input, request IngestRequest) (ListObjectsV2Output, error) {
+	var lastErr error
+	for attempt := 0; attempt <= request.MaxThrottleRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return ListObjectsV2Output{}, err
+		}
+		out, err := i.API.ListObjectsV2(ctx, input)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		if !isThrottling(err) {
+			return ListObjectsV2Output{}, err
+		}
+		if attempt == request.MaxThrottleRetries {
+			break
+		}
+		i.sleep(request.ThrottleBackoff * time.Duration(attempt+1))
+	}
+	return ListObjectsV2Output{}, lastErr
+}
+
+// s3RawRecord pairs a parsed CloudTrailRecord with the raw JSON of
+// that single record. The raw JSON is fed back into the cloudtrail
+// engine's NormalizeEvent so the allow-listed metadata extraction
+// (sessionContext attributes etc.) sees the full payload.
+type s3RawRecord struct {
+	Record CloudTrailRecord
+	Event  cloudtrail.Event
+}
+
+func (i *S3Ingester) downloadAndParse(ctx context.Context, key string) ([]s3RawRecord, error) {
+	resp, err := i.API.GetObject(ctx, GetObjectInput{Bucket: i.Bucket, Key: key})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	gzReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("open gzip stream for %s: %w", key, err)
+	}
+	defer gzReader.Close()
+	payload, err := io.ReadAll(gzReader)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip stream for %s: %w", key, err)
+	}
+	return parseCloudTrailLogFile(payload)
+}
+
+// parseCloudTrailLogFile decodes a CloudTrail S3 log file
+// `{ "Records": [...] }` and returns each record alongside its raw
+// per-record JSON so cloudtrail.NormalizeEvent can re-extract the
+// allow-listed metadata.
+func parseCloudTrailLogFile(payload []byte) ([]s3RawRecord, error) {
+	var envelope struct {
+		Records []json.RawMessage `json:"Records"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("decode CloudTrail log envelope: %w", err)
+	}
+	out := make([]s3RawRecord, 0, len(envelope.Records))
+	for _, raw := range envelope.Records {
+		var record CloudTrailRecord
+		if err := json.Unmarshal(raw, &record); err != nil {
+			// Skip malformed records but keep the rest of the file.
+			continue
+		}
+		out = append(out, s3RawRecord{Record: record, Event: record.toCloudTrailEvent(string(raw))})
+	}
+	return out, nil
+}
+
+func (i *S3Ingester) callerNow() time.Time {
+	if i == nil || i.Now == nil {
+		return time.Now().UTC()
+	}
+	return i.Now().UTC()
+}
+
+func (i *S3Ingester) sleep(d time.Duration) {
+	if i == nil || i.Sleep == nil || d <= 0 {
+		return
+	}
+	i.Sleep(d)
+}
+
+func finalizeBlocked(result IngestResult, err error, reason string) IngestResult {
+	result.Status = "blocked"
+	result.Events = nil
+	result.HistoryTruncated = false
+	result.Diagnostics = append([]cloudtrail.Diagnostic{}, cloudtrail.Diagnostic{
+		SourceID:    string(result.Source),
+		Code:        "permission_denied",
+		Message:     fmt.Sprintf("%s: %v", reason, err),
+		Remediation: "Grant the connector role metadata-only access to the CloudTrail S3 bucket or EventBridge target.",
+		Retryable:   true,
+	})
+	result.FailureReasons = []string{reason}
+	result.RemediationHints = []string{"Grant the connector role metadata-only access to the configured CloudTrail delivery channel."}
+	result.CoverageGaps = []cloudtrail.CoverageGap{{
+		Capability:  "cloudtrail_" + string(result.Source) + "_delivery",
+		Status:      "permission_denied",
+		Reason:      reason,
+		Remediation: "Add the required IAM permissions and retry.",
+	}}
+	return result
+}
+
+func finalizeEmptyOrTruncated(result *IngestResult) {
+	if result.HistoryTruncated {
+		result.FailureReasons = append(result.FailureReasons, "CloudTrail delivery ingestion stopped at a bounded budget")
+		result.RemediationHints = append(result.RemediationHints, "Narrow the lookback window or raise the per-run budget; partial coverage is preserved.")
+		result.CoverageGaps = append(result.CoverageGaps, cloudtrail.CoverageGap{
+			Capability:  "cloudtrail_" + string(result.Source) + "_delivery",
+			Status:      "history_truncated",
+			Reason:      "Delivery ingestion stopped at the configured MaxFiles/MaxMessages/MaxEvents budget; more records were available.",
+			Remediation: "Narrow the lookback window or raise the per-run budget so the trail tail is covered.",
+		})
+		if result.Status == "ready" {
+			result.Status = "degraded"
+		}
+	}
+	if len(result.Events) == 0 && result.Status == "ready" {
+		result.Status = "degraded"
+		result.FailureReasons = append(result.FailureReasons, "no CloudTrail delivery records matched the scoped window")
+		result.RemediationHints = append(result.RemediationHints, "Confirm CloudTrail trail/EventBridge delivery is enabled and the connector can read it.")
+		result.CoverageGaps = append(result.CoverageGaps, cloudtrail.CoverageGap{
+			Capability:  "cloudtrail_" + string(result.Source) + "_delivery",
+			Status:      "empty",
+			Reason:      "CloudTrail delivery returned no records in the scanned window.",
+			Remediation: "Widen the lookback window or confirm the trail is actively writing.",
+		})
+	}
+}
+
+func finalizeDiagnosticDegrade(result *IngestResult) {
+	if result.Status == "ready" && len(result.Diagnostics) > 0 {
+		result.Status = "degraded"
+		result.FailureReasons = append(result.FailureReasons, "CloudTrail delivery ingestion returned diagnostics")
+		result.RemediationHints = append(result.RemediationHints, "Review diagnostics before treating runtime coverage as complete.")
+	}
+}

--- a/internal/runtime/cloudtraildelivery/s3.go
+++ b/internal/runtime/cloudtraildelivery/s3.go
@@ -111,7 +111,7 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 	request = request.withDefaults()
 	result := IngestResult{Source: DeliverySourceS3, Status: "ready"}
 
-	objects, listErr := i.listObjects(ctx, request, now)
+	objects, listTruncated, listErr := i.listObjects(ctx, request, now)
 	if listErr != nil {
 		if errors.Is(listErr, context.Canceled) || errors.Is(listErr, context.DeadlineExceeded) {
 			return IngestResult{}, listErr
@@ -142,6 +142,9 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 	seen := map[string]struct{}{}
 	checkpoint := strings.TrimSpace(request.Checkpoint)
 	checkpointBlocked := false
+	if listTruncated {
+		result.HistoryTruncated = true
+	}
 	for idx, obj := range objects {
 		result.FilesProcessed++
 		if result.FilesProcessed > request.MaxFiles {
@@ -241,27 +244,38 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 // (already strictly greater than any earlier key for the same trail).
 // When the checkpoint is empty the lookback window scopes the listing
 // to the last LookbackWindow worth of activity.
-func (i *S3Ingester) listObjects(ctx context.Context, request IngestRequest, now time.Time) ([]S3Object, error) {
+func (i *S3Ingester) listObjects(ctx context.Context, request IngestRequest, now time.Time) ([]S3Object, bool, error) {
 	startAfter := strings.TrimSpace(request.Checkpoint)
 	prefix := strings.TrimSpace(i.Prefix)
-	out, err := i.listWithRetry(ctx, ListObjectsV2Input{
-		Bucket:     i.Bucket,
-		Prefix:     prefix,
-		MaxKeys:    int32(request.MaxFiles),
-		StartAfter: startAfter,
-	}, request)
-	if err != nil {
-		return nil, err
-	}
-	filtered := make([]S3Object, 0, len(out.Objects))
+	filtered := make([]S3Object, 0, request.MaxFiles)
 	cutoff := now.Add(-request.LookbackWindow)
-	for _, obj := range out.Objects {
-		if startAfter == "" && !obj.LastModified.IsZero() && obj.LastModified.Before(cutoff) {
-			continue
+	nextToken := ""
+	for {
+		out, err := i.listWithRetry(ctx, ListObjectsV2Input{
+			Bucket:            i.Bucket,
+			Prefix:            prefix,
+			MaxKeys:           int32(request.MaxFiles),
+			StartAfter:        startAfter,
+			ContinuationToken: nextToken,
+		}, request)
+		if err != nil {
+			return nil, false, err
 		}
-		filtered = append(filtered, obj)
+		for _, obj := range out.Objects {
+			if startAfter == "" && !obj.LastModified.IsZero() && obj.LastModified.Before(cutoff) {
+				continue
+			}
+			filtered = append(filtered, obj)
+			if len(filtered) >= request.MaxFiles {
+				return filtered, out.IsTruncated || strings.TrimSpace(out.NextToken) != "", nil
+			}
+		}
+		nextToken = strings.TrimSpace(out.NextToken)
+		if !out.IsTruncated || nextToken == "" {
+			break
+		}
 	}
-	return filtered, nil
+	return filtered, false, nil
 }
 
 func (i *S3Ingester) listWithRetry(ctx context.Context, input ListObjectsV2Input, request IngestRequest) (ListObjectsV2Output, error) {

--- a/internal/runtime/cloudtraildelivery/s3.go
+++ b/internal/runtime/cloudtraildelivery/s3.go
@@ -250,7 +250,15 @@ func (i *S3Ingester) listObjects(ctx context.Context, request IngestRequest, now
 	filtered := make([]S3Object, 0, request.MaxFiles)
 	cutoff := now.Add(-request.LookbackWindow)
 	nextToken := ""
-	for {
+	// maxListPages caps how many S3 list pages we fetch so an
+	// unbounded prefix with many old objects doesn't cause us to
+	// traverse the entire bucket. One page returns up to MaxFiles
+	// keys, so MaxFiles pages is a generous upper bound.
+	maxListPages := request.MaxFiles
+	if maxListPages < 1 {
+		maxListPages = DefaultMaxFiles
+	}
+	for page := 0; page < maxListPages; page++ {
 		out, err := i.listWithRetry(ctx, ListObjectsV2Input{
 			Bucket:            i.Bucket,
 			Prefix:            prefix,
@@ -274,6 +282,11 @@ func (i *S3Ingester) listObjects(ctx context.Context, request IngestRequest, now
 		if !out.IsTruncated || nextToken == "" {
 			break
 		}
+	}
+	// If we exhausted the page budget without filling the file budget
+	// and there are still more pages, report truncation.
+	if nextToken != "" && len(filtered) < request.MaxFiles {
+		return filtered, true, nil
 	}
 	return filtered, false, nil
 }

--- a/internal/runtime/cloudtraildelivery/s3.go
+++ b/internal/runtime/cloudtraildelivery/s3.go
@@ -133,15 +133,15 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 		return result, nil
 	}
 
-	// Objects are returned key-sorted; sort by LastModified for
-	// deterministic checkpoint advancement even if S3 returns them in
-	// list-key order.
+	// The checkpoint is an S3 key fed back through StartAfter, so keep
+	// processing order key-sorted to match S3 resume semantics.
 	sort.SliceStable(objects, func(a, b int) bool {
-		return objects[a].LastModified.Before(objects[b].LastModified)
+		return objects[a].Key < objects[b].Key
 	})
 
 	seen := map[string]struct{}{}
 	checkpoint := strings.TrimSpace(request.Checkpoint)
+	checkpointBlocked := false
 	for idx, obj := range objects {
 		result.FilesProcessed++
 		if result.FilesProcessed > request.MaxFiles {
@@ -156,9 +156,10 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 				Remediation: "Raise the MaxFileBytes budget or split the trail's destination so each file is smaller.",
 				Retryable:   false,
 			})
+			checkpointBlocked = true
 			continue
 		}
-		records, recordErr := i.downloadAndParse(ctx, obj.Key)
+		records, recordErr := i.downloadAndParse(ctx, obj.Key, request.MaxFileBytes)
 		if recordErr != nil {
 			if errors.Is(recordErr, context.Canceled) || errors.Is(recordErr, context.DeadlineExceeded) {
 				return IngestResult{}, recordErr
@@ -174,8 +175,10 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 				Retryable:   isRetryable(recordErr),
 			})
 			result.Status = "degraded"
+			checkpointBlocked = true
 			continue
 		}
+		fileComplete := true
 		for _, raw := range records {
 			result.EventsConsidered++
 			eventID := strings.TrimSpace(raw.Event.EventID)
@@ -203,11 +206,13 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 			remaining := request.MaxEvents - len(result.Events)
 			if remaining <= 0 {
 				result.HistoryTruncated = true
+				fileComplete = false
 				break
 			}
 			if len(normalized) > remaining {
 				normalized = normalized[:remaining]
 				result.HistoryTruncated = true
+				fileComplete = false
 			}
 			result.Events = append(result.Events, normalized...)
 		}
@@ -216,10 +221,14 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 			if idx+1 < len(objects) {
 				result.HistoryTruncated = true
 			}
-			checkpoint = obj.Key
+			if !checkpointBlocked && fileComplete {
+				checkpoint = obj.Key
+			}
 			break
 		}
-		checkpoint = obj.Key
+		if !checkpointBlocked && fileComplete {
+			checkpoint = obj.Key
+		}
 	}
 	result.Checkpoint = checkpoint
 	finalizeEmptyOrTruncated(&result)
@@ -286,7 +295,7 @@ type s3RawRecord struct {
 	Event  cloudtrail.Event
 }
 
-func (i *S3Ingester) downloadAndParse(ctx context.Context, key string) ([]s3RawRecord, error) {
+func (i *S3Ingester) downloadAndParse(ctx context.Context, key string, maxBytes int64) ([]s3RawRecord, error) {
 	resp, err := i.API.GetObject(ctx, GetObjectInput{Bucket: i.Bucket, Key: key})
 	if err != nil {
 		return nil, err
@@ -297,11 +306,26 @@ func (i *S3Ingester) downloadAndParse(ctx context.Context, key string) ([]s3RawR
 		return nil, fmt.Errorf("open gzip stream for %s: %w", key, err)
 	}
 	defer gzReader.Close()
-	payload, err := io.ReadAll(gzReader)
+	payload, err := readAllLimited(gzReader, maxBytes)
 	if err != nil {
 		return nil, fmt.Errorf("read gzip stream for %s: %w", key, err)
 	}
 	return parseCloudTrailLogFile(payload)
+}
+
+func readAllLimited(reader io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return io.ReadAll(reader)
+	}
+	limited := io.LimitReader(reader, maxBytes+1)
+	payload, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(payload)) > maxBytes {
+		return nil, fmt.Errorf("decompressed CloudTrail S3 object exceeds MaxFileBytes=%d", maxBytes)
+	}
+	return payload, nil
 }
 
 // parseCloudTrailLogFile decodes a CloudTrail S3 log file

--- a/internal/runtime/cloudtraildelivery/s3.go
+++ b/internal/runtime/cloudtraildelivery/s3.go
@@ -206,6 +206,9 @@ func (i *S3Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestR
 			if !ok {
 				continue
 			}
+			if !isWithinScope(request.AccountID, request.Region, raw.Record.RecipientAccount, raw.Record.AWSRegion) {
+				continue
+			}
 			remaining := request.MaxEvents - len(result.Events)
 			if remaining <= 0 {
 				result.HistoryTruncated = true

--- a/internal/runtime/cloudtraildelivery/s3_test.go
+++ b/internal/runtime/cloudtraildelivery/s3_test.go
@@ -1,0 +1,265 @@
+package cloudtraildelivery
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeS3 struct {
+	objects     []S3Object
+	bodyByKey   map[string][]byte
+	listErr     error
+	getErrByKey map[string]error
+	listCalls   int
+	getCalls    int
+}
+
+func (f *fakeS3) ListObjectsV2(_ context.Context, _ ListObjectsV2Input) (ListObjectsV2Output, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return ListObjectsV2Output{}, f.listErr
+	}
+	return ListObjectsV2Output{Objects: f.objects}, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, input GetObjectInput) (GetObjectOutput, error) {
+	f.getCalls++
+	if err, ok := f.getErrByKey[input.Key]; ok {
+		return GetObjectOutput{}, err
+	}
+	body, ok := f.bodyByKey[input.Key]
+	if !ok {
+		return GetObjectOutput{}, fmt.Errorf("fake: missing body for %s", input.Key)
+	}
+	return GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body)), ContentLength: int64(len(body))}, nil
+}
+
+type codedErr struct {
+	code, msg string
+}
+
+func (e codedErr) Error() string     { return e.msg }
+func (e codedErr) ErrorCode() string { return e.code }
+
+func cloudTrailRecord(id, name, source string, eventTime time.Time, resources []map[string]string) map[string]any {
+	rs := []map[string]any{}
+	for _, r := range resources {
+		rs = append(rs, map[string]any{"type": r["type"], "ARN": r["arn"]})
+	}
+	return map[string]any{
+		"eventID":            id,
+		"eventName":          name,
+		"eventSource":        source,
+		"eventTime":          eventTime.UTC().Format(time.RFC3339),
+		"awsRegion":          "us-east-1",
+		"recipientAccountId": "123456789012",
+		"resources":          rs,
+		"userIdentity": map[string]any{
+			"type": "AssumedRole",
+			"arn":  "arn:aws:sts::123456789012:assumed-role/identrail-runtime-reader/sess-runtime-reader",
+		},
+	}
+}
+
+func gzipLogFile(t *testing.T, records ...map[string]any) []byte {
+	t.Helper()
+	envelope := map[string]any{"Records": records}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestS3IngesterDownloadsAndNormalizesRecords(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	key := "AWSLogs/123456789012/CloudTrail/us-east-1/2026/06/15/123456789012_CloudTrail_us-east-1_20260615T1800Z_aaa.json.gz"
+	body := gzipLogFile(t,
+		cloudTrailRecord("evt-secret", "GetSecretValue", "secretsmanager.amazonaws.com", now.Add(-3*time.Minute), []map[string]string{
+			{"type": "AWS::SecretsManager::Secret", "arn": "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai"},
+		}),
+		cloudTrailRecord("evt-kms", "Decrypt", "kms.amazonaws.com", now.Add(-2*time.Minute), []map[string]string{
+			{"type": "AWS::KMS::Key", "arn": "arn:aws:kms:us-east-1:123456789012:key/abc"},
+		}),
+	)
+	fake := &fakeS3{
+		objects:   []S3Object{{Key: key, Size: int64(len(body)), LastModified: now.Add(-1 * time.Minute)}},
+		bodyByKey: map[string][]byte{key: body},
+	}
+	ing := NewS3Ingester(fake, "bucket", "AWSLogs/123456789012/CloudTrail/us-east-1/")
+	ing.Now = func() time.Time { return now }
+
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Source != DeliverySourceS3 {
+		t.Fatalf("expected source=s3, got %q", result.Source)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected status=ready, got %q (%+v)", result.Status, result)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d (%+v)", len(result.Events), result.Events)
+	}
+	if result.Checkpoint != key {
+		t.Fatalf("expected checkpoint to advance to %q, got %q", key, result.Checkpoint)
+	}
+	if result.FilesProcessed != 1 {
+		t.Fatalf("expected 1 file processed, got %d", result.FilesProcessed)
+	}
+}
+
+func TestS3IngesterDedupesEventIDAcrossFiles(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	dupeRecord := cloudTrailRecord("evt-dupe", "AssumeRole", "sts.amazonaws.com", now.Add(-2*time.Minute), nil)
+	file1 := gzipLogFile(t, dupeRecord)
+	file2 := gzipLogFile(t,
+		dupeRecord,
+		cloudTrailRecord("evt-new", "Decrypt", "kms.amazonaws.com", now.Add(-1*time.Minute), nil),
+	)
+	key1, key2 := "log-1.json.gz", "log-2.json.gz"
+	fake := &fakeS3{
+		objects: []S3Object{
+			{Key: key1, Size: int64(len(file1)), LastModified: now.Add(-3 * time.Minute)},
+			{Key: key2, Size: int64(len(file2)), LastModified: now.Add(-2 * time.Minute)},
+		},
+		bodyByKey: map[string][]byte{key1: file1, key2: file2},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events after dedupe, got %d", len(result.Events))
+	}
+	ids := map[string]bool{}
+	for _, ev := range result.Events {
+		ids[ev.EventID] = true
+	}
+	if !ids["evt-dupe"] || !ids["evt-new"] {
+		t.Fatalf("expected evt-dupe + evt-new, got %v", ids)
+	}
+}
+
+func TestS3IngesterReportsPermissionDeniedAsBlocked(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeS3{listErr: codedErr{code: "AccessDeniedException", msg: "User is not authorized to perform s3:ListBucket (AccessDeniedException)"}}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Status != "blocked" || len(result.Events) != 0 {
+		t.Fatalf("expected blocked status with no records, got %+v", result)
+	}
+	if len(result.CoverageGaps) == 0 || result.CoverageGaps[0].Status != "permission_denied" {
+		t.Fatalf("expected permission_denied coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
+func TestS3IngesterEmptyWindowReportsDegradedNotBlocked(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	fake := &fakeS3{}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected degraded for empty window, got %q", result.Status)
+	}
+	if len(result.CoverageGaps) != 1 || result.CoverageGaps[0].Status != "empty" {
+		t.Fatalf("expected empty coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
+func TestS3IngesterRespectsMaxEventsBudgetAndMarksTruncated(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	body := gzipLogFile(t,
+		cloudTrailRecord("evt-1", "AssumeRole", "sts.amazonaws.com", now.Add(-3*time.Minute), nil),
+		cloudTrailRecord("evt-2", "AssumeRole", "sts.amazonaws.com", now.Add(-2*time.Minute), nil),
+		cloudTrailRecord("evt-3", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute), nil),
+	)
+	key := "log.json.gz"
+	fake := &fakeS3{
+		objects:   []S3Object{{Key: key, Size: int64(len(body)), LastModified: now}},
+		bodyByKey: map[string][]byte{key: body},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxEvents: 2})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+	if !result.HistoryTruncated {
+		t.Fatalf("expected HistoryTruncated when budget caps fan-in")
+	}
+}
+
+func TestS3IngesterPartialFileFailureKeepsOtherFiles(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	good := gzipLogFile(t, cloudTrailRecord("evt-good", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute), nil))
+	badKey, goodKey := "bad.json.gz", "good.json.gz"
+	fake := &fakeS3{
+		objects: []S3Object{
+			{Key: badKey, Size: 32, LastModified: now.Add(-2 * time.Minute)},
+			{Key: goodKey, Size: int64(len(good)), LastModified: now.Add(-1 * time.Minute)},
+		},
+		bodyByKey:   map[string][]byte{badKey: []byte("not a gzip"), goodKey: good},
+		getErrByKey: map[string]error{},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 1 || result.Events[0].EventID != "evt-good" {
+		t.Fatalf("expected the good file's record preserved, got %+v", result.Events)
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected degraded after partial file failure, got %q", result.Status)
+	}
+	foundDiag := false
+	for _, diag := range result.Diagnostics {
+		if strings.Contains(diag.Message, "bad.json.gz") {
+			foundDiag = true
+		}
+	}
+	if !foundDiag {
+		t.Fatalf("expected a diagnostic naming the failed file, got %+v", result.Diagnostics)
+	}
+}
+
+func TestS3IngesterPropagatesContextCancellation(t *testing.T) {
+	fake := &fakeS3{listErr: context.Canceled}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return time.Now().UTC() }
+	if _, err := ing.Ingest(context.Background(), IngestRequest{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled propagation, got %v", err)
+	}
+}

--- a/internal/runtime/cloudtraildelivery/s3_test.go
+++ b/internal/runtime/cloudtraildelivery/s3_test.go
@@ -22,7 +22,10 @@ type fakeS3 struct {
 	getCalls    int
 }
 
-func (f *fakeS3) ListObjectsV2(_ context.Context, _ ListObjectsV2Input) (ListObjectsV2Output, error) {
+func (f *fakeS3) ListObjectsV2(ctx context.Context, _ ListObjectsV2Input) (ListObjectsV2Output, error) {
+	if err := ctx.Err(); err != nil {
+		return ListObjectsV2Output{}, err
+	}
 	f.listCalls++
 	if f.listErr != nil {
 		return ListObjectsV2Output{}, f.listErr
@@ -30,7 +33,10 @@ func (f *fakeS3) ListObjectsV2(_ context.Context, _ ListObjectsV2Input) (ListObj
 	return ListObjectsV2Output{Objects: f.objects}, nil
 }
 
-func (f *fakeS3) GetObject(_ context.Context, input GetObjectInput) (GetObjectOutput, error) {
+func (f *fakeS3) GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return GetObjectOutput{}, err
+	}
 	f.getCalls++
 	if err, ok := f.getErrByKey[input.Key]; ok {
 		return GetObjectOutput{}, err
@@ -252,6 +258,95 @@ func TestS3IngesterPartialFileFailureKeepsOtherFiles(t *testing.T) {
 	}
 	if !foundDiag {
 		t.Fatalf("expected a diagnostic naming the failed file, got %+v", result.Diagnostics)
+	}
+}
+
+func TestS3IngesterDoesNotAdvanceCheckpointPastFailedFile(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	good := gzipLogFile(t, cloudTrailRecord("evt-good", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute), nil))
+	previousCheckpoint := "log-0.json.gz"
+	badKey, goodKey := "log-1.json.gz", "log-2.json.gz"
+	fake := &fakeS3{
+		objects: []S3Object{
+			{Key: badKey, Size: 32, LastModified: now.Add(-1 * time.Minute)},
+			{Key: goodKey, Size: int64(len(good)), LastModified: now.Add(-2 * time.Minute)},
+		},
+		bodyByKey: map[string][]byte{badKey: []byte("not a gzip"), goodKey: good},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+
+	result, err := ing.Ingest(context.Background(), IngestRequest{
+		AccountID:  "123456789012",
+		Region:     "us-east-1",
+		Checkpoint: previousCheckpoint,
+	})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 1 || result.Events[0].EventID != "evt-good" {
+		t.Fatalf("expected later good file to be preserved, got %+v", result.Events)
+	}
+	if result.Checkpoint != previousCheckpoint {
+		t.Fatalf("checkpoint advanced past failed file: got %q want %q", result.Checkpoint, previousCheckpoint)
+	}
+}
+
+func TestS3IngesterOrdersByKeyForStartAfterCheckpoint(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	earlyKey := "log-1.json.gz"
+	lateKey := "log-2.json.gz"
+	earlyBody := gzipLogFile(t, cloudTrailRecord("evt-early-key", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute), nil))
+	lateBody := gzipLogFile(t, cloudTrailRecord("evt-late-key", "Decrypt", "kms.amazonaws.com", now.Add(-2*time.Minute), nil))
+	fake := &fakeS3{
+		objects: []S3Object{
+			{Key: lateKey, Size: int64(len(lateBody)), LastModified: now.Add(-2 * time.Minute)},
+			{Key: earlyKey, Size: int64(len(earlyBody)), LastModified: now.Add(-1 * time.Minute)},
+		},
+		bodyByKey: map[string][]byte{earlyKey: earlyBody, lateKey: lateBody},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Checkpoint != lateKey {
+		t.Fatalf("expected key-ordered checkpoint %q, got %q", lateKey, result.Checkpoint)
+	}
+	if len(result.Events) != 2 || result.Events[0].EventID != "evt-early-key" || result.Events[1].EventID != "evt-late-key" {
+		t.Fatalf("expected events processed in key order, got %+v", result.Events)
+	}
+}
+
+func TestS3IngesterEnforcesDecompressedMaxFileBytes(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	key := "large-decompressed.json.gz"
+	body := gzipLogFile(t, cloudTrailRecord("evt-large", strings.Repeat("A", 512), "sts.amazonaws.com", now, nil))
+	fake := &fakeS3{
+		objects:   []S3Object{{Key: key, Size: int64(len(body)), LastModified: now}},
+		bodyByKey: map[string][]byte{key: body},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+
+	result, err := ing.Ingest(context.Background(), IngestRequest{
+		AccountID:    "123456789012",
+		Region:       "us-east-1",
+		MaxFileBytes: int64(len(body)),
+	})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if result.Checkpoint != "" {
+		t.Fatalf("expected checkpoint to stay empty after oversized decompressed object, got %q", result.Checkpoint)
+	}
+	if result.Status != "degraded" || len(result.Diagnostics) == 0 {
+		t.Fatalf("expected degraded diagnostic for oversized decompressed payload, got %+v", result)
+	}
+	if !strings.Contains(result.Diagnostics[0].Message, "MaxFileBytes") {
+		t.Fatalf("expected MaxFileBytes diagnostic, got %+v", result.Diagnostics)
 	}
 }
 

--- a/internal/runtime/cloudtraildelivery/s3_test.go
+++ b/internal/runtime/cloudtraildelivery/s3_test.go
@@ -15,20 +15,30 @@ import (
 
 type fakeS3 struct {
 	objects     []S3Object
+	listPages   []ListObjectsV2Output
 	bodyByKey   map[string][]byte
 	listErr     error
 	getErrByKey map[string]error
+	listInputs  []ListObjectsV2Input
 	listCalls   int
 	getCalls    int
 }
 
-func (f *fakeS3) ListObjectsV2(ctx context.Context, _ ListObjectsV2Input) (ListObjectsV2Output, error) {
+func (f *fakeS3) ListObjectsV2(ctx context.Context, input ListObjectsV2Input) (ListObjectsV2Output, error) {
 	if err := ctx.Err(); err != nil {
 		return ListObjectsV2Output{}, err
 	}
 	f.listCalls++
+	f.listInputs = append(f.listInputs, input)
 	if f.listErr != nil {
 		return ListObjectsV2Output{}, f.listErr
+	}
+	if len(f.listPages) > 0 {
+		page := f.listCalls - 1
+		if page >= len(f.listPages) {
+			return ListObjectsV2Output{}, nil
+		}
+		return f.listPages[page], nil
 	}
 	return ListObjectsV2Output{Objects: f.objects}, nil
 }
@@ -320,6 +330,64 @@ func TestS3IngesterOrdersByKeyForStartAfterCheckpoint(t *testing.T) {
 	}
 }
 
+func TestS3IngesterPagesPastOldObjectsIntoLookbackWindow(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	key := "AWSLogs/123/CloudTrail/us-east-1/2026/06/15/recent.json.gz"
+	body := gzipLogFile(t, cloudTrailRecord("evt-recent", "AssumeRole", "sts.amazonaws.com", now.Add(-1*time.Minute), nil))
+	fake := &fakeS3{
+		listPages: []ListObjectsV2Output{
+			{
+				Objects: []S3Object{
+					{Key: "old-1.json.gz", Size: 10, LastModified: now.Add(-2 * time.Hour)},
+					{Key: "old-2.json.gz", Size: 10, LastModified: now.Add(-90 * time.Minute)},
+				},
+				NextToken:   "page-2",
+				IsTruncated: true,
+			},
+			{
+				Objects: []S3Object{{Key: key, Size: int64(len(body)), LastModified: now.Add(-1 * time.Minute)}},
+			},
+		},
+		bodyByKey: map[string][]byte{key: body},
+	}
+	ing := NewS3Ingester(fake, "bucket", "AWSLogs/123/CloudTrail/us-east-1/")
+	ing.Now = func() time.Time { return now }
+
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxFiles: 2})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if fake.listCalls != 2 || fake.listInputs[1].ContinuationToken != "page-2" {
+		t.Fatalf("expected second S3 listing page, calls=%d inputs=%+v", fake.listCalls, fake.listInputs)
+	}
+	if len(result.Events) != 1 || result.Events[0].EventID != "evt-recent" {
+		t.Fatalf("expected recent event from second page, got %+v", result.Events)
+	}
+}
+
+func TestS3IngesterMarksTruncatedListing(t *testing.T) {
+	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
+	key := "log-1.json.gz"
+	body := gzipLogFile(t, cloudTrailRecord("evt-1", "AssumeRole", "sts.amazonaws.com", now, nil))
+	fake := &fakeS3{
+		listPages: []ListObjectsV2Output{{
+			Objects:     []S3Object{{Key: key, Size: int64(len(body)), LastModified: now}},
+			NextToken:   "more",
+			IsTruncated: true,
+		}},
+		bodyByKey: map[string][]byte{key: body},
+	}
+	ing := NewS3Ingester(fake, "bucket", "")
+	ing.Now = func() time.Time { return now }
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1", MaxFiles: 1})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if !result.HistoryTruncated {
+		t.Fatalf("expected truncated listing to mark HistoryTruncated")
+	}
+}
+
 func TestS3IngesterEnforcesDecompressedMaxFileBytes(t *testing.T) {
 	now := time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC)
 	key := "large-decompressed.json.gz"
@@ -347,6 +415,20 @@ func TestS3IngesterEnforcesDecompressedMaxFileBytes(t *testing.T) {
 	}
 	if !strings.Contains(result.Diagnostics[0].Message, "MaxFileBytes") {
 		t.Fatalf("expected MaxFileBytes diagnostic, got %+v", result.Diagnostics)
+	}
+}
+
+func TestParseCloudTrailLogFileAcceptsBooleanReadOnly(t *testing.T) {
+	payload := []byte(`{"Records":[{"eventID":"evt-readonly","eventName":"GetObject","eventSource":"s3.amazonaws.com","eventTime":"2026-06-15T18:00:00Z","readOnly":true}]}`)
+	records, err := parseCloudTrailLogFile(payload)
+	if err != nil {
+		t.Fatalf("parse log file: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one record, got %d", len(records))
+	}
+	if records[0].Event.ReadOnly != "true" {
+		t.Fatalf("expected boolean readOnly to normalize to true string, got %q", records[0].Event.ReadOnly)
 	}
 }
 

--- a/internal/runtime/cloudtraildelivery/sdk_s3.go
+++ b/internal/runtime/cloudtraildelivery/sdk_s3.go
@@ -1,0 +1,147 @@
+package cloudtraildelivery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// S3Client is the minimal seam from the AWS SDK S3 client this
+// package depends on. Defining it here lets the adapter swap in a
+// fake for SDK-layer tests without taking a hard dep on the SDK.
+type S3Client interface {
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+// SDKS3API implements S3API against the AWS SDK. Only the read-side
+// operations are exposed; PutObject, DeleteObject, and any mutating
+// API are deliberately absent so the adapter cannot accidentally
+// invoke a write.
+type SDKS3API struct {
+	client S3Client
+}
+
+// NewSDKS3APIFromClient wraps a pre-built S3 client.
+func NewSDKS3APIFromClient(client S3Client) *SDKS3API {
+	return &SDKS3API{client: client}
+}
+
+// NewSDKS3APIFromAssumeRole builds the SDK-backed adapter after
+// assuming the supplied connector role with the supplied external ID.
+func NewSDKS3APIFromAssumeRole(ctx context.Context, region, profile, roleARN, externalID, sessionName string) (S3API, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, errors.New("cloudtraildelivery: aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(o *stscreds.AssumeRoleOptions) {
+			name := strings.TrimSpace(sessionName)
+			if name == "" {
+				name = "identrail-cloudtrail-s3-delivery"
+			}
+			o.RoleSessionName = name
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(o *stscreds.AssumeRoleOptions) {
+			o.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	return NewSDKS3APIFromClient(s3.NewFromConfig(cfg)), nil
+}
+
+// ListObjectsV2 maps the engine input onto the SDK shape and trims
+// the response down to the metadata the ingester actually uses.
+func (a *SDKS3API) ListObjectsV2(ctx context.Context, input ListObjectsV2Input) (ListObjectsV2Output, error) {
+	if a == nil || a.client == nil {
+		return ListObjectsV2Output{}, errors.New("cloudtraildelivery: SDK S3 client is required")
+	}
+	params := &s3.ListObjectsV2Input{Bucket: awsv2.String(input.Bucket)}
+	if prefix := strings.TrimSpace(input.Prefix); prefix != "" {
+		params.Prefix = awsv2.String(prefix)
+	}
+	if next := strings.TrimSpace(input.ContinuationToken); next != "" {
+		params.ContinuationToken = awsv2.String(next)
+	}
+	if input.MaxKeys > 0 {
+		params.MaxKeys = awsv2.Int32(input.MaxKeys)
+	}
+	if start := strings.TrimSpace(input.StartAfter); start != "" {
+		params.StartAfter = awsv2.String(start)
+	}
+	out, err := a.client.ListObjectsV2(ctx, params)
+	if err != nil {
+		return ListObjectsV2Output{}, err
+	}
+	if out == nil {
+		return ListObjectsV2Output{}, nil
+	}
+	resp := ListObjectsV2Output{NextToken: strings.TrimSpace(awsv2.ToString(out.NextContinuationToken))}
+	if out.IsTruncated != nil {
+		resp.IsTruncated = *out.IsTruncated
+	}
+	for _, item := range out.Contents {
+		entry := S3Object{
+			Key: strings.TrimSpace(awsv2.ToString(item.Key)),
+		}
+		if item.Size != nil {
+			entry.Size = *item.Size
+		}
+		if item.LastModified != nil {
+			entry.LastModified = item.LastModified.UTC()
+		}
+		resp.Objects = append(resp.Objects, entry)
+	}
+	return resp, nil
+}
+
+// GetObject maps the engine input onto the SDK shape. The caller
+// owns closing the response body.
+func (a *SDKS3API) GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error) {
+	if a == nil || a.client == nil {
+		return GetObjectOutput{}, errors.New("cloudtraildelivery: SDK S3 client is required")
+	}
+	out, err := a.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: awsv2.String(input.Bucket),
+		Key:    awsv2.String(input.Key),
+	})
+	if err != nil {
+		return GetObjectOutput{}, err
+	}
+	if out == nil {
+		return GetObjectOutput{}, errors.New("cloudtraildelivery: SDK GetObject returned nil")
+	}
+	resp := GetObjectOutput{Body: out.Body}
+	if out.ContentLength != nil {
+		resp.ContentLength = *out.ContentLength
+	}
+	return resp, nil
+}
+
+func loadSDKConfig(ctx context.Context, region, profile string) (awsv2.Config, error) {
+	options := []func(*awsconfig.LoadOptions) error{}
+	if trimmedRegion := strings.TrimSpace(region); trimmedRegion != "" {
+		options = append(options, awsconfig.WithRegion(trimmedRegion))
+	}
+	if trimmedProfile := strings.TrimSpace(profile); trimmedProfile != "" {
+		options = append(options, awsconfig.WithSharedConfigProfile(trimmedProfile))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, options...)
+	if err != nil {
+		return awsv2.Config{}, fmt.Errorf("cloudtraildelivery: load aws config: %w", err)
+	}
+	return cfg, nil
+}

--- a/internal/runtime/cloudtraildelivery/sdk_sqs.go
+++ b/internal/runtime/cloudtraildelivery/sdk_sqs.go
@@ -1,0 +1,132 @@
+package cloudtraildelivery
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// SQSClient is the minimal seam from the AWS SDK SQS client.
+type SQSClient interface {
+	ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
+	DeleteMessageBatch(ctx context.Context, params *sqs.DeleteMessageBatchInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageBatchOutput, error)
+}
+
+// SDKSQSAPI implements SQSAPI against the AWS SDK. Only the
+// read-and-acknowledge operations are exposed; SendMessage,
+// PurgeQueue, and any mutating producer API are deliberately absent
+// so the adapter cannot accidentally produce or destroy queue
+// content.
+type SDKSQSAPI struct {
+	client SQSClient
+}
+
+// NewSDKSQSAPIFromClient wraps a pre-built SQS client.
+func NewSDKSQSAPIFromClient(client SQSClient) *SDKSQSAPI {
+	return &SDKSQSAPI{client: client}
+}
+
+// NewSDKSQSAPIFromAssumeRole builds the SDK-backed adapter after
+// assuming the supplied connector role.
+func NewSDKSQSAPIFromAssumeRole(ctx context.Context, region, profile, roleARN, externalID, sessionName string) (SQSAPI, error) {
+	cfg, err := loadSDKConfig(ctx, region, profile)
+	if err != nil {
+		return nil, err
+	}
+	trimmedRoleARN := strings.TrimSpace(roleARN)
+	if trimmedRoleARN == "" {
+		return nil, errors.New("cloudtraildelivery: aws connector role arn is required")
+	}
+	options := []func(*stscreds.AssumeRoleOptions){
+		func(o *stscreds.AssumeRoleOptions) {
+			name := strings.TrimSpace(sessionName)
+			if name == "" {
+				name = "identrail-cloudtrail-eventbridge-delivery"
+			}
+			o.RoleSessionName = name
+		},
+	}
+	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
+		options = append(options, func(o *stscreds.AssumeRoleOptions) {
+			o.ExternalID = &trimmedExternalID
+		})
+	}
+	cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), trimmedRoleARN, options...))
+	return NewSDKSQSAPIFromClient(sqs.NewFromConfig(cfg)), nil
+}
+
+// ReceiveMessage maps the engine input onto the SDK shape and trims
+// the response down to the metadata the ingester actually uses.
+func (a *SDKSQSAPI) ReceiveMessage(ctx context.Context, input ReceiveMessageInput) (ReceiveMessageOutput, error) {
+	if a == nil || a.client == nil {
+		return ReceiveMessageOutput{}, errors.New("cloudtraildelivery: SDK SQS client is required")
+	}
+	params := &sqs.ReceiveMessageInput{QueueUrl: awsv2.String(input.QueueURL)}
+	if input.MaxNumberOfMessages > 0 {
+		params.MaxNumberOfMessages = input.MaxNumberOfMessages
+	}
+	if input.WaitTimeSeconds > 0 {
+		params.WaitTimeSeconds = input.WaitTimeSeconds
+	}
+	if input.VisibilityTimeout > 0 {
+		params.VisibilityTimeout = input.VisibilityTimeout
+	}
+	out, err := a.client.ReceiveMessage(ctx, params)
+	if err != nil {
+		return ReceiveMessageOutput{}, err
+	}
+	if out == nil {
+		return ReceiveMessageOutput{}, nil
+	}
+	resp := ReceiveMessageOutput{}
+	for _, msg := range out.Messages {
+		resp.Messages = append(resp.Messages, SQSMessage{
+			MessageID:     strings.TrimSpace(awsv2.ToString(msg.MessageId)),
+			ReceiptHandle: strings.TrimSpace(awsv2.ToString(msg.ReceiptHandle)),
+			Body:          awsv2.ToString(msg.Body),
+		})
+	}
+	return resp, nil
+}
+
+// DeleteMessageBatch acks one or more successfully-processed messages.
+func (a *SDKSQSAPI) DeleteMessageBatch(ctx context.Context, input DeleteMessageBatchInput) (DeleteMessageBatchOutput, error) {
+	if a == nil || a.client == nil {
+		return DeleteMessageBatchOutput{}, errors.New("cloudtraildelivery: SDK SQS client is required")
+	}
+	entries := make([]sqstypes.DeleteMessageBatchRequestEntry, 0, len(input.Entries))
+	for _, e := range input.Entries {
+		entries = append(entries, sqstypes.DeleteMessageBatchRequestEntry{
+			Id:            awsv2.String(e.ID),
+			ReceiptHandle: awsv2.String(e.ReceiptHandle),
+		})
+	}
+	out, err := a.client.DeleteMessageBatch(ctx, &sqs.DeleteMessageBatchInput{
+		QueueUrl: awsv2.String(input.QueueURL),
+		Entries:  entries,
+	})
+	if err != nil {
+		return DeleteMessageBatchOutput{}, err
+	}
+	if out == nil {
+		return DeleteMessageBatchOutput{}, nil
+	}
+	resp := DeleteMessageBatchOutput{}
+	for _, ok := range out.Successful {
+		resp.Successful = append(resp.Successful, strings.TrimSpace(awsv2.ToString(ok.Id)))
+	}
+	for _, failure := range out.Failed {
+		resp.Failed = append(resp.Failed, DeleteMessageBatchFailure{
+			ID:      strings.TrimSpace(awsv2.ToString(failure.Id)),
+			Code:    strings.TrimSpace(awsv2.ToString(failure.Code)),
+			Message: strings.TrimSpace(awsv2.ToString(failure.Message)),
+		})
+	}
+	return resp, nil
+}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -18,6 +18,7 @@ import (
 	awsprovider "github.com/identrail/identrail/internal/providers/aws"
 	k8sprovider "github.com/identrail/identrail/internal/providers/kubernetes"
 	"github.com/identrail/identrail/internal/runtime/cloudtrail"
+	"github.com/identrail/identrail/internal/runtime/cloudtraildelivery"
 	"github.com/identrail/identrail/internal/scheduler"
 	"github.com/identrail/identrail/internal/secretstore"
 	"github.com/identrail/identrail/internal/userexport"
@@ -379,6 +380,32 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 			return nil, lookupErr
 		}
 		return api.NewCloudTrailRuntimeEventIngester(cloudtrail.New(lookupAPI)), nil
+	}
+	svc.AWSCloudTrailDeliveryFactory = func(ctx context.Context, connection api.AWSConnectionStatus, source api.AWSCloudTrailDeliverySource) (api.AWSCloudTrailRuntimeEventIngester, error) {
+		switch source {
+		case api.AWSCloudTrailDeliverySourceS3:
+			bucket := strings.TrimSpace(cfg.AWSCloudTrailS3Bucket)
+			if bucket == "" {
+				return nil, fmt.Errorf("IDENTRAIL_AWS_CLOUDTRAIL_S3_BUCKET is required for delivery_source=s3")
+			}
+			s3API, s3Err := cloudtraildelivery.NewSDKS3APIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-cloudtrail-s3-delivery")
+			if s3Err != nil {
+				return nil, s3Err
+			}
+			return api.NewCloudTrailS3DeliveryIngester(cloudtraildelivery.NewS3Ingester(s3API, bucket, cfg.AWSCloudTrailS3Prefix)), nil
+		case api.AWSCloudTrailDeliverySourceEventBridge:
+			queueURL := strings.TrimSpace(cfg.AWSCloudTrailEventBridgeQueue)
+			if queueURL == "" {
+				return nil, fmt.Errorf("IDENTRAIL_AWS_CLOUDTRAIL_EVENTBRIDGE_QUEUE_URL is required for delivery_source=eventbridge")
+			}
+			sqsAPI, sqsErr := cloudtraildelivery.NewSDKSQSAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-cloudtrail-eventbridge-delivery")
+			if sqsErr != nil {
+				return nil, sqsErr
+			}
+			return api.NewCloudTrailEventBridgeDeliveryIngester(cloudtraildelivery.NewEventBridgeIngester(sqsAPI, queueURL)), nil
+		default:
+			return nil, fmt.Errorf("unsupported CloudTrail delivery source %q", source)
+		}
 	}
 	svc.DefaultScope = db.Scope{
 		TenantID:    cfg.DefaultTenantID,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2244,8 +2244,21 @@ export type AWSRuntimeEventResult = {
   updated_at: string;
 };
 
+// AWSRuntimeEventDeliverySource selects which CloudTrail delivery
+// channel the API drives for a request. `lookup_events` (the default)
+// keeps the existing LookupEvents-API path; `s3` reads from the
+// trail's S3 log destination; `eventbridge` consumes the EventBridge
+// target SQS queue; `all` fans out across every wired channel and
+// dedupes by EventID.
+export type AWSRuntimeEventDeliverySource =
+  | 'lookup_events'
+  | 's3'
+  | 'eventbridge'
+  | 'all';
+
 export type AWSRuntimeEventQuery = {
   connectorID?: string;
+  deliverySource?: AWSRuntimeEventDeliverySource;
   fixtureState?: AWSRuntimeEventFixtureStateRequest;
   accountID?: string;
   region?: string;
@@ -5350,6 +5363,7 @@ export const apiClient = {
     return request<{ runtime: AWSRuntimeEventResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/runtime-events${buildQuery({
         connector_id: query?.connectorID,
+        delivery_source: query?.deliverySource,
         fixture_state: query?.fixtureState,
         account_id: query?.accountID,
         region: query?.region,


### PR DESCRIPTION
## Summary
- Add a bounded, metadata-only **S3 trail-log ingester** in `internal/runtime/cloudtraildelivery/s3.go` that lists CloudTrail objects with `ListObjectsV2(StartAfter=checkpoint)`, downloads `.json.gz` files, parses the `Records[]` envelope, dedupes by `eventID`, advances the per-key checkpoint, and reuses `cloudtrail.NormalizeEvent` for metadata-only field extraction.
- Add a bounded, metadata-only **EventBridge (SQS-backed) ingester** in `internal/runtime/cloudtraildelivery/eventbridge.go` that consumes the EventBridge target SQS queue, normalizes each envelope's CloudTrail `detail`, deletes successfully-processed messages so they are not re-delivered, and leaves malformed envelopes in-queue so the redrive policy applies.
- Add a new `delivery_source` query parameter to `GET /v1/.../aws/runtime-events`: `lookup_events` (default) keeps the existing LookupEvents behavior; `s3`, `eventbridge`, or `all` drive the new delivery channels. `all` fans out across every wired channel and dedupes by `EventID`.
- Wire `Service.AWSCloudTrailDeliveryFactory` (mirrors the LookupEvents factory). The `runtime_evidence` capability gate, fixture-state guard, and connector-health gate apply identically; discovery-only connectors and unwired factories fall back to fixtures with a `cloudtrail_delivery_unavailable` diagnostic.
- SDK adapters for S3 (`sdk_s3.go`) and SQS (`sdk_sqs.go`) expose only read-and-acknowledge operations — `PutObject`, `DeleteObject`, `SendMessage`, and `PurgeQueue` are deliberately absent.
- Docs: extend [`docs/aws-runtime-events.md`](docs/aws-runtime-events.md) with the per-channel IAM permission matrix, bounded-budget table, delivery semantics, and live-validation steps. [`docs/openapi-v1.yaml`](docs/openapi-v1.yaml) documents the `delivery_source` enum. CHANGELOG updated.
- Frontend: add `AWSRuntimeEventDeliverySource` to [`web/src/api/client.ts`](web/src/api/client.ts) and thread it through `getAWSProjectRuntimeEvents`.

## Safety
- Metadata-only: ingesters never read, log, or persist object bodies, request parameters, response elements, secret values, decrypted plaintext, or customer payloads. Only the allow-list defined by `cloudtrail.NormalizeEvent` crosses the boundary.
- Required IAM permissions: `s3:ListBucket`+`s3:GetObject` on the trail's S3 destination for the S3 channel; `sqs:ReceiveMessage`+`sqs:DeleteMessage` on the EventBridge target queue for the EventBridge channel. No write or mutation grants requested.
- Bounded budgets: `MaxFiles` (50), `MaxMessages` (100), `MaxEvents` (1000), `MaxFileBytes` (32 MiB), `MaxThrottleRetries` (4) — caps cap one run so a misbehaving trail or queue cannot exhaust the worker.
- `AccessDeniedException` collapses to `status=blocked` with `permission_denied` coverage gap and zero records; partial-file failures degrade with the surviving files preserved; context cancellation propagates as the request error (no stale degraded response).
- Cross-channel dedupe by `EventID` prevents double-counting when the same CloudTrail event arrives on multiple channels under `delivery_source=all`.

## Failure-state coverage
- `permission_denied` → `status=blocked` (zero records, `permission_denied` gap, structured diagnostic).
- Bounded budget hit → `history_truncated` gap + `status=degraded`, records preserved.
- Empty window → `status=degraded` + `empty` gap.
- Partial file failure (S3) → per-file diagnostic, other files preserved, `status=degraded`.
- Unparseable envelope (EventBridge) → message left in queue for redrive, `status=degraded`.
- Unknown `delivery_source` → HTTP 400 (`ErrInvalidAWSConnectionRequest`).
- Discovery-only connector → fixture fallback + `cloudtrail_delivery_unavailable` diagnostic + downgrade.

## Validation
- `go test ./internal/runtime/cloudtraildelivery ./internal/api -count=1`
- `make ci`

Closes #1515

AI disclosure usage: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 and EventBridge (SQS) CloudTrail ingestion with a new `delivery_source` selector for runtime events, delivering data events too. Returns an S3 `Checkpoint` for resume, bounds S3 pagination, reports EventBridge truncation, and preserves per-path blocked status while fixing fan‑out so one blocked source doesn’t block `all` (for #1515).

- **New Features**
  - S3 ingester: lists after a checkpoint, downloads `.json.gz`, parses `Records[]`, dedupes by `eventID`, returns and preserves per-key `Checkpoint`, reuses `cloudtrail.NormalizeEvent`, and caps listing pages to avoid traversing large prefixes.
  - EventBridge ingester: consumes SQS, normalizes `detail`, deletes processed and engine-rejected; leaves malformed for redrive; reports `history_truncated` when the message budget is exhausted and messages remain.
  - API: `GET /v1/.../aws/runtime-events` adds `delivery_source` = `lookup_events` (default) | `s3` | `eventbridge` | `all`; `all` fans out, dedupes by `EventID`, preserves per-path blocked status, and avoids mixed-source blocked merges. Accepts common hyphen/case variants; unknown values return 400. OpenAPI adds `fixture_state=capability_unavailable` and extends `evidence` to `s3-delivery` and `eventbridge-delivery`.
  - Service wiring: `Service.AWSCloudTrailDeliveryFactory` uses the same capability and health gates; fixture fallback when delivery is unavailable. Read-only SDK adapters (`internal/runtime/cloudtraildelivery/sdk_s3.go`, `sdk_sqs.go`); frontend adds `AWSRuntimeEventDeliverySource` in `web/src/api/client.ts`; docs and `docs/openapi-v1.yaml` updated.

- **Migration**
  - Permissions: `s3:ListBucket` + `s3:GetObject` on the trail bucket; `sqs:ReceiveMessage` + `sqs:DeleteMessage` on the EventBridge queue.
  - To enable: set `IDENTRAIL_AWS_CLOUDTRAIL_S3_BUCKET` (and optional `IDENTRAIL_AWS_CLOUDTRAIL_S3_PREFIX`) and/or `IDENTRAIL_AWS_CLOUDTRAIL_EVENTBRIDGE_QUEUE_URL`, then call the API with `delivery_source` (`s3`, `eventbridge`, or `all`).

<sup>Written for commit 5e1155edac5f9a00901f33f3c30373bc4c7229b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

