### PR TITLE
AWS Platform Wave 5.08: Agent runtime and tool-call event ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS agent runtime / tool-call access correlation** (#1520). Adds
+  a metadata-only correlation engine (`internal/runtime/agentaccess`)
+  that joins observed agent `agent-tool` runtime events with the static
+  AI-agent inventory (declared agents, backing runtime role, declared
+  tools). Each `(agent, tool)` pair is classified `confirmed`,
+  `observed_without_declaration` (shadow agent or undeclared tool), or
+  `declared_unused`, with a correlation confidence, backing-role,
+  target-resource and outcome context, and caveats including
+  `observed_backing_role_differs_from_declared` and
+  `observed_tool_call_failed`. Prompts, completions, and tool payloads
+  are never read. The new endpoint
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/agent-runtime-access`
+  exposes a queryable correlation timeline filterable by identity
+  (backing role), agent, tool, target resource, outcome, account,
+  region, and correlation status, with `ready`/`degraded`/`blocked`
+  states, coverage gaps, diagnostics, and graph relationships. Defaults
+  the runtime source to the CloudTrail delivery channels (`all`) since
+  agent tool-call telemetry is not indexed by LookupEvents; when the
+  inventory is unavailable in live mode it surfaces a neutral caveat
+  rather than mislabeling real agents as shadow agents. Adds no new AWS
+  permissions. Surfaced in the AWS runtime app surface. Closes #1520.
+  See [docs/aws-agent-runtime-access.md](docs/aws-agent-runtime-access.md).
 - Add **AWS S3 runtime data access correlation** (#1519). Adds a
   metadata-only correlation engine (`internal/runtime/s3access`) that
   joins observed S3 read/write/list runtime events with the static

--- a/docs/aws-agent-runtime-access.md
+++ b/docs/aws-agent-runtime-access.md
@@ -1,0 +1,123 @@
+# AWS agent runtime / tool-call access correlation
+
+Issue #1520 adds a correlation layer that ties **observed** agent runtime /
+tool-call events back to the static **AI-agent inventory** Identrail already
+discovered (#1512: declared agents, their backing runtime role, and their
+declared tools). Without it, runtime evidence and the agent inventory live in
+separate surfaces and an operator cannot tell whether an agent actually
+exercised a declared tool, ran a tool it never declared, or is a shadow agent
+not in the inventory at all.
+
+The correlation is **metadata-only**. It never reads, logs, or persists
+prompts, completions, tool inputs/outputs, browser pages, code-interpreter
+output, or any other customer payload — only the already-redacted
+runtime-event (#1513) and agent-inventory (#1512) metadata.
+
+## What it correlates
+
+For each `(agent, tool)` pair the engine
+(`internal/runtime/agentaccess`) joins:
+
+- **Observed tool-calls** — `agent-tool` runtime events, keyed by agent node id
+  and tool name, with the backing role (the machine identity that ran the
+  agent), target resource, and outcome.
+- **Declared tools** — the agent inventory's declared tools per agent, with the
+  agent's declared backing runtime role.
+
+## Correlation statuses
+
+| Status | Meaning | Confidence |
+|---|---|---|
+| `confirmed` | The agent and tool are declared in the inventory **and** a tool-call was observed. | 0.95 (capped to 0.85 on unresolved lineage; capped to 0.8 on backing-role mismatch) |
+| `observed_without_declaration` | A tool-call was observed for an agent not in the inventory (**shadow agent**) or for a tool the agent does not declare (**undeclared tool**). | 0.6 |
+| `declared_unused` | The agent declares the tool but no tool-call was observed in the window. | 0.7, reduced to 0.5 when tool-call telemetry coverage is unknown |
+
+### Caveats
+
+Stable caveat codes attached to correlations or the result:
+
+- `agent_tool_telemetry_may_be_incomplete` — agent tool-call telemetry is not
+  guaranteed complete from the available runtime sources, so `declared_unused`
+  may reflect missing telemetry. **Absence of evidence is not evidence of
+  absence.**
+- `agent_not_in_inventory` — a shadow agent: a tool-call from an agent not in
+  the inventory.
+- `tool_not_declared_by_agent` — a known agent invoking a tool it does not
+  declare.
+- `observed_backing_role_differs_from_declared` — the observed backing role
+  differs from the agent's declared runtime role (privilege drift).
+- `observed_tool_call_failed` — a failed tool-call outcome was observed.
+- `agent_inventory_unavailable_for_confirmation` — the inventory could not be
+  loaded, so an observed tool-call is surfaced neutrally rather than being
+  mislabeled as a shadow agent.
+- `session_lineage_unresolved`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-runtime-access`
+
+Query parameters: `connector_id`, `fixture_state` (`success` default, `empty`,
+`degraded`, `partial_failure`, `permission_denied`), `delivery_source`
+(`lookup_events` / `s3` / `eventbridge` / `all`, **defaults to `all`** because
+agent tool-call telemetry arrives as data events LookupEvents does not index),
+`account_id`, `region`, `identity` (backing role), `agent_id`, `tool`,
+`resource`, `outcome` (`succeeded` / `failed` / `unknown`), and `status`.
+
+The response (`AWSAgentRuntimeAccessResult`) carries one record per `(agent,
+tool)` correlation with the status, confidence, backing roles, declared backing
+role, target resources, outcomes, caveats, evidence references, and graph
+relationships (`confirmed_agent_tool_call`,
+`observed_tool_call_without_declaration`, `unused_declared_tool`, and
+`agent_tool_targeted_resource`) joining back to the identity, agent, and
+resource nodes. It also returns a summary, coverage gaps, diagnostics, and the
+`ready` / `degraded` / `blocked` status.
+
+## Live vs fixture
+
+Live composition is attempted when the connector is active and healthy, the
+operator did not pin a `fixture_state`, the connector's effective capability set
+includes `runtime_evidence`, and the CloudTrail delivery factory is wired. In
+that case the handler composes runtime-events (driven through the resolved
+`delivery_source`) and the AI-agent inventory. The inventory reader is
+fixture-shaped today, so live mode forces an empty inventory and reports it as
+unavailable — the engine then surfaces observed tool-calls with the neutral
+`agent_inventory_unavailable_for_confirmation` caveat rather than mislabeling
+real agents as shadow agents. When the connector is healthy but no delivery
+factory is wired, the endpoint returns an explicit delivery-unavailable degraded
+state. Otherwise it returns the deterministic correlation fixtures, which
+exercise all statuses (including a shadow agent, an undeclared tool, a
+backing-role mismatch, and a failed tool-call).
+
+## AWS permissions
+
+This capability adds **no** new AWS permissions. It reuses the read-only,
+metadata-only permissions the runtime-events (`cloudtrail:LookupEvents` and
+optional delivery-channel reads) and AI-agent inventory collectors already
+require. No prompt, completion, or tool-payload read is requested or used.
+
+## Intentionally not collected / not modeled
+
+- **Prompts, completions, tool inputs/outputs, browser pages, code-interpreter
+  output.** Never collected. Only metadata (agent, tool, backing role, target
+  resource) is correlated.
+- **Explicit tool-call outcomes.** Live success/failure outcomes are not yet
+  extracted from the runtime sources (it requires error-code extraction in the
+  ingestion layer), so live outcomes are reported as `unknown` with a coverage
+  gap.
+- **IAM identity-policy reachability** of the backing role is out of scope; this
+  correlation compares observed agents/tools against the agent inventory only.
+
+## Live validation and troubleshooting
+
+1. Confirm the connector is active and healthy, has the `runtime_evidence`
+   capability, and a wired CloudTrail delivery channel.
+2. Query the endpoint with no `fixture_state`. A `blocked` status with a
+   `permission_denied` diagnostic means CloudTrail access is missing; a
+   `degraded` status with a `delivery_unavailable` gap means no delivery channel
+   is wired for the data events.
+3. `observed_without_declaration` with `agent_not_in_inventory` flags a shadow
+   agent worth urgent review; with `tool_not_declared_by_agent` it flags a known
+   agent using an undeclared tool.
+4. `observed_backing_role_differs_from_declared` flags an agent running under a
+   different role than the inventory declares — investigate before trusting the
+   tool-call.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -564,6 +564,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-runtime-access
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4796,6 +4801,94 @@ paths:
                     $ref: "#/components/schemas/AWSS3RuntimeAccessResult"
         "400":
           description: Invalid AWS s3 runtime access request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-runtime-access:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS agent runtime / tool-call access correlation
+      operationId: getAWSProjectAgentRuntimeAccess
+      description: Correlates observed, metadata-only agent runtime / tool-call events with the static AI-agent inventory Identrail discovered (declared agents, backing runtime role, and declared tools). Each (agent, tool) correlation is classified confirmed, observed_without_declaration (shadow agent or undeclared tool), or declared_unused, with a correlation confidence, backing-role-mismatch and failed-tool-call caveats, and target-resource context. Prompts, completions, tool inputs/outputs, browser pages, and code-interpreter output are never read or returned.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only runtime evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: delivery_source
+          schema:
+            type: string
+            enum: [lookup_events, s3, eventbridge, all]
+          description: Optional CloudTrail delivery channel for the observed agent tool-call events. Defaults to `all` because these arrive as data events that the LookupEvents API does not index.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional backing-role principal or identity-node search.
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent ID, name, or agent-node search.
+        - in: query
+          name: tool
+          schema: { type: string }
+          description: Optional tool name or tool target-ref search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional target resource ARN search.
+        - in: query
+          name: outcome
+          schema:
+            type: string
+            enum: [succeeded, failed, unknown]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [confirmed, observed_without_declaration, declared_unused]
+      responses:
+        "200":
+          description: AWS agent runtime access correlation contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  correlation:
+                    $ref: "#/components/schemas/AWSAgentRuntimeAccessResult"
+        "400":
+          description: Invalid AWS agent runtime access request
           content:
             application/json:
               schema:
@@ -11455,6 +11548,168 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSS3RuntimeAccessDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAgentRuntimeAccessRecord:
+      type: object
+      properties:
+        correlation_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        agent_node_id: { type: string }
+        agent_id: { type: string }
+        agent_name: { type: string }
+        agent_type: { type: string }
+        runtime_version: { type: string }
+        tool_name: { type: string }
+        tool_target_ref: { type: string }
+        status:
+          type: string
+          enum: [confirmed, observed_without_declaration, declared_unused]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_count: { type: integer }
+        observed_event_ids:
+          type: array
+          items: { type: string }
+        backing_role_arns:
+          type: array
+          items: { type: string }
+        backing_role_node_ids:
+          type: array
+          items: { type: string }
+        declared_backing_role: { type: string }
+        target_resource_arns:
+          type: array
+          items: { type: string }
+        outcomes:
+          type: array
+          items: { type: string }
+        session_ids:
+          type: array
+          items: { type: string }
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        declared_in_inventory: { type: boolean }
+        caveats:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        redaction_boundary: { type: string }
+    AWSAgentRuntimeAccessRelationship:
+      type: object
+      properties:
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAgentRuntimeAccessDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSAgentRuntimeAccessCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSAgentRuntimeAccessSummary:
+      type: object
+      properties:
+        total_correlations: { type: integer }
+        filtered_correlations: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        confirmed_count: { type: integer }
+        observed_without_declaration_count: { type: integer }
+        declared_unused_count: { type: integer }
+        shadow_agent_count: { type: integer }
+        undeclared_tool_count: { type: integer }
+        backing_role_mismatch_count: { type: integer }
+        failed_tool_call_count: { type: integer }
+        agent_count: { type: integer }
+        tool_count: { type: integer }
+        observed_tool_call_count: { type: integer }
+        declared_tool_count: { type: integer }
+        relationship_count: { type: integer }
+    AWSAgentRuntimeAccessResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSAgentRuntimeAccessSummary"
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentRuntimeAccessRecord"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentRuntimeAccessRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentRuntimeAccessCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentRuntimeAccessDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -756,6 +756,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_agent_runtime_access.go
+++ b/internal/api/aws_agent_runtime_access.go
@@ -609,10 +609,21 @@ func awsAgentRuntimeAccessRelationships(records []AWSAgentRuntimeAccessRecord) [
 		case agentaccess.StatusDeclaredUnused:
 			edgeType = "unused_declared_tool"
 		}
-		for _, roleNode := range record.BackingRoleNodeIDs {
-			if strings.TrimSpace(roleNode) == "" {
+		roleNodes := append([]string{}, record.BackingRoleNodeIDs...)
+		if record.Status == agentaccess.StatusDeclaredUnused && strings.TrimSpace(record.DeclaredBackingRoleNode) != "" {
+			roleNodes = append(roleNodes, record.DeclaredBackingRoleNode)
+		}
+		seenRoleNodes := map[string]struct{}{}
+		for _, roleNode := range roleNodes {
+			roleNode = strings.TrimSpace(roleNode)
+			if roleNode == "" {
 				continue
 			}
+			roleKey := strings.ToLower(roleNode)
+			if _, ok := seenRoleNodes[roleKey]; ok {
+				continue
+			}
+			seenRoleNodes[roleKey] = struct{}{}
 			out = append(out, AWSAgentRuntimeAccessRelationship{
 				Type:        edgeType,
 				FromNodeID:  roleNode,

--- a/internal/api/aws_agent_runtime_access.go
+++ b/internal/api/aws_agent_runtime_access.go
@@ -1,0 +1,656 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/agentaccess"
+)
+
+const (
+	awsAgentRuntimeAccessCurrentIssue = 1520
+	awsAgentRuntimeAccessVersion      = "aws-agent-runtime-access-correlation-v1"
+)
+
+// AWSAgentRuntimeAccessRequest is the operator-facing request. It scopes
+// the correlation to a connector/account/region and exposes the runtime
+// timeline/query filters the issue requires: by identity (backing role),
+// agent, tool, target resource, outcome, and correlation status.
+type AWSAgentRuntimeAccessRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Tool         string `json:"tool,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Outcome      string `json:"outcome,omitempty"`
+	Status       string `json:"status,omitempty"`
+	// DeliverySource selects the CloudTrail ingestion channel used to
+	// observe the agent tool-call events: `lookup_events`, `s3`,
+	// `eventbridge`, or `all`. Empty defaults to `all` because agent
+	// tool-call telemetry arrives as data events that LookupEvents does
+	// not index. Unknown values return HTTP 400.
+	DeliverySource string `json:"delivery_source,omitempty"`
+}
+
+// AWSAgentRuntimeAccessRecord is one (agent, tool) correlation projected
+// for the API/app surface.
+type AWSAgentRuntimeAccessRecord struct {
+	CorrelationID       string    `json:"correlation_id"`
+	AccountID           string    `json:"account_id"`
+	Region              string    `json:"region"`
+	AgentNodeID         string    `json:"agent_node_id"`
+	AgentID             string    `json:"agent_id,omitempty"`
+	AgentName           string    `json:"agent_name,omitempty"`
+	AgentType           string    `json:"agent_type,omitempty"`
+	RuntimeVersion      string    `json:"runtime_version,omitempty"`
+	ToolName            string    `json:"tool_name,omitempty"`
+	ToolTargetRef       string    `json:"tool_target_ref,omitempty"`
+	Status              string    `json:"status"`
+	Confidence          float64   `json:"confidence"`
+	ObservedCount       int       `json:"observed_count"`
+	ObservedEventIDs    []string  `json:"observed_event_ids,omitempty"`
+	BackingRoleARNs     []string  `json:"backing_role_arns,omitempty"`
+	BackingRoleNodeIDs  []string  `json:"backing_role_node_ids,omitempty"`
+	DeclaredBackingRole string    `json:"declared_backing_role,omitempty"`
+	TargetResourceARNs  []string  `json:"target_resource_arns,omitempty"`
+	Outcomes            []string  `json:"outcomes,omitempty"`
+	SessionIDs          []string  `json:"session_ids,omitempty"`
+	FirstObservedAt     time.Time `json:"first_observed_at,omitzero"`
+	LastObservedAt      time.Time `json:"last_observed_at,omitzero"`
+	DeclaredInInventory bool      `json:"declared_in_inventory"`
+	Caveats             []string  `json:"caveats,omitempty"`
+	EvidenceRef         string    `json:"evidence_ref"`
+	EvidenceRefs        []string  `json:"evidence_refs,omitempty"`
+	NextAction          string    `json:"next_action"`
+	RedactionBoundary   string    `json:"redaction_boundary"`
+}
+
+// AWSAgentRuntimeAccessRelationship is one correlation graph edge so the
+// runtime evidence joins back to the static identity/agent graph.
+type AWSAgentRuntimeAccessRelationship struct {
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSAgentRuntimeAccessDiagnostic is a structured diagnostic propagated
+// from the correlated sources.
+type AWSAgentRuntimeAccessDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSAgentRuntimeAccessCoverageGap names a coverage limitation.
+type AWSAgentRuntimeAccessCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSAgentRuntimeAccessSummary aggregates the correlation outcome.
+type AWSAgentRuntimeAccessSummary struct {
+	TotalCorrelations        int            `json:"total_correlations"`
+	FilteredCorrelations     int            `json:"filtered_correlations"`
+	StatusCounts             map[string]int `json:"status_counts"`
+	ConfirmedCount           int            `json:"confirmed_count"`
+	ObservedWithoutDeclCount int            `json:"observed_without_declaration_count"`
+	DeclaredUnusedCount      int            `json:"declared_unused_count"`
+	ShadowAgentCount         int            `json:"shadow_agent_count"`
+	UndeclaredToolCount      int            `json:"undeclared_tool_count"`
+	BackingRoleMismatchCount int            `json:"backing_role_mismatch_count"`
+	FailedToolCallCount      int            `json:"failed_tool_call_count"`
+	AgentCount               int            `json:"agent_count"`
+	ToolCount                int            `json:"tool_count"`
+	ObservedToolCallCount    int            `json:"observed_tool_call_count"`
+	DeclaredToolCount        int            `json:"declared_tool_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+}
+
+// AWSAgentRuntimeAccessResult is the deterministic envelope.
+type AWSAgentRuntimeAccessResult struct {
+	TenantID           string                              `json:"tenant_id"`
+	WorkspaceID        string                              `json:"workspace_id"`
+	ProjectID          string                              `json:"project_id"`
+	ConnectorID        string                              `json:"connector_id,omitempty"`
+	AccountID          string                              `json:"account_id,omitempty"`
+	Region             string                              `json:"region,omitempty"`
+	ParentIssueNumber  int                                 `json:"parent_issue_number"`
+	ParentIssueRef     string                              `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                 `json:"current_issue_number"`
+	CurrentIssueRef    string                              `json:"current_issue_ref"`
+	Version            string                              `json:"version"`
+	Status             string                              `json:"status"`
+	FixtureState       string                              `json:"fixture_state,omitempty"`
+	Confidence         float64                             `json:"confidence"`
+	AppliedFilters     map[string]string                   `json:"applied_filters"`
+	Summary            AWSAgentRuntimeAccessSummary        `json:"summary"`
+	Records            []AWSAgentRuntimeAccessRecord       `json:"records"`
+	Relationships      []AWSAgentRuntimeAccessRelationship `json:"relationships"`
+	Caveats            []string                            `json:"caveats"`
+	FailureReasons     []string                            `json:"failure_reasons"`
+	RemediationHints   []string                            `json:"remediation_hints"`
+	EvidenceLinks      []string                            `json:"evidence_links"`
+	CoverageGaps       []AWSAgentRuntimeAccessCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSAgentRuntimeAccessDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                           `json:"generated_at"`
+	UpdatedAt          time.Time                           `json:"updated_at"`
+}
+
+// GetAWSAgentRuntimeAccess correlates observed agent runtime / tool-call
+// events with the static AI-agent inventory, returning a queryable
+// correlation timeline.
+func (s *Service) GetAWSAgentRuntimeAccess(ctx context.Context, workspaceID string, projectID string, request AWSAgentRuntimeAccessRequest) (AWSAgentRuntimeAccessResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAgentRuntimeAccessResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAgentRuntimeAccessResult{}, err
+	}
+	now := s.Now().UTC()
+
+	fixtureState := normalizeAWSAgentRuntimeAccessFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAgentRuntimeAccessResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	// Agent tool-call telemetry arrives as CloudTrail data events, which
+	// LookupEvents does not index. Default to `all` so the correlation can
+	// observe the events it correlates; operators can pin a channel.
+	deliverySource := strings.TrimSpace(request.DeliverySource)
+	if deliverySource == "" {
+		deliverySource = "all"
+	}
+	var deliveryErr error
+	deliverySource, deliveryErr = normalizeDeliverySource(deliverySource)
+	if deliveryErr != nil {
+		return AWSAgentRuntimeAccessResult{}, deliveryErr
+	}
+
+	useLive := awsAgentRuntimeAccessHasLiveRuntimeFactory(s, deliverySource) &&
+		hasConnection && connection.Connected &&
+		strings.TrimSpace(request.FixtureState) == "" &&
+		awsConnectorHasRuntimeEvidence(connection)
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	var (
+		observed           []agentaccess.ObservedToolCall
+		declared           []agentaccess.DeclaredTool
+		knownAgents        []string
+		inventoryAvailable bool
+		diagnostics        []AWSAgentRuntimeAccessDiagnostic
+		coverageGaps       []AWSAgentRuntimeAccessCoverageGap
+		failures           []string
+		remediations       []string
+		sourceStatus       string
+		coverageUnknown    bool
+	)
+
+	if useLive {
+		observed, declared, knownAgents, inventoryAvailable, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown, err =
+			s.awsAgentRuntimeAccessLiveInputs(ctx, workspaceID, projectID, connectorID, accountID, region, deliverySource)
+		if err != nil {
+			return AWSAgentRuntimeAccessResult{}, err
+		}
+		fixtureState = ""
+	} else if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		observed, declared, knownAgents, inventoryAvailable, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsAgentRuntimeAccessLiveUnavailableInputs(deliverySource)
+		fixtureState = ""
+	} else {
+		observed, declared, knownAgents, inventoryAvailable, diagnostics, coverageGaps, failures, remediations, sourceStatus, coverageUnknown =
+			awsAgentRuntimeAccessFixtureInputs(accountID, region, fixtureState, now)
+	}
+
+	correlationResult := agentaccess.Correlate(agentaccess.CorrelateRequest{
+		AccountID:                accountID,
+		Region:                   region,
+		Observed:                 observed,
+		Declared:                 declared,
+		KnownAgentNodeIDs:        knownAgents,
+		InventoryAvailable:       inventoryAvailable,
+		DataEventCoverageUnknown: coverageUnknown,
+	})
+
+	records := awsAgentRuntimeAccessRecords(correlationResult.Correlations)
+	filtered, applied := filterAWSAgentRuntimeAccessRecords(records, request)
+	relationships := awsAgentRuntimeAccessRelationships(filtered)
+	summary := summarizeAWSAgentRuntimeAccess(correlationResult, records, filtered, relationships)
+
+	status, confidence := summarizeAWSAgentRuntimeAccessStatus(sourceStatus, filtered, diagnostics)
+	caveats := dedupeStrings(correlationResult.Caveats)
+
+	return AWSAgentRuntimeAccessResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAgentRuntimeAccessCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAgentRuntimeAccessCurrentIssue),
+		Version:            awsAgentRuntimeAccessVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Records:            filtered,
+		Relationships:      relationships,
+		Caveats:            caveats,
+		FailureReasons:     emptyStrings(dedupeStrings(failures)),
+		RemediationHints:   emptyStrings(dedupeStrings(remediations)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAgentRuntimeAccessCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsAIAgentIdentityCurrentIssue),
+			"/docs/aws-agent-runtime-access",
+			"/docs/aws-runtime-events",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSAgentRuntimeAccessFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsAgentRuntimeAccessHasLiveRuntimeFactory(s *Service, deliverySource string) bool {
+	switch strings.TrimSpace(deliverySource) {
+	case "lookup_events":
+		return s.AWSCloudTrailLookupEventsFactory != nil
+	case "s3", "eventbridge", "all":
+		return s.AWSCloudTrailDeliveryFactory != nil
+	default:
+		return false
+	}
+}
+
+func awsAgentRuntimeAccessLiveUnavailableInputs(deliverySource string) ([]agentaccess.ObservedToolCall, []agentaccess.DeclaredTool, []string, bool, []AWSAgentRuntimeAccessDiagnostic, []AWSAgentRuntimeAccessCoverageGap, []string, []string, string, bool) {
+	source := strings.TrimSpace(deliverySource)
+	if source == "" {
+		source = "all"
+	}
+	diagnostics := []AWSAgentRuntimeAccessDiagnostic{{
+		Collector:   agentaccess.CollectorName,
+		SourceID:    "runtime_delivery:" + source,
+		Code:        "runtime_delivery_unavailable",
+		Message:     "Live agent tool-call telemetry is unavailable for this connector; fixture correlations were suppressed.",
+		Remediation: "Configure the selected CloudTrail delivery channel and grant the runtime_evidence capability, or request a fixture_state explicitly for demo data.",
+		Retryable:   true,
+	}}
+	coverageGaps := []AWSAgentRuntimeAccessCoverageGap{{
+		Capability:  "agent_tool_call_delivery",
+		Status:      "delivery_unavailable",
+		Reason:      "The selected runtime delivery source is not available, so real agent tool-call events cannot be correlated.",
+		Remediation: "Wire CloudTrail S3/EventBridge delivery for this connector and grant runtime_evidence before relying on live correlation output.",
+	}}
+	failures := []string{"agent tool-call runtime delivery is unavailable; fixture correlations suppressed"}
+	remediations := []string{"Configure CloudTrail data-event delivery or request fixture_state explicitly for sample data."}
+	return nil, nil, nil, false, diagnostics, coverageGaps, failures, remediations, awsPlatformDependencyStatusDegraded, true
+}
+
+// awsAgentRuntimeAccessLiveInputs composes the runtime-events and AI-agent
+// inventory services into the engine's observed/declared inputs. The
+// inventory reader is fixture-shaped today, so live mode forces an empty
+// inventory state and reports it as unavailable — the engine then surfaces
+// observed tool-calls with a neutral "inventory unavailable" caveat rather
+// than mislabeling real agents as shadow agents.
+func (s *Service) awsAgentRuntimeAccessLiveInputs(ctx context.Context, workspaceID, projectID, connectorID, accountID, region, deliverySource string) ([]agentaccess.ObservedToolCall, []agentaccess.DeclaredTool, []string, bool, []AWSAgentRuntimeAccessDiagnostic, []AWSAgentRuntimeAccessCoverageGap, []string, []string, string, bool, error) {
+	var (
+		diagnostics  []AWSAgentRuntimeAccessDiagnostic
+		coverageGaps []AWSAgentRuntimeAccessCoverageGap
+		failures     []string
+		remediations []string
+	)
+
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:    connectorID,
+		AccountID:      accountID,
+		Region:         region,
+		DeliverySource: deliverySource,
+	})
+	if err != nil {
+		return nil, nil, nil, false, nil, nil, nil, nil, "", false, fmt.Errorf("correlate runtime events: %w", err)
+	}
+	inventory, err := s.GetAWSAIAgentIdentityInventory(ctx, workspaceID, projectID, AWSAIAgentIdentityInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: awsRuntimeCorrelationLiveNoStaticState,
+	})
+	if err != nil {
+		return nil, nil, nil, false, nil, nil, nil, nil, "", false, fmt.Errorf("correlate agent inventory: %w", err)
+	}
+
+	observed := observedAgentToolCallsFromRuntimeRecords(runtime.Records)
+	declared, knownAgents := declaredToolsFromAgentInventory(inventory.Records)
+	inventoryAvailable := len(inventory.Records) > 0
+
+	for _, diag := range runtime.Diagnostics {
+		diagnostics = append(diagnostics, AWSAgentRuntimeAccessDiagnostic(diag))
+	}
+	for _, gap := range runtime.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSAgentRuntimeAccessCoverageGap(gap))
+	}
+	failures = append(failures, runtime.FailureReasons...)
+	remediations = append(remediations, runtime.RemediationHints...)
+
+	// A blocked runtime source (or a degraded one that projected no agent
+	// tool-calls) means the observed side is missing, not empty — drop the
+	// declared side so declared tools are not surfaced as unused work.
+	if runtime.Status == awsPlatformDependencyStatusBlocked || (runtime.Status == awsPlatformDependencyStatusDegraded && len(observed) == 0) {
+		observed = nil
+		declared = nil
+		knownAgents = nil
+	}
+
+	sourceStatus := runtime.Status
+	return observed, declared, knownAgents, inventoryAvailable, diagnostics, coverageGaps, failures, remediations, sourceStatus, true, nil
+}
+
+// observedAgentToolCallsFromRuntimeRecords projects agent-tool runtime
+// event records into engine observed tool-calls. Other event types are
+// dropped. The backing role is the actor identity that ran the agent.
+func observedAgentToolCallsFromRuntimeRecords(records []AWSRuntimeEventRecord) []agentaccess.ObservedToolCall {
+	out := []agentaccess.ObservedToolCall{}
+	for _, record := range records {
+		if !strings.EqualFold(strings.TrimSpace(record.EventType), "agent-tool") {
+			continue
+		}
+		if strings.TrimSpace(record.AgentNodeID) == "" && strings.TrimSpace(record.AgentID) == "" {
+			continue
+		}
+		out = append(out, agentaccess.ObservedToolCall{
+			EventID:              record.EventID,
+			AgentNodeID:          record.AgentNodeID,
+			AgentID:              record.AgentID,
+			ToolName:             record.ToolName,
+			ToolTargetRef:        record.ToolTargetRef,
+			BackingRoleARN:       firstNonEmptyAWSValue(record.Session.SessionIssuerARN, record.ActorPrincipalARN),
+			BackingRoleNodeID:    record.ActorIdentityNodeID,
+			TargetResourceARN:    record.TargetResourceARN,
+			TargetResourceNodeID: record.ResourceNodeID,
+			// The runtime-event contract does not yet carry an explicit
+			// tool-call success/failure outcome (it requires error-code
+			// extraction in the ingestion layer), so live outcome is
+			// unknown — surfaced as a coverage gap, never fabricated.
+			Outcome:       agentaccess.OutcomeUnknown,
+			SessionID:     record.Session.SessionID,
+			AccountID:     record.AccountID,
+			Region:        record.Region,
+			LineageStatus: record.Session.LineageStatus,
+			ObservedAt:    record.ObservedAt,
+			EvidenceRef:   record.EvidenceRef,
+		})
+	}
+	return out
+}
+
+// declaredToolsFromAgentInventory projects AI-agent inventory records into
+// declared (agent, tool) pairs, and returns the set of known agent node
+// ids (including agents that declare no tools).
+func declaredToolsFromAgentInventory(records []AWSAIAgentIdentityRecord) ([]agentaccess.DeclaredTool, []string) {
+	out := []agentaccess.DeclaredTool{}
+	known := make([]string, 0, len(records))
+	for _, record := range records {
+		agentNode := strings.TrimSpace(record.AgentNodeID)
+		if agentNode == "" && strings.TrimSpace(record.AgentID) == "" {
+			continue
+		}
+		if agentNode != "" {
+			known = append(known, agentNode)
+		}
+		base := agentaccess.DeclaredTool{
+			AgentNodeID:       record.AgentNodeID,
+			AgentID:           record.AgentID,
+			AgentName:         record.AgentName,
+			AgentType:         record.AgentType,
+			RuntimeVersion:    record.RuntimeVersion,
+			BackingRoleARN:    record.RuntimeRoleARN,
+			BackingRoleNodeID: record.RuntimeRoleNodeID,
+			AccountID:         record.AccountID,
+			Region:            record.Region,
+			Confidence:        record.Confidence,
+			EvidenceRef:       record.EvidenceRef,
+		}
+		if len(record.ToolNames) == 0 {
+			// Mark the agent as known with an empty-tool declaration so a
+			// known agent invoking an undeclared tool is not mislabeled as
+			// a shadow agent.
+			out = append(out, base)
+			continue
+		}
+		for i, tool := range record.ToolNames {
+			declared := base
+			declared.ToolName = strings.TrimSpace(tool)
+			if i < len(record.ToolTargetRefs) {
+				declared.ToolTargetRef = strings.TrimSpace(record.ToolTargetRefs[i])
+			}
+			out = append(out, declared)
+		}
+	}
+	return out, known
+}
+
+func awsAgentRuntimeAccessRecords(correlations []agentaccess.Correlation) []AWSAgentRuntimeAccessRecord {
+	out := make([]AWSAgentRuntimeAccessRecord, 0, len(correlations))
+	for _, correlation := range correlations {
+		out = append(out, AWSAgentRuntimeAccessRecord{
+			CorrelationID:       correlation.CorrelationID,
+			AccountID:           correlation.AccountID,
+			Region:              correlation.Region,
+			AgentNodeID:         correlation.AgentNodeID,
+			AgentID:             correlation.AgentID,
+			AgentName:           correlation.AgentName,
+			AgentType:           correlation.AgentType,
+			RuntimeVersion:      correlation.RuntimeVersion,
+			ToolName:            correlation.ToolName,
+			ToolTargetRef:       correlation.ToolTargetRef,
+			Status:              correlation.Status,
+			Confidence:          correlation.Confidence,
+			ObservedCount:       correlation.ObservedCount,
+			ObservedEventIDs:    correlation.ObservedEventIDs,
+			BackingRoleARNs:     correlation.BackingRoleARNs,
+			BackingRoleNodeIDs:  correlation.BackingRoleNodeIDs,
+			DeclaredBackingRole: correlation.DeclaredBackingRole,
+			TargetResourceARNs:  correlation.TargetResourceARNs,
+			Outcomes:            correlation.Outcomes,
+			SessionIDs:          correlation.SessionIDs,
+			FirstObservedAt:     correlation.FirstObservedAt,
+			LastObservedAt:      correlation.LastObservedAt,
+			DeclaredInInventory: correlation.DeclaredInInventory,
+			Caveats:             correlation.Caveats,
+			EvidenceRef:         fmt.Sprintf("runtime-correlation://%s", correlation.CorrelationID),
+			EvidenceRefs:        correlation.EvidenceRefs,
+			NextAction:          awsAgentRuntimeAccessNextAction(correlation.Status),
+			RedactionBoundary:   correlation.RedactionBoundary,
+		})
+	}
+	return out
+}
+
+func awsAgentRuntimeAccessNextAction(status string) string {
+	switch status {
+	case agentaccess.StatusConfirmed:
+		return "Confirm the observed tool-call matches an expected agent workflow before relying on it for remediation."
+	case agentaccess.StatusObservedWithoutDeclaration:
+		return "Investigate the observed tool-call — confirm the agent and tool are expected, or treat it as a shadow agent / undeclared tool."
+	case agentaccess.StatusDeclaredUnused:
+		return "Review the declared but unused tool for least-privilege; confirm tool-call telemetry coverage before removing it."
+	default:
+		return "Correlate runtime evidence with the agent inventory graph."
+	}
+}
+
+func filterAWSAgentRuntimeAccessRecords(records []AWSAgentRuntimeAccessRecord, request AWSAgentRuntimeAccessRequest) ([]AWSAgentRuntimeAccessRecord, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"identity":   strings.TrimSpace(request.Identity),
+		"agent_id":   strings.TrimSpace(request.AgentID),
+		"tool":       strings.TrimSpace(request.Tool),
+		"resource":   strings.TrimSpace(request.Resource),
+		"outcome":    normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		token := strings.ToLower(strings.TrimSpace(value))
+		if token == "" || token == "all" {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSAgentRuntimeAccessRecord, 0, len(records))
+	for _, record := range records {
+		if filters["account_id"] != "" && filters["account_id"] != record.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], record.Region) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(record.Status) {
+			continue
+		}
+		if filters["outcome"] != "" && !awsAgentRuntimeAccessHasOutcome(record, filters["outcome"]) {
+			continue
+		}
+		if filters["agent_id"] != "" && !awsRuntimeEventMatchesAny(filters["agent_id"], record.AgentID, record.AgentNodeID, record.AgentName) {
+			continue
+		}
+		if filters["tool"] != "" && !awsRuntimeEventMatchesAny(filters["tool"], record.ToolName, record.ToolTargetRef) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], append(append([]string{}, record.BackingRoleARNs...), record.BackingRoleNodeIDs...)...) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], record.TargetResourceARNs...) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	return filtered, applied
+}
+
+func awsAgentRuntimeAccessHasOutcome(record AWSAgentRuntimeAccessRecord, outcome string) bool {
+	for _, value := range record.Outcomes {
+		if normalizeAWSRuntimeEventFilterToken(value) == outcome {
+			return true
+		}
+	}
+	return false
+}
+
+func awsAgentRuntimeAccessRelationships(records []AWSAgentRuntimeAccessRecord) []AWSAgentRuntimeAccessRelationship {
+	out := []AWSAgentRuntimeAccessRelationship{}
+	for _, record := range records {
+		if record.AgentNodeID == "" {
+			continue
+		}
+		edgeType := "runtime_tool_call_correlation"
+		switch record.Status {
+		case agentaccess.StatusConfirmed:
+			edgeType = "confirmed_agent_tool_call"
+		case agentaccess.StatusObservedWithoutDeclaration:
+			edgeType = "observed_tool_call_without_declaration"
+		case agentaccess.StatusDeclaredUnused:
+			edgeType = "unused_declared_tool"
+		}
+		for _, roleNode := range record.BackingRoleNodeIDs {
+			if strings.TrimSpace(roleNode) == "" {
+				continue
+			}
+			out = append(out, AWSAgentRuntimeAccessRelationship{
+				Type:        edgeType,
+				FromNodeID:  roleNode,
+				ToNodeID:    record.AgentNodeID,
+				EvidenceRef: record.EvidenceRef,
+			})
+		}
+		for _, target := range record.TargetResourceARNs {
+			if strings.TrimSpace(target) == "" {
+				continue
+			}
+			out = append(out, AWSAgentRuntimeAccessRelationship{
+				Type:        "agent_tool_targeted_resource",
+				FromNodeID:  record.AgentNodeID,
+				ToNodeID:    target,
+				EvidenceRef: record.EvidenceRef,
+			})
+		}
+	}
+	return out
+}
+
+func summarizeAWSAgentRuntimeAccess(correlation agentaccess.Result, allRecords []AWSAgentRuntimeAccessRecord, filtered []AWSAgentRuntimeAccessRecord, relationships []AWSAgentRuntimeAccessRelationship) AWSAgentRuntimeAccessSummary {
+	statusCounts := map[string]int{}
+	for _, record := range allRecords {
+		statusCounts[record.Status]++
+	}
+	return AWSAgentRuntimeAccessSummary{
+		TotalCorrelations:        len(allRecords),
+		FilteredCorrelations:     len(filtered),
+		StatusCounts:             statusCounts,
+		ConfirmedCount:           correlation.ConfirmedCount,
+		ObservedWithoutDeclCount: correlation.ObservedWithoutDecl,
+		DeclaredUnusedCount:      correlation.DeclaredUnusedCount,
+		ShadowAgentCount:         correlation.ShadowAgentCount,
+		UndeclaredToolCount:      correlation.UndeclaredToolCount,
+		BackingRoleMismatchCount: correlation.BackingRoleMismatchCount,
+		FailedToolCallCount:      correlation.FailedToolCallCount,
+		AgentCount:               correlation.AgentCount,
+		ToolCount:                correlation.ToolCount,
+		ObservedToolCallCount:    correlation.ObservedToolCallsConsidered,
+		DeclaredToolCount:        correlation.DeclaredToolsConsidered,
+		RelationshipCount:        len(relationships),
+	}
+}
+
+func summarizeAWSAgentRuntimeAccessStatus(sourceStatus string, filtered []AWSAgentRuntimeAccessRecord, diagnostics []AWSAgentRuntimeAccessDiagnostic) (string, float64) {
+	switch sourceStatus {
+	case awsPlatformDependencyStatusBlocked:
+		return awsPlatformDependencyStatusBlocked, 0
+	case awsPlatformDependencyStatusDegraded:
+		return awsPlatformDependencyStatusDegraded, 0.7
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusDegraded, 0.5
+	}
+	if len(diagnostics) > 0 {
+		return awsPlatformDependencyStatusDegraded, 0.8
+	}
+	return awsPlatformDependencyStatusReady, 0.92
+}

--- a/internal/api/aws_agent_runtime_access.go
+++ b/internal/api/aws_agent_runtime_access.go
@@ -40,34 +40,36 @@ type AWSAgentRuntimeAccessRequest struct {
 // AWSAgentRuntimeAccessRecord is one (agent, tool) correlation projected
 // for the API/app surface.
 type AWSAgentRuntimeAccessRecord struct {
-	CorrelationID       string    `json:"correlation_id"`
-	AccountID           string    `json:"account_id"`
-	Region              string    `json:"region"`
-	AgentNodeID         string    `json:"agent_node_id"`
-	AgentID             string    `json:"agent_id,omitempty"`
-	AgentName           string    `json:"agent_name,omitempty"`
-	AgentType           string    `json:"agent_type,omitempty"`
-	RuntimeVersion      string    `json:"runtime_version,omitempty"`
-	ToolName            string    `json:"tool_name,omitempty"`
-	ToolTargetRef       string    `json:"tool_target_ref,omitempty"`
-	Status              string    `json:"status"`
-	Confidence          float64   `json:"confidence"`
-	ObservedCount       int       `json:"observed_count"`
-	ObservedEventIDs    []string  `json:"observed_event_ids,omitempty"`
-	BackingRoleARNs     []string  `json:"backing_role_arns,omitempty"`
-	BackingRoleNodeIDs  []string  `json:"backing_role_node_ids,omitempty"`
-	DeclaredBackingRole string    `json:"declared_backing_role,omitempty"`
-	TargetResourceARNs  []string  `json:"target_resource_arns,omitempty"`
-	Outcomes            []string  `json:"outcomes,omitempty"`
-	SessionIDs          []string  `json:"session_ids,omitempty"`
-	FirstObservedAt     time.Time `json:"first_observed_at,omitzero"`
-	LastObservedAt      time.Time `json:"last_observed_at,omitzero"`
-	DeclaredInInventory bool      `json:"declared_in_inventory"`
-	Caveats             []string  `json:"caveats,omitempty"`
-	EvidenceRef         string    `json:"evidence_ref"`
-	EvidenceRefs        []string  `json:"evidence_refs,omitempty"`
-	NextAction          string    `json:"next_action"`
-	RedactionBoundary   string    `json:"redaction_boundary"`
+	CorrelationID           string    `json:"correlation_id"`
+	AccountID               string    `json:"account_id"`
+	Region                  string    `json:"region"`
+	AgentNodeID             string    `json:"agent_node_id"`
+	AgentID                 string    `json:"agent_id,omitempty"`
+	AgentName               string    `json:"agent_name,omitempty"`
+	AgentType               string    `json:"agent_type,omitempty"`
+	RuntimeVersion          string    `json:"runtime_version,omitempty"`
+	ToolName                string    `json:"tool_name,omitempty"`
+	ToolTargetRef           string    `json:"tool_target_ref,omitempty"`
+	Status                  string    `json:"status"`
+	Confidence              float64   `json:"confidence"`
+	ObservedCount           int       `json:"observed_count"`
+	ObservedEventIDs        []string  `json:"observed_event_ids,omitempty"`
+	BackingRoleARNs         []string  `json:"backing_role_arns,omitempty"`
+	BackingRoleNodeIDs      []string  `json:"backing_role_node_ids,omitempty"`
+	DeclaredBackingRole     string    `json:"declared_backing_role,omitempty"`
+	DeclaredBackingRoleNode string    `json:"declared_backing_role_node_id,omitempty"`
+	TargetResourceARNs      []string  `json:"target_resource_arns,omitempty"`
+	TargetResourceNodeIDs   []string  `json:"target_resource_node_ids,omitempty"`
+	Outcomes                []string  `json:"outcomes,omitempty"`
+	SessionIDs              []string  `json:"session_ids,omitempty"`
+	FirstObservedAt         time.Time `json:"first_observed_at,omitzero"`
+	LastObservedAt          time.Time `json:"last_observed_at,omitzero"`
+	DeclaredInInventory     bool      `json:"declared_in_inventory"`
+	Caveats                 []string  `json:"caveats,omitempty"`
+	EvidenceRef             string    `json:"evidence_ref"`
+	EvidenceRefs            []string  `json:"evidence_refs,omitempty"`
+	NextAction              string    `json:"next_action"`
+	RedactionBoundary       string    `json:"redaction_boundary"`
 }
 
 // AWSAgentRuntimeAccessRelationship is one correlation graph edge so the
@@ -467,34 +469,36 @@ func awsAgentRuntimeAccessRecords(correlations []agentaccess.Correlation) []AWSA
 	out := make([]AWSAgentRuntimeAccessRecord, 0, len(correlations))
 	for _, correlation := range correlations {
 		out = append(out, AWSAgentRuntimeAccessRecord{
-			CorrelationID:       correlation.CorrelationID,
-			AccountID:           correlation.AccountID,
-			Region:              correlation.Region,
-			AgentNodeID:         correlation.AgentNodeID,
-			AgentID:             correlation.AgentID,
-			AgentName:           correlation.AgentName,
-			AgentType:           correlation.AgentType,
-			RuntimeVersion:      correlation.RuntimeVersion,
-			ToolName:            correlation.ToolName,
-			ToolTargetRef:       correlation.ToolTargetRef,
-			Status:              correlation.Status,
-			Confidence:          correlation.Confidence,
-			ObservedCount:       correlation.ObservedCount,
-			ObservedEventIDs:    correlation.ObservedEventIDs,
-			BackingRoleARNs:     correlation.BackingRoleARNs,
-			BackingRoleNodeIDs:  correlation.BackingRoleNodeIDs,
-			DeclaredBackingRole: correlation.DeclaredBackingRole,
-			TargetResourceARNs:  correlation.TargetResourceARNs,
-			Outcomes:            correlation.Outcomes,
-			SessionIDs:          correlation.SessionIDs,
-			FirstObservedAt:     correlation.FirstObservedAt,
-			LastObservedAt:      correlation.LastObservedAt,
-			DeclaredInInventory: correlation.DeclaredInInventory,
-			Caveats:             correlation.Caveats,
-			EvidenceRef:         fmt.Sprintf("runtime-correlation://%s", correlation.CorrelationID),
-			EvidenceRefs:        correlation.EvidenceRefs,
-			NextAction:          awsAgentRuntimeAccessNextAction(correlation.Status),
-			RedactionBoundary:   correlation.RedactionBoundary,
+			CorrelationID:           correlation.CorrelationID,
+			AccountID:               correlation.AccountID,
+			Region:                  correlation.Region,
+			AgentNodeID:             correlation.AgentNodeID,
+			AgentID:                 correlation.AgentID,
+			AgentName:               correlation.AgentName,
+			AgentType:               correlation.AgentType,
+			RuntimeVersion:          correlation.RuntimeVersion,
+			ToolName:                correlation.ToolName,
+			ToolTargetRef:           correlation.ToolTargetRef,
+			Status:                  correlation.Status,
+			Confidence:              correlation.Confidence,
+			ObservedCount:           correlation.ObservedCount,
+			ObservedEventIDs:        correlation.ObservedEventIDs,
+			BackingRoleARNs:         correlation.BackingRoleARNs,
+			BackingRoleNodeIDs:      correlation.BackingRoleNodeIDs,
+			DeclaredBackingRole:     correlation.DeclaredBackingRole,
+			DeclaredBackingRoleNode: correlation.DeclaredBackingRoleNode,
+			TargetResourceARNs:      correlation.TargetResourceARNs,
+			TargetResourceNodeIDs:   correlation.TargetResourceNodeIDs,
+			Outcomes:                correlation.Outcomes,
+			SessionIDs:              correlation.SessionIDs,
+			FirstObservedAt:         correlation.FirstObservedAt,
+			LastObservedAt:          correlation.LastObservedAt,
+			DeclaredInInventory:     correlation.DeclaredInInventory,
+			Caveats:                 correlation.Caveats,
+			EvidenceRef:             fmt.Sprintf("runtime-correlation://%s", correlation.CorrelationID),
+			EvidenceRefs:            correlation.EvidenceRefs,
+			NextAction:              awsAgentRuntimeAccessNextAction(correlation.Status),
+			RedactionBoundary:       correlation.RedactionBoundary,
 		})
 	}
 	return out
@@ -554,10 +558,26 @@ func filterAWSAgentRuntimeAccessRecords(records []AWSAgentRuntimeAccessRecord, r
 		if filters["tool"] != "" && !awsRuntimeEventMatchesAny(filters["tool"], record.ToolName, record.ToolTargetRef) {
 			continue
 		}
-		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], append(append([]string{}, record.BackingRoleARNs...), record.BackingRoleNodeIDs...)...) {
-			continue
+		if filters["identity"] != "" {
+			// Match against both observed backing roles and the inventory's
+			// declared backing role so a `?identity=<role>` filter still
+			// surfaces declared_unused tools for that role (where no runtime
+			// event was observed). Without this, the advertised backing-role
+			// query drops every unused declared tool — exactly the
+			// least-privilege cleanup case the filter is for.
+			identityValues := append([]string{}, record.BackingRoleARNs...)
+			identityValues = append(identityValues, record.BackingRoleNodeIDs...)
+			if record.DeclaredBackingRole != "" {
+				identityValues = append(identityValues, record.DeclaredBackingRole)
+			}
+			if record.DeclaredBackingRoleNode != "" {
+				identityValues = append(identityValues, record.DeclaredBackingRoleNode)
+			}
+			if !awsRuntimeEventMatchesAny(filters["identity"], identityValues...) {
+				continue
+			}
 		}
-		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], record.TargetResourceARNs...) {
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], append(append([]string{}, record.TargetResourceARNs...), record.TargetResourceNodeIDs...)...) {
 			continue
 		}
 		filtered = append(filtered, record)
@@ -600,7 +620,14 @@ func awsAgentRuntimeAccessRelationships(records []AWSAgentRuntimeAccessRecord) [
 				EvidenceRef: record.EvidenceRef,
 			})
 		}
-		for _, target := range record.TargetResourceARNs {
+		// Prefer the graph resource node id from the runtime-event contract
+		// so edges join to the same node other AWS graph edges key on; fall
+		// back to the raw ARN only when no node id was projected.
+		targetNodes := record.TargetResourceNodeIDs
+		if len(targetNodes) == 0 {
+			targetNodes = record.TargetResourceARNs
+		}
+		for _, target := range targetNodes {
 			if strings.TrimSpace(target) == "" {
 				continue
 			}

--- a/internal/api/aws_agent_runtime_access_fixtures.go
+++ b/internal/api/aws_agent_runtime_access_fixtures.go
@@ -1,0 +1,228 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/identrail/identrail/internal/runtime/agentaccess"
+)
+
+// awsAgentRuntimeAccessFixtureInputs returns deterministic observed
+// tool-calls and declared tools for each fixture state. The default
+// success state exercises all three correlation outcomes — confirmed,
+// observed_without_declaration (both a shadow agent and an undeclared
+// tool), and declared_unused — plus a backing-role mismatch and a failed
+// tool-call, so the surface and tests cover the taxonomy without a live
+// AWS account. All inputs are metadata-only (no prompts/completions).
+func awsAgentRuntimeAccessFixtureInputs(accountID string, region string, fixtureState string, checkedAt time.Time) ([]agentaccess.ObservedToolCall, []agentaccess.DeclaredTool, []string, bool, []AWSAgentRuntimeAccessDiagnostic, []AWSAgentRuntimeAccessCoverageGap, []string, []string, string, bool) {
+	base := checkedAt.Add(-30 * time.Minute)
+
+	triageAgent := awsAIAgentNodeID(accountID, region, "agentcore_runtime", "case-triage", "2026-06-01")
+	invoiceAgent := awsAIAgentNodeID(accountID, region, "bedrock_agent", "invoice-bot", "")
+	shadowAgent := awsAIAgentNodeID(accountID, region, "agentcore_runtime", "rogue-exporter", "2026-06-10")
+
+	triageRole := fmt.Sprintf("arn:aws:iam::%s:role/case-triage-runtime", accountID)
+	triageRoleNode := awsIdentityNodeIDForAPI(triageRole)
+	invoiceRole := fmt.Sprintf("arn:aws:iam::%s:role/invoice-bot-runtime", accountID)
+	invoiceRoleNode := awsIdentityNodeIDForAPI(invoiceRole)
+	unexpectedRole := fmt.Sprintf("arn:aws:iam::%s:role/adhoc-operator", accountID)
+	unexpectedRoleNode := awsIdentityNodeIDForAPI(unexpectedRole)
+
+	triageEndpoint := fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/case-triage/blue", region, accountID)
+	invoiceEndpoint := fmt.Sprintf("arn:aws:bedrock-agent:%s:%s:agent/invoice-bot", region, accountID)
+	shadowEndpoint := fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/rogue-exporter/red", region, accountID)
+
+	observed := []agentaccess.ObservedToolCall{
+		{
+			EventID:           "evt-agent-confirmed",
+			AgentNodeID:       triageAgent,
+			AgentID:           "case-triage",
+			AgentType:         "agentcore_runtime",
+			RuntimeVersion:    "2026-06-01",
+			ToolName:          "case-router",
+			ToolTargetRef:     "case-router-policy",
+			BackingRoleARN:    triageRole,
+			BackingRoleNodeID: triageRoleNode,
+			TargetResourceARN: triageEndpoint,
+			Outcome:           agentaccess.OutcomeSucceeded,
+			SessionID:         "ASIA-triage-sess",
+			LineageStatus:     "resolved",
+			ObservedAt:        base.Add(4 * time.Minute),
+			EvidenceRef:       fmt.Sprintf("runtime-evidence://%s/%s/evt-agent-confirmed", accountID, region),
+		},
+		{
+			// Declared tool, but the observed backing role differs from the
+			// agent's declared runtime role, and the tool-call failed.
+			EventID:           "evt-agent-mismatch",
+			AgentNodeID:       invoiceAgent,
+			AgentID:           "invoice-bot",
+			AgentType:         "bedrock_agent",
+			ToolName:          "ticket-writer",
+			BackingRoleARN:    unexpectedRole,
+			BackingRoleNodeID: unexpectedRoleNode,
+			TargetResourceARN: invoiceEndpoint,
+			Outcome:           agentaccess.OutcomeFailed,
+			SessionID:         "ASIA-invoice-sess",
+			LineageStatus:     "resolved",
+			ObservedAt:        base.Add(7 * time.Minute),
+			EvidenceRef:       fmt.Sprintf("runtime-evidence://%s/%s/evt-agent-mismatch", accountID, region),
+		},
+		{
+			// Known agent, undeclared tool.
+			EventID:           "evt-agent-undeclared-tool",
+			AgentNodeID:       triageAgent,
+			AgentID:           "case-triage",
+			AgentType:         "agentcore_runtime",
+			RuntimeVersion:    "2026-06-01",
+			ToolName:          "bulk-export",
+			BackingRoleARN:    triageRole,
+			BackingRoleNodeID: triageRoleNode,
+			TargetResourceARN: triageEndpoint,
+			Outcome:           agentaccess.OutcomeSucceeded,
+			SessionID:         "ASIA-triage-sess",
+			LineageStatus:     "source_identity_missing",
+			ObservedAt:        base.Add(9 * time.Minute),
+			EvidenceRef:       fmt.Sprintf("runtime-evidence://%s/%s/evt-agent-undeclared-tool", accountID, region),
+		},
+		{
+			// Shadow agent: not in the inventory at all.
+			EventID:           "evt-agent-shadow",
+			AgentNodeID:       shadowAgent,
+			AgentID:           "rogue-exporter",
+			AgentType:         "agentcore_runtime",
+			RuntimeVersion:    "2026-06-10",
+			ToolName:          "exfiltrate",
+			BackingRoleARN:    unexpectedRole,
+			BackingRoleNodeID: unexpectedRoleNode,
+			TargetResourceARN: shadowEndpoint,
+			Outcome:           agentaccess.OutcomeSucceeded,
+			SessionID:         "ASIA-rogue-sess",
+			LineageStatus:     "resolved",
+			ObservedAt:        base.Add(12 * time.Minute),
+			EvidenceRef:       fmt.Sprintf("runtime-evidence://%s/%s/evt-agent-shadow", accountID, region),
+		},
+	}
+
+	declared := []agentaccess.DeclaredTool{
+		{
+			AgentNodeID:       triageAgent,
+			AgentID:           "case-triage",
+			AgentName:         "Case Triage",
+			AgentType:         "agentcore_runtime",
+			RuntimeVersion:    "2026-06-01",
+			ToolName:          "case-router",
+			ToolTargetRef:     "case-router-policy",
+			BackingRoleARN:    triageRole,
+			BackingRoleNodeID: triageRoleNode,
+			AccountID:         accountID,
+			Region:            region,
+			Confidence:        0.9,
+			EvidenceRef:       triageEndpoint,
+		},
+		{
+			// Declared but never observed → declared_unused.
+			AgentNodeID:       triageAgent,
+			AgentID:           "case-triage",
+			AgentName:         "Case Triage",
+			AgentType:         "agentcore_runtime",
+			RuntimeVersion:    "2026-06-01",
+			ToolName:          "policy-checker",
+			BackingRoleARN:    triageRole,
+			BackingRoleNodeID: triageRoleNode,
+			AccountID:         accountID,
+			Region:            region,
+			Confidence:        0.9,
+			EvidenceRef:       triageEndpoint,
+		},
+		{
+			AgentNodeID:       invoiceAgent,
+			AgentID:           "invoice-bot",
+			AgentName:         "Invoice Bot",
+			AgentType:         "bedrock_agent",
+			ToolName:          "ticket-writer",
+			BackingRoleARN:    invoiceRole,
+			BackingRoleNodeID: invoiceRoleNode,
+			AccountID:         accountID,
+			Region:            region,
+			Confidence:        0.88,
+			EvidenceRef:       invoiceEndpoint,
+		},
+	}
+	known := []string{triageAgent, invoiceAgent}
+
+	switch fixtureState {
+	case "empty":
+		return nil, nil, known, true, nil, []AWSAgentRuntimeAccessCoverageGap{{
+			Capability:  "agent_runtime_access",
+			Status:      "empty",
+			Reason:      "No agent tool-calls or declared tools were available in the fixture window.",
+			Remediation: "Confirm agent runtime / tool-call telemetry is enabled, then retry.",
+		}}, nil, nil, awsPlatformDependencyStatusReady, true
+	case "degraded":
+		return observed, declared, known, true, []AWSAgentRuntimeAccessDiagnostic{{
+			Collector:   agentaccess.CollectorName,
+			SourceID:    "evt-agent-undeclared-tool",
+			Code:        "runtime_event_delivery_delayed",
+			Message:     "One agent tool-call arrived after the expected collection window; correlation confidence is reduced.",
+			Remediation: "Keep delayed evidence visible and avoid automated remediation until delivery catches up.",
+			Retryable:   true,
+		}}, nil, []string{"runtime correlation includes delayed or low-confidence evidence"}, []string{"Review delayed agent tool-call delivery before using correlations for remediation."}, awsPlatformDependencyStatusDegraded, true
+	case "partial_failure":
+		// The agent inventory failed to load; observed tool-calls remain
+		// visible but cannot be confirmed against declarations.
+		return observed, nil, nil, false, []AWSAgentRuntimeAccessDiagnostic{{
+				Collector:   agentaccess.CollectorName,
+				SourceID:    "agent_inventory",
+				Code:        "agent_inventory_unavailable",
+				Message:     "The AI-agent inventory could not be loaded; observed tool-calls cannot be confirmed against declarations.",
+				Remediation: "Retry the AI-agent inventory collection and re-run the correlation without discarding observed evidence.",
+				Retryable:   true,
+			}}, []AWSAgentRuntimeAccessCoverageGap{{
+				Capability:  "agent_inventory_join",
+				Status:      "partial_failure",
+				Reason:      "The agent inventory was unavailable, so observed tool-calls could not be confirmed against declared tools.",
+				Remediation: "Retry the AI-agent inventory collection and re-run the correlation.",
+			}}, []string{"agent inventory join is incomplete; observed tool-calls are unconfirmed"}, []string{"Retry the AI-agent inventory collection and re-run the correlation."}, awsPlatformDependencyStatusDegraded, true
+	case "permission_denied":
+		return nil, nil, nil, true, []AWSAgentRuntimeAccessDiagnostic{{
+				Collector:   agentaccess.CollectorName,
+				SourceID:    "cloudtrail",
+				Code:        "permission_denied",
+				Message:     "Runtime event sources are not authorized for this connector; no agent tool-calls can be correlated.",
+				Remediation: "Grant metadata-only CloudTrail access. Do not grant prompt, completion, or tool-payload reads.",
+				Retryable:   true,
+			}}, []AWSAgentRuntimeAccessCoverageGap{{
+				Capability:  "agent_runtime_access",
+				Status:      "permission_denied",
+				Reason:      "Runtime event source cannot be queried with the current connector permissions.",
+				Remediation: "Add read-only CloudTrail access and retry.",
+			}}, []string{"runtime event sources are not authorized for this connector"}, []string{"Grant metadata-only CloudTrail access; do not grant prompt/completion/tool-payload reads."}, awsPlatformDependencyStatusBlocked, true
+	default:
+		return observed, declared, known, true, nil, awsAgentRuntimeAccessBaseCoverageGaps(), nil, nil, awsPlatformDependencyStatusReady, true
+	}
+}
+
+// awsAgentRuntimeAccessBaseCoverageGaps documents what this correlation
+// intentionally does not model and the redaction boundary it enforces.
+func awsAgentRuntimeAccessBaseCoverageGaps() []AWSAgentRuntimeAccessCoverageGap {
+	return []AWSAgentRuntimeAccessCoverageGap{
+		{
+			Capability:  "tool_call_outcome",
+			Status:      "degraded",
+			Reason:      "Explicit tool-call success/failure outcomes are not extracted from live runtime sources yet (it requires error-code extraction in the ingestion layer), so live outcomes are reported as 'unknown'.",
+			Remediation: "Use observed/declared correlation and backing-role checks for triage; explicit outcomes will follow when error-code extraction is wired.",
+		},
+		{
+			Capability:  "agent_payload_visibility",
+			Status:      "unsupported",
+			Reason:      "Prompts, completions, tool inputs/outputs, browser pages, and code-interpreter output are never collected. Only metadata (agent, tool, backing role, target resource) is correlated.",
+			Remediation: "Inspect agent payloads directly in the agent platform when investigating a specific tool-call.",
+		},
+		{
+			Capability:  "data_event_completeness",
+			Status:      "degraded",
+			Reason:      "Agent tool-call telemetry is not guaranteed complete from the available runtime sources, so declared_unused may reflect missing telemetry.",
+			Remediation: "Enable agent runtime / tool-call data-event delivery to make declared_unused conclusions reliable.",
+		},
+	}
+}

--- a/internal/api/aws_agent_runtime_access_test.go
+++ b/internal/api/aws_agent_runtime_access_test.go
@@ -130,6 +130,36 @@ func TestGetAWSAgentRuntimeAccessFiltersByStatusAndAgent(t *testing.T) {
 	}
 }
 
+func TestGetAWSAgentRuntimeAccessIdentityFilterIncludesDeclaredUnusedRole(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-identity-filter", now)
+
+	result, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-identity-filter", AWSAgentRuntimeAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     "case-triage-runtime",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	var policyChecker *AWSAgentRuntimeAccessRecord
+	for i := range result.Records {
+		if result.Records[i].ToolName == "policy-checker" {
+			policyChecker = &result.Records[i]
+			break
+		}
+	}
+	if policyChecker == nil {
+		t.Fatalf("identity filter dropped declared_unused tool for declared role: %+v", result.Records)
+	}
+	if policyChecker.Status != agentaccess.StatusDeclaredUnused {
+		t.Fatalf("expected declared_unused policy-checker, got %+v", policyChecker)
+	}
+	if !strings.Contains(policyChecker.DeclaredBackingRole, "case-triage-runtime") || policyChecker.DeclaredBackingRoleNode == "" {
+		t.Fatalf("expected declared backing role metadata projected, got %+v", policyChecker)
+	}
+}
+
 func TestGetAWSAgentRuntimeAccessPermissionDeniedIsExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
 	svc, ws := newAgentRuntimeAccessService(t, "project-agent-denied", now)
@@ -305,5 +335,35 @@ func TestDeclaredToolsFromAgentInventoryExpandsToolsAndKnownAgents(t *testing.T)
 	}
 	if t1 == nil || t1.ToolTargetRef != "ref1" {
 		t.Fatalf("expected t1 with target ref, got %+v", declared)
+	}
+}
+
+func TestAWSAgentRuntimeAccessRelationshipsUseTargetResourceNodeIDs(t *testing.T) {
+	agentNode := "aws:agent:123456789012:us-east-1:agentcore_runtime/case-triage/blue"
+	resourceARN := "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/case-triage/blue"
+	resourceNode := "aws:resource:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/case-triage/blue"
+	relationships := awsAgentRuntimeAccessRelationships([]AWSAgentRuntimeAccessRecord{{
+		AgentNodeID:           agentNode,
+		Status:                agentaccess.StatusConfirmed,
+		TargetResourceARNs:    []string{resourceARN},
+		TargetResourceNodeIDs: []string{resourceNode},
+		EvidenceRef:           "runtime-correlation://case-triage",
+	}})
+
+	foundTargetEdge := false
+	for _, rel := range relationships {
+		if rel.Type != "agent_tool_targeted_resource" {
+			continue
+		}
+		foundTargetEdge = true
+		if rel.FromNodeID != agentNode || rel.ToNodeID != resourceNode {
+			t.Fatalf("expected target edge to graph resource node, got %+v", rel)
+		}
+		if rel.ToNodeID == resourceARN {
+			t.Fatalf("target edge must not use raw ARN when graph node id is available: %+v", rel)
+		}
+	}
+	if !foundTargetEdge {
+		t.Fatalf("expected agent_tool_targeted_resource relationship, got %+v", relationships)
 	}
 }

--- a/internal/api/aws_agent_runtime_access_test.go
+++ b/internal/api/aws_agent_runtime_access_test.go
@@ -1,0 +1,309 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/runtime/agentaccess"
+)
+
+func newAgentRuntimeAccessService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, project)
+	seedAWSConnectorForScanTest(t, store, ctx, project, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	return svc, "default"
+}
+
+func agentRecordsByStatus(records []AWSAgentRuntimeAccessRecord) map[string]int {
+	counts := map[string]int{}
+	for _, record := range records {
+		counts[record.Status]++
+	}
+	return counts
+}
+
+func hasAgentCaveat(caveats []string, want string) bool {
+	for _, caveat := range caveats {
+		if caveat == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetAWSAgentRuntimeAccessBuildsCorrelationContract(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-corr", now)
+
+	result, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-corr", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1520" || result.Version != awsAgentRuntimeAccessVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	counts := agentRecordsByStatus(result.Records)
+	if counts[agentaccess.StatusConfirmed] != 2 || counts[agentaccess.StatusObservedWithoutDeclaration] != 2 || counts[agentaccess.StatusDeclaredUnused] != 1 {
+		t.Fatalf("unexpected status distribution: %+v (records=%+v)", counts, result.Records)
+	}
+	if result.Summary.ShadowAgentCount != 1 || result.Summary.UndeclaredToolCount != 1 {
+		t.Fatalf("expected one shadow agent and one undeclared tool, got %+v", result.Summary)
+	}
+	if result.Summary.BackingRoleMismatchCount != 1 || result.Summary.FailedToolCallCount != 1 {
+		t.Fatalf("expected one backing-role mismatch and one failed tool-call, got %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected relationships: %+v", result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps")
+	}
+	for _, record := range result.Records {
+		if record.RedactionBoundary != agentaccess.RedactionBoundary {
+			t.Fatalf("record leaked unsafe redaction boundary: %+v", record)
+		}
+		if record.EvidenceRef == "" || record.AgentNodeID == "" || record.Confidence <= 0 || record.NextAction == "" {
+			t.Fatalf("record missing required fields: %+v", record)
+		}
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessConfirmedFlagsMismatchAndFailure(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-mismatch", now)
+
+	result, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-mismatch", AWSAgentRuntimeAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Tool:         "ticket-writer",
+	})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(result.Records) != 1 {
+		t.Fatalf("expected one ticket-writer correlation, got %+v", result.Records)
+	}
+	record := result.Records[0]
+	if record.Status != agentaccess.StatusConfirmed {
+		t.Fatalf("expected confirmed (tool declared), got %q", record.Status)
+	}
+	if !hasAgentCaveat(record.Caveats, agentaccess.CaveatBackingRoleMismatch) || !hasAgentCaveat(record.Caveats, agentaccess.CaveatToolCallFailed) {
+		t.Fatalf("expected backing-role-mismatch + tool-call-failed caveats, got %+v", record.Caveats)
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessFiltersByStatusAndAgent(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-filter", now)
+
+	shadow, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-filter", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success", Status: "observed_without_declaration"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if len(shadow.Records) != 2 {
+		t.Fatalf("expected two observed_without_declaration records, got %+v", shadow.Records)
+	}
+	for _, record := range shadow.Records {
+		if record.Status != agentaccess.StatusObservedWithoutDeclaration {
+			t.Fatalf("status filter leaked: %+v", record)
+		}
+	}
+	if shadow.AppliedFilters["status"] != "observed-without-declaration" {
+		t.Fatalf("expected normalized applied status filter, got %+v", shadow.AppliedFilters)
+	}
+
+	triage, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-filter", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "success", AgentID: "case-triage"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	// case-triage: case-router (confirmed) + policy-checker (declared_unused) + bulk-export (undeclared tool).
+	if len(triage.Records) != 3 {
+		t.Fatalf("expected three case-triage correlations, got %+v", triage.Records)
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-denied", now)
+
+	result, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-denied", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "permission_denied"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" || result.Confidence != 0 {
+		t.Fatalf("expected blocked permission-denied, got status=%q confidence=%v", result.Status, result.Confidence)
+	}
+	if len(result.Records) != 0 || len(result.Diagnostics) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected no records + diagnostics + coverage gaps, got %+v", result)
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessEmptyAndPartialFailure(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-states", now)
+
+	empty, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-states", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "empty"})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Records) != 0 || len(empty.CoverageGaps) == 0 {
+		t.Fatalf("unexpected empty state: %+v", empty)
+	}
+
+	partial, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-states", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod", FixtureState: "partial_failure"})
+	if err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if partial.Status != "degraded" {
+		t.Fatalf("expected degraded partial-failure, got %q", partial.Status)
+	}
+	// Inventory failed → no confirmed, and observed tool-calls carry the
+	// inventory-unavailable caveat instead of shadow accusations.
+	for _, record := range partial.Records {
+		if record.Status == agentaccess.StatusConfirmed {
+			t.Fatalf("partial-failure must not produce confirmed correlations: %+v", record)
+		}
+		if hasAgentCaveat(record.Caveats, agentaccess.CaveatAgentNotInInventory) {
+			t.Fatalf("must not accuse shadow agent when inventory unavailable: %+v", record.Caveats)
+		}
+	}
+	if partial.Summary.DeclaredUnusedCount != 0 {
+		t.Fatalf("partial-failure has no declared tools, so no declared_unused expected: %+v", partial.Summary)
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessDefaultLiveRequiresDeliveryFactory(t *testing.T) {
+	now := time.Date(2026, 6, 19, 18, 0, 0, 0, time.UTC)
+	svc, ws := newAgentRuntimeAccessService(t, "project-agent-live-default", now)
+
+	result, err := svc.GetAWSAgentRuntimeAccess(defaultScopeContext(), ws, "project-agent-live-default", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded || len(result.Records) != 0 {
+		t.Fatalf("expected degraded with no records when live delivery unavailable, got status=%q records=%d", result.Status, len(result.Records))
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessLiveRoutesThroughDeliveryAndInventoryUnavailable(t *testing.T) {
+	now := time.Date(2026, 6, 19, 19, 0, 0, 0, time.UTC)
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-agent-live")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-agent-live", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-agent-live", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	role := "arn:aws:iam::123456789012:role/agent-runtime"
+	agentARN := "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/live-agent/blue"
+	deliveryRecord := liveRuntimeRecord(t, "evt-agent-live", "agent-tool", "InvokeTool", "bedrock-agentcore.amazonaws.com", "bedrock-agentcore:InvokeTool", "security", "agent-runtime", role, agentARN, "AWS::BedrockAgentCore::Runtime", now.Add(-2*time.Minute))
+	deliveryRecord.AgentID = "live-agent"
+	deliveryRecord.AgentNodeID = "aws:agent:123456789012:us-east-1:agentcore_runtime/live-agent/blue"
+	deliveryRecord.ToolName = "live-tool"
+	fake := &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "ready", Records: []AWSRuntimeEventRecord{deliveryRecord}}}
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return fake, nil
+	}
+
+	result, err := svc.GetAWSAgentRuntimeAccess(ctx, "default", "project-agent-live", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if fake.calls == 0 {
+		t.Fatalf("delivery factory was never used — agent tool-calls not routed through delivery")
+	}
+	var found *AWSAgentRuntimeAccessRecord
+	for i := range result.Records {
+		if result.Records[i].ToolName == "live-tool" {
+			found = &result.Records[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a correlation for the observed live tool-call, got %+v", result.Records)
+	}
+	// Inventory is forced empty in live mode → observed_without_declaration
+	// with the neutral inventory-unavailable caveat, not a shadow accusation.
+	if found.Status != agentaccess.StatusObservedWithoutDeclaration {
+		t.Fatalf("expected observed_without_declaration, got %q", found.Status)
+	}
+	if !hasAgentCaveat(found.Caveats, agentaccess.CaveatInventoryUnavailable) {
+		t.Fatalf("expected inventory-unavailable caveat, got %+v", found.Caveats)
+	}
+	if hasAgentCaveat(found.Caveats, agentaccess.CaveatAgentNotInInventory) {
+		t.Fatalf("must not accuse shadow agent when inventory unavailable: %+v", found.Caveats)
+	}
+}
+
+func TestGetAWSAgentRuntimeAccessBlockedRuntimeSuppressesDeclaredUnused(t *testing.T) {
+	now := time.Date(2026, 6, 19, 19, 30, 0, 0, time.UTC)
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-agent-blocked")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-agent-blocked", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-agent-blocked", "aws-prod")
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailDeliveryFactory = func(_ context.Context, _ AWSConnectionStatus, _ AWSCloudTrailDeliverySource) (AWSCloudTrailRuntimeEventIngester, error) {
+		return &fakeDeliveryIngester{result: AWSCloudTrailIngestResult{Status: "blocked", FailureReasons: []string{"runtime event sources are not authorized for this connector"}}}, nil
+	}
+
+	result, err := svc.GetAWSAgentRuntimeAccess(ctx, "default", "project-agent-blocked", AWSAgentRuntimeAccessRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get correlation: %v", err)
+	}
+	if result.Status != "blocked" || len(result.Records) != 0 || result.Summary.DeclaredUnusedCount != 0 {
+		t.Fatalf("blocked runtime must not surface declared_unused: status=%q records=%d summary=%+v", result.Status, len(result.Records), result.Summary)
+	}
+}
+
+func TestObservedAgentToolCallsFromRuntimeRecordsFiltersEventTypes(t *testing.T) {
+	records := []AWSRuntimeEventRecord{
+		{EventID: "tool", EventType: "agent-tool", AgentNodeID: "agent-1", AgentID: "a1", ToolName: "router", ActorIdentityNodeID: "role-1"},
+		{EventID: "secret", EventType: "secret-read", AgentNodeID: "agent-x", ActorIdentityNodeID: "role-x"},
+		{EventID: "no-agent", EventType: "agent-tool", ToolName: "router"},
+	}
+	observed := observedAgentToolCallsFromRuntimeRecords(records)
+	if len(observed) != 1 || observed[0].EventID != "tool" {
+		t.Fatalf("expected only the attributable agent-tool event, got %+v", observed)
+	}
+	if observed[0].Outcome != agentaccess.OutcomeUnknown {
+		t.Fatalf("expected unknown outcome from live record, got %q", observed[0].Outcome)
+	}
+}
+
+func TestDeclaredToolsFromAgentInventoryExpandsToolsAndKnownAgents(t *testing.T) {
+	records := []AWSAIAgentIdentityRecord{
+		{AgentID: "a", AgentNodeID: "node-a", RuntimeRoleARN: "arn:aws:iam::1:role/a", ToolNames: []string{"t1", "t2"}, ToolTargetRefs: []string{"ref1"}},
+		{AgentID: "b", AgentNodeID: "node-b", ToolNames: nil},
+	}
+	declared, known := declaredToolsFromAgentInventory(records)
+	// a expands to 2 tools; b contributes one empty-tool marker.
+	if len(declared) != 3 {
+		t.Fatalf("expected 3 declared entries (2 tools + 1 marker), got %+v", declared)
+	}
+	if len(known) != 2 || !strings.Contains(strings.Join(known, ","), "node-a") || !strings.Contains(strings.Join(known, ","), "node-b") {
+		t.Fatalf("expected both agents known, got %+v", known)
+	}
+	// First tool of agent a carries its target ref.
+	var t1 *agentaccess.DeclaredTool
+	for i := range declared {
+		if declared[i].ToolName == "t1" {
+			t1 = &declared[i]
+		}
+	}
+	if t1 == nil || t1.ToolTargetRef != "ref1" {
+		t.Fatalf("expected t1 with target ref, got %+v", declared)
+	}
+}

--- a/internal/api/aws_agent_runtime_access_test.go
+++ b/internal/api/aws_agent_runtime_access_test.go
@@ -367,3 +367,22 @@ func TestAWSAgentRuntimeAccessRelationshipsUseTargetResourceNodeIDs(t *testing.T
 		t.Fatalf("expected agent_tool_targeted_resource relationship, got %+v", relationships)
 	}
 }
+
+func TestAWSAgentRuntimeAccessRelationshipsUseDeclaredRoleForUnusedTools(t *testing.T) {
+	agentNode := "aws:agent:123456789012:us-east-1:agentcore_runtime/case-triage/blue"
+	roleNode := "aws:identity:123456789012:role/case-triage-runtime"
+	relationships := awsAgentRuntimeAccessRelationships([]AWSAgentRuntimeAccessRecord{{
+		AgentNodeID:             agentNode,
+		Status:                  agentaccess.StatusDeclaredUnused,
+		DeclaredBackingRoleNode: roleNode,
+		EvidenceRef:             "runtime-correlation://policy-checker",
+	}})
+
+	if len(relationships) != 1 {
+		t.Fatalf("expected one declared role relationship, got %+v", relationships)
+	}
+	rel := relationships[0]
+	if rel.Type != "unused_declared_tool" || rel.FromNodeID != roleNode || rel.ToNodeID != agentNode {
+		t.Fatalf("expected declared role to agent unused edge, got %+v", rel)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2981,6 +2981,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"correlation": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAgentRuntimeAccess(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAgentRuntimeAccessRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			Identity:       strings.TrimSpace(c.Query("identity")),
+			AgentID:        strings.TrimSpace(c.Query("agent_id")),
+			Tool:           strings.TrimSpace(c.Query("tool")),
+			Resource:       strings.TrimSpace(c.Query("resource")),
+			Outcome:        strings.TrimSpace(c.Query("outcome")),
+			Status:         strings.TrimSpace(c.Query("status")),
+			DeliverySource: strings.TrimSpace(c.Query("delivery_source")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws agent runtime access request"})
+			default:
+				logger.Error("get aws agent runtime access",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws agent runtime access"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"correlation": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/runtime/agentaccess/correlate.go
+++ b/internal/runtime/agentaccess/correlate.go
@@ -1,0 +1,575 @@
+// Package agentaccess correlates observed agent runtime / tool-call
+// events with the static AI-agent inventory Identrail already discovered
+// (declared agents, their backing runtime role, and their declared
+// tools). The output ties observed behavior back to agent identity,
+// backing role, tool, target resource, and outcome so an operator can
+// answer, per (agent, tool) pair:
+//
+//   - confirmed:                    the agent and tool are declared in the
+//     inventory AND a tool-call was observed. Behavior matches the
+//     discovered agent surface.
+//   - observed_without_declaration: a tool-call was observed for an agent
+//     that is not in the inventory (a shadow agent) or for a tool the
+//     agent does not declare (an undeclared tool). Treated as a caveat,
+//     never a silent success.
+//   - declared_unused:              the agent declares the tool but no
+//     tool-call was observed in the window. Carries a missing-event
+//     caveat because agent tool-call telemetry is not guaranteed to be
+//     complete; absence is not proof the tool was never used.
+//
+// On top of the inventory join, the correlation flags when the observed
+// backing role differs from the agent's declared runtime role
+// (privilege drift) and surfaces failed tool-call outcomes.
+//
+// Safety boundary: the engine is metadata-only. It never reads, logs, or
+// persists prompts, completions, tool inputs/outputs, browser pages,
+// code-interpreter output, or any other customer payload — only the
+// already-redacted runtime-event and agent-inventory metadata. Every
+// emitted correlation re-stamps the redaction boundary.
+package agentaccess
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Correlation statuses.
+const (
+	StatusConfirmed                  = "confirmed"
+	StatusObservedWithoutDeclaration = "observed_without_declaration"
+	StatusDeclaredUnused             = "declared_unused"
+)
+
+// Tool-call outcomes.
+const (
+	OutcomeSucceeded = "succeeded"
+	OutcomeFailed    = "failed"
+	OutcomeUnknown   = "unknown"
+)
+
+// invocationToolToken is the synthetic tool key used when an observed
+// agent invocation carries no specific tool name (e.g. InvokeAgent) so a
+// bare invocation does not merge with a named tool-call.
+const invocationToolToken = "<invocation>"
+
+const (
+	// CollectorName tags every diagnostic and result the correlator
+	// emits so the API layer can scope diagnostics by collector.
+	CollectorName = "aws_agent_runtime_access"
+
+	// RedactionBoundary documents that the correlator only ever crossed
+	// the metadata boundary — no prompts, completions, or tool payloads.
+	RedactionBoundary = "metadata_only_no_prompts_no_completions_no_tool_payloads"
+)
+
+// Caveat codes attached to individual correlations or the result.
+const (
+	CaveatDataEventCoverage    = "agent_tool_telemetry_may_be_incomplete"
+	CaveatAgentNotInInventory  = "agent_not_in_inventory"
+	CaveatToolNotDeclared      = "tool_not_declared_by_agent"
+	CaveatBackingRoleMismatch  = "observed_backing_role_differs_from_declared"
+	CaveatToolCallFailed       = "observed_tool_call_failed"
+	CaveatLineageUnresolved    = "session_lineage_unresolved"
+	CaveatInventoryUnavailable = "agent_inventory_unavailable_for_confirmation"
+)
+
+// ObservedToolCall is one metadata-only agent runtime / tool-call event
+// projected from the runtime-event contract.
+type ObservedToolCall struct {
+	EventID              string
+	AgentNodeID          string
+	AgentID              string
+	AgentType            string
+	RuntimeVersion       string
+	ToolName             string
+	ToolTargetRef        string
+	BackingRoleARN       string
+	BackingRoleNodeID    string
+	TargetResourceARN    string
+	TargetResourceNodeID string
+	Outcome              string
+	SessionID            string
+	AccountID            string
+	Region               string
+	LineageStatus        string
+	ObservedAt           time.Time
+	EvidenceRef          string
+}
+
+// DeclaredTool is one declared (agent, tool) pair from the AI-agent
+// inventory. A tool name of "" represents an agent that declares no
+// tools (so the agent itself can still be surfaced as declared_unused).
+type DeclaredTool struct {
+	AgentNodeID       string
+	AgentID           string
+	AgentName         string
+	AgentType         string
+	RuntimeVersion    string
+	ToolName          string
+	ToolTargetRef     string
+	BackingRoleARN    string
+	BackingRoleNodeID string
+	AccountID         string
+	Region            string
+	Confidence        float64
+	EvidenceRef       string
+}
+
+// CorrelateRequest configures one correlation pass.
+type CorrelateRequest struct {
+	AccountID string
+	Region    string
+	Observed  []ObservedToolCall
+	Declared  []DeclaredTool
+	// KnownAgentNodeIDs is the set of agent node ids present in the
+	// inventory (including agents that declare no tools). It lets the
+	// engine distinguish a shadow agent (agent_not_in_inventory) from a
+	// known agent invoking an undeclared tool (tool_not_declared).
+	KnownAgentNodeIDs []string
+	// InventoryAvailable reports whether the AI-agent inventory was
+	// actually available for this correlation pass. When false (e.g. the
+	// inventory could not be loaded in live mode), an observed tool-call
+	// is surfaced with a neutral "inventory unavailable" caveat rather
+	// than being mislabeled as a shadow agent, since absence of the
+	// inventory is not evidence the agent is undeclared.
+	InventoryAvailable bool
+	// DataEventCoverageUnknown marks that the observed set comes from a
+	// runtime source that does not guarantee agent tool-call telemetry is
+	// complete. When true, declared_unused correlations and the result
+	// carry the missing-event caveat.
+	DataEventCoverageUnknown bool
+}
+
+// Correlation is one (agent, tool) correlation record.
+type Correlation struct {
+	CorrelationID       string
+	AgentNodeID         string
+	AgentID             string
+	AgentName           string
+	AgentType           string
+	RuntimeVersion      string
+	ToolName            string
+	ToolTargetRef       string
+	AccountID           string
+	Region              string
+	Status              string
+	Confidence          float64
+	ObservedCount       int
+	ObservedEventIDs    []string
+	BackingRoleARNs     []string
+	BackingRoleNodeIDs  []string
+	DeclaredBackingRole string
+	TargetResourceARNs  []string
+	Outcomes            []string
+	SessionIDs          []string
+	FirstObservedAt     time.Time
+	LastObservedAt      time.Time
+	DeclaredInInventory bool
+	Caveats             []string
+	EvidenceRefs        []string
+	RedactionBoundary   string
+}
+
+// Result is the bounded outcome of one correlation pass.
+type Result struct {
+	Correlations                []Correlation
+	Caveats                     []string
+	ConfirmedCount              int
+	ObservedWithoutDecl         int
+	DeclaredUnusedCount         int
+	ShadowAgentCount            int
+	UndeclaredToolCount         int
+	BackingRoleMismatchCount    int
+	FailedToolCallCount         int
+	AgentCount                  int
+	ToolCount                   int
+	ObservedToolCallsConsidered int
+	DeclaredToolsConsidered     int
+}
+
+type correlationKey struct {
+	agent string
+	tool  string
+}
+
+type correlationAgg struct {
+	agentNodeID    string
+	agentID        string
+	agentName      string
+	agentType      string
+	runtimeVersion string
+	toolName       string
+	toolTargetRef  string
+	accountID      string
+	region         string
+	observed       []ObservedToolCall
+	declared       []DeclaredTool
+	order          int
+}
+
+// Correlate joins observed tool-calls with the declared agent inventory
+// and returns one correlation per (agent, tool) pair. It never returns
+// an error: documented gaps surface as caveats so the API layer can
+// return a stable response.
+func Correlate(request CorrelateRequest) Result {
+	knownAgents := map[string]struct{}{}
+	for _, id := range request.KnownAgentNodeIDs {
+		if trimmed := normalize(id); trimmed != "" {
+			knownAgents[trimmed] = struct{}{}
+		}
+	}
+
+	index := map[correlationKey]*correlationAgg{}
+	order := 0
+	get := func(agentNodeID, agentID, agentName, agentType, runtimeVersion, toolName, toolTargetRef, account, region string) *correlationAgg {
+		agent := firstNonEmpty(agentNodeID, agentID)
+		toolKey := normalize(toolName)
+		if toolKey == "" {
+			toolKey = invocationToolToken
+		}
+		k := correlationKey{agent: normalize(agent), tool: toolKey}
+		agg, ok := index[k]
+		if !ok {
+			agg = &correlationAgg{
+				agentNodeID:    strings.TrimSpace(agentNodeID),
+				agentID:        strings.TrimSpace(agentID),
+				agentName:      strings.TrimSpace(agentName),
+				agentType:      strings.TrimSpace(agentType),
+				runtimeVersion: strings.TrimSpace(runtimeVersion),
+				toolName:       strings.TrimSpace(toolName),
+				toolTargetRef:  strings.TrimSpace(toolTargetRef),
+				accountID:      strings.TrimSpace(account),
+				region:         strings.TrimSpace(region),
+				order:          order,
+			}
+			order++
+			index[k] = agg
+		}
+		if agg.agentNodeID == "" {
+			agg.agentNodeID = strings.TrimSpace(agentNodeID)
+		}
+		if agg.agentID == "" {
+			agg.agentID = strings.TrimSpace(agentID)
+		}
+		if agg.agentName == "" {
+			agg.agentName = strings.TrimSpace(agentName)
+		}
+		if agg.agentType == "" {
+			agg.agentType = strings.TrimSpace(agentType)
+		}
+		if agg.runtimeVersion == "" {
+			agg.runtimeVersion = strings.TrimSpace(runtimeVersion)
+		}
+		if agg.toolTargetRef == "" {
+			agg.toolTargetRef = strings.TrimSpace(toolTargetRef)
+		}
+		if agg.accountID == "" {
+			agg.accountID = strings.TrimSpace(account)
+		}
+		if agg.region == "" {
+			agg.region = strings.TrimSpace(region)
+		}
+		return agg
+	}
+
+	considered := 0
+	for _, observed := range request.Observed {
+		if strings.TrimSpace(observed.AgentNodeID) == "" && strings.TrimSpace(observed.AgentID) == "" {
+			continue
+		}
+		considered++
+		agg := get(observed.AgentNodeID, observed.AgentID, "", observed.AgentType, observed.RuntimeVersion, observed.ToolName, observed.ToolTargetRef, observed.AccountID, observed.Region)
+		agg.observed = append(agg.observed, observed)
+	}
+
+	declaredConsidered := 0
+	for _, declared := range request.Declared {
+		if strings.TrimSpace(declared.AgentNodeID) == "" && strings.TrimSpace(declared.AgentID) == "" {
+			continue
+		}
+		declaredConsidered++
+		agg := get(declared.AgentNodeID, declared.AgentID, declared.AgentName, declared.AgentType, declared.RuntimeVersion, declared.ToolName, declared.ToolTargetRef, declared.AccountID, declared.Region)
+		agg.declared = append(agg.declared, declared)
+	}
+
+	aggs := make([]*correlationAgg, 0, len(index))
+	for _, agg := range index {
+		aggs = append(aggs, agg)
+	}
+	sort.SliceStable(aggs, func(i, j int) bool {
+		ai := firstNonEmpty(aggs[i].agentNodeID, aggs[i].agentID)
+		aj := firstNonEmpty(aggs[j].agentNodeID, aggs[j].agentID)
+		if normalize(ai) != normalize(aj) {
+			return normalize(ai) < normalize(aj)
+		}
+		if normalize(aggs[i].toolName) != normalize(aggs[j].toolName) {
+			return normalize(aggs[i].toolName) < normalize(aggs[j].toolName)
+		}
+		return aggs[i].order < aggs[j].order
+	})
+
+	result := Result{
+		ObservedToolCallsConsidered: considered,
+		DeclaredToolsConsidered:     declaredConsidered,
+	}
+	agents := map[string]struct{}{}
+	tools := map[string]struct{}{}
+	for _, agg := range aggs {
+		// A correlation needs at least one observed tool-call or one
+		// declared tool. (The "<invocation>" key with neither cannot
+		// occur.)
+		if len(agg.observed) == 0 && len(agg.declared) == 0 {
+			continue
+		}
+		// A declared entry whose tool name is empty only exists to mark
+		// the agent as known; it should not surface as a declared_unused
+		// "tool" on its own when no tool-call was observed.
+		if len(agg.observed) == 0 && agg.toolName == "" {
+			continue
+		}
+		correlation := buildCorrelation(agg, knownAgents, request.InventoryAvailable, request.DataEventCoverageUnknown)
+		result.Correlations = append(result.Correlations, correlation)
+		switch correlation.Status {
+		case StatusConfirmed:
+			result.ConfirmedCount++
+		case StatusObservedWithoutDeclaration:
+			result.ObservedWithoutDecl++
+		case StatusDeclaredUnused:
+			result.DeclaredUnusedCount++
+		}
+		if containsString(correlation.Caveats, CaveatAgentNotInInventory) {
+			result.ShadowAgentCount++
+		}
+		if containsString(correlation.Caveats, CaveatToolNotDeclared) {
+			result.UndeclaredToolCount++
+		}
+		if containsString(correlation.Caveats, CaveatBackingRoleMismatch) {
+			result.BackingRoleMismatchCount++
+		}
+		if containsString(correlation.Caveats, CaveatToolCallFailed) {
+			result.FailedToolCallCount++
+		}
+		agents[normalize(firstNonEmpty(correlation.AgentNodeID, correlation.AgentID))] = struct{}{}
+		if strings.TrimSpace(correlation.ToolName) != "" {
+			tools[normalize(correlation.AgentNodeID)+"|"+normalize(correlation.ToolName)] = struct{}{}
+		}
+	}
+	result.AgentCount = len(agents)
+	result.ToolCount = len(tools)
+
+	if request.DataEventCoverageUnknown && (result.DeclaredUnusedCount > 0 || considered == 0) {
+		result.Caveats = append(result.Caveats, "Agent tool-call telemetry is not guaranteed to be complete from the available runtime sources; 'declared_unused' correlations may reflect missing telemetry rather than truly unused tools.")
+	}
+	if result.ObservedWithoutDecl > 0 {
+		result.Caveats = append(result.Caveats, "Some observed tool-calls have no matching inventory declaration. They may be shadow agents or undeclared tools; review them before treating them as expected behavior.")
+	}
+	return result
+}
+
+func buildCorrelation(agg *correlationAgg, knownAgents map[string]struct{}, inventoryAvailable bool, dataEventCoverageUnknown bool) Correlation {
+	correlation := Correlation{
+		AgentNodeID:       agg.agentNodeID,
+		AgentID:           agg.agentID,
+		AgentName:         agg.agentName,
+		AgentType:         agg.agentType,
+		RuntimeVersion:    agg.runtimeVersion,
+		ToolName:          agg.toolName,
+		ToolTargetRef:     agg.toolTargetRef,
+		AccountID:         agg.accountID,
+		Region:            agg.region,
+		RedactionBoundary: RedactionBoundary,
+	}
+	correlation.CorrelationID = correlationID(agg)
+
+	eventIDs := map[string]struct{}{}
+	backingRoleARNs := map[string]struct{}{}
+	backingRoleNodes := map[string]struct{}{}
+	targets := map[string]struct{}{}
+	outcomes := map[string]struct{}{}
+	sessions := map[string]struct{}{}
+	evidence := map[string]struct{}{}
+	lineageUnresolved := false
+	failed := false
+	for _, observed := range agg.observed {
+		correlation.ObservedCount++
+		if id := strings.TrimSpace(observed.EventID); id != "" {
+			eventIDs[id] = struct{}{}
+		}
+		if arn := strings.TrimSpace(observed.BackingRoleARN); arn != "" {
+			backingRoleARNs[arn] = struct{}{}
+		}
+		if node := strings.TrimSpace(observed.BackingRoleNodeID); node != "" {
+			backingRoleNodes[node] = struct{}{}
+		}
+		if target := strings.TrimSpace(observed.TargetResourceARN); target != "" {
+			targets[target] = struct{}{}
+		}
+		if session := strings.TrimSpace(observed.SessionID); session != "" {
+			sessions[session] = struct{}{}
+		}
+		if ref := strings.TrimSpace(observed.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+		outcome := normalizeOutcome(observed.Outcome)
+		outcomes[outcome] = struct{}{}
+		if outcome == OutcomeFailed {
+			failed = true
+		}
+		observedAt := observed.ObservedAt.UTC()
+		if !observedAt.IsZero() {
+			if correlation.FirstObservedAt.IsZero() || observedAt.Before(correlation.FirstObservedAt) {
+				correlation.FirstObservedAt = observedAt
+			}
+			if observedAt.After(correlation.LastObservedAt) {
+				correlation.LastObservedAt = observedAt
+			}
+		}
+		switch strings.TrimSpace(observed.LineageStatus) {
+		case "", "resolved":
+		default:
+			lineageUnresolved = true
+		}
+	}
+	correlation.ObservedEventIDs = sortedKeys(eventIDs)
+	correlation.BackingRoleARNs = sortedKeys(backingRoleARNs)
+	correlation.BackingRoleNodeIDs = sortedKeys(backingRoleNodes)
+	correlation.TargetResourceARNs = sortedKeys(targets)
+	correlation.Outcomes = sortedKeys(outcomes)
+	correlation.SessionIDs = sortedKeys(sessions)
+
+	declaredHere := false
+	declaredBackingRoleNode := ""
+	declaredBackingRoleARN := ""
+	for _, declared := range agg.declared {
+		if strings.TrimSpace(declared.ToolName) != "" {
+			declaredHere = true
+		}
+		declaredBackingRoleNode = firstNonEmpty(declaredBackingRoleNode, declared.BackingRoleNodeID)
+		declaredBackingRoleARN = firstNonEmpty(declaredBackingRoleARN, declared.BackingRoleARN)
+		if ref := strings.TrimSpace(declared.EvidenceRef); ref != "" {
+			evidence[ref] = struct{}{}
+		}
+	}
+	correlation.DeclaredInInventory = declaredHere
+	correlation.DeclaredBackingRole = firstNonEmpty(declaredBackingRoleARN, declaredBackingRoleNode)
+	correlation.EvidenceRefs = sortedKeys(evidence)
+
+	agentKnown := declaredHere
+	if !agentKnown {
+		if _, ok := knownAgents[normalize(firstNonEmpty(agg.agentNodeID, agg.agentID))]; ok {
+			agentKnown = true
+		}
+	}
+
+	caveats := map[string]struct{}{}
+	switch {
+	case correlation.ObservedCount > 0 && declaredHere:
+		correlation.Status = StatusConfirmed
+		correlation.Confidence = 0.95
+		if lineageUnresolved {
+			if correlation.Confidence > 0.85 {
+				correlation.Confidence = 0.85
+			}
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+		if declaredBackingRoleNode != "" && len(correlation.BackingRoleNodeIDs) > 0 && !containsFold(correlation.BackingRoleNodeIDs, declaredBackingRoleNode) {
+			caveats[CaveatBackingRoleMismatch] = struct{}{}
+			if correlation.Confidence > 0.8 {
+				correlation.Confidence = 0.8
+			}
+		}
+		if failed {
+			caveats[CaveatToolCallFailed] = struct{}{}
+		}
+	case correlation.ObservedCount > 0:
+		correlation.Status = StatusObservedWithoutDeclaration
+		correlation.Confidence = 0.6
+		switch {
+		case !inventoryAvailable:
+			// The inventory was not available to confirm against; do not
+			// accuse a possibly-legitimate agent of being a shadow.
+			caveats[CaveatInventoryUnavailable] = struct{}{}
+		case agentKnown:
+			caveats[CaveatToolNotDeclared] = struct{}{}
+		default:
+			caveats[CaveatAgentNotInInventory] = struct{}{}
+		}
+		if lineageUnresolved {
+			caveats[CaveatLineageUnresolved] = struct{}{}
+		}
+		if failed {
+			caveats[CaveatToolCallFailed] = struct{}{}
+		}
+	default:
+		correlation.Status = StatusDeclaredUnused
+		correlation.Confidence = 0.7
+		if dataEventCoverageUnknown {
+			correlation.Confidence = 0.5
+			caveats[CaveatDataEventCoverage] = struct{}{}
+		}
+	}
+	correlation.Caveats = sortedKeys(caveats)
+	return correlation
+}
+
+func normalizeOutcome(outcome string) string {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case OutcomeSucceeded, "success", "ok":
+		return OutcomeSucceeded
+	case OutcomeFailed, "failure", "error", "denied":
+		return OutcomeFailed
+	default:
+		return OutcomeUnknown
+	}
+}
+
+func correlationID(agg *correlationAgg) string {
+	agent := firstNonEmpty(agg.agentNodeID, agg.agentID, "unknown-agent")
+	tool := firstNonEmpty(agg.toolName, invocationToolToken)
+	return fmt.Sprintf("agent_tool|%s|%s", normalize(agent), normalize(tool))
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/agentaccess/correlate.go
+++ b/internal/runtime/agentaccess/correlate.go
@@ -144,32 +144,34 @@ type CorrelateRequest struct {
 
 // Correlation is one (agent, tool) correlation record.
 type Correlation struct {
-	CorrelationID       string
-	AgentNodeID         string
-	AgentID             string
-	AgentName           string
-	AgentType           string
-	RuntimeVersion      string
-	ToolName            string
-	ToolTargetRef       string
-	AccountID           string
-	Region              string
-	Status              string
-	Confidence          float64
-	ObservedCount       int
-	ObservedEventIDs    []string
-	BackingRoleARNs     []string
-	BackingRoleNodeIDs  []string
-	DeclaredBackingRole string
-	TargetResourceARNs  []string
-	Outcomes            []string
-	SessionIDs          []string
-	FirstObservedAt     time.Time
-	LastObservedAt      time.Time
-	DeclaredInInventory bool
-	Caveats             []string
-	EvidenceRefs        []string
-	RedactionBoundary   string
+	CorrelationID           string
+	AgentNodeID             string
+	AgentID                 string
+	AgentName               string
+	AgentType               string
+	RuntimeVersion          string
+	ToolName                string
+	ToolTargetRef           string
+	AccountID               string
+	Region                  string
+	Status                  string
+	Confidence              float64
+	ObservedCount           int
+	ObservedEventIDs        []string
+	BackingRoleARNs         []string
+	BackingRoleNodeIDs      []string
+	DeclaredBackingRole     string
+	DeclaredBackingRoleNode string
+	TargetResourceARNs      []string
+	TargetResourceNodeIDs   []string
+	Outcomes                []string
+	SessionIDs              []string
+	FirstObservedAt         time.Time
+	LastObservedAt          time.Time
+	DeclaredInInventory     bool
+	Caveats                 []string
+	EvidenceRefs            []string
+	RedactionBoundary       string
 }
 
 // Result is the bounded outcome of one correlation pass.
@@ -387,6 +389,7 @@ func buildCorrelation(agg *correlationAgg, knownAgents map[string]struct{}, inve
 	backingRoleARNs := map[string]struct{}{}
 	backingRoleNodes := map[string]struct{}{}
 	targets := map[string]struct{}{}
+	targetNodes := map[string]struct{}{}
 	outcomes := map[string]struct{}{}
 	sessions := map[string]struct{}{}
 	evidence := map[string]struct{}{}
@@ -405,6 +408,9 @@ func buildCorrelation(agg *correlationAgg, knownAgents map[string]struct{}, inve
 		}
 		if target := strings.TrimSpace(observed.TargetResourceARN); target != "" {
 			targets[target] = struct{}{}
+		}
+		if node := strings.TrimSpace(observed.TargetResourceNodeID); node != "" {
+			targetNodes[node] = struct{}{}
 		}
 		if session := strings.TrimSpace(observed.SessionID); session != "" {
 			sessions[session] = struct{}{}
@@ -436,6 +442,7 @@ func buildCorrelation(agg *correlationAgg, knownAgents map[string]struct{}, inve
 	correlation.BackingRoleARNs = sortedKeys(backingRoleARNs)
 	correlation.BackingRoleNodeIDs = sortedKeys(backingRoleNodes)
 	correlation.TargetResourceARNs = sortedKeys(targets)
+	correlation.TargetResourceNodeIDs = sortedKeys(targetNodes)
 	correlation.Outcomes = sortedKeys(outcomes)
 	correlation.SessionIDs = sortedKeys(sessions)
 
@@ -454,6 +461,7 @@ func buildCorrelation(agg *correlationAgg, knownAgents map[string]struct{}, inve
 	}
 	correlation.DeclaredInInventory = declaredHere
 	correlation.DeclaredBackingRole = firstNonEmpty(declaredBackingRoleARN, declaredBackingRoleNode)
+	correlation.DeclaredBackingRoleNode = declaredBackingRoleNode
 	correlation.EvidenceRefs = sortedKeys(evidence)
 
 	agentKnown := declaredHere

--- a/internal/runtime/agentaccess/correlate_test.go
+++ b/internal/runtime/agentaccess/correlate_test.go
@@ -1,0 +1,285 @@
+package agentaccess
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func observedAt(min int) time.Time {
+	return time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC).Add(time.Duration(min) * time.Minute)
+}
+
+func findByTool(t *testing.T, result Result, tool string) Correlation {
+	t.Helper()
+	for _, correlation := range result.Correlations {
+		if correlation.ToolName == tool {
+			return correlation
+		}
+	}
+	t.Fatalf("no correlation for tool %q in %+v", tool, result.Correlations)
+	return Correlation{}
+}
+
+func hasCaveat(caveats []string, want string) bool {
+	for _, caveat := range caveats {
+		if caveat == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCorrelateConfirmedJoinsObservedWithDeclaredTool(t *testing.T) {
+	agent := "aws:agent:111122223333:us-east-1:agentcore_runtime/case-triage/2026-06-01"
+	role := "arn:aws:iam::111122223333:role/case-triage-runtime"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{{
+			EventID:           "evt-1",
+			AgentNodeID:       agent,
+			AgentID:           "case-triage",
+			AgentType:         "agentcore_runtime",
+			ToolName:          "case-router",
+			ToolTargetRef:     "case-router-policy",
+			BackingRoleARN:    role,
+			BackingRoleNodeID: "aws:identity:role:case-triage-runtime",
+			TargetResourceARN: "arn:aws:bedrock-agentcore:us-east-1:111122223333:agent-runtime-endpoint/case-triage/blue",
+			Outcome:           OutcomeSucceeded,
+			SessionID:         "ASIA-sess",
+			LineageStatus:     "resolved",
+			ObservedAt:        observedAt(5),
+			EvidenceRef:       "runtime-evidence://evt-1",
+		}},
+		Declared: []DeclaredTool{{
+			AgentNodeID:       agent,
+			AgentID:           "case-triage",
+			AgentName:         "Case Triage",
+			AgentType:         "agentcore_runtime",
+			ToolName:          "case-router",
+			BackingRoleARN:    role,
+			BackingRoleNodeID: "aws:identity:role:case-triage-runtime",
+			Confidence:        0.9,
+			EvidenceRef:       "agent-evidence://case-triage",
+		}},
+		KnownAgentNodeIDs: []string{agent},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed, got %q", correlation.Status)
+	}
+	if correlation.Confidence != 0.95 {
+		t.Fatalf("expected 0.95 confidence, got %v", correlation.Confidence)
+	}
+	if !correlation.DeclaredInInventory || correlation.ToolName != "case-router" {
+		t.Fatalf("unexpected correlation: %+v", correlation)
+	}
+	if len(correlation.Caveats) != 0 {
+		t.Fatalf("clean confirmed should carry no caveats, got %+v", correlation.Caveats)
+	}
+	if correlation.RedactionBoundary != RedactionBoundary {
+		t.Fatalf("missing redaction boundary: %+v", correlation)
+	}
+	if result.ConfirmedCount != 1 || result.AgentCount != 1 || result.ToolCount != 1 {
+		t.Fatalf("unexpected result counts: %+v", result)
+	}
+}
+
+func TestCorrelateBackingRoleMismatchAndFailure(t *testing.T) {
+	agent := "aws:agent:1:us-east-1:agentcore_runtime/a/v"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{{
+			EventID: "e", AgentNodeID: agent, ToolName: "writer", BackingRoleNodeID: "aws:identity:role:unexpected", Outcome: OutcomeFailed, ObservedAt: observedAt(1),
+		}},
+		Declared: []DeclaredTool{{
+			AgentNodeID: agent, ToolName: "writer", BackingRoleNodeID: "aws:identity:role:declared", Confidence: 0.9,
+		}},
+		KnownAgentNodeIDs: []string{agent},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed {
+		t.Fatalf("expected confirmed (tool is declared), got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatBackingRoleMismatch) {
+		t.Fatalf("expected backing-role-mismatch caveat, got %+v", correlation.Caveats)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatToolCallFailed) {
+		t.Fatalf("expected tool-call-failed caveat, got %+v", correlation.Caveats)
+	}
+	if correlation.Confidence != 0.8 {
+		t.Fatalf("expected confidence capped to 0.8, got %v", correlation.Confidence)
+	}
+	if result.BackingRoleMismatchCount != 1 || result.FailedToolCallCount != 1 {
+		t.Fatalf("unexpected result counts: %+v", result)
+	}
+}
+
+func TestCorrelateShadowAgentVsUndeclaredTool(t *testing.T) {
+	knownAgent := "aws:agent:1:us-east-1:agentcore_runtime/known/v"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{
+			{EventID: "shadow", AgentNodeID: "aws:agent:1:us-east-1:agentcore_runtime/shadow/v", ToolName: "exfil", ObservedAt: observedAt(1)},
+			{EventID: "undeclared", AgentNodeID: knownAgent, ToolName: "surprise", ObservedAt: observedAt(2)},
+		},
+		Declared: []DeclaredTool{
+			{AgentNodeID: knownAgent, ToolName: "expected"},
+		},
+		KnownAgentNodeIDs:        []string{knownAgent},
+		InventoryAvailable:       true,
+		DataEventCoverageUnknown: true,
+	})
+	shadow := findByTool(t, result, "exfil")
+	if shadow.Status != StatusObservedWithoutDeclaration || !hasCaveat(shadow.Caveats, CaveatAgentNotInInventory) {
+		t.Fatalf("expected shadow-agent caveat, got %+v", shadow)
+	}
+	undeclared := findByTool(t, result, "surprise")
+	if undeclared.Status != StatusObservedWithoutDeclaration || !hasCaveat(undeclared.Caveats, CaveatToolNotDeclared) {
+		t.Fatalf("expected tool-not-declared caveat, got %+v", undeclared)
+	}
+	if hasCaveat(undeclared.Caveats, CaveatAgentNotInInventory) {
+		t.Fatalf("known agent must not be flagged as shadow: %+v", undeclared.Caveats)
+	}
+	expected := findByTool(t, result, "expected")
+	if expected.Status != StatusDeclaredUnused || !hasCaveat(expected.Caveats, CaveatDataEventCoverage) {
+		t.Fatalf("expected declared_unused + missing-event caveat, got %+v", expected)
+	}
+	if expected.Confidence != 0.5 {
+		t.Fatalf("expected 0.5 confidence for declared_unused with unknown coverage, got %v", expected.Confidence)
+	}
+	if result.ShadowAgentCount != 1 || result.UndeclaredToolCount != 1 || result.DeclaredUnusedCount != 1 {
+		t.Fatalf("unexpected result counts: %+v", result)
+	}
+}
+
+func TestCorrelateInventoryUnavailableDoesNotAccuseShadowAgent(t *testing.T) {
+	// In live mode the inventory may be unavailable. An observed tool-call
+	// must not be mislabeled as a shadow agent in that case.
+	result := Correlate(CorrelateRequest{
+		Observed:           []ObservedToolCall{{EventID: "e", AgentNodeID: "aws:agent:1:us-east-1:agentcore_runtime/real/v", ToolName: "router", ObservedAt: observedAt(1)}},
+		InventoryAvailable: false,
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusObservedWithoutDeclaration {
+		t.Fatalf("expected observed_without_declaration, got %q", correlation.Status)
+	}
+	if !hasCaveat(correlation.Caveats, CaveatInventoryUnavailable) {
+		t.Fatalf("expected inventory-unavailable caveat, got %+v", correlation.Caveats)
+	}
+	if hasCaveat(correlation.Caveats, CaveatAgentNotInInventory) {
+		t.Fatalf("must not accuse shadow agent when inventory is unavailable: %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateDeclaredUnusedHigherConfidenceWhenCoverageKnown(t *testing.T) {
+	agent := "aws:agent:1:us-east-1:agentcore_runtime/a/v"
+	result := Correlate(CorrelateRequest{
+		Declared:          []DeclaredTool{{AgentNodeID: agent, ToolName: "t"}},
+		KnownAgentNodeIDs: []string{agent},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusDeclaredUnused || correlation.Confidence != 0.7 {
+		t.Fatalf("expected declared_unused at 0.7 when coverage known, got %+v", correlation)
+	}
+	if hasCaveat(correlation.Caveats, CaveatDataEventCoverage) {
+		t.Fatalf("did not expect missing-event caveat when coverage known: %+v", correlation.Caveats)
+	}
+}
+
+func TestCorrelateLineageUnresolvedCapsConfirmedConfidence(t *testing.T) {
+	agent := "aws:agent:1:us-east-1:agentcore_runtime/a/v"
+	result := Correlate(CorrelateRequest{
+		Observed:          []ObservedToolCall{{EventID: "e", AgentNodeID: agent, ToolName: "t", LineageStatus: "source_identity_missing", ObservedAt: observedAt(1)}},
+		Declared:          []DeclaredTool{{AgentNodeID: agent, ToolName: "t"}},
+		KnownAgentNodeIDs: []string{agent},
+	})
+	correlation := result.Correlations[0]
+	if correlation.Status != StatusConfirmed || correlation.Confidence != 0.85 || !hasCaveat(correlation.Caveats, CaveatLineageUnresolved) {
+		t.Fatalf("expected confirmed capped to 0.85 with lineage caveat, got %+v", correlation)
+	}
+}
+
+func TestCorrelateAgentWithNoToolsNotSurfacedAsUnusedTool(t *testing.T) {
+	agent := "aws:agent:1:us-east-1:agentcore_runtime/a/v"
+	result := Correlate(CorrelateRequest{
+		Declared:          []DeclaredTool{{AgentNodeID: agent, ToolName: ""}},
+		KnownAgentNodeIDs: []string{agent},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("an agent that declares no tools and was never observed must not surface a phantom tool: %+v", result.Correlations)
+	}
+}
+
+func TestCorrelateBareInvocationDoesNotMergeWithNamedTool(t *testing.T) {
+	agent := "aws:agent:1:us-east-1:agentcore_runtime/a/v"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{
+			{EventID: "inv", AgentNodeID: agent, ToolName: "", ObservedAt: observedAt(1)},
+			{EventID: "named", AgentNodeID: agent, ToolName: "router", ObservedAt: observedAt(2)},
+		},
+	})
+	if len(result.Correlations) != 2 {
+		t.Fatalf("expected bare invocation and named tool to stay separate, got %d (%+v)", len(result.Correlations), result.Correlations)
+	}
+}
+
+func TestCorrelateAggregatesRepeatedCallsCaseInsensitive(t *testing.T) {
+	agent := "AWS:Agent:1:us-east-1:agentcore_runtime/A/v"
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{
+			{EventID: "a", AgentNodeID: agent, ToolName: "router", SessionID: "s1", ObservedAt: observedAt(10)},
+			{EventID: "b", AgentNodeID: strings.ToLower(agent), ToolName: "router", SessionID: "s2", ObservedAt: observedAt(2)},
+		},
+		Declared:          []DeclaredTool{{AgentNodeID: strings.ToLower(agent), ToolName: "router"}},
+		KnownAgentNodeIDs: []string{strings.ToLower(agent)},
+	})
+	if len(result.Correlations) != 1 {
+		t.Fatalf("expected case-insensitive aggregation into 1 correlation, got %d", len(result.Correlations))
+	}
+	correlation := result.Correlations[0]
+	if correlation.ObservedCount != 2 || len(correlation.SessionIDs) != 2 {
+		t.Fatalf("expected aggregated observations, got %+v", correlation)
+	}
+	if !correlation.FirstObservedAt.Equal(observedAt(2)) || !correlation.LastObservedAt.Equal(observedAt(10)) {
+		t.Fatalf("unexpected observed window: first=%v last=%v", correlation.FirstObservedAt, correlation.LastObservedAt)
+	}
+}
+
+func TestCorrelateSkipsUnattributableRecords(t *testing.T) {
+	result := Correlate(CorrelateRequest{
+		Observed: []ObservedToolCall{{EventID: "no-agent", ToolName: "x"}},
+		Declared: []DeclaredTool{{ToolName: "y"}},
+	})
+	if len(result.Correlations) != 0 {
+		t.Fatalf("expected unattributable records skipped, got %+v", result.Correlations)
+	}
+	if result.ObservedToolCallsConsidered != 0 || result.DeclaredToolsConsidered != 0 {
+		t.Fatalf("expected zero considered, got %+v", result)
+	}
+}
+
+func TestCorrelateDeterministicOrdering(t *testing.T) {
+	build := func() []Correlation {
+		return Correlate(CorrelateRequest{
+			Observed: []ObservedToolCall{
+				{EventID: "1", AgentNodeID: "z-agent", ToolName: "b", ObservedAt: observedAt(1)},
+				{EventID: "2", AgentNodeID: "a-agent", ToolName: "b", ObservedAt: observedAt(1)},
+				{EventID: "3", AgentNodeID: "a-agent", ToolName: "a", ObservedAt: observedAt(1)},
+			},
+		}).Correlations
+	}
+	first := build()
+	second := build()
+	if len(first) != 3 {
+		t.Fatalf("expected 3 correlations, got %d", len(first))
+	}
+	for i := range first {
+		if first[i].CorrelationID != second[i].CorrelationID {
+			t.Fatalf("ordering not deterministic at %d", i)
+		}
+	}
+	if first[0].AgentNodeID != "a-agent" || first[0].ToolName != "a" || first[1].ToolName != "b" {
+		t.Fatalf("unexpected ordering: %+v", first)
+	}
+}

--- a/internal/runtime/agentaccess/correlate_test.go
+++ b/internal/runtime/agentaccess/correlate_test.go
@@ -33,22 +33,24 @@ func hasCaveat(caveats []string, want string) bool {
 func TestCorrelateConfirmedJoinsObservedWithDeclaredTool(t *testing.T) {
 	agent := "aws:agent:111122223333:us-east-1:agentcore_runtime/case-triage/2026-06-01"
 	role := "arn:aws:iam::111122223333:role/case-triage-runtime"
+	targetNode := "aws:resource:bedrock-agentcore:us-east-1:111122223333:agent-runtime-endpoint/case-triage/blue"
 	result := Correlate(CorrelateRequest{
 		Observed: []ObservedToolCall{{
-			EventID:           "evt-1",
-			AgentNodeID:       agent,
-			AgentID:           "case-triage",
-			AgentType:         "agentcore_runtime",
-			ToolName:          "case-router",
-			ToolTargetRef:     "case-router-policy",
-			BackingRoleARN:    role,
-			BackingRoleNodeID: "aws:identity:role:case-triage-runtime",
-			TargetResourceARN: "arn:aws:bedrock-agentcore:us-east-1:111122223333:agent-runtime-endpoint/case-triage/blue",
-			Outcome:           OutcomeSucceeded,
-			SessionID:         "ASIA-sess",
-			LineageStatus:     "resolved",
-			ObservedAt:        observedAt(5),
-			EvidenceRef:       "runtime-evidence://evt-1",
+			EventID:              "evt-1",
+			AgentNodeID:          agent,
+			AgentID:              "case-triage",
+			AgentType:            "agentcore_runtime",
+			ToolName:             "case-router",
+			ToolTargetRef:        "case-router-policy",
+			BackingRoleARN:       role,
+			BackingRoleNodeID:    "aws:identity:role:case-triage-runtime",
+			TargetResourceARN:    "arn:aws:bedrock-agentcore:us-east-1:111122223333:agent-runtime-endpoint/case-triage/blue",
+			TargetResourceNodeID: targetNode,
+			Outcome:              OutcomeSucceeded,
+			SessionID:            "ASIA-sess",
+			LineageStatus:        "resolved",
+			ObservedAt:           observedAt(5),
+			EvidenceRef:          "runtime-evidence://evt-1",
 		}},
 		Declared: []DeclaredTool{{
 			AgentNodeID:       agent,
@@ -81,6 +83,9 @@ func TestCorrelateConfirmedJoinsObservedWithDeclaredTool(t *testing.T) {
 	}
 	if correlation.RedactionBoundary != RedactionBoundary {
 		t.Fatalf("missing redaction boundary: %+v", correlation)
+	}
+	if len(correlation.TargetResourceNodeIDs) != 1 || correlation.TargetResourceNodeIDs[0] != targetNode {
+		t.Fatalf("expected target resource node id preserved, got %+v", correlation.TargetResourceNodeIDs)
 	}
 	if result.ConfirmedCount != 1 || result.AgentCount != 1 || result.ToolCount != 1 {
 		t.Fatalf("unexpected result counts: %+v", result)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2597,7 +2597,9 @@ export type AWSAgentRuntimeAccessRecord = {
   backing_role_arns?: string[];
   backing_role_node_ids?: string[];
   declared_backing_role?: string;
+  declared_backing_role_node_id?: string;
   target_resource_arns?: string[];
+  target_resource_node_ids?: string[];
   outcomes?: string[];
   session_ids?: string[];
   first_observed_at?: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2562,6 +2562,138 @@ export type AWSS3RuntimeAccessQuery = {
   status?: string;
 };
 
+// AWSAgentRuntimeAccess* types describe the agent runtime / tool-call
+// correlation: observed agent tool-call events joined with the static
+// AI-agent inventory (declared agents, backing roles, declared tools),
+// classified per (agent, tool) pair. Prompts, completions, and tool
+// payloads are never present.
+export type AWSAgentRuntimeAccessStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAgentRuntimeAccessFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSAgentRuntimeAccessCorrelationStatus =
+  | 'confirmed'
+  | 'observed_without_declaration'
+  | 'declared_unused';
+
+export type AWSAgentRuntimeAccessRecord = {
+  correlation_id: string;
+  account_id: string;
+  region: string;
+  agent_node_id: string;
+  agent_id?: string;
+  agent_name?: string;
+  agent_type?: string;
+  runtime_version?: string;
+  tool_name?: string;
+  tool_target_ref?: string;
+  status: AWSAgentRuntimeAccessCorrelationStatus | string;
+  confidence: number;
+  observed_count: number;
+  observed_event_ids?: string[];
+  backing_role_arns?: string[];
+  backing_role_node_ids?: string[];
+  declared_backing_role?: string;
+  target_resource_arns?: string[];
+  outcomes?: string[];
+  session_ids?: string[];
+  first_observed_at?: string;
+  last_observed_at?: string;
+  declared_in_inventory: boolean;
+  caveats?: string[];
+  evidence_ref: string;
+  evidence_refs?: string[];
+  next_action: string;
+  redaction_boundary: string;
+};
+
+export type AWSAgentRuntimeAccessRelationship = {
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSAgentRuntimeAccessDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSAgentRuntimeAccessCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSAgentRuntimeAccessSummary = {
+  total_correlations: number;
+  filtered_correlations: number;
+  status_counts: Record<string, number>;
+  confirmed_count: number;
+  observed_without_declaration_count: number;
+  declared_unused_count: number;
+  shadow_agent_count: number;
+  undeclared_tool_count: number;
+  backing_role_mismatch_count: number;
+  failed_tool_call_count: number;
+  agent_count: number;
+  tool_count: number;
+  observed_tool_call_count: number;
+  declared_tool_count: number;
+  relationship_count: number;
+};
+
+export type AWSAgentRuntimeAccessResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAgentRuntimeAccessStatus;
+  fixture_state?: AWSAgentRuntimeAccessFixtureState;
+  confidence: number;
+  applied_filters: Record<string, string>;
+  summary: AWSAgentRuntimeAccessSummary;
+  records: AWSAgentRuntimeAccessRecord[];
+  relationships: AWSAgentRuntimeAccessRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSAgentRuntimeAccessCoverageGap[];
+  diagnostics: AWSAgentRuntimeAccessDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSAgentRuntimeAccessQuery = {
+  connectorID?: string;
+  fixtureState?: AWSAgentRuntimeAccessFixtureState;
+  deliverySource?: AWSRuntimeEventDeliverySource;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  agentID?: string;
+  tool?: string;
+  resource?: string;
+  outcome?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -5710,6 +5842,29 @@ export const apiClient = {
         access_mode: query?.accessMode,
         sensitivity: query?.sensitivity,
         exposure: query?.exposure,
+        status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAgentRuntimeAccess(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSAgentRuntimeAccessQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ correlation: AWSAgentRuntimeAccessResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/agent-runtime-access${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        delivery_source: query?.deliverySource,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        agent_id: query?.agentID,
+        tool: query?.tool,
+        resource: query?.resource,
+        outcome: query?.outcome,
         status: query?.status
       })}`,
       auth

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -53,6 +53,8 @@ import {
   type AWSSecretsKMSRuntimeAccessResult,
   type AWSS3RuntimeAccessRecord,
   type AWSS3RuntimeAccessResult,
+  type AWSAgentRuntimeAccessRecord,
+  type AWSAgentRuntimeAccessResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10295,6 +10297,130 @@ function AWSS3RuntimeAccessContent({
   );
 }
 
+function awsAgentRuntimeAccessStatusLabel(status: string): string {
+  switch (status) {
+    case 'confirmed':
+      return 'Confirmed';
+    case 'observed_without_declaration':
+      return 'Observed · undeclared';
+    case 'declared_unused':
+      return 'Declared · unused';
+    default:
+      return formatTokenLabel(status);
+  }
+}
+
+function awsAgentRuntimeAccessStage(status: string): AWSCapabilityStage {
+  switch (status) {
+    case 'confirmed':
+      return 'wired';
+    case 'observed_without_declaration':
+      return 'coming';
+    default:
+      return 'not-available';
+  }
+}
+
+function awsAgentRuntimeAccessLabel(record: AWSAgentRuntimeAccessRecord): string {
+  const agent = record.agent_name || record.agent_id || record.agent_node_id;
+  const tool = record.tool_name ? ` · ${record.tool_name}` : '';
+  return `${agent}${tool}`;
+}
+
+function awsAgentRuntimeAccessContextLabel(record: AWSAgentRuntimeAccessRecord): string {
+  const outcomes = (record.outcomes ?? []).filter((outcome) => outcome && outcome !== 'unknown');
+  const outcomeLabel = outcomes.length > 0 ? outcomes.map((outcome) => formatTokenLabel(outcome)).join(', ') : '';
+  const caveats = (record.caveats ?? []).map((caveat) => formatTokenLabel(caveat)).join(' · ');
+  return [outcomeLabel, caveats].filter(Boolean).join(' · ') || '—';
+}
+
+function AWSAgentRuntimeAccessContent({
+  correlation,
+  loading,
+  error,
+  onRetry
+}: {
+  correlation: AWSAgentRuntimeAccessResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const records = correlation?.records ?? [];
+  const summaryLine = correlation
+    ? `${correlation.summary.confirmed_count} confirmed · ${correlation.summary.observed_without_declaration_count} undeclared · ${correlation.summary.declared_unused_count} declared unused`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="Agent runtime and tool-call correlation">
+      <h3>Agent runtime / tool-call correlation</h3>
+      <p className="idt-app-kicker">
+        Observed agent tool-calls joined with the AI-agent inventory — confirmed, observed-without-declaration (shadow
+        agent or undeclared tool), or declared-but-unused. Prompts and tool payloads are never shown. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load agent runtime correlation"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Correlating agent tool-calls"
+          body="Identrail is joining observed agent tool-calls with the AI-agent inventory."
+        />
+      ) : null}
+      {!error && !loading && correlation && records.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={correlation.status === 'blocked' ? 'Permission required' : 'No correlations'}
+          title={
+            correlation.status === 'blocked'
+              ? 'Agent runtime correlation needs read-only event access'
+              : 'No agent tool-call correlations'
+          }
+          body={
+            correlation.failure_reasons[0] ??
+            'No observed agent tool-calls or declared tools were available for the current environment.'
+          }
+        />
+      ) : null}
+      {!error && !loading && correlation && correlation.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {correlation.caveats.map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {records.length > 0 ? (
+        <DomainDataTable
+          label="Agent runtime / tool-call correlations"
+          rows={records}
+          getRowKey={(row) => row.correlation_id}
+          columns={[
+            { key: 'agent', header: 'Agent · tool', render: (row) => <strong>{awsAgentRuntimeAccessLabel(row)}</strong> },
+            { key: 'identity', header: 'Backing role', render: (row) => (row.backing_role_arns ?? []).join(', ') || row.declared_backing_role || '—' },
+            {
+              key: 'evidence',
+              header: 'Evidence',
+              render: (row) =>
+                `${row.observed_count} observed · ${row.declared_in_inventory ? 'declared' : 'undeclared'} · ${formatConfidenceScore(row.confidence)}`
+            },
+            { key: 'context', header: 'Outcome / caveats', render: (row) => awsAgentRuntimeAccessContextLabel(row) },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action },
+            {
+              key: 'status',
+              header: 'Correlation',
+              render: (row) => (
+                <AWSInventoryPill stage={awsAgentRuntimeAccessStage(row.status)} label={awsAgentRuntimeAccessStatusLabel(row.status)} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -10789,6 +10915,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [s3RuntimeAccessLoading, setS3RuntimeAccessLoading] = useState(false);
   const [s3RuntimeAccessError, setS3RuntimeAccessError] = useState('');
   const s3RuntimeAccessRequestRef = useRef(0);
+  const [agentRuntimeAccess, setAgentRuntimeAccess] = useState<AWSAgentRuntimeAccessResult | null>(null);
+  const [agentRuntimeAccessLoading, setAgentRuntimeAccessLoading] = useState(false);
+  const [agentRuntimeAccessError, setAgentRuntimeAccessError] = useState('');
+  const agentRuntimeAccessRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -10948,6 +11078,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadS3RuntimeAccess]);
 
+  const loadAgentRuntimeAccess = useCallback(async () => {
+    const requestID = ++agentRuntimeAccessRequestRef.current;
+    setAgentRuntimeAccess(null);
+    setAgentRuntimeAccessError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAgentRuntimeAccessLoading(false);
+      return;
+    }
+    setAgentRuntimeAccessLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAgentRuntimeAccess(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== agentRuntimeAccessRequestRef.current) {
+        return;
+      }
+      setAgentRuntimeAccess(response.correlation);
+    } catch (error) {
+      if (requestID !== agentRuntimeAccessRequestRef.current) {
+        return;
+      }
+      setAgentRuntimeAccessError(formatAPIError(error, 'Unable to load agent runtime access correlation.'));
+    } finally {
+      if (requestID === agentRuntimeAccessRequestRef.current) {
+        setAgentRuntimeAccessLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadAgentRuntimeAccess();
+    return () => {
+      agentRuntimeAccessRequestRef.current += 1;
+    };
+  }, [loadAgentRuntimeAccess]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -11055,6 +11233,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={s3RuntimeAccessLoading}
             error={s3RuntimeAccessError}
             onRetry={loadS3RuntimeAccess}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSAgentRuntimeAccessContent
+            correlation={agentRuntimeAccess}
+            loading={agentRuntimeAccessLoading}
+            error={agentRuntimeAccessError}
+            onRetry={loadAgentRuntimeAccess}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
Closes #1520.

## Summary

Wave 5.08 adds the **agent runtime / tool-call access correlation** — the agent analogue of the Secrets/KMS (#1518) and S3 (#1519) correlations. It joins **observed** agent `agent-tool` runtime events with the static **AI-agent inventory** Identrail already discovered (#1512: declared agents, backing runtime role, declared tools), so operators can prove what agents actually did versus what the inventory declares.

Both blockers (#1513, #1512) are closed.

## What it does

Per `(agent, tool)` pair:

| Status | Meaning |
|---|---|
| `confirmed` | Agent + tool declared in the inventory **and** a tool-call observed |
| `observed_without_declaration` | Shadow agent (not in inventory) or undeclared tool |
| `declared_unused` | Declared tool never observed in the window |

On top of the join it flags **`observed_backing_role_differs_from_declared`** (the agent ran under a different role than the inventory declares — privilege drift) and **`observed_tool_call_failed`**, and carries the standard data-event coverage caveat.

## Safety

**Prompts, completions, tool inputs/outputs, browser pages, and code-interpreter output are never read.** Only metadata (agent, tool, backing role, target resource) crosses the boundary; every record stamps `metadata_only_no_prompts_no_completions_no_tool_payloads`. A key correctness nuance: when the inventory is unavailable in live mode, observed tool-calls get a neutral `agent_inventory_unavailable_for_confirmation` caveat rather than being mislabeled as shadow agents.

## Changes

- **Engine** `internal/runtime/agentaccess` — pure correlation join with shadow/undeclared/backing-role/outcome logic (13 unit tests).
- **API** `GET /v1/.../aws/agent-runtime-access` — queryable timeline filterable by identity (backing role), agent, tool, resource, outcome, account, region, status; `ready`/`degraded`/`blocked` states, coverage gaps, diagnostics, graph relationships. Live mode composes runtime-events (defaulting to CloudTrail delivery channels) + agent inventory; fixtures cover all states (11 API tests).
- **Route policy registry + OpenAPI v1 spec** updated (path, schemas, scope headers).
- **Web** — TypeScript client types + `getAWSProjectAgentRuntimeAccess`, and a correlation panel on the AWS runtime page with loading / empty / error / degraded / permission-denied states.
- **Docs** `docs/aws-agent-runtime-access.md` + CHANGELOG.

## Testing

- `make fmt-check`, `make vet` — clean
- `go test ./...` — all 48 packages pass
- `make api-example-contract-check`, `make web-route-integrity-check` — pass
- `npm run build --prefix web`, `npm run test:ci --prefix web` (426 tests) — pass

## AI Disclosure

- AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS agent runtime/tool-call access correlation per #1520, joining observed agent–tool events with the agent inventory so operators can verify declared vs actual behavior. Metadata-only (no prompts, completions, or tool payloads) and no new AWS permissions.

- New Features
  - Correlation engine in `internal/runtime/agentaccess` classifies each (agent, tool) as `confirmed`, `observed_without_declaration`, or `declared_unused`, with caveats like `observed_backing_role_differs_from_declared` and `observed_tool_call_failed`; now also emits declared role edges for `declared_unused` tools.
  - API `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-runtime-access` with filters (role, agent, tool, resource, outcome, account, region, status), `ready`/`degraded`/`blocked` states, coverage gaps, diagnostics, evidence links, and graph relationships; OpenAPI and route policy updated.
  - Web: adds client types and `getAWSProjectAgentRuntimeAccess`, plus a correlation panel on the AWS runtime page with loading/empty/error/degraded/permission-denied states.
  - Docs (`docs/aws-agent-runtime-access.md`) and tests for the engine and API.

<sup>Written for commit 724b0af83737efd6f0054411a064aad4741ce8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

