### PR TITLE
AWS Platform Wave 5.07: S3 runtime data access mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS S3 runtime data access correlation** (#1519). Adds a
+  metadata-only correlation engine (`internal/runtime/s3access`) that
+  joins observed S3 read/write/list runtime events with the static
+  reachability edges Identrail discovered (S3 bucket-policy grants) and
+  each bucket's exposure / sensitivity classification. Each `(identity,
+  bucket)` pair is classified `confirmed`, `observed_without_grant`, or
+  `granted_unused`, with observed access modes, a correlation
+  confidence, and caveats — including `observed_mode_exceeds_grant`
+  (e.g. an observed write where only read is granted) and
+  `sensitive_bucket_publicly_or_cross_account_exposed`. Object keys and
+  object contents are never read: access is correlated at bucket
+  granularity and object keys are redacted into bounded, sanitized safe
+  prefixes. The new endpoint
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/s3-runtime-access` exposes a
+  queryable correlation timeline filterable by identity, agent, bucket,
+  access mode, sensitivity, exposure, account, region, and correlation
+  status, with `ready`/`degraded`/`blocked` states, coverage gaps,
+  diagnostics, and graph relationships. Defaults the runtime source to
+  the CloudTrail delivery channels (`all`) because S3 data events are
+  not indexed by LookupEvents. Adds no new AWS permissions. Surfaced in
+  the AWS runtime app surface. Closes #1519. See
+  [docs/aws-s3-runtime-access.md](docs/aws-s3-runtime-access.md).
 - Add **AWS Secrets Manager read / KMS decrypt runtime access
   correlation** (#1518). Adds a metadata-only correlation engine
   (`internal/runtime/secretsaccess`) that joins observed `secret-read`

--- a/docs/aws-s3-runtime-access.md
+++ b/docs/aws-s3-runtime-access.md
@@ -1,0 +1,137 @@
+# AWS S3 runtime data access correlation
+
+Issue #1519 adds a correlation layer that ties **observed** S3 read/write/list
+runtime access back to the **static reachability** edges Identrail already
+discovered (S3 bucket-policy `can_access` grants from #1488) and each bucket's
+**exposure and sensitivity** classification. Without it, runtime evidence and
+static reachability live in separate surfaces and an operator cannot tell
+whether a machine identity actually exercised a grant, used access no modeled
+grant explains, or holds a grant it never uses.
+
+The correlation is **metadata-only and, for S3, never touches object keys or
+object contents.** It operates on the already-redacted runtime-event
+(#1513–#1517) and S3 reachability (#1488) contracts. Object keys are redacted
+into bounded, sanitized "safe prefixes" before they reach the engine; access is
+correlated at **bucket granularity**.
+
+## What it correlates
+
+For each `(identity, bucket)` pair the engine
+(`internal/runtime/s3access`) joins:
+
+- **Observed access** — S3 runtime events (`EventSource s3.amazonaws.com`),
+  keyed by actor identity node and bucket ARN, reduced to read / write / list
+  access modes.
+- **Static grants** — S3 bucket-policy grants for real IAM principals, with the
+  allowed modes derived from the grant's actions, plus the bucket's exposure and
+  sensitivity tier.
+
+## Correlation statuses
+
+| Status | Meaning | Confidence |
+|---|---|---|
+| `confirmed` | Observed access **and** a static allow grant exist. | 0.95 (capped to 0.85 on unresolved lineage; −0.05 conditional; capped to 0.8 when an observed mode exceeds the grant) |
+| `observed_without_grant` | Observed but no static allow edge explains it. Most S3 access is authorized by IAM **identity** policies, which this wave's static collector does not enumerate, so this means "needs IAM-policy confirmation", not automatically drift. | 0.6 |
+| `granted_unused` | A static allow grant exists but no access was observed in the window. | 0.7, reduced to 0.5 when data-event coverage is unknown |
+
+### Caveats
+
+Stable caveat codes attached to correlations or the result:
+
+- `runtime_data_events_may_be_incomplete` — S3 `GetObject`/`PutObject`/
+  `ListBucket` are CloudTrail **data** events. Unless an S3 data-event trail or
+  CloudTrail Lake is configured, observed coverage is incomplete and
+  `granted_unused` may reflect missing telemetry. **Absence of evidence is not
+  evidence of absence.**
+- `observed_mode_exceeds_grant` — the bucket is reachable, but an observed mode
+  (e.g. write) is not authorized by the static grant (e.g. read-only) — genuine
+  drift worth investigating.
+- `no_static_reachability_edge` — observed access with no modeled grant.
+- `observed_despite_explicit_deny` — observed access against a bucket carrying an
+  explicit `Deny` for the identity.
+- `sensitive_bucket_publicly_or_cross_account_exposed` — a sensitive bucket that
+  is also publicly or cross-account exposed, raising the stakes of the access.
+- `static_grant_is_conditional` / `static_grant_is_cross_account` /
+  `session_lineage_unresolved`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/s3-runtime-access`
+
+Query parameters:
+
+- `connector_id` — scope the account, region, and read-only runtime evidence.
+- `fixture_state` — `success` (default), `empty`, `degraded`,
+  `partial_failure`, `permission_denied`.
+- `delivery_source` — `lookup_events`, `s3`, `eventbridge`, or `all`.
+  **Defaults to `all`.** S3 read/write/list are CloudTrail data events that the
+  LookupEvents API does not index, so the correlation fans out across every
+  wired delivery channel; `lookup_events` alone will not observe these accesses.
+- `account_id`, `region` — scope filters.
+- `identity` — actor principal / identity-node search.
+- `agent_id` — agent ID / agent-node search.
+- `resource` — bucket ARN, name, or resource-node search.
+- `access_mode` — `read`, `write`, or `list` (matches observed or granted modes).
+- `sensitivity` — bucket sensitivity tier (e.g. `standard`, `elevated`, `high`).
+- `exposure` — bucket exposure (e.g. `private`, `restricted`, `cross_account`,
+  `public`).
+- `status` — `confirmed`, `observed_without_grant`, or `granted_unused`.
+
+The response (`AWSS3RuntimeAccessResult`) carries one record per correlation with
+the status, confidence, observed access modes, granted modes, safe prefixes,
+exposure/sensitivity, caveats, evidence references, and a graph relationship
+(`confirmed_runtime_access`, `observed_runtime_access_without_grant`, or
+`unused_static_grant`) joining back to the identity and bucket nodes. It also
+returns a summary, coverage gaps, diagnostics, and the `ready` / `degraded` /
+`blocked` status.
+
+## Live vs fixture
+
+Live composition is attempted when the connector is active and healthy, the
+operator did not pin a `fixture_state`, the connector's effective capability set
+includes `runtime_evidence`, and the CloudTrail factory for the selected source
+is wired (the **delivery** factory carries the data events). In that case the
+handler composes runtime-events (driven through the resolved `delivery_source`)
+and S3 bucket reachability and joins their results; the reachability reader is
+fixture-shaped today, so live mode forces an empty static state to avoid
+joining real observed events to synthetic grants. When the connector is healthy
+but no delivery factory is wired, the endpoint returns an explicit
+delivery-unavailable degraded state rather than serving fixtures as if they were
+live. Otherwise it returns the deterministic correlation fixtures, which
+exercise all statuses (including a write that exceeds a read-only grant and a
+sensitive, cross-account-exposed bucket).
+
+## AWS permissions
+
+This capability adds **no** new AWS permissions. It reuses the read-only,
+metadata-only permissions the runtime-events (`cloudtrail:LookupEvents` and
+optional delivery-channel reads) and S3 bucket reachability collectors already
+require. No `s3:GetObject` or any other object-content permission is requested or
+used.
+
+## Intentionally not collected / not modeled
+
+- **Object keys and object contents.** Never collected. Access is correlated at
+  bucket granularity; only a bounded, sanitized top-level prefix is surfaced,
+  and identifying prefixes (UUIDs, long/hex tokens, anything not a plain folder
+  name) are redacted to `<redacted>`.
+- **IAM identity-policy reachability.** Static reachability is sourced from S3
+  bucket policies only, so an observed access can correctly show as
+  `observed_without_grant`.
+- **Data-event completeness.** Without an S3 data-event trail, `granted_unused`
+  conclusions are advisory.
+
+## Live validation and troubleshooting
+
+1. Confirm the connector is active and healthy and has the `runtime_evidence`
+   capability and a wired CloudTrail delivery channel.
+2. Query the endpoint with no `fixture_state`. A `blocked` status with a
+   `permission_denied` diagnostic means CloudTrail access is missing. A
+   `degraded` status with a `delivery_unavailable` gap means no delivery channel
+   is wired for the data events.
+3. A `data_event_completeness` coverage gap with `granted_unused` correlations
+   usually means S3 data events are not enabled — enable them before treating
+   `granted_unused` as a least-privilege finding.
+4. `observed_without_grant` correlations are expected when access is authorized
+   by IAM identity policies — confirm the identity policy before treating them as
+   drift.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -8969,6 +8969,7 @@ components:
           enum: [ready, degraded, blocked]
         fixture_state:
           type: string
+          description: Present only when the response was generated from an explicit fixture state; omitted for live S3 runtime data.
           enum: [success, empty, degraded, partial_failure, permission_denied]
         confidence:
           type: number

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -559,6 +559,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/s3-runtime-access
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4699,6 +4704,98 @@ paths:
                     $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessResult"
         "400":
           description: Invalid AWS secrets/kms runtime access request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/s3-runtime-access:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS S3 runtime data access correlation
+      operationId: getAWSProjectS3RuntimeAccess
+      description: Correlates observed, metadata-only S3 read/write/list runtime events with the static reachability edges Identrail discovered (S3 bucket-policy grants) and each bucket's exposure / sensitivity classification. Each (identity, bucket) correlation is classified confirmed, observed_without_grant, or granted_unused with a correlation confidence, observed access modes, and explicit caveats. Object keys and object contents are never read or returned; access is correlated at bucket granularity with bounded, sanitized safe prefixes only.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only runtime evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: delivery_source
+          schema:
+            type: string
+            enum: [lookup_events, s3, eventbridge, all]
+          description: Optional CloudTrail delivery channel for the observed S3 data events. Defaults to `all` because these are CloudTrail data events that the LookupEvents API does not index.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional actor principal or identity-node search.
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent ID or agent-node search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional bucket ARN, name, or resource-node search.
+        - in: query
+          name: access_mode
+          schema:
+            type: string
+            enum: [read, write, list]
+        - in: query
+          name: sensitivity
+          schema: { type: string }
+          description: Optional bucket sensitivity tier filter (e.g. standard, elevated, high).
+        - in: query
+          name: exposure
+          schema: { type: string }
+          description: Optional bucket exposure filter (e.g. private, restricted, cross_account, public).
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [confirmed, observed_without_grant, granted_unused]
+      responses:
+        "200":
+          description: AWS S3 runtime access correlation contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  correlation:
+                    $ref: "#/components/schemas/AWSS3RuntimeAccessResult"
+        "400":
+          description: Invalid AWS s3 runtime access request
           content:
             application/json:
               schema:
@@ -11184,6 +11281,179 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSecretsKMSRuntimeAccessDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSS3RuntimeAccessRecord:
+      type: object
+      properties:
+        correlation_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        bucket_arn: { type: string }
+        bucket_name: { type: string }
+        resource_node_id: { type: string }
+        status:
+          type: string
+          enum: [confirmed, observed_without_grant, granted_unused]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_count: { type: integer }
+        observed_event_ids:
+          type: array
+          items: { type: string }
+        observed_modes:
+          type: array
+          items:
+            type: string
+            enum: [read, write, list]
+        granted_modes:
+          type: array
+          items:
+            type: string
+            enum: [read, write, list]
+        safe_prefixes:
+          type: array
+          items: { type: string }
+        actions:
+          type: array
+          items: { type: string }
+        session_ids:
+          type: array
+          items: { type: string }
+        agent_id: { type: string }
+        agent_node_id: { type: string }
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        static_sources:
+          type: array
+          items: { type: string }
+        static_effect: { type: string }
+        exposure: { type: string }
+        sensitivity: { type: string }
+        conditional: { type: boolean }
+        cross_account: { type: boolean }
+        caveats:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        redaction_boundary: { type: string }
+    AWSS3RuntimeAccessRelationship:
+      type: object
+      properties:
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSS3RuntimeAccessDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSS3RuntimeAccessCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSS3RuntimeAccessSummary:
+      type: object
+      properties:
+        total_correlations: { type: integer }
+        filtered_correlations: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        confirmed_count: { type: integer }
+        observed_without_grant_count: { type: integer }
+        granted_unused_count: { type: integer }
+        read_count: { type: integer }
+        write_count: { type: integer }
+        list_count: { type: integer }
+        sensitive_exposed_count: { type: integer }
+        mode_exceeds_grant_count: { type: integer }
+        identity_count: { type: integer }
+        bucket_count: { type: integer }
+        observed_access_count: { type: integer }
+        static_grant_count: { type: integer }
+        relationship_count: { type: integer }
+    AWSS3RuntimeAccessResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSS3RuntimeAccessSummary"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSS3RuntimeAccessRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSS3RuntimeAccessRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSS3RuntimeAccessCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSS3RuntimeAccessDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -755,6 +755,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -558,6 +558,9 @@ func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3acce
 	for _, record := range records {
 		sensitivity := s3BucketSensitivity(record)
 		for _, grant := range record.IdentityGrants {
+			if grant.NotAction {
+				continue
+			}
 			modes := s3GrantAllowedModes(grant.Actions)
 			if len(modes) == 0 {
 				continue

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -138,7 +138,7 @@ type AWSS3RuntimeAccessResult struct {
 	CurrentIssueRef    string                           `json:"current_issue_ref"`
 	Version            string                           `json:"version"`
 	Status             string                           `json:"status"`
-	FixtureState       string                           `json:"fixture_state"`
+	FixtureState       string                           `json:"fixture_state,omitempty"`
 	Confidence         float64                          `json:"confidence"`
 	AppliedFilters     map[string]string                `json:"applied_filters"`
 	Summary            AWSS3RuntimeAccessSummary        `json:"summary"`
@@ -219,6 +219,7 @@ func (s *Service) GetAWSS3RuntimeAccess(ctx context.Context, workspaceID string,
 		if err != nil {
 			return AWSS3RuntimeAccessResult{}, err
 		}
+		fixtureState = ""
 	} else if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
 		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
 			awsS3RuntimeAccessLiveUnavailableInputs(deliverySource)

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -558,10 +558,8 @@ func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3acce
 	for _, record := range records {
 		sensitivity := s3BucketSensitivity(record)
 		for _, grant := range record.IdentityGrants {
-			if grant.NotAction {
-				continue
-			}
-			modes := s3GrantAllowedModes(grant.Actions)
+			effect := firstNonEmptyAWSValue(grant.Effect, "Allow")
+			modes := s3GrantAllowedModesForEffect(grant.Actions, grant.NotAction, effect)
 			if len(modes) == 0 {
 				continue
 			}
@@ -588,7 +586,7 @@ func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3acce
 				BucketName:     firstNonEmptyAWSValue(record.BucketName, displayNameFromARN(record.BucketARN)),
 				AllowedModes:   modes,
 				Source:         s3access.SourceBucketPolicy,
-				Effect:         firstNonEmptyAWSValue(grant.Effect, "Allow"),
+				Effect:         effect,
 				Conditional:    grant.HasCondition || len(grant.ConditionKeys) > 0,
 				CrossAccount:   grant.IsCrossAccount,
 				Exposure:       record.ExposureClassification,
@@ -596,6 +594,26 @@ func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3acce
 				Confidence:     record.Confidence,
 				EvidenceRef:    record.EvidenceRef,
 			})
+		}
+	}
+	return out
+}
+
+func s3GrantAllowedModesForEffect(actions []string, notAction bool, effect string) []string {
+	if !notAction {
+		return s3GrantAllowedModes(actions)
+	}
+	if !strings.EqualFold(strings.TrimSpace(effect), "Deny") {
+		return nil
+	}
+	excluded := map[string]struct{}{}
+	for _, mode := range s3GrantAllowedModes(actions) {
+		excluded[mode] = struct{}{}
+	}
+	out := []string{}
+	for _, mode := range []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList} {
+		if _, ok := excluded[mode]; !ok {
+			out = append(out, mode)
 		}
 	}
 	return out

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -428,8 +428,7 @@ func isS3RuntimeEvent(record AWSRuntimeEventRecord) bool {
 	if s3AccessModeForEvent(record.EventName, record.Action) == "" {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(record.EventSource), "s3.amazonaws.com") ||
-		strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.Action)), "s3:")
+	return strings.EqualFold(strings.TrimSpace(record.EventSource), "s3.amazonaws.com")
 }
 
 // s3AccessModeForEvent reduces an S3 event name (or action) to read /
@@ -606,17 +605,37 @@ func s3GrantAllowedModesForEffect(actions []string, notAction bool, effect strin
 	if !strings.EqualFold(strings.TrimSpace(effect), "Deny") {
 		return nil
 	}
-	excluded := map[string]struct{}{}
-	for _, mode := range s3GrantAllowedModes(actions) {
-		excluded[mode] = struct{}{}
-	}
+
 	out := []string{}
-	for _, mode := range []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList} {
-		if _, ok := excluded[mode]; !ok {
+	for _, mode := range s3DataAccessModes {
+		if !s3ModeFullyExcludedByNotAction(mode, actions) {
 			out = append(out, mode)
 		}
 	}
 	return out
+}
+
+func s3ModeFullyExcludedByNotAction(mode string, actions []string) bool {
+	hasSample := false
+	for _, sample := range s3DataAccessActionSamples {
+		if sample.mode != mode {
+			continue
+		}
+		hasSample = true
+		if !s3ActionExcludedByNotAction(sample.action, actions) {
+			return false
+		}
+	}
+	return hasSample
+}
+
+func s3ActionExcludedByNotAction(action string, notActions []string) bool {
+	for _, notAction := range notActions {
+		if awsActionPatternMatches(notAction, action) {
+			return true
+		}
+	}
+	return false
 }
 
 // s3GrantAllowedModes maps a bucket-policy statement's S3 actions to the
@@ -683,6 +702,8 @@ var s3DataAccessActionSamples = []struct {
 	{s3access.ModeList, "s3:listbucketversions"},
 	{s3access.ModeList, "s3:listmultipartuploadparts"},
 }
+
+var s3DataAccessModes = []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList}
 
 // s3BucketSensitivity derives a coarse sensitivity tier for a bucket from
 // an operator override tag, data-classification tags, or name heuristics.

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -385,10 +385,10 @@ func (s *Service) awsS3RuntimeAccessLiveInputs(ctx context.Context, workspaceID,
 	return observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, true, nil
 }
 
-// observedS3AccessFromRuntimeRecords projects S3 runtime event records
-// (EventSource s3.amazonaws.com) into engine observed accesses. The object
-// key is redacted into a bounded safe prefix; only the bucket crosses the
-// boundary as the join resource.
+// observedS3AccessFromRuntimeRecords projects S3 runtime data-access
+// records into engine observed accesses. The object key is redacted into a
+// bounded safe prefix; only the bucket crosses the boundary as the join
+// resource.
 func observedS3AccessFromRuntimeRecords(records []AWSRuntimeEventRecord) []s3access.ObservedAccess {
 	out := []s3access.ObservedAccess{}
 	for _, record := range records {
@@ -424,42 +424,56 @@ func observedS3AccessFromRuntimeRecords(records []AWSRuntimeEventRecord) []s3acc
 }
 
 func isS3RuntimeEvent(record AWSRuntimeEventRecord) bool {
-	if strings.EqualFold(strings.TrimSpace(record.EventSource), "s3.amazonaws.com") {
-		return true
+	if s3AccessModeForEvent(record.EventName, record.Action) == "" {
+		return false
 	}
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.Action)), "s3:")
+	return strings.EqualFold(strings.TrimSpace(record.EventSource), "s3.amazonaws.com") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.Action)), "s3:")
 }
 
 // s3AccessModeForEvent reduces an S3 event name (or action) to read /
-// write / list. Unknown S3 verbs default to read — the conservative
-// assumption for a data event.
+// write / list. Management-plane verbs return an empty mode so they are not
+// projected as runtime data access.
 func s3AccessModeForEvent(eventName string, action string) string {
-	name := strings.ToLower(strings.TrimSpace(eventName))
-	if name == "" {
-		// Action is like "s3:GetObject"; take the verb after the colon.
-		if colon := strings.LastIndex(action, ":"); colon >= 0 {
-			name = strings.ToLower(strings.TrimSpace(action[colon+1:]))
-		}
+	return s3AccessModeForVerb(s3ActionVerb(eventName, action))
+}
+
+func s3ActionVerb(eventName string, action string) string {
+	name := strings.TrimSpace(eventName)
+	if name != "" {
+		return strings.ToLower(name)
 	}
+	// Action is like "s3:GetObject"; take the verb after the colon.
+	if colon := strings.LastIndex(action, ":"); colon >= 0 {
+		return strings.ToLower(strings.TrimSpace(action[colon+1:]))
+	}
+	return strings.ToLower(strings.TrimSpace(action))
+}
+
+func s3AccessModeForVerb(name string) string {
 	switch {
-	case strings.HasPrefix(name, "put"),
-		strings.HasPrefix(name, "delete"),
+	case strings.HasPrefix(name, "putobject"),
+		strings.HasPrefix(name, "deleteobject"),
 		strings.HasPrefix(name, "copy"),
 		strings.HasPrefix(name, "restore"),
 		strings.HasPrefix(name, "createmultipart"),
 		strings.HasPrefix(name, "completemultipart"),
 		strings.HasPrefix(name, "uploadpart"),
-		strings.HasPrefix(name, "abortmultipart"),
-		strings.HasPrefix(name, "write"):
+		strings.HasPrefix(name, "abortmultipart"):
 		return s3access.ModeWrite
-	case strings.HasPrefix(name, "list"):
+	case name == "listbucket",
+		name == "listbucketversions",
+		name == "listbucketmultipartuploads",
+		name == "listmultipartuploadparts",
+		name == "listobjects",
+		name == "listobjectsv2":
 		return s3access.ModeList
-	case strings.HasPrefix(name, "get"),
-		strings.HasPrefix(name, "head"),
-		strings.HasPrefix(name, "select"):
+	case strings.HasPrefix(name, "getobject"),
+		strings.HasPrefix(name, "headobject"),
+		strings.HasPrefix(name, "selectobject"):
 		return s3access.ModeRead
 	default:
-		return s3access.ModeRead
+		return ""
 	}
 }
 
@@ -585,16 +599,8 @@ func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3acce
 
 // s3GrantAllowedModes maps a bucket-policy statement's S3 actions to the
 // read/write/list access modes they authorize, matching AWS action
-// patterns (e.g. s3:*, s3:Get*) against representative APIs.
+// patterns (e.g. s3:*, s3:Get*) against concrete S3 data-access APIs.
 func s3GrantAllowedModes(actions []string) []string {
-	representatives := []struct {
-		mode   string
-		sample string
-	}{
-		{s3access.ModeRead, "s3:getobject"},
-		{s3access.ModeWrite, "s3:putobject"},
-		{s3access.ModeList, "s3:listbucket"},
-	}
 	seen := map[string]struct{}{}
 	out := []string{}
 	for _, action := range actions {
@@ -602,17 +608,58 @@ func s3GrantAllowedModes(actions []string) []string {
 		if trimmed == "" {
 			continue
 		}
-		for _, rep := range representatives {
-			if _, ok := seen[rep.mode]; ok {
+		for _, sample := range s3DataAccessActionSamples {
+			if _, ok := seen[sample.mode]; ok {
 				continue
 			}
-			if awsActionPatternMatches(trimmed, rep.sample) {
-				seen[rep.mode] = struct{}{}
-				out = append(out, rep.mode)
+			if awsActionPatternMatches(trimmed, sample.action) {
+				seen[sample.mode] = struct{}{}
+				out = append(out, sample.mode)
 			}
 		}
 	}
 	return out
+}
+
+var s3DataAccessActionSamples = []struct {
+	mode   string
+	action string
+}{
+	{s3access.ModeRead, "s3:getobject"},
+	{s3access.ModeRead, "s3:getobjectacl"},
+	{s3access.ModeRead, "s3:getobjectattributes"},
+	{s3access.ModeRead, "s3:getobjectlegalhold"},
+	{s3access.ModeRead, "s3:getobjectretention"},
+	{s3access.ModeRead, "s3:getobjecttagging"},
+	{s3access.ModeRead, "s3:getobjecttorrent"},
+	{s3access.ModeRead, "s3:getobjectversion"},
+	{s3access.ModeRead, "s3:getobjectversionacl"},
+	{s3access.ModeRead, "s3:getobjectversionattributes"},
+	{s3access.ModeRead, "s3:getobjectversionforreplication"},
+	{s3access.ModeRead, "s3:getobjectversiontagging"},
+	{s3access.ModeRead, "s3:getobjectversiontorrent"},
+	{s3access.ModeRead, "s3:headobject"},
+	{s3access.ModeRead, "s3:selectobjectcontent"},
+	{s3access.ModeWrite, "s3:abortmultipartupload"},
+	{s3access.ModeWrite, "s3:completemultipartupload"},
+	{s3access.ModeWrite, "s3:copyobject"},
+	{s3access.ModeWrite, "s3:createmultipartupload"},
+	{s3access.ModeWrite, "s3:deleteobject"},
+	{s3access.ModeWrite, "s3:deleteobjecttagging"},
+	{s3access.ModeWrite, "s3:deleteobjectversion"},
+	{s3access.ModeWrite, "s3:deleteobjectversiontagging"},
+	{s3access.ModeWrite, "s3:putobject"},
+	{s3access.ModeWrite, "s3:putobjectacl"},
+	{s3access.ModeWrite, "s3:putobjectlegalhold"},
+	{s3access.ModeWrite, "s3:putobjectretention"},
+	{s3access.ModeWrite, "s3:putobjecttagging"},
+	{s3access.ModeWrite, "s3:restoreobject"},
+	{s3access.ModeWrite, "s3:uploadpart"},
+	{s3access.ModeWrite, "s3:uploadpartcopy"},
+	{s3access.ModeList, "s3:listbucket"},
+	{s3access.ModeList, "s3:listbucketmultipartuploads"},
+	{s3access.ModeList, "s3:listbucketversions"},
+	{s3access.ModeList, "s3:listmultipartuploadparts"},
 }
 
 // s3BucketSensitivity derives a coarse sensitivity tier for a bucket from

--- a/internal/api/aws_s3_runtime_access.go
+++ b/internal/api/aws_s3_runtime_access.go
@@ -1,0 +1,847 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/s3access"
+)
+
+const (
+	awsS3RuntimeAccessCurrentIssue = 1519
+	awsS3RuntimeAccessVersion      = "aws-s3-runtime-access-correlation-v1"
+)
+
+// AWSS3RuntimeAccessRequest is the operator-facing request. It scopes the
+// correlation to a connector/account/region and exposes the runtime
+// timeline/query filters the issue requires: by identity, agent, bucket,
+// access mode, sensitivity, exposure, and correlation status.
+type AWSS3RuntimeAccessRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	AccessMode   string `json:"access_mode,omitempty"`
+	Sensitivity  string `json:"sensitivity,omitempty"`
+	Exposure     string `json:"exposure,omitempty"`
+	Status       string `json:"status,omitempty"`
+	// DeliverySource selects the CloudTrail ingestion channel used to
+	// observe the S3 data events: `lookup_events`, `s3`, `eventbridge`,
+	// or `all`. Empty defaults to `all` because S3 read/write/list are
+	// data events that LookupEvents does not index. Unknown values return
+	// HTTP 400.
+	DeliverySource string `json:"delivery_source,omitempty"`
+}
+
+// AWSS3RuntimeAccessRecord is one (identity, bucket) correlation projected
+// for the API/app surface.
+type AWSS3RuntimeAccessRecord struct {
+	CorrelationID     string    `json:"correlation_id"`
+	AccountID         string    `json:"account_id"`
+	Region            string    `json:"region"`
+	IdentityNodeID    string    `json:"identity_node_id"`
+	PrincipalARN      string    `json:"principal_arn,omitempty"`
+	BucketARN         string    `json:"bucket_arn"`
+	BucketName        string    `json:"bucket_name,omitempty"`
+	ResourceNodeID    string    `json:"resource_node_id"`
+	Status            string    `json:"status"`
+	Confidence        float64   `json:"confidence"`
+	ObservedCount     int       `json:"observed_count"`
+	ObservedEventIDs  []string  `json:"observed_event_ids,omitempty"`
+	ObservedModes     []string  `json:"observed_modes,omitempty"`
+	GrantedModes      []string  `json:"granted_modes,omitempty"`
+	SafePrefixes      []string  `json:"safe_prefixes,omitempty"`
+	Actions           []string  `json:"actions,omitempty"`
+	SessionIDs        []string  `json:"session_ids,omitempty"`
+	AgentID           string    `json:"agent_id,omitempty"`
+	AgentNodeID       string    `json:"agent_node_id,omitempty"`
+	FirstObservedAt   time.Time `json:"first_observed_at,omitzero"`
+	LastObservedAt    time.Time `json:"last_observed_at,omitzero"`
+	StaticSources     []string  `json:"static_sources,omitempty"`
+	StaticEffect      string    `json:"static_effect,omitempty"`
+	Exposure          string    `json:"exposure,omitempty"`
+	Sensitivity       string    `json:"sensitivity,omitempty"`
+	Conditional       bool      `json:"conditional,omitempty"`
+	CrossAccount      bool      `json:"cross_account,omitempty"`
+	Caveats           []string  `json:"caveats,omitempty"`
+	EvidenceRef       string    `json:"evidence_ref"`
+	EvidenceRefs      []string  `json:"evidence_refs,omitempty"`
+	NextAction        string    `json:"next_action"`
+	RedactionBoundary string    `json:"redaction_boundary"`
+}
+
+// AWSS3RuntimeAccessRelationship is one correlation graph edge so the
+// runtime evidence joins back to the static identity/bucket graph.
+type AWSS3RuntimeAccessRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSS3RuntimeAccessDiagnostic is a structured diagnostic propagated from
+// the correlated sources.
+type AWSS3RuntimeAccessDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSS3RuntimeAccessCoverageGap names a coverage limitation.
+type AWSS3RuntimeAccessCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSS3RuntimeAccessSummary aggregates the correlation outcome.
+type AWSS3RuntimeAccessSummary struct {
+	TotalCorrelations         int            `json:"total_correlations"`
+	FilteredCorrelations      int            `json:"filtered_correlations"`
+	StatusCounts              map[string]int `json:"status_counts"`
+	ConfirmedCount            int            `json:"confirmed_count"`
+	ObservedWithoutGrantCount int            `json:"observed_without_grant_count"`
+	GrantedUnusedCount        int            `json:"granted_unused_count"`
+	ReadCount                 int            `json:"read_count"`
+	WriteCount                int            `json:"write_count"`
+	ListCount                 int            `json:"list_count"`
+	SensitiveExposedCount     int            `json:"sensitive_exposed_count"`
+	ModeExceedsGrantCount     int            `json:"mode_exceeds_grant_count"`
+	IdentityCount             int            `json:"identity_count"`
+	BucketCount               int            `json:"bucket_count"`
+	ObservedAccessCount       int            `json:"observed_access_count"`
+	StaticGrantCount          int            `json:"static_grant_count"`
+	RelationshipCount         int            `json:"relationship_count"`
+}
+
+// AWSS3RuntimeAccessResult is the deterministic envelope.
+type AWSS3RuntimeAccessResult struct {
+	TenantID           string                           `json:"tenant_id"`
+	WorkspaceID        string                           `json:"workspace_id"`
+	ProjectID          string                           `json:"project_id"`
+	ConnectorID        string                           `json:"connector_id,omitempty"`
+	AccountID          string                           `json:"account_id,omitempty"`
+	Region             string                           `json:"region,omitempty"`
+	ParentIssueNumber  int                              `json:"parent_issue_number"`
+	ParentIssueRef     string                           `json:"parent_issue_ref"`
+	CurrentIssueNumber int                              `json:"current_issue_number"`
+	CurrentIssueRef    string                           `json:"current_issue_ref"`
+	Version            string                           `json:"version"`
+	Status             string                           `json:"status"`
+	FixtureState       string                           `json:"fixture_state"`
+	Confidence         float64                          `json:"confidence"`
+	AppliedFilters     map[string]string                `json:"applied_filters"`
+	Summary            AWSS3RuntimeAccessSummary        `json:"summary"`
+	Records            []AWSS3RuntimeAccessRecord       `json:"records"`
+	Relationships      []AWSS3RuntimeAccessRelationship `json:"relationships"`
+	Caveats            []string                         `json:"caveats"`
+	FailureReasons     []string                         `json:"failure_reasons"`
+	RemediationHints   []string                         `json:"remediation_hints"`
+	EvidenceLinks      []string                         `json:"evidence_links"`
+	CoverageGaps       []AWSS3RuntimeAccessCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSS3RuntimeAccessDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                        `json:"generated_at"`
+	UpdatedAt          time.Time                        `json:"updated_at"`
+}
+
+// GetAWSS3RuntimeAccess correlates observed S3 read/write/list runtime
+// events with the static reachability edges Identrail discovered and the
+// bucket's exposure / sensitivity classification, returning a queryable
+// correlation timeline.
+func (s *Service) GetAWSS3RuntimeAccess(ctx context.Context, workspaceID string, projectID string, request AWSS3RuntimeAccessRequest) (AWSS3RuntimeAccessResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSS3RuntimeAccessResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSS3RuntimeAccessResult{}, err
+	}
+	now := s.Now().UTC()
+
+	fixtureState := normalizeAWSS3RuntimeAccessFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSS3RuntimeAccessResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	// S3 read/write/list are CloudTrail *data* events, which LookupEvents
+	// does not index — they are delivered through the S3 trail log /
+	// EventBridge channels. Default to `all` so the correlation can
+	// observe the events it correlates; operators can pin a channel.
+	// Unknown tokens are validated and surface as HTTP 400.
+	deliverySource := strings.TrimSpace(request.DeliverySource)
+	if deliverySource == "" {
+		deliverySource = "all"
+	}
+	var deliveryErr error
+	deliverySource, deliveryErr = normalizeDeliverySource(deliverySource)
+	if deliveryErr != nil {
+		return AWSS3RuntimeAccessResult{}, deliveryErr
+	}
+
+	// Live composition is attempted when the connector is healthy, the
+	// operator did not force a fixture state, the connector's effective
+	// capability set includes runtime_evidence, and the CloudTrail factory
+	// for the selected source is wired.
+	useLive := awsS3RuntimeAccessHasLiveRuntimeFactory(s, deliverySource) &&
+		hasConnection && connection.Connected &&
+		strings.TrimSpace(request.FixtureState) == "" &&
+		awsConnectorHasRuntimeEvidence(connection)
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	var (
+		observed        []s3access.ObservedAccess
+		static          []s3access.StaticGrant
+		diagnostics     []AWSS3RuntimeAccessDiagnostic
+		coverageGaps    []AWSS3RuntimeAccessCoverageGap
+		failures        []string
+		remediations    []string
+		sourceStatus    string
+		coverageUnknown bool
+	)
+
+	if useLive {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown, err =
+			s.awsS3RuntimeAccessLiveInputs(ctx, workspaceID, projectID, connectorID, accountID, region, deliverySource)
+		if err != nil {
+			return AWSS3RuntimeAccessResult{}, err
+		}
+	} else if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsS3RuntimeAccessLiveUnavailableInputs(deliverySource)
+		fixtureState = ""
+	} else {
+		observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsS3RuntimeAccessFixtureInputs(accountID, region, fixtureState, now)
+	}
+
+	correlationResult := s3access.Correlate(s3access.CorrelateRequest{
+		AccountID:                accountID,
+		Region:                   region,
+		Observed:                 observed,
+		Static:                   static,
+		DataEventCoverageUnknown: coverageUnknown,
+	})
+
+	records := awsS3RuntimeAccessRecords(correlationResult.Correlations)
+	filtered, applied := filterAWSS3RuntimeAccessRecords(records, request)
+	relationships := awsS3RuntimeAccessRelationships(filtered)
+	summary := summarizeAWSS3RuntimeAccess(correlationResult, records, filtered, relationships)
+
+	status, confidence := summarizeAWSS3RuntimeAccessStatus(sourceStatus, filtered, diagnostics)
+	caveats := dedupeStrings(correlationResult.Caveats)
+
+	return AWSS3RuntimeAccessResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsS3RuntimeAccessCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsS3RuntimeAccessCurrentIssue),
+		Version:            awsS3RuntimeAccessVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Records:            filtered,
+		Relationships:      relationships,
+		Caveats:            caveats,
+		FailureReasons:     emptyStrings(dedupeStrings(failures)),
+		RemediationHints:   emptyStrings(dedupeStrings(remediations)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsS3RuntimeAccessCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsS3BucketReachabilityCurrentIssue),
+			"/docs/aws-s3-runtime-access",
+			"/docs/aws-runtime-events",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSS3RuntimeAccessFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsS3RuntimeAccessHasLiveRuntimeFactory(s *Service, deliverySource string) bool {
+	switch strings.TrimSpace(deliverySource) {
+	case "lookup_events":
+		return s.AWSCloudTrailLookupEventsFactory != nil
+	case "s3", "eventbridge", "all":
+		return s.AWSCloudTrailDeliveryFactory != nil
+	default:
+		return false
+	}
+}
+
+func awsS3RuntimeAccessLiveUnavailableInputs(deliverySource string) ([]s3access.ObservedAccess, []s3access.StaticGrant, []AWSS3RuntimeAccessDiagnostic, []AWSS3RuntimeAccessCoverageGap, []string, []string, string, bool) {
+	source := strings.TrimSpace(deliverySource)
+	if source == "" {
+		source = "all"
+	}
+	diagnostics := []AWSS3RuntimeAccessDiagnostic{{
+		Collector:   s3access.CollectorName,
+		SourceID:    "runtime_delivery:" + source,
+		Code:        "runtime_delivery_unavailable",
+		Message:     "Live S3 data-event delivery is unavailable for this connector; fixture correlations were suppressed.",
+		Remediation: "Configure the selected CloudTrail delivery channel and grant the runtime_evidence capability, or request a fixture_state explicitly for demo data.",
+		Retryable:   true,
+	}}
+	coverageGaps := []AWSS3RuntimeAccessCoverageGap{{
+		Capability:  "s3_data_event_delivery",
+		Status:      "delivery_unavailable",
+		Reason:      "The selected runtime delivery source is not available, so real S3 read/write/list events cannot be correlated.",
+		Remediation: "Wire CloudTrail S3/EventBridge delivery for this connector and grant runtime_evidence before relying on live correlation output.",
+	}}
+	failures := []string{"S3 runtime delivery is unavailable; fixture correlations suppressed"}
+	remediations := []string{"Configure CloudTrail data-event delivery or request fixture_state explicitly for sample data."}
+	return nil, nil, diagnostics, coverageGaps, failures, remediations, awsPlatformDependencyStatusDegraded, true
+}
+
+// awsS3RuntimeAccessLiveInputs composes the runtime-events and S3 bucket
+// reachability services into the engine's observed/static inputs.
+func (s *Service) awsS3RuntimeAccessLiveInputs(ctx context.Context, workspaceID, projectID, connectorID, accountID, region, deliverySource string) ([]s3access.ObservedAccess, []s3access.StaticGrant, []AWSS3RuntimeAccessDiagnostic, []AWSS3RuntimeAccessCoverageGap, []string, []string, string, bool, error) {
+	var (
+		diagnostics  []AWSS3RuntimeAccessDiagnostic
+		coverageGaps []AWSS3RuntimeAccessCoverageGap
+		failures     []string
+		remediations []string
+	)
+
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:    connectorID,
+		AccountID:      accountID,
+		Region:         region,
+		DeliverySource: deliverySource,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate runtime events: %w", err)
+	}
+	// The S3 reachability reader is fixture-shaped today; force an empty
+	// static state in live mode so observed events are not joined to
+	// synthetic grants that would create false correlations.
+	s3Inventory, err := s.GetAWSS3BucketReachabilityInventory(ctx, workspaceID, projectID, AWSS3BucketReachabilityInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: awsRuntimeCorrelationLiveNoStaticState,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, "", false, fmt.Errorf("correlate s3 reachability: %w", err)
+	}
+
+	observed := observedS3AccessFromRuntimeRecords(runtime.Records)
+	static := staticGrantsFromS3Records(s3Inventory.Records)
+
+	for _, diag := range runtime.Diagnostics {
+		diagnostics = append(diagnostics, AWSS3RuntimeAccessDiagnostic(diag))
+	}
+	for _, gap := range runtime.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSS3RuntimeAccessCoverageGap(gap))
+	}
+	failures = append(failures, runtime.FailureReasons...)
+	remediations = append(remediations, runtime.RemediationHints...)
+
+	// A blocked runtime source (or a degraded one that projected no S3
+	// events) means the observed side is missing, not empty — drop static
+	// so unused grants are not surfaced as least-privilege cleanup work.
+	if runtime.Status == awsPlatformDependencyStatusBlocked || (runtime.Status == awsPlatformDependencyStatusDegraded && len(observed) == 0) {
+		observed = nil
+		static = nil
+	}
+
+	sourceStatus := runtime.Status
+	return observed, static, diagnostics, coverageGaps, failures, remediations, sourceStatus, true, nil
+}
+
+// observedS3AccessFromRuntimeRecords projects S3 runtime event records
+// (EventSource s3.amazonaws.com) into engine observed accesses. The object
+// key is redacted into a bounded safe prefix; only the bucket crosses the
+// boundary as the join resource.
+func observedS3AccessFromRuntimeRecords(records []AWSRuntimeEventRecord) []s3access.ObservedAccess {
+	out := []s3access.ObservedAccess{}
+	for _, record := range records {
+		if !isS3RuntimeEvent(record) {
+			continue
+		}
+		bucketARN, bucketName, safePrefixes := s3BucketAndSafePrefixes(record.TargetResourceARN)
+		if bucketARN == "" {
+			continue
+		}
+		out = append(out, s3access.ObservedAccess{
+			EventID:         record.EventID,
+			IdentityNodeID:  record.ActorIdentityNodeID,
+			PrincipalARN:    firstNonEmptyAWSValue(record.Session.SessionIssuerARN, record.ActorPrincipalARN),
+			AccountID:       record.AccountID,
+			Region:          record.Region,
+			BucketARN:       bucketARN,
+			BucketName:      bucketName,
+			AccessMode:      s3AccessModeForEvent(record.EventName, record.Action),
+			SafePrefixes:    safePrefixes,
+			Action:          record.Action,
+			SessionID:       record.Session.SessionID,
+			SessionNodeID:   record.Session.SessionNodeID,
+			AgentID:         record.AgentID,
+			AgentNodeID:     record.AgentNodeID,
+			SourceIPAddress: record.Session.SourceIPAddress,
+			LineageStatus:   record.Session.LineageStatus,
+			ObservedAt:      record.ObservedAt,
+			EvidenceRef:     record.EvidenceRef,
+		})
+	}
+	return out
+}
+
+func isS3RuntimeEvent(record AWSRuntimeEventRecord) bool {
+	if strings.EqualFold(strings.TrimSpace(record.EventSource), "s3.amazonaws.com") {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.Action)), "s3:")
+}
+
+// s3AccessModeForEvent reduces an S3 event name (or action) to read /
+// write / list. Unknown S3 verbs default to read — the conservative
+// assumption for a data event.
+func s3AccessModeForEvent(eventName string, action string) string {
+	name := strings.ToLower(strings.TrimSpace(eventName))
+	if name == "" {
+		// Action is like "s3:GetObject"; take the verb after the colon.
+		if colon := strings.LastIndex(action, ":"); colon >= 0 {
+			name = strings.ToLower(strings.TrimSpace(action[colon+1:]))
+		}
+	}
+	switch {
+	case strings.HasPrefix(name, "put"),
+		strings.HasPrefix(name, "delete"),
+		strings.HasPrefix(name, "copy"),
+		strings.HasPrefix(name, "restore"),
+		strings.HasPrefix(name, "createmultipart"),
+		strings.HasPrefix(name, "completemultipart"),
+		strings.HasPrefix(name, "uploadpart"),
+		strings.HasPrefix(name, "abortmultipart"),
+		strings.HasPrefix(name, "write"):
+		return s3access.ModeWrite
+	case strings.HasPrefix(name, "list"):
+		return s3access.ModeList
+	case strings.HasPrefix(name, "get"),
+		strings.HasPrefix(name, "head"),
+		strings.HasPrefix(name, "select"):
+		return s3access.ModeRead
+	default:
+		return s3access.ModeRead
+	}
+}
+
+var s3SafePrefixPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,40}$`)
+var s3UUIDLikePattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`)
+var s3HexBlobPattern = regexp.MustCompile(`(?i)^[0-9a-f]{16,}$`)
+
+// s3BucketAndSafePrefixes splits an S3 resource ARN
+// (arn:aws:s3:::bucket/key/path/object) into the bucket ARN (the only
+// part used as a join resource) and at most one *safe* top-level prefix.
+// The object key is never recorded: only the first path segment, and only
+// when it looks like a non-identifying folder token, crosses the
+// boundary; anything else (or a deeper key) is dropped or marked
+// "<redacted>".
+func s3BucketAndSafePrefixes(resourceARN string) (bucketARN string, bucketName string, safePrefixes []string) {
+	trimmed := strings.TrimSpace(resourceARN)
+	const s3Prefix = "arn:aws:s3:::"
+	const s3GovPrefix = "arn:aws-us-gov:s3:::"
+	const s3CNPrefix = "arn:aws-cn:s3:::"
+	resource := ""
+	prefix := ""
+	switch {
+	case strings.HasPrefix(trimmed, s3Prefix):
+		prefix = s3Prefix
+		resource = trimmed[len(s3Prefix):]
+	case strings.HasPrefix(trimmed, s3GovPrefix):
+		prefix = s3GovPrefix
+		resource = trimmed[len(s3GovPrefix):]
+	case strings.HasPrefix(trimmed, s3CNPrefix):
+		prefix = s3CNPrefix
+		resource = trimmed[len(s3CNPrefix):]
+	default:
+		// Not an S3 ARN we recognize; treat the whole value as a bucket
+		// name only if it has no path separator (no object key to leak).
+		if trimmed == "" || strings.Contains(trimmed, "/") {
+			return "", "", nil
+		}
+		return s3Prefix + trimmed, trimmed, nil
+	}
+	resource = strings.TrimSpace(resource)
+	if resource == "" {
+		return "", "", nil
+	}
+	parts := strings.SplitN(resource, "/", 3)
+	bucketName = strings.TrimSpace(parts[0])
+	if bucketName == "" {
+		return "", "", nil
+	}
+	bucketARN = prefix + bucketName
+	if len(parts) > 1 {
+		if prefixToken := safeS3Prefix(parts[1]); prefixToken != "" {
+			safePrefixes = []string{prefixToken}
+		}
+	}
+	return bucketARN, bucketName, safePrefixes
+}
+
+// safeS3Prefix returns a redaction-safe representation of an S3 key's
+// top-level segment. Object keys can carry customer identifiers (emails,
+// IDs, tokens), so a segment is only surfaced verbatim when it looks like
+// a generic folder name; anything that looks identifying is replaced with
+// "<redacted>" so the operator still sees that a prefix existed without
+// the value leaking.
+func safeS3Prefix(segment string) string {
+	segment = strings.TrimSpace(segment)
+	if segment == "" {
+		return ""
+	}
+	if !s3SafePrefixPattern.MatchString(segment) || s3UUIDLikePattern.MatchString(segment) || s3HexBlobPattern.MatchString(segment) {
+		return "<redacted>"
+	}
+	return segment
+}
+
+// staticGrantsFromS3Records projects S3 bucket-policy grants (allow and
+// deny) for IAM principals into engine static grants, deriving the
+// allowed access modes from the grant's actions and attaching the
+// bucket's exposure and sensitivity classification.
+func staticGrantsFromS3Records(records []AWSS3BucketReachabilityRecord) []s3access.StaticGrant {
+	out := []s3access.StaticGrant{}
+	for _, record := range records {
+		sensitivity := s3BucketSensitivity(record)
+		for _, grant := range record.IdentityGrants {
+			modes := s3GrantAllowedModes(grant.Actions)
+			if len(modes) == 0 {
+				continue
+			}
+			principal := strings.TrimSpace(grant.PrincipalARN)
+			isWildcardPrincipal := grant.WildcardPrincipal || principal == "*"
+			if isWildcardPrincipal {
+				if !strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+					continue
+				}
+				principal = "*"
+			} else if !isIAMPrincipalARNForS3Edge(principal) {
+				continue
+			}
+			identityNodeID := ""
+			if !isWildcardPrincipal {
+				identityNodeID = awsIdentityNodeIDForAPI(principal)
+			}
+			out = append(out, s3access.StaticGrant{
+				IdentityNodeID: identityNodeID,
+				PrincipalARN:   principal,
+				AccountID:      record.AccountID,
+				Region:         record.Region,
+				BucketARN:      record.BucketARN,
+				BucketName:     firstNonEmptyAWSValue(record.BucketName, displayNameFromARN(record.BucketARN)),
+				AllowedModes:   modes,
+				Source:         s3access.SourceBucketPolicy,
+				Effect:         firstNonEmptyAWSValue(grant.Effect, "Allow"),
+				Conditional:    grant.HasCondition || len(grant.ConditionKeys) > 0,
+				CrossAccount:   grant.IsCrossAccount,
+				Exposure:       record.ExposureClassification,
+				Sensitivity:    sensitivity,
+				Confidence:     record.Confidence,
+				EvidenceRef:    record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+// s3GrantAllowedModes maps a bucket-policy statement's S3 actions to the
+// read/write/list access modes they authorize, matching AWS action
+// patterns (e.g. s3:*, s3:Get*) against representative APIs.
+func s3GrantAllowedModes(actions []string) []string {
+	representatives := []struct {
+		mode   string
+		sample string
+	}{
+		{s3access.ModeRead, "s3:getobject"},
+		{s3access.ModeWrite, "s3:putobject"},
+		{s3access.ModeList, "s3:listbucket"},
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, action := range actions {
+		trimmed := strings.ToLower(strings.TrimSpace(action))
+		if trimmed == "" {
+			continue
+		}
+		for _, rep := range representatives {
+			if _, ok := seen[rep.mode]; ok {
+				continue
+			}
+			if awsActionPatternMatches(trimmed, rep.sample) {
+				seen[rep.mode] = struct{}{}
+				out = append(out, rep.mode)
+			}
+		}
+	}
+	return out
+}
+
+// s3BucketSensitivity derives a coarse sensitivity tier for a bucket from
+// an operator override tag, data-classification tags, or name heuristics.
+// It never inspects object contents.
+func s3BucketSensitivity(record AWSS3BucketReachabilityRecord) string {
+	if override := strings.ToLower(strings.TrimSpace(record.Tags["identrail:sensitivity_classification"])); override != "" {
+		return override
+	}
+	for key, value := range record.Tags {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "classification", "data-classification", "data_classification", "sensitivity":
+			switch strings.ToLower(strings.TrimSpace(value)) {
+			case "pii", "phi", "pci", "confidential", "restricted", "sensitive", "high":
+				return "high"
+			}
+		}
+	}
+	name := strings.ToLower(record.BucketName)
+	for _, token := range []string{"pii", "phi", "payment", "financial", "secret", "customer", "billing", "invoice", "confidential"} {
+		if strings.Contains(name, token) {
+			return "elevated"
+		}
+	}
+	return "standard"
+}
+
+func awsS3RuntimeAccessRecords(correlations []s3access.Correlation) []AWSS3RuntimeAccessRecord {
+	out := make([]AWSS3RuntimeAccessRecord, 0, len(correlations))
+	for _, correlation := range correlations {
+		out = append(out, AWSS3RuntimeAccessRecord{
+			CorrelationID:     correlation.CorrelationID,
+			AccountID:         correlation.AccountID,
+			Region:            correlation.Region,
+			IdentityNodeID:    correlation.IdentityNodeID,
+			PrincipalARN:      correlation.PrincipalARN,
+			BucketARN:         correlation.BucketARN,
+			BucketName:        correlation.BucketName,
+			ResourceNodeID:    awsS3RuntimeAccessBucketNodeID(correlation.BucketARN),
+			Status:            correlation.Status,
+			Confidence:        correlation.Confidence,
+			ObservedCount:     correlation.ObservedCount,
+			ObservedEventIDs:  correlation.ObservedEventIDs,
+			ObservedModes:     correlation.ObservedModes,
+			GrantedModes:      correlation.GrantedModes,
+			SafePrefixes:      correlation.SafePrefixes,
+			Actions:           correlation.Actions,
+			SessionIDs:        correlation.SessionIDs,
+			AgentID:           correlation.AgentID,
+			AgentNodeID:       correlation.AgentNodeID,
+			FirstObservedAt:   correlation.FirstObservedAt,
+			LastObservedAt:    correlation.LastObservedAt,
+			StaticSources:     correlation.StaticSources,
+			StaticEffect:      correlation.StaticEffect,
+			Exposure:          correlation.Exposure,
+			Sensitivity:       correlation.Sensitivity,
+			Conditional:       correlation.Conditional,
+			CrossAccount:      correlation.CrossAccount,
+			Caveats:           correlation.Caveats,
+			EvidenceRef:       fmt.Sprintf("runtime-correlation://%s", correlation.CorrelationID),
+			EvidenceRefs:      correlation.EvidenceRefs,
+			NextAction:        awsS3RuntimeAccessNextAction(correlation.Status),
+			RedactionBoundary: correlation.RedactionBoundary,
+		})
+	}
+	return out
+}
+
+func awsS3RuntimeAccessBucketNodeID(bucketARN string) string {
+	arn := strings.TrimSpace(bucketARN)
+	if arn == "" {
+		return ""
+	}
+	return "aws:resource:s3-bucket:" + arn
+}
+
+func awsS3RuntimeAccessNextAction(status string) string {
+	switch status {
+	case s3access.StatusConfirmed:
+		return "Confirm the observed S3 access matches an expected workload path before relying on it for remediation."
+	case s3access.StatusObservedWithoutGrant:
+		return "Investigate observed S3 access with no modeled grant — confirm IAM identity-policy authorization or treat as drift."
+	case s3access.StatusGrantedUnused:
+		return "Review the unused S3 grant for least-privilege; confirm data-event coverage before removing it."
+	default:
+		return "Correlate runtime evidence with the static reachability graph."
+	}
+}
+
+func filterAWSS3RuntimeAccessRecords(records []AWSS3RuntimeAccessRecord, request AWSS3RuntimeAccessRequest) ([]AWSS3RuntimeAccessRecord, map[string]string) {
+	filters := map[string]string{
+		"account_id":  strings.TrimSpace(request.AccountID),
+		"region":      strings.TrimSpace(request.Region),
+		"identity":    strings.TrimSpace(request.Identity),
+		"agent_id":    strings.TrimSpace(request.AgentID),
+		"resource":    strings.TrimSpace(request.Resource),
+		"access_mode": normalizeAWSRuntimeEventFilterToken(request.AccessMode),
+		"sensitivity": normalizeAWSRuntimeEventFilterToken(request.Sensitivity),
+		"exposure":    normalizeAWSRuntimeEventFilterToken(request.Exposure),
+		"status":      normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		token := strings.ToLower(strings.TrimSpace(value))
+		if token == "" || token == "all" {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSS3RuntimeAccessRecord, 0, len(records))
+	for _, record := range records {
+		if filters["account_id"] != "" && filters["account_id"] != record.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], record.Region) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(record.Status) {
+			continue
+		}
+		if filters["sensitivity"] != "" && filters["sensitivity"] != normalizeAWSRuntimeEventFilterToken(record.Sensitivity) {
+			continue
+		}
+		if filters["exposure"] != "" && filters["exposure"] != normalizeAWSRuntimeEventFilterToken(record.Exposure) {
+			continue
+		}
+		if filters["access_mode"] != "" && !awsS3RuntimeAccessHasMode(record, filters["access_mode"]) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], record.IdentityNodeID, record.PrincipalARN) {
+			continue
+		}
+		if filters["agent_id"] != "" && !awsRuntimeEventMatchesAny(filters["agent_id"], record.AgentID, record.AgentNodeID) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], record.BucketARN, record.BucketName, record.ResourceNodeID) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered, applied
+}
+
+func awsS3RuntimeAccessHasMode(record AWSS3RuntimeAccessRecord, mode string) bool {
+	for _, observed := range record.ObservedModes {
+		if normalizeAWSRuntimeEventFilterToken(observed) == mode {
+			return true
+		}
+	}
+	for _, granted := range record.GrantedModes {
+		if normalizeAWSRuntimeEventFilterToken(granted) == mode {
+			return true
+		}
+	}
+	return false
+}
+
+func awsS3RuntimeAccessRelationships(records []AWSS3RuntimeAccessRecord) []AWSS3RuntimeAccessRelationship {
+	out := []AWSS3RuntimeAccessRelationship{}
+	for _, record := range records {
+		if record.IdentityNodeID == "" || record.ResourceNodeID == "" {
+			continue
+		}
+		edgeType := "runtime_access_correlation"
+		switch record.Status {
+		case s3access.StatusConfirmed:
+			edgeType = "confirmed_runtime_access"
+		case s3access.StatusObservedWithoutGrant:
+			edgeType = "observed_runtime_access_without_grant"
+		case s3access.StatusGrantedUnused:
+			edgeType = "unused_static_grant"
+		}
+		out = append(out, AWSS3RuntimeAccessRelationship{
+			Type:        edgeType,
+			FromNodeID:  record.IdentityNodeID,
+			ToNodeID:    record.ResourceNodeID,
+			EvidenceRef: record.EvidenceRef,
+		})
+		if record.AgentNodeID != "" {
+			out = append(out, AWSS3RuntimeAccessRelationship{
+				Type:        "agent_runtime_access_correlation",
+				FromNodeID:  record.AgentNodeID,
+				ToNodeID:    record.ResourceNodeID,
+				EvidenceRef: record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+func summarizeAWSS3RuntimeAccess(correlation s3access.Result, allRecords []AWSS3RuntimeAccessRecord, filtered []AWSS3RuntimeAccessRecord, relationships []AWSS3RuntimeAccessRelationship) AWSS3RuntimeAccessSummary {
+	statusCounts := map[string]int{}
+	for _, record := range allRecords {
+		statusCounts[record.Status]++
+	}
+	return AWSS3RuntimeAccessSummary{
+		TotalCorrelations:         len(allRecords),
+		FilteredCorrelations:      len(filtered),
+		StatusCounts:              statusCounts,
+		ConfirmedCount:            correlation.ConfirmedCount,
+		ObservedWithoutGrantCount: correlation.ObservedWithoutGrant,
+		GrantedUnusedCount:        correlation.GrantedUnusedCount,
+		ReadCount:                 correlation.ReadCount,
+		WriteCount:                correlation.WriteCount,
+		ListCount:                 correlation.ListCount,
+		SensitiveExposedCount:     correlation.SensitiveExposedCount,
+		ModeExceedsGrantCount:     correlation.ModeExceedsGrantCount,
+		IdentityCount:             correlation.IdentityCount,
+		BucketCount:               correlation.BucketCount,
+		ObservedAccessCount:       correlation.ObservedAccessConsidered,
+		StaticGrantCount:          correlation.StaticGrantsConsidered,
+		RelationshipCount:         len(relationships),
+	}
+}
+
+func summarizeAWSS3RuntimeAccessStatus(sourceStatus string, filtered []AWSS3RuntimeAccessRecord, diagnostics []AWSS3RuntimeAccessDiagnostic) (string, float64) {
+	switch sourceStatus {
+	case awsPlatformDependencyStatusBlocked:
+		return awsPlatformDependencyStatusBlocked, 0
+	case awsPlatformDependencyStatusDegraded:
+		return awsPlatformDependencyStatusDegraded, 0.7
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusDegraded, 0.5
+	}
+	if len(diagnostics) > 0 {
+		return awsPlatformDependencyStatusDegraded, 0.8
+	}
+	return awsPlatformDependencyStatusReady, 0.92
+}

--- a/internal/api/aws_s3_runtime_access_fixtures.go
+++ b/internal/api/aws_s3_runtime_access_fixtures.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/s3access"
+)
+
+// awsS3RuntimeAccessFixtureInputs returns deterministic observed accesses
+// and static grants for each fixture state. The default success state
+// exercises all three correlation outcomes — confirmed,
+// observed_without_grant, and granted_unused — plus a write that exceeds
+// a read-only grant and a sensitive, publicly exposed bucket, so the
+// surface and tests cover the taxonomy without a live AWS account. Object
+// keys are never present: only bucket ARNs and bounded safe prefixes.
+func awsS3RuntimeAccessFixtureInputs(accountID string, region string, fixtureState string, checkedAt time.Time) ([]s3access.ObservedAccess, []s3access.StaticGrant, []AWSS3RuntimeAccessDiagnostic, []AWSS3RuntimeAccessCoverageGap, []string, []string, string, bool) {
+	base := checkedAt.Add(-30 * time.Minute)
+	reportsRole := fmt.Sprintf("arn:aws:iam::%s:role/reporting-app", accountID)
+	pipelineRole := fmt.Sprintf("arn:aws:iam::%s:role/ingest-pipeline", accountID)
+	analyticsRole := fmt.Sprintf("arn:aws:iam::%s:role/analytics-export", accountID)
+	partnerRole := "arn:aws:iam::999999999999:role/partner-reader"
+
+	reportsBucket := fmt.Sprintf("arn:aws:s3:::%s-financial-reports", accountID)
+	ingestBucket := fmt.Sprintf("arn:aws:s3:::%s-ingest-landing", accountID)
+	ungovernedBucket := fmt.Sprintf("arn:aws:s3:::%s-adhoc-exports", accountID)
+	analyticsBucket := fmt.Sprintf("arn:aws:s3:::%s-analytics-archive", accountID)
+	piiBucket := fmt.Sprintf("arn:aws:s3:::%s-pii-customer", accountID)
+
+	observed := []s3access.ObservedAccess{
+		{
+			EventID:        "evt-s3-read-confirmed",
+			IdentityNodeID: awsIdentityNodeIDForAPI(reportsRole),
+			PrincipalARN:   reportsRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      reportsBucket,
+			BucketName:     fmt.Sprintf("%s-financial-reports", accountID),
+			AccessMode:     s3access.ModeRead,
+			SafePrefixes:   []string{"daily"},
+			Action:         "s3:GetObject",
+			SessionID:      "ASIA-reports-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     base.Add(4 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-s3-read-confirmed", accountID, region),
+		},
+		{
+			// Write observed on a bucket the role can only read → confirmed
+			// (bucket reachable) but flagged observed_mode_exceeds_grant.
+			EventID:        "evt-s3-write-exceeds",
+			IdentityNodeID: awsIdentityNodeIDForAPI(pipelineRole),
+			PrincipalARN:   pipelineRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      ingestBucket,
+			BucketName:     fmt.Sprintf("%s-ingest-landing", accountID),
+			AccessMode:     s3access.ModeWrite,
+			SafePrefixes:   []string{"incoming"},
+			Action:         "s3:PutObject",
+			SessionID:      "ASIA-pipeline-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     base.Add(7 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-s3-write-exceeds", accountID, region),
+		},
+		{
+			// Observed access with no static grant (authorized via IAM
+			// identity policy, which the static collector does not model).
+			EventID:        "evt-s3-no-grant",
+			IdentityNodeID: awsIdentityNodeIDForAPI(reportsRole),
+			PrincipalARN:   reportsRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      ungovernedBucket,
+			BucketName:     fmt.Sprintf("%s-adhoc-exports", accountID),
+			AccessMode:     s3access.ModeList,
+			SafePrefixes:   []string{"<redacted>"},
+			Action:         "s3:ListBucket",
+			SessionID:      "ASIA-reports-sess",
+			LineageStatus:  "source_identity_missing",
+			ObservedAt:     base.Add(9 * time.Minute),
+			EvidenceRef:    fmt.Sprintf("runtime-evidence://%s/%s/evt-s3-no-grant", accountID, region),
+		},
+	}
+
+	static := []s3access.StaticGrant{
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(reportsRole),
+			PrincipalARN:   reportsRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      reportsBucket,
+			BucketName:     fmt.Sprintf("%s-financial-reports", accountID),
+			AllowedModes:   []string{s3access.ModeRead, s3access.ModeList},
+			Source:         s3access.SourceBucketPolicy,
+			Effect:         "Allow",
+			Sensitivity:    "elevated",
+			Exposure:       "restricted",
+			Confidence:     0.9,
+			EvidenceRef:    reportsBucket,
+		},
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(pipelineRole),
+			PrincipalARN:   pipelineRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      ingestBucket,
+			BucketName:     fmt.Sprintf("%s-ingest-landing", accountID),
+			AllowedModes:   []string{s3access.ModeRead},
+			Source:         s3access.SourceBucketPolicy,
+			Effect:         "Allow",
+			Sensitivity:    "standard",
+			Exposure:       "private",
+			Confidence:     0.88,
+			EvidenceRef:    ingestBucket,
+		},
+		{
+			IdentityNodeID: awsIdentityNodeIDForAPI(analyticsRole),
+			PrincipalARN:   analyticsRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      analyticsBucket,
+			BucketName:     fmt.Sprintf("%s-analytics-archive", accountID),
+			AllowedModes:   []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList},
+			Source:         s3access.SourceBucketPolicy,
+			Effect:         "Allow",
+			Sensitivity:    "standard",
+			Exposure:       "private",
+			Confidence:     0.86,
+			EvidenceRef:    analyticsBucket,
+		},
+		{
+			// Sensitive bucket exposed cross-account and never observed.
+			IdentityNodeID: awsIdentityNodeIDForAPI(partnerRole),
+			PrincipalARN:   partnerRole,
+			AccountID:      accountID,
+			Region:         region,
+			BucketARN:      piiBucket,
+			BucketName:     fmt.Sprintf("%s-pii-customer", accountID),
+			AllowedModes:   []string{s3access.ModeRead},
+			Source:         s3access.SourceBucketPolicy,
+			Effect:         "Allow",
+			CrossAccount:   true,
+			Sensitivity:    "high",
+			Exposure:       "cross_account",
+			Confidence:     0.82,
+			EvidenceRef:    piiBucket,
+		},
+	}
+
+	switch fixtureState {
+	case "empty":
+		return nil, nil, nil, []AWSS3RuntimeAccessCoverageGap{{
+			Capability:  "s3_runtime_access",
+			Status:      "empty",
+			Reason:      "No S3 runtime accesses or static reachability grants were available in the fixture window.",
+			Remediation: "Confirm CloudTrail S3 data-event logging is enabled, then retry.",
+		}}, nil, nil, awsPlatformDependencyStatusReady, true
+	case "degraded":
+		return observed, static, []AWSS3RuntimeAccessDiagnostic{{
+			Collector:   s3access.CollectorName,
+			SourceID:    "evt-s3-no-grant",
+			Code:        "runtime_event_delivery_delayed",
+			Message:     "One S3 access arrived after the expected collection window; correlation confidence is reduced.",
+			Remediation: "Keep delayed evidence visible and avoid automated remediation until delivery catches up.",
+			Retryable:   true,
+		}}, nil, []string{"runtime correlation includes delayed or low-confidence evidence"}, []string{"Review delayed CloudTrail delivery before using correlations for remediation."}, awsPlatformDependencyStatusDegraded, true
+	case "partial_failure":
+		return observed, nil, []AWSS3RuntimeAccessDiagnostic{{
+				Collector:   s3access.CollectorName,
+				SourceID:    "static_reachability",
+				Code:        "static_reachability_unavailable",
+				Message:     "S3 bucket reachability could not be loaded; observed accesses cannot be confirmed.",
+				Remediation: "Retry the S3 reachability collector and re-run the correlation without discarding observed evidence.",
+				Retryable:   true,
+			}}, []AWSS3RuntimeAccessCoverageGap{{
+				Capability:  "static_reachability_join",
+				Status:      "partial_failure",
+				Reason:      "Static reachability edges were unavailable, so observed accesses could not be confirmed against grants.",
+				Remediation: "Retry S3 reachability collection and re-run the correlation.",
+			}}, []string{"static reachability join is incomplete; observed accesses are unconfirmed"}, []string{"Retry the S3 reachability collector and re-run the correlation."}, awsPlatformDependencyStatusDegraded, true
+	case "permission_denied":
+		return nil, nil, []AWSS3RuntimeAccessDiagnostic{{
+				Collector:   s3access.CollectorName,
+				SourceID:    "cloudtrail",
+				Code:        "permission_denied",
+				Message:     "Runtime event sources are not authorized for this connector; no S3 runtime access can be correlated.",
+				Remediation: "Grant metadata-only CloudTrail access. Do not grant object-content reads.",
+				Retryable:   true,
+			}}, []AWSS3RuntimeAccessCoverageGap{{
+				Capability:  "s3_runtime_access",
+				Status:      "permission_denied",
+				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only CloudTrail access and retry.",
+			}}, []string{"runtime event sources are not authorized for this connector"}, []string{"Grant metadata-only CloudTrail access; do not grant object-content reads."}, awsPlatformDependencyStatusBlocked, true
+	default:
+		return observed, static, nil, awsS3RuntimeAccessBaseCoverageGaps(), nil, nil, awsPlatformDependencyStatusReady, true
+	}
+}
+
+// awsS3RuntimeAccessBaseCoverageGaps documents what this correlation
+// intentionally does not model and the redaction boundary it enforces.
+func awsS3RuntimeAccessBaseCoverageGaps() []AWSS3RuntimeAccessCoverageGap {
+	return []AWSS3RuntimeAccessCoverageGap{
+		{
+			Capability:  "iam_identity_policy_reachability",
+			Status:      "unsupported",
+			Reason:      "Static reachability is sourced from S3 bucket policies only. Access authorized by IAM identity policies is not enumerated, so an observed access can show as observed_without_grant.",
+			Remediation: "Treat observed_without_grant as 'needs IAM-policy confirmation', not automatically as drift.",
+		},
+		{
+			Capability:  "object_key_visibility",
+			Status:      "unsupported",
+			Reason:      "Object keys and object contents are never collected. Access is correlated at bucket granularity; only a bounded, sanitized top-level prefix is surfaced, and identifying prefixes are redacted.",
+			Remediation: "Use the bucket, access mode, and safe prefix for triage; inspect specific keys directly in AWS when investigating.",
+		},
+		{
+			Capability:  "data_event_completeness",
+			Status:      "degraded",
+			Reason:      "S3 GetObject/PutObject/ListBucket are CloudTrail data events. Unless an S3 data-event trail or CloudTrail Lake is configured, observed coverage is incomplete and granted_unused may reflect missing telemetry.",
+			Remediation: "Enable CloudTrail S3 data events to make granted_unused conclusions reliable.",
+		},
+	}
+}

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -1,0 +1,374 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/runtime/s3access"
+)
+
+func newS3RuntimeAccessService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, project)
+	seedAWSConnectorForScanTest(t, store, ctx, project, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	return svc, "default"
+}
+
+func s3RecordsByStatus(records []AWSS3RuntimeAccessRecord) map[string]int {
+	counts := map[string]int{}
+	for _, record := range records {
+		counts[record.Status]++
+	}
+	return counts
+}
+
+func TestGetAWSS3RuntimeAccessBuildsCorrelationContract(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-corr", now)
+
+	result, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-corr", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1519" || result.Version != awsS3RuntimeAccessVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	counts := s3RecordsByStatus(result.Records)
+	if counts[s3access.StatusConfirmed] != 2 || counts[s3access.StatusObservedWithoutGrant] != 1 || counts[s3access.StatusGrantedUnused] != 2 {
+		t.Fatalf("unexpected status distribution: %+v (records=%+v)", counts, result.Records)
+	}
+	if result.Summary.ReadCount == 0 || result.Summary.WriteCount == 0 || result.Summary.ListCount == 0 {
+		t.Fatalf("expected read/write/list observed modes, got %+v", result.Summary)
+	}
+	if result.Summary.ModeExceedsGrantCount != 1 {
+		t.Fatalf("expected one mode-exceeds-grant correlation, got %+v", result.Summary)
+	}
+	if result.Summary.SensitiveExposedCount != 1 {
+		t.Fatalf("expected one sensitive-exposed correlation, got %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected relationships: %+v", result.Relationships)
+	}
+	if len(result.Caveats) == 0 {
+		t.Fatalf("expected correlation caveats")
+	}
+	for _, record := range result.Records {
+		if record.RedactionBoundary != s3access.RedactionBoundary {
+			t.Fatalf("record leaked unsafe redaction boundary: %+v", record)
+		}
+		if record.EvidenceRef == "" || record.IdentityNodeID == "" || record.ResourceNodeID == "" || record.Confidence <= 0 || record.NextAction == "" {
+			t.Fatalf("record missing required fields: %+v", record)
+		}
+		// No object keys may leak: bucket ARN must have no path separator
+		// after the bucket name.
+		if strings.Contains(strings.TrimPrefix(record.BucketARN, "arn:aws:s3:::"), "/") {
+			t.Fatalf("bucket ARN leaked an object key: %q", record.BucketARN)
+		}
+	}
+	if len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected base coverage gaps documenting object-key and data-event limits")
+	}
+}
+
+func TestGetAWSS3RuntimeAccessFlagsModeExceedingGrant(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-mode", now)
+
+	result, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-mode", AWSS3RuntimeAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Resource:     "ingest-landing",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(result.Records) != 1 {
+		t.Fatalf("expected one correlation for the ingest bucket, got %+v", result.Records)
+	}
+	record := result.Records[0]
+	if record.Status != s3access.StatusConfirmed {
+		t.Fatalf("expected confirmed (bucket reachable), got %q", record.Status)
+	}
+	if !hasS3Caveat(record.Caveats, s3access.CaveatModeExceedsGrant) {
+		t.Fatalf("expected mode-exceeds-grant caveat, got %+v", record.Caveats)
+	}
+}
+
+func TestGetAWSS3RuntimeAccessFiltersBySensitivityAndStatus(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-filter", now)
+
+	high, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-filter", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success", Sensitivity: "high"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(high.Records) != 1 || high.Records[0].Sensitivity != "high" {
+		t.Fatalf("expected one high-sensitivity correlation, got %+v", high.Records)
+	}
+	if !hasS3Caveat(high.Records[0].Caveats, s3access.CaveatSensitiveExposed) {
+		t.Fatalf("expected sensitive-exposed caveat on high+cross_account bucket: %+v", high.Records[0])
+	}
+
+	unused, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-filter", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success", Status: "granted_unused"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(unused.Records) != 2 {
+		t.Fatalf("expected two granted_unused correlations, got %+v", unused.Records)
+	}
+	for _, record := range unused.Records {
+		if record.Status != s3access.StatusGrantedUnused {
+			t.Fatalf("status filter leaked: %+v", record)
+		}
+	}
+	if unused.AppliedFilters["status"] != "granted-unused" {
+		t.Fatalf("expected applied (normalized) status filter, got %+v", unused.AppliedFilters)
+	}
+}
+
+func TestGetAWSS3RuntimeAccessPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-denied", now)
+
+	result, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-denied", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" || result.Confidence != 0 {
+		t.Fatalf("expected blocked permission-denied, got status=%q confidence=%v", result.Status, result.Confidence)
+	}
+	if len(result.Records) != 0 || len(result.Diagnostics) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected no records + diagnostics + coverage gaps, got %+v", result)
+	}
+}
+
+func TestGetAWSS3RuntimeAccessEmptyAndPartialFailure(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-states", now)
+
+	empty, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-states", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Records) != 0 || len(empty.CoverageGaps) == 0 {
+		t.Fatalf("unexpected empty state: %+v", empty)
+	}
+
+	partial, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-states", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if partial.Status != "degraded" {
+		t.Fatalf("expected degraded partial-failure, got %q", partial.Status)
+	}
+	for _, record := range partial.Records {
+		if record.Status == s3access.StatusConfirmed {
+			t.Fatalf("partial-failure must not produce confirmed correlations: %+v", record)
+		}
+	}
+}
+
+func TestGetAWSS3RuntimeAccessDefaultLiveRequiresDeliveryFactory(t *testing.T) {
+	// No fixture state + connected connector + no delivery factory wired:
+	// the endpoint must not serve fixture data as if it were live.
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newS3RuntimeAccessService(t, "project-s3-live-default", now)
+
+	result, err := svc.GetAWSS3RuntimeAccess(defaultScopeContext(), ws, "project-s3-live-default", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded when live delivery unavailable, got %q", result.Status)
+	}
+	if len(result.Records) != 0 {
+		t.Fatalf("expected no records when live delivery is unavailable, got %+v", result.Records)
+	}
+}
+
+func TestGetAWSS3RuntimeAccessLiveRoutesDataEventsThroughDelivery(t *testing.T) {
+	now := time.Date(2026, 6, 19, 19, 0, 0, 0, time.UTC)
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-s3-live")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-s3-live", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-s3-live", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	role := "arn:aws:iam::123456789012:role/data-reader"
+	deliveryRecord := liveRuntimeRecord(t, "evt-s3-live", "api-call", "GetObject", "s3.amazonaws.com", "s3:GetObject", "application", "s3-delivery", role, "arn:aws:s3:::live-bucket/reports/q1.csv", "AWS::S3::Object", now.Add(-2*time.Minute))
+	fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready", Records: []AWSRuntimeEventRecord{deliveryRecord}}}
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return fake, nil
+	}
+
+	result, err := svc.GetAWSS3RuntimeAccess(ctx, "default", "project-s3-live", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if fake.calls == 0 {
+		t.Fatalf("delivery factory was never used — S3 data events were not routed through delivery")
+	}
+	var found *AWSS3RuntimeAccessRecord
+	for i := range result.Records {
+		if result.Records[i].BucketARN == "arn:aws:s3:::live-bucket" {
+			found = &result.Records[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a correlation for the observed live-bucket access, got %+v", result.Records)
+	}
+	// Live static is empty, so the observed access is observed_without_grant.
+	if found.Status != s3access.StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant for live observed access, got %q", found.Status)
+	}
+	// The object key must not have leaked: bucket only, plus a safe prefix.
+	if found.BucketARN != "arn:aws:s3:::live-bucket" {
+		t.Fatalf("bucket ARN leaked a key: %q", found.BucketARN)
+	}
+	if len(found.SafePrefixes) != 1 || found.SafePrefixes[0] != "reports" {
+		t.Fatalf("expected single safe prefix 'reports', got %+v", found.SafePrefixes)
+	}
+	if !hasS3Mode(found.ObservedModes, s3access.ModeRead) {
+		t.Fatalf("expected read mode, got %+v", found.ObservedModes)
+	}
+}
+
+func TestGetAWSS3RuntimeAccessBlockedRuntimeSuppressesUnusedGrants(t *testing.T) {
+	now := time.Date(2026, 6, 19, 19, 30, 0, 0, time.UTC)
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-s3-blocked")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-s3-blocked", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-s3-blocked", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "blocked", FailureReasons: []string{"runtime event sources are not authorized for this connector"}}}, nil
+	}
+
+	result, err := svc.GetAWSS3RuntimeAccess(ctx, "default", "project-s3-blocked", AWSS3RuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" || len(result.Records) != 0 || result.Summary.GrantedUnusedCount != 0 {
+		t.Fatalf("blocked runtime must not surface granted_unused grants: status=%q records=%d summary=%+v", result.Status, len(result.Records), result.Summary)
+	}
+}
+
+func TestObservedS3AccessFromRuntimeRecordsFiltersAndRedacts(t *testing.T) {
+	records := []AWSRuntimeEventRecord{
+		{EventID: "s3get", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "GetObject", Action: "s3:GetObject", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:aws:s3:::bucket/reports/2026/secret-customer@example.com.csv"},
+		{EventID: "s3uuid", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "PutObject", Action: "s3:PutObject", ActorIdentityNodeID: "id-2", TargetResourceARN: "arn:aws:s3:::bucket/3f9a1b2c-1111-2222-3333-444455556666/data"},
+		{EventID: "kms", EventType: "kms-decrypt", EventSource: "kms.amazonaws.com", Action: "kms:Decrypt", ActorIdentityNodeID: "id-3", TargetResourceARN: "arn:aws:kms:us-east-1:1:key/k"},
+	}
+	observed := observedS3AccessFromRuntimeRecords(records)
+	if len(observed) != 2 {
+		t.Fatalf("expected only the two S3 events, got %d (%+v)", len(observed), observed)
+	}
+	for _, access := range observed {
+		if strings.Contains(strings.TrimPrefix(access.BucketARN, "arn:aws:s3:::"), "/") {
+			t.Fatalf("bucket ARN leaked a key: %q", access.BucketARN)
+		}
+		for _, prefix := range access.SafePrefixes {
+			if strings.Contains(prefix, "@") || strings.Contains(prefix, "example.com") {
+				t.Fatalf("safe prefix leaked an identifying value: %q", prefix)
+			}
+		}
+	}
+	// First event: top-level prefix "reports" is a safe folder name.
+	if len(observed[0].SafePrefixes) != 1 || observed[0].SafePrefixes[0] != "reports" {
+		t.Fatalf("expected safe prefix 'reports', got %+v", observed[0].SafePrefixes)
+	}
+	if observed[0].AccessMode != s3access.ModeRead {
+		t.Fatalf("expected read mode, got %q", observed[0].AccessMode)
+	}
+	// Second event: UUID-like prefix must be redacted, write mode.
+	if len(observed[1].SafePrefixes) != 1 || observed[1].SafePrefixes[0] != "<redacted>" {
+		t.Fatalf("expected UUID prefix redacted, got %+v", observed[1].SafePrefixes)
+	}
+	if observed[1].AccessMode != s3access.ModeWrite {
+		t.Fatalf("expected write mode, got %q", observed[1].AccessMode)
+	}
+}
+
+func TestS3GrantAllowedModesMapsActionPatterns(t *testing.T) {
+	cases := []struct {
+		actions []string
+		want    []string
+	}{
+		{actions: []string{"s3:GetObject"}, want: []string{s3access.ModeRead}},
+		{actions: []string{"s3:PutObject", "s3:DeleteObject"}, want: []string{s3access.ModeWrite}},
+		{actions: []string{"s3:ListBucket"}, want: []string{s3access.ModeList}},
+		{actions: []string{"s3:*"}, want: []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList}},
+		{actions: []string{"s3:Get*"}, want: []string{s3access.ModeRead}},
+	}
+	for _, tc := range cases {
+		got := s3GrantAllowedModes(tc.actions)
+		if len(got) != len(tc.want) {
+			t.Fatalf("actions %v: expected modes %v, got %v", tc.actions, tc.want, got)
+		}
+		for _, mode := range tc.want {
+			if !hasS3Mode(got, mode) {
+				t.Fatalf("actions %v: missing mode %q in %v", tc.actions, mode, got)
+			}
+		}
+	}
+}
+
+func TestStaticGrantsFromS3RecordsProjectsIAMPrincipalsOnly(t *testing.T) {
+	records := []AWSS3BucketReachabilityRecord{{
+		AccountID:              "111122223333",
+		Region:                 "us-east-1",
+		BucketARN:              "arn:aws:s3:::pii-data",
+		BucketName:             "pii-data",
+		ExposureClassification: "cross_account",
+		Confidence:             0.9,
+		Tags:                   map[string]string{"data-classification": "pii"},
+		IdentityGrants: []AWSS3IdentityGrant{
+			{PrincipalARN: "arn:aws:iam::111122223333:role/reader", Effect: "Allow", Actions: []string{"s3:GetObject", "s3:ListBucket"}},
+			{PrincipalARN: "*", WildcardPrincipal: true, Effect: "Allow", Actions: []string{"s3:GetObject"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/no-recognized-action", Effect: "Allow", Actions: []string{"s3:GetBucketTagging"}},
+		},
+	}}
+	grants := staticGrantsFromS3Records(records)
+	if len(grants) != 1 || grants[0].PrincipalARN != "arn:aws:iam::111122223333:role/reader" {
+		t.Fatalf("expected one IAM grant with recognized modes, got %+v", grants)
+	}
+	if grants[0].Sensitivity != "high" || grants[0].Exposure != "cross_account" {
+		t.Fatalf("expected sensitivity/exposure projected, got %+v", grants[0])
+	}
+	if !hasS3Mode(grants[0].AllowedModes, s3access.ModeRead) || !hasS3Mode(grants[0].AllowedModes, s3access.ModeList) {
+		t.Fatalf("expected read+list modes, got %+v", grants[0].AllowedModes)
+	}
+}
+
+func hasS3Caveat(caveats []string, want string) bool {
+	for _, caveat := range caveats {
+		if caveat == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasS3Mode(modes []string, want string) bool {
+	for _, mode := range modes {
+		if mode == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -272,7 +272,10 @@ func TestObservedS3AccessFromRuntimeRecordsFiltersAndRedacts(t *testing.T) {
 	records := []AWSRuntimeEventRecord{
 		{EventID: "s3get", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "GetObject", Action: "s3:GetObject", ActorIdentityNodeID: "id-1", TargetResourceARN: "arn:aws:s3:::bucket/reports/2026/secret-customer@example.com.csv"},
 		{EventID: "s3uuid", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "PutObject", Action: "s3:PutObject", ActorIdentityNodeID: "id-2", TargetResourceARN: "arn:aws:s3:::bucket/3f9a1b2c-1111-2222-3333-444455556666/data"},
-		{EventID: "kms", EventType: "kms-decrypt", EventSource: "kms.amazonaws.com", Action: "kms:Decrypt", ActorIdentityNodeID: "id-3", TargetResourceARN: "arn:aws:kms:us-east-1:1:key/k"},
+		{EventID: "bucket-policy", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "PutBucketPolicy", Action: "s3:PutBucketPolicy", ActorIdentityNodeID: "id-3", TargetResourceARN: "arn:aws:s3:::bucket"},
+		{EventID: "bucket-encryption", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "GetBucketEncryption", Action: "s3:GetBucketEncryption", ActorIdentityNodeID: "id-4", TargetResourceARN: "arn:aws:s3:::bucket"},
+		{EventID: "bucket-create", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "CreateBucket", Action: "s3:CreateBucket", ActorIdentityNodeID: "id-5", TargetResourceARN: "arn:aws:s3:::bucket"},
+		{EventID: "kms", EventType: "kms-decrypt", EventSource: "kms.amazonaws.com", Action: "kms:Decrypt", ActorIdentityNodeID: "id-6", TargetResourceARN: "arn:aws:kms:us-east-1:1:key/k"},
 	}
 	observed := observedS3AccessFromRuntimeRecords(records)
 	if len(observed) != 2 {
@@ -310,8 +313,11 @@ func TestS3GrantAllowedModesMapsActionPatterns(t *testing.T) {
 		want    []string
 	}{
 		{actions: []string{"s3:GetObject"}, want: []string{s3access.ModeRead}},
+		{actions: []string{"s3:GetObjectVersion"}, want: []string{s3access.ModeRead}},
 		{actions: []string{"s3:PutObject", "s3:DeleteObject"}, want: []string{s3access.ModeWrite}},
+		{actions: []string{"s3:PutObjectAcl"}, want: []string{s3access.ModeWrite}},
 		{actions: []string{"s3:ListBucket"}, want: []string{s3access.ModeList}},
+		{actions: []string{"s3:ListBucketVersions"}, want: []string{s3access.ModeList}},
 		{actions: []string{"s3:*"}, want: []string{s3access.ModeRead, s3access.ModeWrite, s3access.ModeList}},
 		{actions: []string{"s3:Get*"}, want: []string{s3access.ModeRead}},
 	}

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -192,6 +192,9 @@ func TestGetAWSS3RuntimeAccessDefaultLiveRequiresDeliveryFactory(t *testing.T) {
 	if len(result.Records) != 0 {
 		t.Fatalf("expected no records when live delivery is unavailable, got %+v", result.Records)
 	}
+	if result.FixtureState != "" {
+		t.Fatalf("expected no fixture state when live delivery is unavailable, got %q", result.FixtureState)
+	}
 }
 
 func TestGetAWSS3RuntimeAccessLiveRoutesDataEventsThroughDelivery(t *testing.T) {
@@ -218,6 +221,9 @@ func TestGetAWSS3RuntimeAccessLiveRoutesDataEventsThroughDelivery(t *testing.T) 
 	}
 	if fake.calls == 0 {
 		t.Fatalf("delivery factory was never used — S3 data events were not routed through delivery")
+	}
+	if result.FixtureState != "" {
+		t.Fatalf("expected no fixture state for live S3 data, got %q", result.FixtureState)
 	}
 	var found *AWSS3RuntimeAccessRecord
 	for i := range result.Records {

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -282,10 +282,11 @@ func TestObservedS3AccessFromRuntimeRecordsFiltersAndRedacts(t *testing.T) {
 		{EventID: "bucket-encryption", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "GetBucketEncryption", Action: "s3:GetBucketEncryption", ActorIdentityNodeID: "id-4", TargetResourceARN: "arn:aws:s3:::bucket"},
 		{EventID: "bucket-create", EventType: "api-call", EventSource: "s3.amazonaws.com", EventName: "CreateBucket", Action: "s3:CreateBucket", ActorIdentityNodeID: "id-5", TargetResourceARN: "arn:aws:s3:::bucket"},
 		{EventID: "kms", EventType: "kms-decrypt", EventSource: "kms.amazonaws.com", Action: "kms:Decrypt", ActorIdentityNodeID: "id-6", TargetResourceARN: "arn:aws:kms:us-east-1:1:key/k"},
+		{EventID: "analyzer-s3-action", EventType: "access-analyzer", EventSource: "access-analyzer.amazonaws.com", EventName: "GetObject", Action: "s3:GetObject", ActorIdentityNodeID: "id-7", TargetResourceARN: "arn:aws:s3:::bucket/reports/analyzer.csv"},
 	}
 	observed := observedS3AccessFromRuntimeRecords(records)
 	if len(observed) != 2 {
-		t.Fatalf("expected only the two S3 events, got %d (%+v)", len(observed), observed)
+		t.Fatalf("expected only the two S3 CloudTrail data events, got %d (%+v)", len(observed), observed)
 	}
 	for _, access := range observed {
 		if strings.Contains(strings.TrimPrefix(access.BucketARN, "arn:aws:s3:::"), "/") {
@@ -387,11 +388,23 @@ func TestStaticGrantsFromS3RecordsInvertsDenyNotAction(t *testing.T) {
 	if grants[0].Effect != "Deny" {
 		t.Fatalf("expected deny effect, got %+v", grants[0])
 	}
-	if hasS3Mode(grants[0].AllowedModes, s3access.ModeRead) {
-		t.Fatalf("NotAction GetObject must exclude read from denied modes, got %+v", grants[0].AllowedModes)
+	if !hasS3Mode(grants[0].AllowedModes, s3access.ModeRead) {
+		t.Fatalf("NotAction GetObject must preserve read because other read APIs are still denied, got %+v", grants[0].AllowedModes)
 	}
 	if !hasS3Mode(grants[0].AllowedModes, s3access.ModeWrite) || !hasS3Mode(grants[0].AllowedModes, s3access.ModeList) {
-		t.Fatalf("NotAction GetObject should deny write+list modes, got %+v", grants[0].AllowedModes)
+		t.Fatalf("NotAction GetObject should deny read+write+list modes, got %+v", grants[0].AllowedModes)
+	}
+}
+
+func TestS3GrantAllowedModesForDenyNotActionDropsOnlyFullyExcludedModes(t *testing.T) {
+	if modes := s3GrantAllowedModesForEffect([]string{"s3:GetObject"}, true, "Deny"); !hasS3Mode(modes, s3access.ModeRead) {
+		t.Fatalf("single excluded read API must not drop the whole read mode, got %+v", modes)
+	}
+	if modes := s3GrantAllowedModesForEffect([]string{"s3:Get*"}, true, "Deny"); !hasS3Mode(modes, s3access.ModeRead) {
+		t.Fatalf("partial read wildcard must not drop head/select read APIs, got %+v", modes)
+	}
+	if modes := s3GrantAllowedModesForEffect([]string{"s3:*"}, true, "Deny"); len(modes) != 0 {
+		t.Fatalf("NotAction s3:* excludes all S3 data samples, got denied modes %+v", modes)
 	}
 }
 

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -368,6 +368,33 @@ func TestStaticGrantsFromS3RecordsProjectsIAMPrincipalsOnly(t *testing.T) {
 	}
 }
 
+func TestStaticGrantsFromS3RecordsInvertsDenyNotAction(t *testing.T) {
+	records := []AWSS3BucketReachabilityRecord{{
+		AccountID: "111122223333",
+		Region:    "us-east-1",
+		BucketARN: "arn:aws:s3:::write-denied",
+		IdentityGrants: []AWSS3IdentityGrant{{
+			PrincipalARN: "arn:aws:iam::111122223333:role/writer",
+			Effect:       "Deny",
+			Actions:      []string{"s3:GetObject"},
+			NotAction:    true,
+		}},
+	}}
+	grants := staticGrantsFromS3Records(records)
+	if len(grants) != 1 {
+		t.Fatalf("expected one inverted deny grant, got %+v", grants)
+	}
+	if grants[0].Effect != "Deny" {
+		t.Fatalf("expected deny effect, got %+v", grants[0])
+	}
+	if hasS3Mode(grants[0].AllowedModes, s3access.ModeRead) {
+		t.Fatalf("NotAction GetObject must exclude read from denied modes, got %+v", grants[0].AllowedModes)
+	}
+	if !hasS3Mode(grants[0].AllowedModes, s3access.ModeWrite) || !hasS3Mode(grants[0].AllowedModes, s3access.ModeList) {
+		t.Fatalf("NotAction GetObject should deny write+list modes, got %+v", grants[0].AllowedModes)
+	}
+}
+
 func hasS3Caveat(caveats []string, want string) bool {
 	for _, caveat := range caveats {
 		if caveat == want {

--- a/internal/api/aws_s3_runtime_access_test.go
+++ b/internal/api/aws_s3_runtime_access_test.go
@@ -352,6 +352,7 @@ func TestStaticGrantsFromS3RecordsProjectsIAMPrincipalsOnly(t *testing.T) {
 		IdentityGrants: []AWSS3IdentityGrant{
 			{PrincipalARN: "arn:aws:iam::111122223333:role/reader", Effect: "Allow", Actions: []string{"s3:GetObject", "s3:ListBucket"}},
 			{PrincipalARN: "*", WildcardPrincipal: true, Effect: "Allow", Actions: []string{"s3:GetObject"}},
+			{PrincipalARN: "arn:aws:iam::111122223333:role/not-action", Effect: "Allow", Actions: []string{"s3:GetObject"}, NotAction: true},
 			{PrincipalARN: "arn:aws:iam::111122223333:role/no-recognized-action", Effect: "Allow", Actions: []string{"s3:GetBucketTagging"}},
 		},
 	}}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2943,6 +2943,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"correlation": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSS3RuntimeAccess(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSS3RuntimeAccessRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			Identity:       strings.TrimSpace(c.Query("identity")),
+			AgentID:        strings.TrimSpace(c.Query("agent_id")),
+			Resource:       strings.TrimSpace(c.Query("resource")),
+			AccessMode:     strings.TrimSpace(c.Query("access_mode")),
+			Sensitivity:    strings.TrimSpace(c.Query("sensitivity")),
+			Exposure:       strings.TrimSpace(c.Query("exposure")),
+			Status:         strings.TrimSpace(c.Query("status")),
+			DeliverySource: strings.TrimSpace(c.Query("delivery_source")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws s3 runtime access request"})
+			default:
+				logger.Error("get aws s3 runtime access",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws s3 runtime access"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"correlation": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/runtime/s3access/correlate.go
+++ b/internal/runtime/s3access/correlate.go
@@ -439,7 +439,6 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 	sources := map[string]struct{}{}
 	grantedModes := map[string]struct{}{}
 	hasAllow := len(agg.allow) > 0
-	hasDeny := len(agg.deny) > 0
 	conditional := false
 	crossAccount := false
 	sensitivity := ""
@@ -483,10 +482,11 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 	correlation.Sensitivity = sensitivity
 	correlation.Exposure = exposure
 	correlation.EvidenceRefs = sortedKeys(evidence)
+	hasMatchingDeny := denyMatchesObservedModes(agg.deny, correlation.ObservedModes)
 
 	caveats := map[string]struct{}{}
 	switch {
-	case correlation.ObservedCount > 0 && hasAllow && !hasDeny:
+	case correlation.ObservedCount > 0 && hasAllow && !hasMatchingDeny:
 		correlation.Status = StatusConfirmed
 		correlation.StaticEffect = "Allow"
 		correlation.Confidence = 0.95
@@ -515,10 +515,10 @@ func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correl
 	case correlation.ObservedCount > 0:
 		// Observed but not a clean confirmation. An explicit Deny
 		// overrides any Allow in AWS, so observed access against a bucket
-		// carrying a specific Deny is anomalous, never confirmed.
+		// carrying a matching Deny is anomalous, never confirmed.
 		correlation.Status = StatusObservedWithoutGrant
 		correlation.Confidence = 0.6
-		if hasDeny {
+		if hasMatchingDeny {
 			caveats[CaveatObservedDespiteDeny] = struct{}{}
 			correlation.StaticEffect = "Deny"
 		} else {
@@ -564,8 +564,42 @@ func modesExceedGrant(observedModes []string, grantedModes map[string]struct{}) 
 	return false
 }
 
+func denyMatchesObservedModes(denies []StaticGrant, observedModes []string) bool {
+	if len(denies) == 0 || len(observedModes) == 0 {
+		return false
+	}
+	observed := map[string]struct{}{}
+	for _, mode := range observedModes {
+		if trimmed := strings.TrimSpace(mode); trimmed != "" {
+			observed[normalize(trimmed)] = struct{}{}
+		}
+	}
+	for _, deny := range denies {
+		modes := nonEmptyStrings(deny.AllowedModes)
+		if len(modes) == 0 {
+			return true
+		}
+		for _, mode := range modes {
+			if _, ok := observed[normalize(mode)]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func isWildcardPrincipalDeny(grant StaticGrant) bool {
 	return strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") && strings.TrimSpace(grant.PrincipalARN) == "*"
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := []string{}
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func isSensitive(sensitivity string) bool {

--- a/internal/runtime/s3access/correlate.go
+++ b/internal/runtime/s3access/correlate.go
@@ -1,0 +1,611 @@
+// Package s3access correlates observed S3 runtime data access (read /
+// write / list events) with the static reachability edges Identrail
+// already discovered (S3 bucket-policy `can_access` grants) and the
+// bucket's exposure / sensitivity classification. The output ties
+// observed behavior back to identity, session, bucket, and agent context
+// so an operator can answer, per (identity, bucket) pair:
+//
+//   - confirmed:               the identity was statically allowed to
+//     reach the bucket AND was observed doing so. Behavior matches policy.
+//   - observed_without_grant:  the identity was observed accessing the
+//     bucket but no static allow edge explains it. Most S3 access is
+//     authorized by IAM identity policies, which this wave's static
+//     collector does not enumerate, or it drifted from the modeled
+//     grants. Treated as a caveat, never a silent success.
+//   - granted_unused:          a static allow edge exists but no runtime
+//     access was observed in the window. Surfaces over-provisioned
+//     grants — but carries a mandatory missing-event caveat because S3
+//     GetObject/PutObject are CloudTrail *data* events; absence in a
+//     management-event lookup is not proof the access never happened.
+//
+// On top of the reachability join, the correlation records the observed
+// access *modes* (read / write / list) and flags when an observed mode
+// exceeds what the static grant authorizes, and elevates a caveat when a
+// sensitive or publicly/cross-account exposed bucket is involved.
+//
+// Safety boundary: the engine is metadata-only and, specifically for S3,
+// never sees object keys or object contents. The API adapter redacts
+// object keys into bounded "safe prefixes" before they reach the engine,
+// and every emitted correlation re-stamps the redaction boundary so
+// downstream consumers cannot mistake it for payload-bearing evidence.
+package s3access
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ResourceKind is fixed for this engine: every correlation is keyed to an
+// S3 bucket (object keys are redacted into safe prefixes, never used as a
+// join key).
+const ResourceKind = "s3_bucket"
+
+// Correlation statuses — the operator-facing classification of a single
+// (identity, bucket) correlation.
+const (
+	StatusConfirmed            = "confirmed"
+	StatusObservedWithoutGrant = "observed_without_grant"
+	StatusGrantedUnused        = "granted_unused"
+)
+
+// Access modes. Each observed S3 event and each static grant is reduced
+// to the set of modes it represents.
+const (
+	ModeRead  = "read"
+	ModeWrite = "write"
+	ModeList  = "list"
+)
+
+// Static grant source.
+const SourceBucketPolicy = "bucket_policy"
+
+const (
+	// CollectorName tags every diagnostic and result the correlator
+	// emits so the API layer can scope diagnostics by collector.
+	CollectorName = "aws_s3_runtime_access"
+
+	// RedactionBoundary documents that the correlator only ever crossed
+	// the metadata boundary — no object keys, no object contents.
+	RedactionBoundary = "metadata_only_no_object_keys_no_object_contents"
+)
+
+// Caveat codes attached to individual correlations or the result. Stable
+// tokens so the UI and downstream consumers can branch without
+// string-matching prose.
+const (
+	CaveatDataEventCoverage   = "runtime_data_events_may_be_incomplete"
+	CaveatNoStaticPath        = "no_static_reachability_edge"
+	CaveatObservedDespiteDeny = "observed_despite_explicit_deny"
+	CaveatModeExceedsGrant    = "observed_mode_exceeds_grant"
+	CaveatConditionalGrant    = "static_grant_is_conditional"
+	CaveatCrossAccountGrant   = "static_grant_is_cross_account"
+	CaveatLineageUnresolved   = "session_lineage_unresolved"
+	CaveatSensitiveExposed    = "sensitive_bucket_publicly_or_cross_account_exposed"
+)
+
+// ObservedAccess is one metadata-only S3 runtime access projected from
+// the runtime-event contract. ResourceARN is always the bucket ARN; the
+// object key has already been redacted into SafePrefixes by the caller.
+type ObservedAccess struct {
+	EventID         string
+	IdentityNodeID  string
+	PrincipalARN    string
+	AccountID       string
+	Region          string
+	BucketARN       string
+	BucketName      string
+	AccessMode      string
+	SafePrefixes    []string
+	Action          string
+	SessionID       string
+	SessionNodeID   string
+	AgentID         string
+	AgentNodeID     string
+	SourceIPAddress string
+	LineageStatus   string
+	ObservedAt      time.Time
+	EvidenceRef     string
+}
+
+// StaticGrant is one static reachability edge from the S3 bucket
+// reachability collector, projected for the join.
+type StaticGrant struct {
+	IdentityNodeID string
+	PrincipalARN   string
+	AccountID      string
+	Region         string
+	BucketARN      string
+	BucketName     string
+	AllowedModes   []string
+	Source         string // bucket_policy
+	Effect         string // Allow | Deny
+	Conditional    bool
+	CrossAccount   bool
+	Exposure       string
+	Sensitivity    string
+	Confidence     float64
+	EvidenceRef    string
+}
+
+// CorrelateRequest configures one correlation pass.
+type CorrelateRequest struct {
+	AccountID string
+	Region    string
+	Observed  []ObservedAccess
+	Static    []StaticGrant
+	// DataEventCoverageUnknown marks that the observed set comes from a
+	// runtime source that does not guarantee S3 data events are captured
+	// (e.g. CloudTrail LookupEvents only indexes management events). When
+	// true, every granted_unused correlation and the result envelope
+	// carry the missing-event caveat so an operator never reads "unused"
+	// as "definitely never used".
+	DataEventCoverageUnknown bool
+}
+
+// Correlation is one (identity, bucket) correlation record.
+type Correlation struct {
+	CorrelationID     string
+	IdentityNodeID    string
+	PrincipalARN      string
+	AccountID         string
+	Region            string
+	BucketARN         string
+	BucketName        string
+	Status            string
+	Confidence        float64
+	ObservedCount     int
+	ObservedEventIDs  []string
+	ObservedModes     []string
+	GrantedModes      []string
+	SafePrefixes      []string
+	Actions           []string
+	SessionIDs        []string
+	AgentID           string
+	AgentNodeID       string
+	FirstObservedAt   time.Time
+	LastObservedAt    time.Time
+	StaticSources     []string
+	StaticEffect      string
+	Exposure          string
+	Sensitivity       string
+	Conditional       bool
+	CrossAccount      bool
+	Caveats           []string
+	EvidenceRefs      []string
+	RedactionBoundary string
+}
+
+// Result is the bounded outcome of one correlation pass.
+type Result struct {
+	Correlations             []Correlation
+	Caveats                  []string
+	ConfirmedCount           int
+	ObservedWithoutGrant     int
+	GrantedUnusedCount       int
+	ReadCount                int
+	WriteCount               int
+	ListCount                int
+	SensitiveExposedCount    int
+	ModeExceedsGrantCount    int
+	IdentityCount            int
+	BucketCount              int
+	ObservedAccessConsidered int
+	StaticGrantsConsidered   int
+}
+
+type correlationKey struct {
+	identity string
+	bucket   string
+}
+
+type correlationAgg struct {
+	identityNodeID string
+	principalARN   string
+	accountID      string
+	region         string
+	bucketARN      string
+	bucketName     string
+	agentID        string
+	agentNodeID    string
+	observed       []ObservedAccess
+	allow          []StaticGrant
+	deny           []StaticGrant
+	order          int
+}
+
+// Correlate joins observed S3 runtime accesses with static reachability
+// grants and returns one correlation per (identity, bucket) pair. It
+// never returns an error: documented gaps (no static path, missing data
+// events) surface as per-correlation and result-level caveats so the API
+// layer can return a stable response.
+func Correlate(request CorrelateRequest) Result {
+	index := map[correlationKey]*correlationAgg{}
+	order := 0
+	get := func(identityNode, principal, account, region, bucketARN, bucketName string) *correlationAgg {
+		identity := firstNonEmpty(identityNode, principal)
+		k := correlationKey{identity: normalize(identity), bucket: normalize(bucketARN)}
+		agg, ok := index[k]
+		if !ok {
+			agg = &correlationAgg{
+				identityNodeID: strings.TrimSpace(identityNode),
+				principalARN:   strings.TrimSpace(principal),
+				accountID:      strings.TrimSpace(account),
+				region:         strings.TrimSpace(region),
+				bucketARN:      strings.TrimSpace(bucketARN),
+				bucketName:     strings.TrimSpace(bucketName),
+				order:          order,
+			}
+			order++
+			index[k] = agg
+		}
+		if agg.identityNodeID == "" {
+			agg.identityNodeID = strings.TrimSpace(identityNode)
+		}
+		if agg.principalARN == "" {
+			agg.principalARN = strings.TrimSpace(principal)
+		}
+		if agg.bucketName == "" {
+			agg.bucketName = strings.TrimSpace(bucketName)
+		}
+		if agg.accountID == "" {
+			agg.accountID = strings.TrimSpace(account)
+		}
+		if agg.region == "" {
+			agg.region = strings.TrimSpace(region)
+		}
+		return agg
+	}
+
+	considered := 0
+	for _, observed := range request.Observed {
+		if strings.TrimSpace(observed.IdentityNodeID) == "" && strings.TrimSpace(observed.PrincipalARN) == "" {
+			continue
+		}
+		if strings.TrimSpace(observed.BucketARN) == "" {
+			continue
+		}
+		considered++
+		agg := get(observed.IdentityNodeID, observed.PrincipalARN, observed.AccountID, observed.Region, observed.BucketARN, observed.BucketName)
+		agg.observed = append(agg.observed, observed)
+		if agg.agentID == "" {
+			agg.agentID = strings.TrimSpace(observed.AgentID)
+		}
+		if agg.agentNodeID == "" {
+			agg.agentNodeID = strings.TrimSpace(observed.AgentNodeID)
+		}
+	}
+
+	staticConsidered := 0
+	for _, grant := range request.Static {
+		if strings.TrimSpace(grant.IdentityNodeID) == "" && strings.TrimSpace(grant.PrincipalARN) == "" {
+			continue
+		}
+		if strings.TrimSpace(grant.BucketARN) == "" {
+			continue
+		}
+		staticConsidered++
+		agg := get(grant.IdentityNodeID, grant.PrincipalARN, grant.AccountID, grant.Region, grant.BucketARN, grant.BucketName)
+		if strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
+			agg.deny = append(agg.deny, grant)
+		} else {
+			agg.allow = append(agg.allow, grant)
+		}
+	}
+
+	aggs := make([]*correlationAgg, 0, len(index))
+	for _, agg := range index {
+		aggs = append(aggs, agg)
+	}
+	sort.SliceStable(aggs, func(i, j int) bool {
+		if normalize(aggs[i].bucketARN) != normalize(aggs[j].bucketARN) {
+			return normalize(aggs[i].bucketARN) < normalize(aggs[j].bucketARN)
+		}
+		identI := firstNonEmpty(aggs[i].identityNodeID, aggs[i].principalARN)
+		identJ := firstNonEmpty(aggs[j].identityNodeID, aggs[j].principalARN)
+		if normalize(identI) != normalize(identJ) {
+			return normalize(identI) < normalize(identJ)
+		}
+		return aggs[i].order < aggs[j].order
+	})
+
+	result := Result{
+		ObservedAccessConsidered: considered,
+		StaticGrantsConsidered:   staticConsidered,
+	}
+	identities := map[string]struct{}{}
+	buckets := map[string]struct{}{}
+	for _, agg := range aggs {
+		if len(agg.observed) == 0 && len(agg.allow) == 0 {
+			continue
+		}
+		correlation := buildCorrelation(agg, request.DataEventCoverageUnknown)
+		result.Correlations = append(result.Correlations, correlation)
+		switch correlation.Status {
+		case StatusConfirmed:
+			result.ConfirmedCount++
+		case StatusObservedWithoutGrant:
+			result.ObservedWithoutGrant++
+		case StatusGrantedUnused:
+			result.GrantedUnusedCount++
+		}
+		if containsString(correlation.ObservedModes, ModeRead) {
+			result.ReadCount++
+		}
+		if containsString(correlation.ObservedModes, ModeWrite) {
+			result.WriteCount++
+		}
+		if containsString(correlation.ObservedModes, ModeList) {
+			result.ListCount++
+		}
+		if containsString(correlation.Caveats, CaveatSensitiveExposed) {
+			result.SensitiveExposedCount++
+		}
+		if containsString(correlation.Caveats, CaveatModeExceedsGrant) {
+			result.ModeExceedsGrantCount++
+		}
+		identities[normalize(firstNonEmpty(correlation.IdentityNodeID, correlation.PrincipalARN))] = struct{}{}
+		buckets[normalize(correlation.BucketARN)] = struct{}{}
+	}
+	result.IdentityCount = len(identities)
+	result.BucketCount = len(buckets)
+
+	if request.DataEventCoverageUnknown && (result.GrantedUnusedCount > 0 || considered == 0) {
+		result.Caveats = append(result.Caveats, "Runtime evidence is sourced from CloudTrail management-event lookups; S3 GetObject/PutObject/ListBucket data access requires an S3 data-event trail or CloudTrail Lake. 'granted_unused' correlations may reflect missing telemetry rather than truly unused grants.")
+	}
+	if result.ObservedWithoutGrant > 0 {
+		result.Caveats = append(result.Caveats, "Some observed S3 access has no matching static reachability edge. Most S3 access is authorized by IAM identity policies, which this correlation does not enumerate; review these before treating them as drift.")
+	}
+	return result
+}
+
+func buildCorrelation(agg *correlationAgg, dataEventCoverageUnknown bool) Correlation {
+	correlation := Correlation{
+		IdentityNodeID:    agg.identityNodeID,
+		PrincipalARN:      agg.principalARN,
+		AccountID:         agg.accountID,
+		Region:            agg.region,
+		BucketARN:         agg.bucketARN,
+		BucketName:        agg.bucketName,
+		AgentID:           agg.agentID,
+		AgentNodeID:       agg.agentNodeID,
+		RedactionBoundary: RedactionBoundary,
+	}
+	correlation.CorrelationID = correlationID(agg)
+
+	eventIDs := map[string]struct{}{}
+	actions := map[string]struct{}{}
+	sessions := map[string]struct{}{}
+	evidence := map[string]struct{}{}
+	observedModes := map[string]struct{}{}
+	prefixes := map[string]struct{}{}
+	lineageUnresolved := false
+	for _, observed := range agg.observed {
+		correlation.ObservedCount++
+		if id := strings.TrimSpace(observed.EventID); id != "" {
+			eventIDs[id] = struct{}{}
+		}
+		if action := strings.TrimSpace(observed.Action); action != "" {
+			actions[action] = struct{}{}
+		}
+		if session := strings.TrimSpace(observed.SessionID); session != "" {
+			sessions[session] = struct{}{}
+		}
+		if ref := strings.TrimSpace(observed.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+		if mode := strings.TrimSpace(observed.AccessMode); mode != "" {
+			observedModes[mode] = struct{}{}
+		}
+		for _, prefix := range observed.SafePrefixes {
+			if trimmed := strings.TrimSpace(prefix); trimmed != "" {
+				prefixes[trimmed] = struct{}{}
+			}
+		}
+		observedAt := observed.ObservedAt.UTC()
+		if !observedAt.IsZero() {
+			if correlation.FirstObservedAt.IsZero() || observedAt.Before(correlation.FirstObservedAt) {
+				correlation.FirstObservedAt = observedAt
+			}
+			if observedAt.After(correlation.LastObservedAt) {
+				correlation.LastObservedAt = observedAt
+			}
+		}
+		switch strings.TrimSpace(observed.LineageStatus) {
+		case "", "resolved":
+		default:
+			lineageUnresolved = true
+		}
+	}
+	correlation.ObservedEventIDs = sortedKeys(eventIDs)
+	correlation.Actions = sortedKeys(actions)
+	correlation.SessionIDs = sortedKeys(sessions)
+	correlation.ObservedModes = sortedKeys(observedModes)
+	correlation.SafePrefixes = sortedKeys(prefixes)
+
+	sources := map[string]struct{}{}
+	grantedModes := map[string]struct{}{}
+	hasAllow := len(agg.allow) > 0
+	hasDeny := len(agg.deny) > 0
+	conditional := false
+	crossAccount := false
+	sensitivity := ""
+	exposure := ""
+	staticConfidence := 0.0
+	for _, grant := range agg.allow {
+		if src := strings.TrimSpace(grant.Source); src != "" {
+			sources[src] = struct{}{}
+		}
+		for _, mode := range grant.AllowedModes {
+			if trimmed := strings.TrimSpace(mode); trimmed != "" {
+				grantedModes[trimmed] = struct{}{}
+			}
+		}
+		if grant.Conditional {
+			conditional = true
+		}
+		if grant.CrossAccount {
+			crossAccount = true
+		}
+		if grant.Confidence > staticConfidence {
+			staticConfidence = grant.Confidence
+		}
+		sensitivity = firstNonEmpty(sensitivity, grant.Sensitivity)
+		exposure = firstNonEmpty(exposure, grant.Exposure)
+		if ref := strings.TrimSpace(grant.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+	}
+	for _, grant := range agg.deny {
+		sensitivity = firstNonEmpty(sensitivity, grant.Sensitivity)
+		exposure = firstNonEmpty(exposure, grant.Exposure)
+		if ref := strings.TrimSpace(grant.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+	}
+	correlation.StaticSources = sortedKeys(sources)
+	correlation.GrantedModes = sortedKeys(grantedModes)
+	correlation.Conditional = conditional
+	correlation.CrossAccount = crossAccount
+	correlation.Sensitivity = sensitivity
+	correlation.Exposure = exposure
+	correlation.EvidenceRefs = sortedKeys(evidence)
+
+	caveats := map[string]struct{}{}
+	switch {
+	case correlation.ObservedCount > 0 && hasAllow && !hasDeny:
+		correlation.Status = StatusConfirmed
+		correlation.StaticEffect = "Allow"
+		correlation.Confidence = 0.95
+		if conditional {
+			correlation.Confidence -= 0.05
+			caveats[CaveatConditionalGrant] = struct{}{}
+		}
+		if crossAccount {
+			caveats[CaveatCrossAccountGrant] = struct{}{}
+		}
+		if lineageUnresolved {
+			if correlation.Confidence > 0.85 {
+				correlation.Confidence = 0.85
+			}
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+		// An observed mode that the static allow grant does not authorize
+		// (e.g. observed write where only read is granted) is genuine
+		// drift even though the bucket is reachable — flag it.
+		if modesExceedGrant(correlation.ObservedModes, grantedModes) {
+			caveats[CaveatModeExceedsGrant] = struct{}{}
+			if correlation.Confidence > 0.8 {
+				correlation.Confidence = 0.8
+			}
+		}
+	case correlation.ObservedCount > 0:
+		// Observed but not a clean confirmation. An explicit Deny
+		// overrides any Allow in AWS, so observed access against a bucket
+		// carrying a specific Deny is anomalous, never confirmed.
+		correlation.Status = StatusObservedWithoutGrant
+		correlation.Confidence = 0.6
+		if hasDeny {
+			caveats[CaveatObservedDespiteDeny] = struct{}{}
+			correlation.StaticEffect = "Deny"
+		} else {
+			caveats[CaveatNoStaticPath] = struct{}{}
+		}
+		if lineageUnresolved {
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+	default:
+		correlation.Status = StatusGrantedUnused
+		correlation.StaticEffect = "Allow"
+		correlation.Confidence = 0.7
+		if dataEventCoverageUnknown {
+			correlation.Confidence = 0.5
+			caveats[CaveatDataEventCoverage] = struct{}{}
+		}
+		if conditional {
+			caveats[CaveatConditionalGrant] = struct{}{}
+		}
+		if crossAccount {
+			caveats[CaveatCrossAccountGrant] = struct{}{}
+		}
+	}
+	// A sensitive bucket that is also publicly or cross-account exposed is
+	// worth surfacing on any correlation status — it raises the stakes of
+	// both observed access and unused grants.
+	if isSensitive(sensitivity) && isExposed(exposure) {
+		caveats[CaveatSensitiveExposed] = struct{}{}
+	}
+	correlation.Caveats = sortedKeys(caveats)
+	return correlation
+}
+
+// modesExceedGrant reports whether any observed mode is absent from the
+// granted mode set. An empty granted set with observed modes counts as
+// exceeding (the allow grant authorized no recognized mode).
+func modesExceedGrant(observedModes []string, grantedModes map[string]struct{}) bool {
+	for _, mode := range observedModes {
+		if _, ok := grantedModes[mode]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isSensitive(sensitivity string) bool {
+	switch strings.ToLower(strings.TrimSpace(sensitivity)) {
+	case "high", "elevated", "confidential", "restricted", "sensitive", "pii", "phi", "pci":
+		return true
+	default:
+		return false
+	}
+}
+
+func isExposed(exposure string) bool {
+	switch strings.ToLower(strings.TrimSpace(exposure)) {
+	case "public", "cross_account":
+		return true
+	default:
+		return false
+	}
+}
+
+func correlationID(agg *correlationAgg) string {
+	identity := firstNonEmpty(agg.identityNodeID, agg.principalARN, "unknown-identity")
+	bucket := firstNonEmpty(agg.bucketARN, "unknown-bucket")
+	return fmt.Sprintf("%s|%s|%s", ResourceKind, normalize(identity), normalize(bucket))
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/s3access/correlate.go
+++ b/internal/runtime/s3access/correlate.go
@@ -278,6 +278,7 @@ func Correlate(request CorrelateRequest) Result {
 	}
 
 	staticConsidered := 0
+	wildcardDeniesByBucket := map[string][]StaticGrant{}
 	for _, grant := range request.Static {
 		if strings.TrimSpace(grant.IdentityNodeID) == "" && strings.TrimSpace(grant.PrincipalARN) == "" {
 			continue
@@ -286,11 +287,22 @@ func Correlate(request CorrelateRequest) Result {
 			continue
 		}
 		staticConsidered++
+		if isWildcardPrincipalDeny(grant) {
+			bucketKey := normalize(grant.BucketARN)
+			wildcardDeniesByBucket[bucketKey] = append(wildcardDeniesByBucket[bucketKey], grant)
+			continue
+		}
 		agg := get(grant.IdentityNodeID, grant.PrincipalARN, grant.AccountID, grant.Region, grant.BucketARN, grant.BucketName)
 		if strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") {
 			agg.deny = append(agg.deny, grant)
 		} else {
 			agg.allow = append(agg.allow, grant)
+		}
+	}
+
+	for _, agg := range index {
+		if denies := wildcardDeniesByBucket[normalize(agg.bucketARN)]; len(denies) > 0 {
+			agg.deny = append(agg.deny, denies...)
 		}
 	}
 
@@ -550,6 +562,10 @@ func modesExceedGrant(observedModes []string, grantedModes map[string]struct{}) 
 		}
 	}
 	return false
+}
+
+func isWildcardPrincipalDeny(grant StaticGrant) bool {
+	return strings.EqualFold(strings.TrimSpace(grant.Effect), "Deny") && strings.TrimSpace(grant.PrincipalARN) == "*"
 }
 
 func isSensitive(sensitivity string) bool {

--- a/internal/runtime/s3access/correlate_test.go
+++ b/internal/runtime/s3access/correlate_test.go
@@ -1,0 +1,305 @@
+package s3access
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func observedAt(min int) time.Time {
+	return time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC).Add(time.Duration(min) * time.Minute)
+}
+
+func findByBucket(t *testing.T, result Result, bucketARN string) Correlation {
+	t.Helper()
+	for _, correlation := range result.Correlations {
+		if correlation.BucketARN == bucketARN {
+			return correlation
+		}
+	}
+	t.Fatalf("no correlation for bucket %q in %+v", bucketARN, result.Correlations)
+	return Correlation{}
+}
+
+func hasCaveat(caveats []string, want string) bool {
+	for _, caveat := range caveats {
+		if caveat == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCorrelateConfirmedJoinsObservedWithStaticGrant(t *testing.T) {
+	bucketARN := "arn:aws:s3:::payments-data"
+	identity := "aws:identity:role:payments-app"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "evt-1",
+			IdentityNodeID: identity,
+			PrincipalARN:   "arn:aws:iam::111122223333:role/payments-app",
+			BucketARN:      bucketARN,
+			BucketName:     "payments-data",
+			AccessMode:     ModeRead,
+			SafePrefixes:   []string{"reports"},
+			Action:         "s3:GetObject",
+			SessionID:      "ASIA-sess",
+			LineageStatus:  "resolved",
+			ObservedAt:     observedAt(5),
+			EvidenceRef:    "runtime-evidence://evt-1",
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity,
+			BucketARN:      bucketARN,
+			AllowedModes:   []string{ModeRead, ModeList},
+			Source:         SourceBucketPolicy,
+			Effect:         "Allow",
+			Confidence:     0.9,
+			EvidenceRef:    "s3-evidence://payments-data",
+		}},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.95 {
+		t.Fatalf("expected 0.95 confidence, got %v", correlation.Confidence)
+	}
+	if !hasMode(correlation.ObservedModes, ModeRead) || !hasMode(correlation.GrantedModes, ModeRead) {
+		t.Fatalf("expected read mode tracked, got observed=%v granted=%v", correlation.ObservedModes, correlation.GrantedModes)
+	}
+	if len(correlation.SafePrefixes) != 1 || correlation.SafePrefixes[0] != "reports" {
+		t.Fatalf("expected safe prefix carried, got %+v", correlation.SafePrefixes)
+	}
+	if hasCaveat(correlation.Caveats, CaveatModeExceedsGrant) {
+		t.Fatalf("read mode is granted, must not flag mode-exceeds-grant: %+v", correlation.Caveats)
+	}
+	if correlation.RedactionBoundary != RedactionBoundary {
+		t.Fatalf("missing redaction boundary: %+v", correlation)
+	}
+	if result.ConfirmedCount != 1 || result.ReadCount != 1 || result.BucketCount != 1 || result.IdentityCount != 1 {
+		t.Fatalf("unexpected result counts: %+v", result)
+	}
+}
+
+func TestCorrelateConfirmedFlagsModeExceedingGrant(t *testing.T) {
+	bucketARN := "arn:aws:s3:::reports"
+	identity := "aws:identity:role:writer"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID: "w", IdentityNodeID: identity, BucketARN: bucketARN, AccessMode: ModeWrite, Action: "s3:PutObject", ObservedAt: observedAt(1),
+		}},
+		Static: []StaticGrant{{
+			IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead}, Source: SourceBucketPolicy, Effect: "Allow",
+		}},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed (bucket is reachable), got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatModeExceedsGrant) {
+		t.Fatalf("expected mode-exceeds-grant caveat (observed write, only read granted): %+v", correlation.Caveats)
+	}
+	if correlation.Confidence != 0.8 {
+		t.Fatalf("expected confidence capped to 0.8 for mode drift, got %v", correlation.Confidence)
+	}
+	if result.ModeExceedsGrantCount != 1 {
+		t.Fatalf("expected mode-exceeds-grant count, got %+v", result)
+	}
+}
+
+func TestCorrelateObservedWithoutGrant(t *testing.T) {
+	bucketARN := "arn:aws:s3:::ungoverned"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID: "evt-2", IdentityNodeID: "aws:identity:role:agent", BucketARN: bucketARN, AccessMode: ModeRead, LineageStatus: "resolved", ObservedAt: observedAt(1),
+		}},
+		DataEventCoverageUnknown: true,
+	})
+	correlation := findByBucket(t, result, bucketARN)
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.6 || !hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("unexpected observed_without_grant correlation: %+v", correlation)
+	}
+	found := false
+	for _, caveat := range result.Caveats {
+		if strings.Contains(caveat, "IAM identity policies") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected IAM-policy result caveat, got %+v", result.Caveats)
+	}
+}
+
+func TestCorrelateGrantedUnusedCarriesMissingEventCaveat(t *testing.T) {
+	bucketARN := "arn:aws:s3:::dormant"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{
+			IdentityNodeID: "aws:identity:role:dormant", BucketARN: bucketARN, AllowedModes: []string{ModeRead, ModeWrite}, Source: SourceBucketPolicy, Effect: "Allow", Confidence: 0.88,
+		}},
+		DataEventCoverageUnknown: true,
+	})
+	correlation := findByBucket(t, result, bucketARN)
+	if correlation.Status != StatusGrantedUnused {
+		t.Fatalf("expected granted_unused, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.5 || !hasCaveat(correlation.Caveats, CaveatDataEventCoverage) {
+		t.Fatalf("expected 0.5 confidence + missing-event caveat, got %+v", correlation)
+	}
+	if len(result.Caveats) == 0 {
+		t.Fatalf("expected result-level missing-event caveat")
+	}
+}
+
+func TestCorrelateConfirmedCappedForLineageAndConditional(t *testing.T) {
+	bucketARN := "arn:aws:s3:::cond"
+	identity := "aws:identity:role:cond"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{EventID: "e", IdentityNodeID: identity, BucketARN: bucketARN, AccessMode: ModeRead, LineageStatus: "source_identity_missing", ObservedAt: observedAt(1)}},
+		Static:   []StaticGrant{{IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead}, Source: SourceBucketPolicy, Effect: "Allow", Conditional: true, CrossAccount: true}},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.85 {
+		t.Fatalf("expected confidence capped to 0.85, got %v", correlation.Confidence)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatConditionalGrant) || !hasCaveat(correlation.Caveats, CaveatCrossAccountGrant) || !hasCaveat(correlation.Caveats, CaveatLineageUnresolved) {
+		t.Fatalf("expected conditional/cross-account/lineage caveats, got %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
+	bucketARN := "arn:aws:s3:::mixed"
+	identity := "aws:identity:role:mixed"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{EventID: "m", IdentityNodeID: identity, BucketARN: bucketARN, AccessMode: ModeRead, ObservedAt: observedAt(1)}},
+		Static: []StaticGrant{
+			{IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead}, Source: SourceBucketPolicy, Effect: "Allow"},
+			{IdentityNodeID: identity, BucketARN: bucketARN, Source: SourceBucketPolicy, Effect: "Deny"},
+		},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutGrant {
+		t.Fatalf("expected observed_without_grant when explicit deny present, got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) || correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected observed-despite-deny + deny effect, got %+v", correlation)
+	}
+	if hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("no-static-path is misleading when an allow exists: %+v", correlation.Caveats)
+	}
+	if result.ConfirmedCount != 0 {
+		t.Fatalf("expected zero confirmed, got %+v", result)
+	}
+}
+
+func TestCorrelateSensitiveExposedBucketCaveat(t *testing.T) {
+	bucketARN := "arn:aws:s3:::pii-public"
+	identity := "aws:identity:role:reader"
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{
+			IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead}, Source: SourceBucketPolicy, Effect: "Allow",
+			Sensitivity: "high", Exposure: "public",
+		}},
+		DataEventCoverageUnknown: true,
+	})
+	correlation := findByBucket(t, result, bucketARN)
+	if !hasCaveat(correlation.Caveats, CaveatSensitiveExposed) {
+		t.Fatalf("expected sensitive-exposed caveat for sensitive+public bucket, got %+v", correlation.Caveats)
+	}
+	if correlation.Sensitivity != "high" || correlation.Exposure != "public" {
+		t.Fatalf("expected sensitivity/exposure carried, got %+v", correlation)
+	}
+	if result.SensitiveExposedCount != 1 {
+		t.Fatalf("expected sensitive-exposed count, got %+v", result)
+	}
+}
+
+func TestCorrelateDenyOnlyWithoutAccessIsNotSurfaced(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Static: []StaticGrant{{IdentityNodeID: "aws:identity:role:x", BucketARN: "arn:aws:s3:::deny-only", Source: SourceBucketPolicy, Effect: "Deny"}},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("expected deny-only grant to be dropped, got %+v", result.Correlations)
+	}
+}
+
+func TestCorrelateAggregatesRepeatedAccessesCaseInsensitive(t *testing.T) {
+	bucketARN := "arn:aws:s3:::multi"
+	identity := "aws:identity:role:Repeated"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{
+			{EventID: "a", IdentityNodeID: identity, BucketARN: bucketARN, AccessMode: ModeRead, SafePrefixes: []string{"a"}, ObservedAt: observedAt(10)},
+			{EventID: "b", IdentityNodeID: "AWS:IDENTITY:ROLE:REPEATED", BucketARN: bucketARN, AccessMode: ModeWrite, SafePrefixes: []string{"b"}, ObservedAt: observedAt(2)},
+		},
+		Static: []StaticGrant{{IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead, ModeWrite}, Source: SourceBucketPolicy, Effect: "Allow"}},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected case-insensitive aggregation into 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.ObservedCount != 2 || len(correlation.ObservedModes) != 2 || len(correlation.SafePrefixes) != 2 {
+		t.Fatalf("expected aggregated observations/modes/prefixes, got %+v", correlation)
+	}
+	if !correlation.FirstObservedAt.Equal(observedAt(2)) || !correlation.LastObservedAt.Equal(observedAt(10)) {
+		t.Fatalf("unexpected observed window, got first=%v last=%v", correlation.FirstObservedAt, correlation.LastObservedAt)
+	}
+}
+
+func TestCorrelateSkipsUnattributableAndBucketlessRecords(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{EventID: "no-identity", BucketARN: "arn:aws:s3:::x"}},
+		Static:   []StaticGrant{{IdentityNodeID: "aws:identity:role:y", BucketARN: ""}},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("expected unattributable + bucketless records skipped, got %+v", result.Correlations)
+	}
+	if result.ObservedAccessConsidered != 0 || result.StaticGrantsConsidered != 0 {
+		t.Fatalf("expected zero considered, got %+v", result)
+	}
+}
+
+func TestCorrelateDeterministicOrdering(t *testing.T) {
+	build := func() []Correlation {
+		return Correlate(CorrelateRequest{
+			Observed: []ObservedAccess{
+				{EventID: "1", IdentityNodeID: "z", BucketARN: "arn:aws:s3:::b", AccessMode: ModeRead, ObservedAt: observedAt(1)},
+				{EventID: "2", IdentityNodeID: "a", BucketARN: "arn:aws:s3:::a", AccessMode: ModeRead, ObservedAt: observedAt(1)},
+				{EventID: "3", IdentityNodeID: "a", BucketARN: "arn:aws:s3:::b", AccessMode: ModeRead, ObservedAt: observedAt(1)},
+			},
+		}).Correlations
+	}
+	first := build()
+	second := build()
+	if len(first) != 3 {
+		t.Fatalf("expected 3 correlations, got %d", len(first))
+	}
+	for i := range first {
+		if first[i].CorrelationID != second[i].CorrelationID {
+			t.Fatalf("ordering not deterministic at %d", i)
+		}
+	}
+	if first[0].BucketARN != "arn:aws:s3:::a" || first[1].PrincipalARN != "" {
+		// bucket :::a sorts first; within :::b, identity a before z.
+		if first[1].BucketARN != "arn:aws:s3:::b" || first[2].BucketARN != "arn:aws:s3:::b" {
+			t.Fatalf("unexpected ordering: %+v", first)
+		}
+	}
+}
+
+func hasMode(modes []string, want string) bool {
+	for _, mode := range modes {
+		if mode == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/s3access/correlate_test.go
+++ b/internal/runtime/s3access/correlate_test.go
@@ -201,6 +201,25 @@ func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestCorrelateIgnoresDenyForUnobservedModes(t *testing.T) {
+	bucketARN := "arn:aws:s3:::read-allowed-write-denied"
+	identity := "aws:identity:role:reader"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{EventID: "read", IdentityNodeID: identity, BucketARN: bucketARN, AccessMode: ModeRead, Action: "s3:GetObject", ObservedAt: observedAt(1)}},
+		Static: []StaticGrant{
+			{IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeRead}, Source: SourceBucketPolicy, Effect: "Allow"},
+			{IdentityNodeID: identity, BucketARN: bucketARN, AllowedModes: []string{ModeWrite}, Source: SourceBucketPolicy, Effect: "Deny"},
+		},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected read access to stay confirmed when only write is denied, got %+v", correlation)
+	}
+	if correlation.StaticEffect != "Allow" || hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) {
+		t.Fatalf("write-only deny must not flag observed read access, got %+v", correlation)
+	}
+}
+
 func TestCorrelateWildcardDenyAppliesToObservedPrincipal(t *testing.T) {
 	bucketARN := "arn:aws:s3:::wildcard-denied"
 	result := Correlate(CorrelateRequest{

--- a/internal/runtime/s3access/correlate_test.go
+++ b/internal/runtime/s3access/correlate_test.go
@@ -201,6 +201,46 @@ func TestCorrelateAllowPlusExplicitDenyIsNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestCorrelateWildcardDenyAppliesToObservedPrincipal(t *testing.T) {
+	bucketARN := "arn:aws:s3:::wildcard-denied"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedAccess{{
+			EventID:        "denied-read",
+			IdentityNodeID: "aws:identity:role:reader",
+			PrincipalARN:   "arn:aws:iam::111122223333:role/reader",
+			BucketARN:      bucketARN,
+			AccessMode:     ModeRead,
+			Action:         "s3:GetObject",
+			ObservedAt:     observedAt(1),
+			EvidenceRef:    "runtime-evidence://denied-read",
+		}},
+		Static: []StaticGrant{{
+			PrincipalARN: "*",
+			BucketARN:    bucketARN,
+			AllowedModes: []string{ModeRead},
+			Source:       SourceBucketPolicy,
+			Effect:       "Deny",
+			EvidenceRef:  "s3-evidence://wildcard-deny",
+		}},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected observed principal correlation only, got %+v", result.Correlations)
+	}
+	correlation := result.Correlations[0]
+	if correlation.PrincipalARN == "*" {
+		t.Fatalf("wildcard deny must not create a standalone wildcard principal correlation: %+v", correlation)
+	}
+	if correlation.Status != StatusObservedWithoutGrant || correlation.StaticEffect != "Deny" {
+		t.Fatalf("expected observed_without_grant with deny effect, got %+v", correlation)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatObservedDespiteDeny) || hasCaveat(correlation.Caveats, CaveatNoStaticPath) {
+		t.Fatalf("expected observed-despite-deny caveat without no-static-path, got %+v", correlation.Caveats)
+	}
+	if !containsString(correlation.EvidenceRefs, "s3-evidence://wildcard-deny") {
+		t.Fatalf("expected wildcard deny evidence to be attached, got %+v", correlation.EvidenceRefs)
+	}
+}
+
 func TestCorrelateSensitiveExposedBucketCaveat(t *testing.T) {
 	bucketARN := "arn:aws:s3:::pii-public"
 	identity := "aws:identity:role:reader"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2531,7 +2531,7 @@ export type AWSS3RuntimeAccessResult = {
   current_issue_ref: string;
   version: string;
   status: AWSS3RuntimeAccessStatus;
-  fixture_state: AWSS3RuntimeAccessFixtureState;
+  fixture_state?: AWSS3RuntimeAccessFixtureState;
   confidence: number;
   applied_filters: Record<string, string>;
   summary: AWSS3RuntimeAccessSummary;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2422,6 +2422,146 @@ export type AWSSecretsKMSRuntimeAccessQuery = {
   status?: string;
 };
 
+// AWSS3RuntimeAccess* types describe the S3 read/write/list runtime data
+// access correlation: observed S3 runtime events joined with the static
+// reachability edges Identrail discovered and the bucket's exposure /
+// sensitivity classification, classified per (identity, bucket) pair.
+// Object keys and contents are never present — only bucket ARNs and
+// bounded, sanitized safe prefixes.
+export type AWSS3RuntimeAccessStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSS3RuntimeAccessFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSS3RuntimeAccessCorrelationStatus =
+  | 'confirmed'
+  | 'observed_without_grant'
+  | 'granted_unused';
+export type AWSS3RuntimeAccessMode = 'read' | 'write' | 'list';
+
+export type AWSS3RuntimeAccessRecord = {
+  correlation_id: string;
+  account_id: string;
+  region: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  bucket_arn: string;
+  bucket_name?: string;
+  resource_node_id: string;
+  status: AWSS3RuntimeAccessCorrelationStatus | string;
+  confidence: number;
+  observed_count: number;
+  observed_event_ids?: string[];
+  observed_modes?: string[];
+  granted_modes?: string[];
+  safe_prefixes?: string[];
+  actions?: string[];
+  session_ids?: string[];
+  agent_id?: string;
+  agent_node_id?: string;
+  first_observed_at?: string;
+  last_observed_at?: string;
+  static_sources?: string[];
+  static_effect?: string;
+  exposure?: string;
+  sensitivity?: string;
+  conditional?: boolean;
+  cross_account?: boolean;
+  caveats?: string[];
+  evidence_ref: string;
+  evidence_refs?: string[];
+  next_action: string;
+  redaction_boundary: string;
+};
+
+export type AWSS3RuntimeAccessRelationship = {
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSS3RuntimeAccessDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSS3RuntimeAccessCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSS3RuntimeAccessSummary = {
+  total_correlations: number;
+  filtered_correlations: number;
+  status_counts: Record<string, number>;
+  confirmed_count: number;
+  observed_without_grant_count: number;
+  granted_unused_count: number;
+  read_count: number;
+  write_count: number;
+  list_count: number;
+  sensitive_exposed_count: number;
+  mode_exceeds_grant_count: number;
+  identity_count: number;
+  bucket_count: number;
+  observed_access_count: number;
+  static_grant_count: number;
+  relationship_count: number;
+};
+
+export type AWSS3RuntimeAccessResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSS3RuntimeAccessStatus;
+  fixture_state: AWSS3RuntimeAccessFixtureState;
+  confidence: number;
+  applied_filters: Record<string, string>;
+  summary: AWSS3RuntimeAccessSummary;
+  records: AWSS3RuntimeAccessRecord[];
+  relationships: AWSS3RuntimeAccessRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSS3RuntimeAccessCoverageGap[];
+  diagnostics: AWSS3RuntimeAccessDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSS3RuntimeAccessQuery = {
+  connectorID?: string;
+  fixtureState?: AWSS3RuntimeAccessFixtureState;
+  deliverySource?: AWSRuntimeEventDeliverySource;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  agentID?: string;
+  resource?: string;
+  accessMode?: string;
+  sensitivity?: string;
+  exposure?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -5546,6 +5686,30 @@ export const apiClient = {
         agent_id: query?.agentID,
         resource: query?.resource,
         resource_kind: query?.resourceKind,
+        status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectS3RuntimeAccess(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSS3RuntimeAccessQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ correlation: AWSS3RuntimeAccessResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/s3-runtime-access${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        delivery_source: query?.deliverySource,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        agent_id: query?.agentID,
+        resource: query?.resource,
+        access_mode: query?.accessMode,
+        sensitivity: query?.sensitivity,
+        exposure: query?.exposure,
         status: query?.status
       })}`,
       auth

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -51,6 +51,8 @@ import {
   type AWSRuntimeEventResult,
   type AWSSecretsKMSRuntimeAccessRecord,
   type AWSSecretsKMSRuntimeAccessResult,
+  type AWSS3RuntimeAccessRecord,
+  type AWSS3RuntimeAccessResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10194,6 +10196,105 @@ function AWSSecretsKMSRuntimeAccessContent({
   );
 }
 
+function awsS3RuntimeAccessResourceLabel(record: AWSS3RuntimeAccessRecord): string {
+  const modes = (record.observed_modes ?? []).length > 0 ? (record.observed_modes ?? []).join('/') : '—';
+  const sensitivity = record.sensitivity ? ` · ${formatTokenLabel(record.sensitivity)}` : '';
+  return `${record.bucket_name || record.bucket_arn} (${modes})${sensitivity}`;
+}
+
+function awsS3RuntimeAccessContextLabel(record: AWSS3RuntimeAccessRecord): string {
+  const prefixes = (record.safe_prefixes ?? []).length > 0 ? `prefix ${(record.safe_prefixes ?? []).join(', ')}` : 'bucket-level';
+  const caveats = (record.caveats ?? []).map((caveat) => formatTokenLabel(caveat)).join(' · ');
+  return caveats ? `${prefixes} · ${caveats}` : prefixes;
+}
+
+function AWSS3RuntimeAccessContent({
+  correlation,
+  loading,
+  error,
+  onRetry
+}: {
+  correlation: AWSS3RuntimeAccessResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const records = correlation?.records ?? [];
+  const summaryLine = correlation
+    ? `${correlation.summary.confirmed_count} confirmed · ${correlation.summary.observed_without_grant_count} observed without grant · ${correlation.summary.granted_unused_count} granted unused`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="S3 runtime data access correlation">
+      <h3>S3 runtime data access correlation</h3>
+      <p className="idt-app-kicker">
+        Observed S3 read/write/list access joined with static reachability and bucket sensitivity — confirmed,
+        observed-without-grant, or unused grant. Object keys are never shown. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load S3 runtime access correlation"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Correlating S3 runtime access"
+          body="Identrail is joining observed S3 runtime events with static reachability and bucket sensitivity."
+        />
+      ) : null}
+      {!error && !loading && correlation && records.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={correlation.status === 'blocked' ? 'Permission required' : 'No correlations'}
+          title={
+            correlation.status === 'blocked'
+              ? 'S3 runtime correlation needs read-only event access'
+              : 'No S3 runtime access correlations'
+          }
+          body={
+            correlation.failure_reasons[0] ??
+            'No observed S3 access or static grants were available for the current environment.'
+          }
+        />
+      ) : null}
+      {!error && !loading && correlation && correlation.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {correlation.caveats.map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {records.length > 0 ? (
+        <DomainDataTable
+          label="S3 runtime data access correlations"
+          rows={records}
+          getRowKey={(row) => row.correlation_id}
+          columns={[
+            { key: 'bucket', header: 'Bucket', render: (row) => <strong>{awsS3RuntimeAccessResourceLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.identity_node_id },
+            {
+              key: 'evidence',
+              header: 'Evidence',
+              render: (row) =>
+                `${row.observed_count} observed · ${(row.static_sources ?? []).map((source) => formatTokenLabel(source)).join(', ') || 'no static grant'} · ${formatConfidenceScore(row.confidence)}`
+            },
+            { key: 'context', header: 'Prefix / caveats', render: (row) => awsS3RuntimeAccessContextLabel(row) },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action },
+            {
+              key: 'status',
+              header: 'Correlation',
+              render: (row) => (
+                <AWSInventoryPill stage={awsSecretsKMSCorrelationStage(row.status)} label={awsSecretsKMSCorrelationStatusLabel(row.status)} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -10684,6 +10785,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [secretsKMSAccessLoading, setSecretsKMSAccessLoading] = useState(false);
   const [secretsKMSAccessError, setSecretsKMSAccessError] = useState('');
   const secretsKMSAccessRequestRef = useRef(0);
+  const [s3RuntimeAccess, setS3RuntimeAccess] = useState<AWSS3RuntimeAccessResult | null>(null);
+  const [s3RuntimeAccessLoading, setS3RuntimeAccessLoading] = useState(false);
+  const [s3RuntimeAccessError, setS3RuntimeAccessError] = useState('');
+  const s3RuntimeAccessRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -10795,6 +10900,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadSecretsKMSAccess]);
 
+  const loadS3RuntimeAccess = useCallback(async () => {
+    const requestID = ++s3RuntimeAccessRequestRef.current;
+    setS3RuntimeAccess(null);
+    setS3RuntimeAccessError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setS3RuntimeAccessLoading(false);
+      return;
+    }
+    setS3RuntimeAccessLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectS3RuntimeAccess(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== s3RuntimeAccessRequestRef.current) {
+        return;
+      }
+      setS3RuntimeAccess(response.correlation);
+    } catch (error) {
+      if (requestID !== s3RuntimeAccessRequestRef.current) {
+        return;
+      }
+      setS3RuntimeAccessError(formatAPIError(error, 'Unable to load S3 runtime access correlation.'));
+    } finally {
+      if (requestID === s3RuntimeAccessRequestRef.current) {
+        setS3RuntimeAccessLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadS3RuntimeAccess();
+    return () => {
+      s3RuntimeAccessRequestRef.current += 1;
+    };
+  }, [loadS3RuntimeAccess]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -10894,6 +11047,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={secretsKMSAccessLoading}
             error={secretsKMSAccessError}
             onRetry={loadSecretsKMSAccess}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSS3RuntimeAccessContent
+            correlation={s3RuntimeAccess}
+            loading={s3RuntimeAccessLoading}
+            error={s3RuntimeAccessError}
+            onRetry={loadS3RuntimeAccess}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
Closes #1519.

## Summary

Wave 5.07 adds the **S3 runtime data access correlation** — the S3 analogue of the Secrets/KMS correlation from #1518. It joins **observed** S3 read/write/list runtime events with the **static reachability** edges Identrail already discovered (S3 bucket-policy grants from #1488) and each bucket's **exposure / sensitivity** classification, so operators can prove what machine identities actually did with S3 versus what policy allowed.

Both blockers (#1516, #1488) are closed.

## What it does

Per `(identity, bucket)` pair:

| Status | Meaning |
|---|---|
| `confirmed` | Observed access **and** a static allow grant |
| `observed_without_grant` | Observed with no modeled grant (usually IAM identity-policy access, not drift) |
| `granted_unused` | Allowed but never observed in the window |

Each carries a confidence, the observed access modes, and caveats — notably **`observed_mode_exceeds_grant`** (e.g. an observed write where only read is granted) and **`sensitive_bucket_publicly_or_cross_account_exposed`**. Because S3 read/write/list are CloudTrail **data** events, `granted_unused` carries a mandatory missing-event caveat.

## S3-specific safety

**Object keys and object contents are never read.** Access is correlated at **bucket granularity**; the object key is redacted into a bounded, sanitized top-level "safe prefix", and anything identifying (UUIDs, long/hex tokens, non-folder values) is replaced with `<redacted>`. Every record re-stamps `metadata_only_no_object_keys_no_object_contents`.

## Changes

- **Engine** `internal/runtime/s3access` — pure correlation join with access-mode and sensitivity logic (12 unit tests).
- **API** `GET /v1/.../aws/s3-runtime-access` — queryable timeline filterable by identity, agent, bucket, access mode, sensitivity, exposure, account, region, status; `ready`/`degraded`/`blocked` states, coverage gaps, diagnostics, graph relationships. Live mode composes runtime-events (defaulting to CloudTrail delivery channels) + S3 reachability; fixtures cover all states (11 API tests).
- **Route policy registry + OpenAPI v1 spec** updated (path, schemas, scope headers).
- **Web** — TypeScript client types + `getAWSProjectS3RuntimeAccess`, and a correlation panel on the AWS runtime page with loading / empty / error / degraded / permission-denied states.
- **Docs** `docs/aws-s3-runtime-access.md` + CHANGELOG.

## Safety

No new AWS permissions. Never reads object keys or contents. Unknown / permission-denied / partial-failure / delivery-unavailable states are explicit, not silent successes.

## Testing

- `make fmt-check`, `make vet` — clean
- `go test ./...` — all 47 packages pass
- `make api-example-contract-check`, `make web-route-integrity-check` — pass
- `npm run build --prefix web`, `npm run test:ci --prefix web` (426 tests) — pass

## AI Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 runtime data access correlation to join observed read/write/list events with bucket-policy reachability and bucket sensitivity, so operators can see what identities actually did vs what policy allowed. Metadata-only at bucket level (keys reduced to safe prefixes); no new AWS permissions. Fulfills #1519.

- **New Features**
  - Engine `internal/runtime/s3access` classifies each (identity, bucket) as `confirmed`, `observed_without_grant`, or `granted_unused`, with observed modes, confidence, and caveats (e.g., `observed_mode_exceeds_grant`, `sensitive_bucket_publicly_or_cross_account_exposed`).
  - API `GET /v1/workspaces/{ws}/projects/{p}/aws/s3-runtime-access` with filters (identity, agent, bucket, mode, sensitivity, exposure, account, region, status), status (`ready`/`degraded`/`blocked`), coverage gaps, diagnostics, evidence links, and graph relationships.
  - Web: TS client types and `getAWSProjectS3RuntimeAccess`, plus a new correlation panel on the AWS runtime page.
  - Spec/docs: OpenAPI v1 updates, `docs/aws-s3-runtime-access.md`, and CHANGELOG.

- **Bug Fixes**
  - Correctly handles explicit Deny and `NotAction`-based deny semantics in S3/IAM policy correlation, with tightened edge-case handling and updated caveats (e.g., `observed_despite_deny`).

<sup>Written for commit 4de4c62a38f6f390512ff1d28ad3e7ab6713f2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

