### PR TITLE
AWS Platform Wave 5.05: IAM last-used and Access Analyzer signals

### DIFF
--- a/docs/aws-runtime-events.md
+++ b/docs/aws-runtime-events.md
@@ -29,6 +29,12 @@ explicit session lineage fields and graph edges. Missing SourceIdentity and
 ambiguous lineage are represented as first-class states instead of being
 treated as successful resolution.
 
+Issue #1517 adds IAM last-used and Access Analyzer signal ingestion to the
+same runtime envelope. Identrail now normalizes IAM role/service last-used
+timestamps and Access Analyzer findings as metadata-only runtime evidence so
+operators can compare observed activity, dormant access, analyzer scope, and
+trust findings before making least-privilege changes.
+
 ## API
 
 `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/runtime-events`
@@ -40,13 +46,13 @@ Supported filters:
 - `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
 - `account_id`
 - `region`
-- `event_type`: `sts-session`, `api-call`, `secret-read`, `kms-decrypt`, or `agent-tool`
+- `event_type`: `sts-session`, `api-call`, `secret-read`, `kms-decrypt`, `agent-tool`, `iam-last-used`, or `access-analyzer`
 - `identity`
 - `agent_id`
 - `resource`
-- `evidence`: `cloudtrail` or `agent-runtime`
+- `evidence`: `cloudtrail`, `s3-delivery`, `eventbridge-delivery`, `agent-runtime`, `iam-last-used`, or `access-analyzer`
 - `owner`: `security`, `platform`, or `application`
-- `status`: `observed`, `delayed`, or `permission-denied`
+- `status`: `observed`, `delayed`, `permission-denied`, `resolved`, `archived`, or `stale`
 
 The response is returned as `{ "runtime": ... }` and includes:
 
@@ -54,6 +60,7 @@ The response is returned as `{ "runtime": ... }` and includes:
 - summary counts for event types, owners, identities, resources, sessions, and relationships
 - event records with actor, session, action, target resource metadata, agent context, timestamp, confidence, evidence, and next action
 - session lineage fields for SourceIdentity, role session names, redacted tag keys, original actors, chained roles, and ambiguous/missing lineage states
+- signal fields for IAM/Access Analyzer category, scope, analyzer ARN, and stale-data timestamp
 - graph relationships from observed actors, runtime sessions, chained actors, or agents to target resources
 - explicit diagnostics, coverage gaps, failure reasons, and remediation hints
 
@@ -68,6 +75,15 @@ STS session tags are represented by tag key only. Tag values are intentionally
 not copied into runtime records because operators can place sensitive business
 context in tag values.
 
+IAM last-used collection reads IAM Access Advisor metadata only: role names,
+role ARNs, service namespaces, last-authenticated entity ARN, last-authenticated
+region, and last-authenticated timestamps. Access Analyzer collection reads
+analyzer metadata and finding summaries only: analyzer ARN/name/type, finding
+status, resource ARN/type/account, action names, public flag, principal
+identifiers, and analyzed/updated timestamps. Identrail does not read policy
+documents, secret values, object bodies, decrypted plaintext, or customer
+payloads for this signal layer.
+
 The fixture contract uses redacted resource identifiers and the
 `metadata_only_no_payloads_no_secret_values` boundary so UI and API tests can
 prove the safe shape without requiring live AWS credentials.
@@ -80,6 +96,57 @@ prove the safe shape without requiring live AWS credentials.
 - `permission_denied`: required metadata-only event lookup permissions are missing.
 
 These states are explicit and are not treated as successful runtime coverage.
+
+## IAM last-used and Access Analyzer signals (#1517)
+
+Live signal ingestion is implemented in `internal/runtime/awssignals` and
+wired through `internal/api.Service.AWSRuntimeSignalFactory`. When the default
+LookupEvents path runs for a connector with the `runtime_evidence` capability,
+the API appends IAM last-used and Access Analyzer records to the same response
+envelope. The fixture path also includes representative signal rows so UI and
+client tests can exercise the contract without AWS credentials.
+
+### Required AWS permissions
+
+The connector role needs read-only signal permissions:
+
+| Source | IAM permissions |
+|---|---|
+| IAM Access Advisor | `iam:ListRoles`, `iam:GenerateServiceLastAccessedDetails`, `iam:GetServiceLastAccessedDetails` |
+| Access Analyzer | `access-analyzer:ListAnalyzers`, `access-analyzer:ListFindings` |
+
+No write APIs are called. The signal ingester is bounded per request and records
+`history_truncated` coverage gaps when role, service, analyzer, or finding
+budgets are exceeded.
+
+### Normalized signal records
+
+IAM signals use `event_type=iam-last-used` and `evidence_category=iam-last-used`.
+Role-level records use `signal_scope=role`; service-level records use
+`signal_scope=service` and a target resource such as `aws-service://lambda`.
+`signal_stale_at` carries the Access Advisor report completion timestamp when
+available, otherwise the collection timestamp, so operators can see when the
+last-used evidence became stale.
+
+Access Analyzer signals use `event_type=access-analyzer` and
+`evidence_category=access-analyzer`. `signal_scope` preserves the analyzer type
+(`account`, `organization`, or the unused/internal access variants),
+`analyzer_arn` links the finding to its analyzer, and `signal_stale_at` carries
+the analyzer's `analyzed_at` timestamp when available.
+
+Analyzer finding states remain visible instead of being collapsed into a single
+success state: active findings become `observed`, resolved findings become
+`resolved`, archived findings become `archived`, and findings with analyzer
+errors are lower confidence.
+
+### Failure handling
+
+If IAM or Access Analyzer permissions are missing, the response includes
+source-specific diagnostics and coverage gaps. If both signal sources are
+permission denied and no signal records can be returned, the signal layer reports
+`blocked`; if CloudTrail records are still available, the overall runtime
+response remains visible with degraded signal coverage so operators do not lose
+unrelated runtime evidence.
 
 ## CloudTrail LookupEvents ingestion (#1514)
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4597,7 +4597,7 @@ paths:
           name: status
           schema:
             type: string
-            enum: [observed, delayed, permission-denied, resolved, archived, stale]
+            enum: [observed, delayed, permission-denied, resolved, archived, stale, unknown]
       responses:
         "200":
           description: AWS runtime event contract
@@ -10779,7 +10779,7 @@ components:
           format: date-time
         status:
           type: string
-          enum: [observed, delayed, permission-denied, resolved, archived, stale]
+          enum: [observed, delayed, permission-denied, resolved, archived, stale, unknown]
         next_action: { type: string }
         redaction_boundary:
           type: string

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4542,7 +4542,7 @@ paths:
       tags: [ProjectManagement]
       summary: Get AWS runtime event contract
       operationId: getAWSProjectRuntimeEvents
-      description: Returns scoped, metadata-only AWS runtime events for API calls, STS sessions, secret reads, KMS decrypts, S3 access, and agent tool calls. The response links actor identity, session, target resource, event source, timestamp, confidence, and evidence without reading or returning secret values, object bodies, prompts, completions, browser pages, code-interpreter output, database rows, or customer payloads.
+      description: Returns scoped, metadata-only AWS runtime events and access signals for API calls, STS sessions, secret reads, KMS decrypts, S3 access, agent tool calls, IAM last-used data, and Access Analyzer findings. The response links actor identity, session, target resource, event source, timestamp, confidence, evidence, analyzer scope, and signal stale-data timestamps without reading or returning secret values, object bodies, prompts, completions, browser pages, code-interpreter output, database rows, or customer payloads.
       parameters:
         - in: query
           name: connector_id
@@ -4570,7 +4570,7 @@ paths:
           name: event_type
           schema:
             type: string
-            enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool]
+            enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool, iam-last-used, access-analyzer]
         - in: query
           name: identity
           schema: { type: string }
@@ -4587,7 +4587,7 @@ paths:
           name: evidence
           schema:
             type: string
-            enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime]
+            enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime, iam-last-used, access-analyzer]
         - in: query
           name: owner
           schema:
@@ -4597,7 +4597,7 @@ paths:
           name: status
           schema:
             type: string
-            enum: [observed, delayed, permission-denied]
+            enum: [observed, delayed, permission-denied, resolved, archived, stale]
       responses:
         "200":
           description: AWS runtime event contract
@@ -10730,7 +10730,7 @@ components:
         region: { type: string }
         event_type:
           type: string
-          enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool]
+          enum: [sts-session, api-call, secret-read, kms-decrypt, agent-tool, iam-last-used, access-analyzer]
         event_source: { type: string }
         event_name: { type: string }
         action: { type: string }
@@ -10747,12 +10747,25 @@ components:
         agent_node_id: { type: string }
         tool_name: { type: string }
         tool_target_ref: { type: string }
+        signal_category:
+          type: string
+          enum: [iam-last-used, access-analyzer]
+        signal_scope:
+          type: string
+          description: Signal scope such as role, service, account, or organization.
+        analyzer_arn:
+          type: string
+          description: Access Analyzer ARN when the record came from an analyzer finding.
+        signal_stale_at:
+          type: string
+          format: date-time
+          description: Timestamp showing how fresh the signal source was when normalized.
         owner:
           type: string
           enum: [security, platform, application]
         evidence_category:
           type: string
-          enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime]
+          enum: [cloudtrail, s3-delivery, eventbridge-delivery, agent-runtime, iam-last-used, access-analyzer]
         evidence_ref: { type: string }
         confidence:
           type: number
@@ -10766,7 +10779,7 @@ components:
           format: date-time
         status:
           type: string
-          enum: [observed, delayed, permission-denied]
+          enum: [observed, delayed, permission-denied, resolved, archived, stale]
         next_action: { type: string }
         redaction_boundary:
           type: string
@@ -10809,6 +10822,18 @@ components:
             - cloudtrail_delivery_throttled
             - cloudtrail_delivery_credentials_expired
             - cloudtrail_delivery_failed
+            - iam_last_used_permission_denied
+            - iam_last_used_failed
+            - iam_last_used_generation_failed
+            - iam_last_used_report_failed
+            - iam_last_used_report_pending
+            - iam_last_used_source_unavailable
+            - access_analyzer_permission_denied
+            - access_analyzer_list_failed
+            - access_analyzer_findings_failed
+            - access_analyzer_source_failed
+            - access_analyzer_source_unavailable
+            - iam_access_signal_ingester_unavailable
         message: { type: string }
         remediation: { type: string }
         retryable: { type: boolean }
@@ -10825,6 +10850,7 @@ components:
             - capability_unavailable
             - history_truncated
             - delivery_unavailable
+            - source_unavailable
         reason: { type: string }
         remediation: { type: string }
     AWSRuntimeEventSummary:
@@ -10850,6 +10876,9 @@ components:
         kms_decrypt_count: { type: integer }
         api_call_count: { type: integer }
         sts_session_count: { type: integer }
+        iam_last_used_signal_count: { type: integer }
+        access_analyzer_finding_count: { type: integer }
+        dormant_access_count: { type: integer }
         relationship_count: { type: integer }
         permission_denied_events: { type: integer }
     AWSRuntimeEventResult:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
+	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.49.5
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.6
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.6
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJa
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaYzsyaPkCHGRRMAOhU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
+github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.49.5 h1:YRmgSZDK5hzQGr3WD/tUVFCwVsnELDbTui7yhEgzy7g=
+github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.49.5/go.mod h1:4v0AkcAcWguJx3gOcZTvunFMbVeJ1e0jiUZPkaDPbhI=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.6 h1:MYVMZUGbJnoRZBtotS/otWTYf8z4YjTiZ1nlwiFOPj0=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.6/go.mod h1:VoWs1kYoXt1E02xMtFUq03ZGys+jcQQPxGqeof39ZmQ=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.6 h1:gVXOXnD5kjDGtkGgWGva7cRXYY7w/nR+1rv23xh5Jag=

--- a/internal/api/aws_runtime_cloudtrail_delivery_test.go
+++ b/internal/api/aws_runtime_cloudtrail_delivery_test.go
@@ -204,6 +204,56 @@ func TestGetAWSRuntimeEventsDeliverySourceAllFansOutAndDedupes(t *testing.T) {
 	}
 }
 
+func TestGetAWSRuntimeEventsDeliverySourceAllAppendsSignalFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 15, 19, 25, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-all-delivery-signals")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-all-delivery-signals", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-all-delivery-signals", "aws-prod")
+
+	s3Fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready"}}
+	ebFake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready"}}
+	signalRecord := liveSignalRuntimeRecord(t, "evt-delivery-analyzer", "access-analyzer", "access-analyzer:external-principal", "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", now.Add(-5*time.Minute))
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status:  "ready",
+		Records: []AWSRuntimeEventRecord{signalRecord},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, source AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		switch source {
+		case AWSCloudTrailDeliverySourceS3:
+			return s3Fake, nil
+		case AWSCloudTrailDeliverySourceEventBridge:
+			return ebFake, nil
+		}
+		t.Fatalf("unknown source %q", source)
+		return nil, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-all-delivery-signals", AWSRuntimeEventRequest{
+		ConnectorID:    "aws-prod",
+		DeliverySource: "all",
+		EventType:      "access-analyzer",
+	})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if s3Fake.calls != 1 || ebFake.calls != 1 || len(signals.calls) != 1 {
+		t.Fatalf("expected delivery and signal ingesters to run once, got s3=%d eb=%d signals=%d", s3Fake.calls, ebFake.calls, len(signals.calls))
+	}
+	if result.Status != "ready" || result.FixtureState != "success" {
+		t.Fatalf("expected delivery signal filter to return ready signal result, got %+v", result)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-delivery-analyzer" {
+		t.Fatalf("expected filtered signal record after delivery merge, got %+v", result.Records)
+	}
+}
+
 func TestGetAWSRuntimeEventsDeliveryUnknownSourceRejectedWith400(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -1176,3 +1176,23 @@ func TestAWSRuntimeEventRelationshipsSkipRoleLastUsedSelfActions(t *testing.T) {
 		}
 	}
 }
+
+func TestAWSRuntimeEventRelationshipsSkipServiceNeverAccessedActions(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/never-used"
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-service-never-accessed",
+		EventType:           "iam-last-used",
+		EventName:           "ServiceNeverAccessed",
+		SignalCategory:      "iam-last-used",
+		SignalScope:         "service",
+		ActorIdentityNodeID: awsIdentityNodeIDForAPI(roleARN),
+		ResourceNodeID:      awsRuntimeEventResourceNodeID("aws-service://sqs", "aws_service"),
+		EvidenceRef:         "runtime-evidence://123456789012/us-east-1/evt-service-never-accessed",
+	}
+	relationships := awsRuntimeEventRelationships([]AWSRuntimeEventRecord{record})
+	for _, relationship := range relationships {
+		if relationship.Type == "observed_runtime_action" {
+			t.Fatalf("service-never-accessed metadata must not create observed action edge, got %+v", relationships)
+		}
+	}
+}

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -719,6 +719,62 @@ func TestGetAWSRuntimeEventsSignalPermissionDeniedDowngradesLiveCloudTrail(t *te
 	}
 }
 
+func TestGetAWSRuntimeEventsSignalPermissionDeniedRespectsSourceFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 25, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signal-source-filter")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signal-source-filter", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-signal-source-filter", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail-runtime-reader/sess"
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{
+			liveRuntimeRecord(t, "evt-live-kms", "kms-decrypt", "Decrypt", "kms.amazonaws.com", "kms:Decrypt", "application", "cloudtrail", role, "arn:aws:kms:us-east-1:123456789012:key/example", "AWS::KMS::Key", now.Add(-10*time.Minute)),
+		},
+	}}
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status: "blocked",
+		Diagnostics: []AWSRuntimeEventDiagnostic{{
+			Collector: "aws_iam_access_signals",
+			SourceID:  "iam",
+			Code:      "iam_last_used_permission_denied",
+			Message:   "IAM last-used collection is not authorized.",
+			Retryable: true,
+		}},
+		CoverageGaps: []AWSRuntimeEventCoverageGap{{
+			Capability: "iam_last_used",
+			Status:     "permission_denied",
+			Reason:     "IAM last-used collection is not authorized.",
+		}},
+		FailureReasons:   []string{"IAM last-used and Access Analyzer permissions are unavailable"},
+		RemediationHints: []string{"Grant metadata-only signal permissions."},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signal-source-filter", AWSRuntimeEventRequest{ConnectorID: "aws-prod", EventType: "secret-read"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.Status != "degraded" || result.FixtureState != "degraded" || result.Confidence != 0.5 {
+		t.Fatalf("expected empty CloudTrail filter state to survive out-of-scope signal denial, got %+v", result)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected source filter to exclude CloudTrail and signal records, got %+v", result.Records)
+	}
+	if strings.Contains(strings.Join(result.FailureReasons, "|"), "permissions are unavailable") {
+		t.Fatalf("out-of-scope signal denial should not override filtered view failures, got %+v", result.FailureReasons)
+	}
+}
+
 func TestGetAWSRuntimeEventsSignalsClearEmptyFilterState(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -51,6 +51,17 @@ func (f *fakeCloudTrailIngester) Ingest(_ context.Context, request AWSCloudTrail
 	return f.result, f.err
 }
 
+type fakeRuntimeSignalIngester struct {
+	calls  []AWSRuntimeSignalIngestRequest
+	result AWSRuntimeSignalIngestResult
+	err    error
+}
+
+func (f *fakeRuntimeSignalIngester) Ingest(_ context.Context, request AWSRuntimeSignalIngestRequest) (AWSRuntimeSignalIngestResult, error) {
+	f.calls = append(f.calls, request)
+	return f.result, f.err
+}
+
 func liveRuntimeRecord(t *testing.T, id string, eventType string, name string, source string, action string, owner string, evidence string, actorARN string, resourceARN string, resourceType string, observed time.Time) AWSRuntimeEventRecord {
 	t.Helper()
 	return AWSRuntimeEventRecord{
@@ -83,6 +94,20 @@ func liveRuntimeRecord(t *testing.T, id string, eventType string, name string, s
 		NextAction:         awsRuntimeEventNextAction(eventType),
 		RedactionBoundary:  "metadata_only_no_payloads_no_secret_values",
 	}
+}
+
+func liveSignalRuntimeRecord(t *testing.T, id string, eventType string, actorARN string, resourceARN string, observed time.Time) AWSRuntimeEventRecord {
+	t.Helper()
+	record := liveRuntimeRecord(t, id, eventType, "Finding", "access-analyzer.amazonaws.com", "secretsmanager:GetSecretValue", "security", eventType, actorARN, resourceARN, "AWS::SecretsManager::Secret", observed)
+	record.SignalCategory = eventType
+	record.SignalScope = "account"
+	record.AnalyzerARN = "arn:aws:access-analyzer:us-east-1:123456789012:analyzer/account"
+	record.SignalStaleAt = observed
+	record.Session = AWSRuntimeEventSession{
+		PrincipalARN:  actorARN,
+		PrincipalType: "external_principal",
+	}
+	return record
 }
 
 func TestGetAWSRuntimeEventsUsesLiveCloudTrailWhenFactoryReturnsIngester(t *testing.T) {
@@ -635,6 +660,106 @@ func TestGetAWSRuntimeEventsLiveBlockedStatusKeepsContractShape(t *testing.T) {
 	}
 	if !foundCollectorDiagnostic {
 		t.Fatalf("expected collector-level permission_denied diagnostic to survive in blocked response, got %+v", result.Diagnostics)
+	}
+}
+
+func TestGetAWSRuntimeEventsSignalPermissionDeniedDowngradesLiveCloudTrail(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signal-denied")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signal-denied", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-signal-denied", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail-runtime-reader/sess"
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{
+			liveRuntimeRecord(t, "evt-live-secret", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "cloudtrail", role, "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", "AWS::SecretsManager::Secret", now.Add(-10*time.Minute)),
+		},
+	}}
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status: "blocked",
+		Diagnostics: []AWSRuntimeEventDiagnostic{{
+			Collector: "aws_iam_access_signals",
+			SourceID:  "iam",
+			Code:      "iam_last_used_permission_denied",
+			Message:   "IAM last-used collection is not authorized.",
+			Retryable: true,
+		}},
+		CoverageGaps: []AWSRuntimeEventCoverageGap{{
+			Capability: "iam_last_used",
+			Status:     "permission_denied",
+			Reason:     "IAM last-used collection is not authorized.",
+		}},
+		FailureReasons:   []string{"IAM last-used and Access Analyzer permissions are unavailable"},
+		RemediationHints: []string{"Grant metadata-only signal permissions."},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signal-denied", AWSRuntimeEventRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.Status != "degraded" || result.FixtureState != "partial_failure" || result.Confidence > 0.72 {
+		t.Fatalf("expected blocked signal coverage to downgrade live CloudTrail result, got %+v", result)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-live-secret" {
+		t.Fatalf("expected CloudTrail evidence to remain visible, got %+v", result.Records)
+	}
+	if len(result.Diagnostics) == 0 || !strings.Contains(strings.Join(result.FailureReasons, "|"), "permissions are unavailable") {
+		t.Fatalf("expected signal denial diagnostics/failures, got diagnostics=%+v failures=%+v", result.Diagnostics, result.FailureReasons)
+	}
+}
+
+func TestGetAWSRuntimeEventsSignalsClearEmptyFilterState(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signal-filter")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signal-filter", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-signal-filter", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail-runtime-reader/sess"
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{
+			liveRuntimeRecord(t, "evt-live-secret", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "cloudtrail", role, "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", "AWS::SecretsManager::Secret", now.Add(-10*time.Minute)),
+		},
+	}}
+	signalRecord := liveSignalRuntimeRecord(t, "evt-live-analyzer", "access-analyzer", "access-analyzer:external-principal", "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", now.Add(-5*time.Minute))
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status:  "ready",
+		Records: []AWSRuntimeEventRecord{signalRecord},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signal-filter", AWSRuntimeEventRequest{ConnectorID: "aws-prod", EventType: "access-analyzer"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.Status != "ready" || result.FixtureState != "success" || result.Confidence != 0.92 {
+		t.Fatalf("expected signal match to clear stale empty-filter state, got %+v", result)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-live-analyzer" {
+		t.Fatalf("expected filtered signal record, got %+v", result.Records)
+	}
+	if strings.Contains(strings.Join(result.FailureReasons, "|"), "filters matched no records") || strings.Contains(strings.Join(result.RemediationHints, "|"), "Clear filters") {
+		t.Fatalf("empty-filter messages should be cleared after signal match, failures=%+v remediations=%+v", result.FailureReasons, result.RemediationHints)
 	}
 }
 

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -775,6 +775,47 @@ func TestGetAWSRuntimeEventsSignalPermissionDeniedRespectsSourceFilters(t *testi
 	}
 }
 
