### PR TITLE
AWS Platform Wave 5.06: Secrets Manager read and KMS decrypt runtime mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS Secrets Manager read / KMS decrypt runtime access
+  correlation** (#1518). Adds a metadata-only correlation engine
+  (`internal/runtime/secretsaccess`) that joins observed `secret-read`
+  and `kms-decrypt` runtime events with the static reachability edges
+  Identrail already discovered (KMS key-policy / grant decrypt edges
+  and Secrets Manager resource-policy grants). Each `(identity,
+  resource)` pair is classified as `confirmed` (observed + statically
+  allowed), `observed_without_grant` (observed with no modeled grant —
+  usually IAM identity-policy access, not drift), or `granted_unused`
+  (allowed but never observed), each with a correlation confidence and
+  explicit caveat codes. Because Secrets Manager `GetSecretValue` and
+  KMS `Decrypt` are CloudTrail data events, `granted_unused` carries a
+  mandatory missing-event caveat so absence is never read as proof. The
+  new endpoint
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/secrets-kms-runtime-access`
+  exposes a queryable correlation timeline filterable by identity,
+  agent, resource, resource kind, account, region, and correlation
+  status, with `ready`/`degraded`/`blocked` states, coverage gaps,
+  diagnostics, and graph relationships that join back to the identity
+  and resource nodes. The capability adds no new AWS permissions and
+  never reads secret values, decrypted plaintext, or
+  encryption-context values. Surfaced in the AWS runtime app surface.
+  Closes #1518. See
+  [docs/aws-secrets-kms-runtime-access.md](docs/aws-secrets-kms-runtime-access.md).
 - Add **AWS CloudTrail S3 + EventBridge delivery ingestion** (#1515).
   Adds two bounded, metadata-only CloudTrail delivery-channel
   ingesters (`internal/runtime/cloudtraildelivery`) that read directly

--- a/docs/aws-secrets-kms-runtime-access.md
+++ b/docs/aws-secrets-kms-runtime-access.md
@@ -1,0 +1,125 @@
+# AWS Secrets Manager / KMS runtime access correlation
+
+Issue #1518 adds a correlation layer that ties **observed** Secrets Manager
+read and KMS decrypt runtime events back to the **static reachability**
+edges Identrail already discovered. Without it, runtime evidence and static
+reachability live in separate surfaces and an operator cannot tell whether a
+machine identity actually exercised a grant, used access that no modeled
+grant explains, or holds a grant it never uses.
+
+The correlation is **metadata-only**. It never reads, logs, or persists
+secret values, decrypted plaintext, encryption-context values, or any other
+customer payload. It operates entirely on the already-redacted runtime-event
+(#1513–#1517) and reachability (#1489 KMS, #1490 Secrets Manager) contracts.
+
+## What it correlates
+
+For each `(identity, resource)` pair the engine
+(`internal/runtime/secretsaccess`) joins:
+
+- **Observed access** — `secret-read` and `kms-decrypt` records from the
+  runtime event contract, keyed by actor identity node and target resource
+  ARN.
+- **Static grants** — KMS key-policy / KMS grant `can_decrypt` edges and
+  Secrets Manager resource-policy `GetSecretValue` grants for real IAM
+  principals (wildcard and non-IAM principals are dropped because they have
+  no identity node to join against).
+
+## Correlation statuses
+
+| Status | Meaning | Confidence |
+|---|---|---|
+| `confirmed` | Observed access **and** a static allow grant exist. Behavior matches policy. | 0.95 (capped to 0.85 when session lineage is unresolved; −0.05 when the grant is conditional). |
+| `observed_without_grant` | Access was observed but no static allow edge explains it. Most Secrets Manager access is authorized by IAM **identity** policies, which this wave's static collectors do not enumerate, so this means "needs IAM-policy confirmation", not automatically drift. | 0.6 |
+| `granted_unused` | A static allow grant exists but no access was observed in the window. Surfaces over-provisioned grants. | 0.7, reduced to 0.5 when data-event coverage is unknown. |
+
+### Caveats
+
+Each correlation and the result envelope carry stable caveat codes so the
+UI and downstream consumers can branch without string-matching prose:
+
+- `runtime_data_events_may_be_incomplete` — Secrets Manager `GetSecretValue`
+  and KMS `Decrypt` are CloudTrail **data** events. Unless a data-event
+  trail or CloudTrail Lake is configured, observed coverage is incomplete
+  and `granted_unused` may reflect missing telemetry rather than a truly
+  unused grant. **Absence of evidence is not evidence of absence.**
+- `no_static_reachability_edge` — observed access with no modeled grant.
+- `observed_despite_explicit_deny` — observed access against a resource that
+  carries an explicit `Deny` for the identity; review the condition scoping.
+- `static_grant_is_conditional` / `static_grant_is_cross_account` — the
+  corroborating grant is condition-scoped or cross-account.
+- `session_lineage_unresolved` — the observed event's STS lineage was
+  `source_identity_missing` or `ambiguous`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-kms-runtime-access`
+
+Query parameters:
+
+- `connector_id` — scope the account, region, and read-only runtime
+  evidence to one AWS connector.
+- `fixture_state` — `success` (default), `empty`, `degraded`,
+  `partial_failure`, `permission_denied` for deterministic UI validation.
+- `account_id`, `region` — scope filters.
+- `identity` — actor principal / identity-node search.
+- `agent_id` — agent ID / agent-node search.
+- `resource` — secret/key ARN, name, or resource-node search.
+- `resource_kind` — `secret` or `kms_key`.
+- `status` — `confirmed`, `observed_without_grant`, or `granted_unused`.
+
+The response (`AWSSecretsKMSRuntimeAccessResult`) carries one record per
+correlation with the status, confidence, observed-event IDs, static
+sources, caveats, evidence references, and a graph relationship
+(`confirmed_runtime_access`, `observed_runtime_access_without_grant`, or
+`unused_static_grant`) that joins the correlation back to the identity and
+resource nodes. It also returns a summary, coverage gaps, diagnostics, and
+the `ready` / `degraded` / `blocked` status with explicit failure reasons.
+
+## Live vs fixture
+
+Live composition is attempted only when the connector is active and healthy,
+the operator did not pin a `fixture_state`, and the connector's effective
+capability set includes `runtime_evidence` — the same gate the
+runtime-events endpoint applies before reading CloudTrail. In that case the
+handler composes the runtime-events, KMS decrypt reachability, and Secrets
+Manager metadata services and joins their results. Otherwise it returns the
+deterministic correlation fixtures, which exercise all three statuses
+(including a cross-account `granted_unused`).
+
+## AWS permissions
+
+This capability adds **no** new AWS permissions. It reuses the read-only,
+metadata-only permissions the runtime-events (`cloudtrail:LookupEvents` and
+optional delivery-channel reads), KMS reachability, and Secrets Manager
+metadata collectors already require. No `secretsmanager:GetSecretValue`,
+`kms:Decrypt`, or any other payload/secret-value/plaintext permission is
+requested or used.
+
+## Intentionally not collected / not modeled
+
+- **IAM identity-policy reachability.** Static reachability is sourced from
+  KMS key policies / grants and Secrets Manager resource policies only.
+  Access authorized by IAM identity policies is not enumerated, so an
+  observed read can correctly show as `observed_without_grant`.
+- **Data-event completeness.** Without a data-event trail, `granted_unused`
+  conclusions are advisory; enable CloudTrail data events for Secrets
+  Manager and KMS to make them reliable.
+- **Secret values, decrypted plaintext, encryption-context values,** and any
+  other customer payload are never read.
+
+## Live validation and troubleshooting
+
+1. Confirm the connector is active and healthy and has the
+   `runtime_evidence` capability.
+2. Query the endpoint with no `fixture_state`. A `blocked` status with a
+   `permission_denied` diagnostic means CloudTrail access is missing —
+   grant metadata-only `cloudtrail:LookupEvents`; do **not** grant
+   secret-value or decrypt reads.
+3. A `degraded` status with a `data_event_completeness` coverage gap and
+   `granted_unused` correlations usually means CloudTrail data events are
+   not enabled for Secrets Manager / KMS. Enable them before treating
+   `granted_unused` as a least-privilege finding.
+4. `observed_without_grant` correlations are expected when access is
+   authorized by IAM identity policies — confirm the identity policy before
+   treating them as drift.

--- a/docs/aws-secrets-kms-runtime-access.md
+++ b/docs/aws-secrets-kms-runtime-access.md
@@ -61,6 +61,12 @@ Query parameters:
   evidence to one AWS connector.
 - `fixture_state` — `success` (default), `empty`, `degraded`,
   `partial_failure`, `permission_denied` for deterministic UI validation.
+- `delivery_source` — `lookup_events`, `s3`, `eventbridge`, or `all`.
+  **Defaults to `all`.** Secrets Manager `GetSecretValue` and KMS `Decrypt`
+  are CloudTrail *data* events that the LookupEvents API does not index, so
+  the correlation defaults to fanning out across every wired delivery
+  channel (and deduping by `EventID`); `lookup_events` alone will not
+  observe these accesses.
 - `account_id`, `region` — scope filters.
 - `identity` — actor principal / identity-node search.
 - `agent_id` — agent ID / agent-node search.
@@ -78,14 +84,16 @@ the `ready` / `degraded` / `blocked` status with explicit failure reasons.
 
 ## Live vs fixture
 
-Live composition is attempted only when the connector is active and healthy,
-the operator did not pin a `fixture_state`, and the connector's effective
-capability set includes `runtime_evidence` — the same gate the
-runtime-events endpoint applies before reading CloudTrail. In that case the
-handler composes the runtime-events, KMS decrypt reachability, and Secrets
-Manager metadata services and joins their results. Otherwise it returns the
-deterministic correlation fixtures, which exercise all three statuses
-(including a cross-account `granted_unused`).
+Live composition is attempted when the connector is active and healthy, the
+operator did not pin a `fixture_state`, the connector's effective capability
+set includes `runtime_evidence`, and at least one CloudTrail ingestion
+factory (LookupEvents **or** delivery) is wired. The delivery factory is the
+load-bearing one because it carries the data events. In that case the
+handler composes the runtime-events (driven through the resolved
+`delivery_source`), KMS decrypt reachability, and Secrets Manager metadata
+services and joins their results. Otherwise it returns the deterministic
+correlation fixtures, which exercise all three statuses (including a
+cross-account `granted_unused`).
 
 ## AWS permissions
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4654,6 +4654,12 @@ paths:
             enum: [success, empty, degraded, partial_failure, permission_denied]
           description: Optional deterministic fixture state for UI validation and contract tests.
         - in: query
+          name: delivery_source
+          schema:
+            type: string
+            enum: [lookup_events, s3, eventbridge, all]
+          description: Optional CloudTrail delivery channel for the observed secret-read / kms-decrypt data events. Defaults to `all` because these are CloudTrail data events that the LookupEvents API does not index; `s3` and `eventbridge` read directly from the trail's delivery channels.
+        - in: query
           name: account_id
           schema: { type: string }
         - in: query

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -554,6 +554,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-kms-runtime-access
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4610,6 +4615,84 @@ paths:
                     $ref: "#/components/schemas/AWSRuntimeEventResult"
         "400":
           description: Invalid AWS runtime event request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-kms-runtime-access:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Secrets Manager / KMS runtime access correlation
+      operationId: getAWSProjectSecretsKMSRuntimeAccess
+      description: Correlates observed, metadata-only Secrets Manager read and KMS decrypt runtime events with the static reachability edges Identrail already discovered (KMS key-policy / grant decrypt edges and Secrets Manager resource-policy grants). Each (identity, resource) correlation is classified as confirmed, observed_without_grant, or granted_unused with a correlation confidence and explicit missing-event caveats. The response never reads or returns secret values, decrypted plaintext, encryption-context values, or other customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only runtime evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional actor principal or identity-node search.
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent ID or agent-node search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional secret/key ARN, name, or resource-node search.
+        - in: query
+          name: resource_kind
+          schema:
+            type: string
+            enum: [secret, kms_key]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [confirmed, observed_without_grant, granted_unused]
+      responses:
+        "200":
+          description: AWS Secrets Manager / KMS runtime access correlation contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  correlation:
+                    $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessResult"
+        "400":
+          description: Invalid AWS secrets/kms runtime access request
           content:
             application/json:
               schema:
@@ -10935,6 +11018,166 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSRuntimeEventDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretsKMSRuntimeAccessRecord:
+      type: object
+      properties:
+        correlation_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        resource_kind:
+          type: string
+          enum: [secret, kms_key]
+        resource_arn: { type: string }
+        resource_name: { type: string }
+        resource_node_id: { type: string }
+        status:
+          type: string
+          enum: [confirmed, observed_without_grant, granted_unused]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_count: { type: integer }
+        observed_event_ids:
+          type: array
+          items: { type: string }
+        actions:
+          type: array
+          items: { type: string }
+        session_ids:
+          type: array
+          items: { type: string }
+        agent_id: { type: string }
+        agent_node_id: { type: string }
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        static_sources:
+          type: array
+          items:
+            type: string
+            enum: [key_policy, kms_grant, resource_policy]
+        static_effect: { type: string }
+        conditional: { type: boolean }
+        cross_account: { type: boolean }
+        caveats:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        redaction_boundary: { type: string }
+    AWSSecretsKMSRuntimeAccessRelationship:
+      type: object
+      properties:
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSSecretsKMSRuntimeAccessDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSSecretsKMSRuntimeAccessCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSSecretsKMSRuntimeAccessSummary:
+      type: object
+      properties:
+        total_correlations: { type: integer }
+        filtered_correlations: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        confirmed_count: { type: integer }
+        observed_without_grant_count: { type: integer }
+        granted_unused_count: { type: integer }
+        secret_correlation_count: { type: integer }
+        kms_key_correlation_count: { type: integer }
+        identity_count: { type: integer }
+        resource_count: { type: integer }
+        observed_access_count: { type: integer }
+        static_grant_count: { type: integer }
+        relationship_count: { type: integer }
+    AWSSecretsKMSRuntimeAccessResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessSummary"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -754,6 +754,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities/:agent_id", Action: policyActionTenancyRead, ResourceType: "ai_agent_identity", ResourceIDParam: "agent_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -331,14 +331,12 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	failures = append(failures, runtime.FailureReasons...)
 	remediations = append(remediations, runtime.RemediationHints...)
 
-	// A blocked runtime source means the observed side is missing, not
-	// empty. Correlating the static grants anyway would emit every grant
-	// as granted_unused under a blocked response — surfacing missing
-	// telemetry as least-privilege cleanup work. Drop the static side so
-	// the response is blocked with no records, matching the fixture
-	// permission_denied path. KMS/Secrets being individually degraded does
-	// not trigger this — only a blocked runtime (observed) source does.
-	if runtime.Status == awsPlatformDependencyStatusBlocked {
+	// Correlation needs usable observed events. For an explicitly blocked
+	// runtime source, or a degraded source with no returned records, static
+	// edges should not appear as confirmed, observed, or granted_unused.
+	// In those cases, suppress static correlation output so the response
+	// stays faithful to what runtime telemetry could actually prove.
+	if runtime.Status == awsPlatformDependencyStatusBlocked || (runtime.Status == awsPlatformDependencyStatusDegraded && len(runtime.Records) == 0) {
 		observed = nil
 		static = nil
 	}
@@ -425,6 +423,7 @@ func staticGrantsFromKMSRecords(records []AWSKMSDecryptReachabilityRecord) []sec
 				CrossAccount:   grant.IsCrossAccount,
 				Confidence:     record.Confidence,
 				EvidenceRef:    record.EvidenceRef,
+				Actions:        dedupeStrings(normalizeStringList(grant.Actions)),
 			})
 		}
 		for _, grant := range record.Grants {
@@ -445,6 +444,7 @@ func staticGrantsFromKMSRecords(records []AWSKMSDecryptReachabilityRecord) []sec
 				CrossAccount:   grant.IsCrossAccount,
 				Confidence:     record.Confidence,
 				EvidenceRef:    record.EvidenceRef,
+				Actions:        dedupeStrings(normalizeStringList(grant.Operations)),
 			})
 		}
 	}

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -180,16 +180,19 @@ func (s *Service) GetAWSSecretsKMSRuntimeAccess(ctx context.Context, workspaceID
 		deliverySource = "all"
 	}
 
+	var deliveryErr error
+	deliverySource, deliveryErr = normalizeDeliverySource(deliverySource)
+	if deliveryErr != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, deliveryErr
+	}
+
 	// Live composition is attempted when the connector is healthy, the
 	// operator did not force a fixture state, the connector's effective
-	// capability set includes runtime_evidence, and at least one
-	// CloudTrail ingestion factory is wired. The delivery factory is the
-	// load-bearing one here because it carries the data events; the
-	// LookupEvents factory is accepted too so management-event-only
-	// deployments still compose live. Otherwise we use the deterministic
-	// correlation fixtures so demos, tests, and capability-gated
-	// environments keep rendering the same contract shape.
-	useLive := (s.AWSCloudTrailLookupEventsFactory != nil || s.AWSCloudTrailDeliveryFactory != nil) &&
+	// capability set includes runtime_evidence, and the CloudTrail factory
+	// required for the selected source is wired. The default data-event
+	// path is delivery-backed, so a LookupEvents factory alone must not
+	// enter live mode and then fall through to delivery fixtures.
+	useLive := awsSecretsKMSRuntimeAccessHasLiveRuntimeFactory(s, deliverySource) &&
 		hasConnection && connection.Connected &&
 		strings.TrimSpace(request.FixtureState) == "" &&
 		awsConnectorHasRuntimeEvidence(connection)
@@ -414,15 +417,28 @@ func staticGrantsFromKMSRecords(records []AWSKMSDecryptReachabilityRecord) []sec
 	out := []secretsaccess.StaticGrant{}
 	for _, record := range records {
 		for _, grant := range record.IdentityGrants {
-			if grant.WildcardPrincipal || grant.PrincipalARN == "*" || !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
-				continue
-			}
 			if !kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
 				continue
 			}
+
+			principal := strings.TrimSpace(grant.PrincipalARN)
+			isWildcardPrincipal := grant.WildcardPrincipal || principal == "*"
+			if isWildcardPrincipal {
+				if !strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+					continue
+				}
+				principal = "*"
+			} else if !isIAMPrincipalARNForKMSEdge(principal) {
+				continue
+			}
+
+			identityNodeID := ""
+			if !isWildcardPrincipal {
+				identityNodeID = awsIdentityNodeIDForAPI(principal)
+			}
 			out = append(out, secretsaccess.StaticGrant{
-				IdentityNodeID: awsIdentityNodeIDForAPI(grant.PrincipalARN),
-				PrincipalARN:   grant.PrincipalARN,
+				IdentityNodeID: identityNodeID,
+				PrincipalARN:   principal,
 				AccountID:      record.AccountID,
 				Region:         record.Region,
 				ResourceKind:   secretsaccess.ResourceKindKMSKey,
@@ -462,6 +478,17 @@ func staticGrantsFromKMSRecords(records []AWSKMSDecryptReachabilityRecord) []sec
 	return out
 }
 
+func awsSecretsKMSRuntimeAccessHasLiveRuntimeFactory(s *Service, deliverySource string) bool {
+	switch strings.TrimSpace(deliverySource) {
+	case "lookup_events":
+		return s.AWSCloudTrailLookupEventsFactory != nil
+	case "s3", "eventbridge", "all":
+		return s.AWSCloudTrailDeliveryFactory != nil
+	default:
+		return false
+	}
+}
+
 // staticGrantsFromSecretsRecords projects Secrets Manager resource-policy
 // grants (allow and deny) for IAM principals that can read the secret
 // into engine static grants.
@@ -469,15 +496,28 @@ func staticGrantsFromSecretsRecords(records []AWSSecretsManagerMetadataRecord) [
 	out := []secretsaccess.StaticGrant{}
 	for _, record := range records {
 		for _, grant := range record.IdentityGrants {
-			if grant.WildcardPrincipal || grant.PrincipalARN == "*" || !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
-				continue
-			}
 			if !secretsActionsIncludeRead(grant.Actions) {
 				continue
 			}
+
+			principal := strings.TrimSpace(grant.PrincipalARN)
+			isWildcardPrincipal := grant.WildcardPrincipal || principal == "*"
+			if isWildcardPrincipal {
+				if !strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+					continue
+				}
+				principal = "*"
+			} else if !isIAMPrincipalARNForKMSEdge(principal) {
+				continue
+			}
+
+			identityNodeID := ""
+			if !isWildcardPrincipal {
+				identityNodeID = awsIdentityNodeIDForAPI(principal)
+			}
 			out = append(out, secretsaccess.StaticGrant{
-				IdentityNodeID: awsIdentityNodeIDForAPI(grant.PrincipalARN),
-				PrincipalARN:   grant.PrincipalARN,
+				IdentityNodeID: identityNodeID,
+				PrincipalARN:   principal,
 				AccountID:      record.AccountID,
 				Region:         record.Region,
 				ResourceKind:   secretsaccess.ResourceKindSecret,

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -331,6 +331,18 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	failures = append(failures, runtime.FailureReasons...)
 	remediations = append(remediations, runtime.RemediationHints...)
 
+	// A blocked runtime source means the observed side is missing, not
+	// empty. Correlating the static grants anyway would emit every grant
+	// as granted_unused under a blocked response — surfacing missing
+	// telemetry as least-privilege cleanup work. Drop the static side so
+	// the response is blocked with no records, matching the fixture
+	// permission_denied path. KMS/Secrets being individually degraded does
+	// not trigger this — only a blocked runtime (observed) source does.
+	if runtime.Status == awsPlatformDependencyStatusBlocked {
+		observed = nil
+		static = nil
+	}
+
 	// A blocked runtime source means we cannot assert any observed
 	// access, so the worst-of source status drives the envelope.
 	sourceStatus := worstAWSStatus(runtime.Status, worstAWSStatus(kms.Status, secrets.Status))
@@ -473,17 +485,35 @@ func staticGrantsFromSecretsRecords(records []AWSSecretsManagerMetadataRecord) [
 }
 
 // secretsActionsIncludeRead reports whether a resource-policy statement's
-// actions authorize reading the secret value. A wildcard action and the
-// explicit GetSecretValue both qualify.
+// actions authorize reading the secret value. It matches the exact read
+// actions, the `*` / `secretsmanager:*` wildcards, and prefix wildcards
+// such as `secretsmanager:Get*` or `secretsmanager:BatchGet*` that the
+// collector preserves verbatim — otherwise a resource policy that really
+// allows the read via a wildcard would be dropped, mislabeling observed
+// reads as observed_without_grant and hiding unused grants.
 func secretsActionsIncludeRead(actions []string) bool {
+	readActions := []string{"secretsmanager:getsecretvalue", "secretsmanager:batchgetsecretvalue"}
 	for _, action := range actions {
 		trimmed := strings.ToLower(strings.TrimSpace(action))
-		switch {
-		case trimmed == "*",
-			trimmed == "secretsmanager:*",
-			trimmed == "secretsmanager:getsecretvalue",
-			trimmed == "secretsmanager:batchgetsecretvalue":
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == "*" {
 			return true
+		}
+		if strings.HasSuffix(trimmed, "*") {
+			prefix := strings.TrimSuffix(trimmed, "*")
+			for _, read := range readActions {
+				if strings.HasPrefix(read, prefix) {
+					return true
+				}
+			}
+			continue
+		}
+		for _, read := range readActions {
+			if trimmed == read {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -478,6 +478,7 @@ func staticGrantsFromSecretsRecords(records []AWSSecretsManagerMetadataRecord) [
 				CrossAccount:   grant.IsCrossAccount,
 				Confidence:     record.Confidence,
 				EvidenceRef:    record.EvidenceRef,
+				Actions:        dedupeStrings(normalizeStringList(grant.Actions)),
 			})
 		}
 	}

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -12,6 +12,7 @@ import (
 const (
 	awsSecretsKMSRuntimeAccessCurrentIssue = 1518
 	awsSecretsKMSRuntimeAccessVersion      = "aws-secrets-kms-runtime-access-correlation-v1"
+	awsRuntimeCorrelationLiveNoStaticState = "empty"
 )
 
 // AWSSecretsKMSRuntimeAccessRequest is the operator-facing request. It
@@ -310,11 +311,21 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate runtime events: %w", err)
 	}
-	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID})
+	// In live correlation mode, avoid joining runtime events to fixture-backed
+	// static grants. The inventory readers are fixture-shaped today; forcing
+	// an empty static state keeps the observed events but suppresses synthetic
+	// grants that could create false granted_unused / observed_without_grant results.
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: awsRuntimeCorrelationLiveNoStaticState,
+	})
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate kms reachability: %w", err)
 	}
-	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID})
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: awsRuntimeCorrelationLiveNoStaticState,
+	})
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate secrets metadata: %w", err)
 	}
