### PR TITLE
Polish appearance preview and shortcuts

### DIFF
--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -439,10 +439,7 @@ export function normalizeAppearancePreferences(value: unknown): AppearancePrefer
     customColors: sanitizeBoolean(source.customColors, DEFAULT_APPEARANCE_PREFERENCES.customColors),
     uiFont: sanitizeFontID(source.uiFont, DEFAULT_APPEARANCE_PREFERENCES.uiFont),
     codeFont: sanitizeFontID(source.codeFont, DEFAULT_APPEARANCE_PREFERENCES.codeFont),
-    translucentSidebar: sanitizeBoolean(
-      source.translucentSidebar,
-      DEFAULT_APPEARANCE_PREFERENCES.translucentSidebar
-    ),
+    translucentSidebar: false,
     contrast: sanitizeNumber(source.contrast, DEFAULT_APPEARANCE_PREFERENCES.contrast, 0, 100),
     pointerCursors: sanitizeBoolean(source.pointerCursors, DEFAULT_APPEARANCE_PREFERENCES.pointerCursors),
     reduceMotion: sanitizeEnum(source.reduceMotion, ['system', 'on', 'off'], DEFAULT_APPEARANCE_PREFERENCES.reduceMotion),

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1963,6 +1963,7 @@ describe('ProductAppearanceSettingsPage', () => {
       customColors: 'yes',
       uiFont: 'url(https://evil.example/font.woff2)',
       codeFont: '<script>alert(1)</script>',
+      translucentSidebar: true,
       contrast: 999,
       reduceMotion: 'drop-table',
       appIcon: '../../private'
@@ -1977,6 +1978,7 @@ describe('ProductAppearanceSettingsPage', () => {
       customColors: false,
       uiFont: 'inter',
       codeFont: 'mono-system',
+      translucentSidebar: false,
       contrast: 100,
       reduceMotion: 'system'
     });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1897,6 +1897,11 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-ui-font')).toContain('Inter');
     expect(document.documentElement.style.getPropertyValue('--appearance-contrast')).toBe('52');
     expect(screen.queryByRole('heading', { name: 'App icon' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Theme preview')).toBeInTheDocument();
+    expect(screen.getByLabelText('App preview')).toBeInTheDocument();
+    expect(screen.getByText('Repository findings')).toBeInTheDocument();
+    expect(screen.getByText('OIDC trust path exposed')).toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: 'Translucent sidebar' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Light' }));
     expect(document.documentElement.dataset.theme).toBe('light');
@@ -2209,6 +2214,50 @@ describe('ProductShellLayout', () => {
     fireEvent.keyDown(screen.getByLabelText(/Search workspace commands/i), { key: 'Enter' });
 
     expect(await screen.findByRole('heading', { level: 2, name: /GitHub findings content/i })).toBeInTheDocument();
+  });
+
+  it('uses Windows shortcut labels when rendering the app shell outside macOS', async () => {
+    vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route index element={<h2>Overview content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Ctrl+K')).toBeInTheDocument();
+    expect(screen.getByText('Ctrl+B')).toBeInTheDocument();
+    expect(screen.getByText('Click to collapse')).toBeInTheDocument();
+    expect(screen.getByText('Drag to resize')).toBeInTheDocument();
+  });
+
+  it('uses macOS shortcut labels when rendering the app shell on Apple platforms', async () => {
+    vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route index element={<h2>Overview content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('⌘K')).toBeInTheDocument();
+    expect(screen.getByText('⌘B')).toBeInTheDocument();
+    expect(screen.getByText('Click to collapse')).toBeInTheDocument();
+    expect(screen.getByText('Drag to resize')).toBeInTheDocument();
   });
 
   it('keeps GitHub domain navigation open when the connector is unavailable', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -15483,6 +15483,11 @@ function isMacPlatform(): boolean {
   return /Mac|iPhone|iPad|iPod/i.test(navigator.platform || '');
 }
 
+function formatPlatformShortcut(key: string): string {
+  const normalizedKey = key.trim().toUpperCase();
+  return isMacPlatform() ? `⌘${normalizedKey}` : `Ctrl+${normalizedKey}`;
+}
+
 export function ProductShellLayout() {
   const params = useParams<ScopeRouteParams>();
   const location = useLocation();
@@ -16052,7 +16057,8 @@ export function ProductShellLayout() {
   const userDisplayName = 'Account';
   const userEmail = '';
   const userInitial = (workspaceDisplayName.charAt(0) || 'A').toUpperCase();
-  const collapseShortcut = isMacPlatform() ? '⌘B' : 'Ctrl+B';
+  const collapseShortcut = formatPlatformShortcut('B');
+  const finderShortcut = formatPlatformShortcut('K');
   const runCommand = (item: CommandPaletteItem) => {
     setCommandOpen(false);
     setOpenDomainFlyout(null);
@@ -16103,13 +16109,19 @@ export function ProductShellLayout() {
             tabIndex={openDomainFlyout ? -1 : 0}
             aria-orientation="vertical"
             aria-label={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar. Drag to resize.`}
-            data-sidebar-action={sidebarCollapsed ? 'Click to expand' : 'Click to collapse'}
-            data-sidebar-shortcut={collapseShortcut}
             onPointerDown={handleSidebarResizeStart}
             onKeyDown={handleSidebarResizeKeyDown}
             onFocus={() => setIsSidebarEdgeFocused(true)}
             onBlur={() => setIsSidebarEdgeFocused(false)}
-          />
+          >
+            <span className="idt-app-sidebar-resize-tooltip" aria-hidden="true">
+              <span className="idt-app-sidebar-resize-tooltip-row">
+                <span>{sidebarCollapsed ? 'Click to expand' : 'Click to collapse'}</span>
+                <kbd>{collapseShortcut}</kbd>
+              </span>
+              <span>Drag to resize</span>
+            </span>
+          </div>
           <div className="idt-app-sidebar-workspace" ref={workspaceMenuRef}>
             <button
               type="button"
@@ -16178,13 +16190,13 @@ export function ProductShellLayout() {
             className="idt-app-quick-find"
             onClick={() => setCommandOpen(true)}
             aria-label="Open workspace finder"
-            title={sidebarCollapsed ? 'Find (⌘K)' : undefined}
+            title={sidebarCollapsed ? `Find (${finderShortcut})` : undefined}
           >
             <span className="idt-app-quick-find-icon" aria-hidden="true">
               <Search size={14} strokeWidth={2} />
             </span>
             <span className="idt-app-quick-find-label">Find</span>
-            <kbd className="idt-app-quick-find-key">⌘K</kbd>
+            <kbd className="idt-app-quick-find-key">{finderShortcut}</kbd>
           </button>
 
           {openDomainFlyout ? (
@@ -23034,6 +23046,37 @@ export function ProductAppearanceSettingsPage() {
           </div>
         </div>
 
+        <div className="idt-appearance-app-preview" aria-label="App preview">
+          <div className="idt-appearance-app-preview-rail" aria-hidden="true">
+            <span className="is-active">
+              <span />
+              GitHub
+            </span>
+            <span>
+              <span />
+              Settings
+            </span>
+          </div>
+          <div className="idt-appearance-app-preview-surface">
+            <div className="idt-appearance-app-preview-head">
+              <span>
+                <strong>Repository findings</strong>
+                <small>GitHub control center</small>
+              </span>
+              <em>Needs review</em>
+            </div>
+            <div className="idt-appearance-app-preview-card">
+              <span className="idt-appearance-app-preview-dot" aria-hidden="true" />
+              <span>
+                <strong>OIDC trust path exposed</strong>
+                <small>8 findings · 1 file</small>
+              </span>
+              <span className="idt-appearance-app-preview-button">Review</span>
+            </div>
+            <div className="idt-appearance-app-preview-input">Search repositories</div>
+          </div>
+        </div>
+
         <div className="idt-appearance-control-list">
           <label className="idt-appearance-control-row">
             <span>
@@ -23127,18 +23170,6 @@ export function ProductAppearanceSettingsPage() {
               ))}
             </select>
           </label>
-
-          <div className="idt-appearance-control-row">
-            <span>
-              <strong>Translucent sidebar</strong>
-              <small>{preferences.translucentSidebar ? 'Sidebar blur is on' : 'Sidebar stays solid'}</small>
-            </span>
-            <AppearanceSwitch
-              checked={preferences.translucentSidebar}
-              label="Translucent sidebar"
-              onChange={(translucentSidebar) => commitPreferences({ translucentSidebar })}
-            />
-          </div>
 
           <label className="idt-appearance-control-row idt-appearance-slider-row">
             <span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -15437,8 +15437,8 @@ const SIDEBAR_MIN_EXPANDED_WIDTH = 196;
 const SIDEBAR_MAX_WIDTH = 360;
 const SIDEBAR_COLLAPSE_THRESHOLD = 140; // dragging below this snaps to collapsed
 const SIDEBAR_COLLAPSED_WIDTH = 60;
-const SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT = 88;
-const SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT = 168;
+const SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT = 68;
+const SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT = 132;
 
 type ScrollNavigatorMetrics = {
   visible: boolean;
@@ -15930,13 +15930,13 @@ export function ProductShellLayout() {
         return;
       }
 
-      const trackTop = Math.min(112, Math.max(80, viewportHeight * 0.13));
-      const trackBottom = Math.min(56, Math.max(36, viewportHeight * 0.05));
+      const trackTop = Math.min(72, Math.max(28, viewportHeight * 0.055));
+      const trackBottom = Math.min(64, Math.max(28, viewportHeight * 0.045));
       const trackHeight = Math.max(120, viewportHeight - trackTop - trackBottom);
       const thumbHeight = Math.round(
         Math.min(
           SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT,
-          Math.max(SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT, trackHeight * 0.22)
+          Math.max(SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT, trackHeight * 0.16)
         )
       );
       const scrollProgress = Math.min(1, Math.max(0, scrollingElement.scrollTop / scrollRange));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19010,7 +19010,7 @@ html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-final-ct
 }
 
 .idt-hero-copy h1 span {
-  color: #3ecf8e;
+  color: #823cf2;
   font-family: inherit;
 }
 
@@ -19019,7 +19019,7 @@ html[data-theme='light'] .idt-hero-copy h1 {
 }
 
 html[data-theme='light'] .idt-hero-copy h1 span {
-  color: #6d37dd;
+  color: #823cf2;
   font-family: inherit;
 }
 
@@ -27213,11 +27213,12 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   display: grid;
   grid-template-columns: 1.35rem minmax(0, 1fr);
   align-items: center;
+  align-content: center;
   gap: 0.65rem;
   width: 100%;
   min-width: 0;
-  min-height: 2.15rem;
-  padding: 0.45rem 0.6rem;
+  min-height: 2.3rem;
+  padding: 0 0.68rem;
   border-radius: 7px;
   border-color: transparent;
   background: transparent;
@@ -27286,7 +27287,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   min-width: 0;
   min-height: 1.1rem;
   overflow: hidden;
-  line-height: 1.1;
+  line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -27410,9 +27411,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   z-index: 20;
   border: 0;
   padding: 0;
-  background: #000000;
-  -webkit-backdrop-filter: blur(28px) saturate(0.84) brightness(0.48);
-  backdrop-filter: blur(28px) saturate(0.84) brightness(0.48);
+  background: transparent;
   cursor: default;
   touch-action: none;
 }
@@ -27423,7 +27422,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   z-index: 40;
   border: 0;
   padding: 0;
-  background: rgba(5, 7, 10, 0.54);
+  background: transparent;
   cursor: default;
   touch-action: none;
 }
@@ -27456,21 +27455,19 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   left: calc(100% + 0.72rem);
   z-index: 50;
   display: grid;
-  gap: 0.58rem;
-  width: min(27rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
+  gap: 0.48rem;
+  width: min(24rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
   max-height: min(78vh, 42rem);
   overflow: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
-  border: 1px solid rgba(255, 255, 255, 0.13);
+  border: 1px solid var(--app-border-soft);
   border-radius: 8px;
-  padding: 0.68rem;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 8rem),
-    #050607;
+  padding: 0.52rem;
+  background: color-mix(in srgb, var(--app-panel) 92%, var(--app-bg));
   box-shadow:
-    0 28px 90px rgba(0, 0, 0, 0.62),
-    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    0 20px 46px rgba(0, 0, 0, 0.28),
+    0 0 0 1px color-mix(in srgb, var(--app-border-soft) 70%, transparent) inset;
   transform-origin: top left;
   animation: idtFlyoutRevealIn var(--idt-motion-slow) var(--idt-motion-ease) both;
 }
@@ -27482,15 +27479,15 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   left: -0.45rem;
   width: 0.85rem;
   height: 0.85rem;
-  border-left: 1px solid rgba(255, 255, 255, 0.13);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.13);
-  background: #050607;
+  border-left: 1px solid var(--app-border-soft);
+  border-bottom: 1px solid var(--app-border-soft);
+  background: color-mix(in srgb, var(--app-panel) 92%, var(--app-bg));
   transform: rotate(45deg);
 }
 
 .idt-domain-flyout-section-label {
   margin: 0;
-  color: #9aa4af;
+  color: var(--app-muted);
   font-size: 0.68rem;
   font-weight: 800;
   line-height: 1.2;
@@ -27501,7 +27498,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-list,
 .idt-domain-flyout-nested-body {
   display: grid;
-  gap: 0.12rem;
+  gap: 0.06rem;
 }
 
 .idt-domain-flyout-section {
@@ -27512,20 +27509,20 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-section + .idt-domain-flyout-section,
 .idt-domain-flyout-nested + .idt-domain-flyout-section {
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-  padding-top: 0.62rem;
+  border-top: 1px solid var(--app-border-soft);
+  padding-top: 0.52rem;
 }
 
 .idt-domain-flyout-link {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.55rem;
+  gap: 0.5rem;
   align-items: center;
-  min-height: 2.28rem;
+  min-height: 2.05rem;
   border: 1px solid transparent;
-  border-radius: 7px;
-  padding: 0.44rem 0.54rem;
-  color: #dce3eb;
+  border-radius: 6px;
+  padding: 0.34rem 0.48rem;
+  color: var(--app-muted);
   text-decoration: none;
   transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
@@ -27533,16 +27530,16 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-link:hover,
 .idt-domain-flyout-link:focus-visible,
 .idt-domain-flyout-link.is-active {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: #10141a;
-  color: #ffffff;
+  border-color: transparent;
+  background: color-mix(in srgb, var(--appearance-accent) 13%, transparent);
+  color: var(--app-text);
   outline: none;
 }
 
 .idt-domain-flyout-link.is-child {
   margin-left: 0.48rem;
-  padding-left: 0.62rem;
-  border-left-color: rgba(255, 255, 255, 0.12);
+  padding-left: 0.56rem;
+  border-left-color: color-mix(in srgb, var(--app-border-soft) 72%, transparent);
 }
 
 .idt-domain-flyout-link-copy {
@@ -27552,33 +27549,33 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link-copy strong {
   color: inherit;
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   font-weight: 750;
   line-height: 1.2;
 }
 
 .idt-domain-flyout-link-copy span,
 .idt-domain-flyout-nested small {
-  color: #8f98a4;
+  color: var(--app-muted);
   font-size: 0.72rem;
   font-weight: 650;
   line-height: 1.2;
 }
 
 .idt-domain-flyout-nested {
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 8px;
-  padding: 0.36rem;
-  background: rgba(255, 255, 255, 0.018);
+  border: 0;
+  border-radius: 6px;
+  padding: 0;
+  background: transparent;
 }
 
 .idt-domain-flyout-nested summary {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  border-radius: 7px;
-  padding: 0.45rem 0.5rem;
-  color: #f3f5f7;
+  border-radius: 6px;
+  padding: 0.34rem 0.48rem;
+  color: var(--app-text);
   cursor: pointer;
   list-style: none;
 }
@@ -27599,7 +27596,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary svg {
-  color: #8f98a4;
+  color: var(--app-muted);
   transition: transform 0.14s ease;
 }
 
@@ -27609,12 +27606,12 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary:hover,
 .idt-domain-flyout-nested summary:focus-visible {
-  background: #10141a;
+  background: color-mix(in srgb, var(--appearance-accent) 10%, transparent);
   outline: none;
 }
 
 .idt-domain-flyout-nested-body {
-  margin-top: 0.34rem;
+  margin-top: 0.08rem;
   transform-origin: top;
   animation: idtFlyoutRevealIn var(--idt-motion-standard) var(--idt-motion-ease) both;
 }
@@ -28840,6 +28837,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.08),
     0 10px 24px rgba(0, 0, 0, 0.42);
+}
+
+html[data-theme='light'] .idt-app-scroll-navigator-thumb {
+  background: rgba(0, 0, 0, 0.74);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.16),
+    0 12px 26px rgba(15, 23, 42, 0.24);
 }
 
 /* Hide the drag handle on narrow viewports — the rail becomes a top bar. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -28737,12 +28737,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   outline: none;
 }
 
-.idt-app-sidebar-resize-handle::before {
-  content: attr(data-sidebar-action) " " attr(data-sidebar-shortcut) "\A Drag to resize";
+.idt-app-sidebar-resize-tooltip {
   position: absolute;
   top: 50%;
   right: calc(100% + 0.8rem);
   z-index: 2;
+  display: grid;
+  gap: 0.22rem;
   min-width: 10.8rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 8px;
@@ -28760,6 +28761,19 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   box-shadow: 0 14px 42px rgba(0, 0, 0, 0.45);
 }
 
+.idt-app-sidebar-resize-tooltip-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-app-sidebar-resize-tooltip kbd {
+  color: rgba(255, 255, 255, 0.72);
+  font: inherit;
+  font-size: 0.78rem;
+}
+
 .idt-app-sidebar-resize-handle::after {
   content: '';
   position: absolute;
@@ -28773,26 +28787,26 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   transition: background-color 0.12s ease, height 0.12s ease;
 }
 
-.idt-app-sidebar-resize-handle:hover::before,
-.idt-app-sidebar-resize-handle:focus::before,
-.idt-app-sidebar-resize-handle:focus-visible::before,
-.idt-app-sidebar-resize-handle.is-focused::before,
-.idt-app-sidebar-resize-handle.is-dragging::before {
+.idt-app-sidebar-resize-handle:hover .idt-app-sidebar-resize-tooltip,
+.idt-app-sidebar-resize-handle:focus .idt-app-sidebar-resize-tooltip,
+.idt-app-sidebar-resize-handle:focus-visible .idt-app-sidebar-resize-tooltip,
+.idt-app-sidebar-resize-handle.is-focused .idt-app-sidebar-resize-tooltip,
+.idt-app-sidebar-resize-handle.is-dragging .idt-app-sidebar-resize-tooltip {
   opacity: 1;
   transform: translateY(-50%) translateX(0);
 }
 
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle::before {
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-tooltip {
   right: auto;
   left: calc(100% + 0.8rem);
   transform: translateY(-50%) translateX(-0.2rem);
 }
 
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:hover::before,
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:focus::before,
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:focus-visible::before,
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle.is-focused::before,
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle.is-dragging::before {
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:hover .idt-app-sidebar-resize-tooltip,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:focus .idt-app-sidebar-resize-tooltip,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle:focus-visible .idt-app-sidebar-resize-tooltip,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle.is-focused .idt-app-sidebar-resize-tooltip,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-resize-handle.is-dragging .idt-app-sidebar-resize-tooltip {
   transform: translateY(-50%) translateX(0);
 }
 
@@ -31348,6 +31362,138 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   content: '+';
 }
 
+.idt-appearance-app-preview {
+  display: grid;
+  grid-template-columns: minmax(9.5rem, 0.34fr) minmax(0, 1fr);
+  gap: 0.85rem;
+  padding: 0.95rem 1.2rem;
+  border-bottom: 1px solid var(--app-border-soft);
+  background: color-mix(in srgb, var(--app-panel) 90%, var(--appearance-accent, #7c6dff) 4%);
+}
+
+.idt-appearance-app-preview-rail,
+.idt-appearance-app-preview-surface,
+.idt-appearance-app-preview-card,
+.idt-appearance-app-preview-input {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  background: var(--app-panel);
+}
+
+.idt-appearance-app-preview-rail {
+  display: grid;
+  align-content: start;
+  gap: 0.3rem;
+  padding: 0.5rem;
+}
+
+.idt-appearance-app-preview-rail > span {
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2rem;
+  border-radius: 6px;
+  padding: 0 0.48rem;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.idt-appearance-app-preview-rail > span > span {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--app-muted) 28%, transparent);
+}
+
+.idt-appearance-app-preview-rail > span.is-active {
+  background: color-mix(in srgb, var(--appearance-accent, #7c6dff) 18%, var(--app-panel));
+  color: var(--app-text);
+}
+
+.idt-appearance-app-preview-rail > span.is-active > span {
+  background: var(--appearance-accent, #7c6dff);
+}
+
+.idt-appearance-app-preview-surface {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.72rem;
+}
+
+.idt-appearance-app-preview-head,
+.idt-appearance-app-preview-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.idt-appearance-app-preview-head strong,
+.idt-appearance-app-preview-card strong {
+  display: block;
+  color: var(--app-text);
+  font-size: 0.88rem;
+  line-height: 1.2;
+}
+
+.idt-appearance-app-preview-head small,
+.idt-appearance-app-preview-card small {
+  display: block;
+  margin-top: 0.16rem;
+  color: var(--app-muted);
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.idt-appearance-app-preview-head em {
+  border: 1px solid color-mix(in srgb, var(--appearance-accent, #7c6dff) 34%, var(--app-border-soft));
+  border-radius: 999px;
+  padding: 0.18rem 0.5rem;
+  background: color-mix(in srgb, var(--appearance-accent, #7c6dff) 14%, transparent);
+  color: var(--app-text);
+  font-style: normal;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.idt-appearance-app-preview-card {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding: 0.58rem;
+}
+
+.idt-appearance-app-preview-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--appearance-accent, #7c6dff);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--appearance-accent, #7c6dff) 14%, transparent);
+}
+
+.idt-appearance-app-preview-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.9rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 0.7rem;
+  background: var(--appearance-accent, #7c6dff);
+  color: var(--app-panel);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.idt-appearance-app-preview-input {
+  min-height: 2rem;
+  padding: 0.45rem 0.62rem;
+  color: var(--app-muted);
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
 .idt-appearance-control-list {
   display: grid;
 }
@@ -31358,8 +31504,8 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 1rem;
-  min-height: 3.4rem;
-  padding: 0.75rem 1.2rem;
+  min-height: 3rem;
+  padding: 0.58rem 1.2rem;
   border-bottom: 1px solid var(--app-border-soft);
   color: var(--app-text);
 }
@@ -31381,10 +31527,10 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
 
 .idt-appearance-control-row select,
 .idt-appearance-number input {
-  min-height: 2.1rem;
+  min-height: 1.95rem;
   border: 1px solid var(--app-border-soft);
   border-radius: 8px;
-  padding: 0 0.8rem;
+  padding: 0 0.72rem;
   background: var(--app-panel);
   color: var(--app-text);
   font: inherit;
@@ -31536,6 +31682,20 @@ html[data-appearance-ready='true'] .idt-app-console-layout .idt-appearance-contr
   .idt-appearance-preview-pane + .idt-appearance-preview-pane {
     border-top: 1px solid var(--appearance-accent, #7c6dff);
     border-left: 0;
+  }
+
+  .idt-appearance-app-preview {
+    grid-template-columns: 1fr;
+    padding: 0.85rem;
+  }
+
+  .idt-appearance-app-preview-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .idt-appearance-app-preview-button {
+    grid-column: 2;
+    justify-self: start;
   }
 
   .idt-appearance-slider input {


### PR DESCRIPTION
## Summary
- Add a compact live app-surface preview to Appearance settings while keeping the code/diff preview for diff markers.
- Remove the visible Translucent sidebar control and tighten Appearance selector row density.
- Replace the sidebar resize tooltip with structured markup and show platform-aware shortcut labels for Mac and Windows/Linux.

Closes #1647

## Validation
- npm ci
- npm test -- productShell.test.tsx --run
- npm run build
- git diff --check
- Production-code safety scan for dynamic HTML/script/CSS injection patterns

## AI disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact, live app preview in Appearance and platform-aware shortcut labels across the shell. Replaces the sidebar resize tooltip with structured markup, polishes shell/flyout styles, and disables the Translucent sidebar. Closes #1647.

- New Features
  - Compact app-surface preview in Appearance; code/diff preview remains.
  - Platform-aware shortcuts via a formatter (⌘ on macOS, Ctrl on Windows/Linux) for Find (K) and Collapse (B) labels/titles.
  - Sidebar resize tooltip uses semantic markup with action + kbd; improved responsiveness.

- Refactors
  - Removed “Translucent sidebar” control and normalize preference to false.
  - UI polish: smaller scroll navigator; tightened quick-find and domain flyout spacing/colors; reduced glass effects.

<sup>Written for commit 1f01a2ee63950c97511edafc6281a8df1f5e7981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