+func TestGetAWSRuntimeEventsSkipsSignalFactoryForCloudTrailOnlyFilters(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 27, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signal-factory-source-filter")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signal-factory-source-filter", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-signal-factory-source-filter", "aws-prod")
+
+	role := "arn:aws:sts::123456789012:assumed-role/identrail-runtime-reader/sess"
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{
+			liveRuntimeRecord(t, "evt-live-secret", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "cloudtrail", role, "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", "AWS::SecretsManager::Secret", now.Add(-10*time.Minute)),
+		},
+	}}
+	signalFactoryCalls := 0
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		signalFactoryCalls++
+		return nil, errors.New("signal factory unavailable")
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signal-factory-source-filter", AWSRuntimeEventRequest{ConnectorID: "aws-prod", EventType: "secret-read"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if signalFactoryCalls != 0 {
+		t.Fatalf("CloudTrail-only filters should not initialize signal factory, got %d calls", signalFactoryCalls)
+	}
+	if result.Status != "ready" || result.Confidence != 0.92 {
+		t.Fatalf("expected healthy CloudTrail-only result to stay ready, got %+v", result)
+	}
+	if len(result.Diagnostics) != 0 || strings.Contains(strings.Join(result.FailureReasons, "|"), "signal") {
+		t.Fatalf("out-of-scope signal factory failure should not leak into response, diagnostics=%+v failures=%+v", result.Diagnostics, result.FailureReasons)
+	}
+}
+
 func TestGetAWSRuntimeEventsSignalsClearEmptyFilterState(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
@@ -816,6 +857,65 @@ func TestGetAWSRuntimeEventsSignalsClearEmptyFilterState(t *testing.T) {
 	}
 	if strings.Contains(strings.Join(result.FailureReasons, "|"), "filters matched no records") || strings.Contains(strings.Join(result.RemediationHints, "|"), "Clear filters") {
 		t.Fatalf("empty-filter messages should be cleared after signal match, failures=%+v remediations=%+v", result.FailureReasons, result.RemediationHints)
+	}
+}
+
+func TestGetAWSRuntimeEventsSignalDiagnosticsRespectRequestedSignalSource(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 35, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signal-source-diagnostics")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signal-source-diagnostics", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-signal-source-diagnostics", "aws-prod")
+
+	role := "arn:aws:iam::123456789012:role/identrail-runtime-reader"
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{Status: "ready"}}
+	iamRecord := liveRuntimeRecord(t, "evt-live-iam-last-used", "iam-last-used", "ServiceLastAccessed", "iam.amazonaws.com", "lambda:LastAuthenticated", "platform", "iam-last-used", role, "aws-service://lambda", "aws_service", now.Add(-120*24*time.Hour))
+	iamRecord.SignalCategory = "iam-last-used"
+	iamRecord.SignalScope = "service"
+	iamRecord.SignalStaleAt = now
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status:  "degraded",
+		Records: []AWSRuntimeEventRecord{iamRecord},
+		Diagnostics: []AWSRuntimeEventDiagnostic{{
+			Collector: "aws_iam_access_signals",
+			SourceID:  "access-analyzer:account",
+			Code:      "access_analyzer_permission_denied",
+			Message:   "Access Analyzer findings could not be listed.",
+			Retryable: true,
+		}},
+		CoverageGaps: []AWSRuntimeEventCoverageGap{{
+			Capability: "access_analyzer",
+			Status:     "permission_denied",
+			Reason:     "Access Analyzer findings could not be listed.",
+		}},
+		FailureReasons:   []string{"Access Analyzer signal permissions are unavailable"},
+		RemediationHints: []string{"Grant metadata-only Access Analyzer permissions."},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signal-source-diagnostics", AWSRuntimeEventRequest{ConnectorID: "aws-prod", EventType: "iam-last-used"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.Status != "ready" || result.FixtureState != "success" {
+		t.Fatalf("expected IAM-only signal view to ignore Access Analyzer diagnostics, got %+v", result)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-live-iam-last-used" {
+		t.Fatalf("expected IAM signal record to remain visible, got %+v", result.Records)
+	}
+	if len(result.Diagnostics) != 0 || len(result.CoverageGaps) != 0 || strings.Contains(strings.Join(result.FailureReasons, "|"), "Access Analyzer") {
+		t.Fatalf("Access Analyzer diagnostics should not leak into IAM-only view, diagnostics=%+v gaps=%+v failures=%+v", result.Diagnostics, result.CoverageGaps, result.FailureReasons)
+	}
+	if result.Summary.AccessAnalyzerCount != 0 || result.Summary.IAMLastUsedSignalCount != 1 {
+		t.Fatalf("summary should be scoped to IAM signals, got %+v", result.Summary)
 	}
 }
 
@@ -1055,5 +1155,24 @@ func TestScopeAWSRuntimeEventDiagnosticsPreservesCollectorLevelSourceIDs(t *test
 	}
 	if codes["evt-b:runtime_event_delivery_delayed"] {
 		t.Fatalf("per-record diagnostic for filtered-out event must be dropped, got %+v", scoped)
+	}
+}
+
+func TestAWSRuntimeEventRelationshipsSkipRoleLastUsedSelfActions(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/never-used"
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-role-never-used",
+		EventType:           "iam-last-used",
+		SignalCategory:      "iam-last-used",
+		SignalScope:         "role",
+		ActorIdentityNodeID: awsIdentityNodeIDForAPI(roleARN),
+		ResourceNodeID:      awsRuntimeEventResourceNodeID(roleARN, "iam_role"),
+		EvidenceRef:         "runtime-evidence://123456789012/us-east-1/evt-role-never-used",
+	}
+	relationships := awsRuntimeEventRelationships([]AWSRuntimeEventRecord{record})
+	for _, relationship := range relationships {
+		if relationship.Type == "observed_runtime_action" {
+			t.Fatalf("role last-used metadata must not create observed action self-edge, got %+v", relationships)
+		}
 	}
 }

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -763,6 +763,60 @@ func TestGetAWSRuntimeEventsSignalsClearEmptyFilterState(t *testing.T) {
 	}
 }
 