@@ -342,8 +353,8 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	}
 
 	// A blocked runtime source means we cannot assert any observed
-	// access, so the worst-of source status drives the envelope.
-	sourceStatus := worstAWSStatus(runtime.Status, worstAWSStatus(kms.Status, secrets.Status))
+	// access, so the runtime status drives the envelope.
+	sourceStatus := runtime.Status
 	// Runtime evidence is sourced from CloudTrail; Secrets Manager
 	// GetSecretValue and KMS Decrypt are data events, so coverage is
 	// never guaranteed complete from a management-event lookup.

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -28,6 +28,12 @@ type AWSSecretsKMSRuntimeAccessRequest struct {
 	Resource     string `json:"resource,omitempty"`
 	ResourceKind string `json:"resource_kind,omitempty"`
 	Status       string `json:"status,omitempty"`
+	// DeliverySource selects the CloudTrail ingestion channel used to
+	// observe the secret-read / kms-decrypt data events: `lookup_events`,
+	// `s3`, `eventbridge`, or `all`. Empty defaults to `all` because these
+	// are data events that LookupEvents does not index. Unknown values
+	// return HTTP 400.
+	DeliverySource string `json:"delivery_source,omitempty"`
 }
 
 // AWSSecretsKMSRuntimeAccessRecord is one (identity, resource)
@@ -158,14 +164,31 @@ func (s *Service) GetAWSSecretsKMSRuntimeAccess(ctx context.Context, workspaceID
 		return AWSSecretsKMSRuntimeAccessResult{}, ErrInvalidAWSConnectionRequest
 	}
 
-	// Live composition is only attempted when the connector is healthy,
-	// the operator did not force a fixture state, and the connector's
-	// effective capability set includes runtime_evidence — the same gate
-	// the runtime-events endpoint applies before reading CloudTrail.
-	// Otherwise we use the deterministic correlation fixtures so demos,
-	// tests, and capability-gated environments keep rendering the same
-	// contract shape.
-	useLive := s.AWSCloudTrailLookupEventsFactory != nil &&
+	// secret-read and kms-decrypt are CloudTrail *data* events, which the
+	// LookupEvents API does not index — they are only delivered through
+	// the S3 trail log / EventBridge delivery channels. So this endpoint
+	// defaults its runtime source to `all` (fan out across every wired
+	// channel and dedupe by EventID) rather than the runtime-events
+	// endpoint's `lookup_events` default; otherwise the correlation would
+	// never observe the data events it correlates and would report real
+	// runtime use as granted_unused. Operators can still pin a specific
+	// channel. Unknown tokens are validated downstream by
+	// GetAWSRuntimeEvents and surface as HTTP 400.
+	deliverySource := strings.TrimSpace(request.DeliverySource)
+	if deliverySource == "" {
+		deliverySource = "all"
+	}
+
+	// Live composition is attempted when the connector is healthy, the
+	// operator did not force a fixture state, the connector's effective
+	// capability set includes runtime_evidence, and at least one
+	// CloudTrail ingestion factory is wired. The delivery factory is the
+	// load-bearing one here because it carries the data events; the
+	// LookupEvents factory is accepted too so management-event-only
+	// deployments still compose live. Otherwise we use the deterministic
+	// correlation fixtures so demos, tests, and capability-gated
+	// environments keep rendering the same contract shape.
+	useLive := (s.AWSCloudTrailLookupEventsFactory != nil || s.AWSCloudTrailDeliveryFactory != nil) &&
 		hasConnection && connection.Connected &&
 		strings.TrimSpace(request.FixtureState) == "" &&
 		awsConnectorHasRuntimeEvidence(connection)
