### PR TITLE
Polish appearance settings

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Geist:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Geist:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
     />
     <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64.png?v=20260527c" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=20260527c" />

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -4,7 +4,6 @@ export const APPEARANCE_STORAGE_KEY = 'identrail-appearance';
 export type AppearanceThemeMode = 'light' | 'dark' | 'system';
 export type AppearanceReduceMotion = 'system' | 'on' | 'off';
 export type AppearanceDiffMarkers = 'color' | 'symbols';
-export type AppearanceAppIcon = 'default' | 'light' | 'dark';
 
 export type AppearancePresetID =
   | 'absolutely'
@@ -14,17 +13,33 @@ export type AppearancePresetID =
   | 'gruvbox'
   | 'identrail'
   | 'linear'
+  | 'neon'
   | 'notion'
   | 'one'
   | 'proof'
   | 'raycast'
   | 'rose-pine'
+  | 'shopify'
+  | 'shopify-light'
+  | 'slack'
+  | 'slack-light'
   | 'solarized'
+  | 'stripe'
+  | 'stripe-light'
+  | 'supabase'
   | 'vercel'
   | 'vs-code-plus'
   | 'xcode';
 
-export type AppearanceFontID = 'system' | 'inter' | 'geist' | 'mono-system' | 'ibm-plex-mono';
+export type AppearanceFontID =
+  | 'system'
+  | 'inter'
+  | 'geist'
+  | 'space-grotesk'
+  | 'barlow-condensed'
+  | 'mono-system'
+  | 'ibm-plex-mono'
+  | 'jetbrains-mono';
 
 export type AppearancePreferences = {
   themeMode: AppearanceThemeMode;
@@ -44,7 +59,6 @@ export type AppearancePreferences = {
   codeFontSize: number;
   diffMarkers: AppearanceDiffMarkers;
   fontSmoothing: boolean;
-  appIcon: AppearanceAppIcon;
 };
 
 export type AppearancePreset = {
@@ -103,6 +117,72 @@ export const APPEARANCE_PRESETS: AppearancePreset[] = [
     panel: '#1e1819',
     border: '#3b282b',
     muted: '#d7b8bc'
+  },
+  {
+    id: 'stripe-light',
+    label: 'Stripe',
+    mode: 'light',
+    accent: '#635bff',
+    background: '#f6f9fc',
+    foreground: '#0a2540',
+    panel: '#ffffff',
+    border: '#d6dee8',
+    muted: '#425466'
+  },
+  {
+    id: 'stripe',
+    label: 'Stripe',
+    mode: 'dark',
+    accent: '#99a3ff',
+    background: '#0a1020',
+    foreground: '#f6f9fc',
+    panel: '#11182b',
+    border: '#27324a',
+    muted: '#a5b4c6'
+  },
+  {
+    id: 'slack-light',
+    label: 'Slack',
+    mode: 'light',
+    accent: '#611f69',
+    background: '#f8f5f7',
+    foreground: '#1d1c1d',
+    panel: '#ffffff',
+    border: '#e8dfe7',
+    muted: '#616061'
+  },
+  {
+    id: 'slack',
+    label: 'Slack',
+    mode: 'dark',
+    accent: '#36c5f0',
+    background: '#101014',
+    foreground: '#f8f8f8',
+    panel: '#1a1d21',
+    border: '#34373b',
+    muted: '#ababad'
+  },
+  {
+    id: 'shopify-light',
+    label: 'Shopify',
+    mode: 'light',
+    accent: '#008060',
+    background: '#f6f6f7',
+    foreground: '#202223',
+    panel: '#ffffff',
+    border: '#d5d8dc',
+    muted: '#6d7175'
+  },
+  {
+    id: 'shopify',
+    label: 'Shopify',
+    mode: 'dark',
+    accent: '#95bf47',
+    background: '#0b1411',
+    foreground: '#f3f8f4',
+    panel: '#101d18',
+    border: '#284033',
+    muted: '#b6c5bb'
   },
   {
     id: 'rose-pine',
@@ -204,6 +284,28 @@ export const APPEARANCE_PRESETS: AppearancePreset[] = [
     muted: '#8b949e'
   },
   {
+    id: 'supabase',
+    label: 'Supabase',
+    mode: 'dark',
+    accent: '#3ecf8e',
+    background: '#0b0f0c',
+    foreground: '#ecfdf5',
+    panel: '#101815',
+    border: '#1f3a2f',
+    muted: '#9fb7aa'
+  },
+  {
+    id: 'neon',
+    label: 'Neon',
+    mode: 'dark',
+    accent: '#00e599',
+    background: '#030712',
+    foreground: '#f8fafc',
+    panel: '#08111f',
+    border: '#1f2a44',
+    muted: '#94a3b8'
+  },
+  {
     id: 'gruvbox',
     label: 'Gruvbox',
     mode: 'dark',
@@ -242,37 +344,42 @@ export const APPEARANCE_FONTS: Record<AppearanceFontID, string> = {
   system: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif',
   inter: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
   geist: 'Geist, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  'space-grotesk': '"Space Grotesk", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  'barlow-condensed': '"Barlow Semi Condensed", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
   'mono-system': 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-  'ibm-plex-mono': '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+  'ibm-plex-mono': '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  'jetbrains-mono': '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
 };
 
 export const APPEARANCE_FONT_LABELS: Record<AppearanceFontID, string> = {
   system: 'System',
   inter: 'Inter',
   geist: 'Geist',
+  'space-grotesk': 'Space Grotesk',
+  'barlow-condensed': 'Barlow Condensed',
   'mono-system': 'System Mono',
-  'ibm-plex-mono': 'IBM Plex Mono'
+  'ibm-plex-mono': 'IBM Plex Mono',
+  'jetbrains-mono': 'JetBrains Mono'
 };
 
 export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
-  themeMode: 'system',
+  themeMode: 'dark',
   lightPreset: 'notion',
-  darkPreset: 'identrail',
-  accent: '#7c6dff',
-  background: '#121518',
-  foreground: '#f5f7f8',
+  darkPreset: 'vercel',
+  accent: '#ffffff',
+  background: '#000000',
+  foreground: '#ededed',
   customColors: false,
-  uiFont: 'system',
+  uiFont: 'inter',
   codeFont: 'mono-system',
   translucentSidebar: false,
-  contrast: 45,
+  contrast: 52,
   pointerCursors: false,
   reduceMotion: 'system',
   uiFontSize: 16,
   codeFontSize: 14,
   diffMarkers: 'color',
-  fontSmoothing: true,
-  appIcon: 'default'
+  fontSmoothing: true
 };
 
 const FONT_IDS: ReadonlySet<string> = new Set(Object.keys(APPEARANCE_FONTS));
@@ -342,8 +449,7 @@ export function normalizeAppearancePreferences(value: unknown): AppearancePrefer
     uiFontSize: sanitizeNumber(source.uiFontSize, DEFAULT_APPEARANCE_PREFERENCES.uiFontSize, 14, 22),
     codeFontSize: sanitizeNumber(source.codeFontSize, DEFAULT_APPEARANCE_PREFERENCES.codeFontSize, 12, 22),
     diffMarkers: sanitizeEnum(source.diffMarkers, ['color', 'symbols'], DEFAULT_APPEARANCE_PREFERENCES.diffMarkers),
-    fontSmoothing: sanitizeBoolean(source.fontSmoothing, DEFAULT_APPEARANCE_PREFERENCES.fontSmoothing),
-    appIcon: sanitizeEnum(source.appIcon, ['default', 'light', 'dark'], DEFAULT_APPEARANCE_PREFERENCES.appIcon)
+    fontSmoothing: sanitizeBoolean(source.fontSmoothing, DEFAULT_APPEARANCE_PREFERENCES.fontSmoothing)
   };
 }
 
@@ -434,7 +540,7 @@ export function applyAppearancePreferences(preferences: AppearancePreferences): 
   root.dataset.diffMarkers = normalized.diffMarkers;
   root.dataset.fontSmoothing = normalized.fontSmoothing ? 'true' : 'false';
   root.dataset.appearanceTranslucentSidebar = normalized.translucentSidebar ? 'true' : 'false';
-  root.dataset.appearanceAppIcon = normalized.appIcon;
+  delete root.dataset.appearanceAppIcon;
 
   style.setProperty('--appearance-accent', colors.accent);
   style.setProperty('--appearance-bg', colors.background);

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1849,33 +1849,38 @@ describe('ProductAppearanceSettingsPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Appearance' })).toBeInTheDocument();
     expect(getWhoAmI).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
     expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.dataset.appearancePreset).toBe('vercel');
