### PR TITLE
AWS Platform Wave 6.01: Blast radius intelligence engine

### DIFF
--- a/docs/aws-blast-radius-engine.md
+++ b/docs/aws-blast-radius-engine.md
@@ -1,0 +1,67 @@
+# AWS Blast Radius Intelligence Engine
+
+Issue: #1521
+
+The AWS blast radius engine ranks identity-centric AWS exposure by composing existing deterministic signals:
+
+- Secrets Manager / KMS runtime access correlation
+- S3 runtime access correlation
+- AI agent runtime / tool-call correlation
+- Static reachability and graph node identifiers projected by those engines
+
+The API is available at:
+
+```text
+GET /v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius
+```
+
+It returns an `intelligence` envelope with:
+
+- stable `finding_id` values
+- `calculation_version`
+- severity, score, confidence, status, and rationale
+- impacted graph path and impacted node ids
+- sensitive nodes, cross-account edges, runtime actions, and agent/tool paths
+- metadata-only evidence references
+- read-only remediation case previews
+- diagnostics, coverage gaps, failure reasons, and remediation hints
+
+## Scoring
+
+The first calculation version is `aws-blast-radius-engine-v1`.
+
+Scores are deterministic and intentionally conservative:
+
+- Secret/KMS runtime access starts high because it reaches sensitive material.
+- S3 access is raised by high sensitivity, external exposure, cross-account reachability, and observed-without-grant evidence.
+- Agent/tool paths are raised for undeclared runtime behavior, backing-role mismatches, and other correlation caveats.
+- Unknown or unavailable runtime evidence lowers status/confidence. It does not upgrade severity.
+
+Findings are sorted by descending score, then stable finding id.
+
+## Evidence Boundaries
+
+The engine only exposes metadata:
+
+- ARNs and graph node ids
+- event/correlation references
+- action names and status codes
+- confidence and timestamps
+
+It does not expose secret values, object keys, prompts, completions, tool payloads, browser pages, or code-interpreter output.
+
+## Failure States
+
+The engine supports the same deterministic states as the prerequisite AWS wave surfaces:
+
+- `success`
+- `empty`
+- `degraded`
+- `partial_failure`
+- `permission_denied`
+
+Blocked evidence returns explicit diagnostics and coverage gaps. Empty evidence returns a degraded result with zero findings rather than fabricating safe conclusions.
+
+## App Surface
+
+The AWS runtime operations page renders blast radius intelligence below the source correlation tables. Operators can see severity, score, identity, impacted path, evidence confidence, next action, caveats, and permission/degraded states.

--- a/docs/aws-risk-engine.md
+++ b/docs/aws-risk-engine.md
@@ -11,11 +11,13 @@ The AWS risk engine evaluates normalized identities and graph relationships to p
 - `escalation_path`
 - `stale_identity`
 - `ownerless_identity`
+- `aws-blast-radius:*` intelligence records from the AWS blast radius engine
 
 ## Rule Inputs
 
 - Normalized identities from the AWS normalizer
 - Relationship edges from the graph builder (`can_assume`, `can_access`, `attached_policy`)
+- AWS runtime correlation surfaces for Secrets Manager / KMS, S3, and agent/tool paths
 
 ## Detection Logic (v1)
 
@@ -31,6 +33,11 @@ The AWS risk engine evaluates normalized identities and graph relationships to p
 - Severity ordering is stable (`critical` -> `high` -> `medium` ...)
 - Evidence-first findings with machine-readable context and clear remediation text
 - Encoded access nodes to avoid ARN delimiter parsing issues
+- Unknown runtime evidence lowers confidence instead of becoming deterministic truth
+
+## Blast Radius Intelligence
+
+The Wave 6.01 blast-radius engine is documented in [aws-blast-radius-engine.md](aws-blast-radius-engine.md). It composes existing AWS runtime and reachability signals into ranked, explainable identity findings with impacted paths, evidence references, confidence, calculation version, and read-only remediation previews.
 
 ## Tunables
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -569,6 +569,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4889,6 +4894,84 @@ paths:
                     $ref: "#/components/schemas/AWSAgentRuntimeAccessResult"
         "400":
           description: Invalid AWS agent runtime access request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS blast radius intelligence
+      operationId: getAWSProjectBlastRadius
+      description: Calculates ranked, explainable AWS blast-radius intelligence by composing metadata-only runtime access, sensitive resource reachability, cross-account edges, and agent/tool paths. Findings carry stable IDs, calculation version, score, severity, confidence, rationale, impacted graph path, evidence refs, and read-only remediation previews. Unknown evidence lowers confidence and never upgrades severity; secret values, object contents, prompts, completions, tool payloads, browser pages, and code-interpreter output are never read or returned.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional principal, identity-node, or display-name search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional impacted resource or graph-node search.
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: risk_type
+          schema: { type: string }
+          description: Optional blast-radius risk type token.
+      responses:
+        "200":
+          description: AWS blast radius intelligence contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  intelligence:
+                    $ref: "#/components/schemas/AWSBlastRadiusResult"
+        "400":
+          description: Invalid AWS blast radius request
           content:
             application/json:
               schema:
@@ -11710,6 +11793,211 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAgentRuntimeAccessDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSBlastRadiusEvidence:
+      type: object
+      properties:
+        source: { type: string }
+        evidence_ref: { type: string }
+        label: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_at:
+          type: string
+          format: date-time
+        relationship: { type: string }
+    AWSBlastRadiusPathStep:
+      type: object
+      properties:
+        node_id: { type: string }
+        node_type: { type: string }
+        label: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+    AWSBlastRadiusRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSBlastRadiusRemediationCasePreview:
+      type: object
+      properties:
+        case_id: { type: string }
+        title: { type: string }
+        recommended_action: { type: string }
+        approval_required: { type: boolean }
+        blocking_evidence:
+          type: array
+          items: { type: string }
+        impacted_node_count: { type: integer }
+        estimated_risk_drop: { type: integer }
+        read_only_projection: { type: boolean }
+    AWSBlastRadiusFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        risk_type: { type: string }
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        display_name: { type: string }
+        rationale: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusPathStep"
+        sensitive_nodes:
+          type: array
+          items: { type: string }
+        cross_account_edges:
+          type: array
+          items: { type: string }
+        runtime_actions:
+          type: array
+          items: { type: string }
+        agent_tool_paths:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSBlastRadiusRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSBlastRadiusSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        risk_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        critical_count: { type: integer }
+        high_count: { type: integer }
+        sensitive_node_count: { type: integer }
+        cross_account_edge_count: { type: integer }
+        runtime_action_count: { type: integer }
+        agent_tool_path_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+    AWSBlastRadiusDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSBlastRadiusCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSBlastRadiusResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSBlastRadiusSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSBlastRadiusDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -757,6 +757,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_blast_radius.go
+++ b/internal/api/aws_blast_radius.go
@@ -545,12 +545,20 @@ func filterAWSBlastRadiusFindings(findings []AWSBlastRadiusFinding, request AWSB
 		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName) {
 			continue
 		}
-		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], append(append([]string{}, finding.ImpactedNodes...), finding.SensitiveNodes...)...) {
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], awsBlastRadiusResourceMatchValues(finding)...) {
 			continue
 		}
 		filtered = append(filtered, finding)
 	}
 	return filtered, applied
+}
+
+func awsBlastRadiusResourceMatchValues(finding AWSBlastRadiusFinding) []string {
+	candidates := append(append([]string{}, finding.ImpactedNodes...), finding.SensitiveNodes...)
+	for _, step := range finding.ImpactedPath {
+		candidates = append(candidates, step.NodeID, step.Label)
+	}
+	return dedupeStrings(candidates)
 }
 
 func awsBlastRadiusRelationships(findings []AWSBlastRadiusFinding) []AWSBlastRadiusRelationship {

--- a/internal/api/aws_blast_radius.go
+++ b/internal/api/aws_blast_radius.go
@@ -232,7 +232,7 @@ func (s *Service) GetAWSBlastRadius(ctx context.Context, workspaceID string, pro
 		CurrentIssueRef:    awsIssueRef(awsBlastRadiusCurrentIssue),
 		Version:            awsBlastRadiusVersion,
 		Status:             status,
-		FixtureState:       fixtureState,
+		FixtureState:       sourceFixtureState,
 		Confidence:         confidence,
 		CalculationVersion: awsBlastRadiusVersion,
 		AppliedFilters:     applied,

--- a/internal/api/aws_blast_radius.go
+++ b/internal/api/aws_blast_radius.go
@@ -413,9 +413,13 @@ func awsBlastRadiusFindingFromS3(record AWSS3RuntimeAccessRecord, now time.Time)
 }
 
 func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time.Time) AWSBlastRadiusFinding {
-	roleNode := firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode, record.AgentNodeID)
+	roleNodes := dedupeStrings(append(append([]string{}, record.BackingRoleNodeIDs...), record.DeclaredBackingRoleNode))
+	if len(roleNodes) == 0 {
+		roleNodes = dedupeStrings([]string{record.AgentNodeID})
+	}
+	roleNode := firstNonEmptyAWSValue(firstString(roleNodes), record.AgentNodeID)
 	roleARN := firstNonEmptyAWSValue(firstString(record.BackingRoleARNs), record.DeclaredBackingRole)
-	targetNode := firstNonEmptyAWSValue(firstString(record.TargetResourceNodeIDs), firstString(record.TargetResourceARNs))
+	targetSteps := awsBlastRadiusAgentTargetSteps(record.TargetResourceNodeIDs, record.TargetResourceARNs, record.AccountID, record.Region)
 	score := 52
 	severity := "medium"
 	riskType := "agent-tool-path"
