### PR TITLE
Add appearance settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ import {
   ProductProjectsPage,
   ProductReportsPage,
   RequireProductAuth,
+  ProductAppearanceSettingsPage,
   ProductSettingsPage,
   ProductShellLayout,
   ProductWorkspacesPage
@@ -105,7 +106,6 @@ function LegacyScopedAppRedirect({ target }: { target: string }) {
 
   return <Navigate to={`/app/${encodeURIComponent(tenantID)}/${encodeURIComponent(workspaceID)}/${target}`} replace />;
 }
-const THEME_STORAGE_KEY = 'identrail-theme';
 const SCAN_CTA_LABEL = 'Request Trust Path Review';
 const INTAKE_TOTAL_STEPS = 4;
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
@@ -4658,15 +4658,6 @@ export function RoutedSite() {
   const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup' || normalizedPath === '/auth/mfa';
   const isAuthShellRoute = isAuthChoiceRoute || normalizedPath === '/auth/callback';
   useEffect(() => {
-    document.documentElement.dataset.theme = 'light';
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
-    } catch {
-      // Ignore storage write failures (blocked/disabled storage).
-    }
-  }, []);
-
-  useEffect(() => {
     if (isProductShellRoute || isOnboardingRoute || isAuthShellRoute) {
       return;
     }
@@ -4828,6 +4819,7 @@ export function RoutedSite() {
             <Route path="kubernetes/remediation" element={<ProductKubernetesRemediationPage />} />
             <Route path="reports" element={<ProductReportsPage />} />
             <Route path="settings" element={<ProductSettingsPage />} />
+            <Route path="settings/appearance" element={<ProductAppearanceSettingsPage />} />
           </Route>
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -33,6 +33,7 @@ export type AppearancePreferences = {
   accent: string;
   background: string;
   foreground: string;
+  customColors: boolean;
   uiFont: AppearanceFontID;
   codeFont: AppearanceFontID;
   translucentSidebar: boolean;
@@ -260,6 +261,7 @@ export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
   accent: '#7c6dff',
   background: '#121518',
   foreground: '#f5f7f8',
+  customColors: false,
   uiFont: 'system',
   codeFont: 'mono-system',
   translucentSidebar: false,
@@ -318,6 +320,7 @@ export function normalizeAppearancePreferences(value: unknown): AppearancePrefer
     accent: sanitizeHexColor(source.accent, DEFAULT_APPEARANCE_PREFERENCES.accent),
     background: sanitizeHexColor(source.background, DEFAULT_APPEARANCE_PREFERENCES.background),
     foreground: sanitizeHexColor(source.foreground, DEFAULT_APPEARANCE_PREFERENCES.foreground),
+    customColors: sanitizeBoolean(source.customColors, DEFAULT_APPEARANCE_PREFERENCES.customColors),
     uiFont: sanitizeFontID(source.uiFont, DEFAULT_APPEARANCE_PREFERENCES.uiFont),
     codeFont: sanitizeFontID(source.codeFont, DEFAULT_APPEARANCE_PREFERENCES.codeFont),
     translucentSidebar: sanitizeBoolean(
@@ -397,6 +400,21 @@ export function applyAppearancePreferences(preferences: AppearancePreferences): 
   const preset = findAppearancePreset(presetID);
   const root = document.documentElement;
   const style = root.style;
+  const colors = normalized.customColors
+    ? {
+        accent: normalized.accent,
+        background: normalized.background,
+        foreground: normalized.foreground
+      }
+    : {
+        accent: preset.accent,
+        background: preset.background,
+        foreground: preset.foreground
+      };
+  const contrast = normalized.contrast / 100;
+  const panelMix = `${Math.round(64 + contrast * 24)}%`;
+  const borderMix = `${Math.round(50 + contrast * 50)}%`;
+  const mutedMix = `${Math.round(58 + contrast * 32)}%`;
 
   root.dataset.theme = resolvedTheme;
   root.dataset.appearanceReady = 'true';
@@ -409,12 +427,15 @@ export function applyAppearancePreferences(preferences: AppearancePreferences): 
   root.dataset.appearanceTranslucentSidebar = normalized.translucentSidebar ? 'true' : 'false';
   root.dataset.appearanceAppIcon = normalized.appIcon;
 
-  style.setProperty('--appearance-accent', normalized.accent || preset.accent);
-  style.setProperty('--appearance-bg', normalized.background || preset.background);
-  style.setProperty('--appearance-fg', normalized.foreground || preset.foreground);
+  style.setProperty('--appearance-accent', colors.accent);
+  style.setProperty('--appearance-bg', colors.background);
+  style.setProperty('--appearance-fg', colors.foreground);
   style.setProperty('--appearance-panel', preset.panel);
   style.setProperty('--appearance-border', preset.border);
   style.setProperty('--appearance-muted', preset.muted);
+  style.setProperty('--appearance-panel-mix', panelMix);
+  style.setProperty('--appearance-border-mix', borderMix);
+  style.setProperty('--appearance-muted-mix', mutedMix);
   style.setProperty('--appearance-ui-font', APPEARANCE_FONTS[normalized.uiFont]);
   style.setProperty('--appearance-code-font', APPEARANCE_FONTS[normalized.codeFont]);
   style.setProperty('--appearance-ui-font-size', `${normalized.uiFontSize}px`);

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -275,7 +275,6 @@ export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
   appIcon: 'default'
 };
 
-const PRESET_IDS: ReadonlySet<string> = new Set(APPEARANCE_PRESETS.map((preset) => preset.id));
 const FONT_IDS: ReadonlySet<string> = new Set(Object.keys(APPEARANCE_FONTS));
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
@@ -287,8 +286,18 @@ function sanitizeEnum<T extends string>(value: unknown, allowed: readonly T[], f
   return typeof value === 'string' && allowed.includes(value as T) ? (value as T) : fallback;
 }
 
-function sanitizePresetID(value: unknown, fallback: AppearancePresetID): AppearancePresetID {
-  return typeof value === 'string' && PRESET_IDS.has(value) ? (value as AppearancePresetID) : fallback;
+function sanitizePresetID(value: unknown, mode: 'light' | 'dark', fallback: AppearancePresetID): AppearancePresetID {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const preset = APPEARANCE_PRESETS.find((candidate) => candidate.id === value);
+  if (!preset) {
+    return fallback;
+  }
+  if (mode === 'light') {
+    return preset.mode === 'light' ? preset.id : fallback;
+  }
+  return preset.mode === 'dark' || preset.mode === 'both' ? preset.id : fallback;
 }
 
 function sanitizeFontID(value: unknown, fallback: AppearanceFontID): AppearanceFontID {
@@ -315,8 +324,8 @@ export function normalizeAppearancePreferences(value: unknown): AppearancePrefer
   const source = isRecord(value) ? value : {};
   return {
     themeMode: sanitizeEnum(source.themeMode, ['light', 'dark', 'system'], DEFAULT_APPEARANCE_PREFERENCES.themeMode),
-    lightPreset: sanitizePresetID(source.lightPreset, DEFAULT_APPEARANCE_PREFERENCES.lightPreset),
-    darkPreset: sanitizePresetID(source.darkPreset, DEFAULT_APPEARANCE_PREFERENCES.darkPreset),
+    lightPreset: sanitizePresetID(source.lightPreset, 'light', DEFAULT_APPEARANCE_PREFERENCES.lightPreset),
+    darkPreset: sanitizePresetID(source.darkPreset, 'dark', DEFAULT_APPEARANCE_PREFERENCES.darkPreset),
     accent: sanitizeHexColor(source.accent, DEFAULT_APPEARANCE_PREFERENCES.accent),
     background: sanitizeHexColor(source.background, DEFAULT_APPEARANCE_PREFERENCES.background),
     foreground: sanitizeHexColor(source.foreground, DEFAULT_APPEARANCE_PREFERENCES.foreground),

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -1,0 +1,445 @@
+export const LEGACY_THEME_STORAGE_KEY = 'identrail-theme';
+export const APPEARANCE_STORAGE_KEY = 'identrail-appearance';
+
+export type AppearanceThemeMode = 'light' | 'dark' | 'system';
+export type AppearanceReduceMotion = 'system' | 'on' | 'off';
+export type AppearanceDiffMarkers = 'color' | 'symbols';
+export type AppearanceAppIcon = 'default' | 'light' | 'dark';
+
+export type AppearancePresetID =
+  | 'absolutely'
+  | 'catppuccin'
+  | 'everforest'
+  | 'github'
+  | 'gruvbox'
+  | 'identrail'
+  | 'linear'
+  | 'notion'
+  | 'one'
+  | 'proof'
+  | 'raycast'
+  | 'rose-pine'
+  | 'solarized'
+  | 'vercel'
+  | 'vs-code-plus'
+  | 'xcode';
+
+export type AppearanceFontID = 'system' | 'inter' | 'geist' | 'mono-system' | 'ibm-plex-mono';
+
+export type AppearancePreferences = {
+  themeMode: AppearanceThemeMode;
+  lightPreset: AppearancePresetID;
+  darkPreset: AppearancePresetID;
+  accent: string;
+  background: string;
+  foreground: string;
+  uiFont: AppearanceFontID;
+  codeFont: AppearanceFontID;
+  translucentSidebar: boolean;
+  contrast: number;
+  pointerCursors: boolean;
+  reduceMotion: AppearanceReduceMotion;
+  uiFontSize: number;
+  codeFontSize: number;
+  diffMarkers: AppearanceDiffMarkers;
+  fontSmoothing: boolean;
+  appIcon: AppearanceAppIcon;
+};
+
+export type AppearancePreset = {
+  id: AppearancePresetID;
+  label: string;
+  mode: 'light' | 'dark' | 'both';
+  accent: string;
+  background: string;
+  foreground: string;
+  panel: string;
+  border: string;
+  muted: string;
+};
+
+export const APPEARANCE_PRESETS: AppearancePreset[] = [
+  {
+    id: 'notion',
+    label: 'Notion',
+    mode: 'light',
+    accent: '#3183d8',
+    background: '#ffffff',
+    foreground: '#37352f',
+    panel: '#f7f6f3',
+    border: '#e6e4df',
+    muted: '#787774'
+  },
+  {
+    id: 'one',
+    label: 'One',
+    mode: 'both',
+    accent: '#6c7cff',
+    background: '#101217',
+    foreground: '#f4f5f8',
+    panel: '#171a21',
+    border: '#2c313b',
+    muted: '#aeb5c2'
+  },
+  {
+    id: 'proof',
+    label: 'Proof',
+    mode: 'light',
+    accent: '#1f8f68',
+    background: '#f7faf6',
+    foreground: '#1f2a22',
+    panel: '#ffffff',
+    border: '#dbe7dd',
+    muted: '#627067'
+  },
+  {
+    id: 'raycast',
+    label: 'Raycast',
+    mode: 'both',
+    accent: '#ff6363',
+    background: '#141112',
+    foreground: '#fff7f7',
+    panel: '#1e1819',
+    border: '#3b282b',
+    muted: '#d7b8bc'
+  },
+  {
+    id: 'rose-pine',
+    label: 'Rose Pine',
+    mode: 'dark',
+    accent: '#eb6f92',
+    background: '#191724',
+    foreground: '#e0def4',
+    panel: '#1f1d2e',
+    border: '#403d52',
+    muted: '#908caa'
+  },
+  {
+    id: 'solarized',
+    label: 'Solarized',
+    mode: 'both',
+    accent: '#268bd2',
+    background: '#002b36',
+    foreground: '#fdf6e3',
+    panel: '#073642',
+    border: '#335b63',
+    muted: '#93a1a1'
+  },
+  {
+    id: 'vercel',
+    label: 'Vercel',
+    mode: 'both',
+    accent: '#ffffff',
+    background: '#000000',
+    foreground: '#ededed',
+    panel: '#0a0a0a',
+    border: '#2a2a2a',
+    muted: '#a1a1a1'
+  },
+  {
+    id: 'vs-code-plus',
+    label: 'VS Code Plus',
+    mode: 'dark',
+    accent: '#007acc',
+    background: '#1e1e1e',
+    foreground: '#d4d4d4',
+    panel: '#252526',
+    border: '#3c3c3c',
+    muted: '#9cdcfe'
+  },
+  {
+    id: 'xcode',
+    label: 'Xcode',
+    mode: 'light',
+    accent: '#147efb',
+    background: '#f5f7fb',
+    foreground: '#1d2433',
+    panel: '#ffffff',
+    border: '#d8dde7',
+    muted: '#667085'
+  },
+  {
+    id: 'absolutely',
+    label: 'Absolutely',
+    mode: 'light',
+    accent: '#3183d8',
+    background: '#fbfcff',
+    foreground: '#171923',
+    panel: '#ffffff',
+    border: '#dce5f2',
+    muted: '#66758a'
+  },
+  {
+    id: 'catppuccin',
+    label: 'Catppuccin',
+    mode: 'dark',
+    accent: '#89b4fa',
+    background: '#1e1e2e',
+    foreground: '#cdd6f4',
+    panel: '#181825',
+    border: '#45475a',
+    muted: '#a6adc8'
+  },
+  {
+    id: 'everforest',
+    label: 'Everforest',
+    mode: 'dark',
+    accent: '#a7c080',
+    background: '#2d353b',
+    foreground: '#d3c6aa',
+    panel: '#232a2e',
+    border: '#475258',
+    muted: '#859289'
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    mode: 'both',
+    accent: '#2f81f7',
+    background: '#0d1117',
+    foreground: '#f0f6fc',
+    panel: '#010409',
+    border: '#30363d',
+    muted: '#8b949e'
+  },
+  {
+    id: 'gruvbox',
+    label: 'Gruvbox',
+    mode: 'dark',
+    accent: '#fabd2f',
+    background: '#282828',
+    foreground: '#ebdbb2',
+    panel: '#1d2021',
+    border: '#504945',
+    muted: '#a89984'
+  },
+  {
+    id: 'identrail',
+    label: 'Identrail',
+    mode: 'dark',
+    accent: '#7c6dff',
+    background: '#121518',
+    foreground: '#f5f7f8',
+    panel: '#090b0e',
+    border: '#2b3037',
+    muted: '#adb5bf'
+  },
+  {
+    id: 'linear',
+    label: 'Linear',
+    mode: 'dark',
+    accent: '#5e6ad2',
+    background: '#0f1014',
+    foreground: '#f7f8f8',
+    panel: '#16171d',
+    border: '#2f3037',
+    muted: '#a7aab3'
+  }
+];
+
+export const APPEARANCE_FONTS: Record<AppearanceFontID, string> = {
+  system: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif',
+  inter: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  geist: 'Geist, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  'mono-system': 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  'ibm-plex-mono': '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+};
+
+export const APPEARANCE_FONT_LABELS: Record<AppearanceFontID, string> = {
+  system: 'System',
+  inter: 'Inter',
+  geist: 'Geist',
+  'mono-system': 'System Mono',
+  'ibm-plex-mono': 'IBM Plex Mono'
+};
+
+export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
+  themeMode: 'system',
+  lightPreset: 'notion',
+  darkPreset: 'identrail',
+  accent: '#7c6dff',
+  background: '#121518',
+  foreground: '#f5f7f8',
+  uiFont: 'system',
+  codeFont: 'mono-system',
+  translucentSidebar: false,
+  contrast: 45,
+  pointerCursors: false,
+  reduceMotion: 'system',
+  uiFontSize: 16,
+  codeFontSize: 14,
+  diffMarkers: 'color',
+  fontSmoothing: true,
+  appIcon: 'default'
+};
+
+const PRESET_IDS: ReadonlySet<string> = new Set(APPEARANCE_PRESETS.map((preset) => preset.id));
+const FONT_IDS: ReadonlySet<string> = new Set(Object.keys(APPEARANCE_FONTS));
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sanitizeEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === 'string' && allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+function sanitizePresetID(value: unknown, fallback: AppearancePresetID): AppearancePresetID {
+  return typeof value === 'string' && PRESET_IDS.has(value) ? (value as AppearancePresetID) : fallback;
+}
+
+function sanitizeFontID(value: unknown, fallback: AppearanceFontID): AppearanceFontID {
+  return typeof value === 'string' && FONT_IDS.has(value) ? (value as AppearanceFontID) : fallback;
+}
+
+function sanitizeHexColor(value: unknown, fallback: string): string {
+  return typeof value === 'string' && HEX_COLOR_PATTERN.test(value) ? value.toLowerCase() : fallback;
+}
+
+function sanitizeNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.round(numberValue)));
+}
+
+function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+export function normalizeAppearancePreferences(value: unknown): AppearancePreferences {
+  const source = isRecord(value) ? value : {};
+  return {
+    themeMode: sanitizeEnum(source.themeMode, ['light', 'dark', 'system'], DEFAULT_APPEARANCE_PREFERENCES.themeMode),
+    lightPreset: sanitizePresetID(source.lightPreset, DEFAULT_APPEARANCE_PREFERENCES.lightPreset),
+    darkPreset: sanitizePresetID(source.darkPreset, DEFAULT_APPEARANCE_PREFERENCES.darkPreset),
+    accent: sanitizeHexColor(source.accent, DEFAULT_APPEARANCE_PREFERENCES.accent),
+    background: sanitizeHexColor(source.background, DEFAULT_APPEARANCE_PREFERENCES.background),
+    foreground: sanitizeHexColor(source.foreground, DEFAULT_APPEARANCE_PREFERENCES.foreground),
+    uiFont: sanitizeFontID(source.uiFont, DEFAULT_APPEARANCE_PREFERENCES.uiFont),
+    codeFont: sanitizeFontID(source.codeFont, DEFAULT_APPEARANCE_PREFERENCES.codeFont),
+    translucentSidebar: sanitizeBoolean(
+      source.translucentSidebar,
+      DEFAULT_APPEARANCE_PREFERENCES.translucentSidebar
+    ),
+    contrast: sanitizeNumber(source.contrast, DEFAULT_APPEARANCE_PREFERENCES.contrast, 0, 100),
+    pointerCursors: sanitizeBoolean(source.pointerCursors, DEFAULT_APPEARANCE_PREFERENCES.pointerCursors),
+    reduceMotion: sanitizeEnum(source.reduceMotion, ['system', 'on', 'off'], DEFAULT_APPEARANCE_PREFERENCES.reduceMotion),
+    uiFontSize: sanitizeNumber(source.uiFontSize, DEFAULT_APPEARANCE_PREFERENCES.uiFontSize, 14, 22),
+    codeFontSize: sanitizeNumber(source.codeFontSize, DEFAULT_APPEARANCE_PREFERENCES.codeFontSize, 12, 22),
+    diffMarkers: sanitizeEnum(source.diffMarkers, ['color', 'symbols'], DEFAULT_APPEARANCE_PREFERENCES.diffMarkers),
+    fontSmoothing: sanitizeBoolean(source.fontSmoothing, DEFAULT_APPEARANCE_PREFERENCES.fontSmoothing),
+    appIcon: sanitizeEnum(source.appIcon, ['default', 'light', 'dark'], DEFAULT_APPEARANCE_PREFERENCES.appIcon)
+  };
+}
+
+function resolveSystemTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'dark';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function resolveAppearanceThemeMode(themeMode: AppearanceThemeMode): 'light' | 'dark' {
+  return themeMode === 'system' ? resolveSystemTheme() : themeMode;
+}
+
+export function findAppearancePreset(id: AppearancePresetID): AppearancePreset {
+  return APPEARANCE_PRESETS.find((preset) => preset.id === id) ?? APPEARANCE_PRESETS[0];
+}
+
+export function readAppearancePreferences(): AppearancePreferences {
+  if (typeof window === 'undefined') {
+    return DEFAULT_APPEARANCE_PREFERENCES;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(APPEARANCE_STORAGE_KEY);
+    if (raw) {
+      return normalizeAppearancePreferences(JSON.parse(raw));
+    }
+    const legacyTheme = window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+    if (legacyTheme === 'light' || legacyTheme === 'dark') {
+      return normalizeAppearancePreferences({
+        ...DEFAULT_APPEARANCE_PREFERENCES,
+        themeMode: legacyTheme
+      });
+    }
+  } catch {
+    return DEFAULT_APPEARANCE_PREFERENCES;
+  }
+  return DEFAULT_APPEARANCE_PREFERENCES;
+}
+
+export function saveAppearancePreferences(preferences: AppearancePreferences): AppearancePreferences {
+  const normalized = normalizeAppearancePreferences(preferences);
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(normalized));
+      window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, resolveAppearanceThemeMode(normalized.themeMode));
+    } catch {
+      // Storage can be blocked by the browser; the in-memory UI state still applies.
+    }
+  }
+  return normalized;
+}
+
+export function applyAppearancePreferences(preferences: AppearancePreferences): AppearancePreferences {
+  const normalized = normalizeAppearancePreferences(preferences);
+  if (typeof document === 'undefined') {
+    return normalized;
+  }
+
+  const resolvedTheme = resolveAppearanceThemeMode(normalized.themeMode);
+  const presetID = resolvedTheme === 'light' ? normalized.lightPreset : normalized.darkPreset;
+  const preset = findAppearancePreset(presetID);
+  const root = document.documentElement;
+  const style = root.style;
+
+  root.dataset.theme = resolvedTheme;
+  root.dataset.appearanceReady = 'true';
+  root.dataset.appearanceMode = normalized.themeMode;
+  root.dataset.appearancePreset = preset.id;
+  root.dataset.pointerCursors = normalized.pointerCursors ? 'true' : 'false';
+  root.dataset.reduceMotion = normalized.reduceMotion;
+  root.dataset.diffMarkers = normalized.diffMarkers;
+  root.dataset.fontSmoothing = normalized.fontSmoothing ? 'true' : 'false';
+  root.dataset.appearanceTranslucentSidebar = normalized.translucentSidebar ? 'true' : 'false';
+  root.dataset.appearanceAppIcon = normalized.appIcon;
+
+  style.setProperty('--appearance-accent', normalized.accent || preset.accent);
+  style.setProperty('--appearance-bg', normalized.background || preset.background);
+  style.setProperty('--appearance-fg', normalized.foreground || preset.foreground);
+  style.setProperty('--appearance-panel', preset.panel);
+  style.setProperty('--appearance-border', preset.border);
+  style.setProperty('--appearance-muted', preset.muted);
+  style.setProperty('--appearance-ui-font', APPEARANCE_FONTS[normalized.uiFont]);
+  style.setProperty('--appearance-code-font', APPEARANCE_FONTS[normalized.codeFont]);
+  style.setProperty('--appearance-ui-font-size', `${normalized.uiFontSize}px`);
+  style.setProperty('--appearance-code-font-size', `${normalized.codeFontSize}px`);
+  style.setProperty('--appearance-contrast', String(normalized.contrast));
+
+  return normalized;
+}
+
+export function applyStoredAppearancePreferences(): AppearancePreferences {
+  return applyAppearancePreferences(readAppearancePreferences());
+}
+
+export function installAppearancePreferenceListener(): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const listener = () => {
+    applyStoredAppearancePreferences();
+  };
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }
+  media.addListener(listener);
+  return () => media.removeListener(listener);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,25 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { applyStoredAppearancePreferences, installAppearancePreferenceListener } from './appearance';
 import './styles/tokens.css';
 import './styles.css';
 
