### PR TITLE
Polish appearance settings and pull settings heading out of container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Polish in-app appearance settings: drop the dual code preview, remove the
+  Code font dropdown and Diff markers toggle, compact the control rows so the
+  selects no longer dominate the card, add **Manrope** as a UI font choice, and
+  rebuild the right-side scroll navigator to update the thumb directly on the
+  compositor via `transform` (eliminating per-scroll React state and the
+  jumpiness it caused). Also pulls the top-level Settings page heading out of
+  its boxed container so it reads as a plain page title.
 - Add **AWS agent runtime / tool-call access correlation** (#1520). Adds
   a metadata-only correlation engine (`internal/runtime/agentaccess`)
   that joins observed agent `agent-tool` runtime events with the static

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Geist:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Geist:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
     />
     <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64.png?v=20260527c" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=20260527c" />

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -37,6 +37,7 @@ export type AppearanceFontID =
   | 'geist'
   | 'space-grotesk'
   | 'barlow-condensed'
+  | 'manrope'
   | 'mono-system'
   | 'ibm-plex-mono'
   | 'jetbrains-mono';
@@ -346,6 +347,7 @@ export const APPEARANCE_FONTS: Record<AppearanceFontID, string> = {
   geist: 'Geist, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
   'space-grotesk': '"Space Grotesk", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
   'barlow-condensed': '"Barlow Semi Condensed", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  manrope: 'Manrope, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
   'mono-system': 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
   'ibm-plex-mono': '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
   'jetbrains-mono': '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
@@ -357,6 +359,7 @@ export const APPEARANCE_FONT_LABELS: Record<AppearanceFontID, string> = {
   geist: 'Geist',
   'space-grotesk': 'Space Grotesk',
   'barlow-condensed': 'Barlow Condensed',
+  manrope: 'Manrope',
   'mono-system': 'System Mono',
   'ibm-plex-mono': 'IBM Plex Mono',
   'jetbrains-mono': 'JetBrains Mono'

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1897,7 +1897,7 @@ describe('ProductAppearanceSettingsPage', () => {
     expect(document.documentElement.style.getPropertyValue('--appearance-ui-font')).toContain('Inter');
     expect(document.documentElement.style.getPropertyValue('--appearance-contrast')).toBe('52');
     expect(screen.queryByRole('heading', { name: 'App icon' })).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Theme preview')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Theme preview')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('App preview')).not.toBeInTheDocument();
     expect(screen.queryByRole('switch', { name: 'Translucent sidebar' })).not.toBeInTheDocument();
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -157,7 +157,6 @@ import {
   readAppearancePreferences,
   resolveAppearanceThemeMode,
   saveAppearancePreferences,
-  type AppearanceDiffMarkers,
   type AppearanceFontID,
   type AppearancePreferences,
   type AppearancePresetID,
@@ -16040,11 +16039,8 @@ export function ProductShellLayout() {
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => readSidebarWidth());
   const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
   const [isSidebarEdgeFocused, setIsSidebarEdgeFocused] = useState(false);
-  const [scrollNavigator, setScrollNavigator] = useState<ScrollNavigatorMetrics>({
-    visible: false,
-    thumbHeight: 0,
-    thumbTop: 0
-  });
+  const scrollNavigatorRef = useRef<HTMLDivElement | null>(null);
+  const scrollNavigatorThumbRef = useRef<HTMLSpanElement | null>(null);
   const [isNarrowViewport, setIsNarrowViewport] = useState<boolean>(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
       return false;
@@ -16446,6 +16442,11 @@ export function ProductShellLayout() {
     const cancelFrame = window.cancelAnimationFrame ?? window.clearTimeout;
     const updateMetrics = () => {
       frameID = undefined;
+      const navigatorEl = scrollNavigatorRef.current;
+      const thumbEl = scrollNavigatorThumbRef.current;
+      if (!navigatorEl || !thumbEl) {
+        return;
+      }
       const scrollingElement = document.scrollingElement ?? document.documentElement;
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
       const scrollHeight = Math.max(
@@ -16456,38 +16457,29 @@ export function ProductShellLayout() {
       const scrollRange = scrollHeight - viewportHeight;
 
       if (scrollRange <= 24 || viewportHeight <= 0) {
-        setScrollNavigator((current) =>
-          current.visible ? { visible: false, thumbHeight: 0, thumbTop: 0 } : current
-        );
+        navigatorEl.style.opacity = '0';
+        navigatorEl.style.visibility = 'hidden';
         return;
       }
 
       const trackTop = Math.min(72, Math.max(28, viewportHeight * 0.055));
       const trackBottom = Math.min(64, Math.max(28, viewportHeight * 0.045));
       const trackHeight = Math.max(120, viewportHeight - trackTop - trackBottom);
-      const thumbHeight = Math.round(
-        Math.min(
-          SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT,
-          Math.max(SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT, trackHeight * 0.16)
-        )
+      const thumbHeight = Math.min(
+        SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT,
+        Math.max(SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT, trackHeight * 0.16)
       );
       const scrollProgress = Math.min(1, Math.max(0, scrollingElement.scrollTop / scrollRange));
-      const thumbTop = Math.round(trackTop + (trackHeight - thumbHeight) * scrollProgress);
+      const thumbTop = trackTop + (trackHeight - thumbHeight) * scrollProgress;
 
-      setScrollNavigator((current) => {
-        if (
-          current.visible &&
-          current.thumbHeight === thumbHeight &&
-          Math.abs(current.thumbTop - thumbTop) <= 1
-        ) {
-          return current;
-        }
-        return { visible: true, thumbHeight, thumbTop };
-      });
+      thumbEl.style.height = `${thumbHeight}px`;
+      thumbEl.style.transform = `translate3d(0, ${thumbTop}px, 0)`;
+      navigatorEl.style.opacity = '1';
+      navigatorEl.style.visibility = 'visible';
     };
     const scheduleUpdate = () => {
       if (frameID !== undefined) {
-        cancelFrame(frameID);
+        return;
       }
       frameID = requestFrame(updateMetrics);
     };
@@ -16907,20 +16899,14 @@ export function ProductShellLayout() {
             <Outlet />
           </main>
         </div>
-        {scrollNavigator.visible ? (
-          <div
-            className="idt-app-scroll-navigator"
-            aria-hidden="true"
-            style={
-              {
-                '--idt-scroll-navigator-thumb-height': `${scrollNavigator.thumbHeight}px`,
-                '--idt-scroll-navigator-thumb-top': `${scrollNavigator.thumbTop}px`
-              } as CSSProperties
-            }
-          >
-            <span className="idt-app-scroll-navigator-thumb" />
-          </div>
-        ) : null}
+        <div
+          ref={scrollNavigatorRef}
+          className="idt-app-scroll-navigator"
+          aria-hidden="true"
+          style={{ opacity: 0, visibility: 'hidden' }}
+        >
+          <span ref={scrollNavigatorThumbRef} className="idt-app-scroll-navigator-thumb" />
+        </div>
       </div>
       <CommandPalette
         open={commandOpen}
@@ -23332,19 +23318,14 @@ const APPEARANCE_MOTION_OPTIONS: Array<{ id: AppearanceReduceMotion; label: stri
   { id: 'off', label: 'Off' }
 ];
 
-const APPEARANCE_DIFF_OPTIONS: Array<{ id: AppearanceDiffMarkers; label: string }> = [
-  { id: 'color', label: 'Color' },
-  { id: 'symbols', label: '+/-' }
-];
-
 const APPEARANCE_UI_FONT_OPTIONS: AppearanceFontID[] = [
   'inter',
   'geist',
   'system',
   'space-grotesk',
-  'barlow-condensed'
+  'barlow-condensed',
+  'manrope'
 ];
-const APPEARANCE_CODE_FONT_OPTIONS: AppearanceFontID[] = ['mono-system', 'ibm-plex-mono', 'jetbrains-mono'];
 
 function appearancePresetOptions(mode: 'light' | 'dark') {
   return APPEARANCE_PRESETS.filter((preset) =>
@@ -23547,37 +23528,6 @@ export function ProductAppearanceSettingsPage() {
           />
         </div>
 
-        <div className="idt-appearance-preview" aria-label="Theme preview">
-          <div className="idt-appearance-preview-pane" data-side="before">
-            {[1, 2, 3, 4, 5].map((line) => (
-              <div key={`before-${line}`} className="idt-appearance-code-line">
-                <span>{line}</span>
-                <code>
-                  {line === 1 ? 'const themePreview: {' : ''}
-                  {line === 2 ? '  surface: "sidebar",' : ''}
-                  {line === 3 ? '  accent: "#2563eb",' : ''}
-                  {line === 4 ? '  contrast: 42,' : ''}
-                  {line === 5 ? '};' : ''}
-                </code>
-              </div>
-            ))}
-          </div>
-          <div className="idt-appearance-preview-pane" data-side="after">
-            {[1, 2, 3, 4, 5].map((line) => (
-              <div key={`after-${line}`} className="idt-appearance-code-line">
-                <span>{line}</span>
-                <code>
-                  {line === 1 ? 'const themePreview: {' : ''}
-                  {line === 2 ? '  surface: "sidebar-edge",' : ''}
-                  {line === 3 ? `  accent: "${effectiveColors.accent}",` : ''}
-                  {line === 4 ? `  contrast: ${preferences.contrast},` : ''}
-                  {line === 5 ? '};' : ''}
-                </code>
-              </div>
-            ))}
-          </div>
-        </div>
-
         <div className="idt-appearance-control-list">
           <label className="idt-appearance-control-row">
             <span>
@@ -23648,23 +23598,6 @@ export function ProductAppearanceSettingsPage() {
               onChange={(event) => commitPreferences({ uiFont: event.target.value as AppearanceFontID })}
             >
               {APPEARANCE_UI_FONT_OPTIONS.map((fontID) => (
-                <option key={fontID} value={fontID}>
-                  {APPEARANCE_FONT_LABELS[fontID]}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="idt-appearance-control-row">
-            <span>
-              <strong>Code font</strong>
-            </span>
-            <select
-              aria-label="Code font"
-              value={preferences.codeFont}
-              onChange={(event) => commitPreferences({ codeFont: event.target.value as AppearanceFontID })}
-            >
-              {APPEARANCE_CODE_FONT_OPTIONS.map((fontID) => (
                 <option key={fontID} value={fontID}>
                   {APPEARANCE_FONT_LABELS[fontID]}
                 </option>
@@ -23750,19 +23683,6 @@ export function ProductAppearanceSettingsPage() {
             <span>px</span>
           </span>
         </label>
-
-        <div className="idt-appearance-behavior-row">
-          <div>
-            <h3>Diff markers</h3>
-            <p>Show changed lines with color or +/- symbols</p>
-          </div>
-          <AppearanceSegmentedControl
-            label="Diff markers"
-            value={preferences.diffMarkers}
-            options={APPEARANCE_DIFF_OPTIONS}
-            onChange={(diffMarkers) => commitPreferences({ diffMarkers })}
-          />
-        </div>
 
         <div className="idt-appearance-behavior-row">
           <div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -16903,7 +16903,6 @@ export function ProductShellLayout() {
           ref={scrollNavigatorRef}
           className="idt-app-scroll-navigator"
           aria-hidden="true"
-          style={{ opacity: 0, visibility: 'hidden' }}
         >
           <span ref={scrollNavigatorThumbRef} className="idt-app-scroll-navigator-thumb" />
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21505,6 +21505,13 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
   background: #080809;
 }
 
+.idt-app-console-layout .idt-settings-page > .idt-settings-header {
+  border: 0;
+  border-radius: 0;
+  padding: 0.25rem 0.25rem 0.5rem;
+  background: transparent;
+}
+
 .idt-app-console-layout .idt-overview-header {
   padding: 1rem 1.1rem;
 }
@@ -28841,19 +28848,22 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   z-index: 70;
   width: 0.82rem;
   pointer-events: none;
+  transition: opacity 160ms ease;
 }
 
 .idt-app-scroll-navigator-thumb {
   position: absolute;
-  top: var(--idt-scroll-navigator-thumb-top);
+  top: 0;
   right: 0.18rem;
   width: 0.38rem;
-  height: var(--idt-scroll-navigator-thumb-height);
+  height: 0;
   border-radius: 999px;
   background: rgba(236, 241, 247, 0.54);
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.08),
     0 10px 24px rgba(0, 0, 0, 0.42);
+  transform: translate3d(0, 0, 0);
+  will-change: transform;
 }
 
 html[data-theme='light'] .idt-app-scroll-navigator-thumb {
@@ -31393,8 +31403,8 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 1rem;
-  min-height: 3rem;
-  padding: 0.58rem 1.2rem;
+  min-height: 2.25rem;
+  padding: 0.4rem 1rem;
   border-bottom: 1px solid var(--app-border-soft);
   color: var(--app-text);
 }
@@ -31416,17 +31426,18 @@ html[data-diff-markers='symbols'] .idt-appearance-preview-pane[data-side='after'
 
 .idt-appearance-control-row select,
 .idt-appearance-number input {
-  min-height: 1.95rem;
+  min-height: 1.75rem;
   border: 1px solid var(--app-border-soft);
-  border-radius: 8px;
-  padding: 0 0.72rem;
+  border-radius: 7px;
+  padding: 0 0.6rem;
   background: var(--app-panel);
   color: var(--app-text);
   font: inherit;
+  font-size: 0.9rem;
 }
 
 .idt-appearance-control-row select {
-  min-width: 12rem;
+  min-width: 8.5rem;
 }
 
 html[data-appearance-ready='true'] .idt-app-console-layout :is(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -28848,6 +28848,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   z-index: 70;
   width: 0.82rem;
   pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
   transition: opacity 160ms ease;
 }
 


### PR DESCRIPTION
## Summary

In-app appearance settings polish + settings-page heading restyle.

- Drop the dual `themePreview` code block from the Theme card.
- Remove the **Code font** dropdown.
- Remove the **Diff markers** behavior row.
- Compact the control rows: smaller padding, lower `min-height`, narrower selects so the labels (Light theme, Dark theme, UI font) no longer sit in oversized boxes.
- Add **Manrope** as a UI font option (loaded via Google Fonts).
- Rebuild the right-side scroll navigator: the thumb now updates via direct DOM mutation (`transform: translate3d(...)`) inside a single rAF, instead of driving React state on every scroll event — fixes the jumpy/stepped feel on long pages.
- Pull the top-level Settings page heading out of its boxed container so it reads as a plain page title. Scoped to `.idt-settings-page > .idt-settings-header` so the reused class on Reports keeps its existing container styling.

## Why

The appearance settings card had three pieces of UI the user does not want — the dual code preview, the Code font selector, and the Diff markers row — and the remaining controls were housed in over-sized boxes. The right rail scroll indicator was visibly jumpy because every scroll tick re-rendered the shell. The Settings page heading was framed in a card-like container which looked over-styled for a page title.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered — `codeFont` and `diffMarkers` preferences remain in storage; only the UI to change them is removed.
- [x] Risk level assessed — UI only.

## Validation

```bash
# Web
npx tsc --noEmit                                                 # clean
npx vitest run src/productShell.test.tsx -t "ProductAppearanceSettingsPage"   # 10 passed
npm run build --prefix web                                       # ok
```

Visual verification of the dev server was blocked by the local API not being available (session check failed), so I verified the new CSS rules by mounting the equivalent DOM in the preview and reading computed styles:

- `.idt-settings-page > .idt-settings-header` resolves to `border: none 0px`, transparent background, compact padding.
- `.idt-reports-page .idt-settings-header` still resolves to `border: solid 1px` with the dark panel background.
- `.idt-app-scroll-navigator-thumb` resolves to `will-change: transform` with a baseline `translate3d` transform.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes — `CHANGELOG.md`.
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the in-app appearance settings and simplified the Settings page header. Removed the dual theme preview, Code font, and Diff markers controls; added `Manrope` as a UI font; rebuilt the scroll navigator for smooth scrolling and to stay visible across re-renders.

- **Refactors**
  - Removed the dual theme preview, Code font dropdown, and Diff markers row.
  - Compacted control rows (smaller padding/min-height, narrower selects).
  - Pulled the Settings page heading out of its container; scoped to `.idt-settings-page > .idt-settings-header`.

- **Bug Fixes**
  - Rebuilt the right-side scroll navigator: thumb moves via `transform: translate3d(...)` in one rAF, and visibility is now controlled in CSS to prevent React re-renders from hiding it — fixes the jumpy feel on long pages.

<sup>Written for commit d7a96737dc56c025206bd4d2b2379ed63dd7c555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