+func TestGetAWSRuntimeEventsCloudTrailDeniedWithSignalsIsPartialCoverage(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 21, 40, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-cloudtrail-denied-signals")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-cloudtrail-denied-signals", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-cloudtrail-denied-signals", "aws-prod")
+
+	cloudTrail := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "blocked",
+		Diagnostics: []AWSRuntimeEventDiagnostic{{
+			Collector: "aws_cloudtrail_lookup_events",
+			SourceID:  "cloudtrail",
+			Code:      "permission_denied",
+			Message:   "CloudTrail LookupEvents permission is not available.",
+			Retryable: true,
+		}},
+		CoverageGaps: []AWSRuntimeEventCoverageGap{{
+			Capability: "cloudtrail_lookup_events",
+			Status:     "permission_denied",
+			Reason:     "CloudTrail LookupEvents permission is not available.",
+		}},
+		FailureReasons:   []string{"runtime event sources are not authorized for this connector"},
+		RemediationHints: []string{"Grant metadata-only CloudTrail LookupEvents."},
+	}}
+	signalRecord := liveSignalRuntimeRecord(t, "evt-live-analyzer", "access-analyzer", "access-analyzer:external-principal", "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", now.Add(-5*time.Minute))
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status:  "ready",
+		Records: []AWSRuntimeEventRecord{signalRecord},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return cloudTrail, nil
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-cloudtrail-denied-signals", AWSRuntimeEventRequest{ConnectorID: "aws-prod", EventType: "access-analyzer"})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if result.Status != "degraded" || result.FixtureState != "partial_failure" || result.Confidence > 0.72 {
+		t.Fatalf("expected mixed CloudTrail-denied/signal-visible result to be partial coverage, got %+v", result)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "evt-live-analyzer" {
+		t.Fatalf("expected signal evidence to remain visible, got %+v", result.Records)
+	}
+	if len(result.CoverageGaps) == 0 || !strings.Contains(strings.Join(result.FailureReasons, "|"), "not authorized") {
+		t.Fatalf("expected CloudTrail denial context to remain visible, gaps=%+v failures=%+v", result.CoverageGaps, result.FailureReasons)
+	}
+}
+
 func TestGetAWSRuntimeEventsFactoryContextCancellationPropagates(t *testing.T) {
 	// Context cancellation / deadline expiry inside the factory
 	// (loading AWS config, assuming the role) is a caller-driven

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	awsRuntimeEventsCurrentIssue = 1516
-	awsRuntimeEventsVersion      = "aws-runtime-events-contract-v2"
+	awsRuntimeEventsCurrentIssue = 1517
+	awsRuntimeEventsVersion      = "aws-runtime-events-contract-v3"
 )
 
 type AWSRuntimeEventRequest struct {
@@ -89,6 +89,10 @@ type AWSRuntimeEventRecord struct {
 	AgentNodeID         string                 `json:"agent_node_id,omitempty"`
 	ToolName            string                 `json:"tool_name,omitempty"`
 	ToolTargetRef       string                 `json:"tool_target_ref,omitempty"`
+	SignalCategory      string                 `json:"signal_category,omitempty"`
+	SignalScope         string                 `json:"signal_scope,omitempty"`
+	AnalyzerARN         string                 `json:"analyzer_arn,omitempty"`
+	SignalStaleAt       time.Time              `json:"signal_stale_at,omitzero"`
 	Owner               string                 `json:"owner"`
 	EvidenceCategory    string                 `json:"evidence_category"`
 	EvidenceRef         string                 `json:"evidence_ref"`
@@ -138,6 +142,9 @@ type AWSRuntimeEventSummary struct {
 	KMSDecryptCount        int            `json:"kms_decrypt_count"`
 	APICallCount           int            `json:"api_call_count"`
 	STSSessionCount        int            `json:"sts_session_count"`
+	IAMLastUsedSignalCount int            `json:"iam_last_used_signal_count"`
+	AccessAnalyzerCount    int            `json:"access_analyzer_finding_count"`
+	DormantAccessCount     int            `json:"dormant_access_count"`
 	LineageResolvedCount   int            `json:"lineage_resolved_count"`
 	MissingSourceIDCount   int            `json:"missing_source_identity_count"`
 	AmbiguousLineageCount  int            `json:"ambiguous_lineage_count"`
@@ -217,7 +224,11 @@ func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, p
 	if s.AWSCloudTrailLookupEventsFactory != nil && hasConnection && connection.Connected && strings.TrimSpace(request.FixtureState) == "" && awsConnectorHasRuntimeEvidence(connection) {
 		ingester, ingErr := s.AWSCloudTrailLookupEventsFactory(ctx, connection)
 		if ingErr == nil && ingester != nil {
-			return buildAWSRuntimeEventsFromCloudTrail(ctx, scope, project, connection, ingester, request, now)
+			result, resultErr := buildAWSRuntimeEventsFromCloudTrail(ctx, scope, project, connection, ingester, request, now)
+			if resultErr != nil {
+				return result, resultErr
+			}
+			return s.appendAWSRuntimeSignals(ctx, scope, project, connection, result, request, now)
 		}
 		// Context cancellation / deadline expiry during factory setup
 		// (loading AWS config, assuming the role) is a caller-driven
@@ -708,6 +719,13 @@ func summarizeAWSRuntimeEvents(records []AWSRuntimeEventRecord, filteredCount in
 			summary.APICallCount++
 		case "sts-session":
 			summary.STSSessionCount++
+		case "iam-last-used":
+			summary.IAMLastUsedSignalCount++
+		case "access-analyzer":
+			summary.AccessAnalyzerCount++
+		}
+		if record.SignalCategory == "iam-last-used" && record.Status == "stale" {
+			summary.DormantAccessCount++
 		}
 		if record.Status == "permission-denied" {
 			summary.PermissionDeniedEvents++
@@ -728,11 +746,11 @@ func summarizeAWSRuntimeEventStatus(fixtureState string, diagnostics []AWSRuntim
 	case "permission_denied":
 		return "blocked", 0,
 			[]string{"runtime event sources are not authorized for this connector"},
-			[]string{"Grant metadata-only CloudTrail LookupEvents and service audit permissions; do not grant payload, secret-value, decrypt, or object-body reads."}
+			[]string{"Grant metadata-only CloudTrail LookupEvents, IAM Access Advisor, and Access Analyzer permissions; do not grant payload, secret-value, decrypt, or object-body reads."}
 	case "empty":
 		return "degraded", 0.45,
-			[]string{"no runtime events matched the scoped account and region"},
-			[]string{"Confirm CloudTrail management events are enabled, then retry runtime event ingestion."}
+			[]string{"no runtime events or IAM access signals matched the scoped account and region"},
+			[]string{"Confirm CloudTrail management events, IAM last-used reporting, and Access Analyzer are enabled, then retry runtime evidence ingestion."}
 	case "partial_failure":
 		return "degraded", 0.74,
 			[]string{"one runtime event source failed while retained events remain visible"},
@@ -817,6 +835,8 @@ func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState
 		awsRuntimeEventFixtureRecord(accountID, region, "evt-kms-decrypt", "kms-decrypt", "kms.amazonaws.com", "Decrypt", "kms:Decrypt", lambdaRole, fmt.Sprintf("arn:aws:kms:%s:%s:key/cmk-agent-secrets", region, accountID), "kms_key", "platform", "cloudtrail", base.Add(10*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
 		awsRuntimeEventFixtureRecord(accountID, region, "evt-s3-access", "api-call", "s3.amazonaws.com", "GetObject", "s3:GetObject", lambdaRole, fmt.Sprintf("arn:aws:s3:::billing-artifacts-%s/reports/redacted", accountID), "s3_object_metadata", "application", "cloudtrail", base.Add(14*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
 		awsRuntimeEventFixtureRecord(accountID, region, "evt-agent-tool", "agent-tool", "bedrock-agentcore.amazonaws.com", "InvokeTool", "bedrock-agentcore:InvokeTool", agentRole, fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/blue", region, accountID), "agent_tool_target", "security", "agent-runtime", base.Add(19*time.Minute), session("sess-agentcore-runtime", agentRole, base.Add(18*time.Minute))),
+		awsRuntimeSignalFixtureRecord(accountID, region, "evt-iam-last-used-lambda", "iam-last-used", "iam.amazonaws.com", "ServiceLastAccessed", "lambda:LastAuthenticated", lambdaRole, "aws-service://lambda", "aws_service", "Lambda", "iam-last-used", checkedAt.Add(-120*24*time.Hour), base.Add(34*time.Minute), "stale", 0.78, "service", ""),
+		awsRuntimeSignalFixtureRecord(accountID, region, "evt-access-analyzer-open-secret", "access-analyzer", "access-analyzer.amazonaws.com", "Finding", "secretsmanager:GetSecretValue", "access-analyzer:external-principal", fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/ai/openai-key", region, accountID), "AWS::SecretsManager::Secret", "prod/ai/openai-key", "access-analyzer", base.Add(24*time.Minute), base.Add(33*time.Minute), "observed", 0.9, "account", fmt.Sprintf("arn:aws:access-analyzer:%s:%s:analyzer/identrail-fixture", region, accountID)),
 	}
 	records[4].AgentID = "runtime-case-triage"
 	records[4].AgentNodeID = awsAIAgentNodeID(accountID, region, "agentcore_runtime", "runtime-case-triage", "2026-06-01")
@@ -842,32 +862,32 @@ func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState
 			Retryable:   true,
 		}}, nil
 	case "partial_failure":
-		return records[:3], []AWSRuntimeEventDiagnostic{{
+		return records[:6], []AWSRuntimeEventDiagnostic{{
 				Collector:   "aws_runtime_events",
-				SourceID:    "agent-runtime",
-				Code:        "agent_runtime_event_source_failed",
-				Message:     "Agent runtime event source failed; CloudTrail events remain visible.",
-				Remediation: "Retry only the agent runtime source and preserve retained CloudTrail evidence.",
+				SourceID:    "access-analyzer",
+				Code:        "access_analyzer_source_failed",
+				Message:     "Access Analyzer source failed; CloudTrail and IAM last-used signals remain visible.",
+				Remediation: "Retry only the Access Analyzer source and preserve retained runtime evidence.",
 				Retryable:   true,
 			}}, []AWSRuntimeEventCoverageGap{{
-				Capability:  "agent_runtime_events",
+				Capability:  "access_analyzer",
 				Status:      "partial_failure",
-				Reason:      "Agent runtime events could not be listed in this fixture.",
-				Remediation: "Retry AgentCore runtime event collection without discarding CloudTrail events.",
+				Reason:      "Access Analyzer findings could not be listed in this fixture.",
+				Remediation: "Retry Access Analyzer collection without discarding CloudTrail or IAM last-used signals.",
 			}}
 	case "permission_denied":
 		return []AWSRuntimeEventRecord{}, []AWSRuntimeEventDiagnostic{{
 				Collector:   "aws_runtime_events",
-				SourceID:    "cloudtrail",
+				SourceID:    "iam-access-signals",
 				Code:        "permission_denied",
-				Message:     "CloudTrail LookupEvents permission is not available for runtime event ingestion.",
-				Remediation: "Grant metadata-only CloudTrail LookupEvents access. Do not grant payload, secret-value, decrypt, or object-body reads.",
+				Message:     "Runtime evidence permissions are not available for CloudTrail, IAM last-used, or Access Analyzer ingestion.",
+				Remediation: "Grant metadata-only CloudTrail LookupEvents, IAM Access Advisor, and Access Analyzer list permissions. Do not grant payload, secret-value, decrypt, or object-body reads.",
 				Retryable:   true,
 			}}, []AWSRuntimeEventCoverageGap{{
-				Capability:  "cloudtrail_lookup_events",
+				Capability:  "iam_access_signals",
 				Status:      "permission_denied",
-				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
-				Remediation: "Add read-only event lookup permissions and retry.",
+				Reason:      "Runtime signal sources cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only event lookup, IAM last-used, and Access Analyzer permissions and retry.",
 			}}
 	default:
 		return records, nil, nil
@@ -913,6 +933,42 @@ func awsRuntimeEventFixtureRecord(accountID string, region string, id string, ev
 	}
 }
 
+func awsRuntimeSignalFixtureRecord(accountID string, region string, id string, eventType string, source string, name string, action string, actorARN string, resourceARN string, resourceType string, resourceName string, evidence string, observedAt time.Time, staleAt time.Time, status string, confidence float64, signalScope string, analyzerARN string) AWSRuntimeEventRecord {
+	return AWSRuntimeEventRecord{
+		EventID:             id,
+		AccountID:           accountID,
+		Region:              region,
+		EventType:           eventType,
+		EventSource:         source,
+		EventName:           name,
+		Action:              action,
+		ActorPrincipalARN:   actorARN,
+		ActorPrincipalType:  "aws_principal",
+		ActorIdentityNodeID: awsIdentityNodeIDForAPI(actorARN),
+		Session: AWSRuntimeEventSession{
+			PrincipalARN:  actorARN,
+			PrincipalType: "aws_principal",
+		},
+		TargetResourceARN:  resourceARN,
+		TargetResourceType: resourceType,
+		TargetResourceName: resourceName,
+		ResourceNodeID:     awsRuntimeEventResourceNodeID(resourceARN, resourceType),
+		SignalCategory:     eventType,
+		SignalScope:        signalScope,
+		AnalyzerARN:        analyzerARN,
+		SignalStaleAt:      staleAt,
+		Owner:              signalOwner(eventType, status),
+		EvidenceCategory:   evidence,
+		EvidenceRef:        fmt.Sprintf("runtime-evidence://%s/%s/%s", accountID, region, id),
+		Confidence:         confidence,
+		ObservedAt:         observedAt,
+		CollectedAt:        staleAt,
+		Status:             status,
+		NextAction:         awsRuntimeEventNextAction(eventType),
+		RedactionBoundary:  "metadata_only_no_payloads_no_secret_values",
+	}
+}
+
 func awsRuntimeEventResourceNodeID(resourceARN string, resourceType string) string {
 	if strings.TrimSpace(resourceARN) == "" {
 		return ""
@@ -930,9 +986,133 @@ func awsRuntimeEventNextAction(eventType string) string {
 		return "Join decrypt evidence with key reachability before remediation."
 	case "agent-tool":
 		return "Review the agent identity and tool target relationship."
+	case "iam-last-used":
+		return "Use IAM last-used timestamps to validate dormant access before least-privilege changes."
+	case "access-analyzer":
+		return "Review Access Analyzer scope and finding status before trusting or remediating access."
 	default:
 		return "Correlate runtime evidence with identity and resource graph context."
 	}
+}
+
+func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, project db.TenancyProject, connection AWSConnectionStatus, base AWSRuntimeEventResult, request AWSRuntimeEventRequest, checkedAt time.Time) (AWSRuntimeEventResult, error) {
+	if s.AWSRuntimeSignalFactory == nil || strings.TrimSpace(request.FixtureState) != "" || !awsConnectorHasRuntimeEvidence(connection) {
+		return base, nil
+	}
+	ingester, err := s.AWSRuntimeSignalFactory(ctx, connection)
+	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return AWSRuntimeEventResult{}, err
+	}
+	if err != nil || ingester == nil {
+		base.Diagnostics = append(base.Diagnostics, AWSRuntimeEventDiagnostic{
+			Collector:   "aws_iam_access_signals",
+			SourceID:    "factory",
+			Code:        "iam_access_signal_ingester_unavailable",
+			Message:     fmt.Sprintf("IAM last-used and Access Analyzer ingester is not available for this connector: %v", err),
+			Remediation: "Confirm the connector role grants metadata-only IAM Access Advisor and Access Analyzer permissions.",
+			Retryable:   true,
+		})
+		base.CoverageGaps = append(base.CoverageGaps, AWSRuntimeEventCoverageGap{
+			Capability:  "iam_access_signals",
+			Status:      "source_unavailable",
+			Reason:      "IAM last-used and Access Analyzer ingester could not be created.",
+			Remediation: "Wire the signal ingester and grant metadata-only IAM/Access Analyzer access.",
+		})
+		base.Status = "degraded"
+		if base.Confidence > 0.78 {
+			base.Confidence = 0.78
+		}
+		base.FailureReasons = dedupeStrings(append(base.FailureReasons, "IAM last-used and Access Analyzer ingester is not available"))
+		base.RemediationHints = dedupeStrings(append(base.RemediationHints, "Confirm metadata-only IAM Access Advisor and Access Analyzer permissions."))
+		return base, nil
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	signalResult, signalErr := ingester.Ingest(ctx, AWSRuntimeSignalIngestRequest{
+		AccountID:   accountID,
+		Region:      region,
+		CollectedAt: checkedAt,
+	})
+	if signalErr != nil {
+		return AWSRuntimeEventResult{}, fmt.Errorf("ingest iam access signals: %w", signalErr)
+	}
+	filtered, _ := filterAWSRuntimeEventRecords(signalResult.Records, request)
+	base.Records = append(base.Records, filtered...)
+	base.Relationships = awsRuntimeEventRelationships(base.Records)
+	base.Diagnostics = append(base.Diagnostics, signalResult.Diagnostics...)
+	base.CoverageGaps = append(base.CoverageGaps, signalResult.CoverageGaps...)
+	base.FailureReasons = dedupeStrings(append(base.FailureReasons, signalResult.FailureReasons...))
+	base.RemediationHints = dedupeStrings(append(base.RemediationHints, signalResult.RemediationHints...))
+	base.EvidenceLinks = dedupeStrings(append(base.EvidenceLinks, "/docs/aws-runtime-events#iam-last-used-and-access-analyzer-signals-1517"))
+	base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, signalResult.Records, len(filtered), len(base.Relationships), base.Records)
+	if signalResult.Status == "blocked" && len(base.Records) == 0 {
+		base.Status = "blocked"
+		base.Confidence = 0
+		base.FixtureState = "permission_denied"
+	} else if signalResult.Status == "degraded" && base.Status == "ready" {
+		base.Status = "degraded"
+		base.FixtureState = "degraded"
+		if base.Confidence > 0.78 {
+			base.Confidence = 0.78
+		}
+	}
+	return base, nil
+}
+
+func mergeAWSRuntimeEventSummaries(base AWSRuntimeEventSummary, signalRecords []AWSRuntimeEventRecord, filteredSignals int, relationshipCount int, visibleRecords []AWSRuntimeEventRecord) AWSRuntimeEventSummary {
+	signalSummary := summarizeAWSRuntimeEvents(signalRecords, filteredSignals, relationshipCount)
+	base.TotalEvents += signalSummary.TotalEvents
+	base.FilteredEvents += signalSummary.FilteredEvents
+	for key, value := range signalSummary.EventTypeCounts {
+		base.EventTypeCounts[key] += value
+	}
+	for key, value := range signalSummary.StatusCounts {
+		base.StatusCounts[key] += value
+	}
+	for key, value := range signalSummary.OwnerCounts {
+		base.OwnerCounts[key] += value
+	}
+	base.RelationshipCount = relationshipCount
+	base.IAMLastUsedSignalCount += signalSummary.IAMLastUsedSignalCount
+	base.AccessAnalyzerCount += signalSummary.AccessAnalyzerCount
+	base.DormantAccessCount += signalSummary.DormantAccessCount
+	base.PermissionDeniedEvents += signalSummary.PermissionDeniedEvents
+	accountCount, regionCount, identityCount, resourceCount := runtimeEventVisibleUniqueCounts(visibleRecords)
+	if accountCount > 0 {
+		base.AccountCount = accountCount
+	}
+	if regionCount > 0 {
+		base.RegionCount = regionCount
+	}
+	if identityCount > 0 {
+		base.IdentityCount = identityCount
+	}
+	if resourceCount > 0 {
+		base.ResourceCount = resourceCount
+	}
+	return base
+}
+
+func runtimeEventVisibleUniqueCounts(records []AWSRuntimeEventRecord) (int, int, int, int) {
+	accounts := map[string]struct{}{}
+	regions := map[string]struct{}{}
+	identities := map[string]struct{}{}
+	resources := map[string]struct{}{}
+	for _, record := range records {
+		if strings.TrimSpace(record.AccountID) != "" {
+			accounts[record.AccountID] = struct{}{}
+		}
+		if strings.TrimSpace(record.Region) != "" {
+			regions[record.Region] = struct{}{}
+		}
+		if strings.TrimSpace(record.ActorIdentityNodeID) != "" {
+			identities[record.ActorIdentityNodeID] = struct{}{}
+		}
+		if strings.TrimSpace(record.ResourceNodeID) != "" {
+			resources[record.ResourceNodeID] = struct{}{}
+		}
+	}
+	return len(accounts), len(regions), len(identities), len(resources)
 }
 
 // getAWSRuntimeEventsFromDelivery handles `delivery_source=s3`,

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -773,7 +773,7 @@ func summarizeAWSRuntimeEventStatus(fixtureState string, diagnostics []AWSRuntim
 func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeEventRelationship {
 	out := []AWSRuntimeEventRelationship{}
 	for _, record := range records {
-		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" {
+		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" && !awsRuntimeEventIsExposureSignal(record) {
 			out = append(out, AWSRuntimeEventRelationship{Type: "observed_runtime_action", FromNodeID: record.ActorIdentityNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
 		}
 		if record.ActorIdentityNodeID != "" && record.Session.SessionNodeID != "" {
@@ -793,6 +793,10 @@ func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeE
 		}
 	}
 	return out
+}
+
+func awsRuntimeEventIsExposureSignal(record AWSRuntimeEventRecord) bool {
+	return normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.SignalCategory, record.EventType)) == "access-analyzer"
 }
 
 func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSRuntimeEventRecord, []AWSRuntimeEventDiagnostic, []AWSRuntimeEventCoverageGap) {

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1443,7 +1443,11 @@ func (s *Service) getAWSRuntimeEventsFromDelivery(ctx context.Context, scope db.
 	// Wrap a fake ingester so we can reuse the existing CloudTrail
 	// envelope builder without duplicating its 80+ lines.
 	stub := &precomputedIngester{result: merged}
-	return buildAWSRuntimeEventsFromCloudTrail(ctx, scope, project, connection, stub, request, now)
+	result, err := buildAWSRuntimeEventsFromCloudTrail(ctx, scope, project, connection, stub, request, now)
+	if err != nil {
+		return result, err
+	}
+	return s.appendAWSRuntimeSignals(ctx, scope, project, connection, result, request, now)
 }
 
 // precomputedIngester satisfies AWSCloudTrailRuntimeEventIngester

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1036,6 +1036,7 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 	if signalErr != nil {
 		return AWSRuntimeEventResult{}, fmt.Errorf("ingest iam access signals: %w", signalErr)
 	}
+	wasEmptyFilterResult := awsRuntimeEventIsEmptyFilterResult(base)
 	filtered, _ := filterAWSRuntimeEventRecords(signalResult.Records, request)
 	base.Records = append(base.Records, filtered...)
 	base.Relationships = awsRuntimeEventRelationships(base.Records)
@@ -1045,10 +1046,27 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 	base.RemediationHints = dedupeStrings(append(base.RemediationHints, signalResult.RemediationHints...))
 	base.EvidenceLinks = dedupeStrings(append(base.EvidenceLinks, "/docs/aws-runtime-events#iam-last-used-and-access-analyzer-signals-1517"))
 	base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, signalResult.Records, len(filtered), len(base.Relationships), base.Records)
-	if signalResult.Status == "blocked" && len(base.Records) == 0 {
-		base.Status = "blocked"
-		base.Confidence = 0
-		base.FixtureState = "permission_denied"
+	if wasEmptyFilterResult && len(filtered) > 0 {
+		base.FailureReasons = removeRuntimeEventEmptyFilterFailures(base.FailureReasons)
+		base.RemediationHints = removeRuntimeEventEmptyFilterRemediations(base.RemediationHints)
+		if signalResult.Status == "ready" {
+			base.Status = "ready"
+			base.FixtureState = "success"
+			base.Confidence = 0.92
+		}
+	}
+	if signalResult.Status == "blocked" {
+		if len(base.Records) == 0 {
+			base.Status = "blocked"
+			base.Confidence = 0
+			base.FixtureState = "permission_denied"
+		} else {
+			base.Status = "degraded"
+			base.FixtureState = "partial_failure"
+			if base.Confidence > 0.72 {
+				base.Confidence = 0.72
+			}
+		}
 	} else if signalResult.Status == "degraded" && base.Status == "ready" {
 		base.Status = "degraded"
 		base.FixtureState = "degraded"
@@ -1057,6 +1075,37 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 		}
 	}
 	return base, nil
+}
+
+func awsRuntimeEventIsEmptyFilterResult(result AWSRuntimeEventResult) bool {
+	if len(result.Records) != 0 || result.Summary.FilteredEvents != 0 {
+		return false
+	}
+	for _, reason := range result.FailureReasons {
+		if strings.Contains(strings.ToLower(reason), "filters matched no records") {
+			return true
+		}
+	}
+	return false
+}
+
+func removeRuntimeEventEmptyFilterFailures(values []string) []string {
+	return filterRuntimeEventMessages(values, "filters matched no records")
+}
+
+func removeRuntimeEventEmptyFilterRemediations(values []string) []string {
+	return filterRuntimeEventMessages(values, "clear filters")
+}
+
+func filterRuntimeEventMessages(values []string, dropSubstring string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), dropSubstring) {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
 }
 
 func mergeAWSRuntimeEventSummaries(base AWSRuntimeEventSummary, signalRecords []AWSRuntimeEventRecord, filteredSignals int, relationshipCount int, visibleRecords []AWSRuntimeEventRecord) AWSRuntimeEventSummary {

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -773,7 +773,7 @@ func summarizeAWSRuntimeEventStatus(fixtureState string, diagnostics []AWSRuntim
 func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeEventRelationship {
 	out := []AWSRuntimeEventRelationship{}
 	for _, record := range records {
-		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" && !awsRuntimeEventIsExposureSignal(record) {
+		if record.ActorIdentityNodeID != "" && record.ResourceNodeID != "" && !awsRuntimeEventSkipsObservedActionEdge(record) {
 			out = append(out, AWSRuntimeEventRelationship{Type: "observed_runtime_action", FromNodeID: record.ActorIdentityNodeID, ToNodeID: record.ResourceNodeID, EvidenceRef: record.EvidenceRef})
 		}
 		if record.ActorIdentityNodeID != "" && record.Session.SessionNodeID != "" {
@@ -795,8 +795,12 @@ func awsRuntimeEventRelationships(records []AWSRuntimeEventRecord) []AWSRuntimeE
 	return out
 }
 
-func awsRuntimeEventIsExposureSignal(record AWSRuntimeEventRecord) bool {
-	return normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.SignalCategory, record.EventType)) == "access-analyzer"
+func awsRuntimeEventSkipsObservedActionEdge(record AWSRuntimeEventRecord) bool {
+	category := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.SignalCategory, record.EventType))
+	if category == "access-analyzer" {
+		return true
+	}
+	return category == "iam-last-used" && normalizeAWSRuntimeEventFilterToken(record.SignalScope) == "role"
 }
 
 func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSRuntimeEventRecord, []AWSRuntimeEventDiagnostic, []AWSRuntimeEventCoverageGap) {
@@ -1003,6 +1007,10 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 	if s.AWSRuntimeSignalFactory == nil || strings.TrimSpace(request.FixtureState) != "" || !awsConnectorHasRuntimeEvidence(connection) {
 		return base, nil
 	}
+	requestedSignalCategory, signalEvidenceInScope := awsRuntimeRequestedSignalCategory(request)
+	if !signalEvidenceInScope {
+		return base, nil
+	}
 	ingester, err := s.AWSRuntimeSignalFactory(ctx, connection)
 	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return AWSRuntimeEventResult{}, err
@@ -1041,17 +1049,17 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 		return AWSRuntimeEventResult{}, fmt.Errorf("ingest iam access signals: %w", signalErr)
 	}
 	wasEmptyFilterResult := awsRuntimeEventIsEmptyFilterResult(base)
+	signalResult, summaryRecords := scopeAWSRuntimeSignalResult(signalResult, requestedSignalCategory)
 	filtered, _ := filterAWSRuntimeEventRecords(signalResult.Records, request)
-	signalEvidenceInScope := awsRuntimeSignalEvidenceInScope(request) || len(filtered) > 0
 	base.Records = append(base.Records, filtered...)
 	base.Relationships = awsRuntimeEventRelationships(base.Records)
-	if signalEvidenceInScope {
+	if signalEvidenceInScope || len(filtered) > 0 {
 		base.Diagnostics = append(base.Diagnostics, signalResult.Diagnostics...)
 		base.CoverageGaps = append(base.CoverageGaps, signalResult.CoverageGaps...)
 		base.FailureReasons = dedupeStrings(append(base.FailureReasons, signalResult.FailureReasons...))
 		base.RemediationHints = dedupeStrings(append(base.RemediationHints, signalResult.RemediationHints...))
 		base.EvidenceLinks = dedupeStrings(append(base.EvidenceLinks, "/docs/aws-runtime-events#iam-last-used-and-access-analyzer-signals-1517"))
-		base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, signalResult.Records, len(filtered), len(base.Relationships), base.Records)
+		base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, summaryRecords, len(filtered), len(base.Relationships), base.Records)
 	}
 	if wasEmptyFilterResult && len(filtered) > 0 {
 		base.FailureReasons = removeRuntimeEventEmptyFilterFailures(base.FailureReasons)
@@ -1062,7 +1070,7 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 			base.Confidence = 0.92
 		}
 	}
-	if signalEvidenceInScope && signalResult.Status == "blocked" {
+	if signalResult.Status == "blocked" {
 		if len(base.Records) == 0 {
 			base.Status = "blocked"
 			base.Confidence = 0
@@ -1080,7 +1088,7 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 		if base.Confidence == 0 || base.Confidence > 0.72 {
 			base.Confidence = 0.72
 		}
-	} else if signalEvidenceInScope && signalResult.Status == "degraded" && base.Status == "ready" {
+	} else if signalResult.Status == "degraded" && base.Status == "ready" {
 		base.Status = "degraded"
 		base.FixtureState = "degraded"
 		if base.Confidence > 0.78 {
@@ -1090,21 +1098,153 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 	return base, nil
 }
 
-func awsRuntimeSignalEvidenceInScope(request AWSRuntimeEventRequest) bool {
-	eventType := normalizeAWSRuntimeEventFilterToken(request.EventType)
-	switch eventType {
-	case "", "all", "iam-last-used", "access-analyzer":
-	default:
-		return false
+func awsRuntimeRequestedSignalCategory(request AWSRuntimeEventRequest) (string, bool) {
+	category := ""
+	for _, token := range []string{
+		normalizeAWSRuntimeEventFilterToken(request.EventType),
+		normalizeAWSRuntimeEventFilterToken(request.Evidence),
+	} {
+		switch token {
+		case "", "all":
+			continue
+		case "iam-last-used", "access-analyzer":
+			if category != "" && category != token {
+				return "", false
+			}
+			category = token
+		default:
+			return "", false
+		}
+	}
+	return category, true
+}
+
+func scopeAWSRuntimeSignalResult(result AWSRuntimeSignalIngestResult, category string) (AWSRuntimeSignalIngestResult, []AWSRuntimeEventRecord) {
+	category = normalizeAWSRuntimeEventFilterToken(category)
+	if category == "" || category == "all" {
+		return result, result.Records
 	}
 
-	evidence := normalizeAWSRuntimeEventFilterToken(request.Evidence)
-	switch evidence {
-	case "", "all", "iam-last-used", "access-analyzer":
+	scoped := AWSRuntimeSignalIngestResult{
+		Status:  "ready",
+		Records: filterAWSRuntimeSignalRecordsByCategory(result.Records, category),
+	}
+	scoped.Diagnostics = filterAWSRuntimeSignalDiagnosticsByCategory(result.Diagnostics, category)
+	scoped.CoverageGaps = filterAWSRuntimeSignalCoverageGapsByCategory(result.CoverageGaps, category)
+	if len(scoped.Diagnostics) > 0 || len(scoped.CoverageGaps) > 0 {
+		scoped.Status = "degraded"
+		scoped.FailureReasons = []string{awsRuntimeSignalScopedFailureReason(category)}
+		scoped.RemediationHints = []string{awsRuntimeSignalScopedRemediation(category)}
+		if len(scoped.Records) == 0 && awsRuntimeSignalCoverageGapsPermissionDenied(scoped.CoverageGaps) {
+			scoped.Status = "blocked"
+			scoped.FailureReasons = []string{awsRuntimeSignalScopedPermissionReason(category)}
+		}
+	}
+	return scoped, scoped.Records
+}
+
+func filterAWSRuntimeSignalRecordsByCategory(records []AWSRuntimeEventRecord, category string) []AWSRuntimeEventRecord {
+	out := make([]AWSRuntimeEventRecord, 0, len(records))
+	for _, record := range records {
+		if awsRuntimeSignalRecordCategory(record) == category {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+func filterAWSRuntimeSignalDiagnosticsByCategory(diagnostics []AWSRuntimeEventDiagnostic, category string) []AWSRuntimeEventDiagnostic {
+	out := make([]AWSRuntimeEventDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if awsRuntimeSignalDiagnosticMatchesCategory(diagnostic, category) {
+			out = append(out, diagnostic)
+		}
+	}
+	return out
+}
+
+func filterAWSRuntimeSignalCoverageGapsByCategory(gaps []AWSRuntimeEventCoverageGap, category string) []AWSRuntimeEventCoverageGap {
+	out := make([]AWSRuntimeEventCoverageGap, 0, len(gaps))
+	for _, gap := range gaps {
+		if awsRuntimeSignalCoverageGapMatchesCategory(gap, category) {
+			out = append(out, gap)
+		}
+	}
+	return out
+}
+
+func awsRuntimeSignalRecordCategory(record AWSRuntimeEventRecord) string {
+	return normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.SignalCategory, record.EventType, record.EvidenceCategory))
+}
+
+func awsRuntimeSignalDiagnosticMatchesCategory(diagnostic AWSRuntimeEventDiagnostic, category string) bool {
+	sourceID := normalizeAWSRuntimeEventFilterToken(diagnostic.SourceID)
+	code := normalizeAWSRuntimeEventFilterToken(diagnostic.Code)
+	switch category {
+	case "iam-last-used":
+		return sourceID == "iam" || strings.HasPrefix(sourceID, "iam-") || strings.HasPrefix(sourceID, "iam:") || strings.Contains(code, "iam-last-used")
+	case "access-analyzer":
+		return sourceID == "access-analyzer" || strings.HasPrefix(sourceID, "access-analyzer-") || strings.HasPrefix(sourceID, "access-analyzer:") || strings.Contains(code, "access-analyzer")
 	default:
+		return true
+	}
+}
+
+func awsRuntimeSignalCoverageGapMatchesCategory(gap AWSRuntimeEventCoverageGap, category string) bool {
+	capability := normalizeAWSRuntimeEventFilterToken(gap.Capability)
+	switch category {
+	case "iam-last-used":
+		return capability == "iam-last-used"
+	case "access-analyzer":
+		return capability == "access-analyzer"
+	default:
+		return true
+	}
+}
+
+func awsRuntimeSignalCoverageGapsPermissionDenied(gaps []AWSRuntimeEventCoverageGap) bool {
+	if len(gaps) == 0 {
 		return false
 	}
+	for _, gap := range gaps {
+		if normalizeAWSRuntimeEventFilterToken(gap.Status) != "permission-denied" {
+			return false
+		}
+	}
 	return true
+}
+
+func awsRuntimeSignalScopedFailureReason(category string) string {
+	switch category {
+	case "iam-last-used":
+		return "IAM last-used signal coverage is incomplete"
+	case "access-analyzer":
+		return "Access Analyzer signal coverage is incomplete"
+	default:
+		return "IAM last-used and Access Analyzer signal coverage is incomplete"
+	}
+}
+
+func awsRuntimeSignalScopedPermissionReason(category string) string {
+	switch category {
+	case "iam-last-used":
+		return "IAM last-used signal permissions are unavailable"
+	case "access-analyzer":
+		return "Access Analyzer signal permissions are unavailable"
+	default:
+		return "IAM last-used and Access Analyzer permissions are unavailable"
+	}
+}
+
+func awsRuntimeSignalScopedRemediation(category string) string {
+	switch category {
+	case "iam-last-used":
+		return "Grant metadata-only iam:ListRoles, iam:GenerateServiceLastAccessedDetails, and iam:GetServiceLastAccessedDetails."
+	case "access-analyzer":
+		return "Grant metadata-only access-analyzer:ListAnalyzers and access-analyzer:ListFindings."
+	default:
+		return "Grant metadata-only IAM Access Advisor and Access Analyzer permissions."
+	}
 }
 
 func awsRuntimeEventIsEmptyFilterResult(result AWSRuntimeEventResult) bool {

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -800,7 +800,14 @@ func awsRuntimeEventSkipsObservedActionEdge(record AWSRuntimeEventRecord) bool {
 	if category == "access-analyzer" {
 		return true
 	}
-	return category == "iam-last-used" && normalizeAWSRuntimeEventFilterToken(record.SignalScope) == "role"
+	if category != "iam-last-used" {
+		return false
+	}
+	scope := normalizeAWSRuntimeEventFilterToken(record.SignalScope)
+	if scope == "role" {
+		return true
+	}
+	return scope == "service" && normalizeAWSRuntimeEventFilterToken(record.EventName) == "serviceneveraccessed"
 }
 
 func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState string, checkedAt time.Time) ([]AWSRuntimeEventRecord, []AWSRuntimeEventDiagnostic, []AWSRuntimeEventCoverageGap) {

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1067,6 +1067,12 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 				base.Confidence = 0.72
 			}
 		}
+	} else if base.Status == "blocked" && len(filtered) > 0 {
+		base.Status = "degraded"
+		base.FixtureState = "partial_failure"
+		if base.Confidence == 0 || base.Confidence > 0.72 {
+			base.Confidence = 0.72
+		}
 	} else if signalResult.Status == "degraded" && base.Status == "ready" {
 		base.Status = "degraded"
 		base.FixtureState = "degraded"

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -1042,14 +1042,17 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 	}
 	wasEmptyFilterResult := awsRuntimeEventIsEmptyFilterResult(base)
 	filtered, _ := filterAWSRuntimeEventRecords(signalResult.Records, request)
+	signalEvidenceInScope := awsRuntimeSignalEvidenceInScope(request) || len(filtered) > 0
 	base.Records = append(base.Records, filtered...)
 	base.Relationships = awsRuntimeEventRelationships(base.Records)
-	base.Diagnostics = append(base.Diagnostics, signalResult.Diagnostics...)
-	base.CoverageGaps = append(base.CoverageGaps, signalResult.CoverageGaps...)
-	base.FailureReasons = dedupeStrings(append(base.FailureReasons, signalResult.FailureReasons...))
-	base.RemediationHints = dedupeStrings(append(base.RemediationHints, signalResult.RemediationHints...))
-	base.EvidenceLinks = dedupeStrings(append(base.EvidenceLinks, "/docs/aws-runtime-events#iam-last-used-and-access-analyzer-signals-1517"))
-	base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, signalResult.Records, len(filtered), len(base.Relationships), base.Records)
+	if signalEvidenceInScope {
+		base.Diagnostics = append(base.Diagnostics, signalResult.Diagnostics...)
+		base.CoverageGaps = append(base.CoverageGaps, signalResult.CoverageGaps...)
+		base.FailureReasons = dedupeStrings(append(base.FailureReasons, signalResult.FailureReasons...))
+		base.RemediationHints = dedupeStrings(append(base.RemediationHints, signalResult.RemediationHints...))
+		base.EvidenceLinks = dedupeStrings(append(base.EvidenceLinks, "/docs/aws-runtime-events#iam-last-used-and-access-analyzer-signals-1517"))
+		base.Summary = mergeAWSRuntimeEventSummaries(base.Summary, signalResult.Records, len(filtered), len(base.Relationships), base.Records)
+	}
 	if wasEmptyFilterResult && len(filtered) > 0 {
 		base.FailureReasons = removeRuntimeEventEmptyFilterFailures(base.FailureReasons)
 		base.RemediationHints = removeRuntimeEventEmptyFilterRemediations(base.RemediationHints)
@@ -1059,7 +1062,7 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 			base.Confidence = 0.92
 		}
 	}
-	if signalResult.Status == "blocked" {
+	if signalEvidenceInScope && signalResult.Status == "blocked" {
 		if len(base.Records) == 0 {
 			base.Status = "blocked"
 			base.Confidence = 0
@@ -1077,7 +1080,7 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 		if base.Confidence == 0 || base.Confidence > 0.72 {
 			base.Confidence = 0.72
 		}
-	} else if signalResult.Status == "degraded" && base.Status == "ready" {
+	} else if signalEvidenceInScope && signalResult.Status == "degraded" && base.Status == "ready" {
 		base.Status = "degraded"
 		base.FixtureState = "degraded"
 		if base.Confidence > 0.78 {
@@ -1085,6 +1088,23 @@ func (s *Service) appendAWSRuntimeSignals(ctx context.Context, scope db.Scope, p
 		}
 	}
 	return base, nil
+}
+
+func awsRuntimeSignalEvidenceInScope(request AWSRuntimeEventRequest) bool {
+	eventType := normalizeAWSRuntimeEventFilterToken(request.EventType)
+	switch eventType {
+	case "", "all", "iam-last-used", "access-analyzer":
+	default:
+		return false
+	}
+
+	evidence := normalizeAWSRuntimeEventFilterToken(request.Evidence)
+	switch evidence {
+	case "", "all", "iam-last-used", "access-analyzer":
+	default:
+		return false
+	}
+	return true
 }
 
 func awsRuntimeEventIsEmptyFilterResult(result AWSRuntimeEventResult) bool {

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -186,6 +186,34 @@ func TestGetAWSRuntimeEventsAppliesFiltersAndRelationships(t *testing.T) {
 	}
 }
 
+func TestAWSRuntimeEventRelationshipsSkipAnalyzerFindings(t *testing.T) {
+	relationships := awsRuntimeEventRelationships([]AWSRuntimeEventRecord{
+		{
+			EventType:           "access-analyzer",
+			SignalCategory:      "access-analyzer",
+			ActorIdentityNodeID: "aws:identity:external:210987654321",
+			ResourceNodeID:      "aws:runtime-resource:secret:prod-payments",
+			EvidenceRef:         "runtime-evidence://123456789012/us-east-1/access-analyzer:finding-1",
+		},
+	})
+	if len(relationships) != 0 {
+		t.Fatalf("Access Analyzer exposure metadata must not produce runtime action edges, got %+v", relationships)
+	}
+
+	relationships = awsRuntimeEventRelationships([]AWSRuntimeEventRecord{
+		{
+			EventType:           "iam-last-used",
+			SignalCategory:      "iam-last-used",
+			ActorIdentityNodeID: "aws:identity:role:payments-worker",
+			ResourceNodeID:      "aws:runtime-resource:service:s3",
+			EvidenceRef:         "runtime-evidence://123456789012/us-east-1/iam-service-last-used:s3",
+		},
+	})
+	if len(relationships) != 1 || relationships[0].Type != "observed_runtime_action" {
+		t.Fatalf("non-analyzer runtime signals should keep observed action edges, got %+v", relationships)
+	}
+}
+
 func TestFilterAWSRuntimeEventRecordsMatchesRegionCaseInsensitive(t *testing.T) {
 	records := []AWSRuntimeEventRecord{{
 		EventID:   "evt-region",

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -26,14 +26,17 @@ func TestGetAWSRuntimeEventsBuildsMetadataOnlyContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get runtime events: %v", err)
 	}
-	if result.CurrentIssueRef != "#1516" || result.Version != awsRuntimeEventsVersion || result.Status != "ready" {
+	if result.CurrentIssueRef != "#1517" || result.Version != awsRuntimeEventsVersion || result.Status != "ready" {
 		t.Fatalf("unexpected runtime event contract metadata: %+v", result)
 	}
-	if result.Summary.TotalEvents != 5 || result.Summary.FilteredEvents != 5 || result.Summary.RelationshipCount != len(result.Relationships) {
+	if result.Summary.TotalEvents != 7 || result.Summary.FilteredEvents != 7 || result.Summary.RelationshipCount != len(result.Relationships) {
 		t.Fatalf("unexpected runtime event summary: %+v relationships=%d", result.Summary, len(result.Relationships))
 	}
-	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 {
+	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 || result.Summary.IAMLastUsedSignalCount != 1 || result.Summary.AccessAnalyzerCount != 1 {
 		t.Fatalf("expected runtime event type counts, got %+v", result.Summary)
+	}
+	if result.Summary.DormantAccessCount != 1 {
+		t.Fatalf("expected dormant access count from stale IAM last-used signal, got %+v", result.Summary)
 	}
 	if result.Summary.LineageResolvedCount == 0 || result.Summary.MissingSourceIDCount == 0 {
 		t.Fatalf("expected explicit STS lineage summary counts, got %+v", result.Summary)
@@ -42,12 +45,78 @@ func TestGetAWSRuntimeEventsBuildsMetadataOnlyContract(t *testing.T) {
 		if record.RedactionBoundary != "metadata_only_no_payloads_no_secret_values" {
 			t.Fatalf("runtime event leaked unsafe redaction boundary: %+v", record)
 		}
-		if record.EvidenceRef == "" || record.ActorIdentityNodeID == "" || record.Session.SessionID == "" || record.Confidence <= 0 {
-			t.Fatalf("runtime event missing evidence/session/identity/confidence: %+v", record)
+		if record.EvidenceRef == "" || record.ActorIdentityNodeID == "" || record.Confidence <= 0 {
+			t.Fatalf("runtime event missing evidence/identity/confidence: %+v", record)
+		}
+		if record.SignalCategory == "" && record.Session.SessionID == "" {
+			t.Fatalf("non-signal runtime event missing session metadata: %+v", record)
+		}
+		if record.SignalCategory != "" && (record.SignalStaleAt.IsZero() || record.SignalScope == "") {
+			t.Fatalf("signal runtime event missing stale timestamp or scope: %+v", record)
 		}
 	}
 	if len(result.EvidenceLinks) == 0 || len(result.FailureReasons) != 0 {
 		t.Fatalf("expected evidence links and no failure reasons, got links=%v failures=%v", result.EvidenceLinks, result.FailureReasons)
+	}
+}
+
+func TestGetAWSRuntimeEventsFiltersIAMAccessSignals(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 18, 35, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-signals")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-signals", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	for _, tc := range []struct {
+		name          string
+		eventType     string
+		evidence      string
+		wantSignal    string
+		wantAnalyzer  bool
+		wantEventType string
+	}{
+		{
+			name:          "iam last-used",
+			eventType:     "iam-last-used",
+			evidence:      "iam-last-used",
+			wantSignal:    "iam-last-used",
+			wantEventType: "iam-last-used",
+		},
+		{
+			name:          "access analyzer",
+			eventType:     "access-analyzer",
+			evidence:      "access-analyzer",
+			wantSignal:    "access-analyzer",
+			wantAnalyzer:  true,
+			wantEventType: "access-analyzer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-signals", AWSRuntimeEventRequest{
+				ConnectorID: "aws-prod",
+				EventType:   tc.eventType,
+				Evidence:    tc.evidence,
+			})
+			if err != nil {
+				t.Fatalf("get filtered signal runtime events: %v", err)
+			}
+			if result.Summary.TotalEvents != 7 || result.Summary.FilteredEvents != 1 || len(result.Records) != 1 {
+				t.Fatalf("expected one filtered signal with retained total count, got summary=%+v records=%+v", result.Summary, result.Records)
+			}
+			record := result.Records[0]
+			if record.EventType != tc.wantEventType || record.SignalCategory != tc.wantSignal || record.EvidenceCategory != tc.evidence {
+				t.Fatalf("expected filtered signal metadata, got %+v", record)
+			}
+			if record.SignalStaleAt.IsZero() || record.SignalScope == "" {
+				t.Fatalf("expected signal stale timestamp and scope, got %+v", record)
+			}
+			if tc.wantAnalyzer && record.AnalyzerARN == "" {
+				t.Fatalf("expected analyzer ARN, got %+v", record)
+			}
+		})
 	}
 }
 

--- a/internal/api/aws_runtime_signals.go
+++ b/internal/api/aws_runtime_signals.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/awssignals"
+)
+
+type AWSRuntimeSignalIngestRequest struct {
+	AccountID   string
+	Region      string
+	CollectedAt time.Time
+}
+
+type AWSRuntimeSignalIngestResult struct {
+	Records          []AWSRuntimeEventRecord
+	Diagnostics      []AWSRuntimeEventDiagnostic
+	CoverageGaps     []AWSRuntimeEventCoverageGap
+	Status           string
+	FailureReasons   []string
+	RemediationHints []string
+}
+
+type AWSRuntimeSignalIngester interface {
+	Ingest(context.Context, AWSRuntimeSignalIngestRequest) (AWSRuntimeSignalIngestResult, error)
+}
+
+type runtimeSignalIngesterAdapter struct {
+	ingester *awssignals.Ingester
+}
+
+func NewAWSRuntimeSignalIngester(ingester *awssignals.Ingester) AWSRuntimeSignalIngester {
+	if ingester == nil {
+		return nil
+	}
+	return &runtimeSignalIngesterAdapter{ingester: ingester}
+}
+
+func (a *runtimeSignalIngesterAdapter) Ingest(ctx context.Context, request AWSRuntimeSignalIngestRequest) (AWSRuntimeSignalIngestResult, error) {
+	engineResult, err := a.ingester.Ingest(ctx, awssignals.IngestRequest{
+		AccountID:   request.AccountID,
+		Region:      request.Region,
+		CollectedAt: request.CollectedAt,
+	})
+	if err != nil {
+		return AWSRuntimeSignalIngestResult{}, err
+	}
+	result := AWSRuntimeSignalIngestResult{
+		Status:           engineResult.Status,
+		FailureReasons:   append([]string{}, engineResult.FailureReasons...),
+		RemediationHints: append([]string{}, engineResult.RemediationHints...),
+	}
+	for _, signal := range engineResult.Signals {
+		result.Records = append(result.Records, runtimeEventRecordFromSignal(signal, request.AccountID, request.Region))
+	}
+	for _, diag := range engineResult.Diagnostics {
+		result.Diagnostics = append(result.Diagnostics, AWSRuntimeEventDiagnostic{
+			Collector:   awssignals.CollectorName,
+			SourceID:    diag.SourceID,
+			Code:        diag.Code,
+			Message:     diag.Message,
+			Remediation: diag.Remediation,
+			Retryable:   diag.Retryable,
+		})
+	}
+	for _, gap := range engineResult.CoverageGaps {
+		result.CoverageGaps = append(result.CoverageGaps, AWSRuntimeEventCoverageGap{
+			Capability:  gap.Capability,
+			Status:      gap.Status,
+			Reason:      gap.Reason,
+			Remediation: gap.Remediation,
+		})
+	}
+	return result, nil
+}
+
+func runtimeEventRecordFromSignal(signal awssignals.Signal, fallbackAccount string, fallbackRegion string) AWSRuntimeEventRecord {
+	accountID := firstNonEmptyAWSValue(signal.AccountID, fallbackAccount)
+	region := firstNonEmptyAWSValue(signal.Region, fallbackRegion, "global")
+	eventType := normalizeSignalCategory(signal.Category)
+	actorARN := strings.TrimSpace(signal.ActorPrincipalARN)
+	if actorARN == "" {
+		actorARN = "aws:unknown-principal"
+	}
+	resourceName := firstNonEmptyAWSValue(signal.TargetResourceName, displayNameFromARN(signal.TargetResourceARN), signal.TargetResourceType)
+	status := firstNonEmptyAWSValue(signal.Status, "observed")
+	confidence := signal.Confidence
+	if confidence <= 0 {
+		confidence = 0.75
+	}
+	observedAt := signal.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = signal.CollectedAt
+	}
+	collectedAt := signal.CollectedAt
+	if collectedAt.IsZero() {
+		collectedAt = observedAt
+	}
+	return AWSRuntimeEventRecord{
+		EventID:             firstNonEmptyAWSValue(signal.EventID, fmt.Sprintf("%s:%s", eventType, signal.TargetResourceARN)),
+		AccountID:           accountID,
+		Region:              region,
+		EventType:           eventType,
+		EventSource:         firstNonEmptyAWSValue(signal.EventSource, "aws-signals"),
+		EventName:           firstNonEmptyAWSValue(signal.EventName, eventType),
+		Action:              firstNonEmptyAWSValue(signal.Action, eventType),
+		ActorPrincipalARN:   actorARN,
+		ActorPrincipalType:  firstNonEmptyAWSValue(signal.ActorPrincipalType, "aws_principal"),
+		ActorIdentityNodeID: awsIdentityNodeIDForAPI(actorARN),
+		Session: AWSRuntimeEventSession{
+			SessionID:     "",
+			PrincipalARN:  actorARN,
+			PrincipalType: firstNonEmptyAWSValue(signal.ActorPrincipalType, "aws_principal"),
+		},
+		TargetResourceARN:  signal.TargetResourceARN,
+		TargetResourceType: signal.TargetResourceType,
+		TargetResourceName: resourceName,
+		ResourceNodeID:     awsRuntimeEventResourceNodeID(signal.TargetResourceARN, signal.TargetResourceType),
+		SignalCategory:     eventType,
+		SignalScope:        signal.Scope,
+		AnalyzerARN:        signal.AnalyzerARN,
+		SignalStaleAt:      signal.StaleAt,
+		Owner:              signalOwner(eventType, status),
+		EvidenceCategory:   eventType,
+		EvidenceRef:        fmt.Sprintf("runtime-evidence://%s/%s/%s", accountID, region, firstNonEmptyAWSValue(signal.EventID, eventType)),
+		Confidence:         confidence,
+		ObservedAt:         observedAt,
+		CollectedAt:        collectedAt,
+		Status:             status,
+		NextAction:         awsRuntimeEventNextAction(eventType),
+		RedactionBoundary:  awssignals.RedactionBoundary,
+	}
+}
+
+func normalizeSignalCategory(category string) string {
+	switch strings.ToLower(strings.TrimSpace(category)) {
+	case "iam-last-used", "iam_last_used":
+		return "iam-last-used"
+	case "access-analyzer", "access_analyzer":
+		return "access-analyzer"
+	default:
+		return normalizeAWSRuntimeEventFilterToken(category)
+	}
+}
+
+func signalOwner(eventType string, status string) string {
+	if eventType == "access-analyzer" {
+		return "security"
+	}
+	if status == "stale" {
+		return "platform"
+	}
+	return "security"
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -163,6 +163,10 @@ const (
 // the runtime-events handler then skips that source for the request.
 type AWSCloudTrailDeliveryIngesterFactory func(ctx context.Context, connection AWSConnectionStatus, source AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error)
 
+// AWSRuntimeSignalFactory builds an IAM last-used / Access Analyzer
+// ingester bound to one persisted AWS connector.
+type AWSRuntimeSignalFactory func(ctx context.Context, connection AWSConnectionStatus) (AWSRuntimeSignalIngester, error)
+
 type queuedScanDepthCounter interface {
 	CountQueuedScansAnyScope(ctx context.Context, provider string) (int, error)
 }
@@ -203,6 +207,7 @@ type Service struct {
 	AWSScannerFactory                  AWSScannerFactory
 	AWSCloudTrailLookupEventsFactory   AWSCloudTrailLookupEventsFactory
 	AWSCloudTrailDeliveryFactory       AWSCloudTrailDeliveryIngesterFactory
+	AWSRuntimeSignalFactory            AWSRuntimeSignalFactory
 	AWSCloudFormationTemplateURL       string
 	AWSAccountID                       string
 	AWSBaselineGitSHA                  string

--- a/internal/connectors/aws/capabilities.go
+++ b/internal/connectors/aws/capabilities.go
@@ -40,7 +40,7 @@ func CapabilityPermissionTiers() []CapabilityPermissionTier {
 			Permissions: []PermissionPreviewItem{
 				{
 					Service:   "IAM",
-					Actions:   []string{"iam:GenerateServiceLastAccessedDetails", "iam:GetServiceLastAccessedDetails"},
+					Actions:   []string{"iam:ListRoles", "iam:GenerateServiceLastAccessedDetails", "iam:GetServiceLastAccessedDetails"},
 					Resources: []string{"*"},
 					Reason:    "Confirms which services a machine identity has actually used so unused high-risk permissions can be flagged.",
 				},

--- a/internal/connectors/aws/capabilities.go
+++ b/internal/connectors/aws/capabilities.go
@@ -52,7 +52,7 @@ func CapabilityPermissionTiers() []CapabilityPermissionTier {
 				},
 				{
 					Service:   "AccessAnalyzer",
-					Actions:   []string{"access-analyzer:ListFindings", "access-analyzer:GetFinding"},
+					Actions:   []string{"access-analyzer:ListAnalyzers", "access-analyzer:ListFindings", "access-analyzer:GetFinding"},
 					Resources: []string{"*"},
 					Reason:    "Reads external-access findings that indicate runtime exposure of an identity.",
 				},

--- a/internal/connectors/aws/capabilities_test.go
+++ b/internal/connectors/aws/capabilities_test.go
@@ -51,6 +51,30 @@ func TestDiscoveryTierMatchesReadOnlyPreview(t *testing.T) {
 	}
 }
 
+func TestRuntimeEvidenceTierIncludesAccessAnalyzerCollectionGrant(t *testing.T) {
+	var actions []string
+	for _, tier := range CapabilityPermissionTiers() {
+		if tier.Capability != domain.ConnectorCapabilityRuntimeEvidence {
+			continue
+		}
+		for _, permission := range tier.Permissions {
+			if permission.Service == "AccessAnalyzer" {
+				actions = permission.Actions
+				break
+			}
+		}
+		break
+	}
+	if len(actions) == 0 {
+		t.Fatal("runtime_evidence must advertise Access Analyzer permissions")
+	}
+	for _, want := range []string{"access-analyzer:ListAnalyzers", "access-analyzer:ListFindings"} {
+		if !containsString(actions, want) {
+			t.Fatalf("runtime_evidence Access Analyzer actions = %v, want %q", actions, want)
+		}
+	}
+}
+
 func TestDefaultCapabilityPolicyAllowsOnlyDiscovery(t *testing.T) {
 	policy := DefaultCapabilityPolicy()
 	if allowed, _ := policy.CapabilityAllowed(domain.ConnectorCapabilityDiscovery); !allowed {
@@ -68,6 +92,15 @@ func TestDefaultCapabilityPolicyAllowsOnlyDiscovery(t *testing.T) {
 			t.Fatalf("capability %q denial must include a reason", capability)
 		}
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestNewCapabilityPolicyEnablesReadOnlyTierButGatesWrite(t *testing.T) {

--- a/internal/connectors/aws/capabilities_test.go
+++ b/internal/connectors/aws/capabilities_test.go
@@ -75,6 +75,30 @@ func TestRuntimeEvidenceTierIncludesAccessAnalyzerCollectionGrant(t *testing.T) 
 	}
 }
 
+func TestRuntimeEvidenceTierIncludesIAMCollectionGrant(t *testing.T) {
+	var actions []string
+	for _, tier := range CapabilityPermissionTiers() {
+		if tier.Capability != domain.ConnectorCapabilityRuntimeEvidence {
+			continue
+		}
+		for _, permission := range tier.Permissions {
+			if permission.Service == "IAM" {
+				actions = permission.Actions
+				break
+			}
+		}
+		break
+	}
+	if len(actions) == 0 {
+		t.Fatal("runtime_evidence must advertise IAM permissions")
+	}
+	for _, want := range []string{"iam:ListRoles", "iam:GenerateServiceLastAccessedDetails", "iam:GetServiceLastAccessedDetails"} {
+		if !containsString(actions, want) {
+			t.Fatalf("runtime_evidence IAM actions = %v, want %q", actions, want)
+		}
+	}
+}
+
 func TestDefaultCapabilityPolicyAllowsOnlyDiscovery(t *testing.T) {
 	policy := DefaultCapabilityPolicy()
 	if allowed, _ := policy.CapabilityAllowed(domain.ConnectorCapabilityDiscovery); !allowed {

--- a/internal/runtime/awssignals/sdk.go
+++ b/internal/runtime/awssignals/sdk.go
@@ -1,0 +1,52 @@
+package awssignals
+
+import (
+	"context"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+func NewSDKClientsFromAssumeRole(ctx context.Context, region string, profile string, roleARN string, externalID string, sessionName string) (IAMAPI, AccessAnalyzerAPI, error) {
+	loadOptions := []func(*awsconfig.LoadOptions) error{}
+	if strings.TrimSpace(region) != "" {
+		loadOptions = append(loadOptions, awsconfig.WithRegion(strings.TrimSpace(region)))
+	}
+	if strings.TrimSpace(profile) != "" {
+		loadOptions = append(loadOptions, awsconfig.WithSharedConfigProfile(strings.TrimSpace(profile)))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+	if err != nil {
+		return nil, nil, err
+	}
+	if strings.TrimSpace(roleARN) != "" {
+		name := strings.TrimSpace(sessionName)
+		if name == "" {
+			name = "identrail-iam-access-signals"
+		}
+		options := []func(*stscreds.AssumeRoleOptions){
+			func(options *stscreds.AssumeRoleOptions) { options.RoleSessionName = name },
+		}
+		if strings.TrimSpace(externalID) != "" {
+			options = append(options, func(options *stscreds.AssumeRoleOptions) {
+				options.ExternalID = awsv2.String(strings.TrimSpace(externalID))
+			})
+		}
+		cfg.Credentials = awsv2.NewCredentialsCache(stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), strings.TrimSpace(roleARN), options...))
+	}
+	return iam.NewFromConfig(cfg), accessanalyzer.NewFromConfig(cfg), nil
+}
+
+func NewSDKClientsFromStaticCredentials(region string, accessKeyID string, secretAccessKey string, sessionToken string) (IAMAPI, AccessAnalyzerAPI) {
+	cfg := awsv2.Config{
+		Region:      strings.TrimSpace(region),
+		Credentials: credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken),
+	}
+	return iam.NewFromConfig(cfg), accessanalyzer.NewFromConfig(cfg)
+}

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -263,6 +263,15 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 				StaleAt:            request.CollectedAt,
 			})
 		} else {
+			status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
+			confidence := 0.52
+			observedAt := request.CollectedAt
+			if role.CreateDate != nil {
+				observedAt = role.CreateDate.UTC()
+			}
+			if status == "stale" {
+				confidence = 0.68
+			}
 			signals = append(signals, Signal{
 				EventID:            "iam-role-never-used:" + sanitizeToken(roleARN),
 				AccountID:          request.AccountID,
@@ -277,9 +286,9 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 				TargetResourceARN:  roleARN,
 				TargetResourceType: "iam_role",
 				TargetResourceName: roleName,
-				Status:             "stale",
-				Confidence:         0.68,
-				ObservedAt:         request.CollectedAt,
+				Status:             status,
+				Confidence:         confidence,
+				ObservedAt:         observedAt,
 				CollectedAt:        request.CollectedAt,
 				StaleAt:            request.CollectedAt,
 			})
@@ -432,6 +441,16 @@ func iamLastUsedStatus(observedAt time.Time, collectedAt time.Time) string {
 		return "stale"
 	}
 	return "observed"
+}
+
+func iamNeverUsedStatus(createdAt *time.Time, collectedAt time.Time) string {
+	if createdAt == nil || collectedAt.IsZero() {
+		return "unknown"
+	}
+	if collectedAt.Sub(createdAt.UTC()) >= dormantAccessAge {
+		return "stale"
+	}
+	return "unknown"
 }
 
 func serviceLastAccessedEventName(hasLastAuthenticated bool) string {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -2,6 +2,7 @@ package awssignals
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -135,7 +136,10 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 
 	result := IngestResult{Status: "ready"}
 	if i.IAM != nil {
-		signals, diagnostics, gaps := i.collectIAMLastUsed(ctx, request)
+		signals, diagnostics, gaps, err := i.collectIAMLastUsed(ctx, request)
+		if err != nil {
+			return IngestResult{}, err
+		}
 		result.Signals = append(result.Signals, signals...)
 		result.Diagnostics = append(result.Diagnostics, diagnostics...)
 		result.CoverageGaps = append(result.CoverageGaps, gaps...)
@@ -155,7 +159,10 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 		})
 	}
 	if i.AccessAnalyzer != nil {
-		signals, diagnostics, gaps := i.collectAccessAnalyzer(ctx, request)
+		signals, diagnostics, gaps, err := i.collectAccessAnalyzer(ctx, request)
+		if err != nil {
+			return IngestResult{}, err
+		}
 		result.Signals = append(result.Signals, signals...)
 		result.Diagnostics = append(result.Diagnostics, diagnostics...)
 		result.CoverageGaps = append(result.CoverageGaps, gaps...)
@@ -207,15 +214,18 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 	return result, nil
 }
 
-func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap) {
+func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap, error) {
 	out, err := i.IAM.ListRoles(ctx, &iam.ListRolesInput{MaxItems: awsv2.Int32(request.MaxRoles)})
 	if err != nil {
+		if isContextCancellation(err) {
+			return nil, nil, nil, err
+		}
 		return nil, []Diagnostic{permissionAwareDiagnostic("iam", "iam_last_used_permission_denied", "iam_last_used_failed", fmt.Sprintf("IAM role listing failed: %v", err), "Grant metadata-only iam:ListRoles and retry.", err)}, []CoverageGap{{
 			Capability:  "iam_last_used",
 			Status:      permissionAwareStatus(err),
 			Reason:      "IAM roles could not be listed for last-used collection.",
 			Remediation: "Grant iam:ListRoles plus service last-accessed read APIs.",
-		}}
+		}}, nil
 	}
 	signals := []Signal{}
 	diagnostics := []Diagnostic{}
@@ -279,11 +289,17 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			Granularity: iamtypes.AccessAdvisorUsageGranularityTypeServiceLevel,
 		})
 		if genErr != nil {
+			if isContextCancellation(genErr) {
+				return nil, nil, nil, genErr
+			}
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
 			continue
 		}
 		details, truncated, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
 		if getErr != nil {
+			if isContextCancellation(getErr) {
+				return nil, nil, nil, getErr
+			}
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
 			continue
 		}
@@ -364,7 +380,7 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			Remediation: "Rerun with a larger IAM last-used role budget or shard by path prefix.",
 		})
 	}
-	return signals, diagnostics, gaps
+	return signals, diagnostics, gaps, nil
 }
 
 func (i *Ingester) getServiceLastAccessedDetails(ctx context.Context, jobID *string, request IngestRequest) (*iam.GetServiceLastAccessedDetailsOutput, bool, error) {
@@ -439,15 +455,18 @@ func serviceLastAccessedAction(namespace string, hasLastAuthenticated bool) stri
 	return namespace + ":NeverAccessed"
 }
 
-func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap) {
+func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap, error) {
 	analyzers, err := i.AccessAnalyzer.ListAnalyzers(ctx, &accessanalyzer.ListAnalyzersInput{MaxResults: awsv2.Int32(request.MaxAnalyzers)})
 	if err != nil {
+		if isContextCancellation(err) {
+			return nil, nil, nil, err
+		}
 		return nil, []Diagnostic{permissionAwareDiagnostic("access-analyzer", "access_analyzer_permission_denied", "access_analyzer_list_failed", fmt.Sprintf("Access Analyzer analyzers could not be listed: %v", err), "Grant access-analyzer:ListAnalyzers and retry.", err)}, []CoverageGap{{
 			Capability:  "access_analyzer",
 			Status:      permissionAwareStatus(err),
 			Reason:      "Access Analyzer analyzers could not be listed.",
 			Remediation: "Grant access-analyzer:ListAnalyzers and access-analyzer:ListFindings.",
-		}}
+		}}, nil
 	}
 	signals := []Signal{}
 	diagnostics := []Diagnostic{}
@@ -459,7 +478,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 			Reason:      "Access Analyzer returned no analyzers for this account and region.",
 			Remediation: "Enable an account or organization analyzer before relying on external-access findings.",
 		})
-		return signals, diagnostics, gaps
+		return signals, diagnostics, gaps, nil
 	}
 	for idx, analyzer := range analyzers.Analyzers {
 		if int32(idx) >= request.MaxAnalyzers {
@@ -475,6 +494,9 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 			MaxResults:  awsv2.Int32(request.MaxFindings),
 		})
 		if findErr != nil {
+			if isContextCancellation(findErr) {
+				return nil, nil, nil, findErr
+			}
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("access-analyzer:"+analyzerName, "access_analyzer_permission_denied", "access_analyzer_findings_failed", fmt.Sprintf("Access Analyzer findings could not be listed for %s: %v", analyzerName, findErr), "Grant access-analyzer:ListFindings and retry.", findErr))
 			gaps = append(gaps, CoverageGap{
 				Capability:  "access_analyzer",
@@ -539,7 +561,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 			Remediation: "Rerun with a larger analyzer budget or shard by analyzer type.",
 		})
 	}