@@ -187,7 +210,7 @@ func (s *Service) GetAWSSecretsKMSRuntimeAccess(ctx context.Context, workspaceID
 
 	if useLive {
 		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown, err =
-			s.awsSecretsKMSRuntimeAccessLiveInputs(ctx, workspaceID, projectID, connectorID, accountID, region)
+			s.awsSecretsKMSRuntimeAccessLiveInputs(ctx, workspaceID, projectID, connectorID, accountID, region, deliverySource)
 		if err != nil {
 			return AWSSecretsKMSRuntimeAccessResult{}, err
 		}
@@ -270,7 +293,7 @@ func normalizeAWSSecretsKMSRuntimeAccessFixtureState(requested string, connectio
 // engine's observed/static inputs. Each sub-service applies its own
 // capability gating and live/fixture decision, so this method stays a
 // thin adapter that joins their results.
-func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, workspaceID, projectID, connectorID, accountID, region string) ([]secretsaccess.ObservedAccess, []secretsaccess.StaticGrant, []AWSSecretsKMSRuntimeAccessDiagnostic, []AWSSecretsKMSRuntimeAccessCoverageGap, []string, []string, string, bool, error) {
+func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, workspaceID, projectID, connectorID, accountID, region, deliverySource string) ([]secretsaccess.ObservedAccess, []secretsaccess.StaticGrant, []AWSSecretsKMSRuntimeAccessDiagnostic, []AWSSecretsKMSRuntimeAccessCoverageGap, []string, []string, string, bool, error) {
 	var (
 		diagnostics  []AWSSecretsKMSRuntimeAccessDiagnostic
 		coverageGaps []AWSSecretsKMSRuntimeAccessCoverageGap
@@ -279,9 +302,10 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	)
 
 	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
-		ConnectorID: connectorID,
-		AccountID:   accountID,
-		Region:      region,
+		ConnectorID:    connectorID,
+		AccountID:      accountID,
+		Region:         region,
+		DeliverySource: deliverySource,
 	})
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate runtime events: %w", err)

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -218,6 +218,10 @@ func (s *Service) GetAWSSecretsKMSRuntimeAccess(ctx context.Context, workspaceID
 		if err != nil {
 			return AWSSecretsKMSRuntimeAccessResult{}, err
 		}
+	} else if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsSecretsKMSRuntimeAccessLiveUnavailableInputs(deliverySource)
+		fixtureState = ""
 	} else {
 		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
 			awsSecretsKMSRuntimeAccessFixtureInputs(accountID, region, fixtureState, now)
@@ -290,6 +294,30 @@ func normalizeAWSSecretsKMSRuntimeAccessFixtureState(requested string, connectio
 	default:
 		return ""
 	}
+}
+
+func awsSecretsKMSRuntimeAccessLiveUnavailableInputs(deliverySource string) ([]secretsaccess.ObservedAccess, []secretsaccess.StaticGrant, []AWSSecretsKMSRuntimeAccessDiagnostic, []AWSSecretsKMSRuntimeAccessCoverageGap, []string, []string, string, bool) {
+	source := strings.TrimSpace(deliverySource)
+	if source == "" {
+		source = "all"
+	}
+	diagnostics := []AWSSecretsKMSRuntimeAccessDiagnostic{{
+		Collector:   secretsaccess.CollectorName,
+		SourceID:    "runtime_delivery:" + source,
+		Code:        "runtime_delivery_unavailable",
+		Message:     "Live Secrets Manager / KMS data-event delivery is unavailable for this connector; fixture correlations were suppressed.",
+		Remediation: "Configure the selected CloudTrail delivery channel and grant the runtime_evidence capability, or request a fixture_state explicitly for demo data.",
+		Retryable:   true,
+	}}
+	coverageGaps := []AWSSecretsKMSRuntimeAccessCoverageGap{{
+		Capability:  "secrets_kms_data_event_delivery",
+		Status:      "delivery_unavailable",
+		Reason:      "The selected runtime delivery source is not available, so real secret-read / kms-decrypt events cannot be correlated.",
+		Remediation: "Wire CloudTrail S3/EventBridge delivery for this connector and grant runtime_evidence before relying on live correlation output.",
+	}}
+	failures := []string{"Secrets Manager / KMS runtime delivery is unavailable; fixture correlations suppressed"}
+	remediations := []string{"Configure CloudTrail data-event delivery or request fixture_state explicitly for sample data."}
+	return nil, nil, diagnostics, coverageGaps, failures, remediations, awsPlatformDependencyStatusDegraded, true
 }
 
 // awsSecretsKMSRuntimeAccessLiveInputs composes the runtime-events, KMS

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -1,0 +1,674 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/secretsaccess"
+)
+
+const (
+	awsSecretsKMSRuntimeAccessCurrentIssue = 1518
+	awsSecretsKMSRuntimeAccessVersion      = "aws-secrets-kms-runtime-access-correlation-v1"
+)
+
+// AWSSecretsKMSRuntimeAccessRequest is the operator-facing request. It
+// scopes the correlation to a connector/account/region and exposes the
+// runtime timeline/query filters the issue requires: by identity, agent,
+// resource, resource kind, and correlation status.
+type AWSSecretsKMSRuntimeAccessRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	ResourceKind string `json:"resource_kind,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// AWSSecretsKMSRuntimeAccessRecord is one (identity, resource)
+// correlation projected for the API/app surface.
+type AWSSecretsKMSRuntimeAccessRecord struct {
+	CorrelationID     string    `json:"correlation_id"`
+	AccountID         string    `json:"account_id"`
+	Region            string    `json:"region"`
+	IdentityNodeID    string    `json:"identity_node_id"`
+	PrincipalARN      string    `json:"principal_arn,omitempty"`
+	ResourceKind      string    `json:"resource_kind"`
+	ResourceARN       string    `json:"resource_arn"`
+	ResourceName      string    `json:"resource_name,omitempty"`
+	ResourceNodeID    string    `json:"resource_node_id"`
+	Status            string    `json:"status"`
+	Confidence        float64   `json:"confidence"`
+	ObservedCount     int       `json:"observed_count"`
+	ObservedEventIDs  []string  `json:"observed_event_ids,omitempty"`
+	Actions           []string  `json:"actions,omitempty"`
+	SessionIDs        []string  `json:"session_ids,omitempty"`
+	AgentID           string    `json:"agent_id,omitempty"`
+	AgentNodeID       string    `json:"agent_node_id,omitempty"`
+	FirstObservedAt   time.Time `json:"first_observed_at,omitzero"`
+	LastObservedAt    time.Time `json:"last_observed_at,omitzero"`
+	StaticSources     []string  `json:"static_sources,omitempty"`
+	StaticEffect      string    `json:"static_effect,omitempty"`
+	Conditional       bool      `json:"conditional,omitempty"`
+	CrossAccount      bool      `json:"cross_account,omitempty"`
+	Caveats           []string  `json:"caveats,omitempty"`
+	EvidenceRef       string    `json:"evidence_ref"`
+	EvidenceRefs      []string  `json:"evidence_refs,omitempty"`
+	NextAction        string    `json:"next_action"`
+	RedactionBoundary string    `json:"redaction_boundary"`
+}
+
+// AWSSecretsKMSRuntimeAccessRelationship is one correlation graph edge so
+// the runtime evidence joins back to the static identity/resource graph.
+type AWSSecretsKMSRuntimeAccessRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSSecretsKMSRuntimeAccessDiagnostic is a structured diagnostic
+// propagated from the correlated sources.
+type AWSSecretsKMSRuntimeAccessDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSSecretsKMSRuntimeAccessCoverageGap names a coverage limitation.
+type AWSSecretsKMSRuntimeAccessCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSSecretsKMSRuntimeAccessSummary aggregates the correlation outcome.
+type AWSSecretsKMSRuntimeAccessSummary struct {
+	TotalCorrelations         int            `json:"total_correlations"`
+	FilteredCorrelations      int            `json:"filtered_correlations"`
+	StatusCounts              map[string]int `json:"status_counts"`
+	ConfirmedCount            int            `json:"confirmed_count"`
+	ObservedWithoutGrantCount int            `json:"observed_without_grant_count"`
+	GrantedUnusedCount        int            `json:"granted_unused_count"`
+	SecretCorrelationCount    int            `json:"secret_correlation_count"`
+	KMSKeyCorrelationCount    int            `json:"kms_key_correlation_count"`
+	IdentityCount             int            `json:"identity_count"`
+	ResourceCount             int            `json:"resource_count"`
+	ObservedAccessCount       int            `json:"observed_access_count"`
+	StaticGrantCount          int            `json:"static_grant_count"`
+	RelationshipCount         int            `json:"relationship_count"`
+}
+
+// AWSSecretsKMSRuntimeAccessResult is the deterministic envelope.
+type AWSSecretsKMSRuntimeAccessResult struct {
+	TenantID           string                                   `json:"tenant_id"`
+	WorkspaceID        string                                   `json:"workspace_id"`
+	ProjectID          string                                   `json:"project_id"`
+	ConnectorID        string                                   `json:"connector_id,omitempty"`
+	AccountID          string                                   `json:"account_id,omitempty"`
+	Region             string                                   `json:"region,omitempty"`
+	ParentIssueNumber  int                                      `json:"parent_issue_number"`
+	ParentIssueRef     string                                   `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                      `json:"current_issue_number"`
+	CurrentIssueRef    string                                   `json:"current_issue_ref"`
+	Version            string                                   `json:"version"`
+	Status             string                                   `json:"status"`
+	FixtureState       string                                   `json:"fixture_state"`
+	Confidence         float64                                  `json:"confidence"`
+	AppliedFilters     map[string]string                        `json:"applied_filters"`
+	Summary            AWSSecretsKMSRuntimeAccessSummary        `json:"summary"`
+	Records            []AWSSecretsKMSRuntimeAccessRecord       `json:"records"`
+	Relationships      []AWSSecretsKMSRuntimeAccessRelationship `json:"relationships"`
+	Caveats            []string                                 `json:"caveats"`
+	FailureReasons     []string                                 `json:"failure_reasons"`
+	RemediationHints   []string                                 `json:"remediation_hints"`
+	EvidenceLinks      []string                                 `json:"evidence_links"`
+	CoverageGaps       []AWSSecretsKMSRuntimeAccessCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSSecretsKMSRuntimeAccessDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                `json:"generated_at"`
+	UpdatedAt          time.Time                                `json:"updated_at"`
+}
+
+// GetAWSSecretsKMSRuntimeAccess correlates observed Secrets Manager read
+// and KMS decrypt runtime events with the static reachability edges
+// Identrail already discovered, returning a queryable correlation
+// timeline.
+func (s *Service) GetAWSSecretsKMSRuntimeAccess(ctx context.Context, workspaceID string, projectID string, request AWSSecretsKMSRuntimeAccessRequest) (AWSSecretsKMSRuntimeAccessResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, err
+	}
+	now := s.Now().UTC()
+
+	fixtureState := normalizeAWSSecretsKMSRuntimeAccessFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSecretsKMSRuntimeAccessResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	// Live composition is only attempted when the connector is healthy,
+	// the operator did not force a fixture state, and the connector's
+	// effective capability set includes runtime_evidence — the same gate
+	// the runtime-events endpoint applies before reading CloudTrail.
+	// Otherwise we use the deterministic correlation fixtures so demos,
+	// tests, and capability-gated environments keep rendering the same
+	// contract shape.
+	useLive := s.AWSCloudTrailLookupEventsFactory != nil &&
+		hasConnection && connection.Connected &&
+		strings.TrimSpace(request.FixtureState) == "" &&
+		awsConnectorHasRuntimeEvidence(connection)
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	var (
+		observed        []secretsaccess.ObservedAccess
+		static          []secretsaccess.StaticGrant
+		diagnostics     []AWSSecretsKMSRuntimeAccessDiagnostic
+		coverageGaps    []AWSSecretsKMSRuntimeAccessCoverageGap
+		failures        []string
+		remediations    []string
+		sourceStatus    string
+		coverageUnknown bool
+	)
+
+	if useLive {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown, err =
+			s.awsSecretsKMSRuntimeAccessLiveInputs(ctx, workspaceID, projectID, connectorID, accountID, region)
+		if err != nil {
+			return AWSSecretsKMSRuntimeAccessResult{}, err
+		}
+	} else {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsSecretsKMSRuntimeAccessFixtureInputs(accountID, region, fixtureState, now)
+	}
+
+	correlationResult := secretsaccess.Correlate(secretsaccess.CorrelateRequest{
+		AccountID:                accountID,
+		Region:                   region,
+		Observed:                 observed,
+		Static:                   static,
+		DataEventCoverageUnknown: coverageUnknown,
+	})
+
+	records := awsSecretsKMSRuntimeAccessRecords(correlationResult.Correlations)
+	filtered, applied := filterAWSSecretsKMSRuntimeAccessRecords(records, request)
+	relationships := awsSecretsKMSRuntimeAccessRelationships(filtered)
+	summary := summarizeAWSSecretsKMSRuntimeAccess(correlationResult, records, filtered, relationships)
+
+	status, confidence := summarizeAWSSecretsKMSRuntimeAccessStatus(sourceStatus, filtered, diagnostics)
+	caveats := dedupeStrings(correlationResult.Caveats)
+
+	return AWSSecretsKMSRuntimeAccessResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsSecretsKMSRuntimeAccessCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsSecretsKMSRuntimeAccessCurrentIssue),
+		Version:            awsSecretsKMSRuntimeAccessVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Records:            filtered,
+		Relationships:      relationships,
+		Caveats:            caveats,
+		FailureReasons:     emptyStrings(dedupeStrings(failures)),
+		RemediationHints:   emptyStrings(dedupeStrings(remediations)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSecretsKMSRuntimeAccessCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsKMSDecryptReachabilityCurrentIssue),
+			awsIssueURL(awsSecretsManagerMetadataCurrentIssue),
+			"/docs/aws-secrets-kms-runtime-access",
+			"/docs/aws-runtime-events",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSSecretsKMSRuntimeAccessFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// awsSecretsKMSRuntimeAccessLiveInputs composes the runtime-events, KMS
+// decrypt reachability, and Secrets Manager metadata services into the
+// engine's observed/static inputs. Each sub-service applies its own
+// capability gating and live/fixture decision, so this method stays a
+// thin adapter that joins their results.
+func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, workspaceID, projectID, connectorID, accountID, region string) ([]secretsaccess.ObservedAccess, []secretsaccess.StaticGrant, []AWSSecretsKMSRuntimeAccessDiagnostic, []AWSSecretsKMSRuntimeAccessCoverageGap, []string, []string, string, bool, error) {
+	var (
+		diagnostics  []AWSSecretsKMSRuntimeAccessDiagnostic
+		coverageGaps []AWSSecretsKMSRuntimeAccessCoverageGap
+		failures     []string
+		remediations []string
+	)
+
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID: connectorID,
+		AccountID:   accountID,
+		Region:      region,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate runtime events: %w", err)
+	}
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID})
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate kms reachability: %w", err)
+	}
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID})
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate secrets metadata: %w", err)
+	}
+
+	observed := observedAccessFromRuntimeRecords(runtime.Records)
+	static := append(staticGrantsFromKMSRecords(kms.Records), staticGrantsFromSecretsRecords(secrets.Records)...)
+
+	for _, diag := range runtime.Diagnostics {
+		diagnostics = append(diagnostics, AWSSecretsKMSRuntimeAccessDiagnostic(diag))
+	}
+	for _, gap := range runtime.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSSecretsKMSRuntimeAccessCoverageGap(gap))
+	}
+	failures = append(failures, runtime.FailureReasons...)
+	remediations = append(remediations, runtime.RemediationHints...)
+
+	// A blocked runtime source means we cannot assert any observed
+	// access, so the worst-of source status drives the envelope.
+	sourceStatus := worstAWSStatus(runtime.Status, worstAWSStatus(kms.Status, secrets.Status))
+	// Runtime evidence is sourced from CloudTrail; Secrets Manager
+	// GetSecretValue and KMS Decrypt are data events, so coverage is
+	// never guaranteed complete from a management-event lookup.
+	return observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, true, nil
+}
+
+// observedAccessFromRuntimeRecords projects the secret-read and
+// kms-decrypt runtime event records into engine observed accesses. Other
+// event types (sts-session, api-call, agent-tool) are not in scope for
+// this correlation and are dropped.
+func observedAccessFromRuntimeRecords(records []AWSRuntimeEventRecord) []secretsaccess.ObservedAccess {
+	out := []secretsaccess.ObservedAccess{}
+	for _, record := range records {
+		kind := resourceKindForRuntimeEventType(record.EventType)
+		if kind == "" {
+			continue
+		}
+		out = append(out, secretsaccess.ObservedAccess{
+			EventID:         record.EventID,
+			IdentityNodeID:  record.ActorIdentityNodeID,
+			PrincipalARN:    firstNonEmptyAWSValue(record.Session.SessionIssuerARN, record.ActorPrincipalARN),
+			AccountID:       record.AccountID,
+			Region:          record.Region,
+			ResourceKind:    kind,
+			ResourceARN:     record.TargetResourceARN,
+			ResourceName:    record.TargetResourceName,
+			Action:          record.Action,
+			SessionID:       record.Session.SessionID,
+			SessionNodeID:   record.Session.SessionNodeID,
+			AgentID:         record.AgentID,
+			AgentNodeID:     record.AgentNodeID,
+			SourceIPAddress: record.Session.SourceIPAddress,
+			LineageStatus:   record.Session.LineageStatus,
+			ObservedAt:      record.ObservedAt,
+			EvidenceRef:     record.EvidenceRef,
+		})
+	}
+	return out
+}
+
+func resourceKindForRuntimeEventType(eventType string) string {
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "secret-read":
+		return secretsaccess.ResourceKindSecret
+	case "kms-decrypt":
+		return secretsaccess.ResourceKindKMSKey
+	default:
+		return ""
+	}
+}
+
+// staticGrantsFromKMSRecords projects KMS key-policy and live-grant
+// decrypt grants (allow and deny) for IAM principals into engine static
+// grants. Wildcard and non-IAM principals are dropped because they have
+// no identity node to join against.
+func staticGrantsFromKMSRecords(records []AWSKMSDecryptReachabilityRecord) []secretsaccess.StaticGrant {
+	out := []secretsaccess.StaticGrant{}
+	for _, record := range records {
+		for _, grant := range record.IdentityGrants {
+			if grant.WildcardPrincipal || grant.PrincipalARN == "*" || !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
+				continue
+			}
+			if !kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
+				continue
+			}
+			out = append(out, secretsaccess.StaticGrant{
+				IdentityNodeID: awsIdentityNodeIDForAPI(grant.PrincipalARN),
+				PrincipalARN:   grant.PrincipalARN,
+				AccountID:      record.AccountID,
+				Region:         record.Region,
+				ResourceKind:   secretsaccess.ResourceKindKMSKey,
+				ResourceARN:    record.KeyARN,
+				ResourceName:   firstNonEmptyAWSValue(displayNameFromARN(record.KeyARN), record.KeyID),
+				Source:         secretsaccess.SourceKeyPolicy,
+				Effect:         firstNonEmptyAWSValue(grant.Effect, "Allow"),
+				Conditional:    grant.HasCondition || len(grant.ConditionKeys) > 0,
+				CrossAccount:   grant.IsCrossAccount,
+				Confidence:     record.Confidence,
+				EvidenceRef:    record.EvidenceRef,
+			})
+		}
+		for _, grant := range record.Grants {
+			if !isIAMPrincipalARNForKMSEdge(grant.GranteePrincipal) || !kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
+				continue
+			}
+			out = append(out, secretsaccess.StaticGrant{
+				IdentityNodeID: awsIdentityNodeIDForAPI(grant.GranteePrincipal),
+				PrincipalARN:   grant.GranteePrincipal,
+				AccountID:      record.AccountID,
+				Region:         record.Region,
+				ResourceKind:   secretsaccess.ResourceKindKMSKey,
+				ResourceARN:    record.KeyARN,
+				ResourceName:   firstNonEmptyAWSValue(displayNameFromARN(record.KeyARN), record.KeyID),
+				Source:         secretsaccess.SourceKMSGrant,
+				Effect:         "Allow",
+				Conditional:    grant.HasConstraints,
+				CrossAccount:   grant.IsCrossAccount,
+				Confidence:     record.Confidence,
+				EvidenceRef:    record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+// staticGrantsFromSecretsRecords projects Secrets Manager resource-policy
+// grants (allow and deny) for IAM principals that can read the secret
+// into engine static grants.
+func staticGrantsFromSecretsRecords(records []AWSSecretsManagerMetadataRecord) []secretsaccess.StaticGrant {
+	out := []secretsaccess.StaticGrant{}
+	for _, record := range records {
+		for _, grant := range record.IdentityGrants {
+			if grant.WildcardPrincipal || grant.PrincipalARN == "*" || !isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) {
+				continue
+			}
+			if !secretsActionsIncludeRead(grant.Actions) {
+				continue
+			}
+			out = append(out, secretsaccess.StaticGrant{
+				IdentityNodeID: awsIdentityNodeIDForAPI(grant.PrincipalARN),
+				PrincipalARN:   grant.PrincipalARN,
+				AccountID:      record.AccountID,
+				Region:         record.Region,
+				ResourceKind:   secretsaccess.ResourceKindSecret,
+				ResourceARN:    record.SecretARN,
+				ResourceName:   firstNonEmptyAWSValue(record.SecretName, displayNameFromARN(record.SecretARN)),
+				Source:         secretsaccess.SourceResourcePolicy,
+				Effect:         firstNonEmptyAWSValue(grant.Effect, "Allow"),
+				Conditional:    grant.HasCondition || len(grant.ConditionKeys) > 0,
+				CrossAccount:   grant.IsCrossAccount,
+				Confidence:     record.Confidence,
+				EvidenceRef:    record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+// secretsActionsIncludeRead reports whether a resource-policy statement's
+// actions authorize reading the secret value. A wildcard action and the
+// explicit GetSecretValue both qualify.
+func secretsActionsIncludeRead(actions []string) bool {
+	for _, action := range actions {
+		trimmed := strings.ToLower(strings.TrimSpace(action))
+		switch {
+		case trimmed == "*",
+			trimmed == "secretsmanager:*",
+			trimmed == "secretsmanager:getsecretvalue",
+			trimmed == "secretsmanager:batchgetsecretvalue":
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretsKMSRuntimeAccessRecords(correlations []secretsaccess.Correlation) []AWSSecretsKMSRuntimeAccessRecord {
+	out := make([]AWSSecretsKMSRuntimeAccessRecord, 0, len(correlations))
+	for _, correlation := range correlations {
+		out = append(out, AWSSecretsKMSRuntimeAccessRecord{
+			CorrelationID:     correlation.CorrelationID,
+			AccountID:         correlation.AccountID,
+			Region:            correlation.Region,
+			IdentityNodeID:    correlation.IdentityNodeID,
+			PrincipalARN:      correlation.PrincipalARN,
+			ResourceKind:      correlation.ResourceKind,
+			ResourceARN:       correlation.ResourceARN,
+			ResourceName:      correlation.ResourceName,
+			ResourceNodeID:    awsSecretsKMSResourceNodeID(correlation.ResourceKind, correlation.ResourceARN),
+			Status:            correlation.Status,
+			Confidence:        correlation.Confidence,
+			ObservedCount:     correlation.ObservedCount,
+			ObservedEventIDs:  correlation.ObservedEventIDs,
+			Actions:           correlation.Actions,
+			SessionIDs:        correlation.SessionIDs,
+			AgentID:           correlation.AgentID,
+			AgentNodeID:       correlation.AgentNodeID,
+			FirstObservedAt:   correlation.FirstObservedAt,
+			LastObservedAt:    correlation.LastObservedAt,
+			StaticSources:     correlation.StaticSources,
+			StaticEffect:      correlation.StaticEffect,
+			Conditional:       correlation.Conditional,
+			CrossAccount:      correlation.CrossAccount,
+			Caveats:           correlation.Caveats,
+			EvidenceRef:       fmt.Sprintf("runtime-correlation://%s", correlation.CorrelationID),
+			EvidenceRefs:      correlation.EvidenceRefs,
+			NextAction:        awsSecretsKMSRuntimeAccessNextAction(correlation.Status, correlation.ResourceKind),
+			RedactionBoundary: correlation.RedactionBoundary,
+		})
+	}
+	return out
+}
+
+func awsSecretsKMSResourceNodeID(resourceKind string, resourceARN string) string {
+	arn := strings.TrimSpace(resourceARN)
+	if arn == "" {
+		return ""
+	}
+	switch resourceKind {
+	case secretsaccess.ResourceKindSecret:
+		return "aws:resource:secrets-manager-secret:" + arn
+	case secretsaccess.ResourceKindKMSKey:
+		return "aws:resource:kms-key:" + arn
+	default:
+		return "aws:resource:" + normalizeName(firstNonEmptyAWSValue(resourceKind, "resource")) + ":" + arn
+	}
+}
+
+func awsSecretsKMSRuntimeAccessNextAction(status string, resourceKind string) string {
+	noun := "secret"
+	if resourceKind == secretsaccess.ResourceKindKMSKey {
+		noun = "key"
+	}
+	switch status {
+	case secretsaccess.StatusConfirmed:
+		return fmt.Sprintf("Confirm the observed %s access matches an expected workload path before relying on it for remediation.", noun)
+	case secretsaccess.StatusObservedWithoutGrant:
+		return fmt.Sprintf("Investigate observed %s access with no modeled grant — confirm IAM identity-policy authorization or treat as drift.", noun)
+	case secretsaccess.StatusGrantedUnused:
+		return fmt.Sprintf("Review the unused %s grant for least-privilege; confirm data-event coverage before removing it.", noun)
+	default:
+		return "Correlate runtime evidence with the static reachability graph."
+	}
+}
+
+func filterAWSSecretsKMSRuntimeAccessRecords(records []AWSSecretsKMSRuntimeAccessRecord, request AWSSecretsKMSRuntimeAccessRequest) ([]AWSSecretsKMSRuntimeAccessRecord, map[string]string) {
+	filters := map[string]string{
+		"account_id":    strings.TrimSpace(request.AccountID),
+		"region":        strings.TrimSpace(request.Region),
+		"identity":      strings.TrimSpace(request.Identity),
+		"agent_id":      strings.TrimSpace(request.AgentID),
+		"resource":      strings.TrimSpace(request.Resource),
+		"resource_kind": normalizeAWSRuntimeEventFilterToken(request.ResourceKind),
+		"status":        normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		token := strings.ToLower(strings.TrimSpace(value))
+		if token == "" || token == "all" {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSSecretsKMSRuntimeAccessRecord, 0, len(records))
+	for _, record := range records {
+		if filters["account_id"] != "" && filters["account_id"] != record.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], record.Region) {
+			continue
+		}
+		if filters["resource_kind"] != "" && filters["resource_kind"] != normalizeAWSRuntimeEventFilterToken(record.ResourceKind) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(record.Status) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], record.IdentityNodeID, record.PrincipalARN) {
+			continue
+		}
+		if filters["agent_id"] != "" && !awsRuntimeEventMatchesAny(filters["agent_id"], record.AgentID, record.AgentNodeID) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], record.ResourceARN, record.ResourceName, record.ResourceNodeID) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered, applied
+}
+
+func awsSecretsKMSRuntimeAccessRelationships(records []AWSSecretsKMSRuntimeAccessRecord) []AWSSecretsKMSRuntimeAccessRelationship {
+	out := []AWSSecretsKMSRuntimeAccessRelationship{}
+	for _, record := range records {
+		if record.IdentityNodeID == "" || record.ResourceNodeID == "" {
+			continue
+		}
+		edgeType := "runtime_access_correlation"
+		switch record.Status {
+		case secretsaccess.StatusConfirmed:
+			edgeType = "confirmed_runtime_access"
+		case secretsaccess.StatusObservedWithoutGrant:
+			edgeType = "observed_runtime_access_without_grant"
+		case secretsaccess.StatusGrantedUnused:
+			edgeType = "unused_static_grant"
+		}
+		out = append(out, AWSSecretsKMSRuntimeAccessRelationship{
+			Type:        edgeType,
+			FromNodeID:  record.IdentityNodeID,
+			ToNodeID:    record.ResourceNodeID,
+			EvidenceRef: record.EvidenceRef,
+		})
+		if record.AgentNodeID != "" {
+			out = append(out, AWSSecretsKMSRuntimeAccessRelationship{
+				Type:        "agent_runtime_access_correlation",
+				FromNodeID:  record.AgentNodeID,
+				ToNodeID:    record.ResourceNodeID,
+				EvidenceRef: record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+func summarizeAWSSecretsKMSRuntimeAccess(correlation secretsaccess.Result, allRecords []AWSSecretsKMSRuntimeAccessRecord, filtered []AWSSecretsKMSRuntimeAccessRecord, relationships []AWSSecretsKMSRuntimeAccessRelationship) AWSSecretsKMSRuntimeAccessSummary {
+	statusCounts := map[string]int{}
+	for _, record := range allRecords {
+		statusCounts[record.Status]++
+	}
+	return AWSSecretsKMSRuntimeAccessSummary{
+		TotalCorrelations:         len(allRecords),
+		FilteredCorrelations:      len(filtered),
+		StatusCounts:              statusCounts,
+		ConfirmedCount:            correlation.ConfirmedCount,
+		ObservedWithoutGrantCount: correlation.ObservedWithoutGrant,
+		GrantedUnusedCount:        correlation.GrantedUnusedCount,
+		SecretCorrelationCount:    correlation.SecretCorrelationCount,
+		KMSKeyCorrelationCount:    correlation.KMSKeyCorrelationCount,
+		IdentityCount:             correlation.IdentityCount,
+		ResourceCount:             correlation.ResourceCount,
+		ObservedAccessCount:       correlation.ObservedAccessConsidered,
+		StaticGrantCount:          correlation.StaticGrantsConsidered,
+		RelationshipCount:         len(relationships),
+	}
+}
+
+func summarizeAWSSecretsKMSRuntimeAccessStatus(sourceStatus string, filtered []AWSSecretsKMSRuntimeAccessRecord, diagnostics []AWSSecretsKMSRuntimeAccessDiagnostic) (string, float64) {
+	switch sourceStatus {
+	case awsPlatformDependencyStatusBlocked:
+		return awsPlatformDependencyStatusBlocked, 0
+	case awsPlatformDependencyStatusDegraded:
+		return awsPlatformDependencyStatusDegraded, 0.7
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusDegraded, 0.5
+	}
+	if len(diagnostics) > 0 {
+		return awsPlatformDependencyStatusDegraded, 0.8
+	}
+	return awsPlatformDependencyStatusReady, 0.92
+}
+
+// worstAWSStatus reduces multiple source statuses to the most severe one.
+func worstAWSStatus(a string, b string) string {
+	rank := func(status string) int {
+		switch status {
+		case awsPlatformDependencyStatusBlocked:
+			return 3
+		case awsPlatformDependencyStatusDegraded:
+			return 2
+		case awsPlatformDependencyStatusReady, "":
+			return 1
+		default:
+			return 2
+		}
+	}
+	if rank(a) >= rank(b) {
+		return a
+	}
+	return b
+}

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -565,12 +565,10 @@ func staticGrantsFromSecretsRecords(records []AWSSecretsManagerMetadataRecord) [
 }
 
 // secretsActionsIncludeRead reports whether a resource-policy statement's
-// actions authorize reading the secret value. It matches the exact read
-// actions, the `*` / `secretsmanager:*` wildcards, and prefix wildcards
-// such as `secretsmanager:Get*` or `secretsmanager:BatchGet*` that the
-// collector preserves verbatim — otherwise a resource policy that really
-// allows the read via a wildcard would be dropped, mislabeling observed
-// reads as observed_without_grant and hiding unused grants.
+// actions authorize reading the secret value. AWS action patterns support
+// `*` and `?` anywhere in the action token, so match the policy action
+// pattern against each concrete secret-value read API before deciding
+// whether to preserve the static grant for correlation.
 func secretsActionsIncludeRead(actions []string) bool {
 	readActions := []string{"secretsmanager:getsecretvalue", "secretsmanager:batchgetsecretvalue"}
 	for _, action := range actions {
@@ -578,25 +576,43 @@ func secretsActionsIncludeRead(actions []string) bool {
 		if trimmed == "" {
 			continue
 		}
-		if trimmed == "*" {
-			return true
-		}
-		if strings.HasSuffix(trimmed, "*") {
-			prefix := strings.TrimSuffix(trimmed, "*")
-			for _, read := range readActions {
-				if strings.HasPrefix(read, prefix) {
-					return true
-				}
-			}
-			continue
-		}
 		for _, read := range readActions {
-			if trimmed == read {
+			if awsActionPatternMatches(trimmed, read) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func awsActionPatternMatches(pattern string, value string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	value = strings.ToLower(strings.TrimSpace(value))
+	if pattern == "" || value == "" {
+		return false
+	}
+	previous := make([]bool, len(value)+1)
+	previous[0] = true
+	for _, r := range pattern {
+		current := make([]bool, len(value)+1)
+		switch r {
+		case '*':
+			current[0] = previous[0]
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i] || current[i-1]
+			}
+		case '?':
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i-1]
+			}
+		default:
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i-1] && rune(value[i-1]) == r
+			}
+		}
+		previous = current
+	}
+	return previous[len(value)]
 }
 
 func awsSecretsKMSRuntimeAccessRecords(correlations []secretsaccess.Correlation) []AWSSecretsKMSRuntimeAccessRecord {

--- a/internal/api/aws_secrets_kms_runtime_access.go
+++ b/internal/api/aws_secrets_kms_runtime_access.go
@@ -332,11 +332,11 @@ func (s *Service) awsSecretsKMSRuntimeAccessLiveInputs(ctx context.Context, work
 	remediations = append(remediations, runtime.RemediationHints...)
 
 	// Correlation needs usable observed events. For an explicitly blocked
-	// runtime source, or a degraded source with no returned records, static
-	// edges should not appear as confirmed, observed, or granted_unused.
-	// In those cases, suppress static correlation output so the response
-	// stays faithful to what runtime telemetry could actually prove.
-	if runtime.Status == awsPlatformDependencyStatusBlocked || (runtime.Status == awsPlatformDependencyStatusDegraded && len(runtime.Records) == 0) {
+	// runtime source, or a degraded source that projects to no relevant
+	// secret-read / kms-decrypt events, static edges should not appear as
+	// confirmed, observed, or granted_unused. This prevents over-calling
+	// static grants when only unrelated runtime channels are returning data.
+	if runtime.Status == awsPlatformDependencyStatusBlocked || (runtime.Status == awsPlatformDependencyStatusDegraded && len(observed) == 0) {
 		observed = nil
 		static = nil
 	}

--- a/internal/api/aws_secrets_kms_runtime_access_fixtures.go
+++ b/internal/api/aws_secrets_kms_runtime_access_fixtures.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/secretsaccess"
+)
+
+// awsSecretsKMSRuntimeAccessFixtureInputs returns deterministic observed
+// accesses and static grants for each fixture state. The default success
+// state intentionally exercises all three correlation outcomes —
+// confirmed, observed_without_grant, and granted_unused — plus a
+// cross-account unused grant, so the operator-facing surface and the
+// tests cover the full taxonomy without a live AWS account. All inputs
+// are metadata-only.
+func awsSecretsKMSRuntimeAccessFixtureInputs(accountID string, region string, fixtureState string, checkedAt time.Time) ([]secretsaccess.ObservedAccess, []secretsaccess.StaticGrant, []AWSSecretsKMSRuntimeAccessDiagnostic, []AWSSecretsKMSRuntimeAccessCoverageGap, []string, []string, string, bool) {
+	base := checkedAt.Add(-30 * time.Minute)
+	paymentsRole := fmt.Sprintf("arn:aws:iam::%s:role/payments-app", accountID)
+	invoiceRole := fmt.Sprintf("arn:aws:iam::%s:role/invoice-agent", accountID)
+	analyticsRole := fmt.Sprintf("arn:aws:iam::%s:role/analytics-export", accountID)
+	partnerRole := "arn:aws:iam::999999999999:role/partner-reader"
+
+	paymentsKey := fmt.Sprintf("arn:aws:kms:%s:%s:key/cmk-payments", region, accountID)
+	analyticsKey := fmt.Sprintf("arn:aws:kms:%s:%s:key/cmk-analytics", region, accountID)
+	stripeSecret := fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/payments/stripe", region, accountID)
+	openAISecret := fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/ai/openai-key", region, accountID)
+	partnerSecret := fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/partner/webhook", region, accountID)
+
+	observed := []secretsaccess.ObservedAccess{
+		{
+			EventID:        "evt-corr-kms-confirmed",
+			IdentityNodeID: awsIdentityNodeIDForAPI(paymentsRole),
+			PrincipalARN:   paymentsRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindKMSKey,
+			ResourceARN:    paymentsKey,
+			ResourceName:   "cmk-payments",
+			Action:         "kms:Decrypt",
+			SessionID:      "ASIA-payments-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     base.Add(4 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-corr-kms-confirmed", accountID, region),
+		},
+		{
+			EventID:        "evt-corr-secret-confirmed",
+			IdentityNodeID: awsIdentityNodeIDForAPI(paymentsRole),
+			PrincipalARN:   paymentsRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindSecret,
+			ResourceARN:    stripeSecret,
+			ResourceName:   "prod/payments/stripe",
+			Action:         "secretsmanager:GetSecretValue",
+			SessionID:      "ASIA-payments-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     base.Add(6 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-corr-secret-confirmed", accountID, region),
+		},
+		{
+			EventID:        "evt-corr-secret-no-grant",
+			IdentityNodeID: awsIdentityNodeIDForAPI(invoiceRole),
+			PrincipalARN:   invoiceRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindSecret,
+			ResourceARN:    openAISecret,
+			ResourceName:   "prod/ai/openai-key",
+			Action:         "secretsmanager:GetSecretValue",
+			SessionID:      "ASIA-invoice-sess",
+			LineageStatus:  "source_identity_missing",
+			ObservedAt:     base.Add(9 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-corr-secret-no-grant", accountID, region),
+		},
+	}
+
+	static := []secretsaccess.StaticGrant{
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(paymentsRole),
+			PrincipalARN:   paymentsRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindKMSKey,
+			ResourceARN:    paymentsKey,
+			ResourceName:   "cmk-payments",
+			Source:         secretsaccess.SourceKeyPolicy,
+			Effect:         "Allow",
+			Confidence:     0.9,
+			EvidenceRef:    paymentsKey,
+		},
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(paymentsRole),
+			PrincipalARN:   paymentsRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindSecret,
+			ResourceARN:    stripeSecret,
+			ResourceName:   "prod/payments/stripe",
+			Source:         secretsaccess.SourceResourcePolicy,
+			Effect:         "Allow",
+			Confidence:     0.88,
+			EvidenceRef:    stripeSecret,
+		},
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(analyticsRole),
+			PrincipalARN:   analyticsRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindKMSKey,
+			ResourceARN:    analyticsKey,
+			ResourceName:   "cmk-analytics",
+			Source:         secretsaccess.SourceKMSGrant,
+			Effect:         "Allow",
+			Confidence:     0.86,
+			EvidenceRef:    analyticsKey,
+		},
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(partnerRole),
+			PrincipalARN:   partnerRole,
+			AccountID:      accountID,
+			Region:         region,
+			ResourceKind:   secretsaccess.ResourceKindSecret,
+			ResourceARN:    partnerSecret,
+			ResourceName:   "prod/partner/webhook",
+			Source:         secretsaccess.SourceResourcePolicy,
+			Effect:         "Allow",
+			CrossAccount:   true,
+			Confidence:     0.82,
+			EvidenceRef:    partnerSecret,
+		},
+	}
+
+	switch fixtureState {
+	case "empty":
+		return nil, nil, nil, []AWSSecretsKMSRuntimeAccessCoverageGap{{
+			Capability:  "secrets_kms_runtime_access",
+			Status:      "empty",
+			Reason:      "No Secrets Manager / KMS runtime accesses or static reachability grants were available in the fixture window.",
+			Remediation: "Confirm CloudTrail data-event logging is enabled for Secrets Manager and KMS, then retry.",
+		}}, nil, nil, awsPlatformDependencyStatusReady, true
+	case "degraded":
+		return observed, static, []AWSSecretsKMSRuntimeAccessDiagnostic{{
+			Collector:   secretsaccess.CollectorName,
+			SourceID:    "evt-corr-secret-no-grant",
+			Code:        "runtime_event_delivery_delayed",
+			Message:     "One Secrets Manager read arrived after the expected collection window; correlation confidence is reduced.",
+			Remediation: "Keep delayed evidence visible and avoid automated remediation until delivery catches up.",
+			Retryable:   true,
+		}}, nil, []string{"runtime correlation includes delayed or low-confidence evidence"}, []string{"Review delayed CloudTrail delivery before using correlations for remediation."}, awsPlatformDependencyStatusDegraded, true
+	case "partial_failure":
+		// The static reachability side failed to load; the observed
+		// runtime accesses remain visible but cannot be confirmed
+		// against a static grant.
+		return observed, nil, []AWSSecretsKMSRuntimeAccessDiagnostic{{
+				Collector:   secretsaccess.CollectorName,
+				SourceID:    "static_reachability",
+				Code:        "static_reachability_unavailable",
+				Message:     "KMS and Secrets Manager static reachability could not be loaded; observed accesses cannot be confirmed.",
+				Remediation: "Retry the static reachability collectors and re-run the correlation without discarding observed evidence.",
+				Retryable:   true,
+			}}, []AWSSecretsKMSRuntimeAccessCoverageGap{{
+				Capability:  "static_reachability_join",
+				Status:      "partial_failure",
+				Reason:      "Static reachability edges were unavailable, so observed accesses could not be confirmed against grants.",
+				Remediation: "Retry KMS/Secrets Manager reachability collection and re-run the correlation.",
+			}}, []string{"static reachability join is incomplete; observed accesses are unconfirmed"}, []string{"Retry the static reachability collectors and re-run the correlation."}, awsPlatformDependencyStatusDegraded, true
+	case "permission_denied":
+		return nil, nil, []AWSSecretsKMSRuntimeAccessDiagnostic{{
+				Collector:   secretsaccess.CollectorName,
+				SourceID:    "cloudtrail",
+				Code:        "permission_denied",
+				Message:     "Runtime event sources are not authorized for this connector; no Secrets Manager / KMS runtime access can be correlated.",
+				Remediation: "Grant metadata-only CloudTrail access. Do not grant secret-value or decrypt reads.",
+				Retryable:   true,
+			}}, []AWSSecretsKMSRuntimeAccessCoverageGap{{
+				Capability:  "secrets_kms_runtime_access",
+				Status:      "permission_denied",
+				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only CloudTrail access and retry.",
+			}}, []string{"runtime event sources are not authorized for this connector"}, []string{"Grant metadata-only CloudTrail access; do not grant secret-value or decrypt reads."}, awsPlatformDependencyStatusBlocked, true
+	default:
+		return observed, static, nil, awsSecretsKMSRuntimeAccessBaseCoverageGaps(), nil, nil, awsPlatformDependencyStatusReady, true
+	}
+}
+
+// awsSecretsKMSRuntimeAccessBaseCoverageGaps documents what this
+// correlation intentionally does not model, so operators do not read an
+// observed_without_grant or granted_unused result as more (or less)
+// than it is.
+func awsSecretsKMSRuntimeAccessBaseCoverageGaps() []AWSSecretsKMSRuntimeAccessCoverageGap {
+	return []AWSSecretsKMSRuntimeAccessCoverageGap{
+		{
+			Capability:  "iam_identity_policy_reachability",
+			Status:      "unsupported",
+			Reason:      "Static reachability is sourced from KMS key policies / grants and Secrets Manager resource policies only. Access authorized by IAM identity policies is not enumerated, so an observed read can show as observed_without_grant.",
+			Remediation: "Treat observed_without_grant as 'needs IAM-policy confirmation', not automatically as drift.",
+		},
+		{
+			Capability:  "data_event_completeness",
+			Status:      "degraded",
+			Reason:      "Secrets Manager GetSecretValue and KMS Decrypt are CloudTrail data events. Unless a data-event trail or CloudTrail Lake is configured, observed coverage is incomplete and granted_unused may reflect missing telemetry.",
+			Remediation: "Enable CloudTrail data events for Secrets Manager and KMS to make granted_unused conclusions reliable.",
+		},
+	}
+}

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -185,6 +187,76 @@ func TestGetAWSSecretsKMSRuntimeAccessEmptyAndPartialFailure(t *testing.T) {
 	}
 	if partial.Summary.GrantedUnusedCount != 0 {
 		t.Fatalf("partial-failure has no static grants, so no granted_unused expected: %+v", partial.Summary)
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *testing.T) {
+	// secret-read / kms-decrypt are CloudTrail data events, so the live
+	// correlation must drive the delivery channels (not LookupEvents).
+	// This wires only the delivery factory and asserts the observed data
+	// event flows through it and confirms against a real static grant.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 19, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-live")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-live", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-corr-live", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	// Discover a real static KMS decrypt grant from the reachability
+	// inventory so the observed event has something to confirm against.
+	kms, err := svc.GetAWSKMSDecryptReachabilityInventory(ctx, "default", "project-corr-live", AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("kms inventory: %v", err)
+	}
+	var keyARN, principal string
+	for _, record := range kms.Records {
+		for _, grant := range record.IdentityGrants {
+			if strings.EqualFold(grant.Effect, "Allow") && isIAMPrincipalARNForKMSEdge(grant.PrincipalARN) && kmsCapabilitiesIncludeDecrypt(grant.Capabilities) {
+				keyARN = record.KeyARN
+				principal = grant.PrincipalARN
+				break
+			}
+		}
+		if keyARN != "" {
+			break
+		}
+	}
+	if keyARN == "" || principal == "" {
+		t.Fatalf("expected a static KMS decrypt grant in the inventory to confirm against")
+	}
+
+	deliveryRecord := liveRuntimeRecord(t, "evt-kms-corr", "kms-decrypt", "Decrypt", "kms.amazonaws.com", "kms:Decrypt", "platform", "s3-delivery", principal, keyARN, "AWS::KMS::Key", now.Add(-2*time.Minute))
+	fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{
+		Status:  "ready",
+		Records: []AWSRuntimeEventRecord{deliveryRecord},
+	}}
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return fake, nil
+	}
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-live", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if fake.calls == 0 {
+		t.Fatalf("delivery factory was never used — data events were not routed through the delivery channel")
+	}
+	var confirmed *AWSSecretsKMSRuntimeAccessRecord
+	for i := range result.Records {
+		record := &result.Records[i]
+		if record.ResourceARN == keyARN && record.Status == secretsaccess.StatusConfirmed {
+			confirmed = record
+			break
+		}
+	}
+	if confirmed == nil {
+		t.Fatalf("expected a confirmed correlation for the observed decrypt on %s, got %+v", keyARN, result.Records)
+	}
+	if confirmed.ObservedCount == 0 || len(confirmed.StaticSources) == 0 {
+		t.Fatalf("confirmed correlation must carry both observed and static evidence: %+v", confirmed)
 	}
 }
 

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -34,7 +34,7 @@ func TestGetAWSSecretsKMSRuntimeAccessBuildsCorrelationContract(t *testing.T) {
 	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
 	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr", now)
 
-	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success"})
 	if err != nil {
 		t.Fatalf("get correlation: %v", err)
 	}
@@ -81,8 +81,9 @@ func TestGetAWSSecretsKMSRuntimeAccessConfirmedCarriesObservedAndStatic(t *testi
 	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr-confirmed", now)
 
 	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-confirmed", AWSSecretsKMSRuntimeAccessRequest{
-		ConnectorID: "aws-prod",
-		Status:      "confirmed",
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Status:       "confirmed",
 	})
 	if err != nil {
 		t.Fatalf("get correlation: %v", err)
@@ -112,6 +113,7 @@ func TestGetAWSSecretsKMSRuntimeAccessFiltersByResourceKindAndIdentity(t *testin
 
 	secretsOnly, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-filter", AWSSecretsKMSRuntimeAccessRequest{
 		ConnectorID:  "aws-prod",
+		FixtureState: "success",
 		ResourceKind: "secret",
 	})
 	if err != nil {
@@ -127,8 +129,9 @@ func TestGetAWSSecretsKMSRuntimeAccessFiltersByResourceKindAndIdentity(t *testin
 	}
 
 	invoiceOnly, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-filter", AWSSecretsKMSRuntimeAccessRequest{
-		ConnectorID: "aws-prod",
-		Identity:    "invoice-agent",
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     "invoice-agent",
 	})
 	if err != nil {
 		t.Fatalf("get correlation: %v", err)
@@ -298,6 +301,34 @@ func TestGetAWSSecretsKMSRuntimeAccessDefaultLiveRequiresDeliveryFactory(t *test
 				t.Fatalf("lookup-only live event leaked into default delivery-backed correlation: %+v", record)
 			}
 		}
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessSuppressesFixturesWhenLiveDeliveryUnavailable(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 19, 20, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-live-unavailable")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-live-unavailable", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-live-unavailable", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded status when live delivery is unavailable, got %q", result.Status)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no fixture records for a real connector without live delivery, got %+v", result.Records)
+	}
+	if result.FixtureState != "" {
+		t.Fatalf("expected no fixture state when live fixtures are suppressed, got %q", result.FixtureState)
+	}
+	if len(result.Diagnostics) == 0 || result.Diagnostics[0].Code != "runtime_delivery_unavailable" {
+		t.Fatalf("expected runtime delivery diagnostic, got %+v", result.Diagnostics)
 	}
 }
 

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -405,6 +405,33 @@ func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
 	}
 }
 