-const THEME_STORAGE_KEY = 'identrail-theme';
-
-function applyInitialTheme() {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  document.documentElement.dataset.theme = 'light';
-  try {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
-  } catch {
-    // Ignore storage write failures (blocked/disabled storage).
-  }
-}
-
-applyInitialTheme();
+applyStoredAppearancePreferences();
+installAppearancePreferenceListener();
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -32,5 +32,6 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/kubernetes/findings',
   '/app/:tenantID/:workspaceID/kubernetes/remediation',
   '/app/:tenantID/:workspaceID/reports',
-  '/app/:tenantID/:workspaceID/settings'
+  '/app/:tenantID/:workspaceID/settings',
+  '/app/:tenantID/:workspaceID/settings/appearance'
 ] as const;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2005,6 +2005,37 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-code-font-size')).toBe('18px');
   });
 
+  it('defers font-size clamping until number inputs commit', async () => {
+    await renderProductAppearanceSettingsPage();
+
+    const uiFontSize = screen.getByLabelText('UI font size') as HTMLInputElement;
+    fireEvent.focus(uiFontSize);
+    fireEvent.change(uiFontSize, { target: { value: '1' } });
+
+    expect(uiFontSize.value).toBe('1');
+    expect(window.localStorage.getItem('identrail-appearance')).toBeNull();
+
+    fireEvent.change(uiFontSize, { target: { value: '18' } });
+    expect(uiFontSize.value).toBe('18');
+
+    fireEvent.blur(uiFontSize);
+    expect(JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}')).toMatchObject({
+      uiFontSize: 18
+    });
+
+    const codeFontSize = screen.getByLabelText('Code font size') as HTMLInputElement;
+    fireEvent.focus(codeFontSize);
+    fireEvent.change(codeFontSize, { target: { value: '2' } });
+
+    expect(codeFontSize.value).toBe('2');
+
+    fireEvent.blur(codeFontSize);
+    await waitFor(() => expect(codeFontSize.value).toBe('12'));
+    expect(JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}')).toMatchObject({
+      codeFontSize: 12
+    });
+  });
+
 });
 
 describe('ProductShellLayout', () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4968,7 +4968,7 @@ describe('ProductFindingsPage states', () => {
       human_summary: 'AssumeRole trust policy allows any principal.',
       remediation: 'Tighten trust policy principals.',
       source_url: 'https://github.com/identrail/identrail/blob/main/policy.tf#L7',
-      line_snippet: '+ allow = true\n- allow = false',
+      line_snippet: '@@ -1 +1 @@\n+ allow = true\n- allow = false',
       created_at: '2026-05-17T11:06:00Z'
     };
 
@@ -4989,6 +4989,7 @@ describe('ProductFindingsPage states', () => {
       Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '- allow = false')
     );
     expect(screen.getByText('Evidence line')).toHaveClass('idt-repo-finding-code-label');
+    expect(screen.getByText('@@ -1 +1 @@')).toHaveClass('idt-repo-finding-code-line');
     expect(addedLine).toHaveClass('idt-repo-finding-code-line', 'is-add');
     expect(removedLine).toHaveClass('idt-repo-finding-code-line', 'is-remove');
     expect(addedLine).not.toHaveClass('idt-repo-finding-code-label');
@@ -5007,7 +5008,7 @@ describe('ProductFindingsPage states', () => {
     });
   });
 
