### PR TITLE
AWS Platform Wave 6.03: Unused and dormant access engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS unused and dormant access engine** (#1523). Adds a read-only,
+  metadata-only intelligence layer that turns least-privilege source evidence,
+  IAM last-used signals, runtime observations, scan timing, and policy scope
+  into ranked cleanup and review findings for `never_used`, `stale`,
+  `no_runtime_evidence`, and `unknown` access states. The new endpoint
+  `GET /v1/workspaces/{ws}/projects/{p}/aws/unused-dormant-access` exposes
+  stable finding IDs, calculation version, severity, confidence, owner context,
+  policy scope, candidate actions, impacted graph path, evidence refs,
+  diagnostics, coverage gaps, and read-only remediation previews. Unknown,
+  degraded, or permission-denied evidence remains review-only instead of a
+  cleanup candidate. The AWS runtime app surface now renders unused/dormant
+  findings alongside the source evidence and least-privilege recommendations.
+  Closes #1523. See
+  [docs/aws-unused-dormant-access-engine.md](docs/aws-unused-dormant-access-engine.md).
 - Add **AWS least-privilege recommendation engine** (#1522). Adds a
   deterministic, metadata-only recommendation layer that composes static
   grants, runtime access correlation, IAM last-used signals, Access Analyzer

--- a/docs/aws-unused-dormant-access-engine.md
+++ b/docs/aws-unused-dormant-access-engine.md
@@ -1,0 +1,87 @@
+# AWS Unused and Dormant Access Engine
+
+The AWS unused and dormant access engine turns metadata-only AWS inventory,
+runtime evidence, IAM last-used signals, scan timestamps, and policy scope into
+ranked findings for cleanup planning.
+
+It is the Wave 6.03 intelligence layer for issue #1523. The engine is read-only:
+it does not mutate AWS, generate IAM policy diffs, disable identities, read
+secret values, inspect object contents, or persist customer payloads.
+
+## API
+
+```text
+GET /v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access
+```
+
+Query filters:
+
+- `connector_id`: optional AWS connector scope.
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied` for deterministic contract and UI validation.
+- `account_id`, `region`, `identity`, `resource`, `service`, `severity`, and
+  `status`.
+- `dormancy_state`: `never_used`, `stale`, `no_runtime_evidence`, or
+  `unknown`.
+
+The response body is returned as:
+
+```json
+{
+  "findings": {
+    "version": "aws-unused-dormant-access-engine-v1",
+    "current_issue_ref": "#1523",
+    "status": "ready",
+    "summary": {
+      "total_findings": 3,
+      "cleanup_candidate_count": 1,
+      "review_required_count": 2
+    },
+    "findings": []
+  }
+}
+```
+
+## Finding Contract
+
+Each finding includes:
+
+- stable `finding_id` and `calculation_version`;
+- `finding_type`, `dormancy_state`, severity, status, score, and confidence;
+- account, region, service, identity, principal ARN, resource, and display
+  labels;
+- owner context and policy scope;
+- rationale, last-used timestamp when available, dormant-days estimate, and
+  scan-window days;
+- candidate, observed, and granted actions;
+- impacted graph nodes/path, metadata-only evidence links, and relationships;
+- read-only remediation case preview and next action.
+
+## Dormancy States
+
+- `never_used`: policy or declaration exists, but the scoped metadata-only
+  evidence window has no matching runtime use.
+- `stale`: IAM last-used or related evidence indicates old access that needs
+  owner confirmation before cleanup.
+- `no_runtime_evidence`: a candidate has reducible policy scope, but runtime
+  evidence is bounded or absent.
+- `unknown`: evidence is degraded, permission-denied, unsupported, or otherwise
+  insufficient.
+
+Unknown, permission-denied, and partial evidence are explicit states. They do
+not become cleanup candidates.
+
+## App Surface
+
+The AWS runtime page renders unused and dormant access findings below runtime,
+correlation, blast-radius, and least-privilege evidence. Operators can inspect
+dormancy state, policy scope, candidate actions, confidence, owner context,
+evidence refs, and next action without reading logs or database rows.
+
+## Safety
+
+The engine composes existing read-only evidence. It never collects or returns
+secret values, prompts, completions, browser output, code-interpreter output,
+database rows, S3 object contents, or customer payloads. Cleanup remains a
+planning preview until downstream owner approval and IAM diff generation are
+available.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -579,6 +579,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/unused-dormant-access
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -5060,6 +5065,89 @@ paths:
                     $ref: "#/components/schemas/AWSLeastPrivilegeResult"
         "400":
           description: Invalid AWS least-privilege request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/unused-dormant-access:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS unused and dormant access findings
+      operationId: getAWSProjectUnusedDormantAccess
+      description: Calculates deterministic, read-only AWS unused and dormant access findings by composing least-privilege source evidence, metadata-only runtime usage, IAM last-used signals, scan timing, and policy scope. Findings carry stable IDs, calculation version, dormant state, score, severity, confidence, rationale, owner context, policy scope, impacted graph path, candidate actions, evidence refs, and read-only remediation previews. Unknown, degraded, partial, or permission-denied evidence remains review-only; secret values, object contents, prompts, completions, tool payloads, browser pages, and code-interpreter output are never read or returned.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional principal, identity-node, or display-name search.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional impacted resource, ARN, display label, or graph-node search.
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Optional AWS service token, such as s3, secretsmanager, kms, lambda, or agent-runtime.
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [cleanup_candidate, review]
+        - in: query
+          name: dormancy_state
+          schema:
+            type: string
+            enum: [never_used, stale, no_runtime_evidence, unknown]
+      responses:
+        "200":
+          description: AWS unused and dormant access finding contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    $ref: "#/components/schemas/AWSUnusedDormantAccessResult"
+        "400":
+          description: Invalid AWS unused and dormant access request
           content:
             application/json:
               schema:
@@ -12288,6 +12376,173 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLeastPrivilegeRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSUnusedDormantAccessRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSUnusedDormantAccessFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        finding_type: { type: string }
+        dormancy_state:
+          type: string
+          enum: [never_used, stale, no_runtime_evidence, unknown]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [cleanup_candidate, review]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        resource_node_id: { type: string }
+        resource_arn: { type: string }
+        display_name: { type: string }
+        owner_context: { type: string }
+        policy_scope: { type: string }
+        rationale: { type: string }
+        last_used_at:
+          type: string
+          format: date-time
+        dormant_days: { type: integer }
+        scan_window_days: { type: integer }
+        candidate_actions:
+          type: array
+          items: { type: string }
+        observed_actions:
+          type: array
+          items: { type: string }
+        granted_actions:
+          type: array
+          items: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSUnusedDormantAccessSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        dormancy_state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        service_counts:
+          type: object
+          additionalProperties: { type: integer }
+        cleanup_candidate_count: { type: integer }
+        review_required_count: { type: integer }
+        no_runtime_evidence_count: { type: integer }
+        unknown_evidence_count: { type: integer }
+        stale_access_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+        permission_denied_evidence_count: { type: integer }
+    AWSUnusedDormantAccessResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSUnusedDormantAccessSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSUnusedDormantAccessFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSUnusedDormantAccessRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -759,6 +759,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_unused_dormant_access.go
+++ b/internal/api/aws_unused_dormant_access.go
@@ -143,7 +143,6 @@ func (s *Service) GetAWSUnusedDormantAccessFindings(ctx context.Context, workspa
 		Resource:     request.Resource,
 		Service:      request.Service,
 		Severity:     request.Severity,
-		Status:       request.Status,
 	})
 	if err != nil {
 		return AWSUnusedDormantAccessResult{}, err

--- a/internal/api/aws_unused_dormant_access.go
+++ b/internal/api/aws_unused_dormant_access.go
@@ -206,13 +206,29 @@ func awsUnusedDormantFindingsFromRecommendations(recommendations []AWSLeastPrivi
 
 func awsUnusedDormantRecommendationQualifies(recommendation AWSLeastPrivilegeRecommendation) bool {
 	recommendationType := normalizeAWSRuntimeEventFilterToken(recommendation.RecommendationType)
-	if strings.Contains(recommendationType, "unused") || strings.Contains(recommendationType, "stale") {
+	if strings.Contains(recommendationType, "unused") || strings.Contains(recommendationType, "stale") || strings.Contains(recommendationType, "no-runtime") || strings.Contains(recommendationType, "dormant") {
 		return true
 	}
-	if recommendation.Decision == "remove" {
+	if recommendation.Decision == "remove" && awsUnusedDormantRecommendationHasDormantEvidence(recommendation) {
 		return true
 	}
-	return recommendation.Decision == "review" && recommendation.BreakagePrediction == "unknown"
+	return recommendation.Decision == "review" && recommendation.BreakagePrediction == "unknown" && awsUnusedDormantRecommendationHasDormantEvidence(recommendation)
+}
+
+func awsUnusedDormantRecommendationHasDormantEvidence(recommendation AWSLeastPrivilegeRecommendation) bool {
+	for _, evidence := range recommendation.Evidence {
+		relationship := normalizeAWSRuntimeEventFilterToken(evidence.Relationship)
+		source := normalizeAWSRuntimeEventFilterToken(evidence.Source)
+		switch {
+		case strings.Contains(relationship, "unused"), strings.Contains(relationship, "stale"), strings.Contains(relationship, "no-runtime"):
+			return true
+		case relationship == "permission-denied" || relationship == "partial-failure" || relationship == "degraded" || relationship == "unsupported" || relationship == "unavailable":
+			return true
+		case source == "coverage-gap" || source == "runtime-evidence-gap":
+			return true
+		}
+	}
+	return false
 }
 
 func awsUnusedDormantFindingFromRecommendation(recommendation AWSLeastPrivilegeRecommendation, now time.Time) AWSUnusedDormantAccessFinding {

--- a/internal/api/aws_unused_dormant_access.go
+++ b/internal/api/aws_unused_dormant_access.go
@@ -1,0 +1,563 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsUnusedDormantAccessCurrentIssue = 1523
+	awsUnusedDormantAccessVersion      = "aws-unused-dormant-access-engine-v1"
+)
+
+// AWSUnusedDormantAccessRequest scopes the unused/dormant calculation to AWS
+// evidence and optional operator drill-down filters.
+type AWSUnusedDormantAccessRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Identity      string `json:"identity,omitempty"`
+	Resource      string `json:"resource,omitempty"`
+	Service       string `json:"service,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	DormancyState string `json:"dormancy_state,omitempty"`
+}
+
+type AWSUnusedDormantAccessEvidence = AWSLeastPrivilegeEvidence
+type AWSUnusedDormantAccessPathStep = AWSLeastPrivilegePathStep
+type AWSUnusedDormantAccessRemediationCasePreview = AWSLeastPrivilegeRemediationCasePreview
+
+// AWSUnusedDormantAccessRelationship lets graph consumers join findings back to
+// identity, resource, and evidence nodes.
+type AWSUnusedDormantAccessRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSUnusedDormantAccessFinding is the persisted-record-shaped output for
+// unused, dormant, no-runtime-evidence, and unknown access decisions.
+type AWSUnusedDormantAccessFinding struct {
+	FindingID          string                                       `json:"finding_id"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	FindingType        string                                       `json:"finding_type"`
+	DormancyState      string                                       `json:"dormancy_state"`
+	Severity           string                                       `json:"severity"`
+	Status             string                                       `json:"status"`
+	Score              int                                          `json:"score"`
+	Confidence         float64                                      `json:"confidence"`
+	AccountID          string                                       `json:"account_id"`
+	Region             string                                       `json:"region"`
+	Service            string                                       `json:"service"`
+	IdentityNodeID     string                                       `json:"identity_node_id"`
+	PrincipalARN       string                                       `json:"principal_arn,omitempty"`
+	ResourceNodeID     string                                       `json:"resource_node_id,omitempty"`
+	ResourceARN        string                                       `json:"resource_arn,omitempty"`
+	DisplayName        string                                       `json:"display_name"`
+	OwnerContext       string                                       `json:"owner_context"`
+	PolicyScope        string                                       `json:"policy_scope"`
+	Rationale          string                                       `json:"rationale"`
+	LastUsedAt         time.Time                                    `json:"last_used_at,omitzero"`
+	DormantDays        int                                          `json:"dormant_days"`
+	ScanWindowDays     int                                          `json:"scan_window_days"`
+	CandidateActions   []string                                     `json:"candidate_actions,omitempty"`
+	ObservedActions    []string                                     `json:"observed_actions,omitempty"`
+	GrantedActions     []string                                     `json:"granted_actions,omitempty"`
+	ImpactedNodes      []string                                     `json:"impacted_nodes"`
+	ImpactedPath       []AWSUnusedDormantAccessPathStep             `json:"impacted_path"`
+	Evidence           []AWSUnusedDormantAccessEvidence             `json:"evidence"`
+	NextAction         string                                       `json:"next_action"`
+	RemediationCase    AWSUnusedDormantAccessRemediationCasePreview `json:"remediation_case"`
+	CreatedAt          time.Time                                    `json:"created_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+type AWSUnusedDormantAccessSummary struct {
+	TotalFindings            int            `json:"total_findings"`
+	FilteredFindings         int            `json:"filtered_findings"`
+	DormancyStateCounts      map[string]int `json:"dormancy_state_counts"`
+	SeverityCounts           map[string]int `json:"severity_counts"`
+	StatusCounts             map[string]int `json:"status_counts"`
+	ServiceCounts            map[string]int `json:"service_counts"`
+	CleanupCandidateCount    int            `json:"cleanup_candidate_count"`
+	ReviewRequiredCount      int            `json:"review_required_count"`
+	NoRuntimeEvidenceCount   int            `json:"no_runtime_evidence_count"`
+	UnknownEvidenceCount     int            `json:"unknown_evidence_count"`
+	StaleAccessCount         int            `json:"stale_access_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+	RemediationPreviewCount  int            `json:"remediation_preview_count"`
+	PermissionDeniedEvidence int            `json:"permission_denied_evidence_count"`
+}
+
+type AWSUnusedDormantAccessDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSUnusedDormantAccessCoverageGap = AWSLeastPrivilegeCoverageGap
+
+type AWSUnusedDormantAccessResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	CalculationVersion string                               `json:"calculation_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Summary            AWSUnusedDormantAccessSummary        `json:"summary"`
+	Findings           []AWSUnusedDormantAccessFinding      `json:"findings"`
+	Relationships      []AWSUnusedDormantAccessRelationship `json:"relationships"`
+	Caveats            []string                             `json:"caveats"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSUnusedDormantAccessCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSUnusedDormantAccessDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// GetAWSUnusedDormantAccessFindings calculates ranked read-only findings for
+// never-used, stale, no-runtime-evidence, and unknown access states.
+func (s *Service) GetAWSUnusedDormantAccessFindings(ctx context.Context, workspaceID string, projectID string, request AWSUnusedDormantAccessRequest) (AWSUnusedDormantAccessResult, error) {
+	leastPrivilege, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
+		ConnectorID:  request.ConnectorID,
+		FixtureState: request.FixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     request.Identity,
+		Resource:     request.Resource,
+		Service:      request.Service,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSUnusedDormantAccessResult{}, err
+	}
+
+	findings := awsUnusedDormantFindingsFromRecommendations(leastPrivilege.Recommendations, leastPrivilege.GeneratedAt)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSUnusedDormantAccessFindings(findings, request)
+	relationships := awsUnusedDormantAccessRelationships(filtered)
+	summary := summarizeAWSUnusedDormantAccess(findings, filtered, relationships)
+
+	return AWSUnusedDormantAccessResult{
+		TenantID:           leastPrivilege.TenantID,
+		WorkspaceID:        leastPrivilege.WorkspaceID,
+		ProjectID:          leastPrivilege.ProjectID,
+		ConnectorID:        leastPrivilege.ConnectorID,
+		AccountID:          leastPrivilege.AccountID,
+		Region:             leastPrivilege.Region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsUnusedDormantAccessCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsUnusedDormantAccessCurrentIssue),
+		Version:            awsUnusedDormantAccessVersion,
+		Status:             awsUnusedDormantAccessStatus(leastPrivilege.Status, filtered, leastPrivilege.Diagnostics),
+		FixtureState:       leastPrivilege.FixtureState,
+		Confidence:         leastPrivilege.Confidence,
+		CalculationVersion: awsUnusedDormantAccessVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsUnusedDormantAccessCaveats(leastPrivilege.Caveats),
+		FailureReasons:     leastPrivilege.FailureReasons,
+		RemediationHints:   awsUnusedDormantAccessRemediationHints(leastPrivilege.RemediationHints),
+		EvidenceLinks: dedupeStrings(append(leastPrivilege.EvidenceLinks,
+			awsIssueURL(awsUnusedDormantAccessCurrentIssue),
+			"/docs/aws-unused-dormant-access-engine",
+		)),
+		CoverageGaps: awsUnusedDormantAccessCoverageGaps(leastPrivilege.CoverageGaps),
+		Diagnostics:  awsUnusedDormantAccessDiagnostics(leastPrivilege.Diagnostics),
+		GeneratedAt:  leastPrivilege.GeneratedAt,
+		UpdatedAt:    leastPrivilege.UpdatedAt,
+	}, nil
+}
+
+func awsUnusedDormantFindingsFromRecommendations(recommendations []AWSLeastPrivilegeRecommendation, now time.Time) []AWSUnusedDormantAccessFinding {
+	findings := []AWSUnusedDormantAccessFinding{}
+	for _, recommendation := range recommendations {
+		if !awsUnusedDormantRecommendationQualifies(recommendation) {
+			continue
+		}
+		findings = append(findings, awsUnusedDormantFindingFromRecommendation(recommendation, now))
+	}
+	return findings
+}
+
+func awsUnusedDormantRecommendationQualifies(recommendation AWSLeastPrivilegeRecommendation) bool {
+	recommendationType := normalizeAWSRuntimeEventFilterToken(recommendation.RecommendationType)
+	if strings.Contains(recommendationType, "unused") || strings.Contains(recommendationType, "stale") {
+		return true
+	}
+	if recommendation.Decision == "remove" {
+		return true
+	}
+	return recommendation.Decision == "review" && recommendation.BreakagePrediction == "unknown"
+}
+
+func awsUnusedDormantFindingFromRecommendation(recommendation AWSLeastPrivilegeRecommendation, now time.Time) AWSUnusedDormantAccessFinding {
+	state := awsUnusedDormantState(recommendation)
+	findingType := "cleanup_candidate"
+	status := "review"
+	if state == "unknown" {
+		findingType = "unknown_evidence"
+		status = "review"
+	} else if state == "stale" {
+		findingType = "dormant_access"
+	} else if state == "no_runtime_evidence" {
+		findingType = "no_runtime_evidence"
+	}
+	if recommendation.Decision == "remove" && recommendation.BreakagePrediction == "low" {
+		status = "cleanup_candidate"
+	}
+
+	observedAt := firstUnusedDormantObservedAt(recommendation.Evidence)
+	dormantDays := 0
+	if !observedAt.IsZero() {
+		dormantDays = int(now.Sub(observedAt).Hours() / 24)
+		if dormantDays < 0 {
+			dormantDays = 0
+		}
+	}
+
+	candidateActions := recommendation.RemoveActions
+	if len(candidateActions) == 0 {
+		candidateActions = recommendation.KeepActions
+	}
+	if len(candidateActions) == 0 {
+		candidateActions = recommendation.GrantedActions
+	}
+
+	return AWSUnusedDormantAccessFinding{
+		FindingID:          "aws-unused-dormant-access:" + stableAWSBlastRadiusToken(recommendation.RecommendationID, state),
+		CalculationVersion: awsUnusedDormantAccessVersion,
+		FindingType:        findingType,
+		DormancyState:      state,
+		Severity:           recommendation.Severity,
+		Status:             status,
+		Score:              recommendation.Score,
+		Confidence:         recommendation.Confidence,
+		AccountID:          recommendation.AccountID,
+		Region:             recommendation.Region,
+		Service:            recommendation.Service,
+		IdentityNodeID:     recommendation.IdentityNodeID,
+		PrincipalARN:       recommendation.PrincipalARN,
+		ResourceNodeID:     recommendation.ResourceNodeID,
+		ResourceARN:        recommendation.ResourceARN,
+		DisplayName:        recommendation.DisplayName,
+		OwnerContext:       awsUnusedDormantOwnerContext(recommendation),
+		PolicyScope:        awsUnusedDormantPolicyScope(recommendation),
+		Rationale:          awsUnusedDormantRationale(recommendation, state),
+		LastUsedAt:         observedAt,
+		DormantDays:        dormantDays,
+		ScanWindowDays:     awsUnusedDormantScanWindowDays(state, dormantDays),
+		CandidateActions:   dedupeStrings(candidateActions),
+		ObservedActions:    recommendation.ObservedActions,
+		GrantedActions:     recommendation.GrantedActions,
+		ImpactedNodes:      recommendation.ImpactedNodes,
+		ImpactedPath:       recommendation.ImpactedPath,
+		Evidence:           recommendation.Evidence,
+		NextAction:         awsUnusedDormantNextAction(recommendation, state),
+		RemediationCase:    awsUnusedDormantRemediationCase(recommendation, state),
+		CreatedAt:          recommendation.CreatedAt,
+		UpdatedAt:          recommendation.UpdatedAt,
+	}
+}
+
+func awsUnusedDormantState(recommendation AWSLeastPrivilegeRecommendation) string {
+	recommendationType := normalizeAWSRuntimeEventFilterToken(recommendation.RecommendationType)
+	if strings.Contains(recommendationType, "stale") || strings.Contains(recommendation.Rationale, "not used for") {
+		return "stale"
+	}
+	for _, evidence := range recommendation.Evidence {
+		relationship := normalizeAWSRuntimeEventFilterToken(evidence.Relationship)
+		if strings.Contains(relationship, "unused") || strings.Contains(relationship, "declared-unused") {
+			return "never_used"
+		}
+		if strings.Contains(relationship, "stale") {
+			return "stale"
+		}
+	}
+	if recommendation.Decision == "remove" {
+		return "no_runtime_evidence"
+	}
+	return "unknown"
+}
+
+func awsUnusedDormantOwnerContext(recommendation AWSLeastPrivilegeRecommendation) string {
+	if strings.Contains(strings.ToLower(recommendation.IdentityNodeID), "agent") || strings.EqualFold(recommendation.Service, "agent-runtime") {
+		return "agent-owner-review"
+	}
+	if recommendation.ResourceARN != "" {
+		return "resource-owner-review"
+	}
+	return "identity-owner-review"
+}
+
+func awsUnusedDormantPolicyScope(recommendation AWSLeastPrivilegeRecommendation) string {
+	actions := dedupeStrings(append(append([]string{}, recommendation.RemoveActions...), recommendation.GrantedActions...))
+	if len(actions) == 0 {
+		actions = recommendation.KeepActions
+	}
+	if len(actions) == 0 {
+		return awsLeastPrivilegeServiceAction(recommendation.Service)
+	}
+	return strings.Join(actions, ", ")
+}
+
+func awsUnusedDormantRationale(recommendation AWSLeastPrivilegeRecommendation, state string) string {
+	switch state {
+	case "never_used":
+		return fmt.Sprintf("%s has granted %s access with no matching runtime evidence in the scoped evidence window.", recommendation.DisplayName, recommendation.Service)
+	case "stale":
+		return fmt.Sprintf("%s has stale %s activity and needs owner confirmation before cleanup.", recommendation.DisplayName, recommendation.Service)
+	case "no_runtime_evidence":
+		return fmt.Sprintf("%s has removable %s policy scope, but the finding is bounded to available metadata-only runtime evidence.", recommendation.DisplayName, recommendation.Service)
+	default:
+		return "Evidence is incomplete or degraded, so this access remains a review finding instead of a cleanup instruction."
+	}
+}
+
+func awsUnusedDormantNextAction(recommendation AWSLeastPrivilegeRecommendation, state string) string {
+	switch state {
+	case "never_used", "no_runtime_evidence":
+		if recommendation.Decision == "remove" && recommendation.BreakagePrediction == "low" {
+			return "Create a read-only cleanup case, confirm owner approval, and verify policy scope before generating an IAM diff."
+		}
+		return "Confirm runtime coverage and owner context before turning this into a cleanup case."
+	case "stale":
+		return "Ask the owner to confirm whether stale access is still required before planning removal."
+	default:
+		return "Close the evidence gap before classifying this as unused or dormant access."
+	}
+}
+
+func awsUnusedDormantRemediationCase(recommendation AWSLeastPrivilegeRecommendation, state string) AWSUnusedDormantAccessRemediationCasePreview {
+	preview := recommendation.RemediationCase
+	preview.CaseID = "aws-unused-dormant-preview:" + stableAWSBlastRadiusToken(recommendation.RecommendationID, state)
+	preview.Title = fmt.Sprintf("%s dormant-access %s", formatAWSBlastRadiusLabel(state), recommendation.Decision)
+	if state == "unknown" {
+		preview.RecommendedAction = "Create a review case; do not generate cleanup changes until evidence coverage is restored."
+		preview.ApprovalRequired = true
+		preview.BreakagePrediction = "unknown"
+	}
+	preview.ReadOnlyProjection = true
+	return preview
+}
+
+func firstUnusedDormantObservedAt(evidence []AWSUnusedDormantAccessEvidence) time.Time {
+	var latest time.Time
+	for _, item := range evidence {
+		if item.ObservedAt.After(latest) {
+			latest = item.ObservedAt
+		}
+	}
+	return latest
+}
+
+func awsUnusedDormantScanWindowDays(state string, dormantDays int) int {
+	if dormantDays > 0 {
+		return dormantDays
+	}
+	if state == "unknown" {
+		return 0
+	}
+	return 90
+}
+
+func filterAWSUnusedDormantAccessFindings(findings []AWSUnusedDormantAccessFinding, request AWSUnusedDormantAccessRequest) ([]AWSUnusedDormantAccessFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id":     strings.TrimSpace(request.AccountID),
+		"region":         strings.TrimSpace(request.Region),
+		"identity":       strings.TrimSpace(request.Identity),
+		"resource":       strings.TrimSpace(request.Resource),
+		"service":        normalizeAWSRuntimeEventFilterToken(request.Service),
+		"severity":       normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":         normalizeAWSRuntimeEventFilterToken(request.Status),
+		"dormancy_state": normalizeAWSRuntimeEventFilterToken(request.DormancyState),
+	}
+	for key, value := range filters {
+		token := strings.TrimSpace(value)
+		if token == "" || strings.EqualFold(token, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSUnusedDormantAccessFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && filters["account_id"] != finding.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["service"] != "" && filters["service"] != normalizeAWSRuntimeEventFilterToken(finding.Service) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(finding.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
+			continue
+		}
+		if filters["dormancy_state"] != "" && filters["dormancy_state"] != normalizeAWSRuntimeEventFilterToken(finding.DormancyState) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], awsUnusedDormantIdentityMatchValues(finding)...) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], awsUnusedDormantResourceMatchValues(finding)...) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, applied
+}
+
+func awsUnusedDormantIdentityMatchValues(finding AWSUnusedDormantAccessFinding) []string {
+	candidates := []string{finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName}
+	for _, step := range finding.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			candidates = append(candidates, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(candidates)
+}
+
+func awsUnusedDormantResourceMatchValues(finding AWSUnusedDormantAccessFinding) []string {
+	candidates := []string{finding.ResourceNodeID, finding.ResourceARN}
+	candidates = append(candidates, finding.ImpactedNodes...)
+	for _, step := range finding.ImpactedPath {
+		candidates = append(candidates, step.NodeID, step.Label)
+	}
+	return dedupeStrings(candidates)
+}
+
+func awsUnusedDormantAccessRelationships(findings []AWSUnusedDormantAccessFinding) []AWSUnusedDormantAccessRelationship {
+	relationships := []AWSUnusedDormantAccessRelationship{}
+	for _, finding := range findings {
+		for i := 0; i+1 < len(finding.ImpactedPath); i++ {
+			from := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
+			to := strings.TrimSpace(finding.ImpactedPath[i+1].NodeID)
+			if from == "" || to == "" {
+				continue
+			}
+			relationships = append(relationships, AWSUnusedDormantAccessRelationship{
+				FindingID:   finding.FindingID,
+				Type:        "unused_dormant_access_scope",
+				FromNodeID:  from,
+				ToNodeID:    to,
+				EvidenceRef: firstLeastPrivilegeEvidenceRef(finding.Evidence),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSUnusedDormantAccess(allFindings []AWSUnusedDormantAccessFinding, filtered []AWSUnusedDormantAccessFinding, relationships []AWSUnusedDormantAccessRelationship) AWSUnusedDormantAccessSummary {
+	stateCounts := map[string]int{}
+	severityCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	serviceCounts := map[string]int{}
+	totalConfidence := 0.0
+	highest := 0
+	remediationCases := map[string]struct{}{}
+	for _, finding := range allFindings {
+		stateCounts[finding.DormancyState]++
+		severityCounts[finding.Severity]++
+		statusCounts[finding.Status]++
+		serviceCounts[finding.Service]++
+		totalConfidence += finding.Confidence
+		if finding.Score > highest {
+			highest = finding.Score
+		}
+		if finding.RemediationCase.CaseID != "" {
+			remediationCases[finding.RemediationCase.CaseID] = struct{}{}
+		}
+	}
+	averageConfidence := 0
+	if len(allFindings) > 0 {
+		averageConfidence = int((totalConfidence / float64(len(allFindings))) * 100)
+	}
+	return AWSUnusedDormantAccessSummary{
+		TotalFindings:            len(allFindings),
+		FilteredFindings:         len(filtered),
+		DormancyStateCounts:      stateCounts,
+		SeverityCounts:           severityCounts,
+		StatusCounts:             statusCounts,
+		ServiceCounts:            serviceCounts,
+		CleanupCandidateCount:    statusCounts["cleanup_candidate"],
+		ReviewRequiredCount:      statusCounts["review"],
+		NoRuntimeEvidenceCount:   stateCounts["no_runtime_evidence"],
+		UnknownEvidenceCount:     stateCounts["unknown"],
+		StaleAccessCount:         stateCounts["stale"],
+		RelationshipCount:        len(relationships),
+		HighestScore:             highest,
+		AverageConfidencePct:     averageConfidence,
+		RemediationPreviewCount:  len(remediationCases),
+		PermissionDeniedEvidence: statusCounts["permission-denied"],
+	}
+}
+
+func awsUnusedDormantAccessStatus(sourceStatus string, filtered []AWSUnusedDormantAccessFinding, diagnostics []AWSLeastPrivilegeDiagnostic) string {
+	if sourceStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked
+	}
+	if len(filtered) == 0 || sourceStatus == awsPlatformDependencyStatusDegraded || len(diagnostics) > 0 {
+		return awsPlatformDependencyStatusDegraded
+	}
+	return awsPlatformDependencyStatusReady
+}
+
+func awsUnusedDormantAccessCaveats(source []string) []string {
+	return dedupeStrings(append(source, "Unknown, degraded, or permission-denied evidence remains a review state and never becomes a cleanup candidate."))
+}
+
+func awsUnusedDormantAccessRemediationHints(source []string) []string {
+	return emptyStrings(dedupeStrings(append(source, "Use unused/dormant findings as read-only cleanup candidates until owner approval and IAM policy diff generation are available.")))
+}
+
+func awsUnusedDormantAccessCoverageGaps(source []AWSLeastPrivilegeCoverageGap) []AWSUnusedDormantAccessCoverageGap {
+	out := []AWSUnusedDormantAccessCoverageGap{{
+		Capability:  "unused_dormant_access_persistence",
+		Status:      "ready",
+		Reason:      "The API emits stable finding IDs, calculation version, dormant state, evidence, policy scope, owner context, and remediation preview fields for downstream persistence/graph consumers.",
+		Remediation: "Persist these findings into the shared AWS intelligence store when the dedicated findings table lands.",
+	}}
+	for _, gap := range source {
+		out = append(out, AWSUnusedDormantAccessCoverageGap(gap))
+	}
+	return out
+}
+
+func awsUnusedDormantAccessDiagnostics(source []AWSLeastPrivilegeDiagnostic) []AWSUnusedDormantAccessDiagnostic {
+	out := make([]AWSUnusedDormantAccessDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSUnusedDormantAccessDiagnostic(diagnostic))
+	}
+	return out
+}

--- a/internal/api/aws_unused_dormant_access_test.go
+++ b/internal/api/aws_unused_dormant_access_test.go
@@ -82,6 +82,26 @@ func TestGetAWSUnusedDormantAccessFiltersDormancyState(t *testing.T) {
 	if result.AppliedFilters["dormancy_state"] != "never-used" {
 		t.Fatalf("expected applied dormancy filter, got %+v", result.AppliedFilters)
 	}
+
+	cleanup, err := svc.GetAWSUnusedDormantAccessFindings(defaultScopeContext(), ws, "project-unused-dormant-filters", AWSUnusedDormantAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Status:       "cleanup_candidate",
+	})
+	if err != nil {
+		t.Fatalf("filter cleanup candidates: %v", err)
+	}
+	if len(cleanup.Findings) == 0 {
+		t.Fatal("expected cleanup candidate findings")
+	}
+	for _, finding := range cleanup.Findings {
+		if finding.Status != "cleanup_candidate" {
+			t.Fatalf("cleanup status filter leaked %+v", finding)
+		}
+	}
+	if cleanup.AppliedFilters["status"] != "cleanup-candidate" {
+		t.Fatalf("expected applied cleanup status filter, got %+v", cleanup.AppliedFilters)
+	}
 }
 
 func TestGetAWSUnusedDormantAccessPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {

--- a/internal/api/aws_unused_dormant_access_test.go
+++ b/internal/api/aws_unused_dormant_access_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetAWSUnusedDormantAccessBuildsFindingContract(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-unused-dormant-access", now)
+
+	result, err := svc.GetAWSUnusedDormantAccessFindings(defaultScopeContext(), ws, "project-unused-dormant-access", AWSUnusedDormantAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get unused dormant access findings: %v", err)
+	}
+	if result.CurrentIssueRef != "#1523" || result.Version != awsUnusedDormantAccessVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected findings summary to match payload: %+v", result.Summary)
+	}
+	if result.Findings[0].Score < result.Findings[len(result.Findings)-1].Score {
+		t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected graph relationships: %+v", result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 || result.Summary.CleanupCandidateCount == 0 {
+		t.Fatalf("expected cleanup candidates and remediation previews: %+v", result.Summary)
+	}
+
+	hasNeverUsed := false
+	hasStaleOrUnknown := false
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsUnusedDormantAccessVersion || finding.Rationale == "" {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.DormancyState == "" || finding.PolicyScope == "" || finding.OwnerContext == "" || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing dormant-access fields: %+v", finding)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+		switch finding.DormancyState {
+		case "never_used":
+			hasNeverUsed = true
+			if len(finding.CandidateActions) == 0 {
+				t.Fatalf("never-used finding must name candidate actions: %+v", finding)
+			}
+		case "stale", "unknown":
+			hasStaleOrUnknown = true
+		}
+	}
+	if !hasNeverUsed || !hasStaleOrUnknown {
+		t.Fatalf("expected never-used plus stale/unknown findings, got %+v", result.Summary.DormancyStateCounts)
+	}
+}
+
+func TestGetAWSUnusedDormantAccessFiltersDormancyState(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 10, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-unused-dormant-filters", now)
+
+	result, err := svc.GetAWSUnusedDormantAccessFindings(defaultScopeContext(), ws, "project-unused-dormant-filters", AWSUnusedDormantAccessRequest{
+		ConnectorID:   "aws-prod",
+		FixtureState:  "success",
+		DormancyState: "never_used",
+	})
+	if err != nil {
+		t.Fatalf("filter unused dormant access findings: %v", err)
+	}
+	if len(result.Findings) == 0 {
+		t.Fatal("expected never-used resource findings")
+	}
+	for _, finding := range result.Findings {
+		if finding.DormancyState != "never_used" {
+			t.Fatalf("dormancy filter leaked %+v", finding)
+		}
+	}
+	if result.AppliedFilters["dormancy_state"] != "never-used" {
+		t.Fatalf("expected applied dormancy filter, got %+v", result.AppliedFilters)
+	}
+}
+
+func TestGetAWSUnusedDormantAccessPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 20, 0, 0, time.UTC)
+	svc, ws := newLeastPrivilegeService(t, "project-unused-dormant-states", now)
+
+	denied, err := svc.GetAWSUnusedDormantAccessFindings(defaultScopeContext(), ws, "project-unused-dormant-states", AWSUnusedDormantAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || denied.Confidence != 0 || len(denied.Findings) != 0 {
+		t.Fatalf("expected blocked permission-denied state, got %+v", denied)
+	}
+	if len(denied.Diagnostics) == 0 || len(denied.CoverageGaps) == 0 {
+		t.Fatalf("expected diagnostics and coverage gaps for denied state")
+	}
+
+	empty, err := svc.GetAWSUnusedDormantAccessFindings(defaultScopeContext(), ws, "project-unused-dormant-states", AWSUnusedDormantAccessRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 {
+		t.Fatalf("expected degraded empty state, got %+v", empty)
+	}
+}

--- a/internal/api/aws_unused_dormant_access_test.go
+++ b/internal/api/aws_unused_dormant_access_test.go
@@ -104,6 +104,34 @@ func TestGetAWSUnusedDormantAccessFiltersDormancyState(t *testing.T) {
 	}
 }
 
+func TestAWSUnusedDormantAccessQualificationSkipsActiveReviewSignals(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 15, 0, 0, time.UTC)
+	activeAnalyzer := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:access-analyzer",
+		RecommendationType: "review-external-access",
+		Decision:           "review",
+		BreakagePrediction: "unknown",
+		ObservedActions:    []string{"secretsmanager:GetSecretValue"},
+		Evidence:           []AWSLeastPrivilegeEvidence{{Source: "access_analyzer", Relationship: "observed", ObservedAt: now}},
+		CalculationVersion: awsLeastPrivilegeVersion,
+	}
+	if awsUnusedDormantRecommendationQualifies(activeAnalyzer) {
+		t.Fatalf("active Access Analyzer review signal must not qualify as dormant access: %+v", activeAnalyzer)
+	}
+
+	staleIAM := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:iam-last-used",
+		RecommendationType: "review-stale-service-access",
+		Decision:           "review",
+		BreakagePrediction: "unknown",
+		Evidence:           []AWSLeastPrivilegeEvidence{{Source: "iam_last_used", Relationship: "stale", ObservedAt: now.Add(-120 * 24 * time.Hour)}},
+		CalculationVersion: awsLeastPrivilegeVersion,
+	}
+	if !awsUnusedDormantRecommendationQualifies(staleIAM) {
+		t.Fatalf("stale IAM review signal should qualify as dormant access: %+v", staleIAM)
+	}
+}
+
 func TestGetAWSUnusedDormantAccessPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 20, 9, 20, 0, 0, time.UTC)
 	svc, ws := newLeastPrivilegeService(t, "project-unused-dormant-states", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3089,6 +3089,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"recommendations": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSUnusedDormantAccessFindings(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSUnusedDormantAccessRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			Identity:      strings.TrimSpace(c.Query("identity")),
+			Resource:      strings.TrimSpace(c.Query("resource")),
+			Service:       strings.TrimSpace(c.Query("service")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			DormancyState: strings.TrimSpace(c.Query("dormancy_state")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws unused dormant access request"})
+			default:
+				logger.Error("get aws unused dormant access",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws unused dormant access"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"findings": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1273,6 +1273,55 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS unused dormant access findings with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        findings: {
+          status: 'ready',
+          summary: {
+            total_findings: 1,
+            filtered_findings: 1
+          },
+          findings: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectUnusedDormantAccess(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'lambda-invoice-agent',
+        resource: 'prod/ai/openai-key',
+        service: 'secretsmanager',
+        severity: 'high',
+        status: 'cleanup_candidate',
+        dormancyState: 'never_used'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/unused-dormant-access?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=lambda-invoice-agent&resource=prod%2Fai%2Fopenai-key&service=secretsmanager&severity=high&status=cleanup_candidate&dormancy_state=never_used'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2996,6 +2996,121 @@ export type AWSLeastPrivilegeQuery = {
   decision?: string;
 };
 
+export type AWSUnusedDormantAccessStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSUnusedDormantAccessFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSUnusedDormantAccessDormancyState = 'never_used' | 'stale' | 'no_runtime_evidence' | 'unknown' | string;
+export type AWSUnusedDormantAccessFindingStatus = 'cleanup_candidate' | 'review' | string;
+
+export type AWSUnusedDormantAccessRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSUnusedDormantAccessFinding = {
+  finding_id: string;
+  calculation_version: string;
+  finding_type: string;
+  dormancy_state: AWSUnusedDormantAccessDormancyState;
+  severity: AWSLeastPrivilegeSeverity;
+  status: AWSUnusedDormantAccessFindingStatus;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  service: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  resource_node_id?: string;
+  resource_arn?: string;
+  display_name: string;
+  owner_context: string;
+  policy_scope: string;
+  rationale: string;
+  last_used_at?: string;
+  dormant_days: number;
+  scan_window_days: number;
+  candidate_actions?: string[];
+  observed_actions?: string[];
+  granted_actions?: string[];
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSUnusedDormantAccessSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  dormancy_state_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  service_counts: Record<string, number>;
+  cleanup_candidate_count: number;
+  review_required_count: number;
+  no_runtime_evidence_count: number;
+  unknown_evidence_count: number;
+  stale_access_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+  permission_denied_evidence_count: number;
+};
+
+export type AWSUnusedDormantAccessResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSUnusedDormantAccessStatus;
+  fixture_state?: AWSUnusedDormantAccessFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSUnusedDormantAccessSummary;
+  findings: AWSUnusedDormantAccessFinding[];
+  relationships: AWSUnusedDormantAccessRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSUnusedDormantAccessQuery = {
+  connectorID?: string;
+  fixtureState?: AWSUnusedDormantAccessFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  resource?: string;
+  service?: string;
+  severity?: string;
+  status?: string;
+  dormancyState?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -6211,6 +6326,28 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         decision: query?.decision
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectUnusedDormantAccess(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSUnusedDormantAccessQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ findings: AWSUnusedDormantAccessResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/unused-dormant-access${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        resource: query?.resource,
+        service: query?.service,
+        severity: query?.severity,
+        status: query?.status,
+        dormancy_state: query?.dormancyState
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -16,6 +16,7 @@ import type {
   AWSPlatformValidationHarnessResult,
   AWSRuntimeEventResult,
   AWSServiceCollectorContractResult,
+  AWSUnusedDormantAccessResult,
   CurrentUserContext,
   Finding,
   GitHubConnectionStatus,
@@ -418,6 +419,104 @@ const readyAWSLeastPrivilege: AWSLeastPrivilegeResult = {
   failure_reasons: [],
   remediation_hints: [],
   evidence_links: ['/docs/aws-least-privilege-engine'],
+  coverage_gaps: [],
+  diagnostics: [],
+  generated_at: '2026-06-14T17:30:00Z',
+  updated_at: '2026-06-14T17:30:00Z'
+};
+
+const readyAWSUnusedDormantAccess: AWSUnusedDormantAccessResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1472,
+  parent_issue_ref: '#1472',
+  current_issue_number: 1523,
+  current_issue_ref: '#1523',
+  version: 'aws-unused-dormant-access-engine-v1',
+  status: 'ready',
+  fixture_state: 'success',
+  confidence: 0.9,
+  calculation_version: 'aws-unused-dormant-access-engine-v1',
+  applied_filters: {},
+  summary: {
+    total_findings: 1,
+    filtered_findings: 1,
+    dormancy_state_counts: { never_used: 1 },
+    severity_counts: { high: 1 },
+    status_counts: { cleanup_candidate: 1 },
+    service_counts: { secretsmanager: 1 },
+    cleanup_candidate_count: 1,
+    review_required_count: 0,
+    no_runtime_evidence_count: 0,
+    unknown_evidence_count: 0,
+    stale_access_count: 0,
+    relationship_count: 1,
+    highest_score: 82,
+    average_confidence_pct: 90,
+    remediation_preview_count: 1,
+    permission_denied_evidence_count: 0
+  },
+  findings: [
+    {
+      finding_id: 'aws-unused-dormant-access:secret-unused',
+      calculation_version: 'aws-unused-dormant-access-engine-v1',
+      finding_type: 'cleanup_candidate',
+      dormancy_state: 'never_used',
+      severity: 'high',
+      status: 'cleanup_candidate',
+      score: 82,
+      confidence: 0.9,
+      account_id: '123456789012',
+      region: 'us-east-1',
+      service: 'secretsmanager',
+      identity_node_id: 'aws:identity:lambda-invoice-agent',
+      principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      resource_node_id: 'aws:resource:secret:openai-key',
+      resource_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/ai/openai-key',
+      display_name: 'lambda-invoice-agent',
+      owner_context: 'resource-owner-review',
+      policy_scope: 'secretsmanager:GetSecretValue',
+      rationale: 'lambda-invoice-agent has granted secretsmanager access with no matching runtime evidence.',
+      dormant_days: 90,
+      scan_window_days: 90,
+      candidate_actions: ['secretsmanager:GetSecretValue'],
+      granted_actions: ['secretsmanager:GetSecretValue'],
+      impacted_nodes: ['aws:identity:lambda-invoice-agent', 'aws:resource:secret:openai-key'],
+      impacted_path: readyAWSLeastPrivilege.recommendations[0].impacted_path,
+      evidence: readyAWSLeastPrivilege.recommendations[0].evidence,
+      next_action: 'Create a read-only cleanup case, confirm owner approval, and verify policy scope before generating an IAM diff.',
+      remediation_case: {
+        case_id: 'aws-unused-dormant-preview:secret-unused',
+        title: 'never used dormant-access remove',
+        recommended_action: 'Create a read-only case to remove unused grants after owner approval.',
+        approval_required: true,
+        blocking_evidence: ['secrets-kms-runtime-access://secret-unused'],
+        impacted_node_count: 1,
+        estimated_risk_drop: 40,
+        breakage_prediction: 'low',
+        read_only_projection: true
+      },
+      created_at: '2026-06-14T17:30:00Z',
+      updated_at: '2026-06-14T17:30:00Z'
+    }
+  ],
+  relationships: [
+    {
+      finding_id: 'aws-unused-dormant-access:secret-unused',
+      type: 'unused_dormant_access_scope',
+      from_node_id: 'aws:identity:lambda-invoice-agent',
+      to_node_id: 'aws:resource:secret:openai-key',
+      evidence_ref: 'secrets-kms-runtime-access://secret-unused'
+    }
+  ],
+  caveats: [],
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: ['/docs/aws-unused-dormant-access-engine'],
   coverage_gaps: [],
   diagnostics: [],
   generated_at: '2026-06-14T17:30:00Z',
@@ -3253,6 +3352,9 @@ describe('Domain-first app routes', () => {
     const getLeastPrivilege = vi
       .spyOn(api.apiClient, 'getAWSProjectLeastPrivilege')
       .mockResolvedValue({ recommendations: readyAWSLeastPrivilege });
+    const getUnusedDormantAccess = vi
+      .spyOn(api.apiClient, 'getAWSProjectUnusedDormantAccess')
+      .mockResolvedValue({ findings: readyAWSUnusedDormantAccess });
 
     const { ProductAWSRuntimePage } = await import('./productShell');
 
@@ -3269,7 +3371,15 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Cleanup candidate/i).length).toBeGreaterThan(0);
     expect(getLeastPrivilege).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getUnusedDormantAccess).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -59,6 +59,8 @@ import {
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
   type AWSLeastPrivilegeResult,
+  type AWSUnusedDormantAccessFinding,
+  type AWSUnusedDormantAccessResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10651,6 +10653,116 @@ function AWSLeastPrivilegeContent({
   );
 }
 
+function awsUnusedDormantAccessStage(finding: AWSUnusedDormantAccessFinding): AWSCapabilityStage {
+  if (finding.status === 'cleanup_candidate') {
+    return 'coming';
+  }
+  if (finding.dormancy_state === 'unknown') {
+    return 'not-available';
+  }
+  return 'wired';
+}
+
+function awsUnusedDormantAccessLabel(finding: AWSUnusedDormantAccessFinding): string {
+  return `${formatTokenLabel(finding.finding_type)} · score ${finding.score}`;
+}
+
+function awsUnusedDormantAccessEvidenceLabel(finding: AWSUnusedDormantAccessFinding): string {
+  const sources = finding.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function awsUnusedDormantAccessPathLabel(finding: AWSUnusedDormantAccessFinding): string {
+  const path = finding.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
+  if (path.length === 0) {
+    return finding.impacted_nodes.join(' -> ') || '-';
+  }
+  return path.join(' -> ');
+}
+
+function awsUnusedDormantAccessActionLabel(finding: AWSUnusedDormantAccessFinding): string {
+  const actions = finding.candidate_actions ?? [];
+  if (actions.length > 0) {
+    return `${actions.slice(0, 3).join(', ')}${actions.length > 3 ? ` +${actions.length - 3}` : ''}`;
+  }
+  return finding.policy_scope || formatTokenLabel(finding.dormancy_state);
+}
+
+function AWSUnusedDormantAccessContent({
+  findings,
+  loading,
+  error,
+  onRetry
+}: {
+  findings: AWSUnusedDormantAccessResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = findings?.findings ?? [];
+  const summaryLine = findings
+    ? `${findings.summary.cleanup_candidate_count} cleanup · ${findings.summary.review_required_count} review · ${findings.summary.stale_access_count} stale · ${findings.summary.unknown_evidence_count} unknown`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS unused and dormant access findings">
+      <h3>AWS unused and dormant access</h3>
+      <p className="idt-app-kicker">
+        Ranked cleanup and review findings for never-used, stale, no-runtime-evidence, and unknown access states.
+        {summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load unused and dormant access findings"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating dormant access"
+          body="Identrail is ranking unused grants, stale identities, owner context, confidence, and evidence boundaries."
+        />
+      ) : null}
+      {!error && !loading && findings && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={findings.status === 'blocked' ? 'Permission required' : 'No dormant access findings'}
+          title={findings.status === 'blocked' ? 'Dormant access needs read-only evidence access' : 'No unused or dormant access'}
+          body={findings.failure_reasons[0] ?? 'No never-used, stale, unknown, or no-runtime-evidence access matched this scope.'}
+        />
+      ) : null}
+      {!error && !loading && findings && findings.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {findings.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS unused and dormant access findings"
+          rows={rows}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsUnusedDormantAccessLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.display_name || row.identity_node_id },
+            { key: 'state', header: 'Dormancy', render: (row) => formatTokenLabel(row.dormancy_state) },
+            { key: 'scope', header: 'Scope', render: (row) => `${formatTokenLabel(row.service)} · ${awsUnusedDormantAccessPathLabel(row)}` },
+            { key: 'actions', header: 'Candidate actions', render: (row) => awsUnusedDormantAccessActionLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsUnusedDormantAccessEvidenceLabel(row) },
+            {
+              key: 'status',
+              header: 'Status',
+              render: (row) => <AWSInventoryPill stage={awsUnusedDormantAccessStage(row)} label={formatTokenLabel(row.status)} />
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTableRow {
   const eventLabel = awsRuntimeEventLabel(record);
   const resourceLabel = record.target_resource_name || record.target_resource_type || record.target_resource_arn || 'Session event';
@@ -11157,6 +11269,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [leastPrivilegeLoading, setLeastPrivilegeLoading] = useState(false);
   const [leastPrivilegeError, setLeastPrivilegeError] = useState('');
   const leastPrivilegeRequestRef = useRef(0);
+  const [unusedDormantAccess, setUnusedDormantAccess] = useState<AWSUnusedDormantAccessResult | null>(null);
+  const [unusedDormantAccessLoading, setUnusedDormantAccessLoading] = useState(false);
+  const [unusedDormantAccessError, setUnusedDormantAccessError] = useState('');
+  const unusedDormantAccessRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11460,6 +11576,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadLeastPrivilege]);
 
+  const loadUnusedDormantAccess = useCallback(async () => {
+    const requestID = ++unusedDormantAccessRequestRef.current;
+    setUnusedDormantAccess(null);
+    setUnusedDormantAccessError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setUnusedDormantAccessLoading(false);
+      return;
+    }
+    setUnusedDormantAccessLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectUnusedDormantAccess(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== unusedDormantAccessRequestRef.current) {
+        return;
+      }
+      setUnusedDormantAccess(response.findings);
+    } catch (error) {
+      if (requestID !== unusedDormantAccessRequestRef.current) {
+        return;
+      }
+      setUnusedDormantAccessError(formatAPIError(error, 'Unable to load AWS unused and dormant access findings.'));
+    } finally {
+      if (requestID === unusedDormantAccessRequestRef.current) {
+        setUnusedDormantAccessLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadUnusedDormantAccess();
+    return () => {
+      unusedDormantAccessRequestRef.current += 1;
+    };
+  }, [loadUnusedDormantAccess]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -11591,6 +11755,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={leastPrivilegeLoading}
             error={leastPrivilegeError}
             onRetry={loadLeastPrivilege}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSUnusedDormantAccessContent
+            findings={unusedDormantAccess}
+            loading={unusedDormantAccessLoading}
+            error={unusedDormantAccessError}
+            onRetry={loadUnusedDormantAccess}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
Closes #1523

## Summary

Adds the AWS unused and dormant access engine for Wave 6.03.

## Why

Operators need ranked, explainable cleanup and review findings for never-used, stale, no-runtime-evidence, and unknown AWS access states without treating missing or degraded evidence as deterministic truth.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

This PR adds:
- A read-only backend engine and `GET /v1/workspaces/{ws}/projects/{project}/aws/unused-dormant-access` API.
- Stable finding records with dormant state, confidence, rationale, owner context, policy scope, candidate actions, impacted graph path, evidence refs, and remediation case previews.
- Conservative handling for unknown, degraded, permission-denied, and partial evidence so they remain review-only instead of cleanup candidates.
- Runtime app surface for operator-visible unused and dormant access findings.
- OpenAPI, docs, changelog, authz metadata, web client types, and focused tests.

## Validation

```bash
go test ./internal/api -run 'TestGetAWSUnusedDormantAccess|TestGetAWSLeastPrivilege'
go test ./internal/api -run 'TestGetAWSUnusedDormantAccess|TestGetAWSLeastPrivilege|TestOpenAPI|TestAuthz|TestPolicy'
go test ./internal/api -run 'TestRouter.*AWS|Test.*UnusedDormant|Test.*LeastPrivilege'
npm run test --prefix web -- src/api/client.test.ts -t "unused dormant access" --run
npm run test --prefix web -- src/productShell.test.tsx -t "AWS runtime" --run
npm run test:ci --prefix web
npm run build --prefix web
git diff --cached --check
```

Note: `go test ./internal/api` currently fails in unrelated GitHub connector tests because the local test environment has no GitHub app installation verifier configured. The targeted AWS/API contract tests above pass.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

No

## Related Issues

Closes #1523

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS unused and dormant access engine and API to rank and explain never-used, stale, no-runtime-evidence, and unknown AWS access. Surfaces findings in the runtime app without treating missing or degraded evidence as truth.

- **New Features**
  - New endpoint: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/unused-dormant-access` with filters (connector, fixture state, account, region, identity, resource, service, severity, status, dormancy state).
  - Stable finding contract: IDs, version, dormancy state (`never_used`, `stale`, `no_runtime_evidence`, `unknown`), severity/score/confidence, rationale, owner context, policy scope, candidate actions, impacted path, evidence refs, relationships, and read-only remediation preview.
  - Conservative handling: unknown, degraded, partial, and permission-denied evidence stay review-only (not cleanup candidates).
  - Platform wiring: OpenAPI schema, route authz, router handler, docs, changelog, and focused Go/web tests.
  - UI: runtime page adds an “AWS unused and dormant access” table; new client method `getAWSProjectUnusedDormantAccess` and TS types to render results.

- **Bug Fixes**
  - Restricted qualification so only recommendations with explicit dormant/no-runtime evidence are included; active Access Analyzer review signals no longer qualify as dormant access.
  - Fixed cleanup status filtering so `status=cleanup_candidate` returns only cleanup-candidate findings and reflects the applied filter correctly.

<sup>Written for commit 4987f36302b139180047613e18a745fb017b275b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