+func TestStaticGrantsFromSecretsPreservesActions(t *testing.T) {
+	records := []AWSSecretsManagerMetadataRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:111122223333:secret:s1",
+		SecretName: "s1",
+		Confidence: 0.92,
+		IdentityGrants: []AWSSecretsManagerIdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/reader", Effect: "Allow", Actions: []string{"secretsmanager:GetSecretValue", "secretsmanager:BatchGetSecretValue"}},
+		},
+	}}
+	grants := staticGrantsFromSecretsRecords(records)
+	if len(grants) != 1 {
+		t.Fatalf("expected one readable secret grant, got %+v", grants)
+	}
+	got := map[string]struct{}{}
+	for _, action := range grants[0].Actions {
+		got[action] = struct{}{}
+	}
+	if _, ok := got["secretsmanager:GetSecretValue"]; !ok {
+		t.Fatalf("expected GetSecretValue action to be preserved, got %+v", grants[0].Actions)
+	}
+	if _, ok := got["secretsmanager:BatchGetSecretValue"]; !ok {
+		t.Fatalf("expected BatchGetSecretValue action to be preserved, got %+v", grants[0].Actions)
+	}
+}
+
 func TestObservedAccessFromRuntimeRecordsFiltersEventTypes(t *testing.T) {
 	records := []AWSRuntimeEventRecord{
 		{EventID: "a", EventType: "secret-read", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:secret", Action: "secretsmanager:GetSecretValue"},
@@ -457,6 +484,9 @@ func TestStaticGrantsFromKMSAndSecretsProjectIAMPrincipalsOnly(t *testing.T) {
 	secretGrants := staticGrantsFromSecretsRecords(secretRecords)
 	if len(secretGrants) != 1 || secretGrants[0].PrincipalARN != "arn:aws:iam::111122223333:role/reader" {
 		t.Fatalf("expected single read grant, got %+v", secretGrants)
+	}
+	if len(secretGrants[0].Actions) != 1 || secretGrants[0].Actions[0] != "secretsmanager:GetSecretValue" {
+		t.Fatalf("expected normalized read action to be preserved, got %+v", secretGrants[0].Actions)
 	}
 	if secretGrants[0].Source != secretsaccess.SourceResourcePolicy {
 		t.Fatalf("unexpected secret grant source: %+v", secretGrants[0])

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -194,7 +194,8 @@ func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *tes
 	// secret-read / kms-decrypt are CloudTrail data events, so the live
 	// correlation must drive the delivery channels (not LookupEvents).
 	// This wires only the delivery factory and asserts the observed data
-	// event flows through it and confirms against a real static grant.
+	// event flows through it while static grants are intentionally suppressed
+	// in live mode to prevent fixture-collection bleed-through.
 	store := db.NewMemoryStore()
 	ctx := defaultScopeContext()
 	now := time.Date(2026, 6, 19, 19, 0, 0, 0, time.UTC)
@@ -205,8 +206,8 @@ func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *tes
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	// Discover a real static KMS decrypt grant from the reachability
-	// inventory so the observed event has something to confirm against.
+	// Discover fixtures from the static reachability inventory so we can still
+	// anchor to a realistic resource identifier.
 	kms, err := svc.GetAWSKMSDecryptReachabilityInventory(ctx, "default", "project-corr-live", AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: "aws-prod"})
 	if err != nil {
 		t.Fatalf("kms inventory: %v", err)
@@ -244,19 +245,19 @@ func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *tes
 	if fake.calls == 0 {
 		t.Fatalf("delivery factory was never used — data events were not routed through the delivery channel")
 	}
-	var confirmed *AWSSecretsKMSRuntimeAccessRecord
+	var observedWithoutGrant *AWSSecretsKMSRuntimeAccessRecord
 	for i := range result.Records {
 		record := &result.Records[i]
-		if record.ResourceARN == keyARN && record.Status == secretsaccess.StatusConfirmed {
-			confirmed = record
+		if record.ResourceARN == keyARN && record.Status == secretsaccess.StatusObservedWithoutGrant {
+			observedWithoutGrant = record
 			break
 		}
 	}
-	if confirmed == nil {
-		t.Fatalf("expected a confirmed correlation for the observed decrypt on %s, got %+v", keyARN, result.Records)
+	if observedWithoutGrant == nil {
+		t.Fatalf("expected an observed_without_grant correlation for the observed decrypt on %s, got %+v", keyARN, result.Records)
 	}
-	if confirmed.ObservedCount == 0 || len(confirmed.StaticSources) == 0 {
-		t.Fatalf("confirmed correlation must carry both observed and static evidence: %+v", confirmed)
+	if observedWithoutGrant.ObservedCount == 0 || len(observedWithoutGrant.StaticSources) != 0 {
+		t.Fatalf("observed-only correlation must carry observed evidence but no synthetic static grants: %+v", observedWithoutGrant)
 	}
 }
 

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -332,6 +332,53 @@ func TestGetAWSSecretsKMSRuntimeAccessDegradedRuntimeWithoutRecordsSuppressesUnu
 	}
 }
 
+func TestGetAWSSecretsKMSRuntimeAccessDegradedRuntimeWithoutUsableEventsSuppressesUnusedGrants(t *testing.T) {
+	// A degraded delivery source can still return non-KMS/secret records (for
+	// example STS/API chatter). If none of those are projectable into our
+	// correlation window, static grants should not be treated as used/unused.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 20, 0, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-degraded-unusable")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-degraded-unusable", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-corr-degraded-unusable", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{
+			Status: "degraded",
+			Records: []AWSRuntimeEventRecord{
+				{
+					EventType:           "api-call",
+					EventID:             "evt-noise",
+					EventName:           "AssumeRole",
+					ActorIdentityNodeID: "role-noise",
+					AccountID:           "111122223333",
+					Region:              "us-east-1",
+					ObservedAt:          now.Add(-1 * time.Minute),
+					TargetResourceARN:   "",
+					TargetResourceName:  "",
+				},
+			},
+		}}, nil
+	}
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-degraded-unusable", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded status, got %q", result.Status)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no records when no usable secret/kms runtime events exist, got %+v", result.Records)
+	}
+	if result.Summary.GrantedUnusedCount != 0 {
+		t.Fatalf("degraded unusable-event path must suppress static grants, got %+v", result.Summary)
+	}
+}
+
 func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
 	records := []AWSSecretsManagerMetadataRecord{{
 		AccountID:  "111122223333",

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -461,6 +461,9 @@ func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
 		IdentityGrants: []AWSSecretsManagerIdentityGrant{
 			{PrincipalARN: "arn:aws:iam::111122223333:role/get-star", Effect: "Allow", Actions: []string{"secretsmanager:Get*"}},
 			{PrincipalARN: "arn:aws:iam::111122223333:role/batch-star", Effect: "Allow", Actions: []string{"secretsmanager:BatchGet*"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/suffix-star", Effect: "Allow", Actions: []string{"secretsmanager:*SecretValue"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/question", Effect: "Allow", Actions: []string{"secretsmanager:GetSecretValu?"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/service-star", Effect: "Allow", Actions: []string{"*:GetSecretValue"}},
 			{PrincipalARN: "arn:aws:iam::111122223333:role/describe-star", Effect: "Allow", Actions: []string{"secretsmanager:Describe*"}},
 		},
 	}}
@@ -469,8 +472,16 @@ func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
 	for _, grant := range grants {
 		got[grant.PrincipalARN] = true
 	}
-	if !got["arn:aws:iam::111122223333:role/get-star"] || !got["arn:aws:iam::111122223333:role/batch-star"] {
-		t.Fatalf("expected Get*/BatchGet* wildcard read grants to be recognized, got %+v", grants)
+	for _, principal := range []string{
+		"arn:aws:iam::111122223333:role/get-star",
+		"arn:aws:iam::111122223333:role/batch-star",
+		"arn:aws:iam::111122223333:role/suffix-star",
+		"arn:aws:iam::111122223333:role/question",
+		"arn:aws:iam::111122223333:role/service-star",
+	} {
+		if !got[principal] {
+			t.Fatalf("expected AWS wildcard read grant %s to be recognized, got %+v", principal, grants)
+		}
 	}
 	if got["arn:aws:iam::111122223333:role/describe-star"] {
 		t.Fatalf("Describe* does not authorize secret-value reads and must be dropped: %+v", grants)

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -260,6 +260,69 @@ func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *tes
 	}
 }
 
+func TestGetAWSSecretsKMSRuntimeAccessBlockedRuntimeSuppressesUnusedGrants(t *testing.T) {
+	// When the runtime (observed) source is blocked, static grants must
+	// not be emitted as granted_unused — that would surface missing
+	// telemetry as least-privilege cleanup work.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 19, 30, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-blocked")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-blocked", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-corr-blocked", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	// Delivery returns a blocked (permission-denied) runtime result with
+	// no records, while the static KMS/Secrets inventories still resolve.
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{
+			Status:         "blocked",
+			FailureReasons: []string{"runtime event sources are not authorized for this connector"},
+		}}, nil
+	}
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-blocked", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected blocked status when runtime telemetry is blocked, got %q", result.Status)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no records (no granted_unused) under a blocked runtime, got %+v", result.Records)
+	}
+	if result.Summary.GrantedUnusedCount != 0 {
+		t.Fatalf("blocked runtime must not surface granted_unused grants, got %+v", result.Summary)
+	}
+}
+
+func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
+	records := []AWSSecretsManagerMetadataRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:111122223333:secret:s1",
+		SecretName: "s1",
+		Confidence: 0.88,
+		IdentityGrants: []AWSSecretsManagerIdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/get-star", Effect: "Allow", Actions: []string{"secretsmanager:Get*"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/batch-star", Effect: "Allow", Actions: []string{"secretsmanager:BatchGet*"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/describe-star", Effect: "Allow", Actions: []string{"secretsmanager:Describe*"}},
+		},
+	}}
+	grants := staticGrantsFromSecretsRecords(records)
+	got := map[string]bool{}
+	for _, grant := range grants {
+		got[grant.PrincipalARN] = true
+	}
+	if !got["arn:aws:iam::111122223333:role/get-star"] || !got["arn:aws:iam::111122223333:role/batch-star"] {
+		t.Fatalf("expected Get*/BatchGet* wildcard read grants to be recognized, got %+v", grants)
+	}
+	if got["arn:aws:iam::111122223333:role/describe-star"] {
+		t.Fatalf("Describe* does not authorize secret-value reads and must be dropped: %+v", grants)
+	}
+}
+
 func TestObservedAccessFromRuntimeRecordsFiltersEventTypes(t *testing.T) {
 	records := []AWSRuntimeEventRecord{
 		{EventID: "a", EventType: "secret-read", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:secret", Action: "secretsmanager:GetSecretValue"},

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -261,6 +261,46 @@ func TestGetAWSSecretsKMSRuntimeAccessLiveRoutesDataEventsThroughDelivery(t *tes
 	}
 }
 
+func TestGetAWSSecretsKMSRuntimeAccessDefaultLiveRequiresDeliveryFactory(t *testing.T) {
+	// The default correlation source is `all`, which is delivery-backed because
+	// secret-read and kms-decrypt are CloudTrail data events. A LookupEvents-only
+	// deployment must not enter live mode and then receive delivery fixtures.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 19, 15, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-lookup-only")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-lookup-only", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-corr-lookup-only", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	lookupCalled := false
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		lookupCalled = true
+		return &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+			Status: "ready",
+			Records: []AWSRuntimeEventRecord{
+				liveRuntimeRecord(t, "evt-lookup-secret", "secret-read", "GetSecretValue", "secretsmanager.amazonaws.com", "secretsmanager:GetSecretValue", "application", "lookup-events", "arn:aws:iam::123456789012:role/payments-app", "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/openai-key", "AWS::SecretsManager::Secret", now.Add(-2*time.Minute)),
+			},
+		}}, nil
+	}
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-lookup-only", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if lookupCalled {
+		t.Fatalf("default data-event correlation should require delivery factory, but LookupEvents was called")
+	}
+	for _, record := range result.Records {
+		for _, eventID := range record.ObservedEventIDs {
+			if eventID == "evt-lookup-secret" {
+				t.Fatalf("lookup-only live event leaked into default delivery-backed correlation: %+v", record)
+			}
+		}
+	}
+}
+
 func TestGetAWSSecretsKMSRuntimeAccessBlockedRuntimeSuppressesUnusedGrants(t *testing.T) {
 	// When the runtime (observed) source is blocked, static grants must
 	// not be emitted as granted_unused — that would surface missing
@@ -433,6 +473,38 @@ func TestStaticGrantsFromSecretsPreservesActions(t *testing.T) {
 	}
 }
 