+    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#000000');
+    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#ededed');
+    expect(document.documentElement.style.getPropertyValue('--appearance-ui-font')).toContain('Inter');
+    expect(document.documentElement.style.getPropertyValue('--appearance-contrast')).toBe('52');
+    expect(screen.queryByRole('heading', { name: 'App icon' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Light' }));
+    expect(document.documentElement.dataset.theme).toBe('light');
     expect(JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}')).toMatchObject({
-      themeMode: 'dark'
+      themeMode: 'light'
     });
   });
 
-  it('persists Codex-style controls through the allowlisted appearance model', async () => {
+  it('persists appearance controls through the allowlisted appearance model', async () => {
     await renderProductAppearanceSettingsPage();
 
     fireEvent.change(screen.getByLabelText('Light theme'), { target: { value: 'xcode' } });
     fireEvent.change(screen.getByLabelText('Accent color'), { target: { value: '#123456' } });
     fireEvent.click(screen.getByRole('switch', { name: 'Use pointer cursors' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Identrail D...' }));
 
     const stored = JSON.parse(window.localStorage.getItem('identrail-appearance') ?? '{}');
     expect(stored).toMatchObject({
       lightPreset: 'xcode',
       accent: '#123456',
       customColors: true,
-      pointerCursors: true,
-      appIcon: 'dark'
+      pointerCursors: true
     });
     expect(document.documentElement.style.getPropertyValue('--appearance-accent')).toBe('#123456');
     expect(document.documentElement.dataset.pointerCursors).toBe('true');
-    expect(document.documentElement.dataset.appearanceAppIcon).toBe('dark');
+    expect(document.documentElement.dataset.appearanceAppIcon).toBeUndefined();
   });
 
   it('keeps dark palettes out of the light appearance preset choices', async () => {
@@ -1886,9 +1891,17 @@ describe('ProductAppearanceSettingsPage', () => {
 
     expect(within(lightTheme).queryByRole('option', { name: 'Vercel' })).not.toBeInTheDocument();
     expect(within(lightTheme).queryByRole('option', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(within(lightTheme).getByRole('option', { name: 'Stripe' })).toBeInTheDocument();
+    expect(within(lightTheme).getByRole('option', { name: 'Slack' })).toBeInTheDocument();
+    expect(within(lightTheme).getByRole('option', { name: 'Shopify' })).toBeInTheDocument();
     expect(within(lightTheme).getByRole('option', { name: 'Xcode' })).toBeInTheDocument();
     expect(within(darkTheme).getByRole('option', { name: 'Vercel' })).toBeInTheDocument();
     expect(within(darkTheme).getByRole('option', { name: 'GitHub' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Stripe' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Slack' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Shopify' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Supabase' })).toBeInTheDocument();
+    expect(within(darkTheme).getByRole('option', { name: 'Neon' })).toBeInTheDocument();
   });
 
   it('sanitizes stored appearance values before they reach CSS variables', async () => {
@@ -1911,16 +1924,15 @@ describe('ProductAppearanceSettingsPage', () => {
 
     expect(normalized).toMatchObject({
       lightPreset: 'notion',
-      darkPreset: 'identrail',
-      accent: '#7c6dff',
-      background: '#121518',
+      darkPreset: 'vercel',
+      accent: '#ffffff',
+      background: '#000000',
       foreground: '#abcdef',
       customColors: false,
-      uiFont: 'system',
+      uiFont: 'inter',
       codeFont: 'mono-system',
       contrast: 100,
-      reduceMotion: 'system',
-      appIcon: 'default'
+      reduceMotion: 'system'
     });
   });
 
@@ -1948,12 +1960,12 @@ describe('ProductAppearanceSettingsPage', () => {
       themeMode: 'dark',
       lightPreset: 'xcode',
       accent: '#123456',
-      background: '#121518',
-      foreground: '#f5f7f8',
+      background: '#000000',
+      foreground: '#ededed',
       customColors: true
     });
-    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#121518');
-    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#f5f7f8');
+    expect(document.documentElement.style.getPropertyValue('--appearance-bg')).toBe('#000000');
+    expect(document.documentElement.style.getPropertyValue('--appearance-fg')).toBe('#ededed');
   });
 
   it('seeds the visible preset colors before enabling custom colors', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,8 +8,8 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   BarChart3,
-  Check,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   ChevronUp,
   ExternalLink,
@@ -22770,8 +22770,14 @@ const APPEARANCE_DIFF_OPTIONS: Array<{ id: AppearanceDiffMarkers; label: string 
   { id: 'symbols', label: '+/-' }
 ];
 
-const APPEARANCE_UI_FONT_OPTIONS: AppearanceFontID[] = ['system', 'inter', 'geist'];
-const APPEARANCE_CODE_FONT_OPTIONS: AppearanceFontID[] = ['mono-system', 'ibm-plex-mono'];
+const APPEARANCE_UI_FONT_OPTIONS: AppearanceFontID[] = [
+  'inter',
+  'geist',
+  'system',
+  'space-grotesk',
+  'barlow-condensed'
+];
+const APPEARANCE_CODE_FONT_OPTIONS: AppearanceFontID[] = ['mono-system', 'ibm-plex-mono', 'jetbrains-mono'];
 
 function appearancePresetOptions(mode: 'light' | 'dark') {
   return APPEARANCE_PRESETS.filter((preset) =>
@@ -22826,7 +22832,10 @@ function AppearanceSwitch({ checked, label, onChange }: AppearanceSwitchProps) {
       aria-label={label}
       onClick={() => onChange(!checked)}
     >
-      <span aria-hidden="true" />
+      <span className="idt-appearance-switch-thumb" aria-hidden="true" />
+      <span className="idt-appearance-switch-label" aria-hidden="true">
+        {checked ? 'On' : 'Off'}
+      </span>
     </button>
   );
 }
@@ -22955,19 +22964,17 @@ export function ProductAppearanceSettingsPage() {
   return (
     <section className="idt-app-panel idt-settings-page idt-appearance-page">
       <header className="idt-settings-header idt-appearance-header">
-        <div>
-          <Link className="idt-appearance-back" to={settingsPath}>
-            Back to settings
-          </Link>
-          <h2>Appearance</h2>
-        </div>
+        <Link className="idt-appearance-back" to={settingsPath} aria-label="Back to settings">
+          <ChevronLeft size={20} aria-hidden="true" />
+        </Link>
+        <h2>Appearance</h2>
       </header>
 
       <section className="idt-settings-card idt-appearance-card" aria-labelledby="idt-appearance-theme-heading">
         <div className="idt-appearance-card-header">
           <div>
             <h3 id="idt-appearance-theme-heading">Theme</h3>
-            <p>Use light, dark, or match your system</p>
+            <p>Choose a theme or follow your system</p>
           </div>
           <AppearanceSegmentedControl
             label="Theme"
@@ -23012,6 +23019,7 @@ export function ProductAppearanceSettingsPage() {
           <label className="idt-appearance-control-row">
             <span>
               <strong>Light theme</strong>
+              <small>{resolvedTheme === 'light' ? 'Active now' : 'Used when Light is selected'}</small>
             </span>
             <select
               aria-label="Light theme"
@@ -23029,6 +23037,7 @@ export function ProductAppearanceSettingsPage() {
           <label className="idt-appearance-control-row">
             <span>
               <strong>Dark theme</strong>
+              <small>{resolvedTheme === 'dark' ? 'Active now' : 'Used when Dark is selected'}</small>
             </span>
             <select
               aria-label="Dark theme"
@@ -23103,6 +23112,7 @@ export function ProductAppearanceSettingsPage() {
           <div className="idt-appearance-control-row">
             <span>
               <strong>Translucent sidebar</strong>
+              <small>{preferences.translucentSidebar ? 'Sidebar blur is on' : 'Sidebar stays solid'}</small>
             </span>
             <AppearanceSwitch
               checked={preferences.translucentSidebar}
@@ -23134,7 +23144,7 @@ export function ProductAppearanceSettingsPage() {
         <div className="idt-appearance-behavior-row">
           <div>
             <h3>Use pointer cursors</h3>
-            <p>Change the cursor to a pointer when hovering over interactive elements</p>
+            <p>Show pointer cursors on interactive controls</p>
           </div>
           <AppearanceSwitch
             checked={preferences.pointerCursors}
@@ -23193,7 +23203,7 @@ export function ProductAppearanceSettingsPage() {
         <div className="idt-appearance-behavior-row">
           <div>
             <h3>Diff markers</h3>
-            <p>Use colored bars and backgrounds or show plus and minus symbols on each changed line</p>
+            <p>Show changed lines with color or +/- symbols</p>
           </div>
           <AppearanceSegmentedControl
             label="Diff markers"
@@ -23206,41 +23216,13 @@ export function ProductAppearanceSettingsPage() {
         <div className="idt-appearance-behavior-row">
           <div>
             <h3>Font smoothing</h3>
-            <p>Use native macOS font anti-aliasing</p>
+            <p>Use native font smoothing where supported</p>
           </div>
           <AppearanceSwitch
             checked={preferences.fontSmoothing}
             label="Font smoothing"
             onChange={(fontSmoothing) => commitPreferences({ fontSmoothing })}
           />
-        </div>
-      </section>
-
-      <section className="idt-appearance-dock-card" aria-labelledby="idt-appearance-icon-heading">
-        <div>
-          <h3 id="idt-appearance-icon-heading">App icon</h3>
-          <p>Choose the icon style Identrail uses inside the app shell</p>
-        </div>
-        <div className="idt-appearance-icon-options">
-          {[
-            ['default', 'Default'],
-            ['light', 'Identrail L...'],
-            ['dark', 'Identrail D...']
-          ].map(([id, label]) => (
-            <button
-              key={id}
-              type="button"
-              className="idt-appearance-icon-option"
-              aria-pressed={preferences.appIcon === id}
-              onClick={() => commitPreferences({ appIcon: id as AppearancePreferences['appIcon'] })}
-            >
-              <span className="idt-appearance-icon-swatch" data-icon-tone={id} aria-hidden="true">
-                <Palette size={22} />
-              </span>
-              <span>{label}</span>
-              {preferences.appIcon === id ? <Check size={16} aria-hidden="true" /> : <span aria-hidden="true" />}
-            </button>
-          ))}
         </div>
       </section>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -31013,25 +31013,6 @@ html[data-appearance-translucent-sidebar='true'] .idt-app-sidebar {
   backdrop-filter: blur(18px);
 }
 
-html[data-appearance-app-icon='light'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark {
-  background: #ffffff;
-  box-shadow: inset 0 0 0 1px rgba(5, 6, 7, 0.14), 0 0 0 1px rgba(255, 255, 255, 0.16);
-}
-
-html[data-appearance-app-icon='light'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark img {
-  filter: none;
-}
-
-html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark {
-  background: #050607;
-  box-shadow: inset 0 0 0 1px var(--appearance-accent, #7c6dff), 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
-
-html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark img {
-  filter: brightness(0.9) saturate(1.15);
-  mix-blend-mode: screen;
-}
-
 .idt-settings-appearance-entry {
   gap: 0.9rem;
 }
@@ -31051,14 +31032,26 @@ html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-w
   margin-left: auto;
 }
 
+.idt-appearance-header {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
 .idt-appearance-header h2 {
-  margin-top: 0.45rem;
+  margin: 0;
 }
 
 .idt-appearance-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  background: var(--app-panel);
   color: var(--app-muted);
-  font-size: 0.92rem;
-  font-weight: 750;
   text-decoration: none;
 }
 
@@ -31088,8 +31081,15 @@ html[data-appearance-app-icon='dark'] .idt-app-console-layout .idt-app-sidebar-w
 
 .idt-appearance-card-header p,
 .idt-appearance-behavior-row p,
-.idt-appearance-dock-card p {
+.idt-appearance-control-row small {
   color: var(--app-muted);
+}
+
+.idt-appearance-control-row small {
+  display: block;
+  margin-top: 0.18rem;
+  font-size: 0.84rem;
+  line-height: 1.35;
 }
 
 .idt-appearance-segmented {
@@ -31230,6 +31230,20 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   min-width: 12rem;
 }
 
+html[data-appearance-ready='true'] .idt-app-console-layout :is(
+  .idt-appearance-control-row select,
+  .idt-appearance-number input
+) {
+  border-color: var(--app-border-soft);
+  background: var(--app-panel);
+  color: var(--app-text);
+}
+
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-appearance-control-row select option {
+  background: var(--app-panel);
+  color: var(--app-text);
+}
+
 .idt-appearance-color-input,
 .idt-appearance-slider,
 .idt-appearance-number {
@@ -31260,96 +31274,62 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
 
 .idt-appearance-switch {
   position: relative;
-  width: 2.9rem;
-  height: 1.65rem;
+  width: 4.45rem;
+  height: 1.8rem;
   border: 0;
   border-radius: 999px;
   background: color-mix(in srgb, var(--app-muted) 32%, var(--app-panel));
+  color: var(--app-text);
+  font: inherit;
 }
 
-.idt-appearance-switch span {
+.idt-appearance-switch-thumb {
   position: absolute;
-  top: 0.2rem;
+  z-index: 1;
+  top: 0.25rem;
   left: 0.22rem;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.3rem;
+  height: 1.3rem;
   border-radius: 999px;
   background: var(--app-text);
-  transition: transform 160ms ease;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.idt-appearance-switch-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 0.62rem;
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  pointer-events: none;
 }
 
 .idt-appearance-switch[aria-checked='true'] {
   background: var(--appearance-accent, #7c6dff);
 }
 
-.idt-appearance-switch[aria-checked='true'] span {
-  transform: translateX(1.2rem);
+.idt-appearance-switch[aria-checked='true'] .idt-appearance-switch-thumb {
+  transform: translateX(2.65rem);
+  background: var(--app-panel);
+}
+
+.idt-appearance-switch[aria-checked='true'] .idt-appearance-switch-label {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 0.62rem;
+  color: var(--app-panel);
 }
 
 .idt-appearance-number input {
   width: 5.3rem;
   text-align: center;
-}
-
-.idt-appearance-dock-card {
-  display: grid;
-  gap: 1rem;
-  border: 1px solid var(--app-border);
-  border-radius: 8px;
-  padding: 1.2rem;
-  background: var(--app-panel);
-}
-
-.idt-appearance-dock-card h3,
-.idt-appearance-dock-card p {
-  margin: 0;
-}
-
-.idt-appearance-icon-options {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.idt-appearance-icon-option {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) 1rem;
-  align-items: center;
-  gap: 0.7rem;
-  min-height: 4.6rem;
-  border: 1px solid var(--app-border-soft);
-  border-radius: 8px;
-  padding: 0.8rem;
-  background: var(--app-panel);
-  color: var(--app-text);
-  font: inherit;
-  text-align: left;
-}
-
-.idt-appearance-icon-option[aria-pressed='true'] {
-  border-color: var(--appearance-accent, #7c6dff);
-  box-shadow: inset 0 0 0 1px var(--appearance-accent, #7c6dff);
-}
-
-.idt-appearance-icon-swatch {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.7rem;
-  height: 2.7rem;
-  border-radius: 8px;
-  background: #111418;
-  color: #ffffff;
-}
-
-.idt-appearance-icon-swatch[data-icon-tone='light'] {
-  background: #ffffff;
-  color: #111418;
-}
-
-.idt-appearance-icon-swatch[data-icon-tone='dark'] {
-  background: #050607;
-  color: var(--appearance-accent, #7c6dff);
 }
 
 @media (max-width: 760px) {
@@ -31376,8 +31356,7 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
     flex: 1 1 0;
   }
 
-  .idt-appearance-preview,
-  .idt-appearance-icon-options {
+  .idt-appearance-preview {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- default Appearance settings to Vercel dark with Inter, System Mono, and contrast 52
- remove the app icon settings section and simplify the Appearance header
- add popular app-inspired theme presets and make switches/state labels more visibly responsive
- load the additional font families exposed by Appearance controls

## Validation
- npm test -- productShell.test.tsx --run
- npm run build
- git diff --check
- pre-push hooks: merge conflict check, YAML check, EOF/whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene
- security scan over touched files for dynamic HTML/script/CSS injection patterns

## AI disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Appearance settings: default to Vercel dark (Inter + System Mono, contrast 52), added popular theme presets and fonts, simplified the page, and removed the app icon setting.

- **New Features**
  - Default mode is Dark with the Vercel preset; accent #ffffff, bg #000000.
  - New presets: Stripe (light/dark), Slack (light/dark), Shopify (light/dark), Supabase, Neon; selectors filter by mode and show “Active now” hints.
  - New fonts: UI — Space Grotesk, Barlow Condensed; Code — JetBrains Mono; fonts loaded via Google Fonts.
  - Switches show On/Off labels; icon-only back button; clearer copy; selects/inputs adopt theme colors when ready.

- **Refactors**
  - Removed the App icon section and styling; dropped `appIcon` from preferences and the `appearanceAppIcon` dataset (stored values are ignored).
  - Updated normalization, application of preferences, tests, and CSS to reflect new defaults and behaviors.

<sup>Written for commit bf5cad1b93d5d734a07058a1173cb9b74cb83222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

