### PR TITLE
AWS Platform Wave 6.02: Least-privilege recommendation engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS least-privilege recommendation engine** (#1522). Adds a
+  deterministic, metadata-only recommendation layer that composes static
+  grants, runtime access correlation, IAM last-used signals, Access Analyzer
+  findings, and agent/tool evidence into ranked keep, remove, and review
+  decisions. The new endpoint
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/least-privilege` exposes stable
+  recommendation IDs, calculation version, severity, confidence, rationale,
+  impacted path, keep/remove actions, breakage prediction, read-only
+  remediation previews, diagnostics, coverage gaps, and filters for account,
+  region, identity, resource, service, severity, status, and decision.
+  Unknown or partial evidence becomes an explicit review state instead of an
+  automatic remove recommendation. The AWS runtime app surface now renders the
+  recommendations alongside the prerequisite runtime and blast-radius evidence.
+  Closes #1522. See
+  [docs/aws-least-privilege-engine.md](docs/aws-least-privilege-engine.md).
 - Polish in-app appearance settings: drop the dual code preview, remove the
   Code font dropdown and Diff markers toggle, compact the control rows so the
   selects no longer dominate the card, add **Manrope** as a UI font choice, and

--- a/docs/aws-least-privilege-engine.md
+++ b/docs/aws-least-privilege-engine.md
@@ -1,0 +1,103 @@
+# AWS Least-Privilege Recommendation Engine
+
+Issue: #1522
+
+The AWS least-privilege recommendation engine turns existing metadata-only AWS evidence into deterministic keep, remove, and review decisions.
+
+It composes:
+
+- Secrets Manager / KMS runtime access correlation
+- S3 runtime access correlation
+- AI agent runtime / tool-call correlation
+- IAM last-used signals
+- Access Analyzer findings
+- graph node identifiers and impacted paths produced by the prerequisite AWS engines
+
+The API is available at:
+
+```text
+GET /v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege
+```
+
+It returns a `recommendations` envelope with:
+
+- stable `recommendation_id` values
+- `calculation_version`
+- keep, remove, or review decision
+- severity, score, confidence, status, and rationale
+- service, identity, resource, impacted graph path, and impacted node ids
+- keep actions, remove actions, observed actions, and granted actions
+- breakage prediction and breakage rationale
+- metadata-only evidence references
+- read-only remediation case previews
+- diagnostics, coverage gaps, failure reasons, remediation hints, and applied filters
+
+## Decisions
+
+The first calculation version is `aws-least-privilege-recommendation-engine-v1`.
+
+Decisions are intentionally conservative:
+
+- `remove` is used for static grants or declared tool access with no matching runtime evidence in the scoped evidence window.
+- `keep` is used when runtime evidence shows the access is actively used or must be authorized before narrowing.
+- `review` is used when evidence proves reachability or uncertainty but is not strong enough for deterministic removal.
+
+Access Analyzer findings always become review recommendations. They prove reachability, not application intent.
+
+## Breakage Prediction
+
+Breakage is predicted from observed usage, source confidence, and source caveats:
+
+- `low`: no matching runtime use, high confidence, and no caveats
+- `medium`: no observed use, but confidence or scope leaves meaningful uncertainty
+- `high`: runtime evidence shows the access is used
+- `unknown`: evidence is partial, caveated, or requires owner review
+
+Unknown evidence never becomes an automatic remove decision.
+
+## Filters
+
+The endpoint supports:
+
+- `account_id`
+- `region`
+- `identity`
+- `resource`
+- `service`
+- `severity`
+- `status`
+- `decision`
+- `fixture_state`
+
+The `resource` filter matches graph node ids, ARNs, and impacted path labels so operators do not need internal node ids to find a recommendation.
+
+## Evidence Boundaries
+
+The engine only exposes metadata:
+
+- ARNs and graph node ids
+- action names and service names
+- event and correlation references
+- confidence, timestamps, status, and caveat context
+
+It does not expose secret values, decrypted plaintext, object bodies, object contents, prompts, completions, browser pages, code-interpreter output, database rows, or customer payloads.
+
+## Failure States
+
+The engine supports deterministic states for validation:
+
+- `success`
+- `empty`
+- `degraded`
+- `partial_failure`
+- `permission_denied`
+
+Blocked evidence returns explicit diagnostics and coverage gaps. Empty evidence returns a degraded result with zero recommendations rather than fabricating a safe state.
+
+## App Surface
+
+The AWS runtime operations page renders least-privilege recommendations below the source evidence and blast-radius intelligence. Operators can see the decision, service scope, impacted path, actions, evidence confidence, breakage prediction, next action, caveats, and permission/degraded states.
+
+## Safety
+
+This engine is read-only. It creates remediation case previews only; it does not mutate AWS IAM, resource policies, permission boundaries, SCPs, agent tools, or Identrail governance state. Policy diff generation, approval workflow, and execution are downstream capabilities.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -574,6 +574,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/least-privilege
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -4972,6 +4977,89 @@ paths:
                     $ref: "#/components/schemas/AWSBlastRadiusResult"
         "400":
           description: Invalid AWS blast radius request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/least-privilege:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS least-privilege recommendations
+      operationId: getAWSProjectLeastPrivilege
+      description: Calculates deterministic, read-only AWS least-privilege keep, remove, and review recommendations by composing static grants, metadata-only runtime usage, IAM last-used signals, Access Analyzer findings, and agent/tool evidence. Recommendations carry stable IDs, calculation version, score, severity, confidence, rationale, impacted graph path, keep/remove actions, breakage prediction, evidence refs, and read-only remediation previews. Unknown or partial evidence produces review states rather than automatic remove decisions; secret values, object contents, prompts, completions, tool payloads, browser pages, and code-interpreter output are never read or returned.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional principal, identity-node, or display-name search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional impacted resource, ARN, display label, or graph-node search.
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Optional AWS service token, such as s3, secretsmanager, kms, lambda, or agent-runtime.
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: decision
+          schema:
+            type: string
+            enum: [keep, remove, review]
+      responses:
+        "200":
+          description: AWS least-privilege recommendation contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  recommendations:
+                    $ref: "#/components/schemas/AWSLeastPrivilegeResult"
+        "400":
+          description: Invalid AWS least-privilege request
           content:
             application/json:
               schema:
@@ -11998,6 +12086,228 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSBlastRadiusDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLeastPrivilegeEvidence:
+      type: object
+      properties:
+        source: { type: string }
+        evidence_ref: { type: string }
+        label: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        observed_at:
+          type: string
+          format: date-time
+        relationship: { type: string }
+    AWSLeastPrivilegePathStep:
+      type: object
+      properties:
+        node_id: { type: string }
+        node_type: { type: string }
+        label: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+    AWSLeastPrivilegeRelationship:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSLeastPrivilegeRemediationCasePreview:
+      type: object
+      properties:
+        case_id: { type: string }
+        title: { type: string }
+        recommended_action: { type: string }
+        approval_required: { type: boolean }
+        blocking_evidence:
+          type: array
+          items: { type: string }
+        impacted_node_count: { type: integer }
+        estimated_risk_drop: { type: integer }
+        breakage_prediction:
+          type: string
+          enum: [low, medium, high, unknown]
+        read_only_projection: { type: boolean }
+    AWSLeastPrivilegeRecommendation:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        calculation_version: { type: string }
+        recommendation_type: { type: string }
+        decision:
+          type: string
+          enum: [keep, remove, review]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        resource_node_id: { type: string }
+        resource_arn: { type: string }
+        display_name: { type: string }
+        rationale: { type: string }
+        breakage_prediction:
+          type: string
+          enum: [low, medium, high, unknown]
+        breakage_rationale: { type: string }
+        keep_actions:
+          type: array
+          items: { type: string }
+        remove_actions:
+          type: array
+          items: { type: string }
+        observed_actions:
+          type: array
+          items: { type: string }
+        granted_actions:
+          type: array
+          items: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLeastPrivilegeSummary:
+      type: object
+      properties:
+        total_recommendations: { type: integer }
+        filtered_recommendations: { type: integer }
+        decision_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        service_counts:
+          type: object
+          additionalProperties: { type: integer }
+        remove_count: { type: integer }
+        keep_count: { type: integer }
+        review_count: { type: integer }
+        low_breakage_count: { type: integer }
+        unknown_breakage_count: { type: integer }
+        runtime_evidence_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+        permission_denied_evidence_count: { type: integer }
+    AWSLeastPrivilegeDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSLeastPrivilegeCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSLeastPrivilegeResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSLeastPrivilegeSummary"
+        recommendations:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeRecommendation"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -758,6 +758,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -204,7 +204,10 @@ func (s *Service) GetAWSLeastPrivilegeRecommendations(ctx context.Context, works
 
 	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
-	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	connectorID := strings.TrimSpace(request.ConnectorID)
+	if connectorID == "" {
+		connectorID = strings.TrimSpace(connection.ConnectorID)
+	}
 
 	sourceFixtureState := fixtureState
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -211,7 +211,8 @@ func (s *Service) GetAWSLeastPrivilegeRecommendations(ctx context.Context, works
 		sourceFixtureState = ""
 	}
 
-	secrets, s3, agents, runtime, err := s.awsLeastPrivilegeSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	suppressRuntimeFixtures := strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected
+	secrets, s3, agents, runtime, err := s.awsLeastPrivilegeSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState, suppressRuntimeFixtures)
 	if err != nil {
 		return AWSLeastPrivilegeResult{}, err
 	}
@@ -284,7 +285,7 @@ func normalizeAWSLeastPrivilegeFixtureState(requested string, connection AWSConn
 	}
 }
 
-func (s *Service) awsLeastPrivilegeSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (AWSSecretsKMSRuntimeAccessResult, AWSS3RuntimeAccessResult, AWSAgentRuntimeAccessResult, AWSRuntimeEventResult, error) {
+func (s *Service) awsLeastPrivilegeSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string, suppressRuntimeFixtures bool) (AWSSecretsKMSRuntimeAccessResult, AWSS3RuntimeAccessResult, AWSAgentRuntimeAccessResult, AWSRuntimeEventResult, error) {
 	secrets, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{
 		ConnectorID:  connectorID,
 		FixtureState: fixtureState,
@@ -307,8 +308,9 @@ func (s *Service) awsLeastPrivilegeSourceSignals(ctx context.Context, workspaceI
 		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate agent least privilege: %w", err)
 	}
 	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
-		ConnectorID:  connectorID,
-		FixtureState: fixtureState,
+		ConnectorID:            connectorID,
+		FixtureState:           fixtureState,
+		SuppressFixtureRecords: suppressRuntimeFixtures,
 	})
 	if err != nil {
 		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate runtime signal least privilege: %w", err)
@@ -521,18 +523,28 @@ func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventReco
 		service := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.TargetResourceName, serviceFromAWSAction(record.Action), record.EventSource))
 		action := awsLeastPrivilegeServiceAction(service)
 		evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))
+		decision := "remove"
+		recommendationType := "remove-stale-service-access"
+		severity := "medium"
+		score := 70
 		breakage := "low"
+		removeActions := []string{action}
 		if record.Confidence < 0.75 {
+			decision = "review"
+			recommendationType = "review-stale-service-access"
+			score = 55
 			breakage = "unknown"
+			removeActions = nil
 		}
+		keepActions, _ := awsLeastPrivilegeKeepRemoveActions(decision, []string{action})
 		return AWSLeastPrivilegeRecommendation{
 			RecommendationID:   "aws-least-privilege:" + record.EventID,
 			CalculationVersion: awsLeastPrivilegeVersion,
-			RecommendationType: "remove-stale-service-access",
-			Decision:           "remove",
-			Severity:           "medium",
+			RecommendationType: recommendationType,
+			Decision:           decision,
+			Severity:           severity,
 			Status:             "review",
-			Score:              70,
+			Score:              score,
 			Confidence:         record.Confidence,
 			AccountID:          record.AccountID,
 			Region:             record.Region,
@@ -545,7 +557,8 @@ func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventReco
 			Rationale:          fmt.Sprintf("IAM last-used reports no recent %s service access for this identity in the scoped signal window.", firstNonEmptyAWSValue(service, "AWS")),
 			BreakagePrediction: breakage,
 			BreakageRationale:  "IAM last-used is metadata-only evidence; verify business owner and CloudTrail coverage before removing service actions.",
-			RemoveActions:      []string{action},
+			KeepActions:        keepActions,
+			RemoveActions:      removeActions,
 			GrantedActions:     []string{action},
 			ImpactedNodes:      dedupeStrings([]string{record.ActorIdentityNodeID, record.ResourceNodeID}),
 			ImpactedPath: []AWSLeastPrivilegePathStep{
@@ -553,8 +566,8 @@ func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventReco
 				awsLeastPrivilegePathStep(record.ResourceNodeID, "aws_service", firstNonEmptyAWSValue(record.TargetResourceName, service), record.AccountID, record.Region),
 			},
 			Evidence:        []AWSLeastPrivilegeEvidence{{Source: "iam_last_used", EvidenceRef: evidenceRef, Label: "IAM last-used signal", Confidence: record.Confidence, ObservedAt: record.ObservedAt, Relationship: record.Status}},
-			NextAction:      awsLeastPrivilegeNextAction("remove", "IAM service", breakage),
-			RemediationCase: awsLeastPrivilegeRemediationCase("remove-stale-service-access", "remove", "medium", 70, breakage, record.ActorIdentityNodeID, []string{evidenceRef}),
+			NextAction:      awsLeastPrivilegeNextAction(decision, "IAM service", breakage),
+			RemediationCase: awsLeastPrivilegeRemediationCase(recommendationType, decision, severity, score, breakage, record.ActorIdentityNodeID, []string{evidenceRef}),
 			CreatedAt:       now,
 			UpdatedAt:       now,
 		}, true

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -1,0 +1,1095 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsLeastPrivilegeCurrentIssue = 1522
+	awsLeastPrivilegeVersion      = "aws-least-privilege-recommendation-engine-v1"
+)
+
+// AWSLeastPrivilegeRequest scopes the least-privilege calculation to an AWS
+// connector and optional drill-down filters. Empty fixture_state attempts live
+// evidence when available; explicit fixture_state keeps tests and demos
+// deterministic.
+type AWSLeastPrivilegeRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Service      string `json:"service,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Decision     string `json:"decision,omitempty"`
+}
+
+// AWSLeastPrivilegeEvidence is a metadata-only pointer to source evidence. It
+// intentionally carries no secret values, prompts, completions, object bodies,
+// database rows, or customer payloads.
+type AWSLeastPrivilegeEvidence struct {
+	Source       string    `json:"source"`
+	EvidenceRef  string    `json:"evidence_ref"`
+	Label        string    `json:"label"`
+	Confidence   float64   `json:"confidence"`
+	ObservedAt   time.Time `json:"observed_at,omitzero"`
+	Relationship string    `json:"relationship,omitempty"`
+}
+
+// AWSLeastPrivilegePathStep is one explainable node in a recommendation path.
+type AWSLeastPrivilegePathStep struct {
+	NodeID    string `json:"node_id"`
+	NodeType  string `json:"node_type"`
+	Label     string `json:"label"`
+	AccountID string `json:"account_id,omitempty"`
+	Region    string `json:"region,omitempty"`
+}
+
+// AWSLeastPrivilegeRelationship is an edge the graph view can join against.
+type AWSLeastPrivilegeRelationship struct {
+	RecommendationID string `json:"recommendation_id"`
+	Type             string `json:"type"`
+	FromNodeID       string `json:"from_node_id"`
+	ToNodeID         string `json:"to_node_id"`
+	EvidenceRef      string `json:"evidence_ref"`
+}
+
+// AWSLeastPrivilegeRemediationCasePreview is the read-only planning shape the
+// app can use to start a remediation case without mutating AWS or Identrail
+// state.
+type AWSLeastPrivilegeRemediationCasePreview struct {
+	CaseID             string   `json:"case_id"`
+	Title              string   `json:"title"`
+	RecommendedAction  string   `json:"recommended_action"`
+	ApprovalRequired   bool     `json:"approval_required"`
+	BlockingEvidence   []string `json:"blocking_evidence,omitempty"`
+	ImpactedNodeCount  int      `json:"impacted_node_count"`
+	EstimatedRiskDrop  int      `json:"estimated_risk_drop"`
+	BreakagePrediction string   `json:"breakage_prediction"`
+	ReadOnlyProjection bool     `json:"read_only_projection"`
+}
+
+// AWSLeastPrivilegeRecommendation is a persisted-record-shaped intelligence
+// result. It preserves the keep/remove/review decision, confidence, breakage
+// prediction, rationale, impacted graph path, and remediation preview in one
+// deterministic contract.
+type AWSLeastPrivilegeRecommendation struct {
+	RecommendationID   string                                  `json:"recommendation_id"`
+	CalculationVersion string                                  `json:"calculation_version"`
+	RecommendationType string                                  `json:"recommendation_type"`
+	Decision           string                                  `json:"decision"`
+	Severity           string                                  `json:"severity"`
+	Status             string                                  `json:"status"`
+	Score              int                                     `json:"score"`
+	Confidence         float64                                 `json:"confidence"`
+	AccountID          string                                  `json:"account_id"`
+	Region             string                                  `json:"region"`
+	Service            string                                  `json:"service"`
+	IdentityNodeID     string                                  `json:"identity_node_id"`
+	PrincipalARN       string                                  `json:"principal_arn,omitempty"`
+	ResourceNodeID     string                                  `json:"resource_node_id,omitempty"`
+	ResourceARN        string                                  `json:"resource_arn,omitempty"`
+	DisplayName        string                                  `json:"display_name"`
+	Rationale          string                                  `json:"rationale"`
+	BreakagePrediction string                                  `json:"breakage_prediction"`
+	BreakageRationale  string                                  `json:"breakage_rationale"`
+	KeepActions        []string                                `json:"keep_actions,omitempty"`
+	RemoveActions      []string                                `json:"remove_actions,omitempty"`
+	ObservedActions    []string                                `json:"observed_actions,omitempty"`
+	GrantedActions     []string                                `json:"granted_actions,omitempty"`
+	ImpactedNodes      []string                                `json:"impacted_nodes"`
+	ImpactedPath       []AWSLeastPrivilegePathStep             `json:"impacted_path"`
+	Evidence           []AWSLeastPrivilegeEvidence             `json:"evidence"`
+	NextAction         string                                  `json:"next_action"`
+	RemediationCase    AWSLeastPrivilegeRemediationCasePreview `json:"remediation_case"`
+	CreatedAt          time.Time                               `json:"created_at"`
+	UpdatedAt          time.Time                               `json:"updated_at"`
+}
+
+// AWSLeastPrivilegeSummary aggregates the unfiltered and filtered set.
+type AWSLeastPrivilegeSummary struct {
+	TotalRecommendations     int            `json:"total_recommendations"`
+	FilteredRecommendations  int            `json:"filtered_recommendations"`
+	DecisionCounts           map[string]int `json:"decision_counts"`
+	SeverityCounts           map[string]int `json:"severity_counts"`
+	StatusCounts             map[string]int `json:"status_counts"`
+	ServiceCounts            map[string]int `json:"service_counts"`
+	RemoveCount              int            `json:"remove_count"`
+	KeepCount                int            `json:"keep_count"`
+	ReviewCount              int            `json:"review_count"`
+	LowBreakageCount         int            `json:"low_breakage_count"`
+	UnknownBreakageCount     int            `json:"unknown_breakage_count"`
+	RuntimeEvidenceCount     int            `json:"runtime_evidence_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+	RemediationPreviewCount  int            `json:"remediation_preview_count"`
+	PermissionDeniedEvidence int            `json:"permission_denied_evidence_count"`
+}
+
+// AWSLeastPrivilegeDiagnostic reports source calculation failures.
+type AWSLeastPrivilegeDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+// AWSLeastPrivilegeCoverageGap names missing or degraded evidence.
+type AWSLeastPrivilegeCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSLeastPrivilegeResult is the deterministic least-privilege envelope.
+type AWSLeastPrivilegeResult struct {
+	TenantID           string                            `json:"tenant_id"`
+	WorkspaceID        string                            `json:"workspace_id"`
+	ProjectID          string                            `json:"project_id"`
+	ConnectorID        string                            `json:"connector_id,omitempty"`
+	AccountID          string                            `json:"account_id,omitempty"`
+	Region             string                            `json:"region,omitempty"`
+	ParentIssueNumber  int                               `json:"parent_issue_number"`
+	ParentIssueRef     string                            `json:"parent_issue_ref"`
+	CurrentIssueNumber int                               `json:"current_issue_number"`
+	CurrentIssueRef    string                            `json:"current_issue_ref"`
+	Version            string                            `json:"version"`
+	Status             string                            `json:"status"`
+	FixtureState       string                            `json:"fixture_state,omitempty"`
+	Confidence         float64                           `json:"confidence"`
+	CalculationVersion string                            `json:"calculation_version"`
+	AppliedFilters     map[string]string                 `json:"applied_filters"`
+	Summary            AWSLeastPrivilegeSummary          `json:"summary"`
+	Recommendations    []AWSLeastPrivilegeRecommendation `json:"recommendations"`
+	Relationships      []AWSLeastPrivilegeRelationship   `json:"relationships"`
+	Caveats            []string                          `json:"caveats"`
+	FailureReasons     []string                          `json:"failure_reasons"`
+	RemediationHints   []string                          `json:"remediation_hints"`
+	EvidenceLinks      []string                          `json:"evidence_links"`
+	CoverageGaps       []AWSLeastPrivilegeCoverageGap    `json:"coverage_gaps"`
+	Diagnostics        []AWSLeastPrivilegeDiagnostic     `json:"diagnostics"`
+	GeneratedAt        time.Time                         `json:"generated_at"`
+	UpdatedAt          time.Time                         `json:"updated_at"`
+}
+
+// GetAWSLeastPrivilegeRecommendations calculates keep/remove/review
+// recommendations from static grants, runtime evidence, IAM last-used, Access
+// Analyzer, and agent/tool correlation. Unknown evidence becomes an explicit
+// review state rather than a deterministic remove decision.
+func (s *Service) GetAWSLeastPrivilegeRecommendations(ctx context.Context, workspaceID string, projectID string, request AWSLeastPrivilegeRequest) (AWSLeastPrivilegeResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSLeastPrivilegeResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSLeastPrivilegeResult{}, err
+	}
+	now := s.Now().UTC()
+
+	fixtureState := normalizeAWSLeastPrivilegeFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSLeastPrivilegeResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	secrets, s3, agents, runtime, err := s.awsLeastPrivilegeSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSLeastPrivilegeResult{}, err
+	}
+
+	recommendations := awsLeastPrivilegeRecommendations(secrets, s3, agents, runtime, now)
+	sort.SliceStable(recommendations, func(i, j int) bool {
+		if recommendations[i].Score == recommendations[j].Score {
+			return recommendations[i].RecommendationID < recommendations[j].RecommendationID
+		}
+		return recommendations[i].Score > recommendations[j].Score
+	})
+	filtered, applied := filterAWSLeastPrivilegeRecommendations(recommendations, request)
+	relationships := awsLeastPrivilegeRelationships(filtered)
+	diagnostics := awsLeastPrivilegeDiagnostics(secrets, s3, agents, runtime)
+	coverageGaps := awsLeastPrivilegeCoverageGaps(secrets, s3, agents, runtime)
+	status, confidence := summarizeAWSLeastPrivilegeStatus([]string{secrets.Status, s3.Status, agents.Status, runtime.Status}, filtered, diagnostics)
+	summary := summarizeAWSLeastPrivilege(recommendations, filtered, relationships)
+
+	return AWSLeastPrivilegeResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsLeastPrivilegeCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsLeastPrivilegeCurrentIssue),
+		Version:            awsLeastPrivilegeVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsLeastPrivilegeVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Recommendations:    filtered,
+		Relationships:      relationships,
+		Caveats:            awsLeastPrivilegeCaveats(secrets, s3, agents, runtime),
+		FailureReasons:     awsLeastPrivilegeFailureReasons(secrets, s3, agents, runtime),
+		RemediationHints:   awsLeastPrivilegeRemediationHints(secrets, s3, agents, runtime),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsBlastRadiusCurrentIssue),
+			"/docs/aws-least-privilege-engine",
+			"/docs/aws-runtime-events",
+			"/docs/aws-blast-radius-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSLeastPrivilegeFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsLeastPrivilegeSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (AWSSecretsKMSRuntimeAccessResult, AWSS3RuntimeAccessResult, AWSAgentRuntimeAccessResult, AWSRuntimeEventResult, error) {
+	secrets, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate secrets/kms least privilege: %w", err)
+	}
+	s3, err := s.GetAWSS3RuntimeAccess(ctx, workspaceID, projectID, AWSS3RuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate s3 least privilege: %w", err)
+	}
+	agents, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate agent least privilege: %w", err)
+	}
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:  connectorID,
+		FixtureState: fixtureState,
+	})
+	if err != nil {
+		return AWSSecretsKMSRuntimeAccessResult{}, AWSS3RuntimeAccessResult{}, AWSAgentRuntimeAccessResult{}, AWSRuntimeEventResult{}, fmt.Errorf("calculate runtime signal least privilege: %w", err)
+	}
+	return secrets, s3, agents, runtime, nil
+}
+
+func awsLeastPrivilegeRecommendations(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, runtime AWSRuntimeEventResult, now time.Time) []AWSLeastPrivilegeRecommendation {
+	recommendations := []AWSLeastPrivilegeRecommendation{}
+	for _, record := range secrets.Records {
+		recommendations = append(recommendations, awsLeastPrivilegeRecommendationFromSecret(record, now))
+	}
+	for _, record := range s3.Records {
+		recommendations = append(recommendations, awsLeastPrivilegeRecommendationFromS3(record, now)...)
+	}
+	for _, record := range agents.Records {
+		recommendations = append(recommendations, awsLeastPrivilegeRecommendationFromAgent(record, now))
+	}
+	for _, record := range runtime.Records {
+		if recommendation, ok := awsLeastPrivilegeRecommendationFromRuntimeSignal(record, now); ok {
+			recommendations = append(recommendations, recommendation)
+		}
+	}
+	return recommendations
+}
+
+func awsLeastPrivilegeRecommendationFromSecret(record AWSSecretsKMSRuntimeAccessRecord, now time.Time) AWSLeastPrivilegeRecommendation {
+	resourceLabel := firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN, record.ResourceNodeID)
+	actions := awsLeastPrivilegeSecretActions(record)
+	decision, status, recommendationType, severity, score := awsLeastPrivilegeDecisionForGrantStatus(record.Status, "secret-kms")
+	breakage := awsLeastPrivilegeBreakagePrediction(decision, record.Status, record.Confidence, record.ObservedCount, record.Caveats)
+	keepActions, removeActions := awsLeastPrivilegeKeepRemoveActions(decision, actions)
+	if decision == "remove" {
+		removeActions = actions
+	}
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, firstString(record.EvidenceRefs), fmt.Sprintf("secrets-kms-runtime-access://%s", record.CorrelationID))
+	rationale := fmt.Sprintf("%s access for %q is %s with %d observed event(s) and %d static grant action(s).", strings.ToUpper(record.ResourceKind), resourceLabel, record.Status, record.ObservedCount, len(actions))
+	if decision == "remove" {
+		rationale = fmt.Sprintf("Static %s grant to %q has no matching runtime evidence in the scoped window.", record.ResourceKind, resourceLabel)
+	}
+	return AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:" + record.CorrelationID,
+		CalculationVersion: awsLeastPrivilegeVersion,
+		RecommendationType: recommendationType,
+		Decision:           decision,
+		Severity:           severity,
+		Status:             status,
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		Service:            awsLeastPrivilegeServiceForSecret(record.ResourceKind, actions),
+		IdentityNodeID:     record.IdentityNodeID,
+		PrincipalARN:       record.PrincipalARN,
+		ResourceNodeID:     record.ResourceNodeID,
+		ResourceARN:        record.ResourceARN,
+		DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID),
+		Rationale:          rationale,
+		BreakagePrediction: breakage,
+		BreakageRationale:  awsLeastPrivilegeBreakageRationale(decision, breakage, record.ObservedCount, record.Caveats),
+		KeepActions:        keepActions,
+		RemoveActions:      removeActions,
+		ObservedActions:    awsLeastPrivilegeObservedActions(record.ObservedCount, actions),
+		GrantedActions:     actions,
+		ImpactedNodes:      dedupeStrings([]string{record.IdentityNodeID, record.ResourceNodeID, record.AgentNodeID}),
+		ImpactedPath: []AWSLeastPrivilegePathStep{
+			awsLeastPrivilegePathStep(record.IdentityNodeID, "identity", firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID), record.AccountID, record.Region),
+			awsLeastPrivilegePathStep(record.ResourceNodeID, record.ResourceKind, resourceLabel, record.AccountID, record.Region),
+		},
+		Evidence:        []AWSLeastPrivilegeEvidence{{Source: "secrets_kms_runtime_access", EvidenceRef: evidenceRef, Label: "Secrets Manager / KMS runtime access", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:      awsLeastPrivilegeNextAction(decision, "secret/KMS", breakage),
+		RemediationCase: awsLeastPrivilegeRemediationCase(recommendationType, decision, severity, score, breakage, record.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func awsLeastPrivilegeRecommendationFromS3(record AWSS3RuntimeAccessRecord, now time.Time) []AWSLeastPrivilegeRecommendation {
+	resourceLabel := firstNonEmptyAWSValue(record.BucketName, record.BucketARN, record.ResourceNodeID)
+	grantedActions := awsLeastPrivilegeS3Actions(record)
+	observedActions := awsLeastPrivilegeS3ObservedActions(record)
+	unusedActions := subtractStringSet(grantedActions, observedActions)
+	recommendations := []AWSLeastPrivilegeRecommendation{}
+	if len(unusedActions) > 0 && normalizeAWSRuntimeEventFilterToken(record.Status) == "confirmed" {
+		recommendations = append(recommendations, awsLeastPrivilegeS3Recommendation(record, now, "remove", "review", "reduce-unused-s3-actions", awsLeastPrivilegeS3Severity(record, 64), 64, unusedActions, observedActions, grantedActions, resourceLabel))
+		return recommendations
+	}
+	decision, status, recommendationType, severity, score := awsLeastPrivilegeDecisionForGrantStatus(record.Status, "s3")
+	if normalizeAWSRuntimeEventFilterToken(record.Sensitivity) == "high" || normalizeAWSRuntimeEventFilterToken(record.Exposure) == "external" {
+		score = minInt(score+8, 100)
+		if severity == "medium" {
+			severity = "high"
+		}
+	}
+	removeActions := []string{}
+	if decision == "remove" {
+		removeActions = grantedActions
+	}
+	recommendations = append(recommendations, awsLeastPrivilegeS3Recommendation(record, now, decision, status, recommendationType, severity, score, removeActions, observedActions, grantedActions, resourceLabel))
+	return recommendations
+}
+
+func awsLeastPrivilegeS3Recommendation(record AWSS3RuntimeAccessRecord, now time.Time, decision string, status string, recommendationType string, severity string, score int, removeActions []string, observedActions []string, grantedActions []string, resourceLabel string) AWSLeastPrivilegeRecommendation {
+	breakage := awsLeastPrivilegeBreakagePrediction(decision, record.Status, record.Confidence, record.ObservedCount, record.Caveats)
+	if recommendationType == "reduce-unused-s3-actions" && breakage == "low" {
+		breakage = "medium"
+	}
+	keepActions := observedActions
+	if decision == "keep" {
+		keepActions = grantedActions
+	}
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, firstString(record.EvidenceRefs), fmt.Sprintf("s3-runtime-access://%s", record.CorrelationID))
+	rationale := fmt.Sprintf("S3 access to %q is %s; observed modes=%s granted modes=%s sensitivity=%s exposure=%s.", resourceLabel, record.Status, strings.Join(record.ObservedModes, "/"), strings.Join(record.GrantedModes, "/"), firstNonEmptyAWSValue(record.Sensitivity, "unknown"), firstNonEmptyAWSValue(record.Exposure, "unknown"))
+	if recommendationType == "reduce-unused-s3-actions" {
+		rationale = fmt.Sprintf("S3 grant to %q includes action modes with no matching runtime evidence: %s.", resourceLabel, strings.Join(removeActions, ", "))
+	}
+	return AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:" + stableAWSBlastRadiusToken(record.CorrelationID, recommendationType),
+		CalculationVersion: awsLeastPrivilegeVersion,
+		RecommendationType: recommendationType,
+		Decision:           decision,
+		Severity:           severity,
+		Status:             status,
+		Score:              clampBlastRadiusScore(score),
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		Service:            "s3",
+		IdentityNodeID:     record.IdentityNodeID,
+		PrincipalARN:       record.PrincipalARN,
+		ResourceNodeID:     record.ResourceNodeID,
+		ResourceARN:        record.BucketARN,
+		DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID),
+		Rationale:          rationale,
+		BreakagePrediction: breakage,
+		BreakageRationale:  awsLeastPrivilegeBreakageRationale(decision, breakage, record.ObservedCount, record.Caveats),
+		KeepActions:        dedupeStrings(keepActions),
+		RemoveActions:      dedupeStrings(removeActions),
+		ObservedActions:    observedActions,
+		GrantedActions:     grantedActions,
+		ImpactedNodes:      dedupeStrings([]string{record.IdentityNodeID, record.ResourceNodeID, record.AgentNodeID}),
+		ImpactedPath: []AWSLeastPrivilegePathStep{
+			awsLeastPrivilegePathStep(record.IdentityNodeID, "identity", firstNonEmptyAWSValue(shortAWSARN(record.PrincipalARN), record.IdentityNodeID), record.AccountID, record.Region),
+			awsLeastPrivilegePathStep(record.ResourceNodeID, "s3_bucket", resourceLabel, record.AccountID, record.Region),
+		},
+		Evidence:        []AWSLeastPrivilegeEvidence{{Source: "s3_runtime_access", EvidenceRef: evidenceRef, Label: "S3 runtime access", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:      awsLeastPrivilegeNextAction(decision, "S3", breakage),
+		RemediationCase: awsLeastPrivilegeRemediationCase(recommendationType, decision, severity, score, breakage, record.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func awsLeastPrivilegeRecommendationFromAgent(record AWSAgentRuntimeAccessRecord, now time.Time) AWSLeastPrivilegeRecommendation {
+	roleNode := firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode, record.AgentNodeID)
+	roleARN := firstNonEmptyAWSValue(firstString(record.BackingRoleARNs), record.DeclaredBackingRole)
+	decision, status, recommendationType, severity, score := awsLeastPrivilegeDecisionForAgentStatus(record.Status)
+	breakage := awsLeastPrivilegeBreakagePrediction(decision, record.Status, record.Confidence, record.ObservedCount, record.Caveats)
+	toolAction := "agent-tool:" + firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef, record.AgentID, record.AgentNodeID)
+	removeActions := []string{}
+	keepActions := []string{}
+	if decision == "remove" {
+		removeActions = []string{toolAction}
+	} else {
+		keepActions = []string{toolAction}
+	}
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, firstString(record.EvidenceRefs), fmt.Sprintf("agent-runtime-access://%s", record.CorrelationID))
+	targetSteps := awsLeastPrivilegeAgentTargetSteps(record.TargetResourceNodeIDs, record.TargetResourceARNs, record.AccountID, record.Region)
+	return AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:" + record.CorrelationID,
+		CalculationVersion: awsLeastPrivilegeVersion,
+		RecommendationType: recommendationType,
+		Decision:           decision,
+		Severity:           severity,
+		Status:             status,
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		Service:            "agent-runtime",
+		IdentityNodeID:     roleNode,
+		PrincipalARN:       roleARN,
+		ResourceNodeID:     firstString(record.TargetResourceNodeIDs),
+		ResourceARN:        firstString(record.TargetResourceARNs),
+		DisplayName:        firstNonEmptyAWSValue(record.AgentName, record.AgentID, shortAWSARN(roleARN), roleNode),
+		Rationale:          fmt.Sprintf("Agent %q tool %q is %s with %d observed call(s).", firstNonEmptyAWSValue(record.AgentName, record.AgentID, record.AgentNodeID), firstNonEmptyAWSValue(record.ToolName, "unknown-tool"), record.Status, record.ObservedCount),
+		BreakagePrediction: breakage,
+		BreakageRationale:  awsLeastPrivilegeBreakageRationale(decision, breakage, record.ObservedCount, record.Caveats),
+		KeepActions:        keepActions,
+		RemoveActions:      removeActions,
+		ObservedActions:    awsLeastPrivilegeObservedActions(record.ObservedCount, []string{toolAction}),
+		GrantedActions:     []string{toolAction},
+		ImpactedNodes:      dedupeStrings(append(append([]string{roleNode, record.AgentNodeID}, record.TargetResourceNodeIDs...), record.TargetResourceARNs...)),
+		ImpactedPath:       awsLeastPrivilegeAgentPath(roleNode, roleARN, record.AgentNodeID, record.AgentName, record.AgentID, targetSteps, record.AccountID, record.Region),
+		Evidence:           []AWSLeastPrivilegeEvidence{{Source: "agent_runtime_access", EvidenceRef: evidenceRef, Label: "Agent runtime / tool path", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:         awsLeastPrivilegeNextAction(decision, "agent tool", breakage),
+		RemediationCase:    awsLeastPrivilegeRemediationCase(recommendationType, decision, severity, score, breakage, roleNode, []string{evidenceRef}),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+}
+
+func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventRecord, now time.Time) (AWSLeastPrivilegeRecommendation, bool) {
+	category := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.SignalCategory, record.EventType))
+	switch category {
+	case "iam-last-used":
+		if normalizeAWSRuntimeEventFilterToken(record.Status) != "stale" {
+			return AWSLeastPrivilegeRecommendation{}, false
+		}
+		service := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.TargetResourceName, serviceFromAWSAction(record.Action), record.EventSource))
+		action := awsLeastPrivilegeServiceAction(service)
+		evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))
+		breakage := "low"
+		if record.Confidence < 0.75 {
+			breakage = "unknown"
+		}
+		return AWSLeastPrivilegeRecommendation{
+			RecommendationID:   "aws-least-privilege:" + record.EventID,
+			CalculationVersion: awsLeastPrivilegeVersion,
+			RecommendationType: "remove-stale-service-access",
+			Decision:           "remove",
+			Severity:           "medium",
+			Status:             "review",
+			Score:              70,
+			Confidence:         record.Confidence,
+			AccountID:          record.AccountID,
+			Region:             record.Region,
+			Service:            service,
+			IdentityNodeID:     record.ActorIdentityNodeID,
+			PrincipalARN:       record.ActorPrincipalARN,
+			ResourceNodeID:     record.ResourceNodeID,
+			ResourceARN:        record.TargetResourceARN,
+			DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.ActorPrincipalARN), record.ActorIdentityNodeID),
+			Rationale:          fmt.Sprintf("IAM last-used reports no recent %s service access for this identity in the scoped signal window.", firstNonEmptyAWSValue(service, "AWS")),
+			BreakagePrediction: breakage,
+			BreakageRationale:  "IAM last-used is metadata-only evidence; verify business owner and CloudTrail coverage before removing service actions.",
+			RemoveActions:      []string{action},
+			GrantedActions:     []string{action},
+			ImpactedNodes:      dedupeStrings([]string{record.ActorIdentityNodeID, record.ResourceNodeID}),
+			ImpactedPath: []AWSLeastPrivilegePathStep{
+				awsLeastPrivilegePathStep(record.ActorIdentityNodeID, "identity", firstNonEmptyAWSValue(shortAWSARN(record.ActorPrincipalARN), record.ActorIdentityNodeID), record.AccountID, record.Region),
+				awsLeastPrivilegePathStep(record.ResourceNodeID, "aws_service", firstNonEmptyAWSValue(record.TargetResourceName, service), record.AccountID, record.Region),
+			},
+			Evidence:        []AWSLeastPrivilegeEvidence{{Source: "iam_last_used", EvidenceRef: evidenceRef, Label: "IAM last-used signal", Confidence: record.Confidence, ObservedAt: record.ObservedAt, Relationship: record.Status}},
+			NextAction:      awsLeastPrivilegeNextAction("remove", "IAM service", breakage),
+			RemediationCase: awsLeastPrivilegeRemediationCase("remove-stale-service-access", "remove", "medium", 70, breakage, record.ActorIdentityNodeID, []string{evidenceRef}),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}, true
+	case "access-analyzer":
+		evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))
+		service := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(serviceFromAWSAction(record.Action), record.EventSource, record.TargetResourceType))
+		return AWSLeastPrivilegeRecommendation{
+			RecommendationID:   "aws-least-privilege:" + record.EventID,
+			CalculationVersion: awsLeastPrivilegeVersion,
+			RecommendationType: "review-external-access",
+			Decision:           "review",
+			Severity:           "high",
+			Status:             "action_required",
+			Score:              78,
+			Confidence:         record.Confidence,
+			AccountID:          record.AccountID,
+			Region:             record.Region,
+			Service:            service,
+			IdentityNodeID:     record.ActorIdentityNodeID,
+			PrincipalARN:       record.ActorPrincipalARN,
+			ResourceNodeID:     record.ResourceNodeID,
+			ResourceARN:        record.TargetResourceARN,
+			DisplayName:        firstNonEmptyAWSValue(shortAWSARN(record.ActorPrincipalARN), record.ActorIdentityNodeID),
+			Rationale:          fmt.Sprintf("Access Analyzer reported externally reachable %s access to %q; do not auto-remove until ownership and analyzer scope are confirmed.", firstNonEmptyAWSValue(service, "resource"), firstNonEmptyAWSValue(record.TargetResourceName, record.TargetResourceARN, record.ResourceNodeID)),
+			BreakagePrediction: "unknown",
+			BreakageRationale:  "Access Analyzer proves reachability, not application intent; owner review is required before generating a policy diff.",
+			KeepActions:        []string{record.Action},
+			ObservedActions:    []string{record.Action},
+			GrantedActions:     []string{record.Action},
+			ImpactedNodes:      dedupeStrings([]string{record.ActorIdentityNodeID, record.ResourceNodeID}),
+			ImpactedPath: []AWSLeastPrivilegePathStep{
+				awsLeastPrivilegePathStep(record.ActorIdentityNodeID, "identity", firstNonEmptyAWSValue(shortAWSARN(record.ActorPrincipalARN), record.ActorIdentityNodeID), record.AccountID, record.Region),
+				awsLeastPrivilegePathStep(record.ResourceNodeID, firstNonEmptyAWSValue(record.TargetResourceType, "resource"), firstNonEmptyAWSValue(record.TargetResourceName, record.TargetResourceARN, record.ResourceNodeID), record.AccountID, record.Region),
+			},
+			Evidence:        []AWSLeastPrivilegeEvidence{{Source: "access_analyzer", EvidenceRef: evidenceRef, Label: "Access Analyzer finding", Confidence: record.Confidence, ObservedAt: record.ObservedAt, Relationship: record.Status}},
+			NextAction:      "Confirm analyzer scope, resource owner, and expected external principal before creating a least-privilege case.",
+			RemediationCase: awsLeastPrivilegeRemediationCase("review-external-access", "review", "high", 78, "unknown", record.ActorIdentityNodeID, []string{evidenceRef}),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}, true
+	default:
+		return AWSLeastPrivilegeRecommendation{}, false
+	}
+}
+
+func awsLeastPrivilegeDecisionForGrantStatus(status string, source string) (string, string, string, string, int) {
+	switch normalizeAWSRuntimeEventFilterToken(status) {
+	case "granted-unused", "declared-unused":
+		severity := "medium"
+		score := 68
+		if source == "secret-kms" {
+			severity = "high"
+			score = 82
+		}
+		return "remove", "review", "remove-unused-" + source + "-grant", severity, score
+	case "observed-without-grant", "observed-without-declaration":
+		return "keep", "action_required", "authorize-observed-" + source + "-access", "high", 78
+	case "confirmed":
+		return "keep", "monitor", "keep-observed-" + source + "-access", "low", 38
+	default:
+		return "review", "review", "review-" + source + "-access", "medium", 55
+	}
+}
+
+func awsLeastPrivilegeDecisionForAgentStatus(status string) (string, string, string, string, int) {
+	switch normalizeAWSRuntimeEventFilterToken(status) {
+	case "declared-unused":
+		return "remove", "review", "remove-unused-agent-tool", "medium", 62
+	case "observed-without-declaration":
+		return "review", "action_required", "review-undeclared-agent-tool", "high", 82
+	case "confirmed":
+		return "keep", "monitor", "keep-observed-agent-tool", "low", 36
+	default:
+		return "review", "review", "review-agent-tool", "medium", 55
+	}
+}
+
+func awsLeastPrivilegeBreakagePrediction(decision string, status string, confidence float64, observedCount int, caveats []string) string {
+	if decision == "keep" {
+		return "high"
+	}
+	if decision == "review" {
+		return "unknown"
+	}
+	if observedCount > 0 || normalizeAWSRuntimeEventFilterToken(status) == "observed-without-grant" || normalizeAWSRuntimeEventFilterToken(status) == "observed-without-declaration" {
+		return "high"
+	}
+	if len(caveats) > 0 || confidence < 0.65 {
+		return "unknown"
+	}
+	if confidence < 0.82 {
+		return "medium"
+	}
+	return "low"
+}
+
+func awsLeastPrivilegeBreakageRationale(decision string, breakage string, observedCount int, caveats []string) string {
+	if decision == "keep" {
+		return "Runtime evidence shows this access is used; removing it would likely break the workload."
+	}
+	if decision == "review" {
+		return "Evidence is not sufficient for deterministic removal; operator review is required."
+	}
+	if observedCount == 0 && len(caveats) == 0 && breakage == "low" {
+		return "No matching runtime use was observed in the scoped evidence window, and source confidence is high."
+	}
+	if len(caveats) > 0 {
+		return "Source caveats are present, so the recommendation must be reviewed before policy changes."
+	}
+	return "Runtime use was not observed, but evidence coverage is not strong enough for a low-breakage prediction."
+}
+
+func awsLeastPrivilegeKeepRemoveActions(decision string, actions []string) ([]string, []string) {
+	switch decision {
+	case "keep":
+		return dedupeStrings(actions), nil
+	case "remove":
+		return nil, dedupeStrings(actions)
+	default:
+		return dedupeStrings(actions), nil
+	}
+}
+
+func awsLeastPrivilegeObservedActions(observedCount int, actions []string) []string {
+	if observedCount <= 0 {
+		return nil
+	}
+	return dedupeStrings(actions)
+}
+
+func awsLeastPrivilegeSecretActions(record AWSSecretsKMSRuntimeAccessRecord) []string {
+	actions := dedupeStrings(record.Actions)
+	if len(actions) > 0 {
+		return actions
+	}
+	switch normalizeAWSRuntimeEventFilterToken(record.ResourceKind) {
+	case "kms-key", "kms_key", "kms":
+		return []string{"kms:Decrypt"}
+	default:
+		return []string{"secretsmanager:GetSecretValue"}
+	}
+}
+
+func awsLeastPrivilegeS3Actions(record AWSS3RuntimeAccessRecord) []string {
+	actions := dedupeStrings(record.Actions)
+	if len(actions) > 0 {
+		return actions
+	}
+	return awsLeastPrivilegeS3ModeActions(record.GrantedModes)
+}
+
+func awsLeastPrivilegeS3ObservedActions(record AWSS3RuntimeAccessRecord) []string {
+	actions := awsLeastPrivilegeS3ModeActions(record.ObservedModes)
+	if len(actions) > 0 {
+		return actions
+	}
+	return awsLeastPrivilegeObservedActions(record.ObservedCount, record.Actions)
+}
+
+func awsLeastPrivilegeS3ModeActions(modes []string) []string {
+	actions := []string{}
+	for _, mode := range modes {
+		switch normalizeAWSRuntimeEventFilterToken(mode) {
+		case "read":
+			actions = append(actions, "s3:GetObject")
+		case "write":
+			actions = append(actions, "s3:PutObject")
+		case "list":
+			actions = append(actions, "s3:ListBucket")
+		}
+	}
+	return dedupeStrings(actions)
+}
+
+func awsLeastPrivilegeS3Severity(record AWSS3RuntimeAccessRecord, score int) string {
+	if score >= 85 {
+		return "critical"
+	}
+	if normalizeAWSRuntimeEventFilterToken(record.Sensitivity) == "high" || normalizeAWSRuntimeEventFilterToken(record.Exposure) == "external" || score >= 70 {
+		return "high"
+	}
+	if score >= 45 {
+		return "medium"
+	}
+	return "low"
+}
+
+func awsLeastPrivilegeServiceForSecret(kind string, actions []string) string {
+	for _, action := range actions {
+		if service := serviceFromAWSAction(action); service != "" {
+			return service
+		}
+	}
+	switch normalizeAWSRuntimeEventFilterToken(kind) {
+	case "kms-key", "kms_key", "kms":
+		return "kms"
+	default:
+		return "secretsmanager"
+	}
+}
+
+func serviceFromAWSAction(action string) string {
+	action = strings.TrimSpace(action)
+	if idx := strings.Index(action, ":"); idx > 0 {
+		return normalizeAWSRuntimeEventFilterToken(action[:idx])
+	}
+	return ""
+}
+
+func awsLeastPrivilegeServiceAction(service string) string {
+	service = normalizeAWSRuntimeEventFilterToken(service)
+	if service == "" {
+		return "aws-service:*"
+	}
+	return service + ":*"
+}
+
+func awsLeastPrivilegePathStep(nodeID string, nodeType string, label string, accountID string, region string) AWSLeastPrivilegePathStep {
+	return AWSLeastPrivilegePathStep{
+		NodeID:    strings.TrimSpace(nodeID),
+		NodeType:  strings.TrimSpace(nodeType),
+		Label:     firstNonEmptyAWSValue(label, nodeID),
+		AccountID: strings.TrimSpace(accountID),
+		Region:    strings.TrimSpace(region),
+	}
+}
+
+func awsLeastPrivilegeAgentTargetSteps(targetResourceNodeIDs []string, targetResourceARNs []string, accountID string, region string) []AWSLeastPrivilegePathStep {
+	targets := dedupeStrings(append(append([]string{}, targetResourceNodeIDs...), targetResourceARNs...))
+	steps := make([]AWSLeastPrivilegePathStep, 0, len(targets))
+	for _, target := range targets {
+		steps = append(steps, awsLeastPrivilegePathStep(target, "target_resource", target, accountID, region))
+	}
+	return steps
+}
+
+func awsLeastPrivilegeAgentPath(roleNode string, roleARN string, agentNodeID string, agentName string, agentID string, targetSteps []AWSLeastPrivilegePathStep, accountID string, region string) []AWSLeastPrivilegePathStep {
+	path := []AWSLeastPrivilegePathStep{
+		awsLeastPrivilegePathStep(roleNode, "identity", firstNonEmptyAWSValue(shortAWSARN(roleARN), roleNode), accountID, region),
+		awsLeastPrivilegePathStep(agentNodeID, "ai_agent", firstNonEmptyAWSValue(agentName, agentID, agentNodeID), accountID, region),
+	}
+	return append(path, targetSteps...)
+}
+
+func awsLeastPrivilegeNextAction(decision string, scope string, breakage string) string {
+	switch decision {
+	case "remove":
+		return fmt.Sprintf("Open a read-only least-privilege case for %s, require owner approval, and verify %s breakage prediction before policy diff generation.", scope, breakage)
+	case "keep":
+		return fmt.Sprintf("Keep observed %s access and document the evidence before considering narrower resource or condition scopes.", scope)
+	default:
+		return fmt.Sprintf("Review %s evidence boundaries before generating a keep/remove decision.", scope)
+	}
+}
+
+func awsLeastPrivilegeRemediationCase(kind, decision, severity string, score int, breakage string, identityNodeID string, evidence []string) AWSLeastPrivilegeRemediationCasePreview {
+	action := "Review evidence and create a least-privilege remediation case."
+	switch decision {
+	case "remove":
+		action = "Create a read-only case to remove unused grants after owner approval."
+	case "keep":
+		action = "Record keep decision with evidence, owner, and scoped follow-up."
+	case "review":
+		action = "Create a review case; do not generate a policy diff until evidence is confirmed."
+	}
+	return AWSLeastPrivilegeRemediationCasePreview{
+		CaseID:             "aws-least-privilege-preview:" + stableAWSBlastRadiusToken(kind, identityNodeID),
+		Title:              fmt.Sprintf("%s least-privilege %s", formatAWSBlastRadiusLabel(kind), decision),
+		RecommendedAction:  action,
+		ApprovalRequired:   severity == "critical" || severity == "high" || decision == "remove",
+		BlockingEvidence:   dedupeStrings(evidence),
+		ImpactedNodeCount:  1,
+		EstimatedRiskDrop:  minInt(score, 40),
+		BreakagePrediction: breakage,
+		ReadOnlyProjection: true,
+	}
+}
+
+func filterAWSLeastPrivilegeRecommendations(recommendations []AWSLeastPrivilegeRecommendation, request AWSLeastPrivilegeRequest) ([]AWSLeastPrivilegeRecommendation, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"identity":   strings.TrimSpace(request.Identity),
+		"resource":   strings.TrimSpace(request.Resource),
+		"service":    normalizeAWSRuntimeEventFilterToken(request.Service),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+		"decision":   normalizeAWSRuntimeEventFilterToken(request.Decision),
+	}
+	for key, value := range filters {
+		token := strings.TrimSpace(value)
+		if token == "" || strings.EqualFold(token, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSLeastPrivilegeRecommendation, 0, len(recommendations))
+	for _, recommendation := range recommendations {
+		if filters["account_id"] != "" && filters["account_id"] != recommendation.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], recommendation.Region) {
+			continue
+		}
+		if filters["service"] != "" && filters["service"] != normalizeAWSRuntimeEventFilterToken(recommendation.Service) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(recommendation.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(recommendation.Status) {
+			continue
+		}
+		if filters["decision"] != "" && filters["decision"] != normalizeAWSRuntimeEventFilterToken(recommendation.Decision) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], awsLeastPrivilegeIdentityMatchValues(recommendation)...) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], awsLeastPrivilegeResourceMatchValues(recommendation)...) {
+			continue
+		}
+		filtered = append(filtered, recommendation)
+	}
+	return filtered, applied
+}
+
+func awsLeastPrivilegeIdentityMatchValues(recommendation AWSLeastPrivilegeRecommendation) []string {
+	candidates := []string{recommendation.IdentityNodeID, recommendation.PrincipalARN, recommendation.DisplayName}
+	for _, step := range recommendation.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			candidates = append(candidates, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(candidates)
+}
+
+func awsLeastPrivilegeResourceMatchValues(recommendation AWSLeastPrivilegeRecommendation) []string {
+	candidates := []string{recommendation.ResourceNodeID, recommendation.ResourceARN}
+	candidates = append(candidates, recommendation.ImpactedNodes...)
+	for _, step := range recommendation.ImpactedPath {
+		candidates = append(candidates, step.NodeID, step.Label)
+	}
+	return dedupeStrings(candidates)
+}
+
+func awsLeastPrivilegeRelationships(recommendations []AWSLeastPrivilegeRecommendation) []AWSLeastPrivilegeRelationship {
+	relationships := []AWSLeastPrivilegeRelationship{}
+	for _, recommendation := range recommendations {
+		for i := 0; i+1 < len(recommendation.ImpactedPath); i++ {
+			from := strings.TrimSpace(recommendation.ImpactedPath[i].NodeID)
+			to := strings.TrimSpace(recommendation.ImpactedPath[i+1].NodeID)
+			if from == "" || to == "" {
+				continue
+			}
+			relationships = append(relationships, AWSLeastPrivilegeRelationship{
+				RecommendationID: recommendation.RecommendationID,
+				Type:             "least_privilege_scope",
+				FromNodeID:       from,
+				ToNodeID:         to,
+				EvidenceRef:      firstLeastPrivilegeEvidenceRef(recommendation.Evidence),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSLeastPrivilege(allRecommendations []AWSLeastPrivilegeRecommendation, filtered []AWSLeastPrivilegeRecommendation, relationships []AWSLeastPrivilegeRelationship) AWSLeastPrivilegeSummary {
+	decisionCounts := map[string]int{}
+	severityCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	serviceCounts := map[string]int{}
+	totalConfidence := 0.0
+	highest := 0
+	runtimeEvidence := 0
+	remediationCases := map[string]struct{}{}
+	for _, recommendation := range allRecommendations {
+		decisionCounts[recommendation.Decision]++
+		severityCounts[recommendation.Severity]++
+		statusCounts[recommendation.Status]++
+		serviceCounts[recommendation.Service]++
+		totalConfidence += recommendation.Confidence
+		if recommendation.Score > highest {
+			highest = recommendation.Score
+		}
+		if recommendation.BreakagePrediction == "low" {
+			// counted below from map for clarity
+		}
+		for _, evidence := range recommendation.Evidence {
+			if strings.TrimSpace(evidence.EvidenceRef) != "" {
+				runtimeEvidence++
+			}
+		}
+		if recommendation.RemediationCase.CaseID != "" {
+			remediationCases[recommendation.RemediationCase.CaseID] = struct{}{}
+		}
+	}
+	averageConfidence := 0
+	if len(allRecommendations) > 0 {
+		averageConfidence = int((totalConfidence / float64(len(allRecommendations))) * 100)
+	}
+	return AWSLeastPrivilegeSummary{
+		TotalRecommendations:     len(allRecommendations),
+		FilteredRecommendations:  len(filtered),
+		DecisionCounts:           decisionCounts,
+		SeverityCounts:           severityCounts,
+		StatusCounts:             statusCounts,
+		ServiceCounts:            serviceCounts,
+		RemoveCount:              decisionCounts["remove"],
+		KeepCount:                decisionCounts["keep"],
+		ReviewCount:              decisionCounts["review"],
+		LowBreakageCount:         countLeastPrivilegeBreakage(allRecommendations, "low"),
+		UnknownBreakageCount:     countLeastPrivilegeBreakage(allRecommendations, "unknown"),
+		RuntimeEvidenceCount:     runtimeEvidence,
+		RelationshipCount:        len(relationships),
+		HighestScore:             highest,
+		AverageConfidencePct:     averageConfidence,
+		RemediationPreviewCount:  len(remediationCases),
+		PermissionDeniedEvidence: statusCounts["permission-denied"],
+	}
+}
+
+func countLeastPrivilegeBreakage(recommendations []AWSLeastPrivilegeRecommendation, breakage string) int {
+	count := 0
+	for _, recommendation := range recommendations {
+		if normalizeAWSRuntimeEventFilterToken(recommendation.BreakagePrediction) == normalizeAWSRuntimeEventFilterToken(breakage) {
+			count++
+		}
+	}
+	return count
+}
+
+func summarizeAWSLeastPrivilegeStatus(sourceStatuses []string, filtered []AWSLeastPrivilegeRecommendation, diagnostics []AWSLeastPrivilegeDiagnostic) (string, float64) {
+	allBlocked := len(sourceStatuses) > 0
+	anyDegraded := len(diagnostics) > 0
+	for _, status := range sourceStatuses {
+		switch status {
+		case awsPlatformDependencyStatusBlocked:
+			anyDegraded = true
+		case awsPlatformDependencyStatusDegraded:
+			allBlocked = false
+			anyDegraded = true
+		default:
+			allBlocked = false
+		}
+	}
+	if allBlocked {
+		return awsPlatformDependencyStatusBlocked, 0
+	}
+	if len(filtered) == 0 || anyDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.7
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsLeastPrivilegeDiagnostics(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, runtime AWSRuntimeEventResult) []AWSLeastPrivilegeDiagnostic {
+	out := []AWSLeastPrivilegeDiagnostic{}
+	for _, diagnostic := range secrets.Diagnostics {
+		out = append(out, AWSLeastPrivilegeDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range s3.Diagnostics {
+		out = append(out, AWSLeastPrivilegeDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range agents.Diagnostics {
+		out = append(out, AWSLeastPrivilegeDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range runtime.Diagnostics {
+		out = append(out, AWSLeastPrivilegeDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsLeastPrivilegeCoverageGaps(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, runtime AWSRuntimeEventResult) []AWSLeastPrivilegeCoverageGap {
+	out := []AWSLeastPrivilegeCoverageGap{{
+		Capability:  "least_privilege_persistence",
+		Status:      "ready",
+		Reason:      "The API emits stable recommendation IDs, calculation version, evidence, keep/remove actions, breakage prediction, and remediation preview fields for downstream persistence/graph consumers.",
+		Remediation: "Persist these intelligence records into the shared findings store when the dedicated AWS findings table lands.",
+	}}
+	for _, gap := range secrets.CoverageGaps {
+		out = append(out, AWSLeastPrivilegeCoverageGap(gap))
+	}
+	for _, gap := range s3.CoverageGaps {
+		out = append(out, AWSLeastPrivilegeCoverageGap(gap))
+	}
+	for _, gap := range agents.CoverageGaps {
+		out = append(out, AWSLeastPrivilegeCoverageGap(gap))
+	}
+	for _, gap := range runtime.CoverageGaps {
+		out = append(out, AWSLeastPrivilegeCoverageGap(gap))
+	}
+	return out
+}
+
+func awsLeastPrivilegeCaveats(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, _ AWSRuntimeEventResult) []string {
+	return dedupeStrings(append(append(append(secrets.Caveats, s3.Caveats...), agents.Caveats...), "Unknown or partial runtime evidence creates review recommendations; it never becomes an automatic remove decision."))
+}
+
+func awsLeastPrivilegeFailureReasons(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, runtime AWSRuntimeEventResult) []string {
+	return emptyStrings(dedupeStrings(append(append(append(secrets.FailureReasons, s3.FailureReasons...), agents.FailureReasons...), runtime.FailureReasons...)))
+}
+
+func awsLeastPrivilegeRemediationHints(secrets AWSSecretsKMSRuntimeAccessResult, s3 AWSS3RuntimeAccessResult, agents AWSAgentRuntimeAccessResult, runtime AWSRuntimeEventResult) []string {
+	return emptyStrings(dedupeStrings(append(append(append(append(secrets.RemediationHints, s3.RemediationHints...), agents.RemediationHints...), runtime.RemediationHints...), "Use the least-privilege remediation preview as a read-only plan until owner approval and policy diff generation are available.")))
+}
+
+func firstLeastPrivilegeEvidenceRef(evidence []AWSLeastPrivilegeEvidence) string {
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}
+
+func subtractStringSet(all []string, used []string) []string {
+	usedSet := map[string]struct{}{}
+	for _, value := range used {
+		token := normalizeAWSRuntimeEventFilterToken(value)
+		if token != "" {
+			usedSet[token] = struct{}{}
+		}
+	}
+	out := []string{}
+	for _, value := range all {
+		token := normalizeAWSRuntimeEventFilterToken(value)
+		if token == "" {
+			continue
+		}
+		if _, ok := usedSet[token]; !ok {
+			out = append(out, value)
+		}
+	}
+	return dedupeStrings(out)
+}

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newLeastPrivilegeService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSLeastPrivilegeBuildsRecommendationContract(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 0, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-least-privilege", now)
+
+	result, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get least privilege recommendations: %v", err)
+	}
+	if result.CurrentIssueRef != "#1522" || result.Version != awsLeastPrivilegeVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Recommendations) == 0 || result.Summary.TotalRecommendations != len(result.Recommendations) {
+		t.Fatalf("expected recommendations summary to match payload: %+v", result.Summary)
+	}
+	if result.Recommendations[0].Score < result.Recommendations[len(result.Recommendations)-1].Score {
+		t.Fatalf("recommendations are not ranked by descending score: %+v", result.Recommendations)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected graph relationships: %+v", result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 || result.Summary.RuntimeEvidenceCount == 0 {
+		t.Fatalf("expected remediation previews and evidence refs: %+v", result.Summary)
+	}
+
+	hasRemove := false
+	hasKeep := false
+	hasReview := false
+	for _, recommendation := range result.Recommendations {
+		if recommendation.RecommendationID == "" || recommendation.CalculationVersion != awsLeastPrivilegeVersion || recommendation.Rationale == "" {
+			t.Fatalf("recommendation missing stable metadata: %+v", recommendation)
+		}
+		if recommendation.Decision == "" || recommendation.BreakagePrediction == "" || recommendation.Confidence <= 0 || len(recommendation.Evidence) == 0 {
+			t.Fatalf("recommendation missing decision/breakage/evidence: %+v", recommendation)
+		}
+		if recommendation.RemediationCase.CaseID == "" || !recommendation.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("recommendation missing read-only remediation preview: %+v", recommendation.RemediationCase)
+		}
+		switch recommendation.Decision {
+		case "remove":
+			hasRemove = true
+			if len(recommendation.RemoveActions) == 0 {
+				t.Fatalf("remove recommendation must name removable actions: %+v", recommendation)
+			}
+		case "keep":
+			hasKeep = true
+			if recommendation.BreakagePrediction != "high" {
+				t.Fatalf("keep recommendation must preserve high breakage prediction: %+v", recommendation)
+			}
+		case "review":
+			hasReview = true
+		}
+	}
+	if !hasRemove || !hasKeep || !hasReview {
+		t.Fatalf("expected keep/remove/review recommendations, got decision counts %+v", result.Summary.DecisionCounts)
+	}
+}
+
+func TestGetAWSLeastPrivilegeFiltersByDecisionServiceAndResource(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 10, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-least-privilege-filters", now)
+
+	remove, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-filters", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Decision:     "remove",
+		Service:      "lambda",
+	})
+	if err != nil {
+		t.Fatalf("decision/service filter: %v", err)
+	}
+	if len(remove.Recommendations) == 0 {
+		t.Fatalf("expected stale IAM last-used remove recommendation")
+	}
+	for _, recommendation := range remove.Recommendations {
+		if recommendation.Decision != "remove" || recommendation.Service != "lambda" {
+			t.Fatalf("decision/service filter leaked %+v", recommendation)
+		}
+	}
+	if remove.AppliedFilters["decision"] != "remove" || remove.AppliedFilters["service"] != "lambda" {
+		t.Fatalf("expected applied filters, got %+v", remove.AppliedFilters)
+	}
+
+	resource, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-filters", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Resource:     "prod/ai/openai-key",
+	})
+	if err != nil {
+		t.Fatalf("resource filter: %v", err)
+	}
+	if len(resource.Recommendations) == 0 {
+		t.Fatalf("expected resource label/ARN matched recommendations")
+	}
+	for _, recommendation := range resource.Recommendations {
+		if !awsRuntimeEventMatchesAny("prod/ai/openai-key", awsLeastPrivilegeResourceMatchValues(recommendation)...) {
+			t.Fatalf("resource filter leaked %+v", recommendation)
+		}
+	}
+}
+
+func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalKeepsAccessAnalyzerInReview(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 20, 0, 0, time.UTC)
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-access-analyzer-secret",
+		AccountID:           "111111111111",
+		Region:              "us-east-1",
+		EventType:           "access-analyzer",
+		EventSource:         "access-analyzer.amazonaws.com",
+		EventName:           "Finding",
+		Action:              "secretsmanager:GetSecretValue",
+		ActorPrincipalARN:   "access-analyzer:external-principal",
+		ActorIdentityNodeID: "aws:identity:external-principal",
+		TargetResourceARN:   "arn:aws:secretsmanager:us-east-1:111111111111:secret:prod/ai/openai-key",
+		TargetResourceType:  "AWS::SecretsManager::Secret",
+		TargetResourceName:  "prod/ai/openai-key",
+		ResourceNodeID:      "aws:runtime-resource:secret:prod-ai-openai-key",
+		SignalCategory:      "access-analyzer",
+		EvidenceRef:         "runtime-evidence://access-analyzer",
+		Confidence:          0.91,
+		ObservedAt:          now.Add(-time.Hour),
+		Status:              "observed",
+	}
+
+	recommendation, ok := awsLeastPrivilegeRecommendationFromRuntimeSignal(record, now)
+	if !ok {
+		t.Fatal("expected Access Analyzer signal to produce a review recommendation")
+	}
+	if recommendation.Decision != "review" || recommendation.BreakagePrediction != "unknown" || len(recommendation.RemoveActions) != 0 {
+		t.Fatalf("Access Analyzer must not become deterministic removal: %+v", recommendation)
+	}
+	if !strings.Contains(recommendation.NextAction, "analyzer scope") {
+		t.Fatalf("expected analyzer-scope next action, got %q", recommendation.NextAction)
+	}
+}
+
+func TestGetAWSLeastPrivilegePermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 30, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-least-privilege-states", now)
+
+	denied, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-states", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || denied.Confidence != 0 || len(denied.Recommendations) != 0 {
+		t.Fatalf("expected blocked permission-denied state, got %+v", denied)
+	}
+	if len(denied.Diagnostics) == 0 || len(denied.CoverageGaps) == 0 {
+		t.Fatalf("expected diagnostics and coverage gaps for denied state")
+	}
+
+	empty, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-states", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Recommendations) != 0 || empty.Summary.TotalRecommendations != 0 {
+		t.Fatalf("expected degraded empty state, got %+v", empty)
+	}
+}
+
+func TestNormalizeAWSLeastPrivilegeFixtureState(t *testing.T) {
+	disconnected := AWSConnectionStatus{Connected: false}
+	if got := normalizeAWSLeastPrivilegeFixtureState("", disconnected, true); got != "permission_denied" {
+		t.Fatalf("expected denied for disconnected default, got %q", got)
+	}
+	if got := normalizeAWSLeastPrivilegeFixtureState("PARTIAL_FAILURE", AWSConnectionStatus{}, false); got != "partial_failure" {
+		t.Fatalf("expected normalized partial failure, got %q", got)
+	}
+	if got := normalizeAWSLeastPrivilegeFixtureState("invalid", AWSConnectionStatus{}, false); got != "" {
+		t.Fatalf("expected invalid fixture state to return empty token, got %q", got)
+	}
+}

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -71,6 +71,38 @@ func TestGetAWSLeastPrivilegeBuildsRecommendationContract(t *testing.T) {
 	}
 }
 
+func TestGetAWSLeastPrivilegeSuppressesImplicitRuntimeFixtures(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 5, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-least-privilege-live-unavailable", now)
+
+	result, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-live-unavailable", AWSLeastPrivilegeRequest{
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("get implicit live least privilege recommendations: %v", err)
+	}
+
+	for _, recommendation := range result.Recommendations {
+		for _, evidence := range recommendation.Evidence {
+			switch evidence.Source {
+			case "iam_last_used", "access_analyzer":
+				t.Fatalf("implicit live request must not convert runtime fixtures into recommendations: %+v", recommendation)
+			}
+		}
+	}
+
+	hasSuppressionDiagnostic := false
+	for _, diagnostic := range result.Diagnostics {
+		if diagnostic.Code == "runtime_fixture_records_suppressed" {
+			hasSuppressionDiagnostic = true
+			break
+		}
+	}
+	if !hasSuppressionDiagnostic {
+		t.Fatalf("expected runtime fixture suppression diagnostic, got %+v", result.Diagnostics)
+	}
+}
+
 func TestGetAWSLeastPrivilegeFiltersByDecisionServiceAndResource(t *testing.T) {
 	now := time.Date(2026, 6, 20, 8, 10, 0, 0, time.UTC)
 	svc, ws := newLeastPrivilegeService(t, "project-least-privilege-filters", now)
@@ -146,6 +178,39 @@ func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalKeepsAccessAnalyzerInRe
 	}
 	if !strings.Contains(recommendation.NextAction, "analyzer scope") {
 		t.Fatalf("expected analyzer-scope next action, got %q", recommendation.NextAction)
+	}
+}
+
+func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalDowngradesLowConfidenceIAMToReview(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 25, 0, 0, time.UTC)
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-iam-last-used-low-confidence",
+		AccountID:           "111111111111",
+		Region:              "us-east-1",
+		EventType:           "iam-last-used",
+		EventSource:         "iam.amazonaws.com",
+		EventName:           "ServiceLastAccessed",
+		Action:              "lambda:LastAuthenticated",
+		ActorPrincipalARN:   "arn:aws:iam::111111111111:role/lambda-invoice-agent",
+		ActorIdentityNodeID: "aws:identity:role:lambda-invoice-agent",
+		TargetResourceName:  "Lambda",
+		ResourceNodeID:      "aws-service://lambda",
+		SignalCategory:      "iam-last-used",
+		EvidenceRef:         "runtime-evidence://iam-low-confidence",
+		Confidence:          0.62,
+		ObservedAt:          now.Add(-120 * 24 * time.Hour),
+		Status:              "stale",
+	}
+
+	recommendation, ok := awsLeastPrivilegeRecommendationFromRuntimeSignal(record, now)
+	if !ok {
+		t.Fatal("expected IAM last-used signal to produce a recommendation")
+	}
+	if recommendation.Decision != "review" || recommendation.BreakagePrediction != "unknown" || len(recommendation.RemoveActions) != 0 {
+		t.Fatalf("low-confidence IAM last-used must stay in review without remove actions: %+v", recommendation)
+	}
+	if len(recommendation.KeepActions) == 0 || recommendation.RemediationCase.RecommendedAction == "Create a read-only case to remove unused grants after owner approval." {
+		t.Fatalf("expected review-oriented action metadata, got %+v", recommendation)
 	}
 }
 

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -17,17 +17,18 @@ const (
 )
 
 type AWSRuntimeEventRequest struct {
-	ConnectorID  string `json:"connector_id,omitempty"`
-	FixtureState string `json:"fixture_state,omitempty"`
-	AccountID    string `json:"account_id,omitempty"`
-	Region       string `json:"region,omitempty"`
-	EventType    string `json:"event_type,omitempty"`
-	Identity     string `json:"identity,omitempty"`
-	AgentID      string `json:"agent_id,omitempty"`
-	Resource     string `json:"resource,omitempty"`
-	Evidence     string `json:"evidence,omitempty"`
-	Owner        string `json:"owner,omitempty"`
-	Status       string `json:"status,omitempty"`
+	ConnectorID            string `json:"connector_id,omitempty"`
+	FixtureState           string `json:"fixture_state,omitempty"`
+	SuppressFixtureRecords bool   `json:"-"`
+	AccountID              string `json:"account_id,omitempty"`
+	Region                 string `json:"region,omitempty"`
+	EventType              string `json:"event_type,omitempty"`
+	Identity               string `json:"identity,omitempty"`
+	AgentID                string `json:"agent_id,omitempty"`
+	Resource               string `json:"resource,omitempty"`
+	Evidence               string `json:"evidence,omitempty"`
+	Owner                  string `json:"owner,omitempty"`
+	Status                 string `json:"status,omitempty"`
 	// DeliverySource selects the CloudTrail ingestion path: empty (or
 	// `lookup_events`) uses the LookupEvents API, `s3` uses the S3
 	// trail log ingester, `eventbridge` uses the EventBridge/SQS
@@ -478,6 +479,23 @@ func buildAWSRuntimeEvents(scope db.Scope, project db.TenancyProject, connection
 	region := firstNonEmptyAWSValue(connection.Region, "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
 	records, diagnostics, gaps := awsRuntimeEventFixtureRecords(accountID, region, fixtureState, checkedAt)
+	if request.SuppressFixtureRecords && strings.TrimSpace(request.FixtureState) == "" {
+		records = nil
+		diagnostics = append(diagnostics, AWSRuntimeEventDiagnostic{
+			Collector:   "aws_runtime_events",
+			SourceID:    "fixture-suppressed",
+			Code:        "runtime_fixture_records_suppressed",
+			Message:     "Synthetic runtime event fixtures were suppressed because the caller did not explicitly request fixture data.",
+			Remediation: "Wire live runtime evidence ingestion or request fixture_state explicitly for demos and tests.",
+			Retryable:   true,
+		})
+		gaps = append(gaps, AWSRuntimeEventCoverageGap{
+			Capability:  "runtime_evidence",
+			Status:      "source_unavailable",
+			Reason:      "Live runtime evidence was unavailable and synthetic fallback records were not used as evidence.",
+			Remediation: "Configure live CloudTrail, IAM last-used, and Access Analyzer ingestion before using runtime records for recommendations.",
+		})
+	}
 	filtered, applied := filterAWSRuntimeEventRecords(records, request)
 	relationships := awsRuntimeEventRelationships(filtered)
 	diagnostics = scopeAWSRuntimeEventDiagnostics(diagnostics, records, filtered)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3053,6 +3053,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"intelligence": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSLeastPrivilegeRecommendations(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSLeastPrivilegeRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			Decision:     strings.TrimSpace(c.Query("decision")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws least privilege request"})
+			default:
+				logger.Error("get aws least privilege",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws least privilege"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"recommendations": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1224,6 +1224,55 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS least privilege recommendations with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        recommendations: {
+          status: 'ready',
+          summary: {
+            total_recommendations: 1,
+            filtered_recommendations: 1
+          },
+          recommendations: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectLeastPrivilege(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'lambda-invoice-agent',
+        resource: 'prod/ai/openai-key',
+        service: 'secretsmanager',
+        severity: 'high',
+        status: 'review',
+        decision: 'remove'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/least-privilege?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=lambda-invoice-agent&resource=prod%2Fai%2Fopenai-key&service=secretsmanager&severity=high&status=review&decision=remove'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2840,6 +2840,162 @@ export type AWSBlastRadiusQuery = {
   riskType?: string;
 };
 
+export type AWSLeastPrivilegeStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSLeastPrivilegeFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSLeastPrivilegeDecision = 'keep' | 'remove' | 'review' | string;
+export type AWSLeastPrivilegeSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSLeastPrivilegeFindingStatus = 'action_required' | 'review' | 'monitor' | string;
+export type AWSLeastPrivilegeBreakagePrediction = 'low' | 'medium' | 'high' | 'unknown' | string;
+
+export type AWSLeastPrivilegeEvidence = {
+  source: string;
+  evidence_ref: string;
+  label: string;
+  confidence: number;
+  observed_at?: string;
+  relationship?: string;
+};
+
+export type AWSLeastPrivilegePathStep = {
+  node_id: string;
+  node_type: string;
+  label: string;
+  account_id?: string;
+  region?: string;
+};
+
+export type AWSLeastPrivilegeRelationship = {
+  recommendation_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSLeastPrivilegeRemediationCasePreview = {
+  case_id: string;
+  title: string;
+  recommended_action: string;
+  approval_required: boolean;
+  blocking_evidence?: string[];
+  impacted_node_count: number;
+  estimated_risk_drop: number;
+  breakage_prediction: AWSLeastPrivilegeBreakagePrediction;
+  read_only_projection: boolean;
+};
+
+export type AWSLeastPrivilegeRecommendation = {
+  recommendation_id: string;
+  calculation_version: string;
+  recommendation_type: string;
+  decision: AWSLeastPrivilegeDecision;
+  severity: AWSLeastPrivilegeSeverity;
+  status: AWSLeastPrivilegeFindingStatus;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  service: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  resource_node_id?: string;
+  resource_arn?: string;
+  display_name: string;
+  rationale: string;
+  breakage_prediction: AWSLeastPrivilegeBreakagePrediction;
+  breakage_rationale: string;
+  keep_actions?: string[];
+  remove_actions?: string[];
+  observed_actions?: string[];
+  granted_actions?: string[];
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSLeastPrivilegeSummary = {
+  total_recommendations: number;
+  filtered_recommendations: number;
+  decision_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  service_counts: Record<string, number>;
+  remove_count: number;
+  keep_count: number;
+  review_count: number;
+  low_breakage_count: number;
+  unknown_breakage_count: number;
+  runtime_evidence_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+  permission_denied_evidence_count: number;
+};
+
+export type AWSLeastPrivilegeDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSLeastPrivilegeCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSLeastPrivilegeResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSLeastPrivilegeStatus;
+  fixture_state?: AWSLeastPrivilegeFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSLeastPrivilegeSummary;
+  recommendations: AWSLeastPrivilegeRecommendation[];
+  relationships: AWSLeastPrivilegeRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSLeastPrivilegeQuery = {
+  connectorID?: string;
+  fixtureState?: AWSLeastPrivilegeFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  resource?: string;
+  service?: string;
+  severity?: string;
+  status?: string;
+  decision?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -6033,6 +6189,28 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         risk_type: query?.riskType
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectLeastPrivilege(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSLeastPrivilegeQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ recommendations: AWSLeastPrivilegeResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/least-privilege${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        resource: query?.resource,
+        service: query?.service,
+        severity: query?.severity,
+        status: query?.status,
+        decision: query?.decision
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -10,6 +10,7 @@ import type {
   AWSEKSWorkloadIdentityInventoryResult,
   AWSECSTaskRoleInventoryResult,
   AWSLambdaExecutionRoleInventoryResult,
+  AWSLeastPrivilegeResult,
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
@@ -295,6 +296,128 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
   failure_reasons: [],
   remediation_hints: [],
   evidence_links: ['/docs/aws-runtime-events'],
+  coverage_gaps: [],
+  diagnostics: [],
+  generated_at: '2026-06-14T17:30:00Z',
+  updated_at: '2026-06-14T17:30:00Z'
+};
+
+const readyAWSLeastPrivilege: AWSLeastPrivilegeResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1472,
+  parent_issue_ref: '#1472',
+  current_issue_number: 1522,
+  current_issue_ref: '#1522',
+  version: 'aws-least-privilege-recommendation-engine-v1',
+  status: 'ready',
+  fixture_state: 'success',
+  confidence: 0.9,
+  calculation_version: 'aws-least-privilege-recommendation-engine-v1',
+  applied_filters: {},
+  summary: {
+    total_recommendations: 1,
+    filtered_recommendations: 1,
+    decision_counts: { remove: 1 },
+    severity_counts: { high: 1 },
+    status_counts: { review: 1 },
+    service_counts: { secretsmanager: 1 },
+    remove_count: 1,
+    keep_count: 0,
+    review_count: 0,
+    low_breakage_count: 1,
+    unknown_breakage_count: 0,
+    runtime_evidence_count: 1,
+    relationship_count: 1,
+    highest_score: 82,
+    average_confidence_pct: 90,
+    remediation_preview_count: 1,
+    permission_denied_evidence_count: 0
+  },
+  recommendations: [
+    {
+      recommendation_id: 'aws-least-privilege:secret-unused',
+      calculation_version: 'aws-least-privilege-recommendation-engine-v1',
+      recommendation_type: 'remove-unused-secret-kms-grant',
+      decision: 'remove',
+      severity: 'high',
+      status: 'review',
+      score: 82,
+      confidence: 0.9,
+      account_id: '123456789012',
+      region: 'us-east-1',
+      service: 'secretsmanager',
+      identity_node_id: 'aws:identity:lambda-invoice-agent',
+      principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      resource_node_id: 'aws:resource:secret:openai-key',
+      resource_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/ai/openai-key',
+      display_name: 'lambda-invoice-agent',
+      rationale: 'Static secret grant has no matching runtime evidence in the scoped window.',
+      breakage_prediction: 'low',
+      breakage_rationale: 'No matching runtime use was observed in the scoped evidence window.',
+      remove_actions: ['secretsmanager:GetSecretValue'],
+      granted_actions: ['secretsmanager:GetSecretValue'],
+      impacted_nodes: ['aws:identity:lambda-invoice-agent', 'aws:resource:secret:openai-key'],
+      impacted_path: [
+        {
+          node_id: 'aws:identity:lambda-invoice-agent',
+          node_type: 'identity',
+          label: 'lambda-invoice-agent',
+          account_id: '123456789012',
+          region: 'us-east-1'
+        },
+        {
+          node_id: 'aws:resource:secret:openai-key',
+          node_type: 'secret',
+          label: 'prod/ai/openai-key',
+          account_id: '123456789012',
+          region: 'us-east-1'
+        }
+      ],
+      evidence: [
+        {
+          source: 'secrets_kms_runtime_access',
+          evidence_ref: 'secrets-kms-runtime-access://secret-unused',
+          label: 'Secrets Manager / KMS runtime access',
+          confidence: 0.9,
+          observed_at: '2026-06-14T17:30:00Z',
+          relationship: 'granted_unused'
+        }
+      ],
+      next_action:
+        'Open a read-only least-privilege case for secret/KMS, require owner approval, and verify low breakage prediction before policy diff generation.',
+      remediation_case: {
+        case_id: 'aws-least-privilege-preview:secret-unused',
+        title: 'remove unused secret grant',
+        recommended_action: 'Create a read-only case to remove unused grants after owner approval.',
+        approval_required: true,
+        blocking_evidence: ['secrets-kms-runtime-access://secret-unused'],
+        impacted_node_count: 1,
+        estimated_risk_drop: 40,
+        breakage_prediction: 'low',
+        read_only_projection: true
+      },
+      created_at: '2026-06-14T17:30:00Z',
+      updated_at: '2026-06-14T17:30:00Z'
+    }
+  ],
+  relationships: [
+    {
+      recommendation_id: 'aws-least-privilege:secret-unused',
+      type: 'least_privilege_scope',
+      from_node_id: 'aws:identity:lambda-invoice-agent',
+      to_node_id: 'aws:resource:secret:openai-key',
+      evidence_ref: 'secrets-kms-runtime-access://secret-unused'
+    }
+  ],
+  caveats: [],
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: ['/docs/aws-least-privilege-engine'],
   coverage_gaps: [],
   diagnostics: [],
   generated_at: '2026-06-14T17:30:00Z',
@@ -3108,6 +3231,28 @@ describe('Domain-first app routes', () => {
     const getRuntimeEvents = vi
       .spyOn(api.apiClient, 'getAWSProjectRuntimeEvents')
       .mockResolvedValue({ runtime: readyAWSRuntimeEvents });
+    vi.spyOn(api.apiClient, 'getAWSProjectSecretsKMSRuntimeAccess').mockResolvedValue({
+      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectS3RuntimeAccess').mockResolvedValue({
+      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectAgentRuntimeAccess').mockResolvedValue({
+      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
+      intelligence: {
+        status: 'degraded',
+        findings: [],
+        summary: { critical_count: 0, high_count: 0, relationship_count: 0, remediation_preview_count: 0 },
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: []
+      } as any
+    });
+    const getLeastPrivilege = vi
+      .spyOn(api.apiClient, 'getAWSProjectLeastPrivilege')
+      .mockResolvedValue({ recommendations: readyAWSLeastPrivilege });
 
     const { ProductAWSRuntimePage } = await import('./productShell');
 
@@ -3122,6 +3267,14 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
     expect(await screen.findByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
     expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
+    expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
+    expect(getLeastPrivilege).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Event type' }), {
       target: { value: 'cloudtrail' }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -57,6 +57,8 @@ import {
   type AWSAgentRuntimeAccessResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
+  type AWSLeastPrivilegeRecommendation,
+  type AWSLeastPrivilegeResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10524,6 +10526,131 @@ function AWSBlastRadiusContent({
   );
 }
 
+function awsLeastPrivilegeDecisionStage(decision: string, breakage: string): AWSCapabilityStage {
+  switch (decision) {
+    case 'remove':
+      return breakage === 'low' ? 'coming' : 'not-available';
+    case 'review':
+      return 'not-available';
+    case 'keep':
+      return 'wired';
+    default:
+      return 'coming';
+  }
+}
+
+function awsLeastPrivilegeRecommendationLabel(recommendation: AWSLeastPrivilegeRecommendation): string {
+  return `${formatTokenLabel(recommendation.recommendation_type)} · score ${recommendation.score}`;
+}
+
+function awsLeastPrivilegeEvidenceLabel(recommendation: AWSLeastPrivilegeRecommendation): string {
+  const sources = recommendation.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(recommendation.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function awsLeastPrivilegePathLabel(recommendation: AWSLeastPrivilegeRecommendation): string {
+  const path = recommendation.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
+  if (path.length === 0) {
+    return recommendation.impacted_nodes.join(' -> ') || '-';
+  }
+  return path.join(' -> ');
+}
+
+function awsLeastPrivilegeActionLabel(recommendation: AWSLeastPrivilegeRecommendation): string {
+  const removeActions = recommendation.remove_actions ?? [];
+  const keepActions = recommendation.keep_actions ?? [];
+  if (removeActions.length > 0) {
+    return `Remove ${removeActions.slice(0, 3).join(', ')}${removeActions.length > 3 ? ` +${removeActions.length - 3}` : ''}`;
+  }
+  if (keepActions.length > 0) {
+    return `Keep ${keepActions.slice(0, 3).join(', ')}${keepActions.length > 3 ? ` +${keepActions.length - 3}` : ''}`;
+  }
+  return formatTokenLabel(recommendation.decision);
+}
+
+function AWSLeastPrivilegeContent({
+  recommendations,
+  loading,
+  error,
+  onRetry
+}: {
+  recommendations: AWSLeastPrivilegeResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = recommendations?.recommendations ?? [];
+  const summaryLine = recommendations
+    ? `${recommendations.summary.remove_count} remove · ${recommendations.summary.keep_count} keep · ${recommendations.summary.review_count} review · ${recommendations.summary.low_breakage_count} low-breakage`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS least privilege recommendations">
+      <h3>AWS least-privilege recommendations</h3>
+      <p className="idt-app-kicker">
+        Ranked keep, remove, and review decisions from static grants, runtime usage, IAM last-used, Access Analyzer, and agent/tool evidence.
+        {summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load least-privilege recommendations"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating least privilege"
+          body="Identrail is comparing static grants, runtime usage, stale signals, confidence, and breakage predictions."
+        />
+      ) : null}
+      {!error && !loading && recommendations && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={recommendations.status === 'blocked' ? 'Permission required' : 'No recommendation records'}
+          title={
+            recommendations.status === 'blocked'
+              ? 'Least privilege needs read-only evidence access'
+              : 'No least-privilege recommendations'
+          }
+          body={recommendations.failure_reasons[0] ?? 'No reducible, observed, stale, or review-required access matched this scope.'}
+        />
+      ) : null}
+      {!error && !loading && recommendations && recommendations.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {recommendations.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS least privilege recommendations"
+          rows={rows}
+          getRowKey={(row) => row.recommendation_id}
+          columns={[
+            { key: 'recommendation', header: 'Recommendation', render: (row) => <strong>{awsLeastPrivilegeRecommendationLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.display_name || row.identity_node_id },
+            { key: 'scope', header: 'Scope', render: (row) => `${formatTokenLabel(row.service)} · ${awsLeastPrivilegePathLabel(row)}` },
+            { key: 'actions', header: 'Actions', render: (row) => awsLeastPrivilegeActionLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsLeastPrivilegeEvidenceLabel(row) },
+            {
+              key: 'breakage',
+              header: 'Breakage',
+              render: (row) => (
+                <AWSInventoryPill
+                  stage={awsLeastPrivilegeDecisionStage(row.decision, row.breakage_prediction)}
+                  label={`${formatTokenLabel(row.decision)} / ${formatTokenLabel(row.breakage_prediction)}`}
+                />
+              )
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -11026,6 +11153,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
   const blastRadiusRequestRef = useRef(0);
+  const [leastPrivilege, setLeastPrivilege] = useState<AWSLeastPrivilegeResult | null>(null);
+  const [leastPrivilegeLoading, setLeastPrivilegeLoading] = useState(false);
+  const [leastPrivilegeError, setLeastPrivilegeError] = useState('');
+  const leastPrivilegeRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11281,6 +11412,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadBlastRadius]);
 
+  const loadLeastPrivilege = useCallback(async () => {
+    const requestID = ++leastPrivilegeRequestRef.current;
+    setLeastPrivilege(null);
+    setLeastPrivilegeError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setLeastPrivilegeLoading(false);
+      return;
+    }
+    setLeastPrivilegeLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectLeastPrivilege(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== leastPrivilegeRequestRef.current) {
+        return;
+      }
+      setLeastPrivilege(response.recommendations);
+    } catch (error) {
+      if (requestID !== leastPrivilegeRequestRef.current) {
+        return;
+      }
+      setLeastPrivilegeError(formatAPIError(error, 'Unable to load AWS least-privilege recommendations.'));
+    } finally {
+      if (requestID === leastPrivilegeRequestRef.current) {
+        setLeastPrivilegeLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadLeastPrivilege();
+    return () => {
+      leastPrivilegeRequestRef.current += 1;
+    };
+  }, [loadLeastPrivilege]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -11404,6 +11583,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={blastRadiusLoading}
             error={blastRadiusError}
             onRetry={loadBlastRadius}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSLeastPrivilegeContent
+            recommendations={leastPrivilege}
+            loading={leastPrivilegeLoading}
+            error={leastPrivilegeError}
+            onRetry={loadLeastPrivilege}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
Closes #1522

## Summary

Adds the AWS least-privilege recommendation engine for Wave 6.02.

## Why

Operators need deterministic keep, remove, and review recommendations from the AWS evidence Identrail already collects, without treating missing or partial evidence as proof that access is safe to remove.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

This PR adds:
- A read-only backend engine and `GET /v1/workspaces/{ws}/projects/{project}/aws/least-privilege` API.
- Stable recommendation records with confidence, rationale, impacted paths, keep/remove actions, breakage prediction, evidence refs, and remediation case previews.
- Conservative handling for IAM last-used, Access Analyzer, Secrets/KMS, S3, and agent/tool evidence.
- Runtime app surface for operator-visible least-privilege recommendations.
- OpenAPI, docs, changelog, authz metadata, and focused tests.

## Validation

```bash
go test ./internal/api
npm run test:ci --prefix web
npm run build --prefix web
```

All checks passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

No

## Related Issues

Closes #1522

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AWS least‑privilege recommendation engine and read‑only API per #1522. Surfaces recommendations in the AWS runtime UI and incorporates review fixes.

- **New Features**
  - New endpoint: `GET /v1/workspaces/{ws}/projects/{project}/aws/least-privilege` (authorized under tenancy.read).
  - Stable recommendation model with IDs, version, decision, score/severity, confidence, rationale, impacted path/nodes, keep/remove actions, breakage prediction, evidence refs, remediation previews, and summary/applied_filters; supports query filters (account, region, identity, resource, service, severity, status, decision) and `fixture_state` for demos/tests.
  - Conservative signal fusion across IAM last‑used, Access Analyzer, Secrets/KMS, S3, and agent/tool runtime access; gaps return “review”, not “remove”.
  - OpenAPI, docs, tests, and the AWS runtime UI updated to display recommendations.

- **Bug Fixes**
  - Addressed review feedback: added parent/current issue refs and calculation_version, aligned route auth and OpenAPI, and tightened web client types and fixtures.
  - Fixed fixture connector fallback for review flows to ensure stable recommendations when connector context is missing.

<sup>Written for commit 033629eba6b14a04dff7129cb18be352ae2e6eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