+func TestStaticGrantsFromSecretsPreservesExplicitWildcardDeny(t *testing.T) {
+	records := []AWSSecretsManagerMetadataRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:111122223333:secret:s1",
+		SecretName: "s1",
+		Confidence: 0.92,
+		IdentityGrants: []AWSSecretsManagerIdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/reader", Effect: "Allow", Actions: []string{"secretsmanager:GetSecretValue"}},
+			{PrincipalARN: "*", WildcardPrincipal: true, Effect: "Deny", Actions: []string{"secretsmanager:GetSecretValue"}},
+			{PrincipalARN: "*", WildcardPrincipal: true, Effect: "Allow", Actions: []string{"secretsmanager:GetSecretValue"}},
+		},
+	}}
+
+	grants := staticGrantsFromSecretsRecords(records)
+	if len(grants) != 2 {
+		t.Fatalf("expected concrete allow plus wildcard deny grants, got %+v", grants)
+	}
+	hasWildcardDeny := false
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") && grant.PrincipalARN == "*" && grant.IdentityNodeID == "" {
+			hasWildcardDeny = true
+		}
+		if strings.EqualFold(grant.Effect, "Allow") && grant.PrincipalARN == "*" {
+			t.Fatalf("wildcard allow grant should not be preserved for secret resource policies: %+v", grant)
+		}
+	}
+	if !hasWildcardDeny {
+		t.Fatalf("expected wildcard deny to be preserved: %+v", grants)
+	}
+}
+
 func TestObservedAccessFromRuntimeRecordsFiltersEventTypes(t *testing.T) {
 	records := []AWSRuntimeEventRecord{
 		{EventID: "a", EventType: "secret-read", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:secret", Action: "secretsmanager:GetSecretValue"},
@@ -491,5 +563,60 @@ func TestStaticGrantsFromKMSAndSecretsProjectIAMPrincipalsOnly(t *testing.T) {
 	}
 	if secretGrants[0].Source != secretsaccess.SourceResourcePolicy {
 		t.Fatalf("unexpected secret grant source: %+v", secretGrants[0])
+	}
+}
+
+func TestStaticGrantsFromKMSPreservesExplicitWildcardDeny(t *testing.T) {
+	kmsRecords := []AWSKMSDecryptReachabilityRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		KeyARN:     "arn:aws:kms:us-east-1:111122223333:key/k1",
+		KeyID:      "k1",
+		Confidence: 0.9,
+		IdentityGrants: []AWSKMSIdentityGrant{
+			{
+				PrincipalARN:      "arn:aws:iam::111122223333:role/app",
+				Effect:            "Allow",
+				Capabilities:      []string{"decrypt"},
+				Actions:           []string{"kms:Decrypt"},
+				WildcardPrincipal: false,
+			},
+			{
+				PrincipalARN:      "*",
+				Effect:            "Deny",
+				Capabilities:      []string{"decrypt"},
+				Actions:           []string{"kms:Decrypt"},
+				WildcardPrincipal: true,
+			},
+			{
+				PrincipalARN:      "*",
+				Effect:            "Allow",
+				Capabilities:      []string{"decrypt"},
+				Actions:           []string{"kms:Decrypt"},
+				WildcardPrincipal: true,
+			},
+		},
+	}}
+
+	grants := staticGrantsFromKMSRecords(kmsRecords)
+	if len(grants) != 2 {
+		t.Fatalf("expected concrete allow plus wildcard deny grants, got %+v", grants)
+	}
+
+	hasWildcardDeny := false
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") && grant.PrincipalARN == "*" {
+			hasWildcardDeny = true
+		}
+		if strings.EqualFold(grant.Effect, "Allow") && strings.Contains(grant.PrincipalARN, "role/app") {
+			// existing behavior: concrete identity allow is still preserved.
+			continue
+		}
+		if strings.EqualFold(grant.Effect, "Allow") && grant.PrincipalARN == "*" {
+			t.Fatalf("wildcard allow grant should not be preserved for KMS identity grants: %+v", grant)
+		}
+	}
+	if !hasWildcardDeny {
+		t.Fatalf("expected wildcard deny to be preserved: %+v", grants)
 	}
 }

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/runtime/secretsaccess"
+)
+
+func newSecretsKMSRuntimeAccessService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, project)
+	seedAWSConnectorForScanTest(t, store, ctx, project, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	return svc, "default"
+}
+
+func recordsByStatus(records []AWSSecretsKMSRuntimeAccessRecord) map[string]int {
+	counts := map[string]int{}
+	for _, record := range records {
+		counts[record.Status]++
+	}
+	return counts
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessBuildsCorrelationContract(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr", now)
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1518" || result.Version != awsSecretsKMSRuntimeAccessVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	counts := recordsByStatus(result.Records)
+	if counts[secretsaccess.StatusConfirmed] != 2 || counts[secretsaccess.StatusObservedWithoutGrant] != 1 || counts[secretsaccess.StatusGrantedUnused] != 2 {
+		t.Fatalf("unexpected status distribution: %+v (records=%+v)", counts, result.Records)
+	}
+	if result.Summary.ConfirmedCount != 2 || result.Summary.GrantedUnusedCount != 2 || result.Summary.ObservedWithoutGrantCount != 1 {
+		t.Fatalf("unexpected summary: %+v", result.Summary)
+	}
+	if result.Summary.SecretCorrelationCount == 0 || result.Summary.KMSKeyCorrelationCount == 0 {
+		t.Fatalf("expected both secret and kms correlations: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected relationships: %+v", result.Relationships)
+	}
+	if len(result.Caveats) == 0 {
+		t.Fatalf("expected correlation caveats (data-event + IAM-policy)")
+	}
+	for _, record := range result.Records {
+		if record.RedactionBoundary != secretsaccess.RedactionBoundary {
+			t.Fatalf("record leaked unsafe redaction boundary: %+v", record)
+		}
+		if record.EvidenceRef == "" || record.IdentityNodeID == "" || record.ResourceNodeID == "" || record.Confidence <= 0 {
+			t.Fatalf("record missing required fields: %+v", record)
+		}
+		if record.NextAction == "" {
+			t.Fatalf("record missing next action: %+v", record)
+		}
+	}
+	if len(result.EvidenceLinks) == 0 || len(result.FailureReasons) != 0 {
+		t.Fatalf("expected evidence links and no failures: links=%v failures=%v", result.EvidenceLinks, result.FailureReasons)
+	}
+	if len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected base coverage gaps documenting IAM-policy / data-event limits")
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessConfirmedCarriesObservedAndStatic(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr-confirmed", now)
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-confirmed", AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID: "aws-prod",
+		Status:      "confirmed",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(result.Records) != 2 {
+		t.Fatalf("expected 2 confirmed records, got %d", len(result.Records))
+	}
+	for _, record := range result.Records {
+		if record.Status != secretsaccess.StatusConfirmed {
+			t.Fatalf("status filter leaked non-confirmed record: %+v", record)
+		}
+		if record.ObservedCount == 0 || len(record.StaticSources) == 0 {
+			t.Fatalf("confirmed record must carry observed + static evidence: %+v", record)
+		}
+		if record.Confidence < 0.9 {
+			t.Fatalf("confirmed confidence too low: %+v", record)
+		}
+	}
+	if result.AppliedFilters["status"] != "confirmed" {
+		t.Fatalf("expected applied status filter, got %+v", result.AppliedFilters)
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessFiltersByResourceKindAndIdentity(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr-filter", now)
+
+	secretsOnly, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-filter", AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID:  "aws-prod",
+		ResourceKind: "secret",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(secretsOnly.Records) != 3 {
+		t.Fatalf("expected 3 secret correlations, got %d", len(secretsOnly.Records))
+	}
+	for _, record := range secretsOnly.Records {
+		if record.ResourceKind != secretsaccess.ResourceKindSecret {
+			t.Fatalf("resource_kind filter leaked: %+v", record)
+		}
+	}
+
+	invoiceOnly, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-filter", AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID: "aws-prod",
+		Identity:    "invoice-agent",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(invoiceOnly.Records) != 1 || invoiceOnly.Records[0].Status != secretsaccess.StatusObservedWithoutGrant {
+		t.Fatalf("expected single observed_without_grant for invoice-agent, got %+v", invoiceOnly.Records)
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr-denied", now)
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-denied", AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" || result.Confidence != 0 {
+		t.Fatalf("expected blocked permission-denied state, got status=%q confidence=%v", result.Status, result.Confidence)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no records when blocked, got %d", len(result.Records))
+	}
+	if len(result.Diagnostics) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected diagnostics and coverage gaps explaining the blocked state")
+	}
+}
+
+func TestGetAWSSecretsKMSRuntimeAccessEmptyAndPartialFailure(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newSecretsKMSRuntimeAccessService(t, "project-corr-states", now)
+
+	empty, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-states", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Records) != 0 || len(empty.CoverageGaps) == 0 {
+		t.Fatalf("unexpected empty state: %+v", empty)
+	}
+
+	partial, err := svc.GetAWSSecretsKMSRuntimeAccess(defaultScopeContext(), ws, "project-corr-states", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if partial.Status != "degraded" {
+		t.Fatalf("expected degraded partial-failure, got %q", partial.Status)
+	}
+	// Static side failed → only observed accesses remain, all unconfirmed.
+	for _, record := range partial.Records {
+		if record.Status == secretsaccess.StatusConfirmed {
+			t.Fatalf("partial-failure must not produce confirmed correlations: %+v", record)
+		}
+	}
+	if partial.Summary.GrantedUnusedCount != 0 {
+		t.Fatalf("partial-failure has no static grants, so no granted_unused expected: %+v", partial.Summary)
+	}
+}
+
+func TestObservedAccessFromRuntimeRecordsFiltersEventTypes(t *testing.T) {
+	records := []AWSRuntimeEventRecord{
+		{EventID: "a", EventType: "secret-read", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:secret", Action: "secretsmanager:GetSecretValue"},
+		{EventID: "b", EventType: "kms-decrypt", ActorIdentityNodeID: "id-2", TargetResourceARN: "arn:key", Action: "kms:Decrypt"},
+		{EventID: "c", EventType: "sts-session", ActorIdentityNodeID: "id-3"},
+		{EventID: "d", EventType: "agent-tool", ActorIdentityNodeID: "id-4"},
+		{EventID: "e", EventType: "api-call", ActorIdentityNodeID: "id-5"},
+	}
+	observed := observedAccessFromRuntimeRecords(records)
+	if len(observed) != 2 {
+		t.Fatalf("expected only secret-read + kms-decrypt, got %d (%+v)", len(observed), observed)
+	}
+	if observed[0].ResourceKind != secretsaccess.ResourceKindSecret || observed[1].ResourceKind != secretsaccess.ResourceKindKMSKey {
+		t.Fatalf("unexpected resource kinds: %+v", observed)
+	}
+}
+
+func TestStaticGrantsFromKMSAndSecretsProjectIAMPrincipalsOnly(t *testing.T) {
+	kmsRecords := []AWSKMSDecryptReachabilityRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		KeyARN:     "arn:aws:kms:us-east-1:111122223333:key/k1",
+		KeyID:      "k1",
+		Confidence: 0.9,
+		IdentityGrants: []AWSKMSIdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/app", Effect: "Allow", Capabilities: []string{"decrypt"}},
+			{PrincipalARN: "*", WildcardPrincipal: true, Effect: "Allow", Capabilities: []string{"decrypt"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/encrypt-only", Effect: "Allow", Capabilities: []string{"encrypt"}},
+		},
+	}}
+	kmsGrants := staticGrantsFromKMSRecords(kmsRecords)
+	if len(kmsGrants) != 1 || kmsGrants[0].PrincipalARN != "arn:aws:iam::111122223333:role/app" {
+		t.Fatalf("expected single IAM decrypt grant, got %+v", kmsGrants)
+	}
+	if kmsGrants[0].ResourceKind != secretsaccess.ResourceKindKMSKey || kmsGrants[0].Source != secretsaccess.SourceKeyPolicy {
+		t.Fatalf("unexpected kms grant projection: %+v", kmsGrants[0])
+	}
+
+	secretRecords := []AWSSecretsManagerMetadataRecord{{
+		AccountID:  "111122223333",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:111122223333:secret:s1",
+		SecretName: "s1",
+		Confidence: 0.88,
+		IdentityGrants: []AWSSecretsManagerIdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/reader", Effect: "Allow", Actions: []string{"secretsmanager:GetSecretValue"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/describe-only", Effect: "Allow", Actions: []string{"secretsmanager:DescribeSecret"}},
+		},
+	}}
+	secretGrants := staticGrantsFromSecretsRecords(secretRecords)
+	if len(secretGrants) != 1 || secretGrants[0].PrincipalARN != "arn:aws:iam::111122223333:role/reader" {
+		t.Fatalf("expected single read grant, got %+v", secretGrants)
+	}
+	if secretGrants[0].Source != secretsaccess.SourceResourcePolicy {
+		t.Fatalf("unexpected secret grant source: %+v", secretGrants[0])
+	}
+}

--- a/internal/api/aws_secrets_kms_runtime_access_test.go
+++ b/internal/api/aws_secrets_kms_runtime_access_test.go
@@ -297,6 +297,41 @@ func TestGetAWSSecretsKMSRuntimeAccessBlockedRuntimeSuppressesUnusedGrants(t *te
 	}
 }
 
+func TestGetAWSSecretsKMSRuntimeAccessDegradedRuntimeWithoutRecordsSuppressesUnusedGrants(t *testing.T) {
+	// A delivery-source failure can return degraded with no runtime records
+	// (for example when no data-event channel is configured). In that path,
+	// static grants cannot be safely interpreted as unused.
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 19, 19, 45, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-corr-degraded-empty")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-corr-degraded-empty", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-corr-degraded-empty", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{
+			Status:         "degraded",
+			FailureReasons: []string{"S3 and EventBridge delivery are unavailable"},
+		}}, nil
+	}
+
+	result, err := svc.GetAWSSecretsKMSRuntimeAccess(ctx, "default", "project-corr-degraded-empty", AWSSecretsKMSRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded status when delivery is unavailable, got %q", result.Status)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no records when runtime had no records and should suppress static grants, got %+v", result.Records)
+	}
+	if result.Summary.GrantedUnusedCount != 0 || result.Summary.ConfirmedCount != 0 || result.Summary.ObservedWithoutGrantCount != 0 {
+		t.Fatalf("expected no correlation output when runtime telemetry is unavailable, got %+v", result.Summary)
+	}
+}
+
 func TestStaticGrantsFromSecretsRecognizesWildcardReadActions(t *testing.T) {
 	records := []AWSSecretsManagerMetadataRecord{{
 		AccountID:  "111122223333",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2907,6 +2907,41 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"runtime": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSecretsKMSRuntimeAccess(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSecretsKMSRuntimeAccessRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			AgentID:      strings.TrimSpace(c.Query("agent_id")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			ResourceKind: strings.TrimSpace(c.Query("resource_kind")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws secrets/kms runtime access request"})
+			default:
+				logger.Error("get aws secrets kms runtime access",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws secrets/kms runtime access"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"correlation": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2913,15 +2913,16 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			return
 		}
 		record, err := svc.GetAWSSecretsKMSRuntimeAccess(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSecretsKMSRuntimeAccessRequest{
-			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
-			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
-			AccountID:    strings.TrimSpace(c.Query("account_id")),
-			Region:       strings.TrimSpace(c.Query("region")),
-			Identity:     strings.TrimSpace(c.Query("identity")),
-			AgentID:      strings.TrimSpace(c.Query("agent_id")),
-			Resource:     strings.TrimSpace(c.Query("resource")),
-			ResourceKind: strings.TrimSpace(c.Query("resource_kind")),
-			Status:       strings.TrimSpace(c.Query("status")),
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			Identity:       strings.TrimSpace(c.Query("identity")),
+			AgentID:        strings.TrimSpace(c.Query("agent_id")),
+			Resource:       strings.TrimSpace(c.Query("resource")),
+			ResourceKind:   strings.TrimSpace(c.Query("resource_kind")),
+			Status:         strings.TrimSpace(c.Query("status")),
+			DeliverySource: strings.TrimSpace(c.Query("delivery_source")),
 		})
 		if err != nil {
 			switch {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -357,7 +357,7 @@ func Correlate(request CorrelateRequest) Result {
 		if len(agg.observed) == 0 && len(agg.allow) == 0 {
 			continue
 		}
-		if len(agg.observed) == 0 && len(agg.deny) > 0 {
+		if len(agg.observed) == 0 && len(agg.deny) > 0 && !staticOnlyAllowHasUndeniedAction(agg) {
 			continue
 		}
 		correlation := buildCorrelation(agg, request.DataEventCoverageUnknown)
@@ -646,6 +646,74 @@ func observedResourceActionDenyAppliesToObserved(agg *correlationAgg) bool {
 	return false
 }
 
+func staticOnlyAllowHasUndeniedAction(agg *correlationAgg) bool {
+	if len(agg.allow) == 0 {
+		return false
+	}
+	if len(agg.deny) == 0 {
+		return true
+	}
+	if !resourceKindRequiresActionMatching(strings.TrimSpace(agg.resourceKind)) {
+		return false
+	}
+	for _, allow := range agg.allow {
+		if len(allow.Actions) == 0 {
+			if !staticGrantHasUnconditionalDeny(agg.deny) {
+				return true
+			}
+			continue
+		}
+		for _, allowedAction := range allow.Actions {
+			if !staticAllowedActionCoveredByDeny(allowedAction, agg.deny) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func staticGrantHasUnconditionalDeny(denies []StaticGrant) bool {
+	for _, deny := range denies {
+		if len(deny.Actions) == 0 {
+			return true
+		}
+		for _, deniedAction := range deny.Actions {
+			if strings.TrimSpace(deniedAction) == "*" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func staticAllowedActionCoveredByDeny(allowedAction string, denies []StaticGrant) bool {
+	allowed := strings.ToLower(strings.TrimSpace(allowedAction))
+	if allowed == "" {
+		return true
+	}
+	for _, deny := range denies {
+		if len(deny.Actions) == 0 {
+			return true
+		}
+		for _, deniedAction := range deny.Actions {
+			denied := strings.ToLower(strings.TrimSpace(deniedAction))
+			if denied == "" {
+				continue
+			}
+			if denied == "*" || denied == allowed {
+				return true
+			}
+			if !strings.ContainsAny(allowed, "*?") && staticGrantActionAuthorizesObservedAction(allowed, denied) {
+				return true
+			}
+			if strings.ContainsAny(allowed, "*?") && denied == allowed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func resourceKindRequiresActionMatching(resourceKind string) bool {
 	return strings.EqualFold(strings.TrimSpace(resourceKind), ResourceKindKMSKey) ||
 		strings.EqualFold(strings.TrimSpace(resourceKind), ResourceKindSecret)
@@ -660,9 +728,8 @@ func staticGrantActionAuthorizesObservedAction(observedAction string, allowedAct
 	if allowed == "*" {
 		return true
 	}
-	if strings.HasSuffix(allowed, "*") {
-		prefix := strings.TrimSuffix(allowed, "*")
-		return strings.HasPrefix(observed, prefix)
+	if strings.ContainsAny(allowed, "*?") {
+		return actionPatternMatches(allowed, observed)
 	}
 	if observed == allowed {
 		return true
@@ -677,6 +744,36 @@ func staticGrantActionAuthorizesObservedAction(observedAction string, allowedAct
 		allowedVerb = suffix
 	}
 	return strings.EqualFold(observedVerb, allowedVerb)
+}
+
+func actionPatternMatches(pattern string, value string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	value = strings.ToLower(strings.TrimSpace(value))
+	if pattern == "" || value == "" {
+		return false
+	}
+	previous := make([]bool, len(value)+1)
+	previous[0] = true
+	for _, r := range pattern {
+		current := make([]bool, len(value)+1)
+		switch r {
+		case '*':
+			current[0] = previous[0]
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i] || current[i-1]
+			}
+		case '?':
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i-1]
+			}
+		default:
+			for i := 1; i <= len(value); i++ {
+				current[i] = previous[i-1] && rune(value[i-1]) == r
+			}
+		}
+		previous = current
+	}
+	return previous[len(value)]
 }
 
 func correlationID(agg *correlationAgg) string {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -357,6 +357,9 @@ func Correlate(request CorrelateRequest) Result {
 		if len(agg.observed) == 0 && len(agg.allow) == 0 {
 			continue
 		}
+		if len(agg.observed) == 0 && len(agg.deny) > 0 {
+			continue
+		}
 		correlation := buildCorrelation(agg, request.DataEventCoverageUnknown)
 		result.Correlations = append(result.Correlations, correlation)
 		switch correlation.Status {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -432,6 +432,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	sources := map[string]struct{}{}
 	hasAllow := len(agg.allow) > 0
+	hasMatchingDeny := observedKMSDenyActionAppliesToObserved(agg)
 	conditional := false
 	crossAccount := false
 	staticConfidence := 0.0
@@ -452,7 +453,6 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 			evidence[ref] = struct{}{}
 		}
 	}
-	hasDeny := len(agg.deny) > 0
 	for _, grant := range agg.deny {
 		if ref := strings.TrimSpace(grant.EvidenceRef); ref != "" {
 			evidence[ref] = struct{}{}
@@ -465,7 +465,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	caveats := map[string]struct{}{}
 	switch {
-	case correlation.ObservedCount > 0 && hasAllow && !hasDeny && allObservedKMSActionsAuthorizedByStatic(agg):
+	case correlation.ObservedCount > 0 && hasAllow && !hasMatchingDeny && allObservedKMSActionsAuthorizedByStatic(agg):
 		correlation.Status = StatusConfirmed
 		correlation.StaticEffect = "Allow"
 		correlation.Confidence = 0.95
@@ -492,7 +492,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 		// allow edge (and no deny) explaining the access.
 		correlation.Status = StatusObservedWithoutGrant
 		correlation.Confidence = 0.6
-		if hasDeny {
+		if hasMatchingDeny {
 			caveats[CaveatObservedDespiteDeny] = struct{}{}
 			correlation.StaticEffect = "Deny"
 		} else {
@@ -531,14 +531,7 @@ func allObservedKMSActionsAuthorizedByStatic(agg *correlationAgg) bool {
 		return true
 	}
 
-	observedActions := map[string]struct{}{}
-	for _, observed := range agg.observed {
-		action := strings.TrimSpace(observed.Action)
-		if action == "" {
-			continue
-		}
-		observedActions[action] = struct{}{}
-	}
+	observedActions := observedKMSActions(agg)
 	if len(observedActions) == 0 {
 		return true
 	}
@@ -569,6 +562,59 @@ func allObservedKMSActionsAuthorizedByStatic(agg *correlationAgg) bool {
 		}
 	}
 	return true
+}
+
+func observedKMSActions(agg *correlationAgg) map[string]struct{} {
+	observedActions := map[string]struct{}{}
+	for _, observed := range agg.observed {
+		if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+			continue
+		}
+		action := strings.TrimSpace(strings.ToLower(observed.Action))
+		if action == "" {
+			continue
+		}
+		observedActions[action] = struct{}{}
+	}
+	return observedActions
+}
+
+func observedKMSDenyActionAppliesToObserved(agg *correlationAgg) bool {
+	if len(agg.observed) == 0 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+		return len(agg.deny) > 0
+	}
+	observedActions := observedKMSActions(agg)
+	if len(agg.deny) == 0 {
+		return false
+	}
+	if len(observedActions) == 0 {
+		return true
+	}
+	for action := range observedActions {
+		denied := false
+		for _, deny := range agg.deny {
+			if len(deny.Actions) == 0 {
+				denied = true
+				break
+			}
+			for _, deniedAction := range deny.Actions {
+				if staticGrantActionAuthorizesObservedAction(action, deniedAction) {
+					denied = true
+					break
+				}
+			}
+			if denied {
+				break
+			}
+		}
+		if denied {
+			return true
+		}
+	}
+	return false
 }
 
 func staticGrantActionAuthorizesObservedAction(observedAction string, allowedAction string) bool {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -219,7 +219,18 @@ func Correlate(request CorrelateRequest) Result {
 	order := 0
 	get := func(identityNode, principal, account, region, kind, arn, name string) *correlationAgg {
 		identity := firstNonEmpty(identityNode, principal)
-		k := correlationKey{identity: normalize(identity), resource: normalize(arn)}
+		// When the runtime event did not resolve a resource ARN, keying on
+		// the ARN alone collapses every unresolved access for an identity
+		// into one aggregate — so an unresolved secret-read and an
+		// unresolved kms-decrypt by the same role would merge and the later
+		// event would inherit the first event's resource_kind, corrupting
+		// the counts and resource_kind filter. Discriminate by kind when
+		// the ARN is missing so the two kinds stay separate.
+		resourceKey := normalize(arn)
+		if resourceKey == "" {
+			resourceKey = "unresolved:" + normalize(kind)
+		}
+		k := correlationKey{identity: normalize(identity), resource: resourceKey}
 		agg, ok := index[k]
 		if !ok {
 			agg = &correlationAgg{
@@ -450,7 +461,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	caveats := map[string]struct{}{}
 	switch {
-	case correlation.ObservedCount > 0 && hasAllow:
+	case correlation.ObservedCount > 0 && hasAllow && !hasDeny:
 		correlation.Status = StatusConfirmed
 		correlation.StaticEffect = "Allow"
 		correlation.Confidence = 0.95
@@ -468,12 +479,20 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 			caveats[CaveatLineageUnresolved] = struct{}{}
 		}
 	case correlation.ObservedCount > 0:
+		// Observed, but not a clean confirmation. An explicit Deny in AWS
+		// overrides any Allow, so an observed access against a resource
+		// that carries a specific Deny is anomalous — never confirmed —
+		// even when an Allow is also present. Surface it as observed
+		// despite deny rather than reporting a clean confirmation. The
+		// no-static-path caveat only applies when there is genuinely no
+		// allow edge (and no deny) explaining the access.
 		correlation.Status = StatusObservedWithoutGrant
 		correlation.Confidence = 0.6
-		caveats[CaveatNoStaticPath] = struct{}{}
 		if hasDeny {
 			caveats[CaveatObservedDespiteDeny] = struct{}{}
 			correlation.StaticEffect = "Deny"
+		} else {
+			caveats[CaveatNoStaticPath] = struct{}{}
 		}
 		if lineageUnresolved {
 			caveats[CaveatLineageUnresolved] = struct{}{}

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -294,11 +294,18 @@ func Correlate(request CorrelateRequest) Result {
 	}
 
 	staticConsidered := 0
+	wildcardDenyByResource := map[string][]StaticGrant{}
 	for _, grant := range request.Static {
 		if strings.TrimSpace(grant.IdentityNodeID) == "" && strings.TrimSpace(grant.PrincipalARN) == "" {
 			continue
 		}
 		if strings.TrimSpace(grant.ResourceARN) == "" {
+			continue
+		}
+		if isResourceWildcardPrincipalDeny(grant) {
+			key := staticResourceIdentityKey(grant.ResourceKind, grant.ResourceARN)
+			wildcardDenyByResource[key] = append(wildcardDenyByResource[key], grant)
+			staticConsidered++
 			continue
 		}
 		staticConsidered++
@@ -307,6 +314,13 @@ func Correlate(request CorrelateRequest) Result {
 			agg.deny = append(agg.deny, grant)
 		} else {
 			agg.allow = append(agg.allow, grant)
+		}
+	}
+
+	for _, agg := range index {
+		wildcardDenyKey := staticResourceIdentityKey(agg.resourceKind, agg.resourceARN)
+		if wildcardDenyForResource, ok := wildcardDenyByResource[wildcardDenyKey]; ok {
+			agg.deny = append(agg.deny, wildcardDenyForResource...)
 		}
 	}
 
@@ -372,6 +386,17 @@ func Correlate(request CorrelateRequest) Result {
 		result.Caveats = append(result.Caveats, "Some observed reads have no matching static reachability edge. Most Secrets Manager access is authorized by IAM identity policies, which this correlation does not enumerate; review these before treating them as drift.")
 	}
 	return result
+}
+
+func staticResourceIdentityKey(resourceKind, resourceARN string) string {
+	return normalize(resourceKind) + "::" + normalize(resourceARN)
+}
+
+func isResourceWildcardPrincipalDeny(grant StaticGrant) bool {
+	if !strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+		return false
+	}
+	return strings.TrimSpace(grant.PrincipalARN) == "*"
 }
 
 func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correlation {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -127,6 +127,10 @@ type StaticGrant struct {
 	CrossAccount   bool
 	Confidence     float64
 	EvidenceRef    string
+	// Actions contains the raw action strings observed on this static edge.
+	// When present, observed KMS actions must match at least one action
+	// to be considered confirmed.
+	Actions []string
 }
 
 // CorrelateRequest configures one correlation pass.
@@ -461,7 +465,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	caveats := map[string]struct{}{}
 	switch {
-	case correlation.ObservedCount > 0 && hasAllow && !hasDeny:
+	case correlation.ObservedCount > 0 && hasAllow && !hasDeny && allObservedKMSActionsAuthorizedByStatic(agg):
 		correlation.Status = StatusConfirmed
 		correlation.StaticEffect = "Allow"
 		correlation.Confidence = 0.95
@@ -517,6 +521,82 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 	}
 	correlation.Caveats = sortedKeys(caveats)
 	return correlation
+}
+
+func allObservedKMSActionsAuthorizedByStatic(agg *correlationAgg) bool {
+	if len(agg.observed) == 0 || len(agg.allow) == 0 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+		return true
+	}
+
+	observedActions := map[string]struct{}{}
+	for _, observed := range agg.observed {
+		action := strings.TrimSpace(observed.Action)
+		if action == "" {
+			continue
+		}
+		observedActions[action] = struct{}{}
+	}
+	if len(observedActions) == 0 {
+		return true
+	}
+
+	for action := range observedActions {
+		actionMatched := false
+		for _, grant := range agg.allow {
+			// Legacy/compat grants may omit action details. Treat them as
+			// providing no stricter action requirement so they do not
+			// accidentally block confirmations.
+			if len(grant.Actions) == 0 {
+				actionMatched = true
+				break
+			}
+
+			for _, allowedAction := range grant.Actions {
+				if staticGrantActionAuthorizesObservedAction(action, allowedAction) {
+					actionMatched = true
+					break
+				}
+			}
+			if actionMatched {
+				break
+			}
+		}
+		if !actionMatched {
+			return false
+		}
+	}
+	return true
+}
+
+func staticGrantActionAuthorizesObservedAction(observedAction string, allowedAction string) bool {
+	observed := strings.ToLower(strings.TrimSpace(observedAction))
+	allowed := strings.ToLower(strings.TrimSpace(allowedAction))
+	if observed == "" || allowed == "" {
+		return false
+	}
+	if allowed == "*" {
+		return true
+	}
+	if strings.HasSuffix(allowed, "*") {
+		prefix := strings.TrimSuffix(allowed, "*")
+		return strings.HasPrefix(observed, prefix)
+	}
+	if observed == allowed {
+		return true
+	}
+
+	observedVerb := observed
+	if _, suffix, ok := strings.Cut(observed, ":"); ok {
+		observedVerb = suffix
+	}
+	allowedVerb := allowed
+	if _, suffix, ok := strings.Cut(allowed, ":"); ok {
+		allowedVerb = suffix
+	}
+	return strings.EqualFold(observedVerb, allowedVerb)
 }
 
 func correlationID(agg *correlationAgg) string {

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -1,0 +1,533 @@
+// Package secretsaccess correlates observed Secrets Manager read and KMS
+// decrypt runtime events with the static reachability edges Identrail
+// already discovered (KMS key-policy / grant `can_decrypt` edges and
+// Secrets Manager resource-policy grants). The output ties observed
+// behavior back to identity, session, resource, and agent context so an
+// operator can answer three distinct questions per (identity, resource)
+// pair:
+//
+//   - confirmed:               the identity was statically allowed to
+//     reach the secret/key AND was observed doing so. This is the
+//     "proof" state — behavior matches policy.
+//   - observed_without_grant:  the identity was observed reading the
+//     secret / decrypting the key but no static allow edge explains it.
+//     Either static reachability collection is incomplete (most secret
+//     reads are authorized by IAM identity policies, which this wave's
+//     static collectors do not enumerate) or the access drifted from
+//     the modeled grants. Treated as a caveat, never a silent success.
+//   - granted_unused:          a static allow edge exists but no runtime
+//     access was observed in the window. Surfaces over-provisioned
+//     grants — but carries a mandatory missing-event caveat because
+//     Secrets Manager GetSecretValue and KMS Decrypt are CloudTrail
+//     *data* events; absence in a management-event lookup is not proof
+//     the access never happened.
+//
+// Safety boundary: the engine is metadata-only. It never reads, logs, or
+// persists secret values, decrypted plaintext, encryption-context
+// values, or any other customer payload. It operates purely on the
+// already-redacted runtime-event and reachability contracts produced
+// upstream, and every emitted correlation re-stamps the redaction
+// boundary so downstream consumers cannot mistake it for payload-bearing
+// evidence.
+package secretsaccess
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Resource kinds the correlator understands. They mirror the runtime
+// event `event_type` → resource mapping (secret-read → secret,
+// kms-decrypt → kms_key).
+const (
+	ResourceKindSecret = "secret"
+	ResourceKindKMSKey = "kms_key"
+)
+
+// Correlation statuses. These are the operator-facing classification of
+// a single (identity, resource) correlation.
+const (
+	StatusConfirmed            = "confirmed"
+	StatusObservedWithoutGrant = "observed_without_grant"
+	StatusGrantedUnused        = "granted_unused"
+)
+
+// Static grant sources. Mirror the upstream reachability collectors so
+// the correlation can attribute which static signal corroborated an
+// observed access.
+const (
+	SourceKeyPolicy      = "key_policy"
+	SourceKMSGrant       = "kms_grant"
+	SourceResourcePolicy = "resource_policy"
+)
+
+const (
+	// CollectorName tags every diagnostic and result the correlator
+	// emits so the API layer can scope diagnostics by collector.
+	CollectorName = "aws_secrets_kms_runtime_access"
+
+	// RedactionBoundary documents that the correlator only ever crossed
+	// the metadata boundary — no secret values, no decrypted plaintext,
+	// no encryption-context values.
+	RedactionBoundary = "metadata_only_no_secret_values_no_plaintext"
+)
+
+// Caveat codes attached to individual correlations or the result. They
+// are stable tokens so the UI and downstream consumers can branch on
+// them without string-matching prose.
+const (
+	CaveatDataEventCoverage   = "runtime_data_events_may_be_incomplete"
+	CaveatNoStaticPath        = "no_static_reachability_edge"
+	CaveatObservedDespiteDeny = "observed_despite_explicit_deny"
+	CaveatConditionalGrant    = "static_grant_is_conditional"
+	CaveatCrossAccountGrant   = "static_grant_is_cross_account"
+	CaveatLineageUnresolved   = "session_lineage_unresolved"
+	CaveatResourceUnresolved  = "runtime_resource_arn_unresolved"
+)
+
+// ObservedAccess is one metadata-only runtime secret-read or kms-decrypt
+// event projected from the runtime-event contract. Every field is
+// payload-safe.
+type ObservedAccess struct {
+	EventID         string
+	IdentityNodeID  string
+	PrincipalARN    string
+	AccountID       string
+	Region          string
+	ResourceKind    string
+	ResourceARN     string
+	ResourceName    string
+	Action          string
+	SessionID       string
+	SessionNodeID   string
+	AgentID         string
+	AgentNodeID     string
+	SourceIPAddress string
+	LineageStatus   string
+	ObservedAt      time.Time
+	EvidenceRef     string
+}
+
+// StaticGrant is one static reachability edge from the KMS or Secrets
+// Manager reachability collectors, projected into a single shape the
+// correlator can join against runtime events.
+type StaticGrant struct {
+	IdentityNodeID string
+	PrincipalARN   string
+	AccountID      string
+	Region         string
+	ResourceKind   string
+	ResourceARN    string
+	ResourceName   string
+	Source         string // key_policy | kms_grant | resource_policy
+	Effect         string // Allow | Deny
+	Conditional    bool
+	CrossAccount   bool
+	Confidence     float64
+	EvidenceRef    string
+}
+
+// CorrelateRequest configures one correlation pass.
+type CorrelateRequest struct {
+	AccountID string
+	Region    string
+	Observed  []ObservedAccess
+	Static    []StaticGrant
+	// DataEventCoverageUnknown marks that the observed set comes from a
+	// runtime source that does not guarantee Secrets Manager / KMS data
+	// events are captured (e.g. CloudTrail LookupEvents only indexes
+	// management events). When true, every granted_unused correlation
+	// and the result envelope carry the missing-event caveat so an
+	// operator never reads "unused" as "definitely never used".
+	DataEventCoverageUnknown bool
+}
+
+// Correlation is one (identity, resource) correlation record.
+type Correlation struct {
+	CorrelationID     string
+	IdentityNodeID    string
+	PrincipalARN      string
+	AccountID         string
+	Region            string
+	ResourceKind      string
+	ResourceARN       string
+	ResourceName      string
+	Status            string
+	Confidence        float64
+	ObservedCount     int
+	ObservedEventIDs  []string
+	Actions           []string
+	SessionIDs        []string
+	AgentID           string
+	AgentNodeID       string
+	FirstObservedAt   time.Time
+	LastObservedAt    time.Time
+	StaticSources     []string
+	StaticEffect      string
+	Conditional       bool
+	CrossAccount      bool
+	Caveats           []string
+	EvidenceRefs      []string
+	RedactionBoundary string
+}
+
+// Result is the bounded outcome of one correlation pass.
+type Result struct {
+	Correlations             []Correlation
+	Caveats                  []string
+	ConfirmedCount           int
+	ObservedWithoutGrant     int
+	GrantedUnusedCount       int
+	SecretCorrelationCount   int
+	KMSKeyCorrelationCount   int
+	IdentityCount            int
+	ResourceCount            int
+	ObservedAccessConsidered int
+	StaticGrantsConsidered   int
+}
+
+type correlationKey struct {
+	identity string
+	resource string
+}
+
+type correlationAgg struct {
+	identityNodeID string
+	principalARN   string
+	accountID      string
+	region         string
+	resourceKind   string
+	resourceARN    string
+	resourceName   string
+	agentID        string
+	agentNodeID    string
+	observed       []ObservedAccess
+	allow          []StaticGrant
+	deny           []StaticGrant
+	order          int
+}
+
+// Correlate joins observed runtime accesses with static reachability
+// grants and returns one correlation per (identity, resource) pair. It
+// never returns an error: documented gaps (no static path, missing data
+// events, unresolved resource ARNs) surface as per-correlation and
+// result-level caveats so the API layer can return a stable response.
+func Correlate(request CorrelateRequest) Result {
+	index := map[correlationKey]*correlationAgg{}
+	order := 0
+	get := func(identityNode, principal, account, region, kind, arn, name string) *correlationAgg {
+		identity := firstNonEmpty(identityNode, principal)
+		k := correlationKey{identity: normalize(identity), resource: normalize(arn)}
+		agg, ok := index[k]
+		if !ok {
+			agg = &correlationAgg{
+				identityNodeID: strings.TrimSpace(identityNode),
+				principalARN:   strings.TrimSpace(principal),
+				accountID:      strings.TrimSpace(account),
+				region:         strings.TrimSpace(region),
+				resourceKind:   strings.TrimSpace(kind),
+				resourceARN:    strings.TrimSpace(arn),
+				resourceName:   strings.TrimSpace(name),
+				order:          order,
+			}
+			order++
+			index[k] = agg
+		}
+		// Backfill identifiers that one side may carry and the other may
+		// not (e.g. the runtime event resolves a principal ARN the
+		// static edge lacked, or the static edge names the resource).
+		if agg.identityNodeID == "" {
+			agg.identityNodeID = strings.TrimSpace(identityNode)
+		}
+		if agg.principalARN == "" {
+			agg.principalARN = strings.TrimSpace(principal)
+		}
+		if agg.resourceKind == "" {
+			agg.resourceKind = strings.TrimSpace(kind)
+		}
+		if agg.resourceName == "" {
+			agg.resourceName = strings.TrimSpace(name)
+		}
+		if agg.accountID == "" {
+			agg.accountID = strings.TrimSpace(account)
+		}
+		if agg.region == "" {
+			agg.region = strings.TrimSpace(region)
+		}
+		return agg
+	}
+
+	considered := 0
+	for _, observed := range request.Observed {
+		if strings.TrimSpace(observed.IdentityNodeID) == "" && strings.TrimSpace(observed.PrincipalARN) == "" {
+			// Cannot attribute the access to an identity — skip rather
+			// than invent an "unknown" node that would join nothing.
+			continue
+		}
+		considered++
+		agg := get(observed.IdentityNodeID, observed.PrincipalARN, observed.AccountID, observed.Region, observed.ResourceKind, observed.ResourceARN, observed.ResourceName)
+		agg.observed = append(agg.observed, observed)
+		if agg.agentID == "" {
+			agg.agentID = strings.TrimSpace(observed.AgentID)
+		}
+		if agg.agentNodeID == "" {
+			agg.agentNodeID = strings.TrimSpace(observed.AgentNodeID)
+		}
+	}
+
+	staticConsidered := 0
+	for _, grant := range request.Static {
+		if strings.TrimSpace(grant.IdentityNodeID) == "" && strings.TrimSpace(grant.PrincipalARN) == "" {
+			continue
+		}
+		if strings.TrimSpace(grant.ResourceARN) == "" {
+			continue
+		}
+		staticConsidered++
+		agg := get(grant.IdentityNodeID, grant.PrincipalARN, grant.AccountID, grant.Region, grant.ResourceKind, grant.ResourceARN, grant.ResourceName)
+		if strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+			agg.deny = append(agg.deny, grant)
+		} else {
+			agg.allow = append(agg.allow, grant)
+		}
+	}
+
+	aggs := make([]*correlationAgg, 0, len(index))
+	for _, agg := range index {
+		aggs = append(aggs, agg)
+	}
+	sort.SliceStable(aggs, func(i, j int) bool {
+		if aggs[i].resourceKind != aggs[j].resourceKind {
+			return aggs[i].resourceKind < aggs[j].resourceKind
+		}
+		if normalize(aggs[i].resourceARN) != normalize(aggs[j].resourceARN) {
+			return normalize(aggs[i].resourceARN) < normalize(aggs[j].resourceARN)
+		}
+		identI := firstNonEmpty(aggs[i].identityNodeID, aggs[i].principalARN)
+		identJ := firstNonEmpty(aggs[j].identityNodeID, aggs[j].principalARN)
+		if normalize(identI) != normalize(identJ) {
+			return normalize(identI) < normalize(identJ)
+		}
+		return aggs[i].order < aggs[j].order
+	})
+
+	result := Result{
+		ObservedAccessConsidered: considered,
+		StaticGrantsConsidered:   staticConsidered,
+	}
+	identities := map[string]struct{}{}
+	resources := map[string]struct{}{}
+	for _, agg := range aggs {
+		// A correlation needs at least one observed access or one allow
+		// grant. A resource that only ever appears with a deny grant has
+		// no reachability and was never observed, so there is nothing to
+		// correlate.
+		if len(agg.observed) == 0 && len(agg.allow) == 0 {
+			continue
+		}
+		correlation := buildCorrelation(agg, request.DataEventCoverageUnknown)
+		result.Correlations = append(result.Correlations, correlation)
+		switch correlation.Status {
+		case StatusConfirmed:
+			result.ConfirmedCount++
+		case StatusObservedWithoutGrant:
+			result.ObservedWithoutGrant++
+		case StatusGrantedUnused:
+			result.GrantedUnusedCount++
+		}
+		switch correlation.ResourceKind {
+		case ResourceKindSecret:
+			result.SecretCorrelationCount++
+		case ResourceKindKMSKey:
+			result.KMSKeyCorrelationCount++
+		}
+		identities[normalize(firstNonEmpty(correlation.IdentityNodeID, correlation.PrincipalARN))] = struct{}{}
+		resources[normalize(correlation.ResourceARN)] = struct{}{}
+	}
+	result.IdentityCount = len(identities)
+	result.ResourceCount = len(resources)
+
+	if request.DataEventCoverageUnknown && (result.GrantedUnusedCount > 0 || considered == 0) {
+		result.Caveats = append(result.Caveats, "Runtime evidence is sourced from CloudTrail management-event lookups; Secrets Manager GetSecretValue and KMS Decrypt are data events that require a data-event trail or CloudTrail Lake. 'granted_unused' correlations may reflect missing telemetry rather than truly unused grants.")
+	}
+	if result.ObservedWithoutGrant > 0 {
+		result.Caveats = append(result.Caveats, "Some observed reads have no matching static reachability edge. Most Secrets Manager access is authorized by IAM identity policies, which this correlation does not enumerate; review these before treating them as drift.")
+	}
+	return result
+}
+
+func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correlation {
+	correlation := Correlation{
+		IdentityNodeID:    agg.identityNodeID,
+		PrincipalARN:      agg.principalARN,
+		AccountID:         agg.accountID,
+		Region:            agg.region,
+		ResourceKind:      agg.resourceKind,
+		ResourceARN:       agg.resourceARN,
+		ResourceName:      agg.resourceName,
+		AgentID:           agg.agentID,
+		AgentNodeID:       agg.agentNodeID,
+		RedactionBoundary: RedactionBoundary,
+	}
+	correlation.CorrelationID = correlationID(agg)
+
+	eventIDs := map[string]struct{}{}
+	actions := map[string]struct{}{}
+	sessions := map[string]struct{}{}
+	evidence := map[string]struct{}{}
+	lineageUnresolved := false
+	resourceUnresolved := false
+	for _, observed := range agg.observed {
+		correlation.ObservedCount++
+		if id := strings.TrimSpace(observed.EventID); id != "" {
+			eventIDs[id] = struct{}{}
+		}
+		if action := strings.TrimSpace(observed.Action); action != "" {
+			actions[action] = struct{}{}
+		}
+		if session := strings.TrimSpace(observed.SessionID); session != "" {
+			sessions[session] = struct{}{}
+		}
+		if ref := strings.TrimSpace(observed.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+		observedAt := observed.ObservedAt.UTC()
+		if !observedAt.IsZero() {
+			if correlation.FirstObservedAt.IsZero() || observedAt.Before(correlation.FirstObservedAt) {
+				correlation.FirstObservedAt = observedAt
+			}
+			if observedAt.After(correlation.LastObservedAt) {
+				correlation.LastObservedAt = observedAt
+			}
+		}
+		switch strings.TrimSpace(observed.LineageStatus) {
+		case "", "resolved":
+		default:
+			lineageUnresolved = true
+		}
+		if strings.TrimSpace(observed.ResourceARN) == "" {
+			resourceUnresolved = true
+		}
+	}
+	correlation.ObservedEventIDs = sortedKeys(eventIDs)
+	correlation.Actions = sortedKeys(actions)
+	correlation.SessionIDs = sortedKeys(sessions)
+
+	sources := map[string]struct{}{}
+	hasAllow := len(agg.allow) > 0
+	conditional := false
+	crossAccount := false
+	staticConfidence := 0.0
+	for _, grant := range agg.allow {
+		if src := strings.TrimSpace(grant.Source); src != "" {
+			sources[src] = struct{}{}
+		}
+		if grant.Conditional {
+			conditional = true
+		}
+		if grant.CrossAccount {
+			crossAccount = true
+		}
+		if grant.Confidence > staticConfidence {
+			staticConfidence = grant.Confidence
+		}
+		if ref := strings.TrimSpace(grant.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+	}
+	hasDeny := len(agg.deny) > 0
+	for _, grant := range agg.deny {
+		if ref := strings.TrimSpace(grant.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+	}
+	correlation.StaticSources = sortedKeys(sources)
+	correlation.Conditional = conditional
+	correlation.CrossAccount = crossAccount
+	correlation.EvidenceRefs = sortedKeys(evidence)
+
+	caveats := map[string]struct{}{}
+	switch {
+	case correlation.ObservedCount > 0 && hasAllow:
+		correlation.Status = StatusConfirmed
+		correlation.StaticEffect = "Allow"
+		correlation.Confidence = 0.95
+		if conditional {
+			correlation.Confidence -= 0.05
+			caveats[CaveatConditionalGrant] = struct{}{}
+		}
+		if crossAccount {
+			caveats[CaveatCrossAccountGrant] = struct{}{}
+		}
+		if lineageUnresolved {
+			if correlation.Confidence > 0.85 {
+				correlation.Confidence = 0.85
+			}
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+	case correlation.ObservedCount > 0:
+		correlation.Status = StatusObservedWithoutGrant
+		correlation.Confidence = 0.6
+		caveats[CaveatNoStaticPath] = struct{}{}
+		if hasDeny {
+			caveats[CaveatObservedDespiteDeny] = struct{}{}
+			correlation.StaticEffect = "Deny"
+		}
+		if lineageUnresolved {
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+		if resourceUnresolved {
+			caveats[CaveatResourceUnresolved] = struct{}{}
+		}
+	default:
+		correlation.Status = StatusGrantedUnused
+		correlation.StaticEffect = "Allow"
+		correlation.Confidence = 0.7
+		if dataEventCoverageUnknown {
+			correlation.Confidence = 0.5
+			caveats[CaveatDataEventCoverage] = struct{}{}
+		}
+		if conditional {
+			caveats[CaveatConditionalGrant] = struct{}{}
+		}
+		if crossAccount {
+			caveats[CaveatCrossAccountGrant] = struct{}{}
+		}
+	}
+	correlation.Caveats = sortedKeys(caveats)
+	return correlation
+}
+
+func correlationID(agg *correlationAgg) string {
+	identity := firstNonEmpty(agg.identityNodeID, agg.principalARN, "unknown-identity")
+	kind := firstNonEmpty(agg.resourceKind, "resource")
+	resource := firstNonEmpty(agg.resourceARN, "unknown-resource")
+	return fmt.Sprintf("%s|%s|%s", kind, normalize(identity), normalize(resource))
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/secretsaccess/correlate.go
+++ b/internal/runtime/secretsaccess/correlate.go
@@ -128,8 +128,9 @@ type StaticGrant struct {
 	Confidence     float64
 	EvidenceRef    string
 	// Actions contains the raw action strings observed on this static edge.
-	// When present, observed KMS actions must match at least one action
-	// to be considered confirmed.
+	// When present, static actions must match each observed action
+	// before an access can be confirmed for resource kinds that require
+	// action authorization (Secrets Manager and KMS key).
 	Actions []string
 }
 
@@ -432,7 +433,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	sources := map[string]struct{}{}
 	hasAllow := len(agg.allow) > 0
-	hasMatchingDeny := observedKMSDenyActionAppliesToObserved(agg)
+	hasMatchingDeny := observedResourceActionDenyAppliesToObserved(agg)
 	conditional := false
 	crossAccount := false
 	staticConfidence := 0.0
@@ -465,7 +466,7 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 
 	caveats := map[string]struct{}{}
 	switch {
-	case correlation.ObservedCount > 0 && hasAllow && !hasMatchingDeny && allObservedKMSActionsAuthorizedByStatic(agg):
+	case correlation.ObservedCount > 0 && hasAllow && !hasMatchingDeny && allObservedActionsAuthorizedByStatic(agg):
 		correlation.Status = StatusConfirmed
 		correlation.StaticEffect = "Allow"
 		correlation.Confidence = 0.95
@@ -523,15 +524,15 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 	return correlation
 }
 
-func allObservedKMSActionsAuthorizedByStatic(agg *correlationAgg) bool {
+func allObservedActionsAuthorizedByStatic(agg *correlationAgg) bool {
 	if len(agg.observed) == 0 || len(agg.allow) == 0 {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+	if !resourceKindRequiresActionMatching(strings.TrimSpace(agg.resourceKind)) {
 		return true
 	}
 
-	observedActions := observedKMSActions(agg)
+	observedActions := observedResourceActions(agg)
 	if len(observedActions) == 0 {
 		return true
 	}
@@ -564,10 +565,10 @@ func allObservedKMSActionsAuthorizedByStatic(agg *correlationAgg) bool {
 	return true
 }
 
-func observedKMSActions(agg *correlationAgg) map[string]struct{} {
+func observedResourceActions(agg *correlationAgg) map[string]struct{} {
 	observedActions := map[string]struct{}{}
 	for _, observed := range agg.observed {
-		if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+		if !resourceKindRequiresActionMatching(strings.TrimSpace(agg.resourceKind)) {
 			continue
 		}
 		action := strings.TrimSpace(strings.ToLower(observed.Action))
@@ -579,14 +580,14 @@ func observedKMSActions(agg *correlationAgg) map[string]struct{} {
 	return observedActions
 }
 
-func observedKMSDenyActionAppliesToObserved(agg *correlationAgg) bool {
+func observedResourceActionDenyAppliesToObserved(agg *correlationAgg) bool {
 	if len(agg.observed) == 0 {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(agg.resourceKind), ResourceKindKMSKey) {
+	if !resourceKindRequiresActionMatching(strings.TrimSpace(agg.resourceKind)) {
 		return len(agg.deny) > 0
 	}
-	observedActions := observedKMSActions(agg)
+	observedActions := observedResourceActions(agg)
 	if len(agg.deny) == 0 {
 		return false
 	}
@@ -615,6 +616,11 @@ func observedKMSDenyActionAppliesToObserved(agg *correlationAgg) bool {
 		}
 	}
 	return false
+}
+
+func resourceKindRequiresActionMatching(resourceKind string) bool {
+	return strings.EqualFold(strings.TrimSpace(resourceKind), ResourceKindKMSKey) ||
+		strings.EqualFold(strings.TrimSpace(resourceKind), ResourceKindSecret)
 }
 
 func staticGrantActionAuthorizesObservedAction(observedAction string, allowedAction string) bool {

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -1,0 +1,328 @@
+package secretsaccess
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func observedAt(min int) time.Time {
+	return time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC).Add(time.Duration(min) * time.Minute)
+}
+
+func findCorrelation(t *testing.T, result Result, resourceARN string) Correlation {
+	t.Helper()
+	for _, correlation := range result.Correlations {
+		if correlation.ResourceARN == resourceARN {
+			return correlation
+		}
+	}
+	t.Fatalf("no correlation for resource %q in %+v", resourceARN, result.Correlations)
+	return Correlation{}
+}
+
+func hasCaveat(caveats []string, want string) bool {
+	for _, caveat := range caveats {
+		if caveat == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCorrelateConfirmedJoinsObservedWithStaticGrant(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/cmk-1"
+	identity := "aws:identity:role:payments-app"
+	result := Correlate(CorrelateRequest{
+		AccountID: "111122223333",
+		Region:    "us-east-1",
+		Observed: []ObservedAccess{{
+			EventID:        "evt-1",
+			IdentityNodeID: identity,
+			PrincipalARN:   "arn:aws:iam::111122223333:role/payments-app",
+			AccountID:      "111122223333",
+			Region:         "us-east-1",
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			ResourceName:   "cmk-1",
+			Action:         "kms:Decrypt",
+			SessionID:      "ASIA-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     observedAt(5),
+			EvidenceRef:    "runtime-evidence://evt-1",
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Source:         SourceKeyPolicy,
+			Effect:         "Allow",
+			Confidence:     0.9,
+			EvidenceRef:    "kms-evidence://key/cmk-1",
+		}},
+	})
+
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.95 {
+		t.Fatalf("expected 0.95 confidence, got %v", correlation.Confidence)
+	}
+	if correlation.ObservedCount != 1 || len(correlation.ObservedEventIDs) != 1 {
+		t.Fatalf("expected one observed event, got %+v", correlation)
+	}
+	if len(correlation.StaticSources) != 1 || correlation.StaticSources[0] != SourceKeyPolicy {
+		t.Fatalf("expected key_policy source, got %+v", correlation.StaticSources)
+	}
+	if len(correlation.EvidenceRefs) != 2 {
+		t.Fatalf("expected runtime+static evidence refs, got %+v", correlation.EvidenceRefs)
+	}
+	if correlation.RedactionBoundary != RedactionBoundary {
+		t.Fatalf("missing redaction boundary: %+v", correlation)
+	}
+	if result.ConfirmedCount != 1 || result.KMSKeyCorrelationCount != 1 || result.IdentityCount != 1 || result.ResourceCount != 1 {
+		t.Fatalf("unexpected result counts: %+v", result)
+	}
+}
+
+func TestCorrelateObservedWithoutGrant(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:111122223333:secret:prod/api-key"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-2",
+			IdentityNodeID: "aws:identity:role:invoice-agent",
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Action:         "secretsmanager:GetSecretValue",
+			LineageStatus:  "resolved",
+			ObservedAt:     observedAt(1),
+		}},
+		DataEventCoverageUnknown: true,
+	})
+
+	correlation := findCorrelation(t, result, secretARN)
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.6 {
+		t.Fatalf("expected 0.6 confidence, got %v", correlation.Confidence)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("expected no-static-path caveat, got %+v", correlation.Caveats)
+	}
+	if result.ObservedWithoutGrant != 1 {
+		t.Fatalf("expected observed_without_grant count, got %+v", result)
+	}
+	// Result-level caveat about IAM-policy authorization must be present.
+	found := false
+	for _, caveat := range result.Caveats {
+		if strings.Contains(caveat, "IAM identity policies") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected IAM-policy caveat in result, got %+v", result.Caveats)
+	}
+}
+
+func TestCorrelateGrantedUnusedCarriesMissingEventCaveat(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/unused"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{
+			IdentityNodeID: "aws:identity:role:dormant",
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Source:         SourceKMSGrant,
+			Effect:         "Allow",
+			Confidence:     0.88,
+		}},
+		DataEventCoverageUnknown: true,
+	})
+
+	correlation := findCorrelation(t, result, keyARN)
+	if correlation.Status != StatusGrantedUnused {
+		t.Fatalf("expected granted_unused, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.5 {
+		t.Fatalf("expected 0.5 confidence when data events unknown, got %v", correlation.Confidence)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatDataEventCoverage) {
+		t.Fatalf("expected missing-event caveat, got %+v", correlation.Caveats)
+	}
+	if len(result.Caveats) == 0 {
+		t.Fatalf("expected result-level missing-event caveat")
+	}
+}
+
+func TestCorrelateGrantedUnusedHigherConfidenceWhenCoverageKnown(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{
+			PrincipalARN: "arn:aws:iam::111122223333:role/dormant",
+			ResourceKind: ResourceKindKMSKey,
+			ResourceARN:  "arn:aws:kms:us-east-1:111122223333:key/unused",
+			Source:       SourceKMSGrant,
+			Effect:       "Allow",
+		}},
+		DataEventCoverageUnknown: false,
+	})
+	correlation := result.Correlations[0]
+	if correlation.Confidence != 0.7 {
+		t.Fatalf("expected 0.7 confidence when coverage known, got %v", correlation.Confidence)
+	}
+	if hasCaveat(correlation.Caveats, CaveatDataEventCoverage) {
+		t.Fatalf("did not expect missing-event caveat when coverage known: %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateConfirmedCappedForUnresolvedLineageAndConditionalGrant(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/cmk-cond"
+	identity := "aws:identity:role:agent"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-3",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			LineageStatus:  "source_identity_missing",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Source:         SourceKeyPolicy,
+			Effect:         "Allow",
+			Conditional:    true,
+			CrossAccount:   true,
+		}},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed, got %q", correlation.Status)
+	}
+	// 0.95 base - 0.05 conditional = 0.90, then capped to 0.85 for unresolved lineage.
+	if correlation.Confidence != 0.85 {
+		t.Fatalf("expected confidence capped to 0.85, got %v", correlation.Confidence)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatConditionalGrant) || !hasCaveat(correlation.Caveats, CaveatCrossAccountGrant) || !hasCaveat(correlation.Caveats, CaveatLineageUnresolved) {
+		t.Fatalf("expected conditional/cross-account/lineage caveats, got %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateObservedDespiteExplicitDeny(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/denied"
+	identity := "aws:identity:role:should-not"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-4",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Source:         SourceKeyPolicy,
+			Effect:         "Deny",
+		}},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant (deny is not an allow), got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("expected observed-despite-deny caveat, got %+v", correlation.Caveats)
+	}
+	if correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected deny static effect, got %q", correlation.StaticEffect)
+	}
+}
+
+func TestCorrelateDenyOnlyWithoutAccessIsNotSurfaced(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{
+			IdentityNodeID: "aws:identity:role:x",
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    "arn:aws:kms:us-east-1:111122223333:key/deny-only",
+			Source:         SourceKeyPolicy,
+			Effect:         "Deny",
+		}},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("expected deny-only grant to be dropped, got %+v", result.Correlations)
+	}
+}
+
+func TestCorrelateAggregatesRepeatedObservationsAndIsCaseInsensitive(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/cmk-multi"
+	identity := "aws:identity:role:Repeated"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{
+			{EventID: "a", IdentityNodeID: identity, ResourceKind: ResourceKindKMSKey, ResourceARN: keyARN, Action: "kms:Decrypt", SessionID: "s1", ObservedAt: observedAt(10)},
+			{EventID: "b", IdentityNodeID: "AWS:IDENTITY:ROLE:REPEATED", ResourceKind: ResourceKindKMSKey, ResourceARN: keyARN, Action: "kms:GenerateDataKey", SessionID: "s2", ObservedAt: observedAt(2)},
+		},
+		Static: []StaticGrant{{IdentityNodeID: identity, ResourceKind: ResourceKindKMSKey, ResourceARN: keyARN, Source: SourceKeyPolicy, Effect: "Allow"}},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected case-insensitive aggregation into 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.ObservedCount != 2 || len(correlation.ObservedEventIDs) != 2 {
+		t.Fatalf("expected 2 observations aggregated, got %+v", correlation)
+	}
+	if len(correlation.Actions) != 2 || len(correlation.SessionIDs) != 2 {
+		t.Fatalf("expected actions/sessions aggregated, got %+v", correlation)
+	}
+	if !correlation.FirstObservedAt.Equal(observedAt(2)) || !correlation.LastObservedAt.Equal(observedAt(10)) {
+		t.Fatalf("expected first/last observed window, got first=%v last=%v", correlation.FirstObservedAt, correlation.LastObservedAt)
+	}
+}
+
+func TestCorrelateSkipsUnattributableAndResourcelessRecords(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{
+			{EventID: "no-identity", ResourceKind: ResourceKindSecret, ResourceARN: "arn:aws:secretsmanager:us-east-1:1:secret:x"},
+		},
+		Static: []StaticGrant{
+			{IdentityNodeID: "aws:identity:role:y", ResourceKind: ResourceKindSecret, ResourceARN: ""},
+		},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("expected unattributable observation and resourceless grant to be skipped, got %+v", result.Correlations)
+	}
+	if result.ObservedAccessConsidered != 0 || result.StaticGrantsConsidered != 0 {
+		t.Fatalf("expected zero considered, got %+v", result)
+	}
+}
+
+func TestCorrelateDeterministicOrdering(t *testing.T) {
+	build := func() []Correlation {
+		return Correlate(CorrelateRequest{
+			Observed: []ObservedAccess{
+				{EventID: "1", IdentityNodeID: "z", ResourceKind: ResourceKindSecret, ResourceARN: "arn:secret:b", ObservedAt: observedAt(1)},
+				{EventID: "2", IdentityNodeID: "a", ResourceKind: ResourceKindKMSKey, ResourceARN: "arn:kms:a", ObservedAt: observedAt(1)},
+				{EventID: "3", IdentityNodeID: "a", ResourceKind: ResourceKindSecret, ResourceARN: "arn:secret:a", ObservedAt: observedAt(1)},
+			},
+		}).Correlations
+	}
+	first := build()
+	second := build()
+	if len(first) != 3 {
+		t.Fatalf("expected 3 correlations, got %d", len(first))
+	}
+	for i := range first {
+		if first[i].CorrelationID != second[i].CorrelationID {
+			t.Fatalf("ordering not deterministic at %d: %q vs %q", i, first[i].CorrelationID, second[i].CorrelationID)
+		}
+	}
+	// kms_key sorts before secret; within secret, arn:secret:a before arn:secret:b.
+	if first[0].ResourceKind != ResourceKindKMSKey || first[1].ResourceARN != "arn:secret:a" || first[2].ResourceARN != "arn:secret:b" {
+		t.Fatalf("unexpected ordering: %+v", first)
+	}
+}

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -405,6 +405,62 @@ func TestCorrelateObservedKMSActionRequiresMatchingStaticAuthorization(t *testin
 	}
 }
 
+func TestCorrelateObservedSecretActionRequiresMatchingStaticAuthorization(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:111122223333:secret:api-key"
+	identity := "aws:identity:role:secret-action-mismatch"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-secret-action-mismatch",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Action:         "secretsmanager:BatchGetSecretValue",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Source:         SourceResourcePolicy,
+			Effect:         "Allow",
+			Actions:        []string{"secretsmanager:GetSecretValue"},
+		}},
+	})
+
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when secret action does not match static authorization, got %q", correlation.Status)
+	}
+}
+
+func TestCorrelateObservedSecretActionMatchConfirmsAccess(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:111122223333:secret:api-key"
+	identity := "aws:identity:role:secret-action-match"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-secret-action-match",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Action:         "secretsmanager:BatchGetSecretValue",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Source:         SourceResourcePolicy,
+			Effect:         "Allow",
+			Actions:        []string{"secretsmanager:BatchGetSecretValue"},
+		}},
+	})
+
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed when secret action matches static authorization, got %q", correlation.Status)
+	}
+}
+
 func TestCorrelateUnresolvedResourcesSeparatedByKind(t *testing.T) {
 	// Same identity, two different unresolved (empty-ARN) accesses of
 	// different kinds must not merge into one correlation.

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -595,6 +595,39 @@ func TestCorrelateDenyOnlyWithoutAccessIsNotSurfaced(t *testing.T) {
 	}
 }
 
+func TestCorrelateStaticAllowPlusDenyWithoutAccessIsNotGrantedUnused(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/static-allow-deny"
+	identity := "aws:identity:role:blocked-unused"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Deny",
+			},
+		},
+	})
+
+	if len(result.Correlations) != 0 {
+		t.Fatalf("static allow+deny without observed access should not surface as unused reachability, got %+v", result.Correlations)
+	}
+	if result.GrantedUnusedCount != 0 {
+		t.Fatalf("explicitly denied static pair must not count as granted_unused, got %+v", result)
+	}
+	if result.StaticGrantsConsidered != 2 {
+		t.Fatalf("expected both static grants to remain considered, got %+v", result)
+	}
+}
+
 func TestCorrelateAggregatesRepeatedObservationsAndIsCaseInsensitive(t *testing.T) {
 	keyARN := "arn:aws:kms:us-east-1:111122223333:key/cmk-multi"
 	identity := "aws:identity:role:Repeated"

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -281,6 +281,42 @@ func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestCorrelateObservedKMSActionRequiresMatchingStaticAuthorization(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/observed-without-kms-decrypt"
+	identity := "aws:identity:role:action-mismatch"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-generate",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Action:         "kms:GenerateDataKey",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Source:         SourceKeyPolicy,
+			Effect:         "Allow",
+			Actions:        []string{"kms:Decrypt"},
+		}},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected one correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when observed action exceeds static authorization, got %q", correlation.Status)
+	}
+	if correlation.ObservedCount != 1 {
+		t.Fatalf("expected one observed event, got %d", correlation.ObservedCount)
+	}
+	if result.ObservedWithoutGrant != 1 || result.ConfirmedCount != 0 {
+		t.Fatalf("expected observed_without_grant to be 1 and confirmed to be 0, got %+v", result)
+	}
+}
+
 func TestCorrelateUnresolvedResourcesSeparatedByKind(t *testing.T) {
 	// Same identity, two different unresolved (empty-ARN) accesses of
 	// different kinds must not merge into one correlation.

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -606,6 +606,7 @@ func TestCorrelateStaticAllowPlusDenyWithoutAccessIsNotGrantedUnused(t *testing.
 				ResourceARN:    keyARN,
 				Source:         SourceKeyPolicy,
 				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt"},
 			},
 			{
 				IdentityNodeID: identity,
@@ -613,6 +614,7 @@ func TestCorrelateStaticAllowPlusDenyWithoutAccessIsNotGrantedUnused(t *testing.
 				ResourceARN:    keyARN,
 				Source:         SourceKeyPolicy,
 				Effect:         "Deny",
+				Actions:        []string{"kms:Decrypt"},
 			},
 		},
 	})
@@ -625,6 +627,129 @@ func TestCorrelateStaticAllowPlusDenyWithoutAccessIsNotGrantedUnused(t *testing.
 	}
 	if result.StaticGrantsConsidered != 2 {
 		t.Fatalf("expected both static grants to remain considered, got %+v", result)
+	}
+}
+
+func TestCorrelateStaticAllowPlusDifferentActionDenyRemainsGrantedUnused(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/static-allow-deny-different-action"
+	identity := "aws:identity:role:decrypt-unused"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt"},
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Deny",
+				Actions:        []string{"kms:GenerateDataKey"},
+			},
+		},
+	})
+
+	correlation := findCorrelation(t, result, keyARN)
+	if correlation.Status != StatusGrantedUnused {
+		t.Fatalf("expected decrypt allow to remain granted_unused when deny targets another action, got %q", correlation.Status)
+	}
+	if correlation.StaticEffect != "Allow" {
+		t.Fatalf("expected allow effect for usable unused grant, got %q", correlation.StaticEffect)
+	}
+	if result.GrantedUnusedCount != 1 {
+		t.Fatalf("expected one granted_unused correlation, got %+v", result)
+	}
+}
+
+func TestCorrelateStaticWildcardAllowWithSpecificDenyRemainsGrantedUnused(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/static-wildcard-allow-specific-deny"
+	identity := "aws:identity:role:broad-unused"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:*"},
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Deny",
+				Actions:        []string{"kms:GenerateDataKey"},
+			},
+		},
+	})
+
+	correlation := findCorrelation(t, result, keyARN)
+	if correlation.Status != StatusGrantedUnused {
+		t.Fatalf("expected broad allow to remain granted_unused when deny covers only one action, got %q", correlation.Status)
+	}
+}
+
+func TestCorrelateStaticAllowCoveredByWildcardDenyIsSuppressed(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/static-allow-wildcard-deny"
+	identity := "aws:identity:role:blocked-decrypt"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt"},
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Deny",
+				Actions:        []string{"kms:*"},
+			},
+		},
+	})
+
+	if len(result.Correlations) != 0 || result.GrantedUnusedCount != 0 {
+		t.Fatalf("allow covered by wildcard deny should be suppressed, got %+v", result)
+	}
+}
+
+func TestCorrelateObservedActionMatchesAWSWildcardPattern(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:111122223333:secret:api-key-wildcard"
+	identity := "aws:identity:role:secret-pattern-match"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-secret-pattern-match",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Action:         "secretsmanager:GetSecretValue",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Source:         SourceResourcePolicy,
+			Effect:         "Allow",
+			Actions:        []string{"*:GetSecretValu?"},
+		}},
+	})
+
+	correlation := findCorrelation(t, result, secretARN)
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected observed action to match AWS wildcard pattern, got %q", correlation.Status)
 	}
 }
 

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -244,6 +244,71 @@ func TestCorrelateObservedDespiteExplicitDeny(t *testing.T) {
 	}
 }
 