@@ -439,6 +443,7 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 	}
 	score = clampBlastRadiusScore(score)
 	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("agent-runtime-access://%s", record.CorrelationID))
+	impactedNodes := dedupeStrings(append(append(roleNodes, record.AgentNodeID), append(record.TargetResourceNodeIDs, record.TargetResourceARNs...)...))
 	return AWSBlastRadiusFinding{
 		FindingID:          "aws-blast-radius:" + record.CorrelationID,
 		CalculationVersion: awsBlastRadiusVersion,
@@ -452,12 +457,18 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 		IdentityNodeID:     roleNode,
 		PrincipalARN:       roleARN,
 		DisplayName:        firstNonEmptyAWSValue(record.AgentName, record.AgentID, shortAWSARN(roleARN), roleNode),
-		Rationale:          fmt.Sprintf("Agent %q tool %q is %s and expands the identity path to %d target node(s).", firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), firstNonEmptyAWSValue(record.ToolName, "unknown-tool"), record.Status, len(record.TargetResourceNodeIDs)),
-		ImpactedNodes:      dedupeStrings(append([]string{roleNode, record.AgentNodeID}, append(record.TargetResourceNodeIDs, record.TargetResourceARNs...)...)),
-		ImpactedPath: append([]AWSBlastRadiusPathStep{
-			{NodeID: roleNode, NodeType: "identity", Label: firstNonEmptyAWSValue(shortAWSARN(roleARN), roleNode), AccountID: record.AccountID, Region: record.Region},
-			{NodeID: record.AgentNodeID, NodeType: "ai_agent", Label: firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), AccountID: record.AccountID, Region: record.Region},
-		}, awsBlastRadiusAgentTargetSteps(targetNode, firstNonEmptyAWSValue(firstString(record.TargetResourceARNs), targetNode), record.AccountID, record.Region)...),
+		Rationale:          fmt.Sprintf("Agent %q tool %q is %s and expands the identity path to %d target node(s).", firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), firstNonEmptyAWSValue(record.ToolName, "unknown-tool"), record.Status, len(targetSteps)),
+		ImpactedNodes:      impactedNodes,
+		ImpactedPath: awsBlastRadiusAgentIdentityRolePath(
+			roleNodes,
+			targetSteps,
+			firstNonEmptyAWSValue(shortAWSARN(roleARN), record.AgentNodeID),
+			record.AgentNodeID,
+			record.AgentName,
+			record.AgentID,
+			record.AccountID,
+			record.Region,
+		),
 		RuntimeActions: dedupeStrings(record.Outcomes),
 		AgentToolPaths: dedupeStrings([]string{
 			strings.TrimSpace(record.AgentNodeID + " -> " + firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef)),
@@ -470,18 +481,53 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 	}
 }
 