-	return signals, diagnostics, gaps
+	return signals, diagnostics, gaps, nil
 }
 
 func permissionAwareDiagnostic(sourceID string, permissionCode string, fallbackCode string, message string, remediation string, err error) Diagnostic {
@@ -563,6 +585,10 @@ func isPermissionDenied(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "accessdenied") || strings.Contains(msg, "access denied") || strings.Contains(msg, "unauthorized") || strings.Contains(msg, "not authorized")
+}
+
+func isContextCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func allSignalCollectorsPermissionDenied(gaps []CoverageGap) bool {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -38,6 +38,8 @@ type IngestRequest struct {
 	MaxServicesPerRole int32
 	MaxAnalyzers       int32
 	MaxFindings        int32
+	MaxReportPolls     int
+	ReportPollInterval time.Duration
 	CollectedAt        time.Time
 }
 
@@ -121,6 +123,14 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 	}
 	if request.MaxFindings <= 0 {
 		request.MaxFindings = 20
+	}
+	if request.MaxReportPolls <= 0 {
+		request.MaxReportPolls = 4
+	}
+	if request.ReportPollInterval == 0 {
+		request.ReportPollInterval = 100 * time.Millisecond
+	} else if request.ReportPollInterval < 0 {
+		request.ReportPollInterval = 0
 	}
 
 	result := IngestResult{Status: "ready"}