+func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
+	// An explicit Deny overrides any Allow in AWS, so an observed access
+	// against a resource carrying both must not be reported as a clean
+	// confirmation.
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/allow-and-deny"
+	identity := "aws:identity:role:mixed"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-mixed",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{
+			{IdentityNodeID: identity, ResourceKind: ResourceKindKMSKey, ResourceARN: keyARN, Source: SourceKeyPolicy, Effect: "Allow"},
+			{IdentityNodeID: identity, ResourceKind: ResourceKindKMSKey, ResourceARN: keyARN, Source: SourceKeyPolicy, Effect: "Deny"},
+		},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when an explicit deny is present, got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("expected observed-despite-deny caveat, got %+v", correlation.Caveats)
+	}
+	if hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("no-static-path caveat is misleading when an allow exists: %+v", correlation.Caveats)
+	}
+	if correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected deny static effect, got %q", correlation.StaticEffect)
+	}
+	if result.ConfirmedCount != 0 {
+		t.Fatalf("expected no confirmed correlations, got %+v", result)
+	}
+}
+
+func TestCorrelateUnresolvedResourcesSeparatedByKind(t *testing.T) {
+	// Same identity, two different unresolved (empty-ARN) accesses of
+	// different kinds must not merge into one correlation.
+	identity := "aws:identity:role:unresolved"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{
+			{EventID: "s", IdentityNodeID: identity, ResourceKind: ResourceKindSecret, ResourceARN: "", ObservedAt: observedAt(1)},
+			{EventID: "k", IdentityNodeID: identity, ResourceKind: ResourceKindKMSKey, ResourceARN: "", ObservedAt: observedAt(2)},
+		},
+	})
+	if len(result.Correlations) != 2 {
+		t.Fatalf("expected unresolved secret and kms accesses to stay separate, got %d (%+v)", len(result.Correlations), result.Correlations)
+	}
+	kinds := map[string]int{}
+	for _, correlation := range result.Correlations {
+		kinds[correlation.ResourceKind]++
+		if !hasCaveat(correlation.Caveats, CaveatResourceUnresolved) {
+			t.Fatalf("expected resource-unresolved caveat, got %+v", correlation.Caveats)
+		}
+	}
+	if kinds[ResourceKindSecret] != 1 || kinds[ResourceKindKMSKey] != 1 {
+		t.Fatalf("expected one secret and one kms correlation, got %+v", kinds)
+	}
+	if result.SecretCorrelationCount != 1 || result.KMSKeyCorrelationCount != 1 {
+		t.Fatalf("expected accurate per-kind counts, got %+v", result)
+	}
+}
+
 func TestCorrelateDenyOnlyWithoutAccessIsNotSurfaced(t *testing.T) {
 	result := Correlate(CorrelateRequest{
 		Static: []StaticGrant{{

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -281,6 +281,94 @@ func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestCorrelateDenySpecificActionDoesNotBlockOtherKMSAction(t *testing.T) {
+	// Explicit deny rules are action-specific in AWS. A deny for a different
+	// KMS action should not downgrade a matching Decrypt access to
+	// observed-without-grant.
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/allow-decrypt-deny-generate"
+	identity := "aws:identity:role:mixed-actions"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-mixed-action",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Action:         "kms:Decrypt",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt"},
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKMSGrant,
+				Effect:         "Deny",
+				Actions:        []string{"kms:GenerateDataKey"},
+			},
+		},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed when deny action does not match observed action, got %q", correlation.Status)
+	}
+	if hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("unexpected observed-despite-deny caveat when deny does not apply, got %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateMatchingKMSDenyStillBlocksObservedAccess(t *testing.T) {
+	// A deny for the observed KMS action should still force observed_without_grant,
+	// even when an allow exists, because that access path is explicitly blocked.
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/allow-deny-match"
+	identity := "aws:identity:role:matching-deny"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-matching-deny",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Action:         "kms:GenerateDataKey",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt", "kms:GenerateDataKey"},
+			},
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Deny",
+				Actions:        []string{"kms:GenerateDataKey"},
+			},
+		},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when observed action is denied, got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("expected observed-despite-deny caveat, got %+v", correlation.Caveats)
+	}
+	if correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected deny static effect, got %q", correlation.StaticEffect)
+	}
+}
+
 func TestCorrelateObservedKMSActionRequiresMatchingStaticAuthorization(t *testing.T) {
 	keyARN := "arn:aws:kms:us-east-1:111122223333:key/observed-without-kms-decrypt"
 	identity := "aws:identity:role:action-mismatch"

--- a/internal/runtime/secretsaccess/correlate_test.go
+++ b/internal/runtime/secretsaccess/correlate_test.go
@@ -281,6 +281,97 @@ func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestCorrelateWildcardPrincipalDenyAppliesToObservedIdentity(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-1:111122223333:key/allow-and-wildcard-deny"
+	identity := "aws:identity:role:observed"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-wildcard-deny",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindKMSKey,
+			ResourceARN:    keyARN,
+			Action:         "kms:Decrypt",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindKMSKey,
+				ResourceARN:    keyARN,
+				Source:         SourceKeyPolicy,
+				Effect:         "Allow",
+				Actions:        []string{"kms:Decrypt"},
+			},
+			{
+				PrincipalARN: "*",
+				ResourceKind: ResourceKindKMSKey,
+				ResourceARN:  keyARN,
+				Source:       SourceKeyPolicy,
+				Effect:       "Deny",
+				Actions:      []string{"kms:Decrypt"},
+			},
+		},
+	})
+
+	correlation := findCorrelation(t, result, keyARN)
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when wildcard deny applies, got %q", correlation.Status)
+	}
+	if correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected deny static effect when wildcard deny applies, got %q", correlation.StaticEffect)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("expected observed-despite-deny caveat, got %+v", correlation.Caveats)
+	}
+	if hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("no-static-path caveat should not appear when deny is present, got %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateWildcardPrincipalSecretDenyAppliesToObservedIdentity(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:111122223333:secret:allow-and-wildcard-deny"
+	identity := "aws:identity:role:secret-reader"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-secret-wildcard-deny",
+			IdentityNodeID: identity,
+			ResourceKind:   ResourceKindSecret,
+			ResourceARN:    secretARN,
+			Action:         "secretsmanager:GetSecretValue",
+			ObservedAt:     observedAt(1),
+		}},
+		Static: []StaticGrant{
+			{
+				IdentityNodeID: identity,
+				ResourceKind:   ResourceKindSecret,
+				ResourceARN:    secretARN,
+				Source:         SourceResourcePolicy,
+				Effect:         "Allow",
+				Actions:        []string{"secretsmanager:GetSecretValue"},
+			},
+			{
+				PrincipalARN: "*",
+				ResourceKind: ResourceKindSecret,
+				ResourceARN:  secretARN,
+				Source:       SourceResourcePolicy,
+				Effect:       "Deny",
+				Actions:      []string{"secretsmanager:GetSecretValue"},
+			},
+		},
+	})
+
+	correlation := findCorrelation(t, result, secretARN)
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when wildcard secret deny applies, got %q", correlation.Status)
+	}
+	if correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected deny static effect when wildcard secret deny applies, got %q", correlation.StaticEffect)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("expected observed-despite-deny caveat, got %+v", correlation.Caveats)
+	}
+}
+
 func TestCorrelateDenySpecificActionDoesNotBlockOtherKMSAction(t *testing.T) {
 	// Explicit deny rules are action-specific in AWS. A deny for a different
 	// KMS action should not downgrade a matching Decrypt access to

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2292,6 +2292,135 @@ export type AWSRuntimeEventQuery = {
   status?: string;
 };
 
+// AWSSecretsKMSRuntimeAccess* types describe the Secrets Manager read /
+// KMS decrypt runtime access correlation: observed runtime events joined
+// with the static reachability edges Identrail discovered, classified per
+// (identity, resource) pair with a correlation confidence and explicit
+// missing-event caveats.
+export type AWSSecretsKMSRuntimeAccessStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSecretsKMSRuntimeAccessFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSSecretsKMSRuntimeAccessCorrelationStatus =
+  | 'confirmed'
+  | 'observed_without_grant'
+  | 'granted_unused';
+export type AWSSecretsKMSRuntimeAccessResourceKind = 'secret' | 'kms_key';
+
+export type AWSSecretsKMSRuntimeAccessRecord = {
+  correlation_id: string;
+  account_id: string;
+  region: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  resource_kind: AWSSecretsKMSRuntimeAccessResourceKind | string;
+  resource_arn: string;
+  resource_name?: string;
+  resource_node_id: string;
+  status: AWSSecretsKMSRuntimeAccessCorrelationStatus | string;
+  confidence: number;
+  observed_count: number;
+  observed_event_ids?: string[];
+  actions?: string[];
+  session_ids?: string[];
+  agent_id?: string;
+  agent_node_id?: string;
+  first_observed_at?: string;
+  last_observed_at?: string;
+  static_sources?: string[];
+  static_effect?: string;
+  conditional?: boolean;
+  cross_account?: boolean;
+  caveats?: string[];
+  evidence_ref: string;
+  evidence_refs?: string[];
+  next_action: string;
+  redaction_boundary: string;
+};
+
+export type AWSSecretsKMSRuntimeAccessRelationship = {
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSSecretsKMSRuntimeAccessDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSSecretsKMSRuntimeAccessCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSSecretsKMSRuntimeAccessSummary = {
+  total_correlations: number;
+  filtered_correlations: number;
+  status_counts: Record<string, number>;
+  confirmed_count: number;
+  observed_without_grant_count: number;
+  granted_unused_count: number;
+  secret_correlation_count: number;
+  kms_key_correlation_count: number;
+  identity_count: number;
+  resource_count: number;
+  observed_access_count: number;
+  static_grant_count: number;
+  relationship_count: number;
+};
+
+export type AWSSecretsKMSRuntimeAccessResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSecretsKMSRuntimeAccessStatus;
+  fixture_state: AWSSecretsKMSRuntimeAccessFixtureState;
+  confidence: number;
+  applied_filters: Record<string, string>;
+  summary: AWSSecretsKMSRuntimeAccessSummary;
+  records: AWSSecretsKMSRuntimeAccessRecord[];
+  relationships: AWSSecretsKMSRuntimeAccessRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSSecretsKMSRuntimeAccessCoverageGap[];
+  diagnostics: AWSSecretsKMSRuntimeAccessDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSSecretsKMSRuntimeAccessQuery = {
+  connectorID?: string;
+  fixtureState?: AWSSecretsKMSRuntimeAccessFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  agentID?: string;
+  resource?: string;
+  resourceKind?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -5394,6 +5523,27 @@ export const apiClient = {
         resource: query?.resource,
         evidence: query?.evidence,
         owner: query?.owner,
+        status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSecretsKMSRuntimeAccess(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSSecretsKMSRuntimeAccessQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ correlation: AWSSecretsKMSRuntimeAccessResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secrets-kms-runtime-access${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        agent_id: query?.agentID,
+        resource: query?.resource,
+        resource_kind: query?.resourceKind,
         status: query?.status
       })}`,
       auth

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2412,6 +2412,7 @@ export type AWSSecretsKMSRuntimeAccessResult = {
 export type AWSSecretsKMSRuntimeAccessQuery = {
   connectorID?: string;
   fixtureState?: AWSSecretsKMSRuntimeAccessFixtureState;
+  deliverySource?: AWSRuntimeEventDeliverySource;
   accountID?: string;
   region?: string;
   identity?: string;
@@ -5538,6 +5539,7 @@ export const apiClient = {
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secrets-kms-runtime-access${buildQuery({
         connector_id: query?.connectorID,
         fixture_state: query?.fixtureState,
+        delivery_source: query?.deliverySource,
         account_id: query?.accountID,
         region: query?.region,
         identity: query?.identity,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -49,6 +49,8 @@ import {
   type AWSAIAgentIdentityRecord,
   type AWSRuntimeEventRecord,
   type AWSRuntimeEventResult,
+  type AWSSecretsKMSRuntimeAccessRecord,
+  type AWSSecretsKMSRuntimeAccessResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10069,6 +10071,129 @@ function AWSRuntimeEvidenceContent({
   );
 }
 
+function awsSecretsKMSCorrelationStatusLabel(status: string): string {
+  switch (status) {
+    case 'confirmed':
+      return 'Confirmed';
+    case 'observed_without_grant':
+      return 'Observed · no static grant';
+    case 'granted_unused':
+      return 'Granted · unused';
+    default:
+      return formatTokenLabel(status);
+  }
+}
+
+function awsSecretsKMSCorrelationStage(status: string): AWSCapabilityStage {
+  switch (status) {
+    case 'confirmed':
+      return 'wired';
+    case 'observed_without_grant':
+      return 'coming';
+    default:
+      return 'not-available';
+  }
+}
+
+function awsSecretsKMSResourceLabel(record: AWSSecretsKMSRuntimeAccessRecord): string {
+  const kind = record.resource_kind === 'kms_key' ? 'KMS key' : 'Secret';
+  return `${kind}: ${record.resource_name || record.resource_arn}`;
+}
+
+function awsSecretsKMSCaveatLabel(record: AWSSecretsKMSRuntimeAccessRecord): string {
+  if (!record.caveats || record.caveats.length === 0) {
+    return '—';
+  }
+  return record.caveats.map((caveat) => formatTokenLabel(caveat)).join(' · ');
+}
+
+function AWSSecretsKMSRuntimeAccessContent({
+  correlation,
+  loading,
+  error,
+  onRetry
+}: {
+  correlation: AWSSecretsKMSRuntimeAccessResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const records = correlation?.records ?? [];
+  const summaryLine = correlation
+    ? `${correlation.summary.confirmed_count} confirmed · ${correlation.summary.observed_without_grant_count} observed without grant · ${correlation.summary.granted_unused_count} granted unused`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="Secrets Manager and KMS runtime access correlation">
+      <h3>Secrets Manager / KMS runtime access correlation</h3>
+      <p className="idt-app-kicker">
+        Observed secret reads and KMS decrypts joined with static reachability — confirmed, observed-without-grant, or
+        unused grant. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load runtime access correlation"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Correlating runtime access"
+          body="Identrail is joining observed Secrets Manager / KMS runtime events with static reachability."
+        />
+      ) : null}
+      {!error && !loading && correlation && records.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={correlation.status === 'blocked' ? 'Permission required' : 'No correlations'}
+          title={
+            correlation.status === 'blocked'
+              ? 'Runtime access correlation needs read-only event access'
+              : 'No Secrets Manager / KMS correlations'
+          }
+          body={
+            correlation.failure_reasons[0] ??
+            'No observed secret reads / KMS decrypts or static grants were available for the current environment.'
+          }
+        />
+      ) : null}
+      {!error && !loading && correlation && correlation.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {correlation.caveats.map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {records.length > 0 ? (
+        <DomainDataTable
+          label="Secrets Manager / KMS runtime access correlations"
+          rows={records}
+          getRowKey={(row) => row.correlation_id}
+          columns={[
+            { key: 'resource', header: 'Resource', render: (row) => <strong>{awsSecretsKMSResourceLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.identity_node_id },
+            {
+              key: 'evidence',
+              header: 'Evidence',
+              render: (row) =>
+                `${row.observed_count} observed · ${(row.static_sources ?? []).map((source) => formatTokenLabel(source)).join(', ') || 'no static grant'} · ${formatConfidenceScore(row.confidence)}`
+            },
+            { key: 'caveats', header: 'Caveats', render: (row) => awsSecretsKMSCaveatLabel(row) },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action },
+            {
+              key: 'status',
+              header: 'Correlation',
+              render: (row) => (
+                <AWSInventoryPill stage={awsSecretsKMSCorrelationStage(row.status)} label={awsSecretsKMSCorrelationStatusLabel(row.status)} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -10555,6 +10680,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [runtimeEventsLoading, setRuntimeEventsLoading] = useState(false);
   const [runtimeEventsError, setRuntimeEventsError] = useState('');
   const runtimeEventsRequestRef = useRef(0);
+  const [secretsKMSAccess, setSecretsKMSAccess] = useState<AWSSecretsKMSRuntimeAccessResult | null>(null);
+  const [secretsKMSAccessLoading, setSecretsKMSAccessLoading] = useState(false);
+  const [secretsKMSAccessError, setSecretsKMSAccessError] = useState('');
+  const secretsKMSAccessRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -10617,6 +10746,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       runtimeEventsRequestRef.current += 1;
     };
   }, [loadRuntimeEvents]);
+
+  const loadSecretsKMSAccess = useCallback(async () => {
+    const requestID = ++secretsKMSAccessRequestRef.current;
+    setSecretsKMSAccess(null);
+    setSecretsKMSAccessError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSecretsKMSAccessLoading(false);
+      return;
+    }
+    setSecretsKMSAccessLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSecretsKMSRuntimeAccess(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== secretsKMSAccessRequestRef.current) {
+        return;
+      }
+      setSecretsKMSAccess(response.correlation);
+    } catch (error) {
+      if (requestID !== secretsKMSAccessRequestRef.current) {
+        return;
+      }
+      setSecretsKMSAccessError(formatAPIError(error, 'Unable to load Secrets Manager / KMS runtime access correlation.'));
+    } finally {
+      if (requestID === secretsKMSAccessRequestRef.current) {
+        setSecretsKMSAccessLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadSecretsKMSAccess();
+    return () => {
+      secretsKMSAccessRequestRef.current += 1;
+    };
+  }, [loadSecretsKMSAccess]);
 
   if (!scope) {
     return (
@@ -10709,6 +10886,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             filters={activeFilters}
             onFiltersChange={onFiltersChange}
             onRetry={loadRuntimeEvents}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSSecretsKMSRuntimeAccessContent
+            correlation={secretsKMSAccess}
+            loading={secretsKMSAccessLoading}
+            error={secretsKMSAccessError}
+            onRetry={loadSecretsKMSAccess}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
Closes #1518.

## Summary

Wave 5.06 adds the **correlation layer** that ties **observed** Secrets Manager read and KMS decrypt runtime events back to the **static reachability** edges Identrail already discovered (KMS key-policy / grant `can_decrypt` edges from #1489 and Secrets Manager resource-policy grants from #1490, joined against the runtime-event contract from #1513–#1517). This lets operators prove what a machine identity *actually did* versus what policy *allowed* — instead of two disconnected surfaces.

All three blockers (#1516, #1489, #1490) are closed.

## What it does

For each `(identity, resource)` pair the engine classifies the access as:

| Status | Meaning | Confidence |
|---|---|---|
| `confirmed` | Observed access **and** a static allow grant exist | 0.95 (capped to 0.85 on unresolved lineage; −0.05 conditional) |
| `observed_without_grant` | Observed but no modeled grant — usually IAM identity-policy access, **not** automatically drift | 0.6 |
| `granted_unused` | Allowed but never observed in the window | 0.7 → 0.5 when data-event coverage is unknown |

Because Secrets Manager `GetSecretValue` and KMS `Decrypt` are CloudTrail **data** events, `granted_unused` always carries a mandatory missing-event caveat — absence is never presented as proof. Other stable caveat codes: `no_static_reachability_edge`, `observed_despite_explicit_deny`, `static_grant_is_conditional`, `static_grant_is_cross_account`, `session_lineage_unresolved`.

## Changes

- **Engine** `internal/runtime/secretsaccess` — pure, metadata-only correlation join (10 unit tests).
- **API** `GET /v1/.../aws/secrets-kms-runtime-access` — queryable correlation timeline filterable by identity, agent, resource, resource kind, account, region, and status; `ready`/`degraded`/`blocked` states, coverage gaps, diagnostics, evidence links, graph relationships. Live mode composes the runtime-events + KMS reachability + Secrets Manager metadata services; deterministic fixtures cover all five states (7 API tests).
- **Route policy registry + OpenAPI v1 spec** updated (path, schemas, scope headers).
- **Web** — TypeScript client types + `getAWSProjectSecretsKMSRuntimeAccess`, and a correlation panel on the AWS runtime page with loading / empty / error / degraded / permission-denied states.
- **Docs** `docs/aws-secrets-kms-runtime-access.md` + CHANGELOG.

## Safety

No new AWS permissions. Never reads secret values, decrypted plaintext, or encryption-context values; every record re-stamps the `metadata_only_no_secret_values_no_plaintext` redaction boundary. Unknown / permission-denied / partial-failure states are explicit, not silent successes.

## Testing

- `make fmt-check`, `make vet` — clean
- `go test ./...` — all 46 packages pass
- `make api-example-contract-check`, `make web-route-integrity-check` — pass
- `npm run build --prefix web`, `npm run test:ci --prefix web` (424 tests) — pass

## AI Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only correlation that links observed Secrets Manager reads and KMS decrypts to static grants, plus a new API and UI timeline. Routes data events via CloudTrail S3/EventBridge using a `delivery_source` filter (default `all`) to avoid false `granted_unused`; never reads secret values or adds AWS permissions, implementing #1518.

- **New Features**
  - Correlates `secret-read`/`kms-decrypt` with KMS key-policy/grant and Secrets Manager resource-policy edges; classifies `(identity, resource)` as `confirmed`, `observed_without_grant`, or `granted_unused`.
  - New endpoint: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secrets-kms-runtime-access` with filters (connector, identity, agent, resource/kind, account, region, status) and `delivery_source` (`all` default). Returns `ready`/`degraded`/`blocked`, coverage gaps, diagnostics, evidence links, and graph relationships.
  - Engine: `internal/runtime/secretsaccess`; OpenAPI, route policy, and router updated; Web: TypeScript client and a correlation panel on the AWS runtime page; docs and CHANGELOG added.

- **Bug Fixes**
  - Recognizes wildcard Secrets Manager read actions (`Get*`, `BatchGet*`, `secretsmanager:*`, `*`) in resource-policy grants.
  - Treats explicit Deny as overriding Allow (including wildcard KMS denies) with an `observed_despite_deny` caveat.
  - Separates unresolved-resource correlations by event kind.
  - Suppresses static-only `granted_unused` when the runtime source is `blocked`; also suppresses fixture static grants and unavailable fixtures in live correlation.

<sup>Written for commit 541b3b149d8eda900dfbeb48c6c6f7abe8d82f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

