### PR TITLE
Add managed AWS RDS Postgres option

### DIFF
--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -44,6 +44,35 @@ on:
         description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
         required: false
         type: string
+      create_api_database:
+        description: "Create managed AWS RDS PostgreSQL and ignore the external database URL secret."
+        required: false
+        type: boolean
+        default: false
+      api_database_subnet_ids_json:
+        description: "Optional JSON array of database subnet IDs. Blank uses private API subnets, then task subnets."
+        required: false
+        type: string
+      api_database_instance_class:
+        description: "RDS instance class for managed Postgres."
+        required: false
+        type: string
+        default: db.t4g.micro
+      api_database_allocated_storage:
+        description: "Allocated managed Postgres storage in GiB."
+        required: false
+        type: string
+        default: "20"
+      api_database_max_allocated_storage:
+        description: "Maximum managed Postgres autoscaled storage in GiB. Use 0 to disable."
+        required: false
+        type: string
+        default: "100"
+      api_database_backup_retention_days:
+        description: "Managed Postgres automated backup retention days."
+        required: false
+        type: string
+        default: "7"
       terraform_state_bucket:
         description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
         required: false
@@ -99,6 +128,36 @@ on:
         required: false
         type: string
         default: ""
+      create_api_database:
+        description: "Create managed AWS RDS PostgreSQL and ignore the external database URL secret."
+        required: false
+        type: boolean
+        default: false
+      api_database_subnet_ids_json:
+        description: "Optional JSON array of database subnet IDs. Blank uses private API subnets, then task subnets."
+        required: false
+        type: string
+        default: ""
+      api_database_instance_class:
+        description: "RDS instance class for managed Postgres."
+        required: false
+        type: string
+        default: db.t4g.micro
+      api_database_allocated_storage:
+        description: "Allocated managed Postgres storage in GiB."
+        required: false
+        type: string
+        default: "20"
+      api_database_max_allocated_storage:
+        description: "Maximum managed Postgres autoscaled storage in GiB. Use 0 to disable."
+        required: false
+        type: string
+        default: "100"
+      api_database_backup_retention_days:
+        description: "Managed Postgres automated backup retention days."
+        required: false
+        type: string
+        default: "7"
       terraform_state_bucket:
         description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
         required: false
@@ -142,6 +201,12 @@ jobs:
       API_WORKER_TASK_CPU: ${{ vars.API_WORKER_TASK_CPU || '256' }}
       API_WORKER_TASK_MEMORY: ${{ vars.API_WORKER_TASK_MEMORY || '512' }}
       API_DATABASE_URL_SECRET_ARN: ${{ inputs.database_url_secret_arn || secrets.API_DATABASE_URL_SECRET_ARN }}
+      API_CREATE_DATABASE: ${{ inputs.create_api_database && 'true' || vars.API_CREATE_DATABASE || 'false' }}
+      API_DATABASE_SUBNET_IDS_JSON: ${{ inputs.api_database_subnet_ids_json || vars.API_DATABASE_SUBNET_IDS_JSON || '' }}
+      API_DATABASE_INSTANCE_CLASS: ${{ inputs.api_database_instance_class || vars.API_DATABASE_INSTANCE_CLASS || 'db.t4g.micro' }}
+      API_DATABASE_ALLOCATED_STORAGE: ${{ inputs.api_database_allocated_storage || vars.API_DATABASE_ALLOCATED_STORAGE || '20' }}
+      API_DATABASE_MAX_ALLOCATED_STORAGE: ${{ inputs.api_database_max_allocated_storage || vars.API_DATABASE_MAX_ALLOCATED_STORAGE || '100' }}
+      API_DATABASE_BACKUP_RETENTION_DAYS: ${{ inputs.api_database_backup_retention_days || vars.API_DATABASE_BACKUP_RETENTION_DAYS || '7' }}
       API_SESSION_KEY_SECRET_ARN: ${{ secrets.API_SESSION_KEY_SECRET_ARN }}
       API_FEATURE_WORKOS_LOGIN: ${{ vars.API_FEATURE_WORKOS_LOGIN || '' }}
       API_FEATURE_ONBOARDING_WIZARD: ${{ vars.API_FEATURE_ONBOARDING_WIZARD || 'true' }}
@@ -199,7 +264,17 @@ jobs:
             exit 1
           fi
           echo "::add-mask::${AWS_ROLE_ARN}"
-          if [ -z "${API_DATABASE_URL_SECRET_ARN}" ]; then
+          api_create_database="$(printf '%s' "${API_CREATE_DATABASE}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+          case "${api_create_database}" in
+            true|false) ;;
+            *)
+              echo "API_CREATE_DATABASE must be true or false."
+              exit 1
+              ;;
+          esac
+          if [ "${api_create_database}" = "true" ]; then
+            echo "Managed AWS RDS PostgreSQL creation is enabled; any external database URL secret is ignored by the Terraform inputs."
+          elif [ -z "${API_DATABASE_URL_SECRET_ARN}" ]; then
             echo "Missing repository secret API_DATABASE_URL_SECRET_ARN."
             exit 1
           fi
@@ -207,7 +282,9 @@ jobs:
             echo "Missing repository secret API_SESSION_KEY_SECRET_ARN."
             exit 1
           fi
-          echo "::add-mask::${API_DATABASE_URL_SECRET_ARN}"
+          if [ -n "${API_DATABASE_URL_SECRET_ARN}" ]; then
+            echo "::add-mask::${API_DATABASE_URL_SECRET_ARN}"
+          fi
           echo "::add-mask::${API_SESSION_KEY_SECRET_ARN}"
           if [ -n "${API_WORKOS_API_KEY_SECRET_ARN}" ]; then
             echo "::add-mask::${API_WORKOS_API_KEY_SECRET_ARN}"
@@ -312,6 +389,9 @@ jobs:
           worker_service="$(terraform output -raw worker_service_name)"
           worker_enabled="$(terraform output -raw worker_hosting_enabled)"
           api_cluster="$(terraform output -raw api_ecs_cluster_name)"