@@ -267,10 +277,7 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
 			continue
 		}
-		details, getErr := i.IAM.GetServiceLastAccessedDetails(ctx, &iam.GetServiceLastAccessedDetailsInput{
-			JobId:    job.JobId,
-			MaxItems: awsv2.Int32(request.MaxServicesPerRole),
-		})
+		details, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
 		if getErr != nil {
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
 			continue
@@ -345,6 +352,47 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 		})
 	}
 	return signals, diagnostics, gaps
+}
+
+func (i *Ingester) getServiceLastAccessedDetails(ctx context.Context, jobID *string, request IngestRequest) (*iam.GetServiceLastAccessedDetailsOutput, error) {
+	var details *iam.GetServiceLastAccessedDetailsOutput
+	for attempt := 0; attempt < request.MaxReportPolls; attempt++ {
+		out, err := i.IAM.GetServiceLastAccessedDetails(ctx, &iam.GetServiceLastAccessedDetailsInput{
+			JobId:    jobID,
+			MaxItems: awsv2.Int32(request.MaxServicesPerRole),
+		})
+		if err != nil {
+			return nil, err
+		}
+		details = out
+		if out.JobStatus == iamtypes.JobStatusTypeCompleted {
+			return out, nil
+		}
+		if attempt == request.MaxReportPolls-1 {
+			break
+		}
+		if err := waitForIAMReportPoll(ctx, request.ReportPollInterval); err != nil {
+			return nil, err
+		}
+	}
+	if details == nil {
+		details = &iam.GetServiceLastAccessedDetailsOutput{}
+	}
+	return details, nil
+}
+
+func waitForIAMReportPoll(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func iamLastUsedStatus(observedAt time.Time, collectedAt time.Time) string {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -349,14 +349,21 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			actor := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedEntity), roleARN)
 			region := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedRegion), request.Region)
 			lastAuthenticated := request.CollectedAt
-			status := "stale"
-			confidence := 0.64
+			status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
+			confidence := 0.52
 			if service.LastAuthenticated != nil {
 				lastAuthenticated = service.LastAuthenticated.UTC()
 				status = iamLastUsedStatus(lastAuthenticated, request.CollectedAt)
 				confidence = 0.86
 				if status == "stale" {
 					confidence = 0.78
+				}
+			} else {
+				if role.CreateDate != nil {
+					lastAuthenticated = role.CreateDate.UTC()
+				}
+				if status == "stale" {
+					confidence = 0.68
 				}
 			}
 			signals = append(signals, Signal{

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -476,6 +476,12 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 		})
 		if findErr != nil {
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("access-analyzer:"+analyzerName, "access_analyzer_permission_denied", "access_analyzer_findings_failed", fmt.Sprintf("Access Analyzer findings could not be listed for %s: %v", analyzerName, findErr), "Grant access-analyzer:ListFindings and retry.", findErr))
+			gaps = append(gaps, CoverageGap{
+				Capability:  "access_analyzer",
+				Status:      permissionAwareStatus(findErr),
+				Reason:      fmt.Sprintf("Access Analyzer findings could not be listed for %s.", analyzerName),
+				Remediation: "Grant access-analyzer:ListFindings for every analyzer used by runtime evidence collection.",
+			})
 			continue
 		}
 		for findingIdx, finding := range findings.Findings {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -521,9 +521,13 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 				staleAt = finding.AnalyzedAt.UTC()
 			}
 			resourceARN := awsv2.ToString(finding.Resource)
+			ownerAccount := strings.TrimSpace(awsv2.ToString(finding.ResourceOwnerAccount))
+			if ownerAccount != "" && request.AccountID != "" && ownerAccount != request.AccountID {
+				continue
+			}
 			signals = append(signals, Signal{
 				EventID:            "access-analyzer:" + sanitizeToken(firstNonEmpty(awsv2.ToString(finding.Id), resourceARN, analyzerARN)),
-				AccountID:          firstNonEmpty(awsv2.ToString(finding.ResourceOwnerAccount), request.AccountID),
+				AccountID:          firstNonEmpty(ownerAccount, request.AccountID),
 				Region:             request.Region,
 				Category:           "access-analyzer",
 				Scope:              strings.ToLower(strings.TrimSpace(string(analyzer.Type))),

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -1,0 +1,614 @@
+package awssignals
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	accessanalyzertypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+const (
+	CollectorName     = "aws_iam_access_signals"
+	RedactionBoundary = "metadata_only_no_payloads_no_secret_values"
+	dormantAccessAge  = 90 * 24 * time.Hour
+)
+
+type IAMAPI interface {
+	ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	GenerateServiceLastAccessedDetails(context.Context, *iam.GenerateServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GenerateServiceLastAccessedDetailsOutput, error)
+	GetServiceLastAccessedDetails(context.Context, *iam.GetServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GetServiceLastAccessedDetailsOutput, error)
+}
+
+type AccessAnalyzerAPI interface {
+	ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error)
+	ListFindings(context.Context, *accessanalyzer.ListFindingsInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsOutput, error)
+}
+
+type IngestRequest struct {
+	AccountID          string
+	Region             string
+	MaxRoles           int32
+	MaxServicesPerRole int32
+	MaxAnalyzers       int32
+	MaxFindings        int32
+	CollectedAt        time.Time
+}
+
+type IngestResult struct {
+	Signals          []Signal
+	Diagnostics      []Diagnostic
+	CoverageGaps     []CoverageGap
+	Status           string
+	FailureReasons   []string
+	RemediationHints []string
+}
+
+type Signal struct {
+	EventID            string
+	AccountID          string
+	Region             string
+	Category           string
+	Scope              string
+	EventSource        string
+	EventName          string
+	Action             string
+	ActorPrincipalARN  string
+	ActorPrincipalType string
+	TargetResourceARN  string
+	TargetResourceType string
+	TargetResourceName string
+	AnalyzerARN        string
+	AnalyzerName       string
+	Status             string
+	Confidence         float64
+	ObservedAt         time.Time
+	CollectedAt        time.Time
+	StaleAt            time.Time
+}
+
+type Diagnostic struct {
+	SourceID    string
+	Code        string
+	Message     string
+	Remediation string
+	Retryable   bool
+}
+
+type CoverageGap struct {
+	Capability  string
+	Status      string
+	Reason      string
+	Remediation string
+}
+
+type Ingester struct {
+	IAM            IAMAPI
+	AccessAnalyzer AccessAnalyzerAPI
+	Now            func() time.Time
+}
+
+func New(iamAPI IAMAPI, analyzerAPI AccessAnalyzerAPI) *Ingester {
+	return &Ingester{IAM: iamAPI, AccessAnalyzer: analyzerAPI}
+}
+
+func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestResult, error) {
+	now := request.CollectedAt
+	if now.IsZero() {
+		if i.Now != nil {
+			now = i.Now().UTC()
+		} else {
+			now = time.Now().UTC()
+		}
+	}
+	request.CollectedAt = now
+	request.AccountID = firstNonEmpty(request.AccountID, "unknown-account")
+	request.Region = firstNonEmpty(request.Region, "global")
+	if request.MaxRoles <= 0 {
+		request.MaxRoles = 8
+	}
+	if request.MaxServicesPerRole <= 0 {
+		request.MaxServicesPerRole = 8
+	}
+	if request.MaxAnalyzers <= 0 {
+		request.MaxAnalyzers = 4
+	}
+	if request.MaxFindings <= 0 {
+		request.MaxFindings = 20
+	}
+
+	result := IngestResult{Status: "ready"}
+	if i.IAM != nil {
+		signals, diagnostics, gaps := i.collectIAMLastUsed(ctx, request)
+		result.Signals = append(result.Signals, signals...)
+		result.Diagnostics = append(result.Diagnostics, diagnostics...)
+		result.CoverageGaps = append(result.CoverageGaps, gaps...)
+	} else {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			SourceID:    "iam",
+			Code:        "iam_last_used_source_unavailable",
+			Message:     "IAM last-used collection is not configured for this connector.",
+			Remediation: "Wire the IAM metadata API before relying on dormant-access signals.",
+			Retryable:   true,
+		})
+		result.CoverageGaps = append(result.CoverageGaps, CoverageGap{
+			Capability:  "iam_last_used",
+			Status:      "source_unavailable",
+			Reason:      "IAM last-used API client is not configured.",
+			Remediation: "Configure metadata-only iam:ListRoles and iam:GetServiceLastAccessedDetails access.",
+		})
+	}
+	if i.AccessAnalyzer != nil {
+		signals, diagnostics, gaps := i.collectAccessAnalyzer(ctx, request)
+		result.Signals = append(result.Signals, signals...)
+		result.Diagnostics = append(result.Diagnostics, diagnostics...)
+		result.CoverageGaps = append(result.CoverageGaps, gaps...)
+	} else {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			SourceID:    "access-analyzer",
+			Code:        "access_analyzer_source_unavailable",
+			Message:     "Access Analyzer collection is not configured for this connector.",
+			Remediation: "Wire the Access Analyzer API before relying on analyzer findings.",
+			Retryable:   true,
+		})
+		result.CoverageGaps = append(result.CoverageGaps, CoverageGap{
+			Capability:  "access_analyzer",
+			Status:      "source_unavailable",
+			Reason:      "Access Analyzer API client is not configured.",
+			Remediation: "Configure metadata-only access-analyzer:ListAnalyzers and access-analyzer:ListFindings access.",
+		})
+	}
+
+	sort.SliceStable(result.Signals, func(a, b int) bool {
+		return result.Signals[a].ObservedAt.After(result.Signals[b].ObservedAt)
+	})
+	if len(result.Signals) == 0 && len(result.Diagnostics) == 0 {
+		result.Status = "degraded"
+		result.FailureReasons = []string{"IAM last-used and Access Analyzer returned no signals"}
+		result.RemediationHints = []string{"Confirm IAM Access Advisor and Access Analyzer are enabled for the account and region."}
+		result.CoverageGaps = append(result.CoverageGaps, CoverageGap{
+			Capability:  "iam_access_signals",
+			Status:      "empty",
+			Reason:      "No IAM last-used or Access Analyzer records were available in the bounded scan.",
+			Remediation: "Confirm roles exist, Access Analyzer is enabled, and retry collection.",
+		})
+	}
+	if len(result.Diagnostics) > 0 && result.Status == "ready" {
+		result.Status = "degraded"
+		result.FailureReasons = dedupeStrings(append(result.FailureReasons, "IAM last-used or Access Analyzer returned diagnostics"))
+		result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Review signal diagnostics before using runtime evidence for least-privilege decisions."))
+	}
+	if len(result.Signals) == 0 && hasPermissionDeniedDiagnostic(result.Diagnostics) {
+		result.Status = "blocked"
+		result.FailureReasons = []string{"IAM last-used and Access Analyzer permissions are unavailable"}
+		result.RemediationHints = []string{"Grant metadata-only iam:ListRoles, iam:GenerateServiceLastAccessedDetails, iam:GetServiceLastAccessedDetails, access-analyzer:ListAnalyzers, and access-analyzer:ListFindings."}
+	}
+	return result, nil
+}
+
+func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap) {
+	out, err := i.IAM.ListRoles(ctx, &iam.ListRolesInput{MaxItems: awsv2.Int32(request.MaxRoles)})
+	if err != nil {
+		return nil, []Diagnostic{permissionAwareDiagnostic("iam", "iam_last_used_permission_denied", "iam_last_used_failed", fmt.Sprintf("IAM role listing failed: %v", err), "Grant metadata-only iam:ListRoles and retry.", err)}, []CoverageGap{{
+			Capability:  "iam_last_used",
+			Status:      permissionAwareStatus(err),
+			Reason:      "IAM roles could not be listed for last-used collection.",
+			Remediation: "Grant iam:ListRoles plus service last-accessed read APIs.",
+		}}
+	}
+	signals := []Signal{}
+	diagnostics := []Diagnostic{}
+	gaps := []CoverageGap{}
+	for idx, role := range out.Roles {
+		if int32(idx) >= request.MaxRoles {
+			break
+		}
+		roleARN := awsv2.ToString(role.Arn)
+		roleName := awsv2.ToString(role.RoleName)
+		if roleARN == "" {
+			continue
+		}
+		if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
+			region := firstNonEmpty(awsv2.ToString(role.RoleLastUsed.Region), request.Region)
+			lastUsed := role.RoleLastUsed.LastUsedDate.UTC()
+			signals = append(signals, Signal{
+				EventID:            "iam-role-last-used:" + sanitizeToken(roleARN),
+				AccountID:          request.AccountID,
+				Region:             region,
+				Category:           "iam-last-used",
+				Scope:              "role",
+				EventSource:        "iam.amazonaws.com",
+				EventName:          "RoleLastUsed",
+				Action:             "iam:RoleLastUsed",
+				ActorPrincipalARN:  roleARN,
+				ActorPrincipalType: "iam_role",
+				TargetResourceARN:  roleARN,
+				TargetResourceType: "iam_role",
+				TargetResourceName: roleName,
+				Status:             iamLastUsedStatus(lastUsed, request.CollectedAt),
+				Confidence:         0.82,
+				ObservedAt:         lastUsed,
+				CollectedAt:        request.CollectedAt,
+				StaleAt:            request.CollectedAt,
+			})
+		} else {
+			signals = append(signals, Signal{
+				EventID:            "iam-role-never-used:" + sanitizeToken(roleARN),
+				AccountID:          request.AccountID,
+				Region:             request.Region,
+				Category:           "iam-last-used",
+				Scope:              "role",
+				EventSource:        "iam.amazonaws.com",
+				EventName:          "RoleNeverUsed",
+				Action:             "iam:RoleNeverUsed",
+				ActorPrincipalARN:  roleARN,
+				ActorPrincipalType: "iam_role",
+				TargetResourceARN:  roleARN,
+				TargetResourceType: "iam_role",
+				TargetResourceName: roleName,
+				Status:             "stale",
+				Confidence:         0.68,
+				ObservedAt:         request.CollectedAt,
+				CollectedAt:        request.CollectedAt,
+				StaleAt:            request.CollectedAt,
+			})
+		}
+		job, genErr := i.IAM.GenerateServiceLastAccessedDetails(ctx, &iam.GenerateServiceLastAccessedDetailsInput{
+			Arn:         awsv2.String(roleARN),
+			Granularity: iamtypes.AccessAdvisorUsageGranularityTypeServiceLevel,
+		})
+		if genErr != nil {
+			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
+			continue
+		}
+		details, getErr := i.IAM.GetServiceLastAccessedDetails(ctx, &iam.GetServiceLastAccessedDetailsInput{
+			JobId:    job.JobId,
+			MaxItems: awsv2.Int32(request.MaxServicesPerRole),
+		})
+		if getErr != nil {
+			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
+			continue
+		}
+		if details.JobStatus != iamtypes.JobStatusTypeCompleted {
+			diagnostics = append(diagnostics, Diagnostic{
+				SourceID:    "iam:" + roleName,
+				Code:        "iam_last_used_report_pending",
+				Message:     fmt.Sprintf("IAM service last-used report for %s is %s.", roleName, details.JobStatus),
+				Remediation: "Retry collection after IAM finishes the report; existing role-last-used evidence remains visible.",
+				Retryable:   true,
+			})
+			gaps = append(gaps, CoverageGap{
+				Capability:  "iam_last_used",
+				Status:      "partial_failure",
+				Reason:      fmt.Sprintf("Service last-used report for %s was not complete.", roleName),
+				Remediation: "Retry collection after IAM report completion.",
+			})
+			continue
+		}
+		staleAt := request.CollectedAt
+		if details.JobCompletionDate != nil {
+			staleAt = details.JobCompletionDate.UTC()
+		}
+		for svcIdx, service := range details.ServicesLastAccessed {
+			if int32(svcIdx) >= request.MaxServicesPerRole {
+				break
+			}
+			serviceNamespace := awsv2.ToString(service.ServiceNamespace)
+			serviceName := firstNonEmpty(awsv2.ToString(service.ServiceName), serviceNamespace)
+			actor := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedEntity), roleARN)
+			region := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedRegion), request.Region)
+			lastAuthenticated := request.CollectedAt
+			status := "stale"
+			confidence := 0.64
+			if service.LastAuthenticated != nil {
+				lastAuthenticated = service.LastAuthenticated.UTC()
+				status = iamLastUsedStatus(lastAuthenticated, request.CollectedAt)
+				confidence = 0.86
+				if status == "stale" {
+					confidence = 0.78
+				}
+			}
+			signals = append(signals, Signal{
+				EventID:            "iam-service-last-used:" + sanitizeToken(roleARN) + ":" + sanitizeToken(serviceNamespace),
+				AccountID:          request.AccountID,
+				Region:             region,
+				Category:           "iam-last-used",
+				Scope:              "service",
+				EventSource:        "iam.amazonaws.com",
+				EventName:          serviceLastAccessedEventName(service.LastAuthenticated != nil),
+				Action:             serviceLastAccessedAction(serviceNamespace, service.LastAuthenticated != nil),
+				ActorPrincipalARN:  actor,
+				ActorPrincipalType: principalTypeFromARN(actor),
+				TargetResourceARN:  "aws-service://" + serviceNamespace,
+				TargetResourceType: "aws_service",
+				TargetResourceName: serviceName,
+				Status:             status,
+				Confidence:         confidence,
+				ObservedAt:         lastAuthenticated,
+				CollectedAt:        request.CollectedAt,
+				StaleAt:            staleAt,
+			})
+		}
+	}
+	if out.IsTruncated {
+		gaps = append(gaps, CoverageGap{
+			Capability:  "iam_last_used",
+			Status:      "history_truncated",
+			Reason:      "IAM role listing exceeded the bounded per-run role budget.",
+			Remediation: "Rerun with a larger IAM last-used role budget or shard by path prefix.",
+		})
+	}
+	return signals, diagnostics, gaps
+}
+
+func iamLastUsedStatus(observedAt time.Time, collectedAt time.Time) string {
+	if observedAt.IsZero() || collectedAt.IsZero() {
+		return "stale"
+	}
+	if collectedAt.Sub(observedAt) >= dormantAccessAge {
+		return "stale"
+	}
+	return "observed"
+}
+
+func serviceLastAccessedEventName(hasLastAuthenticated bool) string {
+	if hasLastAuthenticated {
+		return "ServiceLastAccessed"
+	}
+	return "ServiceNeverAccessed"
+}
+
+func serviceLastAccessedAction(namespace string, hasLastAuthenticated bool) string {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		if hasLastAuthenticated {
+			return "iam:ServiceLastAccessed"
+		}
+		return "iam:ServiceNeverAccessed"
+	}
+	if hasLastAuthenticated {
+		return namespace + ":LastAuthenticated"
+	}
+	return namespace + ":NeverAccessed"
+}
+
+func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap) {
+	analyzers, err := i.AccessAnalyzer.ListAnalyzers(ctx, &accessanalyzer.ListAnalyzersInput{MaxResults: awsv2.Int32(request.MaxAnalyzers)})
+	if err != nil {
+		return nil, []Diagnostic{permissionAwareDiagnostic("access-analyzer", "access_analyzer_permission_denied", "access_analyzer_list_failed", fmt.Sprintf("Access Analyzer analyzers could not be listed: %v", err), "Grant access-analyzer:ListAnalyzers and retry.", err)}, []CoverageGap{{
+			Capability:  "access_analyzer",
+			Status:      permissionAwareStatus(err),
+			Reason:      "Access Analyzer analyzers could not be listed.",
+			Remediation: "Grant access-analyzer:ListAnalyzers and access-analyzer:ListFindings.",
+		}}
+	}
+	signals := []Signal{}
+	diagnostics := []Diagnostic{}
+	gaps := []CoverageGap{}
+	for idx, analyzer := range analyzers.Analyzers {
+		if int32(idx) >= request.MaxAnalyzers {
+			break
+		}
+		analyzerARN := awsv2.ToString(analyzer.Arn)
+		analyzerName := awsv2.ToString(analyzer.Name)
+		if analyzerARN == "" {
+			continue
+		}
+		findings, findErr := i.AccessAnalyzer.ListFindings(ctx, &accessanalyzer.ListFindingsInput{
+			AnalyzerArn: awsv2.String(analyzerARN),
+			MaxResults:  awsv2.Int32(request.MaxFindings),
+		})
+		if findErr != nil {
+			diagnostics = append(diagnostics, permissionAwareDiagnostic("access-analyzer:"+analyzerName, "access_analyzer_permission_denied", "access_analyzer_findings_failed", fmt.Sprintf("Access Analyzer findings could not be listed for %s: %v", analyzerName, findErr), "Grant access-analyzer:ListFindings and retry.", findErr))
+			continue
+		}
+		for findingIdx, finding := range findings.Findings {
+			if int32(findingIdx) >= request.MaxFindings {
+				break
+			}
+			observed := request.CollectedAt
+			if finding.UpdatedAt != nil {
+				observed = finding.UpdatedAt.UTC()
+			} else if finding.CreatedAt != nil {
+				observed = finding.CreatedAt.UTC()
+			}
+			staleAt := observed
+			if finding.AnalyzedAt != nil {
+				staleAt = finding.AnalyzedAt.UTC()
+			}
+			resourceARN := awsv2.ToString(finding.Resource)
+			signals = append(signals, Signal{
+				EventID:            "access-analyzer:" + sanitizeToken(firstNonEmpty(awsv2.ToString(finding.Id), resourceARN, analyzerARN)),
+				AccountID:          firstNonEmpty(awsv2.ToString(finding.ResourceOwnerAccount), request.AccountID),
+				Region:             request.Region,
+				Category:           "access-analyzer",
+				Scope:              strings.ToLower(strings.TrimSpace(string(analyzer.Type))),
+				EventSource:        "access-analyzer.amazonaws.com",
+				EventName:          "Finding",
+				Action:             firstNonEmpty(strings.Join(finding.Action, ","), "access-analyzer:Finding"),
+				ActorPrincipalARN:  principalFromFinding(finding.Principal),
+				ActorPrincipalType: "external_principal",
+				TargetResourceARN:  resourceARN,
+				TargetResourceType: firstNonEmpty(string(finding.ResourceType), "access_analyzer_resource"),
+				TargetResourceName: displayNameFromARN(resourceARN),
+				AnalyzerARN:        analyzerARN,
+				AnalyzerName:       analyzerName,
+				Status:             accessAnalyzerStatus(finding),
+				Confidence:         accessAnalyzerConfidence(finding),
+				ObservedAt:         observed,
+				CollectedAt:        request.CollectedAt,
+				StaleAt:            staleAt,
+			})
+		}
+		if findings.NextToken != nil {
+			gaps = append(gaps, CoverageGap{
+				Capability:  "access_analyzer",
+				Status:      "history_truncated",
+				Reason:      fmt.Sprintf("Access Analyzer findings for %s exceeded the bounded per-run finding budget.", analyzerName),
+				Remediation: "Rerun with a larger findings budget or analyzer-specific pagination.",
+			})
+		}
+	}
+	if analyzers.NextToken != nil {
+		gaps = append(gaps, CoverageGap{
+			Capability:  "access_analyzer",
+			Status:      "history_truncated",
+			Reason:      "Access Analyzer listing exceeded the bounded per-run analyzer budget.",
+			Remediation: "Rerun with a larger analyzer budget or shard by analyzer type.",
+		})
+	}
+	return signals, diagnostics, gaps
+}
+
+func permissionAwareDiagnostic(sourceID string, permissionCode string, fallbackCode string, message string, remediation string, err error) Diagnostic {
+	code := fallbackCode
+	if isPermissionDenied(err) {
+		code = permissionCode
+	}
+	return Diagnostic{SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: true}
+}
+
+func permissionAwareStatus(err error) string {
+	if isPermissionDenied(err) {
+		return "permission_denied"
+	}
+	return "partial_failure"
+}
+
+func isPermissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "accessdenied") || strings.Contains(msg, "access denied") || strings.Contains(msg, "unauthorized") || strings.Contains(msg, "not authorized")
+}
+
+func hasPermissionDeniedDiagnostic(diagnostics []Diagnostic) bool {
+	if len(diagnostics) == 0 {
+		return false
+	}
+	for _, diagnostic := range diagnostics {
+		if !strings.Contains(diagnostic.Code, "permission_denied") {
+			return false
+		}
+	}
+	return true
+}
+
+func accessAnalyzerStatus(finding accessanalyzertypes.FindingSummary) string {
+	switch finding.Status {
+	case accessanalyzertypes.FindingStatusActive:
+		return "observed"
+	case accessanalyzertypes.FindingStatusResolved:
+		return "resolved"
+	case accessanalyzertypes.FindingStatusArchived:
+		return "archived"
+	default:
+		return strings.ToLower(strings.TrimSpace(string(finding.Status)))
+	}
+}
+
+func accessAnalyzerConfidence(finding accessanalyzertypes.FindingSummary) float64 {
+	if finding.Error != nil && strings.TrimSpace(*finding.Error) != "" {
+		return 0.54
+	}
+	if finding.IsPublic != nil && *finding.IsPublic {
+		return 0.9
+	}
+	if finding.Status == accessanalyzertypes.FindingStatusActive {
+		return 0.84
+	}
+	return 0.72
+}
+
+func principalFromFinding(principal map[string]string) string {
+	if len(principal) == 0 {
+		return "access-analyzer:external-principal"
+	}
+	keys := make([]string, 0, len(principal))
+	for key := range principal {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+principal[key])
+	}
+	return strings.Join(parts, ";")
+}
+
+func principalTypeFromARN(arn string) string {
+	switch {
+	case strings.Contains(arn, ":role/"):
+		return "iam_role"
+	case strings.Contains(arn, ":user/"):
+		return "iam_user"
+	case strings.Contains(arn, ":assumed-role/"):
+		return "assumed_role"
+	default:
+		return "aws_principal"
+	}
+}
+
+func displayNameFromARN(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if slash := strings.LastIndex(ref, "/"); slash >= 0 && slash < len(ref)-1 {
+		return ref[slash+1:]
+	}
+	if colon := strings.LastIndex(ref, ":"); colon >= 0 && colon < len(ref)-1 {
+		return ref[colon+1:]
+	}
+	return ref
+}
+
+func sanitizeToken(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return "unknown"
+	}
+	replacer := strings.NewReplacer(":", "-", "/", "-", "_", "-", " ", "-", ".", "-", "@", "-")
+	value = replacer.Replace(value)
+	parts := strings.Split(value, "-")
+	kept := parts[:0]
+	for _, part := range parts {
+		if part != "" {
+			kept = append(kept, part)
+		}
+	}
+	return strings.Join(kept, "-")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -194,6 +194,11 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 		result.FailureReasons = dedupeStrings(append(result.FailureReasons, "IAM last-used or Access Analyzer returned diagnostics"))
 		result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Review signal diagnostics before using runtime evidence for least-privilege decisions."))
 	}