-func awsBlastRadiusAgentTargetSteps(targetNode string, targetLabel string, accountID string, region string) []AWSBlastRadiusPathStep {
-	targetNode = strings.TrimSpace(targetNode)
-	if targetNode == "" {
+func awsBlastRadiusAgentTargetSteps(targetResourceNodeIDs []string, targetResourceARNs []string, accountID string, region string) []AWSBlastRadiusPathStep {
+	targetSteps := dedupeStrings(append(append([]string{}, targetResourceNodeIDs...), targetResourceARNs...))
+	if len(targetSteps) == 0 {
 		return nil
 	}
-	return []AWSBlastRadiusPathStep{{
-		NodeID:    targetNode,
-		NodeType:  "target_resource",
-		Label:     targetLabel,
+	steps := make([]AWSBlastRadiusPathStep, 0, len(targetSteps))
+	for _, targetNode := range targetSteps {
+		steps = append(steps, AWSBlastRadiusPathStep{
+			NodeID:    targetNode,
+			NodeType:  "target_resource",
+			Label:     strings.TrimSpace(targetNode),
+			AccountID: strings.TrimSpace(accountID),
+			Region:    strings.TrimSpace(region),
+		})
+	}
+	return steps
+}
+
+func awsBlastRadiusAgentIdentityRolePath(roleNodes []string, targetSteps []AWSBlastRadiusPathStep, roleLabel string, agentNodeID string, agentName string, agentID string, accountID string, region string) []AWSBlastRadiusPathStep {
+	if len(roleNodes) == 0 {
+		return nil
+	}
+	agentStep := AWSBlastRadiusPathStep{
+		NodeID:    agentNodeID,
+		NodeType:  "ai_agent",
+		Label:     firstNonEmptyAWSValue(agentName, agentID, agentNodeID),
 		AccountID: strings.TrimSpace(accountID),
 		Region:    strings.TrimSpace(region),
-	}}
+	}
+	paths := make([]AWSBlastRadiusPathStep, 0, len(roleNodes)*(len(targetSteps)+1))
+	for _, roleNode := range roleNodes {
+		paths = append(paths, AWSBlastRadiusPathStep{
+			NodeID:    roleNode,
+			NodeType:  "identity",
+			Label:     firstNonEmptyAWSValue(shortAWSARN(roleNode), roleLabel),
+			AccountID: strings.TrimSpace(accountID),
+			Region:    strings.TrimSpace(region),
+		})
+		if len(targetSteps) == 0 {
+			paths = append(paths, agentStep)
+			continue
+		}
+		for _, targetStep := range targetSteps {
+			paths = append(paths, agentStep, targetStep)
+		}
+	}
+	return paths
 }
 
 func awsBlastRadiusFindingStatus(sourceStatus string) string {
@@ -556,7 +602,7 @@ func filterAWSBlastRadiusFindings(findings []AWSBlastRadiusFinding, request AWSB
 		if filters["risk_type"] != "" && filters["risk_type"] != normalizeAWSRuntimeEventFilterToken(finding.RiskType) {
 			continue
 		}
-		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName) {
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], awsBlastRadiusIdentityMatchValues(finding)...) {
 			continue
 		}
 		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], awsBlastRadiusResourceMatchValues(finding)...) {
@@ -575,13 +621,30 @@ func awsBlastRadiusResourceMatchValues(finding AWSBlastRadiusFinding) []string {
 	return dedupeStrings(candidates)
 }
 
+func awsBlastRadiusIdentityMatchValues(finding AWSBlastRadiusFinding) []string {
+	candidates := []string{finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName}
+	for _, step := range finding.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			candidates = append(candidates, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(candidates)
+}
+
 func awsBlastRadiusRelationships(findings []AWSBlastRadiusFinding) []AWSBlastRadiusRelationship {
 	relationships := []AWSBlastRadiusRelationship{}
 	for _, finding := range findings {
 		for i := 0; i+1 < len(finding.ImpactedPath); i++ {
-			from := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
-			to := strings.TrimSpace(finding.ImpactedPath[i+1].NodeID)
+			fromNode := finding.ImpactedPath[i]
+			toNode := finding.ImpactedPath[i+1]
+			from := strings.TrimSpace(fromNode.NodeID)
+			to := strings.TrimSpace(toNode.NodeID)
 			if from == "" || to == "" {
+				continue
+			}
+			fromType := strings.TrimSpace(fromNode.NodeType)
+			toType := strings.TrimSpace(toNode.NodeType)
+			if !awsBlastRadiusAllowsPathTransition(finding.RiskType, fromType, toType) {
 				continue
 			}
 			relationships = append(relationships, AWSBlastRadiusRelationship{
@@ -607,6 +670,15 @@ func awsBlastRadiusRelationships(findings []AWSBlastRadiusFinding) []AWSBlastRad
 		}
 	}
 	return relationships
+}
+
+func awsBlastRadiusAllowsPathTransition(findingType string, fromType string, toType string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(findingType) {
+	case "agent-tool-path", "agent-tool-path-with-caveats", "undeclared-agent-tool-path", "unused-agent-tool-path":
+		return (fromType == "identity" && toType == "ai_agent") || (fromType == "ai_agent" && toType == "target_resource")
+	default:
+		return true
+	}
 }
 
 func summarizeAWSBlastRadius(allFindings []AWSBlastRadiusFinding, filtered []AWSBlastRadiusFinding, relationships []AWSBlastRadiusRelationship) AWSBlastRadiusSummary {

--- a/internal/api/aws_blast_radius.go
+++ b/internal/api/aws_blast_radius.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"github.com/identrail/identrail/internal/runtime/agentaccess"
 	"sort"
 	"strings"
 	"time"
@@ -414,7 +415,7 @@ func awsBlastRadiusFindingFromS3(record AWSS3RuntimeAccessRecord, now time.Time)
 func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time.Time) AWSBlastRadiusFinding {
 	roleNode := firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode, record.AgentNodeID)
 	roleARN := firstNonEmptyAWSValue(firstString(record.BackingRoleARNs), record.DeclaredBackingRole)
-	targetNode := firstNonEmptyAWSValue(firstString(record.TargetResourceNodeIDs), firstString(record.TargetResourceARNs), record.AgentNodeID)
+	targetNode := firstNonEmptyAWSValue(firstString(record.TargetResourceNodeIDs), firstString(record.TargetResourceARNs))
 	score := 52
 	severity := "medium"
 	riskType := "agent-tool-path"
@@ -433,7 +434,7 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 			riskType = "agent-tool-path-with-caveats"
 		}
 	}
-	if awsStringSliceContains(record.Caveats, "backing_role_mismatch") {
+	if awsStringSliceContains(record.Caveats, agentaccess.CaveatBackingRoleMismatch) {
 		score += 8
 	}
 	score = clampBlastRadiusScore(score)
@@ -453,11 +454,10 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 		DisplayName:        firstNonEmptyAWSValue(record.AgentName, record.AgentID, shortAWSARN(roleARN), roleNode),
 		Rationale:          fmt.Sprintf("Agent %q tool %q is %s and expands the identity path to %d target node(s).", firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), firstNonEmptyAWSValue(record.ToolName, "unknown-tool"), record.Status, len(record.TargetResourceNodeIDs)),
 		ImpactedNodes:      dedupeStrings(append([]string{roleNode, record.AgentNodeID}, append(record.TargetResourceNodeIDs, record.TargetResourceARNs...)...)),
-		ImpactedPath: []AWSBlastRadiusPathStep{
+		ImpactedPath: append([]AWSBlastRadiusPathStep{
 			{NodeID: roleNode, NodeType: "identity", Label: firstNonEmptyAWSValue(shortAWSARN(roleARN), roleNode), AccountID: record.AccountID, Region: record.Region},
 			{NodeID: record.AgentNodeID, NodeType: "ai_agent", Label: firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), AccountID: record.AccountID, Region: record.Region},
-			{NodeID: targetNode, NodeType: "target_resource", Label: firstNonEmptyAWSValue(firstString(record.TargetResourceARNs), targetNode), AccountID: record.AccountID, Region: record.Region},
-		},
+		}, awsBlastRadiusAgentTargetSteps(targetNode, firstNonEmptyAWSValue(firstString(record.TargetResourceARNs), targetNode), record.AccountID, record.Region)...),
 		RuntimeActions: dedupeStrings(record.Outcomes),
 		AgentToolPaths: dedupeStrings([]string{
 			strings.TrimSpace(record.AgentNodeID + " -> " + firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef)),
@@ -468,6 +468,20 @@ func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
+}
+
+func awsBlastRadiusAgentTargetSteps(targetNode string, targetLabel string, accountID string, region string) []AWSBlastRadiusPathStep {
+	targetNode = strings.TrimSpace(targetNode)
+	if targetNode == "" {
+		return nil
+	}
+	return []AWSBlastRadiusPathStep{{
+		NodeID:    targetNode,
+		NodeType:  "target_resource",
+		Label:     targetLabel,
+		AccountID: strings.TrimSpace(accountID),
+		Region:    strings.TrimSpace(region),
+	}}
 }
 
 func awsBlastRadiusFindingStatus(sourceStatus string) string {

--- a/internal/api/aws_blast_radius.go
+++ b/internal/api/aws_blast_radius.go
@@ -1,0 +1,791 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsBlastRadiusCurrentIssue = 1521
+	awsBlastRadiusVersion      = "aws-blast-radius-engine-v1"
+)
+
+// AWSBlastRadiusRequest scopes the blast-radius calculation to an AWS
+// connector and optional drill-down filters. Empty fixture_state attempts live
+// evidence when available; explicit fixture_state keeps tests and demos
+// deterministic.
+type AWSBlastRadiusRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+	RiskType     string `json:"risk_type,omitempty"`
+}
+
+// AWSBlastRadiusEvidence is a metadata-only pointer to source evidence. It
+// intentionally carries no secret values, prompt text, completion text, or tool
+// payloads.
+type AWSBlastRadiusEvidence struct {
+	Source       string    `json:"source"`
+	EvidenceRef  string    `json:"evidence_ref"`
+	Label        string    `json:"label"`
+	Confidence   float64   `json:"confidence"`
+	ObservedAt   time.Time `json:"observed_at,omitzero"`
+	Relationship string    `json:"relationship,omitempty"`
+}
+
+// AWSBlastRadiusPathStep is one explainable graph node in an impacted path.
+type AWSBlastRadiusPathStep struct {
+	NodeID    string `json:"node_id"`
+	NodeType  string `json:"node_type"`
+	Label     string `json:"label"`
+	AccountID string `json:"account_id,omitempty"`
+	Region    string `json:"region,omitempty"`
+}
+
+// AWSBlastRadiusRelationship is an edge the graph view can join against.
+type AWSBlastRadiusRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSBlastRadiusRemediationCasePreview is the read-only planning shape the app
+// can use to start a remediation case without mutating server state.
+type AWSBlastRadiusRemediationCasePreview struct {
+	CaseID             string   `json:"case_id"`
+	Title              string   `json:"title"`
+	RecommendedAction  string   `json:"recommended_action"`
+	ApprovalRequired   bool     `json:"approval_required"`
+	BlockingEvidence   []string `json:"blocking_evidence,omitempty"`
+	ImpactedNodeCount  int      `json:"impacted_node_count"`
+	EstimatedRiskDrop  int      `json:"estimated_risk_drop"`
+	ReadOnlyProjection bool     `json:"read_only_projection"`
+}
+
+// AWSBlastRadiusFinding is a persisted-record-shaped intelligence result. The
+// API owns stable IDs, versioning, score/rationale, evidence, impacted graph
+// nodes, and a remediation preview so findings, graph, and remediation surfaces
+// can consume the same contract.
+type AWSBlastRadiusFinding struct {
+	FindingID          string                               `json:"finding_id"`
+	CalculationVersion string                               `json:"calculation_version"`
+	RiskType           string                               `json:"risk_type"`
+	Severity           string                               `json:"severity"`
+	Status             string                               `json:"status"`
+	Score              int                                  `json:"score"`
+	Confidence         float64                              `json:"confidence"`
+	AccountID          string                               `json:"account_id"`
+	Region             string                               `json:"region"`
+	IdentityNodeID     string                               `json:"identity_node_id"`
+	PrincipalARN       string                               `json:"principal_arn,omitempty"`
+	DisplayName        string                               `json:"display_name"`
+	Rationale          string                               `json:"rationale"`
+	ImpactedNodes      []string                             `json:"impacted_nodes"`
+	ImpactedPath       []AWSBlastRadiusPathStep             `json:"impacted_path"`
+	SensitiveNodes     []string                             `json:"sensitive_nodes,omitempty"`
+	CrossAccountEdges  []string                             `json:"cross_account_edges,omitempty"`
+	RuntimeActions     []string                             `json:"runtime_actions,omitempty"`
+	AgentToolPaths     []string                             `json:"agent_tool_paths,omitempty"`
+	Evidence           []AWSBlastRadiusEvidence             `json:"evidence"`
+	NextAction         string                               `json:"next_action"`
+	RemediationCase    AWSBlastRadiusRemediationCasePreview `json:"remediation_case"`
+	CreatedAt          time.Time                            `json:"created_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// AWSBlastRadiusSummary aggregates the unfiltered and filtered finding set.
+type AWSBlastRadiusSummary struct {
+	TotalFindings           int            `json:"total_findings"`
+	FilteredFindings        int            `json:"filtered_findings"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	RiskTypeCounts          map[string]int `json:"risk_type_counts"`
+	CriticalCount           int            `json:"critical_count"`
+	HighCount               int            `json:"high_count"`
+	SensitiveNodeCount      int            `json:"sensitive_node_count"`
+	CrossAccountEdgeCount   int            `json:"cross_account_edge_count"`
+	RuntimeActionCount      int            `json:"runtime_action_count"`
+	AgentToolPathCount      int            `json:"agent_tool_path_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+	RemediationPreviewCount int            `json:"remediation_preview_count"`
+}
+
+// AWSBlastRadiusDiagnostic reports source calculation failures.
+type AWSBlastRadiusDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSBlastRadiusCoverageGap names missing or degraded evidence.
+type AWSBlastRadiusCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSBlastRadiusResult is the deterministic blast-radius intelligence envelope.
+type AWSBlastRadiusResult struct {
+	TenantID           string                       `json:"tenant_id"`
+	WorkspaceID        string                       `json:"workspace_id"`
+	ProjectID          string                       `json:"project_id"`
+	ConnectorID        string                       `json:"connector_id,omitempty"`
+	AccountID          string                       `json:"account_id,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	ParentIssueNumber  int                          `json:"parent_issue_number"`
+	ParentIssueRef     string                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                          `json:"current_issue_number"`
+	CurrentIssueRef    string                       `json:"current_issue_ref"`
+	Version            string                       `json:"version"`
+	Status             string                       `json:"status"`
+	FixtureState       string                       `json:"fixture_state,omitempty"`
+	Confidence         float64                      `json:"confidence"`
+	CalculationVersion string                       `json:"calculation_version"`
+	AppliedFilters     map[string]string            `json:"applied_filters"`
+	Summary            AWSBlastRadiusSummary        `json:"summary"`
+	Findings           []AWSBlastRadiusFinding      `json:"findings"`
+	Relationships      []AWSBlastRadiusRelationship `json:"relationships"`
+	Caveats            []string                     `json:"caveats"`
+	FailureReasons     []string                     `json:"failure_reasons"`
+	RemediationHints   []string                     `json:"remediation_hints"`
+	EvidenceLinks      []string                     `json:"evidence_links"`
+	CoverageGaps       []AWSBlastRadiusCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSBlastRadiusDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	UpdatedAt          time.Time                    `json:"updated_at"`
+}
+
+// GetAWSBlastRadius calculates ranked blast-radius intelligence from existing
+// inventory, static reachability, runtime access, and agent/tool correlation
+// sources. It preserves uncertainty: absent evidence degrades confidence instead
+// of becoming deterministic truth.
+func (s *Service) GetAWSBlastRadius(ctx context.Context, workspaceID string, projectID string, request AWSBlastRadiusRequest) (AWSBlastRadiusResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSBlastRadiusResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSBlastRadiusResult{}, err
+	}
+	now := s.Now().UTC()
+
+	fixtureState := normalizeAWSBlastRadiusFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSBlastRadiusResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	secrets, s3, agents, err := s.awsBlastRadiusSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSBlastRadiusResult{}, err
+	}
+
+	findings := awsBlastRadiusFindings(secrets, s3, agents, now)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSBlastRadiusFindings(findings, request)
+	relationships := awsBlastRadiusRelationships(filtered)
+	diagnostics := awsBlastRadiusDiagnostics(secrets, s3, agents)
+	coverageGaps := awsBlastRadiusCoverageGaps(secrets, s3, agents)
+	status, confidence := summarizeAWSBlastRadiusStatus([]string{secrets.Status, s3.Status, agents.Status}, filtered, diagnostics)
+	summary := summarizeAWSBlastRadius(findings, filtered, relationships)
+
+	return AWSBlastRadiusResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsBlastRadiusCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsBlastRadiusCurrentIssue),
+		Version:            awsBlastRadiusVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsBlastRadiusVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsBlastRadiusCaveats(secrets, s3, agents),
+		FailureReasons:     awsBlastRadiusFailureReasons(secrets, s3, agents),
+		RemediationHints:   awsBlastRadiusRemediationHints(secrets, s3, agents),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsBlastRadiusCurrentIssue),
+			awsIssueURL(awsSecretsKMSRuntimeAccessCurrentIssue),
+			awsIssueURL(awsS3RuntimeAccessCurrentIssue),
+			awsIssueURL(awsAgentRuntimeAccessCurrentIssue),
+			"/docs/aws-blast-radius-engine",
+			"/docs/aws-risk-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSBlastRadiusFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsBlastRadiusSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (AWSSecretsKMSRuntimeAccessResult, AWSS3RuntimeAccessResult, AWSAgentRuntimeAccessResult, error) {
+	secrets, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, fmt.Errorf("calculate secrets/kms blast radius: %w", err)
+	}
+	s3, err := s.GetAWSS3RuntimeAccess(ctx, workspaceID, projectID, AWSS3RuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, fmt.Errorf("calculate s3 blast radius: %w", err)
+	}
+	agents, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, fmt.Errorf("calculate agent blast radius: %w", err)
+	}
+	return secrets, s3, agents, nil
+}
+
+func awsBlastRadiusFindings(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, now time.Time) []AWSBlastRadiusFinding {
+	findings := []AWSBlastRadiusFinding{}
+	for _, record := range secrets.Records {
+		findings = append(findings, awsBlastRadiusFindingFromSecret(record, now))
+	}
+	for _, record := range s3.Records {
+		findings = append(findings, awsBlastRadiusFindingFromS3(record, now))
+	}
+	for _, record := range agents.Records {
+		findings = append(findings, awsBlastRadiusFindingFromAgent(record, now))
+	}
+	return findings
+}
+
+func awsBlastRadiusFindingFromSecret(record AWSSecretsKMSRuntimeAccessRecord, now time.Time) AWSBlastRadiusFinding {
+	resourceLabel := firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN, record.ResourceNodeID)
+	score := 68
+	riskType := "sensitive-secret-runtime-access"
+	severity := "high"
+	if record.CrossAccount {
+		score += 12
+		riskType = "cross-account-secret-runtime-access"
+		severity = "critical"
+	}
+	if record.Status == "observed_without_grant" {
+		score += 10
+	}
+	score = clampBlastRadiusScore(score)
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("secrets-kms-runtime-access://%s", record.CorrelationID))
+	return AWSBlastRadiusFinding{
+		FindingID:          "aws-blast-radius:" + record.CorrelationID,
+		CalculationVersion: awsBlastRadiusVersion,
+		RiskType:           riskType,
+		Severity:           severity,
+		Status:             awsBlastRadiusFindingStatus(record.Status),
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     record.IdentityNodeID,
+		PrincipalARN:       record.PrincipalARN,
+		DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID),
+		Rationale:          fmt.Sprintf("Identity can reach sensitive %s %q with %s runtime/static correlation.", record.ResourceKind, resourceLabel, record.Status),
+		ImpactedNodes:      dedupeStrings([]string{record.IdentityNodeID, record.ResourceNodeID, record.AgentNodeID}),
+		ImpactedPath: []AWSBlastRadiusPathStep{
+			{NodeID: record.IdentityNodeID, NodeType: "identity", Label: firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.ResourceNodeID, NodeType: record.ResourceKind, Label: resourceLabel, AccountID: record.AccountID, Region: record.Region},
+		},
+		SensitiveNodes:    dedupeStrings([]string{record.ResourceNodeID}),
+		CrossAccountEdges: crossAccountEdge(record.CrossAccount, record.IdentityNodeID, record.ResourceNodeID),
+		RuntimeActions:    dedupeStrings(record.Actions),
+		AgentToolPaths:    dedupeStrings([]string{record.AgentNodeID}),
+		Evidence:          []AWSBlastRadiusEvidence{{Source: "secrets_kms_runtime_access", EvidenceRef: evidenceRef, Label: "Secrets Manager / KMS runtime access", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:        "Validate owner-approved secret/KMS access, then remove unused grants or constrain runtime conditions before automation.",
+		RemediationCase:   awsBlastRadiusRemediationCase("secret-runtime-access", severity, score, record.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+func awsBlastRadiusFindingFromS3(record AWSS3RuntimeAccessRecord, now time.Time) AWSBlastRadiusFinding {
+	resourceLabel := firstNonEmptyAWSValue(record.BucketName, record.BucketARN, record.ResourceNodeID)
+	score := 58
+	riskType := "s3-runtime-access"
+	severity := "medium"
+	if normalizeAWSRuntimeEventFilterToken(record.Sensitivity) == "high" || normalizeAWSRuntimeEventFilterToken(record.Exposure) == "external" {
+		score += 18
+		severity = "high"
+		riskType = "sensitive-s3-runtime-access"
+	}
+	if record.CrossAccount {
+		score += 10
+		riskType = "cross-account-s3-runtime-access"
+	}
+	if record.Status == "observed_without_grant" {
+		score += 8
+	}
+	score = clampBlastRadiusScore(score)
+	if score >= 85 {
+		severity = "critical"
+	}
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("s3-runtime-access://%s", record.CorrelationID))
+	return AWSBlastRadiusFinding{
+		FindingID:          "aws-blast-radius:" + record.CorrelationID,
+		CalculationVersion: awsBlastRadiusVersion,
+		RiskType:           riskType,
+		Severity:           severity,
+		Status:             awsBlastRadiusFindingStatus(record.Status),
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     record.IdentityNodeID,
+		PrincipalARN:       record.PrincipalARN,
+		DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID),
+		Rationale:          fmt.Sprintf("Identity has %s S3 access to %q; sensitivity=%s exposure=%s status=%s.", strings.Join(record.ObservedModes, "/"), resourceLabel, firstNonEmptyAWSValue(record.Sensitivity, "unknown"), firstNonEmptyAWSValue(record.Exposure, "unknown"), record.Status),
+		ImpactedNodes:      dedupeStrings([]string{record.IdentityNodeID, record.ResourceNodeID, record.AgentNodeID}),
+		ImpactedPath: []AWSBlastRadiusPathStep{
+			{NodeID: record.IdentityNodeID, NodeType: "identity", Label: firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.ResourceNodeID, NodeType: "s3_bucket", Label: resourceLabel, AccountID: record.AccountID, Region: record.Region},
+		},
+		SensitiveNodes:    sensitiveS3Node(record),
+		CrossAccountEdges: crossAccountEdge(record.CrossAccount, record.IdentityNodeID, record.ResourceNodeID),
+		RuntimeActions:    dedupeStrings(append(append([]string{}, record.Actions...), record.ObservedModes...)),
+		AgentToolPaths:    dedupeStrings([]string{record.AgentNodeID}),
+		Evidence:          []AWSBlastRadiusEvidence{{Source: "s3_runtime_access", EvidenceRef: evidenceRef, Label: "S3 runtime access", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:        "Confirm the data owner and reduce bucket actions, prefixes, or cross-account grants before scheduling automated deny changes.",
+		RemediationCase:   awsBlastRadiusRemediationCase("s3-runtime-access", severity, score, record.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+func awsBlastRadiusFindingFromAgent(record AWSAgentRuntimeAccessRecord, now time.Time) AWSBlastRadiusFinding {
+	roleNode := firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode, record.AgentNodeID)
+	roleARN := firstNonEmptyAWSValue(firstString(record.BackingRoleARNs), record.DeclaredBackingRole)
+	targetNode := firstNonEmptyAWSValue(firstString(record.TargetResourceNodeIDs), firstString(record.TargetResourceARNs), record.AgentNodeID)
+	score := 52
+	severity := "medium"
+	riskType := "agent-tool-path"
+	switch normalizeAWSRuntimeEventFilterToken(record.Status) {
+	case "observed-without-declaration":
+		score = 78
+		severity = "high"
+		riskType = "undeclared-agent-tool-path"
+	case "declared-unused":
+		score = 46
+		riskType = "unused-agent-tool-path"
+	case "confirmed":
+		if len(record.Caveats) > 0 {
+			score = 64
+			severity = "high"
+			riskType = "agent-tool-path-with-caveats"
+		}
+	}
+	if awsStringSliceContains(record.Caveats, "backing_role_mismatch") {
+		score += 8
+	}
+	score = clampBlastRadiusScore(score)
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("agent-runtime-access://%s", record.CorrelationID))
+	return AWSBlastRadiusFinding{
+		FindingID:          "aws-blast-radius:" + record.CorrelationID,
+		CalculationVersion: awsBlastRadiusVersion,
+		RiskType:           riskType,
+		Severity:           severity,
+		Status:             awsBlastRadiusFindingStatus(record.Status),
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     roleNode,
+		PrincipalARN:       roleARN,
+		DisplayName:        firstNonEmptyAWSValue(record.AgentName, record.AgentID, shortAWSARN(roleARN), roleNode),
+		Rationale:          fmt.Sprintf("Agent %q tool %q is %s and expands the identity path to %d target node(s).", firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), firstNonEmptyAWSValue(record.ToolName, "unknown-tool"), record.Status, len(record.TargetResourceNodeIDs)),
+		ImpactedNodes:      dedupeStrings(append([]string{roleNode, record.AgentNodeID}, append(record.TargetResourceNodeIDs, record.TargetResourceARNs...)...)),
+		ImpactedPath: []AWSBlastRadiusPathStep{
+			{NodeID: roleNode, NodeType: "identity", Label: firstNonEmptyAWSValue(shortAWSARN(roleARN), roleNode), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.AgentNodeID, NodeType: "ai_agent", Label: firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: targetNode, NodeType: "target_resource", Label: firstNonEmptyAWSValue(firstString(record.TargetResourceARNs), targetNode), AccountID: record.AccountID, Region: record.Region},
+		},
+		RuntimeActions: dedupeStrings(record.Outcomes),
+		AgentToolPaths: dedupeStrings([]string{
+			strings.TrimSpace(record.AgentNodeID + " -> " + firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef)),
+		}),
+		Evidence:        []AWSBlastRadiusEvidence{{Source: "agent_runtime_access", EvidenceRef: evidenceRef, Label: "Agent runtime / tool path", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:      "Confirm whether the agent/tool path is expected, then remove undeclared tools or stale declarations before policy automation.",
+		RemediationCase: awsBlastRadiusRemediationCase("agent-tool-path", severity, score, roleNode, []string{evidenceRef}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func awsBlastRadiusFindingStatus(sourceStatus string) string {
+	switch normalizeAWSRuntimeEventFilterToken(sourceStatus) {
+	case "observed-without-grant", "observed-without-declaration":
+		return "action_required"
+	case "declared-unused", "granted-unused":
+		return "review"
+	case "confirmed":
+		return "monitor"
+	default:
+		return "review"
+	}
+}
+
+func awsBlastRadiusRemediationCase(kind, severity string, score int, identityNodeID string, evidence []string) AWSBlastRadiusRemediationCasePreview {
+	action := "Review owner approval and create a least-privilege remediation case."
+	switch kind {
+	case "secret-runtime-access":
+		action = "Create a case to remove stale secret/KMS grants or add scoped conditions."
+	case "s3-runtime-access":
+		action = "Create a case to reduce bucket actions, prefixes, or external account grants."
+	case "agent-tool-path":
+		action = "Create a case to remove undeclared/stale agent tool access after owner approval."
+	}
+	return AWSBlastRadiusRemediationCasePreview{
+		CaseID:             "aws-remediation-preview:" + stableAWSBlastRadiusToken(kind, identityNodeID),
+		Title:              fmt.Sprintf("%s blast-radius remediation", formatAWSBlastRadiusLabel(kind)),
+		RecommendedAction:  action,
+		ApprovalRequired:   severity == "critical" || severity == "high",
+		BlockingEvidence:   dedupeStrings(evidence),
+		ImpactedNodeCount:  1,
+		EstimatedRiskDrop:  minInt(score, 35),
+		ReadOnlyProjection: true,
+	}
+}
+
+func filterAWSBlastRadiusFindings(findings []AWSBlastRadiusFinding, request AWSBlastRadiusRequest) ([]AWSBlastRadiusFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"identity":   strings.TrimSpace(request.Identity),
+		"resource":   strings.TrimSpace(request.Resource),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+		"risk_type":  normalizeAWSRuntimeEventFilterToken(request.RiskType),
+	}
+	for key, value := range filters {
+		token := strings.TrimSpace(value)
+		if token == "" || strings.EqualFold(token, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSBlastRadiusFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && filters["account_id"] != finding.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(finding.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
+			continue
+		}
+		if filters["risk_type"] != "" && filters["risk_type"] != normalizeAWSRuntimeEventFilterToken(finding.RiskType) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], append(append([]string{}, finding.ImpactedNodes...), finding.SensitiveNodes...)...) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, applied
+}
+
+func awsBlastRadiusRelationships(findings []AWSBlastRadiusFinding) []AWSBlastRadiusRelationship {
+	relationships := []AWSBlastRadiusRelationship{}
+	for _, finding := range findings {
+		for i := 0; i+1 < len(finding.ImpactedPath); i++ {
+			from := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
+			to := strings.TrimSpace(finding.ImpactedPath[i+1].NodeID)
+			if from == "" || to == "" {
+				continue
+			}
+			relationships = append(relationships, AWSBlastRadiusRelationship{
+				FindingID:   finding.FindingID,
+				Type:        "blast_radius_path",
+				FromNodeID:  from,
+				ToNodeID:    to,
+				EvidenceRef: firstEvidenceRef(finding.Evidence),
+			})
+		}
+		for _, edge := range finding.CrossAccountEdges {
+			parts := strings.Split(edge, "->")
+			if len(parts) != 2 {
+				continue
+			}
+			relationships = append(relationships, AWSBlastRadiusRelationship{
+				FindingID:   finding.FindingID,
+				Type:        "cross_account_blast_radius",
+				FromNodeID:  strings.TrimSpace(parts[0]),
+				ToNodeID:    strings.TrimSpace(parts[1]),
+				EvidenceRef: firstEvidenceRef(finding.Evidence),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSBlastRadius(allFindings []AWSBlastRadiusFinding, filtered []AWSBlastRadiusFinding, relationships []AWSBlastRadiusRelationship) AWSBlastRadiusSummary {
+	severityCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	riskTypeCounts := map[string]int{}
+	sensitiveNodes := map[string]struct{}{}
+	crossAccountEdges := map[string]struct{}{}
+	totalRuntimeActions := 0
+	totalAgentPaths := 0
+	totalConfidence := 0.0
+	highest := 0
+	remediationCases := map[string]struct{}{}
+	for _, finding := range allFindings {
+		severityCounts[finding.Severity]++
+		statusCounts[finding.Status]++
+		riskTypeCounts[finding.RiskType]++
+		for _, node := range finding.SensitiveNodes {
+			sensitiveNodes[node] = struct{}{}
+		}
+		for _, edge := range finding.CrossAccountEdges {
+			crossAccountEdges[edge] = struct{}{}
+		}
+		totalRuntimeActions += len(finding.RuntimeActions)
+		totalAgentPaths += len(finding.AgentToolPaths)
+		totalConfidence += finding.Confidence
+		if finding.Score > highest {
+			highest = finding.Score
+		}
+		if finding.RemediationCase.CaseID != "" {
+			remediationCases[finding.RemediationCase.CaseID] = struct{}{}
+		}
+	}
+	averageConfidence := 0
+	if len(allFindings) > 0 {
+		averageConfidence = int((totalConfidence / float64(len(allFindings))) * 100)
+	}
+	return AWSBlastRadiusSummary{
+		TotalFindings:           len(allFindings),
+		FilteredFindings:        len(filtered),
+		SeverityCounts:          severityCounts,
+		StatusCounts:            statusCounts,
+		RiskTypeCounts:          riskTypeCounts,
+		CriticalCount:           severityCounts["critical"],
+		HighCount:               severityCounts["high"],
+		SensitiveNodeCount:      len(sensitiveNodes),
+		CrossAccountEdgeCount:   len(crossAccountEdges),
+		RuntimeActionCount:      totalRuntimeActions,
+		AgentToolPathCount:      totalAgentPaths,
+		RelationshipCount:       len(relationships),
+		HighestScore:            highest,
+		AverageConfidencePct:    averageConfidence,
+		RemediationPreviewCount: len(remediationCases),
+	}
+}
+
+func summarizeAWSBlastRadiusStatus(sourceStatuses []string, filtered []AWSBlastRadiusFinding, diagnostics []AWSBlastRadiusDiagnostic) (string, float64) {
+	allBlocked := len(sourceStatuses) > 0
+	anyDegraded := len(diagnostics) > 0
+	for _, status := range sourceStatuses {
+		switch status {
+		case awsPlatformDependencyStatusBlocked:
+			anyDegraded = true
+		case awsPlatformDependencyStatusDegraded:
+			allBlocked = false
+			anyDegraded = true
+		default:
+			allBlocked = false
+		}
+	}
+	if allBlocked {
+		return awsPlatformDependencyStatusBlocked, 0
+	}
+	if len(filtered) == 0 || anyDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.68
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsBlastRadiusDiagnostics(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult) []AWSBlastRadiusDiagnostic {
+	out := []AWSBlastRadiusDiagnostic{}
+	for _, diagnostic := range secrets.Diagnostics {
+		out = append(out, AWSBlastRadiusDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range s3.Diagnostics {
+		out = append(out, AWSBlastRadiusDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range agents.Diagnostics {
+		out = append(out, AWSBlastRadiusDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsBlastRadiusCoverageGaps(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult) []AWSBlastRadiusCoverageGap {
+	out := []AWSBlastRadiusCoverageGap{{
+		Capability:  "blast_radius_persistence",
+		Status:      "ready",
+		Reason:      "The API emits stable finding IDs, calculation version, evidence, impacted path, and remediation preview fields for downstream persistence/graph consumers.",
+		Remediation: "Persist these intelligence records into the shared findings store when the dedicated AWS findings table lands.",
+	}}
+	for _, gap := range secrets.CoverageGaps {
+		out = append(out, AWSBlastRadiusCoverageGap(gap))
+	}
+	for _, gap := range s3.CoverageGaps {
+		out = append(out, AWSBlastRadiusCoverageGap(gap))
+	}
+	for _, gap := range agents.CoverageGaps {
+		out = append(out, AWSBlastRadiusCoverageGap(gap))
+	}
+	return out
+}
+
+func awsBlastRadiusCaveats(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult) []string {
+	return dedupeStrings(append(append(secrets.Caveats, s3.Caveats...), append(agents.Caveats, "Unknown runtime evidence lowers confidence; it never upgrades severity by itself.")...))
+}
+
+func awsBlastRadiusFailureReasons(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult) []string {
+	return emptyStrings(dedupeStrings(append(append(secrets.FailureReasons, s3.FailureReasons...), agents.FailureReasons...)))
+}
+
+func awsBlastRadiusRemediationHints(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult) []string {
+	return emptyStrings(dedupeStrings(append(append(append(secrets.RemediationHints, s3.RemediationHints...), agents.RemediationHints...), "Use the remediation preview as a read-only plan until an owner approves policy changes.")))
+}
+
+func crossAccountEdge(enabled bool, from string, to string) []string {
+	if !enabled || strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" {
+		return nil
+	}
+	return []string{strings.TrimSpace(from) + " -> " + strings.TrimSpace(to)}
+}
+
+func sensitiveS3Node(record AWSS3RuntimeAccessRecord) []string {
+	if normalizeAWSRuntimeEventFilterToken(record.Sensitivity) == "high" || normalizeAWSRuntimeEventFilterToken(record.Exposure) == "external" {
+		return dedupeStrings([]string{record.ResourceNodeID})
+	}
+	return nil
+}
+
+func shortAWSARN(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(value, "/"); idx >= 0 && idx+1 < len(value) {
+		return value[idx+1:]
+	}
+	if idx := strings.LastIndex(value, ":"); idx >= 0 && idx+1 < len(value) {
+		return value[idx+1:]
+	}
+	return value
+}
+
+func firstString(values []string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func firstEvidenceRef(evidence []AWSBlastRadiusEvidence) string {
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}
+
+func awsStringSliceContains(values []string, want string) bool {
+	want = normalizeAWSRuntimeEventFilterToken(want)
+	for _, value := range values {
+		if normalizeAWSRuntimeEventFilterToken(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stableAWSBlastRadiusToken(parts ...string) string {
+	return strings.ReplaceAll(strings.Trim(strings.ToLower(strings.Join(parts, "-")), "-"), " ", "-")
+}
+
+func formatAWSBlastRadiusLabel(token string) string {
+	return strings.ReplaceAll(strings.TrimSpace(token), "-", " ")
+}
+
+func clampBlastRadiusScore(score int) int {
+	if score < 0 {
+		return 0
+	}
+	if score > 100 {
+		return 100
+	}
+	return score
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func newBlastRadiusService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, project)
+	seedAWSConnectorForScanTest(t, store, ctx, project, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	return svc, "default"
+}
+
+func TestGetAWSBlastRadiusBuildsRankedIntelligenceContract(t *testing.T) {
+	now := time.Date(2026, 6, 19, 20, 0, 0, 0, time.UTC)
+	svc, ws := newBlastRadiusService(t, "project-blast-radius", now)
+
+	result, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get blast radius: %v", err)
+	}
+	if result.CurrentIssueRef != "#1521" || result.Version != awsBlastRadiusVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected findings summary to match payload: %+v", result.Summary)
+	}
+	if result.Findings[0].Score < result.Findings[len(result.Findings)-1].Score {
+		t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected graph relationships: %+v", result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 {
+		t.Fatalf("expected remediation previews: %+v", result.Summary)
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsBlastRadiusVersion || finding.Rationale == "" {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.Score <= 0 || finding.Confidence <= 0 || len(finding.ImpactedPath) < 2 || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing score/path/evidence: %+v", finding)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+	}
+}
+
+func TestGetAWSBlastRadiusFiltersBySeverityStatusRiskAndIdentity(t *testing.T) {
+	now := time.Date(2026, 6, 19, 20, 5, 0, 0, time.UTC)
+	svc, ws := newBlastRadiusService(t, "project-blast-radius-filters", now)
+
+	critical, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-filters", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "critical",
+	})
+	if err != nil {
+		t.Fatalf("critical filter: %v", err)
+	}
+	if len(critical.Findings) == 0 {
+		t.Fatalf("expected critical findings")
+	}
+	for _, finding := range critical.Findings {
+		if finding.Severity != "critical" {
+			t.Fatalf("severity filter leaked %+v", finding)
+		}
+	}
+	if critical.AppliedFilters["severity"] != "critical" {
+		t.Fatalf("expected severity applied filter, got %+v", critical.AppliedFilters)
+	}
+
+	agent, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-filters", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		RiskType:     "undeclared-agent-tool-path",
+		Status:       "action_required",
+	})
+	if err != nil {
+		t.Fatalf("agent filter: %v", err)
+	}
+	if len(agent.Findings) == 0 {
+		all, allErr := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-filters", AWSBlastRadiusRequest{ConnectorID: "aws-prod", FixtureState: "success"})
+		if allErr != nil {
+			t.Fatalf("expected undeclared agent tool finding; also failed to load unfiltered result: %v", allErr)
+		}
+		t.Fatalf("expected undeclared agent tool finding; risk counts=%+v status counts=%+v", all.Summary.RiskTypeCounts, all.Summary.StatusCounts)
+	}
+	for _, finding := range agent.Findings {
+		if finding.RiskType != "undeclared-agent-tool-path" || finding.Status != "action_required" {
+			t.Fatalf("risk/status filter leaked %+v", finding)
+		}
+	}
+
+	identity, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-filters", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     "case-triage-runtime",
+	})
+	if err != nil {
+		t.Fatalf("identity filter: %v", err)
+	}
+	if len(identity.Findings) == 0 {
+		t.Fatalf("expected identity-matched findings")
+	}
+	for _, finding := range identity.Findings {
+		if !awsRuntimeEventMatchesAny("case-triage-runtime", finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName) {
+			t.Fatalf("identity filter leaked %+v", finding)
+		}
+	}
+}
+
+func TestGetAWSBlastRadiusPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 19, 20, 10, 0, 0, time.UTC)
+	svc, ws := newBlastRadiusService(t, "project-blast-radius-states", now)
+
+	denied, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-states", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || denied.Confidence != 0 || len(denied.Findings) != 0 {
+		t.Fatalf("expected blocked permission-denied state, got %+v", denied)
+	}
+	if len(denied.Diagnostics) == 0 || len(denied.CoverageGaps) == 0 {
+		t.Fatalf("expected diagnostics and coverage gaps for denied state")
+	}
+
+	empty, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-states", AWSBlastRadiusRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 {
+		t.Fatalf("expected degraded empty state, got %+v", empty)
+	}
+}
+
+func TestNormalizeAWSBlastRadiusFixtureState(t *testing.T) {
+	disconnected := AWSConnectionStatus{Connected: false}
+	if got := normalizeAWSBlastRadiusFixtureState("", disconnected, true); got != "permission_denied" {
+		t.Fatalf("expected denied for disconnected default, got %q", got)
+	}
+	if got := normalizeAWSBlastRadiusFixtureState("EMPTY", AWSConnectionStatus{}, false); got != "empty" {
+		t.Fatalf("expected normalized empty, got %q", got)
+	}
+	if got := normalizeAWSBlastRadiusFixtureState("bogus", AWSConnectionStatus{}, false); got != "" {
+		t.Fatalf("expected invalid fixture state to return empty token, got %q", got)
+	}
+}

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -204,8 +204,8 @@ func TestAWSBlastRadiusFindingFromAgentUsesBackingRoleMismatchCaveatToken(t *tes
 	}
 
 	finding := awsBlastRadiusFindingFromAgent(record, time.Date(2026, 6, 19, 20, 30, 0, 0, time.UTC))
-	if finding.Score != 60 {
-		t.Fatalf("expected backing-role mismatch score bump to 60, got %d", finding.Score)
+	if finding.Score != 72 {
+		t.Fatalf("expected backing-role mismatch score bump to 72, got %d", finding.Score)
 	}
 }
 

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -122,6 +122,70 @@ func TestGetAWSBlastRadiusFiltersBySeverityStatusRiskAndIdentity(t *testing.T) {
 	}
 }
 
+func TestFilterAWSBlastRadiusFindingsMatchesResourcePathLabels(t *testing.T) {
+	findings := []AWSBlastRadiusFinding{
+		{
+			FindingID:      "finding-1",
+			Severity:       "high",
+			Status:         "action_required",
+			RiskType:       "sensitive_resource",
+			AccountID:      "111111111111",
+			Region:         "us-east-1",
+			IdentityNodeID: "iam-role/case-triage-runtime",
+			PrincipalARN:   "arn:aws:iam::111111111111:role/case-triage-runtime",
+			DisplayName:    "case-triage-runtime",
+			ImpactedNodes:  []string{"aws:identity:iam:case-triage-runtime"},
+			SensitiveNodes: []string{"aws:resource:secret:legacy-database"},
+			ImpactedPath: []AWSBlastRadiusPathStep{
+				{
+					NodeID:   "aws:identity:iam:case-triage-runtime",
+					NodeType: "identity",
+					Label:    "case-triage-runtime",
+				},
+				{
+					NodeID:   "aws:resource:secret:legacy-database",
+					NodeType: "secret",
+					Label:    "legacy-database-secret",
+				},
+			},
+		},
+		{
+			FindingID:      "finding-2",
+			Severity:       "medium",
+			Status:         "action_required",
+			RiskType:       "agent_tool_target",
+			AccountID:      "222222222222",
+			Region:         "us-west-2",
+			IdentityNodeID: "iam-role/agent-worker",
+			PrincipalARN:   "arn:aws:iam::222222222222:role/agent-worker",
+			DisplayName:    "agent-worker",
+			ImpactedNodes:  []string{"aws:identity:iam:agent-worker"},
+			ImpactedPath: []AWSBlastRadiusPathStep{
+				{
+					NodeID:   "aws:identity:iam:agent-worker",
+					NodeType: "identity",
+					Label:    "agent-worker",
+				},
+				{
+					NodeID:   "aws:resource:s3:payments-bucket",
+					NodeType: "s3_bucket",
+					Label:    "arn:aws:s3:::payments-bucket",
+				},
+			},
+		},
+	}
+
+	filtered, _ := filterAWSBlastRadiusFindings(findings, AWSBlastRadiusRequest{Resource: "legacy-database-secret"})
+	if len(filtered) != 1 || filtered[0].FindingID != "finding-1" {
+		t.Fatalf("expected resource label filtering to match path labels, got %+v", filtered)
+	}
+
+	filtered, _ = filterAWSBlastRadiusFindings(findings, AWSBlastRadiusRequest{Resource: "arn:aws:s3:::payments-bucket"})
+	if len(filtered) != 1 || filtered[0].FindingID != "finding-2" {
+		t.Fatalf("expected resource ARN filtering to match path labels, got %+v", filtered)
+	}
+}
+
 func TestGetAWSBlastRadiusPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 19, 20, 10, 0, 0, time.UTC)
 	svc, ws := newBlastRadiusService(t, "project-blast-radius-states", now)

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -152,6 +152,24 @@ func TestGetAWSBlastRadiusPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T
 	}
 }
 
+func TestGetAWSBlastRadiusOmitsFixtureStateForLiveDefault(t *testing.T) {
+	now := time.Date(2026, 6, 19, 20, 15, 0, 0, time.UTC)
+	svc, ws := newBlastRadiusService(t, "project-blast-radius-live-default", now)
+
+	result, err := svc.GetAWSBlastRadius(defaultScopeContext(), ws, "project-blast-radius-live-default", AWSBlastRadiusRequest{
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("live default: %v", err)
+	}
+	if result.FixtureState != "" {
+		t.Fatalf("expected no fixture_state when caller did not request fixtures, got %q", result.FixtureState)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded live-unavailable state, got %q", result.Status)
+	}
+}
+
 func TestNormalizeAWSBlastRadiusFixtureState(t *testing.T) {
 	disconnected := AWSConnectionStatus{Connected: false}
 	if got := normalizeAWSBlastRadiusFixtureState("", disconnected, true); got != "permission_denied" {

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -231,6 +232,80 @@ func TestAWSBlastRadiusFindingFromAgentOmitsMissingTargetPathStep(t *testing.T) 
 		if step.NodeType == "target_resource" {
 			t.Fatalf("expected no target_resource path when target is missing, got %+v", finding.ImpactedPath)
 		}
+	}
+}
+
+func TestAWSBlastRadiusFindingFromAgentPreservesAllBackingRolesAndTargets(t *testing.T) {
+	record := AWSAgentRuntimeAccessRecord{
+		CorrelationID:         "agent-3",
+		AccountID:             "111111111111",
+		Region:                "us-east-1",
+		AgentNodeID:           "aws:identity:agent:agent-c",
+		AgentName:             "search-agent",
+		ToolName:              "scan",
+		Status:                "confirmed",
+		Confidence:            0.93,
+		BackingRoleNodeIDs:    []string{"aws:identity:role:agent-role-b", "aws:identity:role:agent-role-a"},
+		BackingRoleARNs:       []string{"arn:aws:iam::111111111111:role/agent-role-a", "arn:aws:iam::111111111111:role/agent-role-b"},
+		TargetResourceNodeIDs: []string{"aws:resource:secret:api-key-a", "aws:resource:secret:api-key-b"},
+		TargetResourceARNs:    []string{"arn:aws:secretsmanager:us-east-1:111111111111:secret:api-key-a", "arn:aws:secretsmanager:us-east-1:111111111111:secret:api-key-b"},
+		EvidenceRef:           "agent-evidence://multi-role-target",
+	}
+
+	record.BackingRoleNodeIDs = dedupeStrings(record.BackingRoleNodeIDs)
+	record.TargetResourceNodeIDs = dedupeStrings(record.TargetResourceNodeIDs)
+	record.TargetResourceARNs = dedupeStrings(record.TargetResourceARNs)
+
+	finding := awsBlastRadiusFindingFromAgent(record, time.Date(2026, 6, 19, 20, 50, 0, 0, time.UTC))
+
+	expectedRoleNodes := map[string]bool{
+		"aws:identity:role:agent-role-a": false,
+		"aws:identity:role:agent-role-b": false,
+	}
+	expectedTargetNodes := map[string]bool{
+		"aws:resource:secret:api-key-a":                                  false,
+		"aws:resource:secret:api-key-b":                                  false,
+		"arn:aws:secretsmanager:us-east-1:111111111111:secret:api-key-a": false,
+		"arn:aws:secretsmanager:us-east-1:111111111111:secret:api-key-b": false,
+	}
+	foundImpactedNodes := map[string]bool{}
+	for _, node := range finding.ImpactedNodes {
+		foundImpactedNodes[node] = true
+	}
+	for node := range expectedRoleNodes {
+		if !foundImpactedNodes[node] {
+			t.Fatalf("missing backing role in impacted_nodes: %s", node)
+		}
+	}
+	for node := range expectedTargetNodes {
+		if !foundImpactedNodes[node] {
+			t.Fatalf("missing target in impacted_nodes: %s", node)
+		}
+	}
+
+	paths := finding.ImpactedPath
+	hasEdge := func(fromNode, toNode string) bool {
+		for i := 0; i+1 < len(paths); i++ {
+			if strings.TrimSpace(paths[i].NodeID) == fromNode && strings.TrimSpace(paths[i+1].NodeID) == toNode {
+				return true
+			}
+		}
+		return false
+	}
+	for role := range expectedRoleNodes {
+		if !hasEdge(role, record.AgentNodeID) {
+			t.Fatalf("expected identity path edge for role %s to agent %s", role, record.AgentNodeID)
+		}
+	}
+	for target := range expectedTargetNodes {
+		if !hasEdge(record.AgentNodeID, target) {
+			t.Fatalf("expected agent path edge for target %s", target)
+		}
+	}
+
+	filtered, _ := filterAWSBlastRadiusFindings([]AWSBlastRadiusFinding{finding}, AWSBlastRadiusRequest{Identity: "agent-role-b"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected second backing role to match identity filter, got %d findings", len(filtered))
 	}
 }
 

--- a/internal/api/aws_blast_radius_test.go
+++ b/internal/api/aws_blast_radius_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/runtime/agentaccess"
 )
 
 func newBlastRadiusService(t *testing.T, project string, now time.Time) (*Service, string) {
@@ -183,6 +184,53 @@ func TestFilterAWSBlastRadiusFindingsMatchesResourcePathLabels(t *testing.T) {
 	filtered, _ = filterAWSBlastRadiusFindings(findings, AWSBlastRadiusRequest{Resource: "arn:aws:s3:::payments-bucket"})
 	if len(filtered) != 1 || filtered[0].FindingID != "finding-2" {
 		t.Fatalf("expected resource ARN filtering to match path labels, got %+v", filtered)
+	}
+}
+
+func TestAWSBlastRadiusFindingFromAgentUsesBackingRoleMismatchCaveatToken(t *testing.T) {
+	record := AWSAgentRuntimeAccessRecord{
+		CorrelationID:           "agent-1",
+		AccountID:               "111111111111",
+		Region:                  "us-east-1",
+		AgentNodeID:             "aws:identity:agent:agent-a",
+		AgentName:               "risk-agent",
+		ToolName:                "query",
+		Status:                  "confirmed",
+		Confidence:              0.81,
+		BackingRoleNodeIDs:      []string{"aws:identity:role:agent-role"},
+		DeclaredBackingRoleNode: "aws:identity:role:declared",
+		Caveats:                 []string{agentaccess.CaveatBackingRoleMismatch},
+		EvidenceRef:             "agent-evidence://case-triage",
+	}
+
+	finding := awsBlastRadiusFindingFromAgent(record, time.Date(2026, 6, 19, 20, 30, 0, 0, time.UTC))
+	if finding.Score != 60 {
+		t.Fatalf("expected backing-role mismatch score bump to 60, got %d", finding.Score)
+	}
+}
+
+func TestAWSBlastRadiusFindingFromAgentOmitsMissingTargetPathStep(t *testing.T) {
+	record := AWSAgentRuntimeAccessRecord{
+		CorrelationID:      "agent-2",
+		AccountID:          "111111111111",
+		Region:             "us-east-1",
+		AgentNodeID:        "aws:identity:agent:agent-b",
+		AgentName:          "background-agent",
+		ToolName:           "ingest",
+		Status:             "declared-unused",
+		Confidence:         0.91,
+		BackingRoleNodeIDs: []string{"aws:identity:role:declared"},
+		EvidenceRef:        "agent-evidence://declared-unused",
+	}
+
+	finding := awsBlastRadiusFindingFromAgent(record, time.Date(2026, 6, 19, 20, 45, 0, 0, time.UTC))
+	if len(finding.ImpactedPath) != 2 {
+		t.Fatalf("expected identity-agent path only when target is missing, got %+v", finding.ImpactedPath)
+	}
+	for _, step := range finding.ImpactedPath {
+		if step.NodeType == "target_resource" {
+			t.Fatalf("expected no target_resource path when target is missing, got %+v", finding.ImpactedPath)
+		}
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3018,6 +3018,41 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"correlation": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSBlastRadius(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSBlastRadiusRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			RiskType:     strings.TrimSpace(c.Query("risk_type")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws blast radius request"})
+			default:
+				logger.Error("get aws blast radius",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws blast radius"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"intelligence": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2696,6 +2696,150 @@ export type AWSAgentRuntimeAccessQuery = {
   status?: string;
 };
 
+export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSBlastRadiusFindingStatus = 'action_required' | 'review' | 'monitor' | string;
+
+export type AWSBlastRadiusEvidence = {
+  source: string;
+  evidence_ref: string;
+  label: string;
+  confidence: number;
+  observed_at?: string;
+  relationship?: string;
+};
+
+export type AWSBlastRadiusPathStep = {
+  node_id: string;
+  node_type: string;
+  label: string;
+  account_id?: string;
+  region?: string;
+};
+
+export type AWSBlastRadiusRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSBlastRadiusRemediationCasePreview = {
+  case_id: string;
+  title: string;
+  recommended_action: string;
+  approval_required: boolean;
+  blocking_evidence?: string[];
+  impacted_node_count: number;
+  estimated_risk_drop: number;
+  read_only_projection: boolean;
+};
+
+export type AWSBlastRadiusFinding = {
+  finding_id: string;
+  calculation_version: string;
+  risk_type: string;
+  severity: AWSBlastRadiusSeverity;
+  status: AWSBlastRadiusFindingStatus;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  display_name: string;
+  rationale: string;
+  impacted_nodes: string[];
+  impacted_path: AWSBlastRadiusPathStep[];
+  sensitive_nodes?: string[];
+  cross_account_edges?: string[];
+  runtime_actions?: string[];
+  agent_tool_paths?: string[];
+  evidence: AWSBlastRadiusEvidence[];
+  next_action: string;
+  remediation_case: AWSBlastRadiusRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSBlastRadiusSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  risk_type_counts: Record<string, number>;
+  critical_count: number;
+  high_count: number;
+  sensitive_node_count: number;
+  cross_account_edge_count: number;
+  runtime_action_count: number;
+  agent_tool_path_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+};
+
+export type AWSBlastRadiusDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSBlastRadiusCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSBlastRadiusResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSBlastRadiusStatus;
+  fixture_state?: AWSBlastRadiusFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSBlastRadiusSummary;
+  findings: AWSBlastRadiusFinding[];
+  relationships: AWSBlastRadiusRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSBlastRadiusCoverageGap[];
+  diagnostics: AWSBlastRadiusDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSBlastRadiusQuery = {
+  connectorID?: string;
+  fixtureState?: AWSBlastRadiusFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  resource?: string;
+  severity?: string;
+  status?: string;
+  riskType?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -5868,6 +6012,27 @@ export const apiClient = {
         resource: query?.resource,
         outcome: query?.outcome,
         status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectBlastRadius(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSBlastRadiusQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ intelligence: AWSBlastRadiusResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/blast-radius${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        resource: query?.resource,
+        severity: query?.severity,
+        status: query?.status,
+        risk_type: query?.riskType
       })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -55,6 +55,8 @@ import {
   type AWSS3RuntimeAccessResult,
   type AWSAgentRuntimeAccessRecord,
   type AWSAgentRuntimeAccessResult,
+  type AWSBlastRadiusFinding,
+  type AWSBlastRadiusResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10421,6 +10423,108 @@ function AWSAgentRuntimeAccessContent({
   );
 }
 
+function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
+  switch (severity) {
+    case 'critical':
+    case 'high':
+      return 'coming';
+    case 'medium':
+      return 'not-available';
+    default:
+      return 'wired';
+  }
+}
+
+function awsBlastRadiusFindingLabel(finding: AWSBlastRadiusFinding): string {
+  return `${formatTokenLabel(finding.risk_type)} · score ${finding.score}`;
+}
+
+function awsBlastRadiusEvidenceLabel(finding: AWSBlastRadiusFinding): string {
+  const sources = finding.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function awsBlastRadiusPathLabel(finding: AWSBlastRadiusFinding): string {
+  const path = finding.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
+  if (path.length === 0) {
+    return finding.impacted_nodes.join(' → ') || '—';
+  }
+  return path.join(' → ');
+}
+
+function AWSBlastRadiusContent({
+  intelligence,
+  loading,
+  error,
+  onRetry
+}: {
+  intelligence: AWSBlastRadiusResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const findings = intelligence?.findings ?? [];
+  const summaryLine = intelligence
+    ? `${intelligence.summary.critical_count} critical · ${intelligence.summary.high_count} high · ${intelligence.summary.relationship_count} graph edges · ${intelligence.summary.remediation_preview_count} plans`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS blast radius intelligence">
+      <h3>AWS blast radius intelligence</h3>
+      <p className="idt-app-kicker">
+        Ranked identity blast radius from static reachability, sensitive resources, runtime access, and agent/tool paths.
+        {summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load blast radius intelligence"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating blast radius"
+          body="Identrail is ranking impacted identities, graph paths, evidence, confidence, and remediation plans."
+        />
+      ) : null}
+      {!error && !loading && intelligence && findings.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={intelligence.status === 'blocked' ? 'Permission required' : 'No intelligence records'}
+          title={intelligence.status === 'blocked' ? 'Blast radius needs read-only evidence access' : 'No blast-radius findings'}
+          body={intelligence.failure_reasons[0] ?? 'No reachable sensitive resources, runtime actions, or agent/tool paths matched.'}
+        />
+      ) : null}
+      {!error && !loading && intelligence && intelligence.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {intelligence.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {findings.length > 0 ? (
+        <DomainDataTable
+          label="AWS blast radius findings"
+          rows={findings}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsBlastRadiusFindingLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.display_name || row.identity_node_id },
+            { key: 'path', header: 'Impacted path', render: (row) => awsBlastRadiusPathLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsBlastRadiusEvidenceLabel(row) },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => <AWSInventoryPill stage={awsBlastRadiusSeverityStage(row.severity)} label={formatTokenLabel(row.severity)} />
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -10919,6 +11023,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [agentRuntimeAccessLoading, setAgentRuntimeAccessLoading] = useState(false);
   const [agentRuntimeAccessError, setAgentRuntimeAccessError] = useState('');
   const agentRuntimeAccessRequestRef = useRef(0);
+  const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
+  const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
+  const [blastRadiusError, setBlastRadiusError] = useState('');
+  const blastRadiusRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11126,6 +11234,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadAgentRuntimeAccess]);
 
+  const loadBlastRadius = useCallback(async () => {
+    const requestID = ++blastRadiusRequestRef.current;
+    setBlastRadius(null);
+    setBlastRadiusError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setBlastRadiusLoading(false);
+      return;
+    }
+    setBlastRadiusLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectBlastRadius(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== blastRadiusRequestRef.current) {
+        return;
+      }
+      setBlastRadius(response.intelligence);
+    } catch (error) {
+      if (requestID !== blastRadiusRequestRef.current) {
+        return;
+      }
+      setBlastRadiusError(formatAPIError(error, 'Unable to load AWS blast radius intelligence.'));
+    } finally {
+      if (requestID === blastRadiusRequestRef.current) {
+        setBlastRadiusLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadBlastRadius();
+    return () => {
+      blastRadiusRequestRef.current += 1;
+    };
+  }, [loadBlastRadius]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -11241,6 +11397,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={agentRuntimeAccessLoading}
             error={agentRuntimeAccessError}
             onRetry={loadAgentRuntimeAccess}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSBlastRadiusContent
+            intelligence={blastRadius}
+            loading={blastRadiusLoading}
+            error={blastRadiusError}
+            onRetry={loadBlastRadius}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
## Summary
- Implements the AWS blast-radius intelligence engine for issue #1521
- Adds a scoped `/aws/blast-radius` API that composes runtime access, S3, Secrets/KMS, and agent/tool-path evidence into ranked findings
- Wires the AWS runtime UI, TypeScript client, OpenAPI contract, authz policy, and docs

## Verification
- `go test ./internal/api -count=1`
- `npm run build`

Closes #1521

## AI disclosure
No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the AWS blast‑radius intelligence engine (issue #1521) to rank identity exposure from runtime access and static reachability. Adds a new API, UI surface, OpenAPI contract, auth policy, tests, and docs for explainable findings with remediation previews.

- **New Features**
  - API: `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius` with optional filters (connector_id, account_id, region, identity, resource, severity, status, risk_type) and deterministic `fixture_state`. Returns an intelligence envelope with stable IDs, `calculation_version`, score/severity/status/confidence, `impacted_path`, relationships, evidence refs, summary, diagnostics, coverage gaps, and read‑only remediation previews.
  - Engine: Composes Secrets/KMS, S3, and agent/tool‑path runtime signals with static reachability. Deterministic scoring where unknown runtime lowers confidence and never upgrades severity. Tests cover ranking, filters, relationships, empty/permission_denied states, and remediation previews.
  - Authz/OpenAPI/Docs: Route added to the runtime policy bundle; OpenAPI includes the new endpoint and schemas; documented in `docs/aws-blast-radius-engine.md` (linked from risk engine docs).
  - Web: Added typed client `getAWSProjectBlastRadius` and a UI block on the AWS runtime operations page showing ranked findings (severity/score/path/evidence) with summary counts and caveats; handles loading, empty, and blocked states.

- **Bug Fixes**
  - Live `fixture_state`: when not provided and a connection exists, the API omits `fixture_state` and attempts live evidence, degrading gracefully if unavailable.
  - Resource filtering: the `resource` filter now matches impacted path labels and sensitive nodes (ARNs or friendly names) for accurate drill‑downs.
  - Agent paths: omit the target path step when no target exists and apply a scoring bump when the `agentaccess.CaveatBackingRoleMismatch` caveat is present.
  - Agent multi‑role/target paths: preserve all backing roles and all target resources in `impacted_nodes` and `impacted_path` for correct graph edges and identity filtering.

<sup>Written for commit b0741f13070799b428fb5bc18087b434db2b1775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