+          database_enabled="$(terraform output -json api_database_enabled | jq -r '.')"
+          database_endpoint="$(terraform output -json api_database_endpoint | jq -r '. // "not-created"')"
+          database_secret_arn="$(terraform output -json api_database_secret_arn | jq -r '. // "external-secret"')"
           {
             echo "## AWS API deploy outputs"
             echo
@@ -320,6 +400,11 @@ jobs:
             echo "- ECS service: \`${api_service}\`"
             echo "- Worker hosting enabled: \`${worker_enabled}\`"
             echo "- Worker service: \`${worker_service}\`"
+            echo "- Managed database enabled: \`${database_enabled}\`"
+            if [ "${database_enabled}" = "true" ]; then
+              echo "- RDS endpoint: \`${database_endpoint}\`"
+              echo "- Database URL secret ARN: \`${database_secret_arn}\`"
+            fi
             echo "- Terraform state key: \`${{ steps.prepare.outputs.state_key }}\`"
             echo
             echo "After health checks pass, create the Namecheap CNAME for \`api.identrail.com\` to the load balancer DNS name."

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -22,6 +22,12 @@ When `create_api_hosting_resources=true`, the root can also create:
 - task execution and task IAM roles
 - a private S3 bucket for self-serve account data export bundles
 
+When `create_api_database=true`, the API hosting plan also creates:
+
+- a single-AZ encrypted RDS PostgreSQL instance for the hosted API
+- a database security group that only accepts PostgreSQL from API tasks
+- a Secrets Manager secret containing the generated `IDENTRAIL_DATABASE_URL`
+
 When `create_worker_hosting_resources=true`, the root also creates:
 
 - an ECS/Fargate worker task definition and service in the API cluster
@@ -36,8 +42,9 @@ That avoids NAT Gateway or private VPC endpoint hourly charges while preserving
 the public ingress boundary at the load balancer security group. Move back to
 private task subnets before higher-volume production use.
 
-It does not write secret values. Runtime secrets should be created by the
-operator or a dedicated secrets workflow and referenced through `api_secrets`.
+The external-secret path does not write secret values. Runtime secrets should be
+created by the operator or a dedicated secrets workflow and referenced through
+`api_secrets`.
 If those secrets use customer-managed KMS keys, list the key ARNs in
 `api_secret_kms_key_arns` so ECS secret injection can decrypt them.
 `api_secrets` may use ECS `valueFrom` selectors for JSON keys or versions, but
@@ -49,6 +56,11 @@ Identrail variables there so Terraform state does not receive secret material.
 When API hosting is enabled, Terraform also validates that the task has a
 database reference and at least one supported Identrail authentication mode
 before it will plan ECS resources.
+The managed-database path is different: Terraform generates the RDS password,
+writes the database URL to Secrets Manager, and stores the generated value in
+the encrypted Terraform state. Use the S3 backend with restricted access before
+enabling `create_api_database=true`, and do not also set
+`api_secrets.IDENTRAIL_DATABASE_URL`.
 The hosted API task also defaults to live AWS collection with
 `IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, and
 `IDENTRAIL_AWS_REGION` from `aws_region`. It binds the API process with
@@ -77,7 +89,8 @@ or session ID hashes.
 
 The default configuration sets `create_foundation_resources=false`,
 `create_api_hosting_resources=false`, and
-`create_worker_hosting_resources=false`, so CI and pull requests can run
+`create_worker_hosting_resources=false`, and `create_api_database=false`, so CI
+and pull requests can run
 `terraform init`, `terraform validate`, and `terraform plan` without creating
 billable AWS resources.
 
@@ -113,7 +126,7 @@ terraform plan \
 
 Only run this after the VPC, at least two distinct public subnets in different
 Availability Zones, task subnets, ACM certificate, immutable API image,
-database, auth configuration, and Secrets Manager references are ready. The
+database plan, auth configuration, and Secrets Manager references are ready. The
 API-hosting plan reads subnet metadata from AWS and fails before apply if the
 load balancer or task subnets are not spread across at least two Availability
 Zones or if any provided subnet is outside `api_vpc_id`. It also reads route
@@ -139,6 +152,31 @@ terraform plan \
   -var='api_secrets={"IDENTRAIL_DATABASE_URL":"<database-url-secret-arn>","IDENTRAIL_API_KEY_SCOPES":"<api-key-scopes-secret-arn>"}' \
   -var='api_secret_kms_key_arns=[]' \
   -var='api_connector_role_arns=[]'
+```
+
+To create the cost-conscious AWS-managed PostgreSQL database instead of
+referencing an external database URL secret, enable `create_api_database` and
+omit `IDENTRAIL_DATABASE_URL` from `api_secrets`:
+
+```bash
+terraform plan \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_foundation_resources=true' \
+  -var='create_api_hosting_resources=true' \
+  -var='create_api_database=true' \
+  -var='api_database_instance_class=db.t4g.micro' \
+  -var='api_database_allocated_storage=20' \
+  -var='api_database_max_allocated_storage=100' \
+  -var='api_database_backup_retention_days=7' \
+  -var='api_vpc_id=<vpc-id>' \
+  -var='api_public_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
+  -var='api_task_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
+  -var='api_task_assign_public_ip=true' \
+  -var='api_certificate_arn=<api-certificate-arn>' \
+  -var='api_container_image=ghcr.io/identrail/identrail-api:<immutable-release-tag>' \
+  -var='api_environment_variables={"IDENTRAIL_FEATURE_NEW_AUTH":"true","IDENTRAIL_PUBLIC_BASE_URL":"https://api.identrail.com"}' \
+  -var='api_secrets={"IDENTRAIL_SESSION_KEY":"<session-key-secret-arn>"}'
 ```
 
 To include the hosted queue worker in the same plan, also provide an immutable

--- a/deploy/aws/terraform/api_database.tf
+++ b/deploy/aws/terraform/api_database.tf
@@ -1,0 +1,175 @@
+locals {
+  api_database_subnet_ids = length(var.api_database_subnet_ids) > 0 ? var.api_database_subnet_ids : (
+    length(var.api_private_subnet_ids) > 0 ? var.api_private_subnet_ids : local.api_task_subnet_ids
+  )
+  api_database_identifier = "${local.api_name_prefix}-db"
+  api_database_secret_name = (
+    "${var.name_prefix}/${var.environment}/api/database-url"
+  )
+  api_database_final_snapshot_identifier = (
+    length(trimspace(var.api_database_final_snapshot_identifier)) > 0 ?
+    trimspace(var.api_database_final_snapshot_identifier) :
+    "${local.api_database_identifier}-final"
+  )
+  api_database_max_allocated_storage = var.api_database_max_allocated_storage == 0 ? null : var.api_database_max_allocated_storage
+}
+
+data "aws_subnet" "api_database" {
+  count = var.create_api_database ? length(local.api_database_subnet_ids) : 0
+
+  id = local.api_database_subnet_ids[count.index]
+}
+
+resource "terraform_data" "api_database_inputs" {
+  count = var.create_api_database ? 1 : 0
+
+  input = local.api_database_identifier
+
+  lifecycle {
+    precondition {
+      condition     = var.create_api_hosting_resources
+      error_message = "create_api_database=true requires create_api_hosting_resources=true so the database can be wired to the API service security group and runtime secret."
+    }
+
+    precondition {
+      condition = length(distinct(local.api_database_subnet_ids)) >= 2 && alltrue([
+        for subnet_id in local.api_database_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+      ])
+      error_message = "create_api_database=true requires at least two distinct valid database subnet IDs. Set api_database_subnet_ids, api_private_subnet_ids, or api_task_subnet_ids."
+    }
+
+    precondition {
+      condition = alltrue([
+        for subnet in data.aws_subnet.api_database : subnet.vpc_id == var.api_vpc_id
+      ])
+      error_message = "api_database_subnet_ids must all belong to api_vpc_id when create_api_database=true."
+    }
+
+    precondition {
+      condition     = length(distinct(data.aws_subnet.api_database[*].availability_zone_id)) >= 2
+      error_message = "api_database_subnet_ids must span at least two distinct Availability Zones when create_api_database=true."
+    }
+
+    precondition {
+      condition     = var.api_database_max_allocated_storage == 0 || var.api_database_max_allocated_storage >= var.api_database_allocated_storage
+      error_message = "api_database_max_allocated_storage must be 0 or greater than or equal to api_database_allocated_storage."
+    }
+
+    precondition {
+      condition     = !contains(keys(var.api_secrets), "IDENTRAIL_DATABASE_URL")
+      error_message = "Do not set api_secrets.IDENTRAIL_DATABASE_URL when create_api_database=true; Terraform creates and wires the managed database URL secret."
+    }
+  }
+}
+
+resource "random_password" "api_database" {
+  count = local.api_database_enabled ? 1 : 0
+
+  length  = 32
+  special = false
+}
+
+resource "aws_security_group" "api_database" {
+  count = local.api_database_enabled ? 1 : 0
+
+  name        = "${local.api_name_prefix}-db"
+  description = "Private PostgreSQL access for the Identrail API database"
+  vpc_id      = var.api_vpc_id
+
+  tags = {
+    Name = "${local.api_service_name}-database"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "api_database_from_api_service" {
+  count = local.api_database_enabled ? 1 : 0
+
+  security_group_id            = aws_security_group.api_database[0].id
+  referenced_security_group_id = aws_security_group.api_service[0].id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Allow PostgreSQL from Identrail API tasks"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "api_database_from_worker_service" {
+  count = local.api_database_enabled && var.create_worker_hosting_resources ? 1 : 0
+
+  security_group_id            = aws_security_group.api_database[0].id
+  referenced_security_group_id = aws_security_group.worker_service[0].id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Allow PostgreSQL from Identrail worker tasks"
+}
+
+resource "aws_db_subnet_group" "api_database" {
+  count = local.api_database_enabled ? 1 : 0
+
+  name       = local.api_database_identifier
+  subnet_ids = local.api_database_subnet_ids
+
+  tags = {
+    Name = "${local.api_service_name}-database"
+  }
+}
+
+resource "aws_db_instance" "api_database" {
+  count = local.api_database_enabled ? 1 : 0
+
+  identifier                      = local.api_database_identifier
+  allocated_storage               = var.api_database_allocated_storage
+  max_allocated_storage           = local.api_database_max_allocated_storage
+  storage_type                    = "gp3"
+  storage_encrypted               = true
+  engine                          = "postgres"
+  engine_version                  = var.api_database_engine_version
+  auto_minor_version_upgrade      = true
+  instance_class                  = var.api_database_instance_class
+  db_name                         = var.api_database_name
+  username                        = var.api_database_username
+  password                        = random_password.api_database[0].result
+  port                            = 5432
+  db_subnet_group_name            = aws_db_subnet_group.api_database[0].name
+  vpc_security_group_ids          = [aws_security_group.api_database[0].id]
+  publicly_accessible             = false
+  multi_az                        = false
+  backup_retention_period         = var.api_database_backup_retention_days
+  copy_tags_to_snapshot           = true
+  deletion_protection             = var.api_database_deletion_protection
+  skip_final_snapshot             = var.api_database_skip_final_snapshot
+  final_snapshot_identifier       = var.api_database_skip_final_snapshot ? null : local.api_database_final_snapshot_identifier
+  apply_immediately               = var.api_database_apply_immediately
+  performance_insights_enabled    = false
+  enabled_cloudwatch_logs_exports = []
+
+  tags = {
+    Name = "${local.api_service_name}-database"
+  }
+
+  depends_on = [
+    terraform_data.api_database_inputs,
+  ]
+}
+
+resource "aws_secretsmanager_secret" "api_database_url" {
+  count = local.api_database_enabled ? 1 : 0
+
+  name                    = local.api_database_secret_name
+  description             = "Identrail ${var.environment} managed RDS PostgreSQL URL"
+  recovery_window_in_days = 7
+}
+
+resource "aws_secretsmanager_secret_version" "api_database_url" {
+  count = local.api_database_enabled ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.api_database_url[0].id
+  secret_string = format(
+    "postgresql://%s:%s@%s:%s/%s?sslmode=require",
+    var.api_database_username,
+    random_password.api_database[0].result,
+    aws_db_instance.api_database[0].address,
+    aws_db_instance.api_database[0].port,
+    var.api_database_name,
+  )
+}

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -21,6 +21,10 @@ locals {
   api_cors_allowed_origins   = join(",", var.api_cors_allowed_origins)
   api_trusted_proxies        = join(",", var.api_trusted_proxy_cidr_blocks)
   api_task_subnet_ids        = length(var.api_task_subnet_ids) > 0 ? var.api_task_subnet_ids : var.api_private_subnet_ids
+  api_database_enabled       = var.create_api_hosting_resources && var.create_api_database
+  api_managed_database_secrets = local.api_database_enabled ? {
+    IDENTRAIL_DATABASE_URL = aws_secretsmanager_secret.api_database_url[0].arn
+  } : {}
   api_default_environment_variables = {
     IDENTRAIL_AWS_REGION           = var.aws_region
     IDENTRAIL_AWS_SOURCE           = "sdk"
@@ -47,10 +51,11 @@ locals {
     IDENTRAIL_USER_DATA_EXPORT_S3_REGION = var.aws_region
   } : {}
   api_runtime_environment_variables = merge(local.api_default_environment_variables, local.api_user_data_export_environment_variables, var.api_environment_variables)
-  api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(var.api_secrets)))
-  api_secret_config_names           = toset(keys(var.api_secrets))
+  api_runtime_secrets               = merge(local.api_managed_database_secrets, var.api_secrets)
+  api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(local.api_runtime_secrets)))
+  api_secret_config_names           = toset(keys(local.api_runtime_secrets))
   api_secret_resource_arns = toset([
-    for value_from in values(var.api_secrets) : join(":", slice(split(":", value_from), 0, 7))
+    for value_from in values(local.api_runtime_secrets) : join(":", slice(split(":", value_from), 0, 7))
   ])
   api_runtime_cors_allowed_origins = compact([
     for origin in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_CORS_ALLOWED_ORIGINS", "")) : trimspace(origin)
@@ -105,7 +110,7 @@ locals {
     }
   ]
   api_secrets = [
-    for name, value_from in var.api_secrets : {
+    for name, value_from in local.api_runtime_secrets : {
       name      = name
       valueFrom = value_from
     }
@@ -228,8 +233,13 @@ resource "terraform_data" "api_inputs" {
     }
 
     precondition {
+      condition     = !var.create_api_database || !contains(keys(var.api_secrets), "IDENTRAIL_DATABASE_URL")
+      error_message = "Do not set api_secrets.IDENTRAIL_DATABASE_URL when create_api_database=true; Terraform creates and wires the managed database URL secret."
+    }
+
+    precondition {
       condition     = contains(local.api_secret_config_names, "IDENTRAIL_DATABASE_URL")
-      error_message = "api_secrets must include IDENTRAIL_DATABASE_URL when create_api_hosting_resources=true."
+      error_message = "API hosting requires IDENTRAIL_DATABASE_URL from api_secrets or create_api_database=true."
     }
 
     precondition {
@@ -320,7 +330,7 @@ data "aws_iam_policy_document" "ecs_tasks_assume_role" {
 }
 
 data "aws_iam_policy_document" "api_task_execution_secrets" {
-  count = var.create_api_hosting_resources && length(var.api_secrets) > 0 ? 1 : 0
+  count = var.create_api_hosting_resources && length(local.api_runtime_secrets) > 0 ? 1 : 0
 
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
@@ -402,7 +412,7 @@ resource "aws_iam_role_policy_attachment" "api_task_execution" {
 }
 
 resource "aws_iam_role_policy" "api_task_execution_secrets" {
-  count = var.create_api_hosting_resources && length(var.api_secrets) > 0 ? 1 : 0
+  count = var.create_api_hosting_resources && length(local.api_runtime_secrets) > 0 ? 1 : 0
 
   name   = "${local.api_policy_name_base}-secrets"
   role   = aws_iam_role.api_task_execution[0].id
@@ -598,6 +608,10 @@ resource "aws_ecs_task_definition" "api" {
       }
     }
   ])
+
+  depends_on = [
+    aws_secretsmanager_secret_version.api_database_url,
+  ]
 }
 
 resource "aws_ecs_service" "api" {

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -6,6 +6,7 @@ name_prefix = "identrail"
 create_foundation_resources = false
 create_api_hosting_resources = false
 create_worker_hosting_resources = false
+create_api_database = false
 
 create_runtime_secret = true
 log_retention_days    = 30
@@ -21,6 +22,14 @@ log_retention_days    = 30
 # restricted to the ALB security group, and move to private task subnets later.
 # api_task_subnet_ids       = ["<public-subnet-a>", "<public-subnet-b>"]
 # api_task_assign_public_ip = true
+# Optional managed AWS RDS PostgreSQL for the first AWS cutover. Leave
+# api_secrets.IDENTRAIL_DATABASE_URL unset when create_api_database=true.
+# create_api_database = true
+# api_database_subnet_ids            = ["<database-subnet-a>", "<database-subnet-b>"]
+# api_database_instance_class        = "db.t4g.micro"
+# api_database_allocated_storage     = 20
+# api_database_max_allocated_storage = 100
+# api_database_backup_retention_days = 7
 # api_certificate_arn    = "<api-certificate-arn>"
 # api_container_image    = "ghcr.io/identrail/identrail-api:<immutable-release-tag>"
 # worker_container_image = "ghcr.io/identrail/identrail-worker:<immutable-release-tag>"

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -33,6 +33,26 @@ output "api_service_name" {
   value       = try(aws_ecs_service.api[0].name, local.api_service_name)
 }
 
+output "api_database_enabled" {
+  description = "Whether this plan creates the managed AWS RDS PostgreSQL database for the API."
+  value       = local.api_database_enabled
+}
+
+output "api_database_identifier" {
+  description = "RDS instance identifier for the managed API database when enabled."
+  value       = try(aws_db_instance.api_database[0].identifier, null)
+}
+
+output "api_database_endpoint" {
+  description = "RDS endpoint address for the managed API database when enabled."
+  value       = try(aws_db_instance.api_database[0].address, null)
+}
+
+output "api_database_secret_arn" {
+  description = "Secrets Manager ARN containing IDENTRAIL_DATABASE_URL for the managed API database when enabled."
+  value       = try(aws_secretsmanager_secret.api_database_url[0].arn, null)
+}
+
 output "user_data_export_bucket_name" {
   description = "S3 bucket used for self-serve account data export bundles when enabled."
   value       = try(aws_s3_bucket.user_data_exports[0].bucket, null)

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -76,6 +76,12 @@ variable "create_api_hosting_resources" {
   default     = false
 }
 
+variable "create_api_database" {
+  description = "Create a cost-conscious single-AZ RDS PostgreSQL database and Secrets Manager IDENTRAIL_DATABASE_URL reference for the hosted API and worker."
+  type        = bool
+  default     = false
+}
+
 variable "api_vpc_id" {
   description = "VPC ID for the API load balancer and ECS service. Required when create_api_hosting_resources=true."
   type        = string
@@ -126,6 +132,116 @@ variable "api_task_assign_public_ip" {
   description = "Assign public IPs to API ECS tasks. Keep false for private-subnet production; set true only for the low-cost first cutover path where task subnets are public and service ingress remains restricted to the ALB security group."
   type        = bool
   default     = false
+}
+
+variable "api_database_subnet_ids" {
+  description = "Optional subnet IDs for the managed RDS PostgreSQL subnet group. Leave empty to use private API subnets when provided, otherwise the ECS task subnets."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = length(var.api_database_subnet_ids) == length(distinct(var.api_database_subnet_ids)) && alltrue([
+      for subnet_id in var.api_database_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+    ])
+    error_message = "api_database_subnet_ids must contain distinct valid subnet IDs."
+  }
+}
+
+variable "api_database_instance_class" {
+  description = "RDS PostgreSQL instance class for the managed API database."
+  type        = string
+  default     = "db.t4g.micro"
+  validation {
+    condition     = can(regex("^db\\.[a-z0-9]+(\\.[a-z0-9]+)+$", var.api_database_instance_class))
+    error_message = "api_database_instance_class must be an RDS class such as db.t4g.micro."
+  }
+}
+
+variable "api_database_engine_version" {
+  description = "RDS PostgreSQL major or minor engine version for the managed API database."
+  type        = string
+  default     = "16"
+  validation {
+    condition     = can(regex("^[0-9]+(\\.[0-9]+)?$", var.api_database_engine_version))
+    error_message = "api_database_engine_version must be a PostgreSQL major or minor version such as 16 or 16.8."
+  }
+}
+
+variable "api_database_name" {
+  description = "Initial PostgreSQL database name for Identrail."
+  type        = string
+  default     = "identrail"
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_]{0,62}$", var.api_database_name))
+    error_message = "api_database_name must be a PostgreSQL identifier of 1-63 letters, numbers, or underscores, starting with a letter."
+  }
+}
+
+variable "api_database_username" {
+  description = "Master username for the managed Identrail PostgreSQL database."
+  type        = string
+  default     = "identrail_app"
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_]{0,62}$", var.api_database_username)) && !startswith(lower(var.api_database_username), "pg_")
+    error_message = "api_database_username must be a PostgreSQL username of 1-63 letters, numbers, or underscores, starting with a letter and not pg_."
+  }
+}
+
+variable "api_database_allocated_storage" {
+  description = "Allocated RDS storage in GiB for the managed API database."
+  type        = number
+  default     = 20
+  validation {
+    condition     = var.api_database_allocated_storage >= 20 && var.api_database_allocated_storage <= 65536
+    error_message = "api_database_allocated_storage must be between 20 and 65536 GiB."
+  }
+}
+
+variable "api_database_max_allocated_storage" {
+  description = "Maximum autoscaled RDS storage in GiB. Set 0 to disable storage autoscaling."
+  type        = number
+  default     = 100
+  validation {
+    condition     = var.api_database_max_allocated_storage == 0 || (var.api_database_max_allocated_storage >= 20 && var.api_database_max_allocated_storage <= 65536)
+    error_message = "api_database_max_allocated_storage must be 0 or between 20 and 65536 GiB."
+  }
+}
+
+variable "api_database_backup_retention_days" {
+  description = "Automated backup retention days for the managed API database."
+  type        = number
+  default     = 7
+  validation {
+    condition     = var.api_database_backup_retention_days >= 0 && var.api_database_backup_retention_days <= 35
+    error_message = "api_database_backup_retention_days must be between 0 and 35."
+  }
+}
+
+variable "api_database_deletion_protection" {
+  description = "Enable RDS deletion protection for the managed API database."
+  type        = bool
+  default     = false
+}
+
+variable "api_database_skip_final_snapshot" {
+  description = "Skip the final RDS snapshot when destroying the managed API database. Keep true for the no-user first cutover; set false once production data matters."
+  type        = bool
+  default     = true
+}
+
+variable "api_database_final_snapshot_identifier" {
+  description = "Optional final snapshot identifier used when api_database_skip_final_snapshot=false. Defaults to a deterministic database-specific identifier."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(trimspace(var.api_database_final_snapshot_identifier)) == 0 || can(regex("^[A-Za-z][A-Za-z0-9-]{0,254}$", trimspace(var.api_database_final_snapshot_identifier)))
+    error_message = "api_database_final_snapshot_identifier must be blank or a valid RDS snapshot identifier."
+  }
+}
+
+variable "api_database_apply_immediately" {
+  description = "Apply managed API database changes immediately instead of waiting for the maintenance window."
+  type        = bool
+  default     = true
 }
 
 variable "api_private_subnet_egress_ready" {

--- a/deploy/aws/terraform/versions.tf
+++ b/deploy/aws/terraform/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0"
+    }
   }
 }