+	if len(result.CoverageGaps) > 0 && result.Status == "ready" {
+		result.Status = "degraded"
+		result.FailureReasons = dedupeStrings(append(result.FailureReasons, "IAM last-used or Access Analyzer coverage is partial"))
+		result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Review signal coverage gaps before using runtime evidence for least-privilege decisions."))
+	}
 	if len(result.Signals) == 0 && hasPermissionDeniedDiagnostic(result.Diagnostics) {
 		result.Status = "blocked"
 		result.FailureReasons = []string{"IAM last-used and Access Analyzer permissions are unavailable"}
@@ -277,7 +282,7 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
 			continue
 		}
-		details, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
+		details, truncated, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
 		if getErr != nil {
 			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
 			continue
@@ -301,6 +306,14 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 		staleAt := request.CollectedAt
 		if details.JobCompletionDate != nil {
 			staleAt = details.JobCompletionDate.UTC()
+		}
+		if truncated {
+			gaps = append(gaps, CoverageGap{
+				Capability:  "iam_last_used",
+				Status:      "history_truncated",
+				Reason:      fmt.Sprintf("Service last-used report for %s exceeded the bounded per-role service budget.", roleName),
+				Remediation: "Rerun with a larger IAM last-used service budget or add paginated report reuse.",
+			})
 		}
 		for svcIdx, service := range details.ServicesLastAccessed {
 			if int32(svcIdx) >= request.MaxServicesPerRole {
@@ -354,7 +367,7 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 	return signals, diagnostics, gaps
 }
 
-func (i *Ingester) getServiceLastAccessedDetails(ctx context.Context, jobID *string, request IngestRequest) (*iam.GetServiceLastAccessedDetailsOutput, error) {
+func (i *Ingester) getServiceLastAccessedDetails(ctx context.Context, jobID *string, request IngestRequest) (*iam.GetServiceLastAccessedDetailsOutput, bool, error) {
 	var details *iam.GetServiceLastAccessedDetailsOutput
 	for attempt := 0; attempt < request.MaxReportPolls; attempt++ {
 		out, err := i.IAM.GetServiceLastAccessedDetails(ctx, &iam.GetServiceLastAccessedDetailsInput{
@@ -362,23 +375,23 @@ func (i *Ingester) getServiceLastAccessedDetails(ctx context.Context, jobID *str
 			MaxItems: awsv2.Int32(request.MaxServicesPerRole),
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		details = out
 		if out.JobStatus == iamtypes.JobStatusTypeCompleted {
-			return out, nil
+			return out, out.IsTruncated || out.Marker != nil, nil
 		}
 		if attempt == request.MaxReportPolls-1 {
 			break
 		}
 		if err := waitForIAMReportPoll(ctx, request.ReportPollInterval); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 	if details == nil {
 		details = &iam.GetServiceLastAccessedDetailsOutput{}
 	}
-	return details, nil
+	return details, details.IsTruncated || details.Marker != nil, nil
 }
 
 func waitForIAMReportPoll(ctx context.Context, interval time.Duration) error {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -199,7 +199,7 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 		result.FailureReasons = dedupeStrings(append(result.FailureReasons, "IAM last-used or Access Analyzer coverage is partial"))
 		result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Review signal coverage gaps before using runtime evidence for least-privilege decisions."))
 	}
-	if len(result.Signals) == 0 && hasPermissionDeniedDiagnostic(result.Diagnostics) {
+	if len(result.Signals) == 0 && allSignalCollectorsPermissionDenied(result.CoverageGaps) {
 		result.Status = "blocked"
 		result.FailureReasons = []string{"IAM last-used and Access Analyzer permissions are unavailable"}
 		result.RemediationHints = []string{"Grant metadata-only iam:ListRoles, iam:GenerateServiceLastAccessedDetails, iam:GetServiceLastAccessedDetails, access-analyzer:ListAnalyzers, and access-analyzer:ListFindings."}
@@ -452,6 +452,15 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 	signals := []Signal{}
 	diagnostics := []Diagnostic{}
 	gaps := []CoverageGap{}
+	if len(analyzers.Analyzers) == 0 {
+		gaps = append(gaps, CoverageGap{
+			Capability:  "access_analyzer",
+			Status:      "empty",
+			Reason:      "Access Analyzer returned no analyzers for this account and region.",
+			Remediation: "Enable an account or organization analyzer before relying on external-access findings.",
+		})
+		return signals, diagnostics, gaps
+	}
 	for idx, analyzer := range analyzers.Analyzers {
 		if int32(idx) >= request.MaxAnalyzers {
 			break
@@ -550,16 +559,14 @@ func isPermissionDenied(err error) bool {
 	return strings.Contains(msg, "accessdenied") || strings.Contains(msg, "access denied") || strings.Contains(msg, "unauthorized") || strings.Contains(msg, "not authorized")
 }
 
-func hasPermissionDeniedDiagnostic(diagnostics []Diagnostic) bool {
-	if len(diagnostics) == 0 {
-		return false
-	}
-	for _, diagnostic := range diagnostics {
-		if !strings.Contains(diagnostic.Code, "permission_denied") {
-			return false
+func allSignalCollectorsPermissionDenied(gaps []CoverageGap) bool {
+	denied := map[string]bool{}
+	for _, gap := range gaps {
+		if gap.Status == "permission_denied" {
+			denied[gap.Capability] = true
 		}
 	}
-	return true
+	return denied["iam_last_used"] && denied["access_analyzer"]
 }
 
 func accessAnalyzerStatus(finding accessanalyzertypes.FindingSummary) string {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -30,6 +30,7 @@ type IAMAPI interface {
 type AccessAnalyzerAPI interface {
 	ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error)
 	ListFindings(context.Context, *accessanalyzer.ListFindingsInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsOutput, error)
+	ListFindingsV2(context.Context, *accessanalyzer.ListFindingsV2Input, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsV2Output, error)
 }
 
 type IngestRequest struct {
@@ -89,6 +90,22 @@ type CoverageGap struct {
 	Status      string
 	Reason      string
 	Remediation string
+}
+
+type accessAnalyzerFinding struct {
+	ID                   string
+	Resource             string
+	ResourceOwnerAccount string
+	ResourceType         accessanalyzertypes.ResourceType
+	Status               accessanalyzertypes.FindingStatus
+	Error                string
+	FindingType          accessanalyzertypes.FindingType
+	Action               []string
+	Principal            map[string]string
+	IsPublic             *bool
+	AnalyzedAt           *time.Time
+	CreatedAt            *time.Time
+	UpdatedAt            *time.Time
 }
 
 type Ingester struct {
@@ -515,10 +532,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 		if analyzerARN == "" {
 			continue
 		}
-		findings, findErr := i.AccessAnalyzer.ListFindings(ctx, &accessanalyzer.ListFindingsInput{
-			AnalyzerArn: awsv2.String(analyzerARN),
-			MaxResults:  awsv2.Int32(request.MaxFindings),
-		})
+		findings, nextToken, findErr := i.listAccessAnalyzerFindings(ctx, analyzerARN, analyzer.Type, request.MaxFindings)
 		if findErr != nil {
 			if isContextCancellation(findErr) {
 				return nil, nil, nil, findErr
@@ -532,7 +546,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 			})
 			continue
 		}
-		for findingIdx, finding := range findings.Findings {
+		for findingIdx, finding := range findings {
 			if int32(findingIdx) >= request.MaxFindings {
 				break
 			}
@@ -546,19 +560,20 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 			if finding.AnalyzedAt != nil {
 				staleAt = finding.AnalyzedAt.UTC()
 			}
-			resourceARN := awsv2.ToString(finding.Resource)
-			ownerAccount := strings.TrimSpace(awsv2.ToString(finding.ResourceOwnerAccount))
+			resourceARN := finding.Resource
+			ownerAccount := strings.TrimSpace(finding.ResourceOwnerAccount)
 			if ownerAccount != "" && request.AccountID != "" && ownerAccount != request.AccountID {
 				continue
 			}
+			eventName := firstNonEmpty(string(finding.FindingType), "Finding")
 			signals = append(signals, Signal{
-				EventID:            "access-analyzer:" + sanitizeToken(firstNonEmpty(awsv2.ToString(finding.Id), resourceARN, analyzerARN)),
+				EventID:            "access-analyzer:" + sanitizeToken(firstNonEmpty(finding.ID, resourceARN, analyzerARN)),
 				AccountID:          firstNonEmpty(ownerAccount, request.AccountID),
 				Region:             request.Region,
 				Category:           "access-analyzer",
 				Scope:              strings.ToLower(strings.TrimSpace(string(analyzer.Type))),
 				EventSource:        "access-analyzer.amazonaws.com",
-				EventName:          "Finding",
+				EventName:          eventName,
 				Action:             firstNonEmpty(strings.Join(finding.Action, ","), "access-analyzer:Finding"),
 				ActorPrincipalARN:  principalFromFinding(finding.Principal),
 				ActorPrincipalType: "external_principal",
@@ -574,7 +589,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 				StaleAt:            staleAt,
 			})
 		}
-		if findings.NextToken != nil {
+		if nextToken != nil {
 			gaps = append(gaps, CoverageGap{
 				Capability:  "access_analyzer",
 				Status:      "history_truncated",
@@ -592,6 +607,69 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 		})
 	}
 	return signals, diagnostics, gaps, nil
+}
+
+func (i *Ingester) listAccessAnalyzerFindings(ctx context.Context, analyzerARN string, analyzerType accessanalyzertypes.Type, maxFindings int32) ([]accessAnalyzerFinding, *string, error) {
+	if accessAnalyzerUsesFindingsV2(analyzerType) {
+		out, err := i.AccessAnalyzer.ListFindingsV2(ctx, &accessanalyzer.ListFindingsV2Input{
+			AnalyzerArn: awsv2.String(analyzerARN),
+			MaxResults:  awsv2.Int32(maxFindings),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		findings := make([]accessAnalyzerFinding, 0, len(out.Findings))
+		for _, finding := range out.Findings {
+			findings = append(findings, accessAnalyzerFinding{
+				ID:                   awsv2.ToString(finding.Id),
+				Resource:             awsv2.ToString(finding.Resource),
+				ResourceOwnerAccount: awsv2.ToString(finding.ResourceOwnerAccount),
+				ResourceType:         finding.ResourceType,
+				Status:               finding.Status,
+				Error:                awsv2.ToString(finding.Error),
+				FindingType:          finding.FindingType,
+				AnalyzedAt:           finding.AnalyzedAt,
+				CreatedAt:            finding.CreatedAt,
+				UpdatedAt:            finding.UpdatedAt,
+			})
+		}
+		return findings, out.NextToken, nil
+	}
+	out, err := i.AccessAnalyzer.ListFindings(ctx, &accessanalyzer.ListFindingsInput{
+		AnalyzerArn: awsv2.String(analyzerARN),
+		MaxResults:  awsv2.Int32(maxFindings),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	findings := make([]accessAnalyzerFinding, 0, len(out.Findings))
+	for _, finding := range out.Findings {
+		findings = append(findings, accessAnalyzerFinding{
+			ID:                   awsv2.ToString(finding.Id),
+			Resource:             awsv2.ToString(finding.Resource),
+			ResourceOwnerAccount: awsv2.ToString(finding.ResourceOwnerAccount),
+			ResourceType:         finding.ResourceType,
+			Status:               finding.Status,
+			Error:                awsv2.ToString(finding.Error),
+			FindingType:          accessanalyzertypes.FindingTypeExternalAccess,
+			Action:               finding.Action,
+			Principal:            finding.Principal,
+			IsPublic:             finding.IsPublic,
+			AnalyzedAt:           finding.AnalyzedAt,
+			CreatedAt:            finding.CreatedAt,
+			UpdatedAt:            finding.UpdatedAt,
+		})
+	}
+	return findings, out.NextToken, nil
+}
+
+func accessAnalyzerUsesFindingsV2(analyzerType accessanalyzertypes.Type) bool {
+	switch analyzerType {
+	case accessanalyzertypes.TypeAccount, accessanalyzertypes.TypeOrganization:
+		return false
+	default:
+		return true
+	}
 }
 
 func permissionAwareDiagnostic(sourceID string, permissionCode string, fallbackCode string, message string, remediation string, err error) Diagnostic {
@@ -631,7 +709,7 @@ func allSignalCollectorsPermissionDenied(gaps []CoverageGap) bool {
 	return denied["iam_last_used"] && denied["access_analyzer"]
 }
 
-func accessAnalyzerStatus(finding accessanalyzertypes.FindingSummary) string {
+func accessAnalyzerStatus(finding accessAnalyzerFinding) string {
 	switch finding.Status {
 	case accessanalyzertypes.FindingStatusActive:
 		return "observed"
@@ -644,8 +722,8 @@ func accessAnalyzerStatus(finding accessanalyzertypes.FindingSummary) string {
 	}
 }
 
-func accessAnalyzerConfidence(finding accessanalyzertypes.FindingSummary) float64 {
-	if finding.Error != nil && strings.TrimSpace(*finding.Error) != "" {
+func accessAnalyzerConfidence(finding accessAnalyzerFinding) float64 {
+	if strings.TrimSpace(finding.Error) != "" {
 		return 0.54
 	}
 	if finding.IsPublic != nil && *finding.IsPublic {

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -566,6 +566,7 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 				continue
 			}
 			eventName := firstNonEmpty(string(finding.FindingType), "Finding")
+			actorPrincipal, actorType := accessAnalyzerActor(finding, analyzerARN)
 			signals = append(signals, Signal{
 				EventID:            "access-analyzer:" + sanitizeToken(firstNonEmpty(finding.ID, resourceARN, analyzerARN)),
 				AccountID:          firstNonEmpty(ownerAccount, request.AccountID),
@@ -574,9 +575,9 @@ func (i *Ingester) collectAccessAnalyzer(ctx context.Context, request IngestRequ
 				Scope:              strings.ToLower(strings.TrimSpace(string(analyzer.Type))),
 				EventSource:        "access-analyzer.amazonaws.com",
 				EventName:          eventName,
-				Action:             firstNonEmpty(strings.Join(finding.Action, ","), "access-analyzer:Finding"),
-				ActorPrincipalARN:  principalFromFinding(finding.Principal),
-				ActorPrincipalType: "external_principal",
+				Action:             accessAnalyzerAction(finding),
+				ActorPrincipalARN:  actorPrincipal,
+				ActorPrincipalType: actorType,
 				TargetResourceARN:  resourceARN,
 				TargetResourceType: firstNonEmpty(string(finding.ResourceType), "access_analyzer_resource"),
 				TargetResourceName: displayNameFromARN(resourceARN),
@@ -733,6 +734,33 @@ func accessAnalyzerConfidence(finding accessAnalyzerFinding) float64 {
 		return 0.84
 	}
 	return 0.72
+}
+
+func accessAnalyzerAction(finding accessAnalyzerFinding) string {
+	if len(finding.Action) > 0 {
+		return strings.Join(finding.Action, ",")
+	}
+	eventName := strings.TrimSpace(string(finding.FindingType))
+	if eventName == "" {
+		return "access-analyzer:Finding"
+	}
+	return "access-analyzer:" + eventName
+}
+
+func accessAnalyzerActor(finding accessAnalyzerFinding, analyzerARN string) (string, string) {
+	if len(finding.Principal) > 0 || finding.FindingType == accessanalyzertypes.FindingTypeExternalAccess {
+		return principalFromFinding(finding.Principal), "external_principal"
+	}
+	switch finding.FindingType {
+	case accessanalyzertypes.FindingTypeUnusedIamRole,
+		accessanalyzertypes.FindingTypeUnusedIamUserAccessKey,
+		accessanalyzertypes.FindingTypeUnusedIamUserPassword,
+		accessanalyzertypes.FindingTypeUnusedPermission:
+		if strings.TrimSpace(finding.Resource) != "" {
+			return finding.Resource, principalTypeFromARN(finding.Resource)
+		}
+	}
+	return firstNonEmpty(analyzerARN, "access-analyzer:"+strings.ToLower(strings.TrimSpace(string(finding.FindingType)))), "access_analyzer"
 }
 
 func principalFromFinding(principal map[string]string) string {

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -70,6 +70,8 @@ type fakeAccessAnalyzerAPI struct {
 	listAnalyzersErr error
 	listFindingsErr  error
 	emptyAnalyzers   bool
+	analyzerType     accessanalyzertypes.Type
+	findings         []accessanalyzertypes.FindingSummary
 }
 
 func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error) {
@@ -86,7 +88,7 @@ func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.Li
 			CreatedAt: &createdAt,
 			Name:      awsv2.String("account"),
 			Status:    accessanalyzertypes.AnalyzerStatusActive,
-			Type:      accessanalyzertypes.TypeAccount,
+			Type:      firstNonEmptyAnalyzerType(f.analyzerType, accessanalyzertypes.TypeAccount),
 		}},
 	}, nil
 }
@@ -94,6 +96,9 @@ func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.Li
 func (f fakeAccessAnalyzerAPI) ListFindings(context.Context, *accessanalyzer.ListFindingsInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsOutput, error) {
 	if f.listFindingsErr != nil {
 		return nil, f.listFindingsErr
+	}
+	if f.findings != nil {
+		return &accessanalyzer.ListFindingsOutput{Findings: f.findings}, nil
 	}
 	createdAt := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC)
 	updatedAt := time.Date(2026, 6, 18, 6, 30, 0, 0, time.UTC)
@@ -113,6 +118,15 @@ func (f fakeAccessAnalyzerAPI) ListFindings(context.Context, *accessanalyzer.Lis
 			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/payments"),
 		}},
 	}, nil
+}
+
+func firstNonEmptyAnalyzerType(values ...accessanalyzertypes.Type) accessanalyzertypes.Type {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
@@ -151,6 +165,53 @@ func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
 	}
 	if analyzerFinding.Category != "access-analyzer" || analyzerFinding.Scope != "account" || analyzerFinding.AnalyzerARN == "" || analyzerFinding.StaleAt.IsZero() || analyzerFinding.Confidence < 0.89 {
 		t.Fatalf("unexpected Access Analyzer signal: %+v", analyzerFinding)
+	}
+}
+
+func TestIngesterSkipsCrossAccountAccessAnalyzerFindings(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC)
+	findings := []accessanalyzertypes.FindingSummary{
+		{
+			CreatedAt:            &createdAt,
+			Id:                   awsv2.String("same-account"),
+			ResourceOwnerAccount: awsv2.String("123456789012"),
+			ResourceType:         accessanalyzertypes.ResourceTypeAwsSecretsmanagerSecret,
+			Status:               accessanalyzertypes.FindingStatusActive,
+			Action:               []string{"secretsmanager:GetSecretValue"},
+			Principal:            map[string]string{"AWS": "arn:aws:iam::210987654321:root"},
+			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/payments"),
+		},
+		{
+			CreatedAt:            &createdAt,
+			Id:                   awsv2.String("member-account"),
+			ResourceOwnerAccount: awsv2.String("999999999999"),
+			ResourceType:         accessanalyzertypes.ResourceTypeAwsSecretsmanagerSecret,
+			Status:               accessanalyzertypes.FindingStatusActive,
+			Action:               []string{"secretsmanager:GetSecretValue"},
+			Principal:            map[string]string{"AWS": "arn:aws:iam::210987654321:root"},
+			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:999999999999:secret:prod/other"),
+		},
+	}
+	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{
+		analyzerType: accessanalyzertypes.TypeOrganization,
+		findings:     findings,
+	}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: collectedAt,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready same-account analyzer result, got %+v", result)
+	}
+	if len(result.Signals) != 1 {
+		t.Fatalf("expected only same-account analyzer finding, got %+v", result.Signals)
+	}
+	if result.Signals[0].AccountID != "123456789012" || !strings.Contains(result.Signals[0].EventID, "same-account") {
+		t.Fatalf("expected retained finding to belong to connector account, got %+v", result.Signals[0])
 	}
 }
 

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -20,6 +20,7 @@ type fakeIAMAPI struct {
 	truncated        bool
 	emptyRoles       bool
 	neverUsedRole    bool
+	neverUsedService bool
 	roleCreationDate *time.Time
 }
 
@@ -56,17 +57,20 @@ func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServi
 	}
 	completedAt := time.Date(2026, 6, 18, 8, 0, 0, 0, time.UTC)
 	lastAuthenticated := time.Date(2026, 6, 16, 7, 30, 0, 0, time.UTC)
+	service := iamtypes.ServiceLastAccessed{
+		ServiceName:      awsv2.String("Amazon S3"),
+		ServiceNamespace: awsv2.String("s3"),
+	}
+	if !f.neverUsedService {
+		service.LastAuthenticated = &lastAuthenticated
+		service.LastAuthenticatedEntity = awsv2.String("arn:aws:iam::123456789012:role/payments-worker")
+		service.LastAuthenticatedRegion = awsv2.String("us-east-1")
+	}
 	return &iam.GetServiceLastAccessedDetailsOutput{
-		JobStatus:         status,
-		JobCompletionDate: &completedAt,
-		IsTruncated:       f.truncated,
-		ServicesLastAccessed: []iamtypes.ServiceLastAccessed{{
-			ServiceName:             awsv2.String("Amazon S3"),
-			ServiceNamespace:        awsv2.String("s3"),
-			LastAuthenticated:       &lastAuthenticated,
-			LastAuthenticatedEntity: awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
-			LastAuthenticatedRegion: awsv2.String("us-east-1"),
-		}},
+		JobStatus:            status,
+		JobCompletionDate:    &completedAt,
+		IsTruncated:          f.truncated,
+		ServicesLastAccessed: []iamtypes.ServiceLastAccessed{service},
 	}, nil
 }
 
@@ -245,6 +249,35 @@ func TestIngesterDoesNotMarkNewNeverUsedRolesStale(t *testing.T) {
 	}
 	if !neverUsedRole.ObservedAt.Equal(createdAt) {
 		t.Fatalf("expected creation date as observed_at, got %+v", neverUsedRole)
+	}
+}
+
+func TestIngesterDoesNotMarkNewNeverAccessedServicesStale(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	createdAt := collectedAt.Add(-2 * time.Hour)
+	result, err := New(fakeIAMAPI{neverUsedRole: true, neverUsedService: true, roleCreationDate: &createdAt}, fakeAccessAnalyzerAPI{emptyAnalyzers: true}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: collectedAt,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	var neverAccessedService *Signal
+	for idx := range result.Signals {
+		if result.Signals[idx].EventName == "ServiceNeverAccessed" {
+			neverAccessedService = &result.Signals[idx]
+			break
+		}
+	}
+	if neverAccessedService == nil {
+		t.Fatalf("expected service-never-accessed signal, got %+v", result.Signals)
+	}
+	if neverAccessedService.Status != "unknown" {
+		t.Fatalf("new never-accessed service should remain unknown until dormant threshold, got %+v", neverAccessedService)
+	}
+	if !neverAccessedService.ObservedAt.Equal(createdAt) {
+		t.Fatalf("expected role creation date as observed_at, got %+v", neverAccessedService)
 	}
 }
 

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -75,11 +75,13 @@ func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServi
 }
 
 type fakeAccessAnalyzerAPI struct {
-	listAnalyzersErr error
-	listFindingsErr  error
-	emptyAnalyzers   bool
-	analyzerType     accessanalyzertypes.Type
-	findings         []accessanalyzertypes.FindingSummary
+	listAnalyzersErr  error
+	listFindingsErr   error
+	listFindingsV2Err error
+	emptyAnalyzers    bool
+	analyzerType      accessanalyzertypes.Type
+	findings          []accessanalyzertypes.FindingSummary
+	findingsV2        []accessanalyzertypes.FindingSummaryV2
 }
 
 func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error) {
@@ -124,6 +126,31 @@ func (f fakeAccessAnalyzerAPI) ListFindings(context.Context, *accessanalyzer.Lis
 			IsPublic:             awsv2.Bool(true),
 			Principal:            map[string]string{"AWS": "arn:aws:iam::210987654321:root"},
 			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/payments"),
+		}},
+	}, nil
+}
+
+func (f fakeAccessAnalyzerAPI) ListFindingsV2(context.Context, *accessanalyzer.ListFindingsV2Input, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsV2Output, error) {
+	if f.listFindingsV2Err != nil {
+		return nil, f.listFindingsV2Err
+	}
+	if f.findingsV2 != nil {
+		return &accessanalyzer.ListFindingsV2Output{Findings: f.findingsV2}, nil
+	}
+	createdAt := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 6, 18, 6, 30, 0, 0, time.UTC)
+	analyzedAt := time.Date(2026, 6, 18, 6, 0, 0, 0, time.UTC)
+	return &accessanalyzer.ListFindingsV2Output{
+		Findings: []accessanalyzertypes.FindingSummaryV2{{
+			AnalyzedAt:           &analyzedAt,
+			CreatedAt:            &createdAt,
+			Id:                   awsv2.String("finding-v2-1"),
+			ResourceOwnerAccount: awsv2.String("123456789012"),
+			ResourceType:         accessanalyzertypes.ResourceTypeAwsIamRole,
+			Status:               accessanalyzertypes.FindingStatusActive,
+			UpdatedAt:            &updatedAt,
+			FindingType:          accessanalyzertypes.FindingTypeInternalAccess,
+			Resource:             awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
 		}},
 	}, nil
 }
@@ -220,6 +247,34 @@ func TestIngesterSkipsCrossAccountAccessAnalyzerFindings(t *testing.T) {
 	}
 	if result.Signals[0].AccountID != "123456789012" || !strings.Contains(result.Signals[0].EventID, "same-account") {
 		t.Fatalf("expected retained finding to belong to connector account, got %+v", result.Signals[0])
+	}
+}
+
+func TestIngesterUsesFindingsV2ForInternalAccessAnalyzers(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{
+		analyzerType:    accessanalyzertypes.TypeAccountInternalAccess,
+		listFindingsErr: errors.New("legacy ListFindings should not be called"),
+	}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: collectedAt,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready internal analyzer result, got %+v", result)
+	}
+	if len(result.Signals) != 1 {
+		t.Fatalf("expected one internal analyzer finding, got %+v", result.Signals)
+	}
+	finding := result.Signals[0]
+	if finding.EventName != string(accessanalyzertypes.FindingTypeInternalAccess) || finding.Scope != strings.ToLower(string(accessanalyzertypes.TypeAccountInternalAccess)) {
+		t.Fatalf("expected internal analyzer finding from ListFindingsV2, got %+v", finding)
+	}
+	if finding.TargetResourceARN != "arn:aws:iam::123456789012:role/payments-worker" || finding.TargetResourceType != string(accessanalyzertypes.ResourceTypeAwsIamRole) {
+		t.Fatalf("expected normalized V2 resource details, got %+v", finding)
 	}
 }
 

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -265,6 +265,23 @@ func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 	}
 }
 
+func TestIngesterBlocksWhenIAMAndAnalyzerFindingsAreDenied(t *testing.T) {
+	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listFindingsErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ingest denied findings signals: %v", err)
+	}
+	if result.Status != "blocked" || len(result.Signals) != 0 {
+		t.Fatalf("expected blocked result when both sources are permission denied, got %+v", result)
+	}
+	if !hasCoverageGap(result.CoverageGaps, "iam_last_used", "permission_denied") || !hasCoverageGap(result.CoverageGaps, "access_analyzer", "permission_denied") {
+		t.Fatalf("expected IAM and Access Analyzer permission coverage gaps, got %+v", result.CoverageGaps)
+	}
+}
+
 func TestIngesterDoesNotBlockWhenOnlyOneCollectorIsDenied(t *testing.T) {
 	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -18,11 +18,15 @@ type fakeIAMAPI struct {
 	listRolesErr error
 	getStatus    iamtypes.JobStatusType
 	truncated    bool
+	emptyRoles   bool
 }
 
 func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
 	if f.listRolesErr != nil {
 		return nil, f.listRolesErr
+	}
+	if f.emptyRoles {
+		return &iam.ListRolesOutput{}, nil
 	}
 	lastUsed := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
 	return &iam.ListRolesOutput{
@@ -65,11 +69,15 @@ func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServi
 type fakeAccessAnalyzerAPI struct {
 	listAnalyzersErr error
 	listFindingsErr  error
+	emptyAnalyzers   bool
 }
 
 func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error) {
 	if f.listAnalyzersErr != nil {
 		return nil, f.listAnalyzersErr
+	}
+	if f.emptyAnalyzers {
+		return &accessanalyzer.ListAnalyzersOutput{}, nil
 	}
 	createdAt := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
 	return &accessanalyzer.ListAnalyzersOutput{
@@ -174,6 +182,23 @@ func TestIngesterDegradesWhenCoverageGapsAreEmitted(t *testing.T) {
 	}
 }
 
+func TestIngesterDegradesWhenAccessAnalyzerHasNoAnalyzers(t *testing.T) {
+	result, err := New(fakeIAMAPI{}, fakeAccessAnalyzerAPI{emptyAnalyzers: true}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if result.Status != "degraded" || len(result.Signals) == 0 {
+		t.Fatalf("expected IAM signals with degraded analyzer coverage, got %+v", result)
+	}
+	if !hasCoverageGap(result.CoverageGaps, "access_analyzer", "empty") {
+		t.Fatalf("expected empty Access Analyzer coverage gap, got %+v", result.CoverageGaps)
+	}
+}
+
 type pollingIAMAPI struct {
 	fakeIAMAPI
 	statuses []iamtypes.JobStatusType
@@ -238,4 +263,33 @@ func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 			t.Fatalf("expected permission-aware diagnostic, got %+v", diagnostic)
 		}
 	}
+}
+
+func TestIngesterDoesNotBlockWhenOnlyOneCollectorIsDenied(t *testing.T) {
+	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ingest mixed coverage signals: %v", err)
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected partial coverage to stay degraded instead of blocked, got %+v", result)
+	}
+	if !hasCoverageGap(result.CoverageGaps, "access_analyzer", "permission_denied") {
+		t.Fatalf("expected denied Access Analyzer coverage gap, got %+v", result.CoverageGaps)
+	}
+	if hasCoverageGap(result.CoverageGaps, "iam_last_used", "permission_denied") {
+		t.Fatalf("IAM collector was reachable and must not be treated as denied, got %+v", result.CoverageGaps)
+	}
+}
+
+func hasCoverageGap(gaps []CoverageGap, capability string, status string) bool {
+	for _, gap := range gaps {
+		if gap.Capability == capability && gap.Status == status {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -273,6 +273,9 @@ func TestIngesterUsesFindingsV2ForInternalAccessAnalyzers(t *testing.T) {
 	if finding.EventName != string(accessanalyzertypes.FindingTypeInternalAccess) || finding.Scope != strings.ToLower(string(accessanalyzertypes.TypeAccountInternalAccess)) {
 		t.Fatalf("expected internal analyzer finding from ListFindingsV2, got %+v", finding)
 	}
+	if finding.ActorPrincipalType != "access_analyzer" || finding.ActorPrincipalARN == "access-analyzer:external-principal" {
+		t.Fatalf("expected V2 internal analyzer finding to stay analyzer-scoped, got %+v", finding)
+	}
 	if finding.TargetResourceARN != "arn:aws:iam::123456789012:role/payments-worker" || finding.TargetResourceType != string(accessanalyzertypes.ResourceTypeAwsIamRole) {
 		t.Fatalf("expected normalized V2 resource details, got %+v", finding)
 	}

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -243,6 +243,19 @@ func TestIngesterPollsPendingIAMLastUsedReport(t *testing.T) {
 	t.Fatalf("expected service last-used signal after polling, got %+v", result.Signals)
 }
 
+func TestIngesterPropagatesContextCancellation(t *testing.T) {
+	for _, wantErr := range []error{context.Canceled, context.DeadlineExceeded} {
+		result, err := New(fakeIAMAPI{listRolesErr: wantErr}, fakeAccessAnalyzerAPI{}).Ingest(context.Background(), IngestRequest{
+			AccountID:   "123456789012",
+			Region:      "us-east-1",
+			CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected %v to propagate, got err=%v result=%+v", wantErr, err, result)
+		}
+	}
+}
+
 func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 type fakeIAMAPI struct {
-	listRolesErr error
-	getStatus    iamtypes.JobStatusType
-	truncated    bool
-	emptyRoles   bool
+	listRolesErr     error
+	getStatus        iamtypes.JobStatusType
+	truncated        bool
+	emptyRoles       bool
+	neverUsedRole    bool
+	roleCreationDate *time.Time
 }
 
 func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
@@ -28,17 +30,19 @@ func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam
 	if f.emptyRoles {
 		return &iam.ListRolesOutput{}, nil
 	}
-	lastUsed := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
-	return &iam.ListRolesOutput{
-		Roles: []iamtypes.Role{{
-			Arn:      awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
-			RoleName: awsv2.String("payments-worker"),
-			RoleLastUsed: &iamtypes.RoleLastUsed{
-				LastUsedDate: &lastUsed,
-				Region:       awsv2.String("us-east-1"),
-			},
-		}},
-	}, nil
+	role := iamtypes.Role{
+		Arn:        awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
+		RoleName:   awsv2.String("payments-worker"),
+		CreateDate: f.roleCreationDate,
+	}
+	if !f.neverUsedRole {
+		lastUsed := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+		role.RoleLastUsed = &iamtypes.RoleLastUsed{
+			LastUsedDate: &lastUsed,
+			Region:       awsv2.String("us-east-1"),
+		}
+	}
+	return &iam.ListRolesOutput{Roles: []iamtypes.Role{role}}, nil
 }
 
 func (f fakeIAMAPI) GenerateServiceLastAccessedDetails(context.Context, *iam.GenerateServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GenerateServiceLastAccessedDetailsOutput, error) {
@@ -212,6 +216,35 @@ func TestIngesterSkipsCrossAccountAccessAnalyzerFindings(t *testing.T) {
 	}
 	if result.Signals[0].AccountID != "123456789012" || !strings.Contains(result.Signals[0].EventID, "same-account") {
 		t.Fatalf("expected retained finding to belong to connector account, got %+v", result.Signals[0])
+	}
+}
+
+func TestIngesterDoesNotMarkNewNeverUsedRolesStale(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	createdAt := collectedAt.Add(-2 * time.Hour)
+	result, err := New(fakeIAMAPI{neverUsedRole: true, roleCreationDate: &createdAt}, fakeAccessAnalyzerAPI{emptyAnalyzers: true}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: collectedAt,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	var neverUsedRole *Signal
+	for idx := range result.Signals {
+		if strings.HasPrefix(result.Signals[idx].EventID, "iam-role-never-used:") {
+			neverUsedRole = &result.Signals[idx]
+			break
+		}
+	}
+	if neverUsedRole == nil {
+		t.Fatalf("expected role-never-used signal, got %+v", result.Signals)
+	}
+	if neverUsedRole.Status != "unknown" {
+		t.Fatalf("new never-used role should remain unknown until dormant threshold, got %+v", neverUsedRole)
+	}
+	if !neverUsedRole.ObservedAt.Equal(createdAt) {
+		t.Fatalf("expected creation date as observed_at, got %+v", neverUsedRole)
 	}
 }
 

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -1,0 +1,167 @@
+package awssignals
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	accessanalyzertypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+type fakeIAMAPI struct {
+	listRolesErr error
+	getStatus    iamtypes.JobStatusType
+}
+
+func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	if f.listRolesErr != nil {
+		return nil, f.listRolesErr
+	}
+	lastUsed := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+	return &iam.ListRolesOutput{
+		Roles: []iamtypes.Role{{
+			Arn:      awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
+			RoleName: awsv2.String("payments-worker"),
+			RoleLastUsed: &iamtypes.RoleLastUsed{
+				LastUsedDate: &lastUsed,
+				Region:       awsv2.String("us-east-1"),
+			},
+		}},
+	}, nil
+}
+
+func (f fakeIAMAPI) GenerateServiceLastAccessedDetails(context.Context, *iam.GenerateServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GenerateServiceLastAccessedDetailsOutput, error) {
+	return &iam.GenerateServiceLastAccessedDetailsOutput{JobId: awsv2.String("job-123")}, nil
+}
+
+func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GetServiceLastAccessedDetailsOutput, error) {
+	status := f.getStatus
+	if status == "" {
+		status = iamtypes.JobStatusTypeCompleted
+	}
+	completedAt := time.Date(2026, 6, 18, 8, 0, 0, 0, time.UTC)
+	lastAuthenticated := time.Date(2026, 6, 16, 7, 30, 0, 0, time.UTC)
+	return &iam.GetServiceLastAccessedDetailsOutput{
+		JobStatus:         status,
+		JobCompletionDate: &completedAt,
+		ServicesLastAccessed: []iamtypes.ServiceLastAccessed{{
+			ServiceName:             awsv2.String("Amazon S3"),
+			ServiceNamespace:        awsv2.String("s3"),
+			LastAuthenticated:       &lastAuthenticated,
+			LastAuthenticatedEntity: awsv2.String("arn:aws:iam::123456789012:role/payments-worker"),
+			LastAuthenticatedRegion: awsv2.String("us-east-1"),
+		}},
+	}, nil
+}
+
+type fakeAccessAnalyzerAPI struct {
+	listAnalyzersErr error
+	listFindingsErr  error
+}
+
+func (f fakeAccessAnalyzerAPI) ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error) {
+	if f.listAnalyzersErr != nil {
+		return nil, f.listAnalyzersErr
+	}
+	createdAt := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
+	return &accessanalyzer.ListAnalyzersOutput{
+		Analyzers: []accessanalyzertypes.AnalyzerSummary{{
+			Arn:       awsv2.String("arn:aws:access-analyzer:us-east-1:123456789012:analyzer/account"),
+			CreatedAt: &createdAt,
+			Name:      awsv2.String("account"),
+			Status:    accessanalyzertypes.AnalyzerStatusActive,
+			Type:      accessanalyzertypes.TypeAccount,
+		}},
+	}, nil
+}
+
+func (f fakeAccessAnalyzerAPI) ListFindings(context.Context, *accessanalyzer.ListFindingsInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListFindingsOutput, error) {
+	if f.listFindingsErr != nil {
+		return nil, f.listFindingsErr
+	}
+	createdAt := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 6, 18, 6, 30, 0, 0, time.UTC)
+	analyzedAt := time.Date(2026, 6, 18, 6, 0, 0, 0, time.UTC)
+	return &accessanalyzer.ListFindingsOutput{
+		Findings: []accessanalyzertypes.FindingSummary{{
+			AnalyzedAt:           &analyzedAt,
+			CreatedAt:            &createdAt,
+			Id:                   awsv2.String("finding-1"),
+			ResourceOwnerAccount: awsv2.String("123456789012"),
+			ResourceType:         accessanalyzertypes.ResourceTypeAwsSecretsmanagerSecret,
+			Status:               accessanalyzertypes.FindingStatusActive,
+			UpdatedAt:            &updatedAt,
+			Action:               []string{"secretsmanager:GetSecretValue"},
+			IsPublic:             awsv2.Bool(true),
+			Principal:            map[string]string{"AWS": "arn:aws:iam::210987654321:root"},
+			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/payments"),
+		}},
+	}, nil
+}
+
+func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	result, err := New(fakeIAMAPI{}, fakeAccessAnalyzerAPI{}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: collectedAt,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if result.Status != "ready" || len(result.Diagnostics) != 0 || len(result.CoverageGaps) != 0 {
+		t.Fatalf("expected ready metadata-only signal result, got %+v", result)
+	}
+	var roleLastUsed, serviceLastUsed, analyzerFinding *Signal
+	for idx := range result.Signals {
+		signal := &result.Signals[idx]
+		switch {
+		case signal.EventID == "iam-role-last-used:arn-aws-iam-123456789012-role-payments-worker":
+			roleLastUsed = signal
+		case signal.EventID == "iam-service-last-used:arn-aws-iam-123456789012-role-payments-worker:s3":
+			serviceLastUsed = signal
+		case strings.HasPrefix(signal.EventID, "access-analyzer:"):
+			analyzerFinding = signal
+		}
+	}
+	if roleLastUsed == nil || serviceLastUsed == nil || analyzerFinding == nil {
+		t.Fatalf("expected role, service, and analyzer signals, got %+v", result.Signals)
+	}
+	if roleLastUsed.Category != "iam-last-used" || roleLastUsed.Scope != "role" || !roleLastUsed.StaleAt.Equal(collectedAt) {
+		t.Fatalf("unexpected role last-used signal: %+v", roleLastUsed)
+	}
+	if serviceLastUsed.TargetResourceARN != "aws-service://s3" || serviceLastUsed.Scope != "service" || serviceLastUsed.StaleAt.IsZero() {
+		t.Fatalf("unexpected service last-used signal: %+v", serviceLastUsed)
+	}
+	if analyzerFinding.Category != "access-analyzer" || analyzerFinding.Scope != "account" || analyzerFinding.AnalyzerARN == "" || analyzerFinding.StaleAt.IsZero() || analyzerFinding.Confidence < 0.89 {
+		t.Fatalf("unexpected Access Analyzer signal: %+v", analyzerFinding)
+	}
+}
+
+func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
+	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ingest denied signals: %v", err)
+	}
+	if result.Status != "blocked" || len(result.Signals) != 0 {
+		t.Fatalf("expected blocked result without partial signal leakage, got %+v", result)
+	}
+	if len(result.Diagnostics) != 2 || len(result.CoverageGaps) != 2 {
+		t.Fatalf("expected IAM and Access Analyzer diagnostics/gaps, got %+v", result)
+	}
+	for _, diagnostic := range result.Diagnostics {
+		if !strings.Contains(diagnostic.Code, "permission_denied") {
+			t.Fatalf("expected permission-aware diagnostic, got %+v", diagnostic)
+		}
+	}
+}

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -17,6 +17,7 @@ import (
 type fakeIAMAPI struct {
 	listRolesErr error
 	getStatus    iamtypes.JobStatusType
+	truncated    bool
 }
 
 func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
@@ -50,6 +51,7 @@ func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServi
 	return &iam.GetServiceLastAccessedDetailsOutput{
 		JobStatus:         status,
 		JobCompletionDate: &completedAt,
+		IsTruncated:       f.truncated,
 		ServicesLastAccessed: []iamtypes.ServiceLastAccessed{{
 			ServiceName:             awsv2.String("Amazon S3"),
 			ServiceNamespace:        awsv2.String("s3"),
@@ -141,6 +143,34 @@ func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
 	}
 	if analyzerFinding.Category != "access-analyzer" || analyzerFinding.Scope != "account" || analyzerFinding.AnalyzerARN == "" || analyzerFinding.StaleAt.IsZero() || analyzerFinding.Confidence < 0.89 {
 		t.Fatalf("unexpected Access Analyzer signal: %+v", analyzerFinding)
+	}
+}
+
+func TestIngesterDegradesWhenCoverageGapsAreEmitted(t *testing.T) {
+	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	result, err := New(fakeIAMAPI{truncated: true}, fakeAccessAnalyzerAPI{}).Ingest(context.Background(), IngestRequest{
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		CollectedAt:        collectedAt,
+		MaxServicesPerRole: 1,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if result.Status != "degraded" {
+		t.Fatalf("expected coverage gap to degrade signal result, got %+v", result)
+	}
+	foundServiceGap := false
+	for _, gap := range result.CoverageGaps {
+		if gap.Capability == "iam_last_used" && gap.Status == "history_truncated" && strings.Contains(gap.Reason, "service budget") {
+			foundServiceGap = true
+		}
+	}
+	if !foundServiceGap {
+		t.Fatalf("expected service report truncation coverage gap, got %+v", result.CoverageGaps)
+	}
+	if len(result.Signals) == 0 {
+		t.Fatalf("expected retained signal rows alongside degraded coverage, got %+v", result)
 	}
 }
 

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -144,6 +144,50 @@ func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
 	}
 }
 
+type pollingIAMAPI struct {
+	fakeIAMAPI
+	statuses []iamtypes.JobStatusType
+	calls    int
+}
+
+func (f *pollingIAMAPI) GetServiceLastAccessedDetails(ctx context.Context, input *iam.GetServiceLastAccessedDetailsInput, options ...func(*iam.Options)) (*iam.GetServiceLastAccessedDetailsOutput, error) {
+	f.calls++
+	status := iamtypes.JobStatusTypeInProgress
+	if f.calls <= len(f.statuses) {
+		status = f.statuses[f.calls-1]
+	}
+	if status != iamtypes.JobStatusTypeCompleted {
+		return &iam.GetServiceLastAccessedDetailsOutput{JobStatus: status}, nil
+	}
+	return f.fakeIAMAPI.GetServiceLastAccessedDetails(ctx, input, options...)
+}
+
+func TestIngesterPollsPendingIAMLastUsedReport(t *testing.T) {
+	iamAPI := &pollingIAMAPI{statuses: []iamtypes.JobStatusType{
+		iamtypes.JobStatusTypeInProgress,
+		iamtypes.JobStatusTypeCompleted,
+	}}
+	result, err := New(iamAPI, fakeAccessAnalyzerAPI{}).Ingest(context.Background(), IngestRequest{
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		CollectedAt:        time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+		MaxReportPolls:     2,
+		ReportPollInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("ingest signals: %v", err)
+	}
+	if iamAPI.calls != 2 {
+		t.Fatalf("expected pending report to be polled with the same job ID, got %d calls", iamAPI.calls)
+	}
+	for _, signal := range result.Signals {
+		if signal.EventID == "iam-service-last-used:arn-aws-iam-123456789012-role-payments-worker:s3" {
+			return
+		}
+	}
+	t.Fatalf("expected service last-used signal after polling, got %+v", result.Signals)
+}
+
 func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/identrail/identrail/internal/db"
 	awsprovider "github.com/identrail/identrail/internal/providers/aws"
 	k8sprovider "github.com/identrail/identrail/internal/providers/kubernetes"
+	"github.com/identrail/identrail/internal/runtime/awssignals"
 	"github.com/identrail/identrail/internal/runtime/cloudtrail"
 	"github.com/identrail/identrail/internal/runtime/cloudtraildelivery"
 	"github.com/identrail/identrail/internal/scheduler"
@@ -406,6 +407,13 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		default:
 			return nil, fmt.Errorf("unsupported CloudTrail delivery source %q", source)
 		}
+	}
+	svc.AWSRuntimeSignalFactory = func(ctx context.Context, connection api.AWSConnectionStatus) (api.AWSRuntimeSignalIngester, error) {
+		iamAPI, analyzerAPI, signalErr := awssignals.NewSDKClientsFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-iam-access-signals")
+		if signalErr != nil {
+			return nil, signalErr
+		}
+		return api.NewAWSRuntimeSignalIngester(awssignals.New(iamAPI, analyzerAPI)), nil
 	}
 	svc.DefaultScope = db.Scope{
 		TenantID:    cfg.DefaultTenantID,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2174,6 +2174,10 @@ export type AWSRuntimeEventRecord = {
   agent_node_id?: string;
   tool_name?: string;
   tool_target_ref?: string;
+  signal_category?: string;
+  signal_scope?: string;
+  analyzer_arn?: string;
+  signal_stale_at?: string;
   owner: string;
   evidence_category: string;
   evidence_ref: string;
@@ -2223,6 +2227,9 @@ export type AWSRuntimeEventSummary = {
   kms_decrypt_count: number;
   api_call_count: number;
   sts_session_count: number;
+  iam_last_used_signal_count?: number;
+  access_analyzer_finding_count?: number;
+  dormant_access_count?: number;
   lineage_resolved_count?: number;
   missing_source_identity_count?: number;
   ambiguous_lineage_count?: number;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -161,28 +161,31 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
   region: 'us-east-1',
   parent_issue_number: 1472,
   parent_issue_ref: '#1472',
-  current_issue_number: 1516,
-  current_issue_ref: '#1516',
-  version: 'aws-runtime-events-contract-v2',
+  current_issue_number: 1517,
+  current_issue_ref: '#1517',
+  version: 'aws-runtime-events-contract-v3',
   status: 'ready',
   fixture_state: 'success',
   confidence: 0.92,
   applied_filters: {},
   summary: {
-    total_events: 2,
-    filtered_events: 2,
-    event_type_counts: { 'api-call': 1, 'agent-tool': 1 },
-    status_counts: { observed: 2 },
-    owner_counts: { security: 2 },
+    total_events: 3,
+    filtered_events: 3,
+    event_type_counts: { 'api-call': 1, 'agent-tool': 1, 'access-analyzer': 1 },
+    status_counts: { observed: 3 },
+    owner_counts: { security: 3 },
     account_count: 1,
     region_count: 1,
     identity_count: 1,
-    resource_count: 2,
+    resource_count: 3,
     agent_event_count: 1,
     secret_read_count: 0,
     kms_decrypt_count: 0,
     api_call_count: 1,
     sts_session_count: 0,
+    iam_last_used_signal_count: 0,
+    access_analyzer_finding_count: 1,
+    dormant_access_count: 0,
     relationship_count: 2,
     permission_denied_events: 0
   },
@@ -251,6 +254,40 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
       collected_at: '2026-06-14T17:21:00Z',
       status: 'observed',
       next_action: 'Review the agent identity and tool target relationship.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    },
+    {
+      event_id: 'evt-access-analyzer-open-secret',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'access-analyzer',
+      event_source: 'access-analyzer.amazonaws.com',
+      event_name: 'Finding',
+      action: 'secretsmanager:GetSecretValue',
+      actor_principal_arn: 'access-analyzer:external-principal',
+      actor_principal_type: 'aws_principal',
+      actor_identity_node_id: 'aws:identity:access-analyzer:external-principal',
+      session: {
+        session_id: '',
+        principal_arn: 'access-analyzer:external-principal',
+        principal_type: 'aws_principal'
+      },
+      target_resource_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/ai/openai-key',
+      target_resource_type: 'AWS::SecretsManager::Secret',
+      target_resource_name: 'prod/ai/openai-key',
+      resource_node_id: 'aws:runtime-resource:aws--secretsmanager--secret:openai-key',
+      signal_category: 'access-analyzer',
+      signal_scope: 'account',
+      analyzer_arn: 'arn:aws:access-analyzer:us-east-1:123456789012:analyzer/identrail-fixture',
+      signal_stale_at: '2026-06-14T17:58:00Z',
+      owner: 'security',
+      evidence_category: 'access-analyzer',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-access-analyzer-open-secret',
+      confidence: 0.9,
+      observed_at: '2026-06-14T17:49:00Z',
+      collected_at: '2026-06-14T17:58:00Z',
+      status: 'observed',
+      next_action: 'Review Access Analyzer scope and finding status before trusting or remediating access.',
       redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
     }
   ],
@@ -3019,6 +3056,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
     expect(await screen.findByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Event type' }), {
       target: { value: 'cloudtrail' }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -452,7 +452,7 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
       productDomainRoute('identities', 'Identities', 'identities', 'Identities', '', 'IAM roles, workload identities, and what they can reach.'),
       productDomainRoute('agents', 'Agents', 'agents', 'Agents', '', 'Bedrock and MCP agents Identrail can see.'),
       productDomainRoute('resources', 'Resources', 'resources', 'Resources', '', 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'),
-      productDomainRoute('runtime', 'Runtime', 'runtime', 'Runtime', '', 'What your AWS roles actually did, from CloudTrail.'),
+      productDomainRoute('runtime', 'Runtime', 'runtime', 'Runtime', '', 'What your AWS roles actually did, from runtime evidence.'),
       productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
       productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
       productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
@@ -2833,7 +2833,7 @@ const AWS_CONTROL_CARDS: AWSControlCard[] = [
     routeID: 'runtime',
     stage: 'coming',
     metric: '',
-    detail: 'What your AWS roles actually did, from CloudTrail.'
+    detail: 'What your AWS roles actually did, from runtime evidence.'
   },
   {
     id: 'findings',
@@ -9603,7 +9603,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     routeID: 'runtime',
     title: 'Runtime',
     eyebrow: '',
-    description: 'What your AWS roles actually did, from CloudTrail.',
+    description: 'What your AWS roles actually did, from CloudTrail, IAM last-used, and Access Analyzer.',
     statusLabel: '',
     currentCapability: '',
     plannedCapability: '',
@@ -9682,7 +9682,9 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
         { label: 'STS AssumeRole', value: 'sts-assume-role' },
         { label: 'Secrets Manager', value: 'secrets-manager' },
         { label: 'KMS decrypt', value: 'kms-decrypt' },
-        { label: 'Agent tool', value: 'agent-tool' }
+        { label: 'Agent tool', value: 'agent-tool' },
+        { label: 'IAM last-used', value: 'iam-last-used' },
+        { label: 'Access Analyzer', value: 'access-analyzer' }
       ]
     },
     {
@@ -9691,7 +9693,9 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
       options: [
         { label: 'All evidence', value: 'all' },
         { label: 'CloudTrail', value: 'cloudtrail' },
-        { label: 'Agent runtime', value: 'agent-runtime' }
+        { label: 'Agent runtime', value: 'agent-runtime' },
+        { label: 'IAM last-used', value: 'iam-last-used' },
+        { label: 'Access Analyzer', value: 'access-analyzer' }
       ]
     },
     {
@@ -10070,7 +10074,8 @@ function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTabl
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
   const observed = formatShortDateLabel(record.observed_at);
   const lineageLabel = awsRuntimeEventLineageLabel(record);
-  const sourceIdentityLabel = record.session?.source_identity ? `SourceIdentity ${record.session.source_identity}` : lineageLabel;
+  const signalLabel = awsRuntimeEventSignalLabel(record);
+  const sourceIdentityLabel = signalLabel || (record.session?.source_identity ? `SourceIdentity ${record.session.source_identity}` : lineageLabel);
   return {
     id: `runtime-${record.event_id}`,
     title: `${eventLabel}: ${record.event_name}`,
@@ -10109,11 +10114,25 @@ function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTabl
       record.agent_id,
       record.tool_name,
       record.tool_target_ref,
+      record.signal_category,
+      record.signal_scope,
+      record.analyzer_arn,
+      record.signal_stale_at,
       record.evidence_ref,
       observed,
       'runtime event metadata only no payloads no secret values'
     ])
   };
+}
+
+function awsRuntimeEventSignalLabel(record: AWSRuntimeEventRecord): string {
+  if (record.signal_category === 'iam-last-used' && record.signal_stale_at) {
+    return `IAM data as of ${formatShortDateLabel(record.signal_stale_at)}`;
+  }
+  if (record.signal_category === 'access-analyzer' && record.analyzer_arn) {
+    return 'Access Analyzer finding';
+  }
+  return '';
 }
 
 function awsRuntimeEventLineageLabel(record: AWSRuntimeEventRecord): string {
@@ -10139,6 +10158,10 @@ function awsRuntimeEventLabel(record: AWSRuntimeEventRecord): string {
       return 'KMS decrypt';
     case 'agent-tool':
       return 'Agent tool';
+    case 'iam-last-used':
+      return 'IAM last-used';
+    case 'access-analyzer':
+      return 'Access Analyzer';
     default:
       return 'CloudTrail';
   }


### PR DESCRIPTION
## Summary
- Add metadata-only IAM last-used and Access Analyzer signal ingestion for AWS runtime evidence.
- Normalize signal records into the runtime event contract with signal scope, analyzer ARN, stale-data timestamps, dormant-access counts, diagnostics, and coverage gaps.
- Update the API contract, OpenAPI docs, runtime UI filters/labels, and tests for the #1517 v3 contract.

## Validation
- `go test ./internal/runtime/awssignals ./internal/api`
- `go test ./...`
- `cd web && npm test -- --run src/productShell.test.tsx src/api/client.test.ts`
- `cd web && npm run build`
- `git diff --check`

## AI disclosure usage
No

Closes #1517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM last‑used and Access Analyzer signals to the AWS runtime evidence API and UI under the v3 contract (#1517). Signals are metadata‑only, scoped to the connected account, respect source filters, track coverage gaps, degrade gracefully, append to CloudTrail delivery‑backed runtime events, and use Access Analyzer V2 findings when required; CloudTrail stays visible.

- **New Features**
  - Append iam‑last‑used and access‑analyzer data to `/v1/.../aws/runtime-events` for lookup and CloudTrail delivery; apply per‑source filters; propagate cancellation; degrade on per‑source permission errors; only block when both are denied and no records remain.
  - Scope Access Analyzer analyzers/findings to the connected account; use V2 findings when required; include `analyzer_arn` and `signal_stale_at`; add `github.com/aws/aws-sdk-go-v2/service/accessanalyzer`.
  - Track Access Analyzer coverage gaps (e.g., no analyzers or listing denied) with remediation hints; include diagnostics without failing the request; handle partial coverage.
  - Normalize records with `signal_category` and `signal_scope`; add summary counts `iam_last_used_signal_count`, `access_analyzer_finding_count`, `dormant_access_count`; wire ingestion via `internal/runtime/awssignals` and `AWSRuntimeSignalFactory`; update web client types/tests and runtime nav copy to “runtime evidence”.
  - Clarify and age “never‑used” IAM semantics: if a role or service has no last‑used data, derive staleness (role creation or collection time) and include it in dormant access calculations; document the unknown runtime signal status.

- **Migration**
  - Connector role needs read‑only permissions:
    - IAM: iam:ListRoles, iam:GenerateServiceLastAccessedDetails, iam:GetServiceLastAccessedDetails
    - Access Analyzer: access-analyzer:ListAnalyzers, access-analyzer:ListFindings, access-analyzer:GetFinding
  - Clients of `/v1/.../aws/runtime-events` must handle new event types/fields; responses remain metadata‑only.

<sup>Written for commit 3b4bcf66c1ad8e68aa3469ad78ce8ba3b71ba455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