-  it('does not mark ordinary source lines that start with a dash as diff removals', async () => {
+  it('does not mark ordinary source lines that start with plus or dash prefixes as diffs', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-with-yaml-source',
@@ -5025,7 +5026,7 @@ describe('ProductFindingsPage states', () => {
       human_summary: 'A workflow permission entry needs review.',
       remediation: 'Limit workflow permissions.',
       source_url: 'https://github.com/identrail/identrail/blob/main/workflow.yml#L12',
-      line_snippet: '- name: prod',
+      line_snippet: '+enabled\n- name: prod',
       created_at: '2026-05-17T11:06:00Z'
     };
 
@@ -5038,10 +5039,16 @@ describe('ProductFindingsPage states', () => {
     if (!rowButton) return;
     fireEvent.click(rowButton);
 
-    const sourceLine = await screen.findByText('- name: prod');
-    expect(sourceLine).toHaveClass('idt-repo-finding-code-line');
-    expect(sourceLine).not.toHaveClass('is-remove');
-    expect(sourceLine.querySelector('.idt-repo-finding-code-marker')).toBeNull();
+    const plusSourceLine = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '+enabled')
+    );
+    const yamlSourceLine = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '- name: prod')
+    );
+    expect(plusSourceLine).not.toHaveClass('is-add');
+    expect(yamlSourceLine).not.toHaveClass('is-remove');
+    expect(plusSourceLine.querySelector('.idt-repo-finding-code-marker')).toBeNull();
+    expect(yamlSourceLine.querySelector('.idt-repo-finding-code-marker')).toBeNull();
   });
 
   it('keeps visible filters when active filters match no findings', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -5069,7 +5069,15 @@ describe('ProductFindingsPage states', () => {
       human_summary: 'A workflow permission entry was added.',
       remediation: 'Limit workflow permissions.',
       source_url: 'https://github.com/identrail/identrail/blob/main/workflow.yml#L12',
-      line_snippet: '@@ -0,0 +1 @@\n+ allow = true',
+      line_snippet: [
+        'diff --git a/workflow.yml b/workflow.yml',
+        'new file mode 100644',
+        'index 0000000..1111111',
+        '--- /dev/null',
+        '+++ b/workflow.yml',
+        '@@ -0,0 +1 @@',
+        '+ allow = true'
+      ].join('\n'),
       created_at: '2026-05-17T11:06:00Z'
     };
     const removalFinding: Finding = {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1860,14 +1860,14 @@ describe('ProductAppearanceSettingsPage', () => {
   it('persists Codex-style controls through the allowlisted appearance model', async () => {
     await renderProductAppearanceSettingsPage();
 
-    fireEvent.change(screen.getByLabelText('Light theme'), { target: { value: 'vercel' } });
+    fireEvent.change(screen.getByLabelText('Light theme'), { target: { value: 'xcode' } });
     fireEvent.change(screen.getByLabelText('Accent color'), { target: { value: '#123456' } });
     fireEvent.click(screen.getByRole('switch', { name: 'Use pointer cursors' }));
     fireEvent.click(screen.getByRole('button', { name: 'Identrail D...' }));
 
     const stored = JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}');
     expect(stored).toMatchObject({
-      lightPreset: 'vercel',
+      lightPreset: 'xcode',
       accent: '#123456',
       customColors: true,
       pointerCursors: true,
@@ -1878,11 +1878,26 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.dataset.appearanceAppIcon).toBe('dark');
   });
 
+  it('keeps dark palettes out of the light appearance preset choices', async () => {
+    await renderProductAppearanceSettingsPage();
+
+    const lightTheme = screen.getByLabelText('Light theme');
+    const darkTheme = screen.getByLabelText('Dark theme');
+
+    expect(within(lightTheme).queryByRole('option', { name: 'Vercel' })).not.toBeInTheDocument();
+    expect(within(lightTheme).queryByRole('option', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(within(lightTheme).getByRole('option', { name: 'Xcode' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Vercel' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'GitHub' })).toBeInTheDocument();
+  });
+
   it('sanitizes stored appearance values before they reach CSS variables', async () => {
     const { normalizeAppearancePreferences } = await import('./appearance');
 
     const normalized = normalizeAppearancePreferences({
       themeMode: 'dark',
+      lightPreset: 'vercel',
+      darkPreset: 'notion',
       accent: 'url(javascript:alert(1))',
       background: 'expression(alert(1))',
       foreground: '#abcdef',
@@ -1895,6 +1910,8 @@ describe('ProductAppearanceSettingsPage', () => {
     });
 
     expect(normalized).toMatchObject({
+      lightPreset: 'notion',
+      darkPreset: 'identrail',
       accent: '#7c6dff',
       background: '#121518',
       foreground: '#abcdef',
@@ -5076,7 +5093,7 @@ describe('ProductFindingsPage states', () => {
         '--- /dev/null',
         '+++ b/workflow.yml',
         '@@ -0,0 +1 @@',
-        '+ allow = true'
+        '+++count'
       ].join('\n'),
       created_at: '2026-05-17T11:06:00Z'
     };
@@ -5085,7 +5102,7 @@ describe('ProductFindingsPage states', () => {
       id: 'finding-remove-only-diff',
       title: 'Workflow removes guardrail',
       human_summary: 'A workflow guardrail was removed.',
-      line_snippet: '@@ -1 +0,0 @@\n- require_review = true'
+      line_snippet: '@@ -1 +0,0 @@\n---count'
     };
 
     await renderFindings({ repoScans: [scan], repoFindings: [additionFinding, removalFinding] });
@@ -5098,7 +5115,7 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(addRow);
 
     const addedLine = await screen.findByText((_, element) =>
-      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '+ allow = true')
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '+++count')
     );
     expect(addedLine).toHaveClass('is-add');
     expect(within(addedLine).getByText('+')).toHaveClass('idt-repo-finding-code-marker');
@@ -5116,9 +5133,7 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(removeRow);
 
     const removedLine = await screen.findByText((_, element) =>
-      Boolean(
-        element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '- require_review = true'
-      )
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '---count')
     );
     expect(removedLine).toHaveClass('is-remove');
     expect(within(removedLine).getByText('-')).toHaveClass('idt-repo-finding-code-marker');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1919,6 +1919,26 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#37352f');
   });
 
+  it('does not seed custom colors from an inactive preset', async () => {
+    await renderProductAppearanceSettingsPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+    fireEvent.change(screen.getByLabelText('Light theme'), { target: { value: 'xcode' } });
+    fireEvent.change(screen.getByLabelText('Accent color'), { target: { value: '#123456' } });
+
+    const stored = JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}');
+    expect(stored).toMatchObject({
+      themeMode: 'dark',
+      lightPreset: 'xcode',
+      accent: '#123456',
+      background: '#121518',
+      foreground: '#f5f7f8',
+      customColors: true
+    });
+    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#121518');
+    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#f5f7f8');
+  });
+
   it('exposes contrast as real color-mix inputs for shell styles', async () => {
     const { applyAppearancePreferences, normalizeAppearancePreferences } = await import('./appearance');
 
@@ -1933,6 +1953,21 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-border-mix')).toBe('100%');
     expect(document.documentElement.style.getPropertyValue('--appearance-muted-mix')).toBe('90%');
   });
+
+  it('applies code typography preferences as root style variables', async () => {
+    const { applyAppearancePreferences, normalizeAppearancePreferences } = await import('./appearance');
+
+    applyAppearancePreferences(
+      normalizeAppearancePreferences({
+        codeFont: 'ibm-plex-mono',
+        codeFontSize: 18
+      })
+    );
+
+    expect(document.documentElement.style.getPropertyValue('--appearance-code-font')).toContain('IBM Plex Mono');
+    expect(document.documentElement.style.getPropertyValue('--appearance-code-font-size')).toBe('18px');
+  });
+
 });
 
 describe('ProductShellLayout', () => {
@@ -4912,6 +4947,8 @@ describe('ProductFindingsPage states', () => {
       title: 'IAM role with wildcard trust',
       human_summary: 'AssumeRole trust policy allows any principal.',
       remediation: 'Tighten trust policy principals.',
+      source_url: 'https://github.com/identrail/identrail/blob/main/policy.tf#L7',
+      line_snippet: '+ allow = true\n- allow = false',
       created_at: '2026-05-17T11:06:00Z'
     };
 
@@ -4924,6 +4961,11 @@ describe('ProductFindingsPage states', () => {
     if (!rowButton) return;
     rowButton.focus();
     fireEvent.click(rowButton);
+
+    const addedLine = await screen.findByText('+ allow = true');
+    const removedLine = await screen.findByText('- allow = false');
+    expect(addedLine).toHaveClass('idt-repo-finding-code-line', 'is-add');
+    expect(removedLine).toHaveClass('idt-repo-finding-code-line', 'is-remove');
 
     const closeButton = await screen.findByRole('button', { name: /Close finding detail/i });
     fireEvent.click(closeButton);

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -5051,6 +5051,71 @@ describe('ProductFindingsPage states', () => {
     expect(yamlSourceLine.querySelector('.idt-repo-finding-code-marker')).toBeNull();
   });
 
+  it('marks one-sided repository diff hunks as changed lines', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-with-one-sided-diff',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+
+    const additionFinding: Finding = {
+      id: 'finding-add-only-diff',
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'medium',
+      title: 'Workflow adds broad permissions',
+      human_summary: 'A workflow permission entry was added.',
+      remediation: 'Limit workflow permissions.',
+      source_url: 'https://github.com/identrail/identrail/blob/main/workflow.yml#L12',
+      line_snippet: '@@ -0,0 +1 @@\n+ allow = true',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+    const removalFinding: Finding = {
+      ...additionFinding,
+      id: 'finding-remove-only-diff',
+      title: 'Workflow removes guardrail',
+      human_summary: 'A workflow guardrail was removed.',
+      line_snippet: '@@ -1 +0,0 @@\n- require_review = true'
+    };
+
+    await renderFindings({ repoScans: [scan], repoFindings: [additionFinding, removalFinding] });
+
+    const addRow = (await screen.findAllByRole('listitem')).find((node) =>
+      node.textContent?.includes('Workflow adds broad permissions')
+    ) as HTMLButtonElement | undefined;
+    expect(addRow).toBeDefined();
+    if (!addRow) return;
+    fireEvent.click(addRow);
+
+    const addedLine = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '+ allow = true')
+    );
+    expect(addedLine).toHaveClass('is-add');
+    expect(within(addedLine).getByText('+')).toHaveClass('idt-repo-finding-code-marker');
+
+    fireEvent.click(await screen.findByRole('button', { name: /Close finding detail/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Close finding detail/i })).not.toBeInTheDocument();
+    });
+
+    const removeRow = (await screen.findAllByRole('listitem')).find((node) =>
+      node.textContent?.includes('Workflow removes guardrail')
+    ) as HTMLButtonElement | undefined;
+    expect(removeRow).toBeDefined();
+    if (!removeRow) return;
+    fireEvent.click(removeRow);
+
+    const removedLine = await screen.findByText((_, element) =>
+      Boolean(
+        element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '- require_review = true'
+      )
+    );
+    expect(removedLine).toHaveClass('is-remove');
+    expect(within(removedLine).getByText('-')).toHaveClass('idt-repo-finding-code-marker');
+  });
+
   it('keeps visible filters when active filters match no findings', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -5007,6 +5007,43 @@ describe('ProductFindingsPage states', () => {
     });
   });
 
+  it('does not mark ordinary source lines that start with a dash as diff removals', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-with-yaml-source',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-yaml-list',
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'medium',
+      title: 'Workflow grants broad permissions',
+      human_summary: 'A workflow permission entry needs review.',
+      remediation: 'Limit workflow permissions.',
+      source_url: 'https://github.com/identrail/identrail/blob/main/workflow.yml#L12',
+      line_snippet: '- name: prod',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+
+    await renderFindings({ repoScans: [scan], repoFindings: [finding] });
+
+    const rowButton = (await screen.findAllByRole('listitem')).find((node) =>
+      node.textContent?.includes('Workflow grants broad permissions')
+    ) as HTMLButtonElement | undefined;
+    expect(rowButton).toBeDefined();
+    if (!rowButton) return;
+    fireEvent.click(rowButton);
+
+    const sourceLine = await screen.findByText('- name: prod');
+    expect(sourceLine).toHaveClass('idt-repo-finding-code-line');
+    expect(sourceLine).not.toHaveClass('is-remove');
+    expect(sourceLine.querySelector('.idt-repo-finding-code-marker')).toBeNull();
+  });
+
   it('keeps visible filters when active filters match no findings', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1384,6 +1384,22 @@ async function renderProductSettingsPage(options: {
   };
 }
 
+async function renderProductAppearanceSettingsPage() {
+  vi.resetModules();
+  const { ProductAppearanceSettingsPage } = await import('./productShell');
+  render(
+    <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/settings/appearance']}>
+      <Routes>
+        <Route
+          path="/app/:tenantID/:workspaceID/settings/appearance"
+          element={<ProductAppearanceSettingsPage />}
+        />
+        <Route path="/app/:tenantID/:workspaceID/settings" element={<h2>Settings</h2>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 async function renderProjectDetail(
   githubBackend: BackendFeatureState,
   githubConnection = connectedGitHub,
@@ -1570,6 +1586,16 @@ describe('ProductSettingsPage profile', () => {
     vi.restoreAllMocks();
     vi.doUnmock('./hooks/useMe');
     vi.resetModules();
+  });
+
+  it('links to the dedicated appearance settings page', async () => {
+    await renderProductSettingsPage();
+
+    expect(await screen.findByRole('heading', { name: 'Appearance' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open appearance settings/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/settings/appearance'
+    );
   });
 
   it('updates profile fields optimistically from settings', async () => {
@@ -1800,6 +1826,82 @@ describe('ProductSettingsPage profile', () => {
 
     fireEvent.pointerDown(document.body);
     expect(screen.queryByRole('menuitem', { name: /Update photo/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('ProductAppearanceSettingsPage', () => {
+  afterEach(() => {
+    window.localStorage.removeItem('identrail-appearance');
+    window.localStorage.removeItem('identrail-theme');
+    delete document.documentElement.dataset.appearanceReady;
+    delete document.documentElement.dataset.appearancePreset;
+    delete document.documentElement.dataset.theme;
+    document.documentElement.removeAttribute('style');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('loads without workspace API calls and applies theme preferences immediately', async () => {
+    const api = await import('./api/client');
+    const getWhoAmI = vi.spyOn(api.apiClient, 'getWhoAmI');
+
+    await renderProductAppearanceSettingsPage();
+
+    expect(await screen.findByRole('heading', { name: 'Appearance' })).toBeInTheDocument();
+    expect(getWhoAmI).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}')).toMatchObject({
+      themeMode: 'dark'
+    });
+  });
+
+  it('persists Codex-style controls through the allowlisted appearance model', async () => {
+    await renderProductAppearanceSettingsPage();
+
+    fireEvent.change(screen.getByLabelText('Light theme'), { target: { value: 'vercel' } });
+    fireEvent.change(screen.getByLabelText('Accent color'), { target: { value: '#123456' } });
+    fireEvent.click(screen.getByRole('switch', { name: 'Use pointer cursors' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Identrail D...' }));
+
+    const stored = JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}');
+    expect(stored).toMatchObject({
+      lightPreset: 'vercel',
+      accent: '#123456',
+      pointerCursors: true,
+      appIcon: 'dark'
+    });
+    expect(document.documentElement.style.getPropertyValue('--appearance-accent')).toBe('#123456');
+    expect(document.documentElement.dataset.pointerCursors).toBe('true');
+    expect(document.documentElement.dataset.appearanceAppIcon).toBe('dark');
+  });
+
+  it('sanitizes stored appearance values before they reach CSS variables', async () => {
+    const { normalizeAppearancePreferences } = await import('./appearance');
+
+    const normalized = normalizeAppearancePreferences({
+      themeMode: 'dark',
+      accent: 'url(javascript:alert(1))',
+      background: 'expression(alert(1))',
+      foreground: '#abcdef',
+      uiFont: 'url(https://evil.example/font.woff2)',
+      codeFont: '<script>alert(1)</script>',
+      contrast: 999,
+      reduceMotion: 'drop-table',
+      appIcon: '../../private'
+    });
+
+    expect(normalized).toMatchObject({
+      accent: '#7c6dff',
+      background: '#121518',
+      foreground: '#abcdef',
+      uiFont: 'system',
+      codeFont: 'mono-system',
+      contrast: 100,
+      reduceMotion: 'system',
+      appIcon: 'default'
+    });
   });
 });
 
@@ -2279,7 +2381,8 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/kubernetes/findings',
       '/app/:tenantID/:workspaceID/kubernetes/remediation',
       '/app/:tenantID/:workspaceID/reports',
-      '/app/:tenantID/:workspaceID/settings'
+      '/app/:tenantID/:workspaceID/settings',
+      '/app/:tenantID/:workspaceID/settings/appearance'
     ]);
     expect(DOMAIN_APP_ROUTE_MANIFEST).not.toContain('/app/:tenantID/:workspaceID/projects');
     expect(DOMAIN_APP_ROUTE_MANIFEST).not.toContain('/app/:tenantID/:workspaceID/findings');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4982,13 +4982,19 @@ describe('ProductFindingsPage states', () => {
     rowButton.focus();
     fireEvent.click(rowButton);
 
-    const addedLine = await screen.findByText('+ allow = true');
-    const removedLine = await screen.findByText('- allow = false');
+    const addedLine = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '+ allow = true')
+    );
+    const removedLine = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('idt-repo-finding-code-line') && element.textContent === '- allow = false')
+    );
     expect(screen.getByText('Evidence line')).toHaveClass('idt-repo-finding-code-label');
     expect(addedLine).toHaveClass('idt-repo-finding-code-line', 'is-add');
     expect(removedLine).toHaveClass('idt-repo-finding-code-line', 'is-remove');
     expect(addedLine).not.toHaveClass('idt-repo-finding-code-label');
     expect(removedLine).not.toHaveClass('idt-repo-finding-code-label');
+    expect(within(addedLine).getByText('+')).toHaveClass('idt-repo-finding-code-marker');
+    expect(within(removedLine).getByText('-')).toHaveClass('idt-repo-finding-code-marker');
 
     const closeButton = await screen.findByRole('button', { name: /Close finding detail/i });
     fireEvent.click(closeButton);

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1869,6 +1869,7 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(stored).toMatchObject({
       lightPreset: 'vercel',
       accent: '#123456',
+      customColors: true,
       pointerCursors: true,
       appIcon: 'dark'
     });
@@ -1885,6 +1886,7 @@ describe('ProductAppearanceSettingsPage', () => {
       accent: 'url(javascript:alert(1))',
       background: 'expression(alert(1))',
       foreground: '#abcdef',
+      customColors: 'yes',
       uiFont: 'url(https://evil.example/font.woff2)',
       codeFont: '<script>alert(1)</script>',
       contrast: 999,
@@ -1896,12 +1898,40 @@ describe('ProductAppearanceSettingsPage', () => {
       accent: '#7c6dff',
       background: '#121518',
       foreground: '#abcdef',
+      customColors: false,
       uiFont: 'system',
       codeFont: 'mono-system',
       contrast: 100,
       reduceMotion: 'system',
       appIcon: 'default'
     });
+  });
+
+  it('uses preset colors for legacy light-theme users without custom colors', async () => {
+    const { applyStoredAppearancePreferences } = await import('./appearance');
+    window.localStorage.setItem('identrail-theme', 'light');
+
+    applyStoredAppearancePreferences();
+
+    expect(document.documentElement.dataset.theme).toBe('light');
+    expect(document.documentElement.dataset.appearancePreset).toBe('notion');
+    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#ffffff');
+    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#37352f');
+  });
+
+  it('exposes contrast as real color-mix inputs for shell styles', async () => {
+    const { applyAppearancePreferences, normalizeAppearancePreferences } = await import('./appearance');
+
+    applyAppearancePreferences(
+      normalizeAppearancePreferences({
+        themeMode: 'dark',
+        contrast: 100
+      })
+    );
+
+    expect(document.documentElement.style.getPropertyValue('--appearance-panel-mix')).toBe('88%');
+    expect(document.documentElement.style.getPropertyValue('--appearance-border-mix')).toBe('100%');
+    expect(document.documentElement.style.getPropertyValue('--appearance-muted-mix')).toBe('90%');
   });
 });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1939,6 +1939,26 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#f5f7f8');
   });
 
+  it('seeds the visible preset colors before enabling custom colors', async () => {
+    await renderProductAppearanceSettingsPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Light' }));
+    fireEvent.change(screen.getByLabelText('Accent color'), { target: { value: '#123456' } });
+
+    const stored = JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}');
+    expect(stored).toMatchObject({
+      themeMode: 'light',
+      lightPreset: 'notion',
+      accent: '#123456',
+      background: '#ffffff',
+      foreground: '#37352f',
+      customColors: true
+    });
+    expect(document.documentElement.style.getPropertyValue('--appearance-accent')).toBe('#123456');
+    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#ffffff');
+    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#37352f');
+  });
+
   it('exposes contrast as real color-mix inputs for shell styles', async () => {
     const { applyAppearancePreferences, normalizeAppearancePreferences } = await import('./appearance');
 
@@ -4964,8 +4984,11 @@ describe('ProductFindingsPage states', () => {
 
     const addedLine = await screen.findByText('+ allow = true');
     const removedLine = await screen.findByText('- allow = false');
+    expect(screen.getByText('Evidence line')).toHaveClass('idt-repo-finding-code-label');
     expect(addedLine).toHaveClass('idt-repo-finding-code-line', 'is-add');
     expect(removedLine).toHaveClass('idt-repo-finding-code-line', 'is-remove');
+    expect(addedLine).not.toHaveClass('idt-repo-finding-code-label');
+    expect(removedLine).not.toHaveClass('idt-repo-finding-code-label');
 
     const closeButton = await screen.findByRole('button', { name: /Close finding detail/i });
     fireEvent.click(closeButton);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20221,7 +20221,7 @@ function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
 }
 
 function repoFindingSnippetDiffMarker(line: string, isDiffSnippet: boolean): '+' | '-' | null {
-  if (!isDiffSnippet || line.startsWith('+++') || line.startsWith('---')) {
+  if (!isDiffSnippet || line.startsWith('+++ ') || line.startsWith('--- ')) {
     return null;
   }
   if (line.startsWith('+')) {
@@ -22774,7 +22774,9 @@ const APPEARANCE_UI_FONT_OPTIONS: AppearanceFontID[] = ['system', 'inter', 'geis
 const APPEARANCE_CODE_FONT_OPTIONS: AppearanceFontID[] = ['mono-system', 'ibm-plex-mono'];
 
 function appearancePresetOptions(mode: 'light' | 'dark') {
-  return APPEARANCE_PRESETS.filter((preset) => preset.mode === mode || preset.mode === 'both');
+  return APPEARANCE_PRESETS.filter((preset) =>
+    mode === 'light' ? preset.mode === 'light' : preset.mode === 'dark' || preset.mode === 'both'
+  );
 }
 
 type AppearanceSegmentedControlProps<T extends string> = {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20184,11 +20184,28 @@ function repoFindingSearchText(finding: ApiFinding): string {
 
 function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
   const meaningfulLines = lines.filter((line) => line.trim().length > 0);
+  const isDiffMetadataLine = (line: string) =>
+    line.startsWith('@@') ||
+    line.startsWith('diff --git') ||
+    line.startsWith('index ') ||
+    line.startsWith('old mode ') ||
+    line.startsWith('new mode ') ||
+    line.startsWith('deleted file mode ') ||
+    line.startsWith('new file mode ') ||
+    line.startsWith('similarity index ') ||
+    line.startsWith('dissimilarity index ') ||
+    line.startsWith('rename from ') ||
+    line.startsWith('rename to ') ||
+    line.startsWith('copy from ') ||
+    line.startsWith('copy to ') ||
+    line.startsWith('--- ') ||
+    line.startsWith('+++ ') ||
+    line.startsWith('\\ ');
   const hasDiffHeader = meaningfulLines.some(
     (line) => line.startsWith('@@') || line.startsWith('diff --git') || line.startsWith('--- ') || line.startsWith('+++ ')
   );
   const diffBodyLines = meaningfulLines.filter(
-    (line) => !line.startsWith('@@') && !line.startsWith('diff --git') && !line.startsWith('--- ') && !line.startsWith('+++ ')
+    (line) => !isDiffMetadataLine(line)
   );
   return (
     hasDiffHeader &&
@@ -20198,8 +20215,7 @@ function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
         line.startsWith('+') ||
         line.startsWith('-') ||
         line.startsWith(' ') ||
-        line.startsWith('@@') ||
-        line.startsWith('diff --git')
+        isDiffMetadataLine(line)
     )
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20193,11 +20193,15 @@ function repoFindingSnippetLineClass(line: string): string {
 }
 
 function renderRepoFindingLineSnippet(snippet: string) {
-  return snippet.split('\n').map((line, index) => (
-    <span className={repoFindingSnippetLineClass(line)} key={`${index}-${line}`}>
-      {line || ' '}
-    </span>
-  ));
+  return snippet.split('\n').map((line, index) => {
+    const diffMarker = line.startsWith('+') || line.startsWith('-') ? line[0] : null;
+    return (
+      <span className={repoFindingSnippetLineClass(line)} key={`${index}-${line}`}>
+        {diffMarker ? <span className="idt-repo-finding-code-marker">{diffMarker}</span> : null}
+        {diffMarker ? line.slice(1) || ' ' : line || ' '}
+      </span>
+    );
+  });
 }
 
 function repoFindingMatchesAny(finding: ApiFinding, tokens: string[]): boolean {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20192,8 +20192,7 @@ function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
   );
   return (
     hasDiffHeader &&
-    diffBodyLines.some((line) => line.startsWith('+')) &&
-    diffBodyLines.some((line) => line.startsWith('-')) &&
+    diffBodyLines.some((line) => line.startsWith('+') || line.startsWith('-')) &&
     meaningfulLines.every(
       (line) =>
         line.startsWith('+') ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20187,12 +20187,21 @@ function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
   const hasDiffHeader = meaningfulLines.some(
     (line) => line.startsWith('@@') || line.startsWith('diff --git') || line.startsWith('--- ') || line.startsWith('+++ ')
   );
+  const diffBodyLines = meaningfulLines.filter(
+    (line) => !line.startsWith('@@') && !line.startsWith('diff --git') && !line.startsWith('--- ') && !line.startsWith('+++ ')
+  );
   return (
     hasDiffHeader &&
-    meaningfulLines.length > 1 &&
-    meaningfulLines.some((line) => line.startsWith('+')) &&
-    meaningfulLines.some((line) => line.startsWith('-')) &&
-    meaningfulLines.every((line) => line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))
+    diffBodyLines.some((line) => line.startsWith('+')) &&
+    diffBodyLines.some((line) => line.startsWith('-')) &&
+    meaningfulLines.every(
+      (line) =>
+        line.startsWith('+') ||
+        line.startsWith('-') ||
+        line.startsWith(' ') ||
+        line.startsWith('@@') ||
+        line.startsWith('diff --git')
+    )
   );
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20182,6 +20182,24 @@ function repoFindingSearchText(finding: ApiFinding): string {
     .join(' ');
 }
 
+function repoFindingSnippetLineClass(line: string): string {
+  if (line.startsWith('+')) {
+    return 'idt-repo-finding-code-line is-add';
+  }
+  if (line.startsWith('-')) {
+    return 'idt-repo-finding-code-line is-remove';
+  }
+  return 'idt-repo-finding-code-line';
+}
+
+function renderRepoFindingLineSnippet(snippet: string) {
+  return snippet.split('\n').map((line, index) => (
+    <span className={repoFindingSnippetLineClass(line)} key={`${index}-${line}`}>
+      {line || ' '}
+    </span>
+  ));
+}
+
 function repoFindingMatchesAny(finding: ApiFinding, tokens: string[]): boolean {
   const haystack = repoFindingSearchText(finding);
   return tokens.some((token) => haystack.includes(token));
@@ -22181,7 +22199,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                   <div className="idt-repo-finding-code">
                     <span>Evidence line</span>
                     <pre>
-                      <code>{selectedFinding.line_snippet}</code>
+                      <code>{renderRepoFindingLineSnippet(selectedFinding.line_snippet)}</code>
                     </pre>
                   </div>
                 ) : null}
@@ -22792,6 +22810,11 @@ export function ProductAppearanceSettingsPage() {
 
   const updatePreset = (key: 'lightPreset' | 'darkPreset', presetID: AppearancePresetID) => {
     const preset = findAppearancePreset(presetID);
+    const activePresetKey = resolvedTheme === 'light' ? 'lightPreset' : 'darkPreset';
+    if (key !== activePresetKey) {
+      commitPreferences({ [key]: preset.id });
+      return;
+    }
     commitPreferences({
       [key]: preset.id,
       accent: preset.accent,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -20182,21 +20182,50 @@ function repoFindingSearchText(finding: ApiFinding): string {
     .join(' ');
 }
 
-function repoFindingSnippetLineClass(line: string): string {
+function repoFindingSnippetLooksLikeDiff(lines: string[]): boolean {
+  const meaningfulLines = lines.filter((line) => line.trim().length > 0);
+  const hasDiffHeader = meaningfulLines.some(
+    (line) => line.startsWith('@@') || line.startsWith('diff --git') || line.startsWith('--- ') || line.startsWith('+++ ')
+  );
+  return (
+    hasDiffHeader &&
+    meaningfulLines.length > 1 &&
+    meaningfulLines.some((line) => line.startsWith('+')) &&
+    meaningfulLines.some((line) => line.startsWith('-')) &&
+    meaningfulLines.every((line) => line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))
+  );
+}
+
+function repoFindingSnippetDiffMarker(line: string, isDiffSnippet: boolean): '+' | '-' | null {
+  if (!isDiffSnippet || line.startsWith('+++') || line.startsWith('---')) {
+    return null;
+  }
   if (line.startsWith('+')) {
-    return 'idt-repo-finding-code-line is-add';
+    return '+';
   }
   if (line.startsWith('-')) {
+    return '-';
+  }
+  return null;
+}
+
+function repoFindingSnippetLineClass(diffMarker: '+' | '-' | null): string {
+  if (diffMarker === '+') {
+    return 'idt-repo-finding-code-line is-add';
+  }
+  if (diffMarker === '-') {
     return 'idt-repo-finding-code-line is-remove';
   }
   return 'idt-repo-finding-code-line';
 }
 
 function renderRepoFindingLineSnippet(snippet: string) {
-  return snippet.split('\n').map((line, index) => {
-    const diffMarker = line.startsWith('+') || line.startsWith('-') ? line[0] : null;
+  const lines = snippet.split('\n');
+  const isDiffSnippet = repoFindingSnippetLooksLikeDiff(lines);
+  return lines.map((line, index) => {
+    const diffMarker = repoFindingSnippetDiffMarker(line, isDiffSnippet);
     return (
-      <span className={repoFindingSnippetLineClass(line)} key={`${index}-${line}`}>
+      <span className={repoFindingSnippetLineClass(diffMarker)} key={`${index}-${line}`}>
         {diffMarker ? <span className="idt-repo-finding-code-marker">{diffMarker}</span> : null}
         {diffMarker ? line.slice(1) || ' ' : line || ' '}
       </span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -22831,6 +22831,63 @@ function AppearanceSwitch({ checked, label, onChange }: AppearanceSwitchProps) {
   );
 }
 
+type AppearanceNumberInputProps = {
+  label: string;
+  max: number;
+  min: number;
+  onCommit: (value: number) => void;
+  value: number;
+};
+
+function AppearanceNumberInput({
+  label,
+  max,
+  min,
+  onCommit,
+  value
+}: AppearanceNumberInputProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [draft, setDraft] = useState(() => String(value));
+
+  useEffect(() => {
+    if (document.activeElement !== inputRef.current) {
+      setDraft(String(value));
+    }
+  }, [value]);
+
+  const commitDraft = () => {
+    const parsed = Number(draft);
+    if (!Number.isFinite(parsed)) {
+      setDraft(String(value));
+      return;
+    }
+    onCommit(parsed);
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      aria-label={label}
+      type="number"
+      min={min}
+      max={max}
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commitDraft}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          commitDraft();
+          event.currentTarget.blur();
+        }
+        if (event.key === 'Escape') {
+          setDraft(String(value));
+          event.currentTarget.blur();
+        }
+      }}
+    />
+  );
+}
+
 export function ProductAppearanceSettingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
@@ -23105,13 +23162,12 @@ export function ProductAppearanceSettingsPage() {
             <p>Adjust the base size used for the Identrail UI</p>
           </span>
           <span className="idt-appearance-number">
-            <input
-              aria-label="UI font size"
-              type="number"
-              min="14"
-              max="22"
+            <AppearanceNumberInput
+              label="UI font size"
+              min={14}
+              max={22}
               value={preferences.uiFontSize}
-              onChange={(event) => commitPreferences({ uiFontSize: Number(event.target.value) })}
+              onCommit={(uiFontSize) => commitPreferences({ uiFontSize })}
             />
             <span>px</span>
           </span>
@@ -23123,13 +23179,12 @@ export function ProductAppearanceSettingsPage() {
             <p>Adjust the base size used for code across previews and diffs</p>
           </span>
           <span className="idt-appearance-number">
-            <input
-              aria-label="Code font size"
-              type="number"
-              min="12"
-              max="22"
+            <AppearanceNumberInput
+              label="Code font size"
+              min={12}
+              max={22}
               value={preferences.codeFontSize}
-              onChange={(event) => commitPreferences({ codeFontSize: Number(event.target.value) })}
+              onCommit={(codeFontSize) => commitPreferences({ codeFontSize })}
             />
             <span>px</span>
           </span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -22197,7 +22197,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                 )}
                 {selectedFinding.line_snippet ? (
                   <div className="idt-repo-finding-code">
-                    <span>Evidence line</span>
+                    <span className="idt-repo-finding-code-label">Evidence line</span>
                     <pre>
                       <code>{renderRepoFindingLineSnippet(selectedFinding.line_snippet)}</code>
                     </pre>
@@ -22828,7 +22828,12 @@ export function ProductAppearanceSettingsPage() {
     key: 'accent' | 'background' | 'foreground',
     value: string
   ) => {
-    commitPreferences({ [key]: value, customColors: true });
+    commitPreferences({
+      accent: key === 'accent' ? value : effectiveColors.accent,
+      background: key === 'background' ? value : effectiveColors.background,
+      foreground: key === 'foreground' ? value : effectiveColors.foreground,
+      customColors: true
+    });
   };
 
   return (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -149,6 +149,7 @@ import {
   findAppearancePreset,
   normalizeAppearancePreferences,
   readAppearancePreferences,
+  resolveAppearanceThemeMode,
   saveAppearancePreferences,
   type AppearanceDiffMarkers,
   type AppearanceFontID,
@@ -22760,6 +22761,21 @@ export function ProductAppearanceSettingsPage() {
   const [preferences, setPreferences] = useState<AppearancePreferences>(() =>
     readAppearancePreferences()
   );
+  const resolvedTheme = resolveAppearanceThemeMode(preferences.themeMode);
+  const activePreset = findAppearancePreset(
+    resolvedTheme === 'light' ? preferences.lightPreset : preferences.darkPreset
+  );
+  const effectiveColors = preferences.customColors
+    ? {
+        accent: preferences.accent,
+        background: preferences.background,
+        foreground: preferences.foreground
+      }
+    : {
+        accent: activePreset.accent,
+        background: activePreset.background,
+        foreground: activePreset.foreground
+      };
 
   useEffect(() => {
     applyAppearancePreferences(preferences);
@@ -22780,7 +22796,8 @@ export function ProductAppearanceSettingsPage() {
       [key]: preset.id,
       accent: preset.accent,
       background: preset.background,
-      foreground: preset.foreground
+      foreground: preset.foreground,
+      customColors: false
     });
   };
 
@@ -22788,7 +22805,7 @@ export function ProductAppearanceSettingsPage() {
     key: 'accent' | 'background' | 'foreground',
     value: string
   ) => {
-    commitPreferences({ [key]: value });
+    commitPreferences({ [key]: value, customColors: true });
   };
 
   return (
@@ -22838,7 +22855,7 @@ export function ProductAppearanceSettingsPage() {
                 <code>
                   {line === 1 ? 'const themePreview: {' : ''}
                   {line === 2 ? '  surface: "sidebar-edge",' : ''}
-                  {line === 3 ? `  accent: "${preferences.accent}",` : ''}
+                  {line === 3 ? `  accent: "${effectiveColors.accent}",` : ''}
                   {line === 4 ? `  contrast: ${preferences.contrast},` : ''}
                   {line === 5 ? '};' : ''}
                 </code>
@@ -22883,9 +22900,9 @@ export function ProductAppearanceSettingsPage() {
           </label>
 
           {[
-            ['accent', 'Accent', preferences.accent],
-            ['background', 'Background', preferences.background],
-            ['foreground', 'Foreground', preferences.foreground]
+            ['accent', 'Accent', effectiveColors.accent],
+            ['background', 'Background', effectiveColors.background],
+            ['foreground', 'Foreground', effectiveColors.foreground]
           ].map(([key, label, value]) => (
             <label key={key} className="idt-appearance-control-row">
               <span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,6 +8,7 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   BarChart3,
+  Check,
   ChevronDown,
   ChevronRight,
   ChevronUp,
@@ -16,9 +17,13 @@ import {
   HelpCircle,
   LayoutDashboard,
   LogOut,
+  Monitor,
+  Moon,
+  Palette,
   Pencil,
   Search,
-  Settings as SettingsIcon
+  Settings as SettingsIcon,
+  Sun
 } from 'lucide-react';
 import {
   ApiError,
@@ -137,6 +142,21 @@ import {
 import { getDomainAsset, type DomainAssetKey } from './design/domainAssets';
 import { clearMeCache, primeMeCache, useMe } from './hooks/useMe';
 import { isFeatureAvailable, type BackendFeatures, useBackendFeatures } from './hooks/useBackendFeatures';
+import {
+  APPEARANCE_FONT_LABELS,
+  APPEARANCE_PRESETS,
+  applyAppearancePreferences,
+  findAppearancePreset,
+  normalizeAppearancePreferences,
+  readAppearancePreferences,
+  saveAppearancePreferences,
+  type AppearanceDiffMarkers,
+  type AppearanceFontID,
+  type AppearancePreferences,
+  type AppearancePresetID,
+  type AppearanceReduceMotion,
+  type AppearanceThemeMode
+} from './appearance';
 import {
   FEATURE_ONBOARDING_CONNECTOR_AWS as FEATURE_CONNECTOR_AWS,
   FEATURE_ONBOARDING_CONNECTOR_GITHUB as FEATURE_CONNECTOR_GITHUB_V2,
@@ -22653,6 +22673,422 @@ function workspaceSoleOwnerMemberLabel(member: WorkspaceSoleOwnerAffectedMember)
   return `${member.user_id || member.member_id} (${member.role})`;
 }
 
+const APPEARANCE_THEME_OPTIONS: Array<{
+  id: AppearanceThemeMode;
+  label: string;
+  icon: ReactNode;
+}> = [
+  { id: 'light', label: 'Light', icon: <Sun size={15} aria-hidden="true" /> },
+  { id: 'dark', label: 'Dark', icon: <Moon size={15} aria-hidden="true" /> },
+  { id: 'system', label: 'System', icon: <Monitor size={15} aria-hidden="true" /> }
+];
+
+const APPEARANCE_MOTION_OPTIONS: Array<{ id: AppearanceReduceMotion; label: string }> = [
+  { id: 'system', label: 'System' },
+  { id: 'on', label: 'On' },
+  { id: 'off', label: 'Off' }
+];
+
+const APPEARANCE_DIFF_OPTIONS: Array<{ id: AppearanceDiffMarkers; label: string }> = [
+  { id: 'color', label: 'Color' },
+  { id: 'symbols', label: '+/-' }
+];
+
+const APPEARANCE_UI_FONT_OPTIONS: AppearanceFontID[] = ['system', 'inter', 'geist'];
+const APPEARANCE_CODE_FONT_OPTIONS: AppearanceFontID[] = ['mono-system', 'ibm-plex-mono'];
+
+function appearancePresetOptions(mode: 'light' | 'dark') {
+  return APPEARANCE_PRESETS.filter((preset) => preset.mode === mode || preset.mode === 'both');
+}
+
+type AppearanceSegmentedControlProps<T extends string> = {
+  label: string;
+  value: T;
+  options: Array<{ id: T; label: string; icon?: ReactNode }>;
+  onChange: (nextValue: T) => void;
+};
+
+function AppearanceSegmentedControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange
+}: AppearanceSegmentedControlProps<T>) {
+  return (
+    <div className="idt-appearance-segmented" role="group" aria-label={label}>
+      {options.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          className="idt-appearance-segment"
+          aria-pressed={value === option.id}
+          onClick={() => onChange(option.id)}
+        >
+          {option.icon}
+          <span>{option.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+type AppearanceSwitchProps = {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+};
+
+function AppearanceSwitch({ checked, label, onChange }: AppearanceSwitchProps) {
+  return (
+    <button
+      type="button"
+      className="idt-appearance-switch"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+    >
+      <span aria-hidden="true" />
+    </button>
+  );
+}
+
+export function ProductAppearanceSettingsPage() {
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  const settingsPath = scope ? buildScopedPath(scope, 'settings') : '/app';
+  const [preferences, setPreferences] = useState<AppearancePreferences>(() =>
+    readAppearancePreferences()
+  );
+
+  useEffect(() => {
+    applyAppearancePreferences(preferences);
+  }, [preferences]);
+
+  const commitPreferences = useCallback((patch: Partial<AppearancePreferences>) => {
+    setPreferences((current) => {
+      const next = normalizeAppearancePreferences({ ...current, ...patch });
+      const saved = saveAppearancePreferences(next);
+      applyAppearancePreferences(saved);
+      return saved;
+    });
+  }, []);
+
+  const updatePreset = (key: 'lightPreset' | 'darkPreset', presetID: AppearancePresetID) => {
+    const preset = findAppearancePreset(presetID);
+    commitPreferences({
+      [key]: preset.id,
+      accent: preset.accent,
+      background: preset.background,
+      foreground: preset.foreground
+    });
+  };
+
+  const updateHexPreference = (
+    key: 'accent' | 'background' | 'foreground',
+    value: string
+  ) => {
+    commitPreferences({ [key]: value });
+  };
+
+  return (
+    <section className="idt-app-panel idt-settings-page idt-appearance-page">
+      <header className="idt-settings-header idt-appearance-header">
+        <div>
+          <Link className="idt-appearance-back" to={settingsPath}>
+            Back to settings
+          </Link>
+          <h2>Appearance</h2>
+        </div>
+      </header>
+
+      <section className="idt-settings-card idt-appearance-card" aria-labelledby="idt-appearance-theme-heading">
+        <div className="idt-appearance-card-header">
+          <div>
+            <h3 id="idt-appearance-theme-heading">Theme</h3>
+            <p>Use light, dark, or match your system</p>
+          </div>
+          <AppearanceSegmentedControl
+            label="Theme"
+            value={preferences.themeMode}
+            options={APPEARANCE_THEME_OPTIONS}
+            onChange={(themeMode) => commitPreferences({ themeMode })}
+          />
+        </div>
+
+        <div className="idt-appearance-preview" aria-label="Theme preview">
+          <div className="idt-appearance-preview-pane" data-side="before">
+            {[1, 2, 3, 4, 5].map((line) => (
+              <div key={`before-${line}`} className="idt-appearance-code-line">
+                <span>{line}</span>
+                <code>
+                  {line === 1 ? 'const themePreview: {' : ''}
+                  {line === 2 ? '  surface: "sidebar",' : ''}
+                  {line === 3 ? '  accent: "#2563eb",' : ''}
+                  {line === 4 ? '  contrast: 42,' : ''}
+                  {line === 5 ? '};' : ''}
+                </code>
+              </div>
+            ))}
+          </div>
+          <div className="idt-appearance-preview-pane" data-side="after">
+            {[1, 2, 3, 4, 5].map((line) => (
+              <div key={`after-${line}`} className="idt-appearance-code-line">
+                <span>{line}</span>
+                <code>
+                  {line === 1 ? 'const themePreview: {' : ''}
+                  {line === 2 ? '  surface: "sidebar-edge",' : ''}
+                  {line === 3 ? `  accent: "${preferences.accent}",` : ''}
+                  {line === 4 ? `  contrast: ${preferences.contrast},` : ''}
+                  {line === 5 ? '};' : ''}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="idt-appearance-control-list">
+          <label className="idt-appearance-control-row">
+            <span>
+              <strong>Light theme</strong>
+            </span>
+            <select
+              aria-label="Light theme"
+              value={preferences.lightPreset}
+              onChange={(event) => updatePreset('lightPreset', event.target.value as AppearancePresetID)}
+            >
+              {appearancePresetOptions('light').map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="idt-appearance-control-row">
+            <span>
+              <strong>Dark theme</strong>
+            </span>
+            <select
+              aria-label="Dark theme"
+              value={preferences.darkPreset}
+              onChange={(event) => updatePreset('darkPreset', event.target.value as AppearancePresetID)}
+            >
+              {appearancePresetOptions('dark').map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {[
+            ['accent', 'Accent', preferences.accent],
+            ['background', 'Background', preferences.background],
+            ['foreground', 'Foreground', preferences.foreground]
+          ].map(([key, label, value]) => (
+            <label key={key} className="idt-appearance-control-row">
+              <span>
+                <strong>{label}</strong>
+              </span>
+              <span className="idt-appearance-color-input">
+                <input
+                  aria-label={`${label} color`}
+                  type="color"
+                  value={value}
+                  onChange={(event) =>
+                    updateHexPreference(key as 'accent' | 'background' | 'foreground', event.target.value)
+                  }
+                />
+                <code>{value}</code>
+              </span>
+            </label>
+          ))}
+
+          <label className="idt-appearance-control-row">
+            <span>
+              <strong>UI font</strong>
+            </span>
+            <select
+              aria-label="UI font"
+              value={preferences.uiFont}
+              onChange={(event) => commitPreferences({ uiFont: event.target.value as AppearanceFontID })}
+            >
+              {APPEARANCE_UI_FONT_OPTIONS.map((fontID) => (
+                <option key={fontID} value={fontID}>
+                  {APPEARANCE_FONT_LABELS[fontID]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="idt-appearance-control-row">
+            <span>
+              <strong>Code font</strong>
+            </span>
+            <select
+              aria-label="Code font"
+              value={preferences.codeFont}
+              onChange={(event) => commitPreferences({ codeFont: event.target.value as AppearanceFontID })}
+            >
+              {APPEARANCE_CODE_FONT_OPTIONS.map((fontID) => (
+                <option key={fontID} value={fontID}>
+                  {APPEARANCE_FONT_LABELS[fontID]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="idt-appearance-control-row">
+            <span>
+              <strong>Translucent sidebar</strong>
+            </span>
+            <AppearanceSwitch
+              checked={preferences.translucentSidebar}
+              label="Translucent sidebar"
+              onChange={(translucentSidebar) => commitPreferences({ translucentSidebar })}
+            />
+          </div>
+
+          <label className="idt-appearance-control-row idt-appearance-slider-row">
+            <span>
+              <strong>Contrast</strong>
+            </span>
+            <span className="idt-appearance-slider">
+              <input
+                aria-label="Contrast"
+                type="range"
+                min="0"
+                max="100"
+                value={preferences.contrast}
+                onChange={(event) => commitPreferences({ contrast: Number(event.target.value) })}
+              />
+              <strong>{preferences.contrast}</strong>
+            </span>
+          </label>
+        </div>
+      </section>
+
+      <section className="idt-settings-card idt-appearance-card idt-appearance-behavior-card">
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Use pointer cursors</h3>
+            <p>Change the cursor to a pointer when hovering over interactive elements</p>
+          </div>
+          <AppearanceSwitch
+            checked={preferences.pointerCursors}
+            label="Use pointer cursors"
+            onChange={(pointerCursors) => commitPreferences({ pointerCursors })}
+          />
+        </div>
+
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Reduce motion</h3>
+            <p>Reduce animations or match your system</p>
+          </div>
+          <AppearanceSegmentedControl
+            label="Reduce motion"
+            value={preferences.reduceMotion}
+            options={APPEARANCE_MOTION_OPTIONS}
+            onChange={(reduceMotion) => commitPreferences({ reduceMotion })}
+          />
+        </div>
+
+        <label className="idt-appearance-behavior-row">
+          <span>
+            <h3>UI font size</h3>
+            <p>Adjust the base size used for the Identrail UI</p>
+          </span>
+          <span className="idt-appearance-number">
+            <input
+              aria-label="UI font size"
+              type="number"
+              min="14"
+              max="22"
+              value={preferences.uiFontSize}
+              onChange={(event) => commitPreferences({ uiFontSize: Number(event.target.value) })}
+            />
+            <span>px</span>
+          </span>
+        </label>
+
+        <label className="idt-appearance-behavior-row">
+          <span>
+            <h3>Code font size</h3>
+            <p>Adjust the base size used for code across previews and diffs</p>
+          </span>
+          <span className="idt-appearance-number">
+            <input
+              aria-label="Code font size"
+              type="number"
+              min="12"
+              max="22"
+              value={preferences.codeFontSize}
+              onChange={(event) => commitPreferences({ codeFontSize: Number(event.target.value) })}
+            />
+            <span>px</span>
+          </span>
+        </label>
+
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Diff markers</h3>
+            <p>Use colored bars and backgrounds or show plus and minus symbols on each changed line</p>
+          </div>
+          <AppearanceSegmentedControl
+            label="Diff markers"
+            value={preferences.diffMarkers}
+            options={APPEARANCE_DIFF_OPTIONS}
+            onChange={(diffMarkers) => commitPreferences({ diffMarkers })}
+          />
+        </div>
+
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Font smoothing</h3>
+            <p>Use native macOS font anti-aliasing</p>
+          </div>
+          <AppearanceSwitch
+            checked={preferences.fontSmoothing}
+            label="Font smoothing"
+            onChange={(fontSmoothing) => commitPreferences({ fontSmoothing })}
+          />
+        </div>
+      </section>
+
+      <section className="idt-appearance-dock-card" aria-labelledby="idt-appearance-icon-heading">
+        <div>
+          <h3 id="idt-appearance-icon-heading">App icon</h3>
+          <p>Choose the icon style Identrail uses inside the app shell</p>
+        </div>
+        <div className="idt-appearance-icon-options">
+          {[
+            ['default', 'Default'],
+            ['light', 'Identrail L...'],
+            ['dark', 'Identrail D...']
+          ].map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              className="idt-appearance-icon-option"
+              aria-pressed={preferences.appIcon === id}
+              onClick={() => commitPreferences({ appIcon: id as AppearancePreferences['appIcon'] })}
+            >
+              <span className="idt-appearance-icon-swatch" data-icon-tone={id} aria-hidden="true">
+                <Palette size={22} />
+              </span>
+              <span>{label}</span>
+              {preferences.appIcon === id ? <Check size={16} aria-hidden="true" /> : <span aria-hidden="true" />}
+            </button>
+          ))}
+        </div>
+      </section>
+
+    </section>
+  );
+}
+
 export function ProductSettingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
@@ -22884,6 +23320,7 @@ export function ProductSettingsPage() {
   const mfaStatus = authConfig?.auth.workos_login_enabled ? 'Hosted login' : 'Not configured';
   const developerScopeLabel = scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'No custom restrictions';
   const developerProviderLabel = authProviders.length ? authProviders.join(', ') : 'None advertised';
+  const appearancePath = scope ? buildScopedPath(scope, 'settings/appearance') : '/app';
 
   const handleProfileEdit = () => {
     if (profileEditing) {
@@ -23306,6 +23743,22 @@ export function ProductSettingsPage() {
           <h2>Settings</h2>
         </div>
       </header>
+
+      <section className="idt-settings-card idt-settings-appearance-entry" aria-labelledby="idt-settings-appearance-heading">
+        <div className="idt-settings-card-header">
+          <div>
+            <h3 id="idt-settings-appearance-heading">Appearance</h3>
+          </div>
+          <Palette size={18} aria-hidden="true" />
+        </div>
+        <p>Theme, fonts, contrast, motion, and app icon preferences.</p>
+        <Link className="idt-settings-action-row" to={appearancePath}>
+          <span>
+            <strong>Open appearance settings</strong>
+          </span>
+          <ChevronRight size={16} aria-hidden="true" />
+        </Link>
+      </section>
 
       <section className="idt-settings-card idt-profile-card" aria-labelledby="idt-profile-heading">
         <div className="idt-settings-card-header">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6421,18 +6421,10 @@ html[data-diff-markers='symbols'] .idt-repo-finding-code-line:is(.is-add, .is-re
   padding-left: 1.2rem;
 }
 
-html[data-diff-markers='symbols'] .idt-repo-finding-code-line:is(.is-add, .is-remove)::before {
+html[data-diff-markers='symbols'] .idt-repo-finding-code-marker {
   position: absolute;
   left: 0;
   font-weight: 900;
-}
-
-html[data-diff-markers='symbols'] .idt-repo-finding-code-line.is-add::before {
-  content: '+';
-}
-
-html[data-diff-markers='symbols'] .idt-repo-finding-code-line.is-remove::before {
-  content: '-';
 }
 
 .idt-repo-finding-remediation {
@@ -30798,6 +30790,84 @@ html[data-appearance-ready='true'] .idt-account-security-page :is(pre, code),
 html[data-appearance-ready='true'] .idt-app-shell-screen :is(pre, code),
 html[data-appearance-ready='true'] .idt-executive-report-shell :is(pre, code) {
   font-size: var(--appearance-code-font-size, 14px);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(
+  .idt-app-shell-header,
+  .idt-overview-header,
+  .idt-workspace-admin-header,
+  .idt-projects-header,
+  .idt-source-onboarding-header,
+  .idt-repo-findings-header,
+  .idt-settings-header,
+  .idt-overview-card,
+  .idt-projects-list,
+  .idt-project-composer,
+  .idt-project-card,
+  .idt-source-card,
+  .idt-source-config,
+  .idt-source-install-card,
+  .idt-source-advanced,
+  .idt-source-diagnostics article,
+  .idt-repo-finding-list,
+  .idt-repo-finding-detail,
+  .idt-repo-finding-trend,
+  .idt-repo-finding-bucket,
+  .idt-repo-finding-detail-section,
+  .idt-repo-finding-detail-modal,
+  .idt-repo-finding-row,
+  .idt-settings-card,
+  .idt-settings-facts div,
+  .idt-overview-risk-row,
+  .idt-overview-scan-row,
+  .idt-overview-projects a,
+  .idt-overview-actions a,
+  .idt-settings-route-grid a
+),
+html[data-appearance-ready='true'] .idt-account-security-page :is(
+  .idt-app-shell-header,
+  .idt-security-overview article,
+  .idt-session-row
+),
+html[data-appearance-ready='true'] .idt-executive-report-shell :is(
+  .idt-executive-report-header,
+  .idt-executive-report-metrics article,
+  .idt-executive-report-section,
+  .idt-executive-severity-list article,
+  .idt-executive-type-list article,
+  .idt-executive-narrative article
+) {
+  border-color: var(--app-border);
+  background: var(--app-panel);
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(h1, h2, h3, h4, strong),
+html[data-appearance-ready='true'] .idt-account-security-page :is(h1, h2, h3, strong),
+html[data-appearance-ready='true'] .idt-executive-report-shell :is(h1, h2, h3, h4, strong) {
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(
+  p,
+  dd,
+  li,
+  .idt-overview-projects span,
+  .idt-overview-actions span,
+  .idt-overview-projects small,
+  .idt-source-card small,
+  .idt-source-diagnostics small,
+  .idt-repo-finding-row-meta,
+  .idt-repo-finding-trend-subtitle,
+  .idt-repo-finding-trend-meta span,
+  .idt-repo-finding-facts dt,
+  .idt-repo-finding-code-label,
+  .idt-settings-route-grid span,
+  .idt-settings-facts dt
+),
+html[data-appearance-ready='true'] .idt-account-security-page :is(p, dd),
+html[data-appearance-ready='true'] .idt-executive-report-shell :is(p, dd, .idt-executive-report-metrics p) {
+  color: var(--app-muted);
 }
 
 html[data-font-smoothing='true'] body {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30726,6 +30726,426 @@ html[data-theme='light'] .idt-settings-sessions-card .idt-session-row {
   white-space: nowrap;
 }
 
+html[data-appearance-ready='true'] #main-content:has(.idt-app-console-layout),
+html[data-appearance-ready='true'] #main-content:has(.idt-account-security-page),
+html[data-appearance-ready='true'] #main-content:has(.idt-app-shell-screen),
+html[data-appearance-ready='true'] #main-content:has(.idt-executive-report-shell) {
+  background: var(--appearance-bg, #121518);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout,
+html[data-appearance-ready='true'] .idt-account-security-page,
+html[data-appearance-ready='true'] .idt-app-shell-screen,
+html[data-appearance-ready='true'] .idt-executive-report-shell {
+  --app-bg: var(--appearance-bg, #121518);
+  --app-panel: var(--appearance-panel, #090b0e);
+  --app-panel-strong: color-mix(in srgb, var(--appearance-panel, #090b0e) 76%, black);
+  --app-border: var(--appearance-border, #2b3037);
+  --app-border-soft: color-mix(in srgb, var(--appearance-border, #2b3037) 72%, transparent);
+  --app-text: var(--appearance-fg, #f5f7f8);
+  --app-muted: var(--appearance-muted, #adb5bf);
+  --app-dim: color-mix(in srgb, var(--appearance-muted, #adb5bf) 74%, var(--appearance-bg, #121518));
+  --idt-console-focus: var(--appearance-accent, #7c6dff);
+  --idt-product-font: var(--appearance-ui-font, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif);
+  background: var(--appearance-bg, #121518);
+  color: var(--appearance-fg, #f5f7f8);
+  font-family: var(--appearance-ui-font, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif);
+  font-size: var(--appearance-ui-font-size, 16px);
+}
+
+html[data-font-smoothing='true'] body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+html[data-pointer-cursors='true'] :is(a, button, summary, select, input[type='checkbox'], input[type='radio'], input[type='range'], input[type='color']) {
+  cursor: pointer;
+}
+
+html[data-reduce-motion='on'] *,
+html[data-reduce-motion='on'] *::before,
+html[data-reduce-motion='on'] *::after {
+  animation-duration: 1ms !important;
+  animation-iteration-count: 1 !important;
+  scroll-behavior: auto !important;
+  transition-duration: 1ms !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-reduce-motion='system'] *,
+  html[data-reduce-motion='system'] *::before,
+  html[data-reduce-motion='system'] *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}
+
+html[data-appearance-translucent-sidebar='true'] .idt-app-sidebar {
+  background: color-mix(in srgb, var(--appearance-panel, #090b0e) 82%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.idt-settings-appearance-entry {
+  gap: 0.9rem;
+}
+
+.idt-settings-appearance-entry > p {
+  margin: -0.35rem 0 0;
+  color: var(--app-muted);
+}
+
+.idt-settings-appearance-entry .idt-settings-card-header > svg {
+  color: var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-page {
+  max-width: 64rem;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.idt-appearance-header h2 {
+  margin-top: 0.45rem;
+}
+
+.idt-appearance-back {
+  color: var(--app-muted);
+  font-size: 0.92rem;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.idt-appearance-back:hover,
+.idt-appearance-back:focus-visible {
+  color: var(--app-text);
+}
+
+.idt-appearance-card {
+  overflow: hidden;
+  padding: 0;
+}
+
+.idt-appearance-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.2rem;
+  border-bottom: 1px solid var(--app-border-soft);
+}
+
+.idt-appearance-card-header h3,
+.idt-appearance-card-header p {
+  margin: 0;
+}
+
+.idt-appearance-card-header p,
+.idt-appearance-behavior-row p,
+.idt-appearance-dock-card p {
+  color: var(--app-muted);
+}
+
+.idt-appearance-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.18rem;
+  border-radius: 999px;
+  padding: 0.18rem;
+  background: color-mix(in srgb, var(--app-panel) 78%, var(--app-text) 8%);
+}
+
+.idt-appearance-segment {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.72rem;
+  background: transparent;
+  color: var(--app-muted);
+  font: inherit;
+  font-weight: 750;
+}
+
+.idt-appearance-segment[aria-pressed='true'] {
+  background: var(--app-panel);
+  color: var(--app-text);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.idt-appearance-preview {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--app-border-soft);
+  background: var(--app-panel);
+  font-family: var(--appearance-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  font-size: var(--appearance-code-font-size, 14px);
+}
+
+.idt-appearance-preview-pane {
+  min-width: 0;
+  padding: 0.85rem 0;
+}
+
+.idt-appearance-preview-pane + .idt-appearance-preview-pane {
+  border-left: 1px solid var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-code-line {
+  position: relative;
+  display: grid;
+  grid-template-columns: 3.2rem minmax(0, 1fr);
+  min-height: 2rem;
+  align-items: center;
+}
+
+.idt-appearance-code-line span {
+  color: var(--app-muted);
+  text-align: right;
+  padding-right: 0.85rem;
+}
+
+.idt-appearance-code-line code {
+  overflow: hidden;
+  color: var(--app-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.idt-appearance-preview-pane[data-side='before'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4) {
+  background: rgba(239, 68, 68, 0.16);
+}
+
+.idt-appearance-preview-pane[data-side='after'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4) {
+  background: color-mix(in srgb, var(--appearance-accent, #7c6dff) 18%, transparent);
+}
+
+html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='before'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4)::before,
+html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4)::before {
+  position: absolute;
+  left: 0.65rem;
+  color: var(--app-text);
+  font-weight: 900;
+}
+
+html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='before'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4)::before {
+  content: '-';
+}
+
+html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'] .idt-appearance-code-line:nth-child(n + 2):nth-child(-n + 4)::before {
+  content: '+';
+}
+
+.idt-appearance-control-list {
+  display: grid;
+}
+
+.idt-appearance-control-row,
+.idt-appearance-behavior-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  min-height: 3.4rem;
+  padding: 0.75rem 1.2rem;
+  border-bottom: 1px solid var(--app-border-soft);
+}
+
+.idt-appearance-control-row:last-child,
+.idt-appearance-behavior-row:last-child {
+  border-bottom: 0;
+}
+
+.idt-appearance-control-row strong,
+.idt-appearance-behavior-row h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.idt-appearance-behavior-row p {
+  margin: 0.15rem 0 0;
+}
+
+.idt-appearance-control-row select,
+.idt-appearance-number input {
+  min-height: 2.1rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0 0.8rem;
+  background: var(--app-panel);
+  color: var(--app-text);
+  font: inherit;
+}
+
+.idt-appearance-control-row select {
+  min-width: 12rem;
+}
+
+.idt-appearance-color-input,
+.idt-appearance-slider,
+.idt-appearance-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.65rem;
+}
+
+.idt-appearance-color-input input {
+  width: 2.2rem;
+  height: 2rem;
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.idt-appearance-color-input code {
+  min-width: 5.5rem;
+  color: var(--app-muted);
+  font-family: var(--appearance-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+}
+
+.idt-appearance-slider input {
+  width: min(13rem, 34vw);
+  accent-color: var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-switch {
+  position: relative;
+  width: 2.9rem;
+  height: 1.65rem;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--app-muted) 32%, var(--app-panel));
+}
+
+.idt-appearance-switch span {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.22rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: var(--app-text);
+  transition: transform 160ms ease;
+}
+
+.idt-appearance-switch[aria-checked='true'] {
+  background: var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-switch[aria-checked='true'] span {
+  transform: translateX(1.2rem);
+}
+
+.idt-appearance-number input {
+  width: 5.3rem;
+  text-align: center;
+}
+
+.idt-appearance-dock-card {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 1.2rem;
+  background: var(--app-panel);
+}
+
+.idt-appearance-dock-card h3,
+.idt-appearance-dock-card p {
+  margin: 0;
+}
+
+.idt-appearance-icon-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-appearance-icon-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 1rem;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 4.6rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.8rem;
+  background: var(--app-panel);
+  color: var(--app-text);
+  font: inherit;
+  text-align: left;
+}
+
+.idt-appearance-icon-option[aria-pressed='true'] {
+  border-color: var(--appearance-accent, #7c6dff);
+  box-shadow: inset 0 0 0 1px var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-icon-swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 8px;
+  background: #111418;
+  color: #ffffff;
+}
+
+.idt-appearance-icon-swatch[data-icon-tone='light'] {
+  background: #ffffff;
+  color: #111418;
+}
+
+.idt-appearance-icon-swatch[data-icon-tone='dark'] {
+  background: #050607;
+  color: var(--appearance-accent, #7c6dff);
+}
+
+@media (max-width: 760px) {
+  .idt-appearance-card-header,
+  .idt-appearance-control-row,
+  .idt-appearance-behavior-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .idt-appearance-card-header {
+    display: grid;
+  }
+
+  .idt-appearance-segmented,
+  .idt-appearance-control-row select,
+  .idt-appearance-color-input,
+  .idt-appearance-slider,
+  .idt-appearance-number {
+    width: 100%;
+  }
+
+  .idt-appearance-segment {
+    flex: 1 1 0;
+  }
+
+  .idt-appearance-preview,
+  .idt-appearance-icon-options {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-appearance-preview-pane + .idt-appearance-preview-pane {
+    border-top: 1px solid var(--appearance-accent, #7c6dff);
+    border-left: 0;
+  }
+
+  .idt-appearance-slider input {
+    width: 100%;
+  }
+}
+
 .idt-app-console-layout .idt-workspace-admin {
   gap: 1rem;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -172,37 +172,37 @@ a {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .idt-modal-backdrop,
-  .idt-modal,
-  .idt-permission-preview-modal,
-  .idt-repo-finding-detail-modal,
-  .idt-danger-modal,
-  .idt-command-palette-backdrop,
-  .idt-command-palette,
-  .idt-domain-drawer-root,
-  .idt-domain-drawer-scrim,
-  .idt-domain-drawer,
-  .idt-domain-flyout,
-  .idt-domain-flyout-section,
-  .idt-domain-flyout-nested-body,
-  .idt-profile-avatar-menu,
-  .idt-auth-theme-menu,
-  .idt-app-sidebar-account-menu,
-  .idt-app-sidebar-workspace-menu,
-  .idt-app-alert,
-  .idt-settings-inline-status,
-  .idt-form-error,
-  .idt-auth-provider-grid,
-  .idt-scan-stepper li.is-active,
-  .idt-danger-modal-error,
-  .idt-danger-modal-blocker,
-  .idt-form-success,
-  .idt-auth-mfa-setup,
-  .idt-auth-provider-stack,
-  .idt-settings-disclosure[open] .idt-settings-disclosure-body,
-  .idt-settings-inline-disclosure[open] .idt-settings-disclosure-body,
-  .idt-hold-confirm.is-holding::before,
-  .idt-hold-confirm.is-rejected {
+  html:not([data-reduce-motion='off']) .idt-modal-backdrop,
+  html:not([data-reduce-motion='off']) .idt-modal,
+  html:not([data-reduce-motion='off']) .idt-permission-preview-modal,
+  html:not([data-reduce-motion='off']) .idt-repo-finding-detail-modal,
+  html:not([data-reduce-motion='off']) .idt-danger-modal,
+  html:not([data-reduce-motion='off']) .idt-command-palette-backdrop,
+  html:not([data-reduce-motion='off']) .idt-command-palette,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer-root,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer-scrim,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer,
+  html:not([data-reduce-motion='off']) .idt-domain-flyout,
+  html:not([data-reduce-motion='off']) .idt-domain-flyout-section,
+  html:not([data-reduce-motion='off']) .idt-domain-flyout-nested-body,
+  html:not([data-reduce-motion='off']) .idt-profile-avatar-menu,
+  html:not([data-reduce-motion='off']) .idt-auth-theme-menu,
+  html:not([data-reduce-motion='off']) .idt-app-sidebar-account-menu,
+  html:not([data-reduce-motion='off']) .idt-app-sidebar-workspace-menu,
+  html:not([data-reduce-motion='off']) .idt-app-alert,
+  html:not([data-reduce-motion='off']) .idt-settings-inline-status,
+  html:not([data-reduce-motion='off']) .idt-form-error,
+  html:not([data-reduce-motion='off']) .idt-auth-provider-grid,
+  html:not([data-reduce-motion='off']) .idt-scan-stepper li.is-active,
+  html:not([data-reduce-motion='off']) .idt-danger-modal-error,
+  html:not([data-reduce-motion='off']) .idt-danger-modal-blocker,
+  html:not([data-reduce-motion='off']) .idt-form-success,
+  html:not([data-reduce-motion='off']) .idt-auth-mfa-setup,
+  html:not([data-reduce-motion='off']) .idt-auth-provider-stack,
+  html:not([data-reduce-motion='off']) .idt-settings-disclosure[open] .idt-settings-disclosure-body,
+  html:not([data-reduce-motion='off']) .idt-settings-inline-disclosure[open] .idt-settings-disclosure-body,
+  html:not([data-reduce-motion='off']) .idt-hold-confirm.is-holding::before,
+  html:not([data-reduce-motion='off']) .idt-hold-confirm.is-rejected {
     animation: none !important;
   }
 }
@@ -30558,23 +30558,23 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .idt-btn::before,
-  .idt-esc-close::before,
-  .idt-modal-close::before,
-  .idt-domain-drawer-close::before,
-  .idt-hold-confirm::before,
-  .idt-onboarding-input-wrap.has-error input,
-  .idt-onboarding-input-wrap.has-error textarea,
-  .idt-onboarding-inline-error {
+  html:not([data-reduce-motion='off']) .idt-btn::before,
+  html:not([data-reduce-motion='off']) .idt-esc-close::before,
+  html:not([data-reduce-motion='off']) .idt-modal-close::before,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer-close::before,
+  html:not([data-reduce-motion='off']) .idt-hold-confirm::before,
+  html:not([data-reduce-motion='off']) .idt-onboarding-input-wrap.has-error input,
+  html:not([data-reduce-motion='off']) .idt-onboarding-input-wrap.has-error textarea,
+  html:not([data-reduce-motion='off']) .idt-onboarding-inline-error {
     animation: none !important;
     transition: none !important;
   }
 
-  .idt-btn:active:not(:disabled),
-  .idt-esc-close:active,
-  .idt-modal-close:active,
-  .idt-domain-drawer-close:active,
-  .idt-domain-drawer {
+  html:not([data-reduce-motion='off']) .idt-btn:active:not(:disabled),
+  html:not([data-reduce-motion='off']) .idt-esc-close:active,
+  html:not([data-reduce-motion='off']) .idt-modal-close:active,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer-close:active,
+  html:not([data-reduce-motion='off']) .idt-domain-drawer {
     transform: none !important;
   }
 }
@@ -30748,6 +30748,10 @@ html[data-appearance-ready='true'] #main-content:has(.idt-account-security-page)
 html[data-appearance-ready='true'] #main-content:has(.idt-app-shell-screen),
 html[data-appearance-ready='true'] #main-content:has(.idt-executive-report-shell) {
   background: var(--appearance-bg, #121518);
+}
+
+html[data-appearance-ready='true'] {
+  font-size: var(--appearance-ui-font-size, 16px);
 }
 
 html[data-appearance-ready='true'] .idt-app-console-layout,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6417,12 +6417,34 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   white-space: pre-wrap;
 }
 
+html[data-diff-markers='color'] .idt-repo-finding-code-line:is(.is-add, .is-remove) {
+  margin-inline: -0.35rem;
+  padding-inline: 0.55rem 0.35rem;
+  border-left: 3px solid transparent;
+  border-radius: 0.35rem;
+}
+
+html[data-diff-markers='color'] .idt-repo-finding-code-line.is-add {
+  border-left-color: rgba(52, 211, 153, 0.72);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+html[data-diff-markers='color'] .idt-repo-finding-code-line.is-remove {
+  border-left-color: rgba(248, 113, 113, 0.72);
+  background: rgba(239, 68, 68, 0.13);
+}
+
+.idt-repo-finding-code-marker {
+  display: none;
+}
+
 html[data-diff-markers='symbols'] .idt-repo-finding-code-line:is(.is-add, .is-remove) {
   padding-left: 1.2rem;
 }
 
 html[data-diff-markers='symbols'] .idt-repo-finding-code-marker {
   position: absolute;
+  display: inline;
   left: 0;
   font-weight: 900;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6410,6 +6410,31 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   font-size: 0.84rem;
 }
 
+.idt-repo-finding-code-line {
+  position: relative;
+  display: block;
+  min-height: 1.45em;
+  white-space: pre-wrap;
+}
+
+html[data-diff-markers='symbols'] .idt-repo-finding-code-line:is(.is-add, .is-remove) {
+  padding-left: 1.2rem;
+}
+
+html[data-diff-markers='symbols'] .idt-repo-finding-code-line:is(.is-add, .is-remove)::before {
+  position: absolute;
+  left: 0;
+  font-weight: 900;
+}
+
+html[data-diff-markers='symbols'] .idt-repo-finding-code-line.is-add::before {
+  content: '+';
+}
+
+html[data-diff-markers='symbols'] .idt-repo-finding-code-line.is-remove::before {
+  content: '-';
+}
+
 .idt-repo-finding-remediation {
   display: grid;
   gap: 0.35rem;
@@ -30745,12 +30770,34 @@ html[data-appearance-ready='true'] .idt-executive-report-shell {
   --app-text: var(--appearance-fg, #f5f7f8);
   --app-muted: var(--appearance-muted, #adb5bf);
   --app-dim: color-mix(in srgb, var(--appearance-muted, #adb5bf) var(--appearance-muted-mix, 74%), var(--appearance-bg, #121518));
+  --idt-console-rail: color-mix(in srgb, var(--appearance-panel, #090b0e) 92%, var(--appearance-bg, #121518));
+  --idt-console-rail-hover: color-mix(in srgb, var(--appearance-panel, #090b0e) 88%, var(--appearance-fg, #f5f7f8) 8%);
+  --idt-console-surface: var(--appearance-panel, #090b0e);
+  --idt-console-surface-raised: color-mix(in srgb, var(--appearance-panel, #090b0e) 92%, var(--appearance-fg, #f5f7f8) 8%);
+  --idt-console-surface-quiet: color-mix(in srgb, var(--appearance-panel, #090b0e) 94%, var(--appearance-bg, #121518) 6%);
+  --idt-console-surface-deep: color-mix(in srgb, var(--appearance-panel, #090b0e) 86%, var(--appearance-bg, #121518) 14%);
   --idt-console-focus: var(--appearance-accent, #7c6dff);
+  --idt-console-shadow: 0 18px 48px color-mix(in srgb, var(--appearance-bg, #121518) 32%, transparent);
   --idt-product-font: var(--appearance-ui-font, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif);
+  --idt-mono: var(--appearance-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
   background: var(--appearance-bg, #121518);
   color: var(--appearance-fg, #f5f7f8);
   font-family: var(--appearance-ui-font, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif);
   font-size: var(--appearance-ui-font-size, 16px);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(pre, code, textarea),
+html[data-appearance-ready='true'] .idt-account-security-page :is(pre, code, textarea),
+html[data-appearance-ready='true'] .idt-app-shell-screen :is(pre, code, textarea),
+html[data-appearance-ready='true'] .idt-executive-report-shell :is(pre, code, textarea) {
+  font-family: var(--appearance-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(pre, code),
+html[data-appearance-ready='true'] .idt-account-security-page :is(pre, code),
+html[data-appearance-ready='true'] .idt-app-shell-screen :is(pre, code),
+html[data-appearance-ready='true'] .idt-executive-report-shell :is(pre, code) {
+  font-size: var(--appearance-code-font-size, 14px);
 }
 
 html[data-font-smoothing='true'] body {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -31303,7 +31303,7 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
 .idt-app-console-layout .idt-workspace-admin-grid > article {
   border: 1px solid var(--app-border);
   border-radius: 8px;
-  background: #050506;
+  background: var(--app-panel);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.035), var(--idt-console-shadow);
 }
 
@@ -31321,7 +31321,7 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   display: grid;
   align-content: center;
   gap: 0.1rem;
-  background: #070708;
+  background: var(--app-panel);
 }
 
 .idt-app-console-layout .idt-workspace-stats h3 {
@@ -31398,12 +31398,12 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   border: 1px solid var(--app-border);
   border-radius: 8px;
   padding: 0.85rem;
-  background: #050506;
+  background: var(--app-panel);
 }
 
 .idt-app-console-layout .idt-workspace-table-wrap {
   border-radius: 8px;
-  background: #050506;
+  background: var(--app-panel);
 }
 
 .idt-app-console-layout .idt-workspace-table th,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30924,6 +30924,61 @@ html[data-appearance-ready='true'] .idt-executive-report-shell :is(p, dd, .idt-e
   color: var(--app-muted);
 }
 
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger {
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(
+  .idt-app-sidebar-workspace-copy strong,
+  .idt-app-sidebar-workspace-meta strong,
+  .idt-app-sidebar-account-name strong,
+  .idt-app-sidebar-account-meta strong
+) {
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-quick-find,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a {
+  color: var(--app-muted);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout :is(
+  .idt-app-sidebar-workspace-caret,
+  .idt-app-sidebar-workspace-meta-eyebrow,
+  .idt-app-sidebar-account-name span,
+  .idt-app-sidebar-account-caret,
+  .idt-app-sidebar-account-meta span,
+  .idt-app-quick-find-icon,
+  .idt-app-quick-find-label,
+  .idt-app-quick-find-key,
+  .idt-app-nav-icon
+) {
+  color: var(--app-muted);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger:hover,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger:focus-visible,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger[aria-expanded='true'],
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger:hover,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger:focus-visible,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger[aria-expanded='true'],
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active) {
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a.active {
+  background: var(--idt-console-rail-hover);
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon {
+  color: var(--app-text);
+}
+
 html[data-font-smoothing='true'] body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30772,7 +30772,10 @@ html[data-appearance-ready='true'] #main-content:has(.idt-executive-report-shell
   background: var(--appearance-bg, #121518);
 }
 
-html[data-appearance-ready='true'] {
+html[data-appearance-ready='true']:has(.idt-app-console-layout),
+html[data-appearance-ready='true']:has(.idt-account-security-page),
+html[data-appearance-ready='true']:has(.idt-app-shell-screen),
+html[data-appearance-ready='true']:has(.idt-executive-report-shell) {
   font-size: var(--appearance-ui-font-size, 16px);
 }
 
@@ -30835,6 +30838,22 @@ html[data-appearance-ready='true'] .idt-app-console-layout :is(
   .idt-source-install-card,
   .idt-source-advanced,
   .idt-source-diagnostics article,
+  .idt-domain-header,
+  .idt-domain-kpi,
+  .idt-domain-status-panel,
+  .idt-domain-empty-state,
+  .idt-domain-error-state,
+  .idt-domain-detail-panel,
+  .idt-domain-evidence-panel,
+  .idt-domain-filter-bar,
+  .idt-domain-filter-fields input,
+  .idt-domain-filter-fields select,
+  .idt-domain-loading-state,
+  .idt-domain-readiness-items article > span,
+  .idt-domain-action-footer,
+  .idt-domain-table-wrap,
+  .idt-domain-evidence-panel pre,
+  .idt-domain-status-panel header > span,
   .idt-repo-finding-list,
   .idt-repo-finding-detail,
   .idt-repo-finding-trend,
@@ -30883,6 +30902,15 @@ html[data-appearance-ready='true'] .idt-app-console-layout :is(
   .idt-overview-projects small,
   .idt-source-card small,
   .idt-source-diagnostics small,
+  .idt-domain-kpi span,
+  .idt-domain-kpi p,
+  .idt-domain-header p,
+  .idt-domain-status-panel p,
+  .idt-domain-empty-state p,
+  .idt-domain-error-state p,
+  .idt-domain-detail-panel p,
+  .idt-domain-filter-fields label,
+  .idt-domain-evidence-panel figcaption span,
   .idt-repo-finding-row-meta,
   .idt-repo-finding-trend-subtitle,
   .idt-repo-finding-trend-meta span,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6387,7 +6387,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   gap: 0.45rem;
 }
 
-.idt-repo-finding-code span {
+.idt-repo-finding-code-label {
   color: #9fb5d8;
   font-size: 0.74rem;
   font-weight: 700;
@@ -8133,7 +8133,7 @@ html[data-theme='light'] .idt-repo-finding-trend {
 html[data-theme='light'] .idt-repo-finding-stat span,
 html[data-theme='light'] .idt-repo-finding-row-meta,
 html[data-theme='light'] .idt-repo-finding-facts dt,
-html[data-theme='light'] .idt-repo-finding-code span {
+html[data-theme='light'] .idt-repo-finding-code-label {
   color: #5473a4;
 }
 
@@ -22446,7 +22446,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-trend-subtitl
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-trend-meta span,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-group h4,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-facts dt,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-code span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-code-label,
 html[data-theme='light'] .idt-app-console-layout .idt-settings-header p,
 html[data-theme='light'] .idt-app-console-layout .idt-settings-card p,
 html[data-theme='light'] .idt-app-console-layout .idt-settings-route-grid span,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30739,12 +30739,12 @@ html[data-appearance-ready='true'] .idt-app-shell-screen,
 html[data-appearance-ready='true'] .idt-executive-report-shell {
   --app-bg: var(--appearance-bg, #121518);
   --app-panel: var(--appearance-panel, #090b0e);
-  --app-panel-strong: color-mix(in srgb, var(--appearance-panel, #090b0e) 76%, black);
+  --app-panel-strong: color-mix(in srgb, var(--appearance-panel, #090b0e) var(--appearance-panel-mix, 76%), black);
   --app-border: var(--appearance-border, #2b3037);
-  --app-border-soft: color-mix(in srgb, var(--appearance-border, #2b3037) 72%, transparent);
+  --app-border-soft: color-mix(in srgb, var(--appearance-border, #2b3037) var(--appearance-border-mix, 72%), transparent);
   --app-text: var(--appearance-fg, #f5f7f8);
   --app-muted: var(--appearance-muted, #adb5bf);
-  --app-dim: color-mix(in srgb, var(--appearance-muted, #adb5bf) 74%, var(--appearance-bg, #121518));
+  --app-dim: color-mix(in srgb, var(--appearance-muted, #adb5bf) var(--appearance-muted-mix, 74%), var(--appearance-bg, #121518));
   --idt-console-focus: var(--appearance-accent, #7c6dff);
   --idt-product-font: var(--appearance-ui-font, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif);
   background: var(--appearance-bg, #121518);
@@ -30785,6 +30785,25 @@ html[data-reduce-motion='on'] *::after {
 html[data-appearance-translucent-sidebar='true'] .idt-app-sidebar {
   background: color-mix(in srgb, var(--appearance-panel, #090b0e) 82%, transparent);
   backdrop-filter: blur(18px);
+}
+
+html[data-appearance-app-icon='light'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark {
+  background: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(5, 6, 7, 0.14), 0 0 0 1px rgba(255, 255, 255, 0.16);
+}
+
+html[data-appearance-app-icon='light'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark img {
+  filter: none;
+}
+
+html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark {
+  background: #050607;
+  box-shadow: inset 0 0 0 1px var(--appearance-accent, #7c6dff), 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark img {
+  filter: brightness(0.9) saturate(1.15);
+  mix-blend-mode: screen;
 }
 
 .idt-settings-appearance-entry {


### PR DESCRIPTION
## Summary
No issue: Appearance settings were requested directly and do not have a tracking issue.

- Add a dedicated Appearance settings page for theme mode, presets, colors, fonts, contrast, motion, pointer cursors, diff markers, font smoothing, and app icon preference.
- Apply saved appearance preferences at startup instead of forcing the product shell back to light mode.
- Persist appearance values through an allowlisted and clamped preference model so unsafe CSS, URLs, scripts, and arbitrary font imports are rejected.

## Impact
Customers can choose the display style they prefer without waiting on workspace settings APIs, and the product shell applies saved appearance preferences immediately on load.

## Validation
- npm test -- productShell.test.tsx --run
- npm run build
- npm audit --omit=dev
- git diff --check

## AI disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Appearance settings page with a safe, persistent model for themes, colors, fonts, sizes, contrast, motion, cursors, diff markers, and the app icon. Preferences apply at boot and on system-theme changes, theming is scoped to product surfaces, repository evidence diffs render per line with selectable markers and stricter detection, and light preset sidebar contrast is fixed.

- New Features
  - Added Appearance page with live preview and route `/app/:tenantID/:workspaceID/settings/appearance` (linked from Settings). Preferences saved to local storage (`identrail-appearance`) with sanitization and legacy `identrail-theme` read/write; applied on boot and when the system theme changes.
  - Theme mode (light/dark/system); preset pickers with light-only vs dark/both filtering; custom accent/background/foreground; UI/code fonts and sizes (font-size commits on blur/Enter with clamped ranges); translucent sidebar; contrast; pointer cursors; reduce motion (system/on/off); diff markers (color or +/-); font smoothing; app icon.
  - Scoped theming via data attributes and CSS variables to product surfaces (app shell, console, account security, executive report).

- Refactors
  - Centralized appearance logic in `web/src/appearance.ts` and applied via `main.tsx` with a system-theme listener. Repo findings: render `line_snippet` line-by-line with add/remove classes driven by user preference, require real diff headers/bodies (supports one‑sided hunks, ignores ordinary `+`/`-` lines), update styles/tests, and fix sidebar contrast for light presets.

<sup>Written for commit 5c19efad6b5e4bd417935e808355211a36b02c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