--- a/deploy/aws/terraform/worker_hosting.tf
+++ b/deploy/aws/terraform/worker_hosting.tf
@@ -22,7 +22,7 @@ locals {
     local.worker_default_environment_variables,
     var.worker_environment_variables
   )
-  worker_runtime_secrets              = merge(var.api_secrets, var.worker_secrets)
+  worker_runtime_secrets              = merge(local.api_runtime_secrets, var.worker_secrets)
   worker_secret_config_names          = toset(keys(local.worker_runtime_secrets))
   worker_combined_secret_kms_key_arns = distinct(concat(var.api_secret_kms_key_arns, var.worker_secret_kms_key_arns))
   worker_secret_resource_arns = toset([
@@ -197,6 +197,10 @@ resource "aws_ecs_task_definition" "worker" {
       }
     }
   ])
+
+  depends_on = [
+    aws_secretsmanager_secret_version.api_database_url,
+  ]
 }
 
 resource "aws_ecs_service" "worker" {

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -16,6 +16,8 @@ When `create_api_hosting_resources=true`, `deploy/aws/terraform` can create:
 - task execution and task IAM roles
 - CloudWatch logs for API runtime output
 - a private S3 bucket for self-serve account data export bundles
+- optionally, a single-AZ encrypted RDS PostgreSQL database plus a generated
+  Secrets Manager `IDENTRAIL_DATABASE_URL` secret when `create_api_database=true`
 
 When `create_worker_hosting_resources=true`, the same Terraform root also
 creates a private ECS/Fargate worker service in the API cluster. The hosted
@@ -83,7 +85,9 @@ Before a manual apply, operators must provide:
   URLs with paths, queries, fragments, or trailing slashes
 - `api_trusted_proxy_cidr_blocks`, defaulting to private VPC ranges used by ALB
   nodes in common AWS VPCs
-- `api_secrets`, including `IDENTRAIL_DATABASE_URL` as a Secrets Manager ARN
+- either `api_secrets.IDENTRAIL_DATABASE_URL` as a Secrets Manager ARN, or
+  `create_api_database=true` so Terraform creates the RDS database and generated
+  database URL secret
 - `api_secret_kms_key_arns` when any referenced secret uses a
   customer-managed KMS key
 - at least one supported API authentication mode:
@@ -134,8 +138,10 @@ Repository configuration required before the workflow can plan:
 - optional variable `API_TASK_SUBNET_IDS_JSON`: JSON array of task subnet IDs;
   leave blank for the low-cost public-task bootstrap path
 - variable `API_CERTIFICATE_ARN`: ACM certificate ARN for `api.identrail.com`
-- secret `API_DATABASE_URL_SECRET_ARN`: Secrets Manager ARN containing
-  `IDENTRAIL_DATABASE_URL`
+- either secret `API_DATABASE_URL_SECRET_ARN` containing an existing
+  `IDENTRAIL_DATABASE_URL` secret ARN, or `API_CREATE_DATABASE=true` to create
+  AWS-managed RDS PostgreSQL and have Terraform output the replacement secret
+  ARN
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
 
@@ -222,6 +228,15 @@ Optional repository variables:
 - `API_WORKER_DESIRED_COUNT`: defaults to `1`
 - `API_WORKER_TASK_CPU`: defaults to `256`
 - `API_WORKER_TASK_MEMORY`: defaults to `512`
+- `API_CREATE_DATABASE`: set to `true` for the first AWS cutover when replacing
+  Neon with managed RDS PostgreSQL
+- `API_DATABASE_SUBNET_IDS_JSON`: optional JSON array of database subnet IDs;
+  blank uses private API subnets when present, otherwise task subnets
+- `API_DATABASE_INSTANCE_CLASS`: defaults to `db.t4g.micro`
+- `API_DATABASE_ALLOCATED_STORAGE`: defaults to `20`
+- `API_DATABASE_MAX_ALLOCATED_STORAGE`: defaults to `100`; set to `0` to
+  disable storage autoscaling
+- `API_DATABASE_BACKUP_RETENTION_DAYS`: defaults to `7`
 - `API_EXTRA_ENVIRONMENT_JSON`: JSON object for additional non-secret runtime
   variables. Use this to enable native SAML/SCIM, for example
   `{"IDENTRAIL_FEATURE_NATIVE_SSO":"true"}`.
@@ -245,6 +260,10 @@ Do not put database URLs, API keys, cookie secrets, or OAuth credentials directl
 in tfvars files, docs, GitHub variables, or Terraform state. Use Secrets Manager
 references through `api_secrets`. Terraform rejects known secret-bearing
 Identrail variables in `api_environment_variables` when API hosting is enabled.
+When `API_CREATE_DATABASE=true`, Terraform generates the RDS password and
+database URL for you, writes the URL to Secrets Manager, and stores the
+generated value in encrypted Terraform state. Treat the S3 state bucket as
+sensitive infrastructure and keep access tightly restricted.
 
 If a referenced secret uses a customer-managed KMS key, add that key ARN to
 `api_secret_kms_key_arns` so ECS can decrypt the secret during task startup.
@@ -254,13 +273,14 @@ key.
 secret version suffix. Terraform still grants IAM access to the base Secrets
 Manager ARN so ECS can fetch the underlying secret during task startup.
 
-For the first manual AWS plan, prefer Secrets Manager references for
-`IDENTRAIL_DATABASE_URL`, `IDENTRAIL_API_KEY_SCOPES`, and, when tenant/workspace
-isolation is ready, `IDENTRAIL_API_KEY_SCOPE_BINDINGS`. The Terraform guard will
-refuse to plan API hosting without a database reference and at least one auth
-mode so ECS tasks do not boot into a known-bad configuration. It also refuses to
-plan API hosting without at least one HTTPS CORS origin and at least one trusted
-proxy CIDR.
+For the first manual AWS plan, either set `API_CREATE_DATABASE=true` or provide a
+Secrets Manager reference for `IDENTRAIL_DATABASE_URL`. Also provide the session
+secret and, when using API-key auth, `IDENTRAIL_API_KEY_SCOPES`; add
+`IDENTRAIL_API_KEY_SCOPE_BINDINGS` when tenant/workspace isolation is ready. The
+Terraform guard will refuse to plan API hosting without a database reference and
+at least one auth mode so ECS tasks do not boot into a known-bad configuration.
+It also refuses to plan API hosting without at least one HTTPS CORS origin and
+at least one trusted proxy CIDR.
 
 Terraform requires either private task egress or the explicit low-cost public
 task mode before creating API hosting resources. Use
@@ -278,6 +298,14 @@ subnets, `api_task_assign_public_ip=true`, and inbound service traffic limited
 to the load balancer security group. That avoids NAT Gateway and private VPC
 endpoint hourly charges during first launch.
 
+For the no-existing-users AWS cutover from Neon, run `AWS API Manual Deploy`
+with `operation=apply`, `create_api_database=true`, and the low-cost database
+defaults unless you have private database subnets ready. After apply, copy the
+`api_database_secret_arn` output into the repository secret
+`API_DATABASE_URL_SECRET_ARN`, replacing any old Neon ARN, and use that ARN when
+running migrations. The old Neon project can then be removed from runtime
+configuration after the AWS-hosted API is healthy.
+
 Run database migrations with the `AWS API Database Migrations` workflow before
 deploying or upgrading the hosted API service. Keep long-running API tasks
 non-migrating.
@@ -288,7 +316,9 @@ The migration workflow is intentionally manual and guarded:
 - keep the default `migrations` directory unless a release note says otherwise
 - type `run-api-migrations` in the confirmation field
 - leave `database_url_secret_arn` blank to use the repository secret
-  `API_DATABASE_URL_SECRET_ARN`
+  `API_DATABASE_URL_SECRET_ARN`, or paste the `api_database_secret_arn` Terraform
+  output directly for the first migration before the repository secret is
+  updated
 
 The workflow assumes the same `AWS_ROLE_ARN` OIDC deployment role as the manual
 deploy workflow, fetches the database URL from Secrets Manager at runtime, masks
@@ -360,7 +390,7 @@ If the failure happens after DNS cutover:
 
 ## What Still Comes Later
 
-- production database provisioning and backups
+- database rotation, private-subnet hardening, and scale-up work after launch
 - runtime secret creation and rotation workflow
 - migration job wiring
 - final `api.identrail.com` DNS cutover

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -121,10 +121,11 @@ Portable deployment profiles:
 ### AWS API Hosting Notes
 
 For AWS-hosted API rollout, keep `create_api_hosting_resources=false` until the
-VPC, subnets, ACM certificate, immutable API image, database, and Secrets
-Manager references are ready. Plan the stack first, verify the load balancer
-health endpoint, and only then point `api.identrail.com` at the load balancer.
-Keep `app.identrail.com` on Vercel.
+VPC, subnets, ACM certificate, immutable API image, database path, and Secrets
+Manager references are ready. Use `create_api_database=true` for the no-user
+AWS RDS cutover, or provide an existing `API_DATABASE_URL_SECRET_ARN`. Plan the
+stack first, verify the load balancer health endpoint, and only then point
+`api.identrail.com` at the load balancer. Keep `app.identrail.com` on Vercel.
 
 Use the `AWS API Manual Deploy` GitHub Actions workflow for controlled API
 cutover preparation. Run `plan` first. Use `apply` only after reviewing the plan; the
@@ -139,6 +140,11 @@ hourly charges. The service security group still accepts inbound traffic only
 from the ALB security group. Revisit private task subnets plus NAT/VPC endpoints
 after the API is live and traffic or customer requirements justify the added
 cost.
+
+If `create_api_database=true`, the first apply outputs `api_database_secret_arn`.
+Use that ARN for the first migration run, then store it as
+`API_DATABASE_URL_SECRET_ARN` so routine production deploys stop depending on
+the old Neon configuration.
 
 ## 3) Rollback Sequence
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -25,7 +25,11 @@ For the hosted AWS API path, the GitHub Actions workflow fetches
 `IDENTRAIL_DATABASE_URL` from AWS Secrets Manager through the configured
 `API_DATABASE_URL_SECRET_ARN`, masks the value, and runs the dedicated
 `cmd/migrate` one-shot runner. The workflow must be dispatched from `dev` with
-the confirmation phrase `run-api-migrations`.
+the confirmation phrase `run-api-migrations`. For a first cutover where
+Terraform creates managed RDS PostgreSQL, run the manual deploy apply first,
+then use the `api_database_secret_arn` Terraform output as the migration
+workflow input or store it as the repository secret
+`API_DATABASE_URL_SECRET_ARN`.
 
 ## Roll Forward (Preferred)
 

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -201,16 +201,28 @@ if [ "${api_worker_enabled}" = "true" ]; then
   fi
 fi
 
-api_database_secret="$(require_value API_DATABASE_URL_SECRET_ARN)"
+api_create_database="$(trim "${API_CREATE_DATABASE:-false}")"
+if [ -z "${api_create_database}" ]; then
+  api_create_database="false"
+fi
+optional_bool API_CREATE_DATABASE
+api_database_secret="$(trim "${API_DATABASE_URL_SECRET_ARN:-}")"
+if [ "${api_create_database}" != "true" ]; then
+  api_database_secret="$(require_value API_DATABASE_URL_SECRET_ARN)"
+fi
 api_session_secret="$(require_value API_SESSION_KEY_SECRET_ARN)"
-for secret_arn in "${api_database_secret}" "${api_session_secret}"; do
+for secret_arn in "${api_session_secret}"; do
   if ! [[ "${secret_arn}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
     fail "API secret references must be Secrets Manager ARNs in ${aws_region}"
   fi
 done
+if [ "${api_create_database}" != "true" ] && ! [[ "${api_database_secret}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
+  fail "API_DATABASE_URL_SECRET_ARN must be a Secrets Manager ARN in ${aws_region}"
+fi
 
 public_subnets="$(json_string_array API_PUBLIC_SUBNET_IDS_JSON)"
 task_subnets="$(json_string_array API_TASK_SUBNET_IDS_JSON "${public_subnets}")"
+database_subnets="$(json_string_array API_DATABASE_SUBNET_IDS_JSON)"
 allowed_cidrs="$(json_string_array API_ALLOWED_CIDR_BLOCKS_JSON '["0.0.0.0/0"]')"
 cors_origins="$(json_string_array API_CORS_ALLOWED_ORIGINS_JSON '["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]')"
 trusted_proxy_cidrs="$(json_string_array API_TRUSTED_PROXY_CIDR_BLOCKS_JSON '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]')"
@@ -426,6 +438,10 @@ fi
 api_desired_count="$(trim "${API_DESIRED_COUNT:-1}")"
 api_task_cpu="$(trim "${API_TASK_CPU:-512}")"
 api_task_memory="$(trim "${API_TASK_MEMORY:-1024}")"
+api_database_instance_class="$(trim "${API_DATABASE_INSTANCE_CLASS:-db.t4g.micro}")"
+api_database_allocated_storage="$(trim "${API_DATABASE_ALLOCATED_STORAGE:-20}")"
+api_database_max_allocated_storage="$(trim "${API_DATABASE_MAX_ALLOCATED_STORAGE:-100}")"
+api_database_backup_retention_days="$(trim "${API_DATABASE_BACKUP_RETENTION_DAYS:-7}")"
 worker_desired_count="$(trim "${API_WORKER_DESIRED_COUNT:-1}")"
 worker_task_cpu="$(trim "${API_WORKER_TASK_CPU:-256}")"
 worker_task_memory="$(trim "${API_WORKER_TASK_MEMORY:-512}")"
@@ -434,6 +450,23 @@ for numeric in api_desired_count api_task_cpu api_task_memory; do
     fail "${numeric^^} must be a positive integer"
   fi
 done
+if ! [[ "${api_database_instance_class}" =~ ^db\.[a-z0-9]+(\.[a-z0-9]+)+$ ]]; then
+  fail "API_DATABASE_INSTANCE_CLASS must be an RDS class such as db.t4g.micro"
+fi
+for numeric in api_database_allocated_storage api_database_max_allocated_storage api_database_backup_retention_days; do
+  if ! [[ "${!numeric}" =~ ^[0-9]+$ ]]; then
+    fail "${numeric^^} must be a non-negative integer"
+  fi
+done
+if [ "${api_database_allocated_storage}" -lt 20 ]; then
+  fail "API_DATABASE_ALLOCATED_STORAGE must be at least 20"
+fi
+if [ "${api_database_max_allocated_storage}" -ne 0 ] && [ "${api_database_max_allocated_storage}" -lt "${api_database_allocated_storage}" ]; then
+  fail "API_DATABASE_MAX_ALLOCATED_STORAGE must be 0 or greater than or equal to API_DATABASE_ALLOCATED_STORAGE"
+fi
+if [ "${api_database_backup_retention_days}" -gt 35 ]; then
+  fail "API_DATABASE_BACKUP_RETENTION_DAYS must be between 0 and 35"
+fi
 for numeric in worker_desired_count worker_task_cpu worker_task_memory; do
   if ! [[ "${!numeric}" =~ ^[0-9]+$ ]]; then
     fail "${numeric^^} must be a positive integer"
@@ -451,11 +484,14 @@ jq -n \
   --arg api_container_image "${api_container_image}" \
   --arg api_worker_enabled "${api_worker_enabled}" \
   --arg worker_container_image "${worker_container_image}" \
+  --arg api_create_database "${api_create_database}" \
   --arg api_database_secret "${api_database_secret}" \
+  --arg api_database_instance_class "${api_database_instance_class}" \
   --arg api_session_secret "${api_session_secret}" \
   --arg onboarding_feature_enabled "${onboarding_feature_enabled}" \
   --argjson api_public_subnet_ids "${public_subnets}" \
   --argjson api_task_subnet_ids "${task_subnets}" \
+  --argjson api_database_subnet_ids "${database_subnets}" \
   --argjson api_allowed_cidr_blocks "${allowed_cidrs}" \
   --argjson api_cors_allowed_origins "${cors_origins}" \
   --argjson api_trusted_proxy_cidr_blocks "${trusted_proxy_cidrs}" \
@@ -471,6 +507,9 @@ jq -n \
   --argjson api_desired_count "${api_desired_count}" \
   --argjson api_task_cpu "${api_task_cpu}" \
   --argjson api_task_memory "${api_task_memory}" \
+  --argjson api_database_allocated_storage "${api_database_allocated_storage}" \
+  --argjson api_database_max_allocated_storage "${api_database_max_allocated_storage}" \
+  --argjson api_database_backup_retention_days "${api_database_backup_retention_days}" \
   --argjson worker_desired_count "${worker_desired_count}" \
   --argjson worker_task_cpu "${worker_task_cpu}" \
   --argjson worker_task_memory "${worker_task_memory}" \
@@ -481,10 +520,16 @@ jq -n \
     create_foundation_resources: true,
     create_api_hosting_resources: true,
     create_worker_hosting_resources: ($api_worker_enabled == "true"),
+    create_api_database: ($api_create_database == "true"),
     create_runtime_secret: true,
     api_vpc_id: $api_vpc_id,
     api_public_subnet_ids: $api_public_subnet_ids,
     api_task_subnet_ids: $api_task_subnet_ids,
+    api_database_subnet_ids: $api_database_subnet_ids,
+    api_database_instance_class: $api_database_instance_class,
+    api_database_allocated_storage: $api_database_allocated_storage,
+    api_database_max_allocated_storage: $api_database_max_allocated_storage,
+    api_database_backup_retention_days: $api_database_backup_retention_days,
     api_task_assign_public_ip: true,
     api_private_subnet_egress_ready: false,
     api_allowed_cidr_blocks: $api_allowed_cidr_blocks,
@@ -505,9 +550,10 @@ jq -n \
       IDENTRAIL_PUBLIC_BASE_URL: "https://api.identrail.com"
     }),
     api_secrets: ($extra_secrets + $workos_secrets + $github_secrets + {
-      IDENTRAIL_DATABASE_URL: $api_database_secret,
       IDENTRAIL_SESSION_KEY: $api_session_secret
-    }),
+    } + (if $api_create_database == "true" then {} else {
+      IDENTRAIL_DATABASE_URL: $api_database_secret
+    } end)),
     api_secret_kms_key_arns: $api_secret_kms_key_arns,
     api_connector_role_arns: $api_connector_role_arns,
     tags: {


### PR DESCRIPTION
## Summary

- Add an optional Terraform-managed AWS RDS PostgreSQL database for the hosted API and worker.
- Wire the generated database URL secret into existing ECS secret injection, including API and worker database access rules.
- Update the manual deploy workflow and preparation script so `API_CREATE_DATABASE=true` no longer requires the old external database URL secret.
- Document the first cutover sequence from Neon to AWS RDS, including migration use of the generated secret ARN and Terraform state sensitivity.

## Validation

- `terraform -chdir=deploy/aws/terraform init -backend=false`
- `terraform -chdir=deploy/aws/terraform validate`
- `terraform -chdir=deploy/aws/terraform fmt -check -recursive`
- `terraform -chdir=deploy/aws/terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example`
- `bash -n scripts/prepare_aws_api_deploy.sh`
- `actionlint .github/workflows/aws-api-manual-deploy.yml`
- deploy-prep script fixture for external database secret mode
- deploy-prep script fixture for managed RDS mode

## AI disclosure

No

## Related issues

No issue: emergency infrastructure cutover for Neon quota outage
