### PR TITLE
Implement AWS privilege escalation path engine

### DIFF
--- a/docs/aws-privilege-escalation-engine.md
+++ b/docs/aws-privilege-escalation-engine.md
@@ -1,0 +1,87 @@
+# AWS privilege escalation path engine
+
+Issue #1525 (Wave 6.05) adds a metadata-only engine that ranks AWS privilege
+escalation paths into explainable findings. It composes the read-only evidence
+from PassRole, KMS decrypt reachability, Secrets Manager metadata, least
+privilege recommendations, and blast-radius graph analysis.
+
+## What it produces
+
+The engine emits `AWSPrivilegeEscalationFinding` records for these path types:
+
+- **`passrole_service_escalation`** — an identity can pass a specific role to a
+  scoped AWS service.
+- **`passrole_wildcard_escalation`** — an identity can pass a wildcard role
+  target.
+- **`passrole_unscoped_trust_path`** — a PassRole grant lacks
+  `iam:PassedToService` scoping.
+- **`policy_attachment_escalation`** — least-privilege evidence found
+  escalation-capable policy actions such as `iam:*`, `iam:PassRole`,
+  `iam:AttachRolePolicy`, or `sts:AssumeRole`.
+- **`kms_admin_equivalence`** — KMS key policy or grant metadata indicates an
+  admin-equivalent or decrypt-capable path.
+- **`secrets_admin_equivalence`** — Secrets Manager resource policy metadata
+  indicates an admin-equivalent or read-capable path.
+- **`cross_account_escalation_path`** — blast-radius evidence found a critical
+  or cross-account graph path.
+
+Each finding carries a stable finding id, calculation version, severity, score,
+confidence, impacted graph path, evidence references, exploitability label,
+status, and read-only `remediation_case` preview. Findings are ranked by
+descending score with stable id tie-breaking.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/privilege-escalation`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | scope filters |
+| `identity` | principal ARN, identity-node id, or display-name search |
+| `target` | target node id, target label, or impacted-node search |
+| `escalation_type` | one of the finding types above |
+| `severity` | `critical`, `high`, `medium`, `low` |
+| `status` | `review`, `action_required` |
+
+Response shape: `{ "findings": AWSPrivilegeEscalationResult }` with summary,
+ranked findings, graph relationships, caveats, failure reasons, remediation
+hints, evidence links, coverage gaps, diagnostics, and standard
+tenant/workspace/project issue metadata.
+
+## Read-only guarantees
+
+The engine performs no AWS mutations and does not read secret values, KMS
+plaintext, prompts, completions, object bodies, database rows, browser pages, or
+customer payloads. It only forwards metadata and evidence references from
+upstream collectors that are already read-only.
+
+Remediation output is a planning preview. It can tell an operator which policy,
+trust, grant, or role path needs review, but it does not change AWS or Identrail
+state.
+
+## Failure handling
+
+- **Ready**: all source engines are available and no diagnostics were emitted.
+- **Degraded**: at least one source is partial, empty because supporting runtime
+  evidence is unavailable, or produced diagnostics. Existing partial evidence
+  remains visible.
+- **Blocked**: every source required for the calculation is permission denied.
+  The result has `confidence=0`, no findings, diagnostics, and failure reasons.
+
+Unknown, degraded, and permission-denied evidence lowers confidence and must not
+be interpreted as absence of privilege escalation paths.
+
+## Live validation
+
+1. Run the upstream PassRole, KMS reachability, Secrets Manager metadata,
+   least-privilege, and blast-radius endpoints with `fixture_state=success`.
+2. Run the privilege escalation endpoint with `fixture_state=success` and
+   confirm PassRole and KMS admin-equivalence findings are ranked.
+3. Filter by `escalation_type=passrole_unscoped_trust_path`, `severity`, and
+   `identity` to verify deterministic drill-down behavior.
+4. Run `fixture_state=permission_denied` and confirm `status=blocked`, zero
+   findings, diagnostics, and failure reasons.
+5. Confirm the app runtime page renders the `AWS privilege escalation paths`
+   panel and never exposes secret values or payload data.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -589,6 +589,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/privilege-escalation
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -5235,6 +5240,84 @@ paths:
                     $ref: "#/components/schemas/AWSIdentitySprawlResult"
         "400":
           description: Invalid AWS identity sprawl request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/privilege-escalation:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS privilege escalation path findings
+      operationId: getAWSProjectPrivilegeEscalation
+      description: Ranked, explainable privilege escalation paths composed from read-only PassRole, policy attachment, trust, KMS, Secrets Manager, least-privilege, and blast-radius evidence. The engine emits stable finding IDs, graph paths, evidence pointers, confidence, status, and read-only remediation previews; it does not mutate AWS resources or read secret values, plaintext, prompts, completions, object bodies, database rows, browser pages, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the calculation.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Filter by principal ARN, identity-node id, or display name.
+        - in: query
+          name: target
+          schema: { type: string }
+          description: Filter by target node id, target label, or impacted-node text.
+        - in: query
+          name: escalation_type
+          schema:
+            type: string
+            enum: [passrole_service_escalation, passrole_wildcard_escalation, passrole_unscoped_trust_path, policy_attachment_escalation, kms_admin_equivalence, secrets_admin_equivalence, cross_account_escalation_path]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [review, action_required]
+      responses:
+        "200":
+          description: AWS privilege escalation path findings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    $ref: "#/components/schemas/AWSPrivilegeEscalationResult"
+        "400":
+          description: Invalid AWS privilege escalation request
           content:
             application/json:
               schema:
@@ -12791,6 +12874,143 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSIdentitySprawlRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPrivilegeEscalationRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSPrivilegeEscalationFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        escalation_type:
+          type: string
+          enum: [passrole_service_escalation, passrole_wildcard_escalation, passrole_unscoped_trust_path, policy_attachment_escalation, kms_admin_equivalence, secrets_admin_equivalence, cross_account_escalation_path]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [review, action_required]
+        score: { type: integer }
+        confidence: { type: number }
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        target_node_id: { type: string }
+        target_label: { type: string }
+        display_name: { type: string }
+        rationale: { type: string }
+        exploitability: { type: string }
+        runtime_context: { type: string }
+        policy_sources:
+          type: array
+          items: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPrivilegeEscalationSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        escalation_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        critical_count: { type: integer }
+        high_count: { type: integer }
+        cross_account_path_count: { type: integer }
+        passrole_path_count: { type: integer }
+        admin_equivalent_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+    AWSPrivilegeEscalationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status: { type: string }
+        fixture_state: { type: string }
+        confidence: { type: number }
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSPrivilegeEscalationSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPrivilegeEscalationFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPrivilegeEscalationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -761,6 +761,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/identity-sprawl", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/privilege-escalation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -310,7 +310,19 @@ func awsPrivilegeEscalationPassRoleKeysMatch(record AWSIAMPassRoleRelationshipRe
 	recordTarget := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.ToNodeID, record.TargetResource)))
 	denySource := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(deny.FromNodeID, deny.SourceRoleARN)))
 	denyTarget := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(deny.ToNodeID, deny.TargetResource)))
-	return recordSource != "" && recordTarget != "" && recordSource == denySource && recordTarget == denyTarget
+	return recordSource != "" && recordTarget != "" &&
+		recordSource == denySource &&
+		awsPrivilegeEscalationPassRoleTargetsMatch(recordTarget, denyTarget)
+}
+
+func awsPrivilegeEscalationPassRoleTargetsMatch(recordTarget, denyTarget string) bool {
+	if recordTarget == "" || denyTarget == "" {
+		return false
+	}
+	if strings.EqualFold(recordTarget, denyTarget) {
+		return true
+	}
+	return awsActionPatternMatches(denyTarget, recordTarget)
 }
 
 func awsPrivilegeEscalationPassRoleActionsOverlap(allowActions, denyActions string) bool {

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -547,13 +547,21 @@ func awsPrivilegeEscalationRelationships(findings []AWSPrivilegeEscalationFindin
 		for i := 0; i+1 < len(finding.ImpactedPath); i++ {
 			from := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
 			to := strings.TrimSpace(finding.ImpactedPath[i+1].NodeID)
-			if from == "" || to == "" {
+			if !awsPrivilegeEscalationPathNodeIDIsConcrete(from) || !awsPrivilegeEscalationPathNodeIDIsConcrete(to) {
 				continue
 			}
 			relationships = append(relationships, AWSPrivilegeEscalationRelationship{FindingID: finding.FindingID, Type: "privilege_escalation_path", FromNodeID: from, ToNodeID: to, EvidenceRef: evidenceRef})
 		}
 	}
 	return relationships
+}
+
+func awsPrivilegeEscalationPathNodeIDIsConcrete(nodeID string) bool {
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "" || nodeID == "*" {
+		return false
+	}
+	return !strings.Contains(nodeID, "*")
 }
 
 func summarizeAWSPrivilegeEscalation(allFindings []AWSPrivilegeEscalationFinding, filtered []AWSPrivilegeEscalationFinding, relationships []AWSPrivilegeEscalationRelationship) AWSPrivilegeEscalationSummary {

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -1,0 +1,807 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsPrivilegeEscalationCurrentIssue = 1525
+	awsPrivilegeEscalationVersion      = "aws-privilege-escalation-engine-v1"
+)
+
+// AWSPrivilegeEscalationRequest scopes the read-only escalation-path
+// calculation to AWS evidence and optional drill-down filters.
+type AWSPrivilegeEscalationRequest struct {
+	ConnectorID    string `json:"connector_id,omitempty"`
+	FixtureState   string `json:"fixture_state,omitempty"`
+	AccountID      string `json:"account_id,omitempty"`
+	Region         string `json:"region,omitempty"`
+	Identity       string `json:"identity,omitempty"`
+	Target         string `json:"target,omitempty"`
+	EscalationType string `json:"escalation_type,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	Status         string `json:"status,omitempty"`
+}
+
+type AWSPrivilegeEscalationEvidence = AWSLeastPrivilegeEvidence
+type AWSPrivilegeEscalationPathStep = AWSLeastPrivilegePathStep
+type AWSPrivilegeEscalationRemediationCasePreview = AWSLeastPrivilegeRemediationCasePreview
+type AWSPrivilegeEscalationDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSPrivilegeEscalationCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSPrivilegeEscalationRelationship lets graph consumers join a finding back
+// to the source identity, escalation primitive, and impacted target.
+type AWSPrivilegeEscalationRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSPrivilegeEscalationFinding is the deterministic finding shape for
+// PassRole, policy attachment, trust, admin, KMS/secrets, and cross-account
+// escalation paths. It is read-only and carries evidence pointers only.
+type AWSPrivilegeEscalationFinding struct {
+	FindingID          string                                       `json:"finding_id"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	EscalationType     string                                       `json:"escalation_type"`
+	Severity           string                                       `json:"severity"`
+	Status             string                                       `json:"status"`
+	Score              int                                          `json:"score"`
+	Confidence         float64                                      `json:"confidence"`
+	AccountID          string                                       `json:"account_id"`
+	Region             string                                       `json:"region"`
+	IdentityNodeID     string                                       `json:"identity_node_id"`
+	PrincipalARN       string                                       `json:"principal_arn,omitempty"`
+	TargetNodeID       string                                       `json:"target_node_id,omitempty"`
+	TargetLabel        string                                       `json:"target_label"`
+	DisplayName        string                                       `json:"display_name"`
+	Rationale          string                                       `json:"rationale"`
+	Exploitability     string                                       `json:"exploitability"`
+	RuntimeContext     string                                       `json:"runtime_context"`
+	PolicySources      []string                                     `json:"policy_sources,omitempty"`
+	ImpactedNodes      []string                                     `json:"impacted_nodes"`
+	ImpactedPath       []AWSPrivilegeEscalationPathStep             `json:"impacted_path"`
+	Evidence           []AWSPrivilegeEscalationEvidence             `json:"evidence"`
+	NextAction         string                                       `json:"next_action"`
+	RemediationCase    AWSPrivilegeEscalationRemediationCasePreview `json:"remediation_case"`
+	CreatedAt          time.Time                                    `json:"created_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+// AWSPrivilegeEscalationSummary aggregates unfiltered and filtered paths.
+type AWSPrivilegeEscalationSummary struct {
+	TotalFindings           int            `json:"total_findings"`
+	FilteredFindings        int            `json:"filtered_findings"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	EscalationTypeCounts    map[string]int `json:"escalation_type_counts"`
+	CriticalCount           int            `json:"critical_count"`
+	HighCount               int            `json:"high_count"`
+	CrossAccountPathCount   int            `json:"cross_account_path_count"`
+	PassRolePathCount       int            `json:"passrole_path_count"`
+	AdminEquivalentCount    int            `json:"admin_equivalent_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+	RemediationPreviewCount int            `json:"remediation_preview_count"`
+}
+
+// AWSPrivilegeEscalationResult is the deterministic engine envelope.
+type AWSPrivilegeEscalationResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	CalculationVersion string                               `json:"calculation_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Summary            AWSPrivilegeEscalationSummary        `json:"summary"`
+	Findings           []AWSPrivilegeEscalationFinding      `json:"findings"`
+	Relationships      []AWSPrivilegeEscalationRelationship `json:"relationships"`
+	Caveats            []string                             `json:"caveats"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSPrivilegeEscalationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSPrivilegeEscalationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+func (s *Service) GetAWSPrivilegeEscalation(ctx context.Context, workspaceID string, projectID string, request AWSPrivilegeEscalationRequest) (AWSPrivilegeEscalationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSPrivilegeEscalationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSPrivilegeEscalationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSPrivilegeEscalationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSPrivilegeEscalationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	passRole, kms, secrets, leastPrivilege, blastRadius, err := s.awsPrivilegeEscalationSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSPrivilegeEscalationResult{}, err
+	}
+	findings := awsPrivilegeEscalationFindings(passRole, kms, secrets, leastPrivilege, blastRadius, now)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSPrivilegeEscalationFindings(findings, request)
+	relationships := awsPrivilegeEscalationRelationships(filtered)
+	diagnostics := awsPrivilegeEscalationDiagnostics(passRole, kms, secrets, leastPrivilege, blastRadius)
+	coverageGaps := awsPrivilegeEscalationCoverageGaps(passRole, kms, secrets, leastPrivilege, blastRadius)
+	status, confidence := summarizeAWSPrivilegeEscalationStatus([]string{passRole.Status, kms.Status, secrets.Status, leastPrivilege.Status, blastRadius.Status}, diagnostics)
+	summary := summarizeAWSPrivilegeEscalation(findings, filtered, relationships)
+
+	return AWSPrivilegeEscalationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPrivilegeEscalationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPrivilegeEscalationCurrentIssue),
+		Version:            awsPrivilegeEscalationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsPrivilegeEscalationCaveats(),
+		FailureReasons:     awsPrivilegeEscalationFailureReasons(passRole, kms, secrets, leastPrivilege, blastRadius),
+		RemediationHints:   awsPrivilegeEscalationRemediationHints(passRole, kms, secrets, leastPrivilege, blastRadius),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPrivilegeEscalationCurrentIssue),
+			awsIssueURL(awsIAMPassRoleRelationshipCurrentIssue),
+			awsIssueURL(awsBlastRadiusCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			"/docs/aws-privilege-escalation-engine",
+			"/docs/aws-iam-passrole-relationships",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSPrivilegeEscalationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsPrivilegeEscalationSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (AWSIAMPassRoleRelationshipInventoryResult, AWSKMSDecryptReachabilityInventoryResult, AWSSecretsManagerMetadataInventoryResult, AWSLeastPrivilegeResult, AWSBlastRadiusResult, error) {
+	passRole, err := s.GetAWSIAMPassRoleRelationshipInventory(ctx, workspaceID, projectID, AWSIAMPassRoleRelationshipInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, fmt.Errorf("privilege escalation passrole relationships: %w", err)
+	}
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, fmt.Errorf("privilege escalation kms reachability: %w", err)
+	}
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, fmt.Errorf("privilege escalation secrets metadata: %w", err)
+	}
+	leastPrivilege, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, fmt.Errorf("privilege escalation least privilege: %w", err)
+	}
+	blastRadius, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, fmt.Errorf("privilege escalation blast radius: %w", err)
+	}
+	return passRole, kms, secrets, leastPrivilege, blastRadius, nil
+}
+
+func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult, now time.Time) []AWSPrivilegeEscalationFinding {
+	findings := []AWSPrivilegeEscalationFinding{}
+	for _, record := range passRole.Records {
+		if strings.EqualFold(record.Effect, "Allow") {
+			findings = append(findings, awsPrivilegeEscalationFindingFromPassRole(record, now))
+		}
+	}
+	for _, record := range kms.Records {
+		for _, grant := range record.IdentityGrants {
+			if strings.EqualFold(grant.Effect, "Allow") && awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, grant.Capabilities) {
+				findings = append(findings, awsPrivilegeEscalationFindingFromKMSGrant(record, grant, now))
+			}
+		}
+	}
+	for _, record := range secrets.Records {
+		for _, grant := range record.IdentityGrants {
+			if strings.EqualFold(grant.Effect, "Allow") && awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, nil) {
+				findings = append(findings, awsPrivilegeEscalationFindingFromSecretGrant(record, grant, now))
+			}
+		}
+	}
+	for _, recommendation := range leastPrivilege.Recommendations {
+		if awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			findings = append(findings, awsPrivilegeEscalationFindingFromLeastPrivilege(recommendation, now))
+		}
+	}
+	for _, finding := range blastRadius.Findings {
+		if finding.Severity == "critical" || len(finding.CrossAccountEdges) > 0 {
+			findings = append(findings, awsPrivilegeEscalationFindingFromBlastRadius(finding, now))
+		}
+	}
+	return findings
+}
+
+func awsPrivilegeEscalationFindingFromPassRole(record AWSIAMPassRoleRelationshipRecord, now time.Time) AWSPrivilegeEscalationFinding {
+	score := 66
+	escalationType := "passrole_service_escalation"
+	if record.TargetWildcardKind != "specific" {
+		score += 14
+		escalationType = "passrole_wildcard_escalation"
+	}
+	if strings.TrimSpace(record.PassedToService) == "" {
+		score += 8
+		escalationType = "passrole_unscoped_trust_path"
+	}
+	if record.NotAction || record.NotResource {
+		score += 5
+	}
+	score = clampBlastRadiusScore(score)
+	severity := awsPrivilegeEscalationSeverity(score)
+	target := firstNonEmptyAWSValue(record.ToNodeID, record.TargetResource)
+	evidence := AWSPrivilegeEscalationEvidence{Source: "iam_passrole_relationship", EvidenceRef: record.EvidenceRef, Label: "IAM PassRole relationship", Confidence: record.Confidence, ObservedAt: record.CollectedAt, Relationship: record.RelationshipType}
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(record.SourceRoleARN, record.TargetResource, record.PolicyName, record.StatementSid),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     escalationType,
+		Severity:           severity,
+		Status:             awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:              score,
+		Confidence:         record.Confidence,
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     record.FromNodeID,
+		PrincipalARN:       record.SourceRoleARN,
+		TargetNodeID:       target,
+		TargetLabel:        firstNonEmptyAWSValue(shortAWSARN(record.TargetResource), record.TargetResource, "wildcard role target"),
+		DisplayName:        firstNonEmptyAWSValue(record.SourceRoleName, shortAWSARN(record.SourceRoleARN), record.FromNodeID),
+		Rationale:          fmt.Sprintf("Role can pass %s through %s; target scope=%s service=%s.", firstNonEmptyAWSValue(record.TargetResource, "a wildcard role"), firstNonEmptyAWSValue(record.PolicyName, "an IAM policy"), record.TargetWildcardKind, firstNonEmptyAWSValue(record.PassedToService, "unscoped")),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "static PassRole grant",
+		PolicySources:      dedupeStrings([]string{record.PolicyName, record.StatementSid, record.ActionExpression}),
+		ImpactedNodes:      dedupeStrings([]string{record.FromNodeID, target}),
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: record.FromNodeID, NodeType: "identity", Label: firstNonEmptyAWSValue(record.SourceRoleName, shortAWSARN(record.SourceRoleARN)), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: target, NodeType: "iam_role", Label: firstNonEmptyAWSValue(shortAWSARN(record.TargetResource), record.TargetResource), AccountID: record.AccountID, Region: record.Region},
+		},
+		Evidence:   []AWSPrivilegeEscalationEvidence{evidence},
+		NextAction: "Constrain iam:PassRole to specific approved role ARNs and iam:PassedToService conditions before remediation automation.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+}
+
+func awsPrivilegeEscalationFindingFromKMSGrant(record AWSKMSDecryptReachabilityRecord, grant AWSKMSIdentityGrant, now time.Time) AWSPrivilegeEscalationFinding {
+	score := 74
+	if grant.IsCrossAccount || record.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if grant.IsPublic || grant.WildcardPrincipal || record.ExposureClassification == "public" {
+		score += 10
+	}
+	if !grant.HasCondition {
+		score += 4
+	}
+	score = clampBlastRadiusScore(score)
+	principal := firstNonEmptyAWSValue(grant.PrincipalARN, "wildcard-principal")
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, "kms-decrypt-reachability:"+record.KeyARN)
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(principal, record.KeyARN, strings.Join(grant.Actions, ",")),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     "kms_admin_equivalence",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:              score,
+		Confidence:         minFloat(record.Confidence, 0.88),
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     awsIdentityNodeIDForAPI(principal),
+		PrincipalARN:       principal,
+		TargetNodeID:       record.FromNodeID,
+		TargetLabel:        firstNonEmptyAWSValue(record.Description, record.KeyARN, record.KeyID),
+		DisplayName:        shortAWSARN(principal),
+		Rationale:          fmt.Sprintf("Principal has KMS key-policy or grant capabilities %s on %s; exposure=%s.", strings.Join(grant.Actions, ", "), firstNonEmptyAWSValue(record.Description, record.KeyID), record.ExposureClassification),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "KMS key-policy/admin equivalence",
+		PolicySources:      dedupeStrings(append(grant.Actions, grant.Capabilities...)),
+		ImpactedNodes:      dedupeStrings([]string{awsIdentityNodeIDForAPI(principal), record.FromNodeID}),
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: awsIdentityNodeIDForAPI(principal), NodeType: "identity", Label: shortAWSARN(principal), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.FromNodeID, NodeType: "kms_key", Label: firstNonEmptyAWSValue(record.Description, record.KeyARN), AccountID: record.AccountID, Region: record.Region},
+		},
+		Evidence:   []AWSPrivilegeEscalationEvidence{{Source: "kms_decrypt_reachability", EvidenceRef: evidenceRef, Label: "KMS key-policy/admin reachability", Confidence: record.Confidence, ObservedAt: record.CollectedAt, Relationship: "can_admin_or_decrypt_key"}},
+		NextAction: "Review key policy and live grants; remove wildcard, public, or cross-account admin-equivalent permissions after owner approval.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+}
+
+func awsPrivilegeEscalationFindingFromSecretGrant(record AWSSecretsManagerMetadataRecord, grant AWSSecretsManagerIdentityGrant, now time.Time) AWSPrivilegeEscalationFinding {
+	score := 68
+	if grant.IsCrossAccount || record.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if grant.IsPublic || grant.WildcardPrincipal || record.ExposureClassification == "public" {
+		score += 10
+	}
+	if !grant.HasCondition {
+		score += 4
+	}
+	score = clampBlastRadiusScore(score)
+	principal := firstNonEmptyAWSValue(grant.PrincipalARN, "wildcard-principal")
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(principal, record.SecretARN, strings.Join(grant.Actions, ",")),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     "secrets_admin_equivalence",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:              score,
+		Confidence:         minFloat(record.Confidence, 0.86),
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     awsIdentityNodeIDForAPI(principal),
+		PrincipalARN:       principal,
+		TargetNodeID:       record.FromNodeID,
+		TargetLabel:        firstNonEmptyAWSValue(record.SecretName, record.SecretARN),
+		DisplayName:        shortAWSARN(principal),
+		Rationale:          fmt.Sprintf("Principal can administer or read sensitive secret metadata %s through actions %s; exposure=%s.", firstNonEmptyAWSValue(record.SecretName, record.SecretARN), strings.Join(grant.Actions, ", "), record.ExposureClassification),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "Secrets Manager policy equivalence",
+		PolicySources:      dedupeStrings(grant.Actions),
+		ImpactedNodes:      dedupeStrings([]string{awsIdentityNodeIDForAPI(principal), record.FromNodeID}),
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: awsIdentityNodeIDForAPI(principal), NodeType: "identity", Label: shortAWSARN(principal), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.FromNodeID, NodeType: "secret", Label: firstNonEmptyAWSValue(record.SecretName, record.SecretARN), AccountID: record.AccountID, Region: record.Region},
+		},
+		Evidence:   []AWSPrivilegeEscalationEvidence{{Source: "secrets_manager_metadata", EvidenceRef: record.EvidenceRef, Label: "Secrets Manager resource policy", Confidence: record.Confidence, ObservedAt: record.CollectedAt, Relationship: "can_admin_or_read_secret"}},
+		NextAction: "Review the secret resource policy and KMS linkage; remove cross-account or wildcard grants before enabling remediation.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+}
+
+func awsPrivilegeEscalationFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, now time.Time) AWSPrivilegeEscalationFinding {
+	score := clampBlastRadiusScore(recommendation.Score + 8)
+	target := firstNonEmptyAWSValue(recommendation.ResourceNodeID, recommendation.ResourceARN, recommendation.Service)
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(recommendation.RecommendationID, "policy-attachment"),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     "policy_attachment_escalation",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, recommendation.Confidence),
+		Score:              score,
+		Confidence:         recommendation.Confidence,
+		AccountID:          recommendation.AccountID,
+		Region:             recommendation.Region,
+		IdentityNodeID:     recommendation.IdentityNodeID,
+		PrincipalARN:       recommendation.PrincipalARN,
+		TargetNodeID:       target,
+		TargetLabel:        firstNonEmptyAWSValue(recommendation.Service, target),
+		DisplayName:        recommendation.DisplayName,
+		Rationale:          fmt.Sprintf("Least-privilege engine found escalation-capable granted actions %s with decision=%s and breakage=%s.", strings.Join(recommendation.GrantedActions, ", "), recommendation.Decision, recommendation.BreakagePrediction),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "least-privilege policy attachment reasoning",
+		PolicySources:      dedupeStrings(append(append([]string{}, recommendation.GrantedActions...), recommendation.RemoveActions...)),
+		ImpactedNodes:      recommendation.ImpactedNodes,
+		ImpactedPath:       []AWSPrivilegeEscalationPathStep(recommendation.ImpactedPath),
+		Evidence:           []AWSPrivilegeEscalationEvidence(recommendation.Evidence),
+		NextAction:         "Open an owner-approved least-privilege case to remove escalation-capable actions or split the role.",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+}
+
+func awsPrivilegeEscalationFindingFromBlastRadius(finding AWSBlastRadiusFinding, now time.Time) AWSPrivilegeEscalationFinding {
+	score := clampBlastRadiusScore(finding.Score + 5)
+	target := firstNonEmptyAWSValue(lastString(finding.ImpactedNodes), finding.IdentityNodeID)
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(finding.FindingID, "cross-account"),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     "cross_account_escalation_path",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, finding.Confidence),
+		Score:              score,
+		Confidence:         finding.Confidence,
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		IdentityNodeID:     finding.IdentityNodeID,
+		PrincipalARN:       finding.PrincipalARN,
+		TargetNodeID:       target,
+		TargetLabel:        target,
+		DisplayName:        finding.DisplayName,
+		Rationale:          fmt.Sprintf("Blast-radius engine found %s with critical or cross-account impact and %d impacted graph nodes.", finding.RiskType, len(finding.ImpactedNodes)),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "blast-radius cross-account/runtime path",
+		PolicySources:      dedupeStrings(finding.RuntimeActions),
+		ImpactedNodes:      finding.ImpactedNodes,
+		ImpactedPath:       awsPrivilegeEscalationPathFromBlastRadius(finding.ImpactedPath),
+		Evidence:           awsPrivilegeEscalationEvidenceFromBlastRadius(finding.Evidence),
+		NextAction:         "Validate the cross-account path and remove unused or unapproved grants before approving remediation.",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+}
+
+func awsPrivilegeEscalationFinding(finding AWSPrivilegeEscalationFinding) AWSPrivilegeEscalationFinding {
+	finding.RemediationCase = AWSPrivilegeEscalationRemediationCasePreview{
+		CaseID:             "aws-privilege-escalation-preview:" + stableAWSBlastRadiusToken(finding.EscalationType, finding.IdentityNodeID, finding.TargetNodeID),
+		Title:              fmt.Sprintf("%s privilege-escalation review", formatAWSBlastRadiusLabel(finding.EscalationType)),
+		RecommendedAction:  finding.NextAction,
+		ApprovalRequired:   finding.Severity == "critical" || finding.Severity == "high",
+		BlockingEvidence:   awsPrivilegeEscalationEvidenceRefs(finding.Evidence),
+		ImpactedNodeCount:  len(finding.ImpactedNodes),
+		EstimatedRiskDrop:  minInt(finding.Score, 40),
+		BreakagePrediction: "unknown",
+		ReadOnlyProjection: true,
+	}
+	return finding
+}
+
+func filterAWSPrivilegeEscalationFindings(findings []AWSPrivilegeEscalationFinding, request AWSPrivilegeEscalationRequest) ([]AWSPrivilegeEscalationFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"identity":        strings.TrimSpace(request.Identity),
+		"target":          strings.TrimSpace(request.Target),
+		"escalation_type": normalizeAWSRuntimeEventFilterToken(request.EscalationType),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":          normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSPrivilegeEscalationFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && filters["account_id"] != finding.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(finding.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
+			continue
+		}
+		if filters["escalation_type"] != "" && filters["escalation_type"] != normalizeAWSRuntimeEventFilterToken(finding.EscalationType) {
+			continue
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], finding.IdentityNodeID, finding.PrincipalARN, finding.DisplayName) {
+			continue
+		}
+		if filters["target"] != "" && !awsRuntimeEventMatchesAny(filters["target"], finding.TargetNodeID, finding.TargetLabel, strings.Join(finding.ImpactedNodes, " ")) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, applied
+}
+
+func awsPrivilegeEscalationRelationships(findings []AWSPrivilegeEscalationFinding) []AWSPrivilegeEscalationRelationship {
+	relationships := []AWSPrivilegeEscalationRelationship{}
+	for _, finding := range findings {
+		evidenceRef := firstLeastPrivilegeEvidenceRef(finding.Evidence)
+		for i := 0; i+1 < len(finding.ImpactedPath); i++ {
+			from := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
+			to := strings.TrimSpace(finding.ImpactedPath[i+1].NodeID)
+			if from == "" || to == "" {
+				continue
+			}
+			relationships = append(relationships, AWSPrivilegeEscalationRelationship{FindingID: finding.FindingID, Type: "privilege_escalation_path", FromNodeID: from, ToNodeID: to, EvidenceRef: evidenceRef})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSPrivilegeEscalation(allFindings []AWSPrivilegeEscalationFinding, filtered []AWSPrivilegeEscalationFinding, relationships []AWSPrivilegeEscalationRelationship) AWSPrivilegeEscalationSummary {
+	severityCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	typeCounts := map[string]int{}
+	totalConfidence := 0.0
+	highest := 0
+	remediationCases := map[string]struct{}{}
+	for _, finding := range allFindings {
+		severityCounts[finding.Severity]++
+		statusCounts[finding.Status]++
+		typeCounts[finding.EscalationType]++
+		totalConfidence += finding.Confidence
+		if finding.Score > highest {
+			highest = finding.Score
+		}
+		if finding.RemediationCase.CaseID != "" {
+			remediationCases[finding.RemediationCase.CaseID] = struct{}{}
+		}
+	}
+	averageConfidence := 0
+	if len(allFindings) > 0 {
+		averageConfidence = int((totalConfidence / float64(len(allFindings))) * 100)
+	}
+	return AWSPrivilegeEscalationSummary{
+		TotalFindings:           len(allFindings),
+		FilteredFindings:        len(filtered),
+		SeverityCounts:          severityCounts,
+		StatusCounts:            statusCounts,
+		EscalationTypeCounts:    typeCounts,
+		CriticalCount:           severityCounts["critical"],
+		HighCount:               severityCounts["high"],
+		CrossAccountPathCount:   typeCounts["cross_account_escalation_path"],
+		PassRolePathCount:       typeCounts["passrole_service_escalation"] + typeCounts["passrole_wildcard_escalation"] + typeCounts["passrole_unscoped_trust_path"],
+		AdminEquivalentCount:    typeCounts["kms_admin_equivalence"] + typeCounts["secrets_admin_equivalence"] + typeCounts["policy_attachment_escalation"],
+		RelationshipCount:       len(relationships),
+		HighestScore:            highest,
+		AverageConfidencePct:    averageConfidence,
+		RemediationPreviewCount: len(remediationCases),
+	}
+}
+
+func summarizeAWSPrivilegeEscalationStatus(sourceStatuses []string, diagnostics []AWSPrivilegeEscalationDiagnostic) (string, float64) {
+	allBlocked := len(sourceStatuses) > 0
+	anyDegraded := len(diagnostics) > 0
+	for _, status := range sourceStatuses {
+		switch status {
+		case awsPlatformDependencyStatusBlocked:
+			anyDegraded = true
+		case awsPlatformDependencyStatusDegraded:
+			allBlocked = false
+			anyDegraded = true
+		default:
+			allBlocked = false
+		}
+	}
+	if allBlocked {
+		return awsPlatformDependencyStatusBlocked, 0
+	}
+	if anyDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.72
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsPrivilegeEscalationDiagnostics(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult) []AWSPrivilegeEscalationDiagnostic {
+	out := []AWSPrivilegeEscalationDiagnostic{}
+	for _, diagnostic := range passRole.Diagnostics {
+		out = append(out, AWSPrivilegeEscalationDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range kms.Diagnostics {
+		out = append(out, AWSPrivilegeEscalationDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range secrets.Diagnostics {
+		out = append(out, AWSPrivilegeEscalationDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range leastPrivilege.Diagnostics {
+		out = append(out, AWSPrivilegeEscalationDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range blastRadius.Diagnostics {
+		out = append(out, awsPrivilegeEscalationDiagnosticFromBlastRadius(diagnostic))
+	}
+	return out
+}
+
+func awsPrivilegeEscalationCoverageGaps(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult) []AWSPrivilegeEscalationCoverageGap {
+	out := []AWSPrivilegeEscalationCoverageGap{{
+		Capability:  "privilege_escalation_persistence",
+		Status:      "ready",
+		Reason:      "The API emits stable finding IDs, calculation version, graph path, evidence, confidence, and remediation preview fields for downstream persistence and governance.",
+		Remediation: "Persist these findings into the shared AWS findings store when the dedicated table lands.",
+	}}
+	for _, gap := range passRole.CoverageGaps {
+		out = append(out, AWSPrivilegeEscalationCoverageGap(gap))
+	}
+	for _, gap := range kms.CoverageGaps {
+		out = append(out, AWSPrivilegeEscalationCoverageGap(gap))
+	}
+	for _, gap := range secrets.CoverageGaps {
+		out = append(out, AWSPrivilegeEscalationCoverageGap(gap))
+	}
+	for _, gap := range leastPrivilege.CoverageGaps {
+		out = append(out, AWSPrivilegeEscalationCoverageGap(gap))
+	}
+	for _, gap := range blastRadius.CoverageGaps {
+		out = append(out, awsPrivilegeEscalationCoverageGapFromBlastRadius(gap))
+	}
+	return out
+}
+
+func awsPrivilegeEscalationPathFromBlastRadius(path []AWSBlastRadiusPathStep) []AWSPrivilegeEscalationPathStep {
+	out := make([]AWSPrivilegeEscalationPathStep, 0, len(path))
+	for _, step := range path {
+		out = append(out, AWSPrivilegeEscalationPathStep{
+			NodeID:    step.NodeID,
+			NodeType:  step.NodeType,
+			Label:     step.Label,
+			AccountID: step.AccountID,
+			Region:    step.Region,
+		})
+	}
+	return out
+}
+
+func awsPrivilegeEscalationEvidenceFromBlastRadius(evidence []AWSBlastRadiusEvidence) []AWSPrivilegeEscalationEvidence {
+	out := make([]AWSPrivilegeEscalationEvidence, 0, len(evidence))
+	for _, item := range evidence {
+		out = append(out, AWSPrivilegeEscalationEvidence{
+			Source:       item.Source,
+			EvidenceRef:  item.EvidenceRef,
+			Label:        item.Label,
+			Confidence:   item.Confidence,
+			ObservedAt:   item.ObservedAt,
+			Relationship: item.Relationship,
+		})
+	}
+	return out
+}
+
+func awsPrivilegeEscalationDiagnosticFromBlastRadius(diagnostic AWSBlastRadiusDiagnostic) AWSPrivilegeEscalationDiagnostic {
+	return AWSPrivilegeEscalationDiagnostic{
+		Collector:   diagnostic.Collector,
+		SourceID:    diagnostic.SourceID,
+		Code:        diagnostic.Code,
+		Message:     diagnostic.Message,
+		Remediation: diagnostic.Remediation,
+		Retryable:   diagnostic.Retryable,
+	}
+}
+
+func awsPrivilegeEscalationCoverageGapFromBlastRadius(gap AWSBlastRadiusCoverageGap) AWSPrivilegeEscalationCoverageGap {
+	return AWSPrivilegeEscalationCoverageGap{
+		Capability:  gap.Capability,
+		Status:      gap.Status,
+		Reason:      gap.Reason,
+		Remediation: gap.Remediation,
+	}
+}
+
+func awsPrivilegeEscalationFailureReasons(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult) []string {
+	return emptyStrings(dedupeStrings(append(append(append(append(passRole.FailureReasons, kms.FailureReasons...), secrets.FailureReasons...), leastPrivilege.FailureReasons...), blastRadius.FailureReasons...)))
+}
+
+func awsPrivilegeEscalationRemediationHints(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult) []string {
+	return emptyStrings(dedupeStrings(append(append(append(append(append(passRole.RemediationHints, kms.RemediationHints...), secrets.RemediationHints...), leastPrivilege.RemediationHints...), blastRadius.RemediationHints...), "Use read-only remediation previews until a role owner approves policy or trust changes.")))
+}
+
+func awsPrivilegeEscalationCaveats() []string {
+	return []string{
+		"Privilege-escalation findings are inferred from metadata-only IAM, PassRole, key-policy, secret-policy, runtime, and blast-radius evidence; they do not execute AWS mutations.",
+		"Unknown, degraded, and permission-denied evidence lowers envelope confidence and must not be interpreted as absence of escalation paths.",
+		"Remediation previews are read-only planning records; no policy, trust, grant, or secret mutation is performed by this engine.",
+	}
+}
+
+func awsPrivilegeEscalationRecommendationQualifies(recommendation AWSLeastPrivilegeRecommendation) bool {
+	actions := append(append([]string{}, recommendation.GrantedActions...), recommendation.RemoveActions...)
+	for _, action := range actions {
+		token := strings.ToLower(strings.TrimSpace(action))
+		if token == "*" || token == "iam:*" || token == "iam:passrole" || token == "iam:attachrolepolicy" || token == "sts:assumerole" {
+			return recommendation.Decision == "remove" || recommendation.Decision == "review"
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationGrantHasAdminSignal(actions []string, capabilities []string) bool {
+	for _, value := range append(append([]string{}, actions...), capabilities...) {
+		token := strings.ToLower(strings.TrimSpace(value))
+		if token == "*" || strings.HasSuffix(token, ":*") || strings.Contains(token, "admin") || strings.Contains(token, "decrypt") || strings.Contains(token, "getsecretvalue") || strings.Contains(token, "putresourcepolicy") {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationSeverity(score int) string {
+	switch {
+	case score >= 88:
+		return "critical"
+	case score >= 72:
+		return "high"
+	case score >= 50:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func awsPrivilegeEscalationFindingStatus(score int, confidence float64) string {
+	if score >= 82 && confidence >= 0.7 {
+		return "action_required"
+	}
+	return "review"
+}
+
+func awsPrivilegeEscalationExploitability(score int) string {
+	switch {
+	case score >= 88:
+		return "high"
+	case score >= 72:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func awsPrivilegeEscalationEvidenceRefs(evidence []AWSPrivilegeEscalationEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		out = append(out, item.EvidenceRef)
+	}
+	return emptyStrings(dedupeStrings(out))
+}
+
+func lastString(values []string) string {
+	for i := len(values) - 1; i >= 0; i-- {
+		if strings.TrimSpace(values[i]) != "" {
+			return strings.TrimSpace(values[i])
+		}
+	}
+	return ""
+}
+
+func minFloat(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -278,6 +278,9 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 			if !awsPrivilegeEscalationGrantHasAdminSignal(grant.Operations, grant.Capabilities) {
 				continue
 			}
+			if awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant, denyKMSIdentityGrants) {
+				continue
+			}
 			findings = append(findings, awsPrivilegeEscalationFindingFromKMSLiveGrant(record, grant, now))
 		}
 	}
@@ -334,6 +337,34 @@ func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIden
 		}
 	}
 	return false
+}
+
+func awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant AWSKMSGrant, denyGrants []AWSKMSIdentityGrant) bool {
+	if strings.TrimSpace(grant.GranteePrincipal) == "" {
+		return false
+	}
+	allowActions := awsPrivilegeEscalationNormalizeKMSLiveGrantActions(grant.Operations, grant.Capabilities)
+	allowGrant := AWSKMSIdentityGrant{
+		PrincipalARN:  grant.GranteePrincipal,
+		PrincipalType: grant.GranteePrincipalType,
+		Actions:       allowActions,
+	}
+	return awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant, denyGrants)
+}
+
+func awsPrivilegeEscalationNormalizeKMSLiveGrantActions(operations, capabilities []string) []string {
+	out := make([]string, 0, len(operations)+len(capabilities))
+	for _, action := range append(append([]string{}, operations...), capabilities...) {
+		trimmed := strings.ToLower(strings.TrimSpace(action))
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+		if !strings.Contains(trimmed, ":") {
+			out = append(out, "kms:"+trimmed)
+		}
+	}
+	return dedupeStrings(out)
 }
 
 func awsPrivilegeEscalationSecretIdentityGrantHasExplicitDeny(allowGrant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant) bool {
@@ -948,8 +979,24 @@ func awsPrivilegeEscalationRecommendationQualifies(recommendation AWSLeastPrivil
 	actions := append(append([]string{}, recommendation.GrantedActions...), recommendation.RemoveActions...)
 	for _, action := range actions {
 		token := strings.ToLower(strings.TrimSpace(action))
-		if token == "*" || token == "iam:*" || token == "iam:passrole" || token == "iam:attachrolepolicy" || token == "sts:assumerole" {
+		if awsPrivilegeEscalationLeastPrivilegeActionSignalsEscalation(token) {
 			return recommendation.Decision == "remove" || recommendation.Decision == "review"
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationLeastPrivilegeActionSignalsEscalation(token string) bool {
+	if token == "" {
+		return false
+	}
+	if token == "*" {
+		return true
+	}
+	escalationActions := []string{"iam:*", "iam:passrole", "iam:attachrolepolicy", "sts:assumerole"}
+	for _, escalationAction := range escalationActions {
+		if awsActionPatternMatches(token, escalationAction) || awsActionPatternMatches(escalationAction, token) {
+			return true
 		}
 	}
 	return false

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -246,8 +246,14 @@ func (s *Service) awsPrivilegeEscalationSourceSignals(ctx context.Context, works
 
 func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventoryResult, kms AWSKMSDecryptReachabilityInventoryResult, secrets AWSSecretsManagerMetadataInventoryResult, leastPrivilege AWSLeastPrivilegeResult, blastRadius AWSBlastRadiusResult, now time.Time) []AWSPrivilegeEscalationFinding {
 	findings := []AWSPrivilegeEscalationFinding{}
+	denyPassRoleRecords := []AWSIAMPassRoleRelationshipRecord{}
 	for _, record := range passRole.Records {
-		if strings.EqualFold(record.Effect, "Allow") {
+		if strings.EqualFold(record.Effect, "Deny") {
+			denyPassRoleRecords = append(denyPassRoleRecords, record)
+		}
+	}
+	for _, record := range passRole.Records {
+		if strings.EqualFold(record.Effect, "Allow") && !awsPrivilegeEscalationPassRoleIsDenied(record, denyPassRoleRecords) {
 			findings = append(findings, awsPrivilegeEscalationFindingFromPassRole(record, now))
 		}
 	}
@@ -285,6 +291,54 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 		}
 	}
 	return findings
+}
+
+func awsPrivilegeEscalationPassRoleIsDenied(record AWSIAMPassRoleRelationshipRecord, denyRecords []AWSIAMPassRoleRelationshipRecord) bool {
+	for _, deny := range denyRecords {
+		if !awsPrivilegeEscalationPassRoleKeysMatch(record, deny) {
+			continue
+		}
+		if awsPrivilegeEscalationPassRoleActionsOverlap(record.ActionExpression, deny.ActionExpression) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationPassRoleKeysMatch(record AWSIAMPassRoleRelationshipRecord, deny AWSIAMPassRoleRelationshipRecord) bool {
+	recordSource := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.FromNodeID, record.SourceRoleARN)))
+	recordTarget := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.ToNodeID, record.TargetResource)))
+	denySource := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(deny.FromNodeID, deny.SourceRoleARN)))
+	denyTarget := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(deny.ToNodeID, deny.TargetResource)))
+	return recordSource != "" && recordTarget != "" && recordSource == denySource && recordTarget == denyTarget
+}
+
+func awsPrivilegeEscalationPassRoleActionsOverlap(allowActions, denyActions string) bool {
+	normalizedAllow := awsPrivilegeEscalationPassRoleNormalizeActions(allowActions)
+	normalizedDeny := awsPrivilegeEscalationPassRoleNormalizeActions(denyActions)
+	if len(normalizedAllow) == 0 || len(normalizedDeny) == 0 {
+		return strings.EqualFold(strings.TrimSpace(allowActions), strings.TrimSpace(denyActions))
+	}
+	for _, allow := range normalizedAllow {
+		for _, deny := range normalizedDeny {
+			if awsActionPatternMatches(allow, deny) || awsActionPatternMatches(deny, allow) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationPassRoleNormalizeActions(actions string) []string {
+	out := make([]string, 0, 4)
+	for _, action := range strings.Split(actions, ",") {
+		trimmed := strings.ToLower(strings.TrimSpace(action))
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return dedupeStrings(out)
 }
 
 func awsPrivilegeEscalationFindingFromKMSLiveGrant(record AWSKMSDecryptReachabilityRecord, grant AWSKMSGrant, now time.Time) AWSPrivilegeEscalationFinding {

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -257,6 +257,15 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 				findings = append(findings, awsPrivilegeEscalationFindingFromKMSGrant(record, grant, now))
 			}
 		}
+		for _, grant := range record.Grants {
+			if strings.TrimSpace(grant.GranteePrincipal) == "" {
+				continue
+			}
+			if !awsPrivilegeEscalationGrantHasAdminSignal(grant.Operations, grant.Capabilities) {
+				continue
+			}
+			findings = append(findings, awsPrivilegeEscalationFindingFromKMSLiveGrant(record, grant, now))
+		}
 	}
 	for _, record := range secrets.Records {
 		for _, grant := range record.IdentityGrants {
@@ -276,6 +285,60 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 		}
 	}
 	return findings
+}
+
+func awsPrivilegeEscalationFindingFromKMSLiveGrant(record AWSKMSDecryptReachabilityRecord, grant AWSKMSGrant, now time.Time) AWSPrivilegeEscalationFinding {
+	score := 74
+	if grant.IsCrossAccount || record.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if record.ExposureClassification == "public" {
+		score += 10
+	}
+	if !grant.HasConstraints {
+		score += 4
+	}
+	score = clampBlastRadiusScore(score)
+	principal := firstNonEmptyAWSValue(grant.GranteePrincipal, "wildcard-principal")
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, "kms-decrypt-reachability:"+record.KeyARN)
+	capabilities := append([]string{}, grant.Capabilities...)
+	actions := append([]string{}, grant.Operations...)
+	return awsPrivilegeEscalationFinding(AWSPrivilegeEscalationFinding{
+		FindingID:          "aws-privilege-escalation:" + stableAWSBlastRadiusToken(principal, record.KeyARN, strings.Join(actions, ",")),
+		CalculationVersion: awsPrivilegeEscalationVersion,
+		EscalationType:     "kms_admin_equivalence",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:              score,
+		Confidence:         minFloat(record.Confidence, 0.88),
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		IdentityNodeID:     awsIdentityNodeIDForAPI(principal),
+		PrincipalARN:       principal,
+		TargetNodeID:       record.FromNodeID,
+		TargetLabel:        firstNonEmptyAWSValue(record.Description, record.KeyARN, record.KeyID),
+		DisplayName:        shortAWSARN(principal),
+		Rationale:          fmt.Sprintf("Principal has KMS grant operations %s and capabilities %s on %s; exposure=%s.", strings.Join(actions, ", "), strings.Join(capabilities, ", "), firstNonEmptyAWSValue(record.Description, record.KeyID), record.ExposureClassification),
+		Exploitability:     awsPrivilegeEscalationExploitability(score),
+		RuntimeContext:     "KMS grant/admin equivalence",
+		PolicySources:      dedupeStrings(append(actions, capabilities...)),
+		ImpactedNodes:      dedupeStrings([]string{awsIdentityNodeIDForAPI(principal), record.FromNodeID}),
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: awsIdentityNodeIDForAPI(principal), NodeType: "identity", Label: shortAWSARN(principal), AccountID: record.AccountID, Region: record.Region},
+			{NodeID: record.FromNodeID, NodeType: "kms_key", Label: firstNonEmptyAWSValue(record.Description, record.KeyARN), AccountID: record.AccountID, Region: record.Region},
+		},
+		Evidence: []AWSPrivilegeEscalationEvidence{{
+			Source:       "kms_decrypt_reachability",
+			EvidenceRef:  evidenceRef,
+			Label:        "KMS grant/admin reachability",
+			Confidence:   record.Confidence,
+			ObservedAt:   record.CollectedAt,
+			Relationship: "can_admin_or_decrypt_key",
+		}},
+		NextAction: "Review live KMS grants and remove broad or cross-account admin-equivalent grants in the grant list before remediation.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
 }
 
 func awsPrivilegeEscalationFindingFromPassRole(record AWSIAMPassRoleRelationshipRecord, now time.Time) AWSPrivilegeEscalationFinding {

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -258,8 +258,16 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 		}
 	}
 	for _, record := range kms.Records {
+		denyKMSIdentityGrants := []AWSKMSIdentityGrant{}
 		for _, grant := range record.IdentityGrants {
-			if strings.EqualFold(grant.Effect, "Allow") && awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, grant.Capabilities) {
+			if strings.EqualFold(grant.Effect, "Deny") {
+				denyKMSIdentityGrants = append(denyKMSIdentityGrants, grant)
+			}
+		}
+		for _, grant := range record.IdentityGrants {
+			if strings.EqualFold(grant.Effect, "Allow") &&
+				awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, grant.Capabilities) &&
+				!awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(grant, denyKMSIdentityGrants) {
 				findings = append(findings, awsPrivilegeEscalationFindingFromKMSGrant(record, grant, now))
 			}
 		}
@@ -300,6 +308,52 @@ func awsPrivilegeEscalationPassRoleIsDenied(record AWSIAMPassRoleRelationshipRec
 		}
 		if awsPrivilegeEscalationPassRoleActionsOverlap(record.ActionExpression, deny.ActionExpression) {
 			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIdentityGrant, denyGrants []AWSKMSIdentityGrant) bool {
+	for _, deny := range denyGrants {
+		if !strings.EqualFold(deny.Effect, "Deny") {
+			continue
+		}
+		if !awsPrivilegeEscalationKMSIdentityGrantPrincipalsMatch(allowGrant, deny) {
+			continue
+		}
+		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowGrant.Actions, deny.Actions) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationKMSIdentityGrantPrincipalsMatch(allowGrant AWSKMSIdentityGrant, denyGrant AWSKMSIdentityGrant) bool {
+	allowPrincipal := strings.TrimSpace(strings.ToLower(allowGrant.PrincipalARN))
+	denyPrincipal := strings.TrimSpace(strings.ToLower(denyGrant.PrincipalARN))
+	if allowPrincipal == "" || denyPrincipal == "" {
+		return false
+	}
+	if denyGrant.WildcardPrincipal || denyPrincipal == "*" {
+		return true
+	}
+	return allowPrincipal == denyPrincipal
+}
+
+func awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowActions, denyActions []string) bool {
+	if len(allowActions) == 0 || len(denyActions) == 0 {
+		return len(allowActions) == 0 && len(denyActions) == 0
+	}
+	for _, allow := range allowActions {
+		for _, deny := range denyActions {
+			trimmedAllow := strings.ToLower(strings.TrimSpace(allow))
+			trimmedDeny := strings.ToLower(strings.TrimSpace(deny))
+			if trimmedAllow == "" || trimmedDeny == "" {
+				continue
+			}
+			if awsActionPatternMatches(trimmedAllow, trimmedDeny) || awsActionPatternMatches(trimmedDeny, trimmedAllow) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -282,8 +282,16 @@ func awsPrivilegeEscalationFindings(passRole AWSIAMPassRoleRelationshipInventory
 		}
 	}
 	for _, record := range secrets.Records {
+		denySecretIdentityGrants := []AWSSecretsManagerIdentityGrant{}
 		for _, grant := range record.IdentityGrants {
-			if strings.EqualFold(grant.Effect, "Allow") && awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, nil) {
+			if strings.EqualFold(grant.Effect, "Deny") {
+				denySecretIdentityGrants = append(denySecretIdentityGrants, grant)
+			}
+		}
+		for _, grant := range record.IdentityGrants {
+			if strings.EqualFold(grant.Effect, "Allow") &&
+				awsPrivilegeEscalationGrantHasAdminSignal(grant.Actions, nil) &&
+				!awsPrivilegeEscalationSecretIdentityGrantHasExplicitDeny(grant, denySecretIdentityGrants) {
 				findings = append(findings, awsPrivilegeEscalationFindingFromSecretGrant(record, grant, now))
 			}
 		}
@@ -318,7 +326,7 @@ func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIden
 		if !strings.EqualFold(deny.Effect, "Deny") {
 			continue
 		}
-		if !awsPrivilegeEscalationKMSIdentityGrantPrincipalsMatch(allowGrant, deny) {
+		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(allowGrant.PrincipalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
 			continue
 		}
 		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowGrant.Actions, deny.Actions) {
@@ -328,13 +336,28 @@ func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIden
 	return false
 }
 
-func awsPrivilegeEscalationKMSIdentityGrantPrincipalsMatch(allowGrant AWSKMSIdentityGrant, denyGrant AWSKMSIdentityGrant) bool {
-	allowPrincipal := strings.TrimSpace(strings.ToLower(allowGrant.PrincipalARN))
-	denyPrincipal := strings.TrimSpace(strings.ToLower(denyGrant.PrincipalARN))
+func awsPrivilegeEscalationSecretIdentityGrantHasExplicitDeny(allowGrant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant) bool {
+	for _, deny := range denyGrants {
+		if !strings.EqualFold(deny.Effect, "Deny") {
+			continue
+		}
+		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(allowGrant.PrincipalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
+			continue
+		}
+		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowGrant.Actions, deny.Actions) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationIdentityGrantPrincipalsMatch(allowPrincipal string, denyPrincipal string, denyWildcardPrincipal bool) bool {
+	allowPrincipal = strings.TrimSpace(strings.ToLower(allowPrincipal))
+	denyPrincipal = strings.TrimSpace(strings.ToLower(denyPrincipal))
 	if allowPrincipal == "" || denyPrincipal == "" {
 		return false
 	}
-	if denyGrant.WildcardPrincipal || denyPrincipal == "*" {
+	if denyWildcardPrincipal || denyPrincipal == "*" {
 		return true
 	}
 	return allowPrincipal == denyPrincipal
@@ -936,6 +959,18 @@ func awsPrivilegeEscalationGrantHasAdminSignal(actions []string, capabilities []
 	for _, value := range append(append([]string{}, actions...), capabilities...) {
 		token := strings.ToLower(strings.TrimSpace(value))
 		if token == "*" || strings.HasSuffix(token, ":*") || strings.Contains(token, "admin") || strings.Contains(token, "decrypt") || strings.Contains(token, "getsecretvalue") || strings.Contains(token, "putresourcepolicy") {
+			return true
+		}
+		if awsPrivilegeEscalationGrantIncludesSecretReadAction(token) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPrivilegeEscalationGrantIncludesSecretReadAction(token string) bool {
+	for _, readAction := range []string{"secretsmanager:getsecretvalue", "secretsmanager:batchgetsecretvalue"} {
+		if awsActionPatternMatches(token, readAction) {
 			return true
 		}
 	}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newPrivilegeEscalationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSPrivilegeEscalationBuildsFindingContract(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	svc, ws := newPrivilegeEscalationService(t, "project-privilege-escalation", now)
+
+	result, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get privilege escalation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1525" || result.Version != awsPrivilegeEscalationVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready status, got %q with diagnostics=%+v", result.Status, result.Diagnostics)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected findings summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.PassRolePathCount == 0 || result.Summary.AdminEquivalentCount == 0 {
+		t.Fatalf("expected passrole and admin-equivalent paths: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected graph relationships: %+v", result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 || len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected remediation previews, caveats, and coverage gaps: summary=%+v caveats=%v gaps=%v", result.Summary, result.Caveats, result.CoverageGaps)
+	}
+	for i := 1; i < len(result.Findings); i++ {
+		if result.Findings[i-1].Score < result.Findings[i].Score {
+			t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+		}
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsPrivilegeEscalationVersion {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.EscalationType == "" || finding.Severity == "" || finding.Status == "" || finding.Rationale == "" {
+			t.Fatalf("finding missing classification fields: %+v", finding)
+		}
+		if finding.Score <= 0 || finding.Confidence <= 0 {
+			t.Fatalf("finding missing score/confidence: %+v", finding)
+		}
+		if finding.IdentityNodeID == "" || finding.TargetLabel == "" || len(finding.ImpactedPath) < 2 || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing path/evidence fields: %+v", finding)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+	}
+}
+
+func TestGetAWSPrivilegeEscalationFiltersByTypeSeverityIdentityAndTarget(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 5, 0, 0, time.UTC)
+	svc, ws := newPrivilegeEscalationService(t, "project-privilege-escalation-filters", now)
+
+	passRole, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-filters", AWSPrivilegeEscalationRequest{
+		ConnectorID:    "aws-prod",
+		FixtureState:   "success",
+		EscalationType: "passrole_unscoped_trust_path",
+	})
+	if err != nil {
+		t.Fatalf("passrole filter: %v", err)
+	}
+	if len(passRole.Findings) == 0 {
+		t.Fatalf("expected wildcard PassRole findings")
+	}
+	for _, finding := range passRole.Findings {
+		if finding.EscalationType != "passrole_unscoped_trust_path" {
+			t.Fatalf("escalation_type filter leaked: %+v", finding)
+		}
+	}
+	if passRole.AppliedFilters["escalation_type"] != "passrole-unscoped-trust-path" {
+		t.Fatalf("expected normalized escalation_type filter, got %+v", passRole.AppliedFilters)
+	}
+
+	critical, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-filters", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "critical",
+	})
+	if err != nil {
+		t.Fatalf("critical filter: %v", err)
+	}
+	if len(critical.Findings) == 0 {
+		t.Fatalf("expected critical privilege escalation findings")
+	}
+	for _, finding := range critical.Findings {
+		if finding.Severity != "critical" {
+			t.Fatalf("severity filter leaked: %+v", finding)
+		}
+	}
+
+	identity, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-filters", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     "security-admin",
+		Target:       "*",
+	})
+	if err != nil {
+		t.Fatalf("identity/target filter: %v", err)
+	}
+	if len(identity.Findings) == 0 {
+		t.Fatalf("expected security-admin wildcard target finding")
+	}
+	for _, finding := range identity.Findings {
+		if !strings.Contains(finding.DisplayName, "security-admin") && !strings.Contains(finding.PrincipalARN, "security-admin") {
+			t.Fatalf("identity filter leaked: %+v", finding)
+		}
+		if !strings.Contains(strings.Join(finding.ImpactedNodes, " "), "*") && !strings.Contains(finding.TargetLabel, "*") {
+			t.Fatalf("target filter leaked: %+v", finding)
+		}
+	}
+}
+
+func TestGetAWSPrivilegeEscalationFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 10, 0, 0, time.UTC)
+	svc, ws := newPrivilegeEscalationService(t, "project-privilege-escalation-states", now)
+
+	denied, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-states", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || denied.Confidence != 0 {
+		t.Fatalf("expected blocked permission-denied state with zero confidence: %+v", denied)
+	}
+	if len(denied.Findings) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must suppress findings and surface diagnostics: %+v", denied)
+	}
+
+	degraded, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-states", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "degraded",
+	})
+	if err != nil {
+		t.Fatalf("degraded: %v", err)
+	}
+	if degraded.Status != "degraded" || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded status with diagnostics: %+v", degraded)
+	}
+	if len(degraded.Findings) == 0 {
+		t.Fatalf("degraded sources should keep partial evidence visible: %+v", degraded)
+	}
+
+	empty, err := svc.GetAWSPrivilegeEscalation(defaultScopeContext(), ws, "project-privilege-escalation-states", AWSPrivilegeEscalationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should be a degraded no-evidence result: %+v", empty)
+	}
+}
+
+func TestAWSPrivilegeEscalationRelationshipsUsePathEdges(t *testing.T) {
+	relationships := awsPrivilegeEscalationRelationships([]AWSPrivilegeEscalationFinding{{
+		FindingID:      "finding-1",
+		IdentityNodeID: "aws:identity:role/source",
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: "aws:identity:role/source", NodeType: "identity"},
+			{NodeID: "aws:iam-role/target", NodeType: "iam_role"},
+			{NodeID: "aws:kms:key/example", NodeType: "kms_key"},
+		},
+		Evidence: []AWSPrivilegeEscalationEvidence{{EvidenceRef: "evidence://privilege-escalation"}},
+	}})
+
+	if len(relationships) != 2 {
+		t.Fatalf("expected two path relationships, got %+v", relationships)
+	}
+	for _, relationship := range relationships {
+		if relationship.Type != "privilege_escalation_path" || relationship.EvidenceRef != "evidence://privilege-escalation" {
+			t.Fatalf("unexpected relationship contract: %+v", relationship)
+		}
+	}
+	if relationships[0].FromNodeID != "aws:identity:role/source" || relationships[0].ToNodeID != "aws:iam-role/target" {
+		t.Fatalf("first edge should preserve path order: %+v", relationships)
+	}
+	if relationships[1].FromNodeID != "aws:iam-role/target" || relationships[1].ToNodeID != "aws:kms:key/example" {
+		t.Fatalf("second edge should preserve path order: %+v", relationships)
+	}
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -198,3 +198,19 @@ func TestAWSPrivilegeEscalationRelationshipsUsePathEdges(t *testing.T) {
 		t.Fatalf("second edge should preserve path order: %+v", relationships)
 	}
 }
+
+func TestAWSPrivilegeEscalationRelationshipsSkipWildcardPassroleTargets(t *testing.T) {
+	relationships := awsPrivilegeEscalationRelationships([]AWSPrivilegeEscalationFinding{{
+		FindingID:      "finding-2",
+		IdentityNodeID: "aws:identity:role/source",
+		ImpactedPath: []AWSPrivilegeEscalationPathStep{
+			{NodeID: "aws:identity:role/source", NodeType: "identity", Label: "security-admin"},
+			{NodeID: "*", NodeType: "iam_role", Label: "wildcard role target"},
+		},
+		Evidence: []AWSPrivilegeEscalationEvidence{{EvidenceRef: "evidence://privilege-escalation"}},
+	}})
+
+	if len(relationships) != 0 {
+		t.Fatalf("expected wildcard passrole target to skip graph edge emission, got %+v", relationships)
+	}
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -256,3 +256,77 @@ func TestAWSPrivilegeEscalationFindingsIncludesLiveKMSGrant(t *testing.T) {
 		t.Fatalf("expected live KMS grant to be converted to kms_admin_equivalence: %+v", findings)
 	}
 }
+
+func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnPassRole(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 20, 0, 0, time.UTC)
+	sourceNode := "aws:identity:arn:aws:iam::123456789012:role/source"
+	targetNode := "aws:identity:arn:aws:iam::123456789012:role/target"
+	targetARN := "arn:aws:iam::123456789012:role/target"
+
+	allowRecord := AWSIAMPassRoleRelationshipRecord{
+		FromNodeID:         sourceNode,
+		ToNodeID:           targetNode,
+		SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+		TargetResource:     targetARN,
+		TargetWildcardKind: "specific",
+		ActionExpression:   "iam:PassRole",
+		Effect:             "Allow",
+		PolicyName:         "AllowPass",
+		StatementSid:       "PassAllowed",
+		CollectedAt:        now,
+		Confidence:         0.88,
+	}
+
+	t.Run("exact action match deny suppresses finding", func(t *testing.T) {
+		passRole := AWSIAMPassRoleRelationshipInventoryResult{
+			Records: []AWSIAMPassRoleRelationshipRecord{
+				allowRecord,
+				{
+					FromNodeID:         sourceNode,
+					ToNodeID:           targetNode,
+					SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+					TargetResource:     targetARN,
+					TargetWildcardKind: "specific",
+					ActionExpression:   "iam:PassRole",
+					Effect:             "Deny",
+					PolicyName:         "DenyPass",
+					StatementSid:       "PassDenied",
+					CollectedAt:        now,
+					Confidence:         0.88,
+				},
+			},
+		}
+		findings := awsPrivilegeEscalationFindings(passRole, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 0 {
+			t.Fatalf("expected allowfinding to be suppressed by explicit deny, got %+v", findings)
+		}
+	})
+
+	t.Run("non-overlapping deny action preserves passrole finding", func(t *testing.T) {
+		passRole := AWSIAMPassRoleRelationshipInventoryResult{
+			Records: []AWSIAMPassRoleRelationshipRecord{
+				allowRecord,
+				{
+					FromNodeID:         sourceNode,
+					ToNodeID:           targetNode,
+					SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+					TargetResource:     targetARN,
+					TargetWildcardKind: "specific",
+					ActionExpression:   "ec2:StartInstances",
+					Effect:             "Deny",
+					PolicyName:         "DenyStartInstances",
+					StatementSid:       "DenyNonPass",
+					CollectedAt:        now,
+					Confidence:         0.88,
+				},
+			},
+		}
+		findings := awsPrivilegeEscalationFindings(passRole, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected passrole finding to remain when deny action does not overlap allow, got %+v", findings)
+		}
+		if !strings.HasPrefix(findings[0].EscalationType, "passrole_") {
+			t.Fatalf("expected passrole escalation type when only passrole allow remains, got %+v", findings[0].EscalationType)
+		}
+	})
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -214,3 +214,45 @@ func TestAWSPrivilegeEscalationRelationshipsSkipWildcardPassroleTargets(t *testi
 		t.Fatalf("expected wildcard passrole target to skip graph edge emission, got %+v", relationships)
 	}
 }
+
+func TestAWSPrivilegeEscalationFindingsIncludesLiveKMSGrant(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 15, 0, 0, time.UTC)
+	kms := AWSKMSDecryptReachabilityInventoryResult{
+		Records: []AWSKMSDecryptReachabilityRecord{{
+			AccountID:              "123456789012",
+			Region:                 "us-east-1",
+			KeyARN:                 "arn:aws:kms:us-east-1:123456789012:key/live-grant",
+			KeyID:                  "live-grant",
+			Description:            "payments key",
+			ExposureClassification: "restricted",
+			FromNodeID:             "aws:resource:kms-key/arn:aws:kms:us-east-1:123456789012:key/live-grant",
+			Confidence:             0.88,
+			EvidenceRef:            "evidence://kms-grant",
+			CollectedAt:            now,
+			Grants: []AWSKMSGrant{{
+				GranteePrincipal:     "arn:aws:iam::123456789012:role/live-grant-role",
+				GranteePrincipalType: "aws",
+				Operations:           []string{"Decrypt"},
+				Capabilities:         []string{"decrypt"},
+				HasConstraints:       true,
+			}},
+		}},
+	}
+
+	findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+	if len(findings) == 0 {
+		t.Fatalf("expected at least one privilege-escalation finding for live KMS grant")
+	}
+	foundLiveGrant := false
+	for _, finding := range findings {
+		if finding.EscalationType == "kms_admin_equivalence" && finding.PrincipalARN == "arn:aws:iam::123456789012:role/live-grant-role" {
+			foundLiveGrant = true
+			if finding.RuntimeContext != "KMS grant/admin equivalence" {
+				t.Fatalf("unexpected runtime context for live KMS grant finding: %s", finding.RuntimeContext)
+			}
+		}
+	}
+	if !foundLiveGrant {
+		t.Fatalf("expected live KMS grant to be converted to kms_admin_equivalence: %+v", findings)
+	}
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -529,3 +529,113 @@ func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnKMSIdentityGrant(t 
 		}
 	})
 }
+
+func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnSecretIdentityGrant(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 45, 0, 0, time.UTC)
+	accountID := "123456789012"
+	region := "us-east-1"
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:restricted-secret"
+	roleARN := "arn:aws:iam::123456789012:role/source"
+	secretNodeID := "aws:resource:secret:" + secretARN
+
+	t.Run("wildcard deny suppresses matching secret grant", func(t *testing.T) {
+		secrets := AWSSecretsManagerMetadataInventoryResult{
+			Records: []AWSSecretsManagerMetadataRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				SecretARN:              secretARN,
+				SecretName:             "restricted-secret",
+				ExposureClassification: "private",
+				FromNodeID:             secretNodeID,
+				Confidence:             0.9,
+				EvidenceRef:            "evidence://secrets",
+				CollectedAt:            now,
+				IdentityGrants: []AWSSecretsManagerIdentityGrant{
+					{
+						PrincipalARN:  roleARN,
+						PrincipalType: "aws",
+						Effect:        "Allow",
+						Actions:       []string{"secretsmanager:GetSecretValue"},
+						StatementSid:  "AllowSecretRead",
+					},
+					{
+						PrincipalARN:      "*",
+						Effect:            "Deny",
+						Actions:           []string{"secretsmanager:Get*"},
+						WildcardPrincipal: true,
+						StatementSid:      "DenyAllSecretRead",
+					},
+				},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, secrets, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 0 {
+			t.Fatalf("expected explicit wildcard deny to suppress secret grant finding, got %+v", findings)
+		}
+	})
+
+	t.Run("wildcard secret read actions are recognized", func(t *testing.T) {
+		secrets := AWSSecretsManagerMetadataInventoryResult{
+			Records: []AWSSecretsManagerMetadataRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				SecretARN:              secretARN,
+				SecretName:             "restricted-secret",
+				ExposureClassification: "private",
+				FromNodeID:             secretNodeID,
+				Confidence:             0.9,
+				EvidenceRef:            "evidence://secrets",
+				CollectedAt:            now,
+				IdentityGrants: []AWSSecretsManagerIdentityGrant{{
+					PrincipalARN:  roleARN,
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"secretsmanager:Get*"},
+					StatementSid:  "AllowSecretReadWildcard",
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, secrets, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected wildcard read action to produce a secret escalation finding, got %+v", findings)
+		}
+		if findings[0].TargetNodeID != secretNodeID || findings[0].EscalationType != "secrets_admin_equivalence" {
+			t.Fatalf("expected secret escalation finding with target node id, got %+v", findings[0])
+		}
+	})
+
+	t.Run("non-overlapping deny does not suppress secret grant", func(t *testing.T) {
+		secrets := AWSSecretsManagerMetadataInventoryResult{
+			Records: []AWSSecretsManagerMetadataRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				SecretARN:              secretARN,
+				SecretName:             "restricted-secret",
+				ExposureClassification: "private",
+				FromNodeID:             secretNodeID,
+				Confidence:             0.9,
+				EvidenceRef:            "evidence://secrets",
+				CollectedAt:            now,
+				IdentityGrants: []AWSSecretsManagerIdentityGrant{
+					{
+						PrincipalARN:  roleARN,
+						PrincipalType: "aws",
+						Effect:        "Allow",
+						Actions:       []string{"secretsmanager:Get*"},
+						StatementSid:  "AllowSecretRead",
+					},
+					{
+						PrincipalARN: "arn:aws:iam::123456789012:role/other",
+						Effect:       "Deny",
+						Actions:      []string{"secretsmanager:*"},
+						StatementSid: "UnrelatedDeny",
+					},
+				},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, secrets, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected unrelated deny principal to preserve secret grant finding, got %+v", findings)
+		}
+	})
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -355,3 +355,177 @@ func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnPassRole(t *testing
 		}
 	})
 }
+
+func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnKMSIdentityGrant(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 30, 0, 0, time.UTC)
+	accountID := "123456789012"
+	region := "us-east-1"
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/99990000-1111-2222-3333-444455556666"
+	roleARN := "arn:aws:iam::123456789012:role/source"
+
+	deniedGrant := AWSKMSIdentityGrant{
+		PrincipalARN:  roleARN,
+		PrincipalType: "aws",
+		Effect:        "Allow",
+		Actions:       []string{"kms:Decrypt"},
+		Capabilities:  []string{"decrypt"},
+		StatementSid:  "AllowDecryptOnly",
+	}
+	denyAllGrant := AWSKMSIdentityGrant{
+		PrincipalARN:      "*",
+		Effect:            "Deny",
+		Actions:           []string{"kms:*"},
+		Capabilities:      []string{"admin", "decrypt", "encrypt"},
+		WildcardPrincipal: true,
+		StatementSid:      "DenyAll",
+	}
+
+	t.Run("wildcard deny blocks matching identity grant", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "restrictive-example",
+				Description:            "restricted key",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-grant",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:  roleARN,
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt", "encrypt", "grant", "sign"},
+					StatementSid:  "AllowAll",
+				}, denyAllGrant},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 0 {
+			t.Fatalf("expected explicit wildcard deny to suppress matching KMS grant finding, got %+v", findings)
+		}
+	})
+
+	t.Run("non-overlapping deny action preserves KMS grant finding", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "allow-only",
+				Description:            "selectively accessible key",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-grant",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{deniedGrant, {
+					PrincipalARN:      roleARN,
+					PrincipalType:     "aws",
+					Effect:            "Deny",
+					Actions:           []string{"kms:GenerateDataKey"},
+					Capabilities:      []string{"decrypt", "encrypt"},
+					WildcardPrincipal: false,
+					StatementSid:      "UnrelatedDeny",
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected decrypt allow finding to remain, got %+v", findings)
+		}
+		if findings[0].PrincipalARN != deniedGrant.PrincipalARN {
+			t.Fatalf("expected finding for deniedGrant principal, got %+v", findings[0])
+		}
+	})
+
+	t.Run("non-matching deny principal preserves finding", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "different-principal",
+				Description:            "other-principal key",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-grant",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:  roleARN,
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt"},
+					StatementSid:  "AllowAll",
+				}, {
+					PrincipalARN:  "arn:aws:iam::123456789012:role/other",
+					PrincipalType: "aws",
+					Effect:        "Deny",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt"},
+					StatementSid:  "UnrelatedPrincipalDeny",
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected allow finding for unmatched deny principal, got %+v", findings)
+		}
+	})
+
+	t.Run("deny from a different key does not suppress grant", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "allow-key",
+				Description:            "target key",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-grant-allow",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:  roleARN,
+					PrincipalType: "aws",
+					Effect:        "Allow",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt"},
+					StatementSid:  "AllowAll",
+				}},
+			}, {
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 "arn:aws:kms:us-east-1:123456789012:key/00000000-1111-2222-3333-444455556666",
+				KeyID:                  "deny-key",
+				Description:            "deny-only key",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/arn:aws:kms:us-east-1:123456789012:key/00000000-1111-2222-3333-444455556666",
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-grant-deny",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:  roleARN,
+					PrincipalType: "aws",
+					Effect:        "Deny",
+					Actions:       []string{"kms:*"},
+					Capabilities:  []string{"admin", "decrypt"},
+					StatementSid:  "BlockOtherKey",
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected only the allow key to yield a finding, got %+v", findings)
+		}
+		if findings[0].TargetNodeID != "aws:resource:kms-key/"+keyARN {
+			t.Fatalf("expected finding to target first key, got %+v", findings[0])
+		}
+	})
+}

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -528,6 +528,83 @@ func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnKMSIdentityGrant(t 
 			t.Fatalf("expected finding to target first key, got %+v", findings[0])
 		}
 	})
+
+	t.Run("live grant is suppressed when explicit deny matches grantee", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "live-denied",
+				Description:            "live grant with key policy deny",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-live-grant",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:      "*",
+					Effect:            "Deny",
+					Actions:           []string{"kms:*"},
+					Capabilities:      []string{"admin", "decrypt"},
+					WildcardPrincipal: true,
+					StatementSid:      "DenyAllLive",
+				}},
+				Grants: []AWSKMSGrant{{
+					GrantID:              "grant-live-1",
+					GranteePrincipal:     roleARN,
+					GranteePrincipalType: "aws",
+					Operations:           []string{"Decrypt"},
+					Capabilities:         []string{"decrypt"},
+					HasConstraints:       true,
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 0 {
+			t.Fatalf("expected live grant to be suppressed by matching explicit deny, got %+v", findings)
+		}
+	})
+
+	t.Run("live grant with non-overlapping explicit deny remains", func(t *testing.T) {
+		kms := AWSKMSDecryptReachabilityInventoryResult{
+			Records: []AWSKMSDecryptReachabilityRecord{{
+				AccountID:              accountID,
+				Region:                 region,
+				KeyARN:                 keyARN,
+				KeyID:                  "live-allowed",
+				Description:            "live grant without matching deny",
+				ExposureClassification: "private",
+				FromNodeID:             "aws:resource:kms-key/" + keyARN,
+				Confidence:             0.91,
+				EvidenceRef:            "evidence://kms-live-grant",
+				CollectedAt:            now,
+				IdentityGrants: []AWSKMSIdentityGrant{{
+					PrincipalARN:      "*",
+					Effect:            "Deny",
+					Actions:           []string{"kms:GenerateDataKey"},
+					Capabilities:      []string{"decrypt", "encrypt"},
+					WildcardPrincipal: true,
+					StatementSid:      "DenyOtherOperation",
+				}},
+				Grants: []AWSKMSGrant{{
+					GrantID:              "grant-live-2",
+					GranteePrincipal:     roleARN,
+					GranteePrincipalType: "aws",
+					Operations:           []string{"Decrypt"},
+					Capabilities:         []string{"decrypt"},
+					HasConstraints:       true,
+				}},
+			}},
+		}
+		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, kms, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 1 {
+			t.Fatalf("expected live grant finding to remain when deny does not overlap actions, got %+v", findings)
+		}
+		if findings[0].EscalationType != "kms_admin_equivalence" || findings[0].PrincipalARN != roleARN {
+			t.Fatalf("expected live KMS admin finding for role principal, got %+v", findings[0])
+		}
+	})
 }
 
 func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnSecretIdentityGrant(t *testing.T) {
@@ -636,6 +713,58 @@ func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnSecretIdentityGrant
 		findings := awsPrivilegeEscalationFindings(AWSIAMPassRoleRelationshipInventoryResult{}, AWSKMSDecryptReachabilityInventoryResult{}, secrets, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
 		if len(findings) != 1 {
 			t.Fatalf("expected unrelated deny principal to preserve secret grant finding, got %+v", findings)
+		}
+	})
+}
+
+func TestAWSPrivilegeEscalationRecommendationQualifiesLeastPrivilegeWildcards(t *testing.T) {
+	t.Run("wildcard escalation actions qualify for remove decisions", func(t *testing.T) {
+		recommendation := AWSLeastPrivilegeRecommendation{
+			Decision:       "remove",
+			GrantedActions: []string{"sts:*"},
+		}
+		if !awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			t.Fatalf("expected wildcard sts:* to qualify")
+		}
+	})
+
+	t.Run("wildcard pass role patterns qualify for remove decisions", func(t *testing.T) {
+		recommendation := AWSLeastPrivilegeRecommendation{
+			Decision:       "remove",
+			GrantedActions: []string{"iam:Pass*"},
+		}
+		if !awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			t.Fatalf("expected wildcard iam:Pass* to qualify")
+		}
+	})
+
+	t.Run("wildcard attach role patterns qualify for remove decisions", func(t *testing.T) {
+		recommendation := AWSLeastPrivilegeRecommendation{
+			Decision:       "review",
+			GrantedActions: []string{"iam:Attach*"},
+		}
+		if !awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			t.Fatalf("expected wildcard iam:Attach* to qualify")
+		}
+	})
+
+	t.Run("non-escalation wildcard actions do not qualify", func(t *testing.T) {
+		recommendation := AWSLeastPrivilegeRecommendation{
+			Decision:       "remove",
+			GrantedActions: []string{"ec2:startinstances"},
+		}
+		if awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			t.Fatalf("expected non-escalation action to not qualify")
+		}
+	})
+
+	t.Run("wildcard escalations only require review/remove decisions", func(t *testing.T) {
+		recommendation := AWSLeastPrivilegeRecommendation{
+			Decision:       "keep",
+			GrantedActions: []string{"sts:*"},
+		}
+		if awsPrivilegeEscalationRecommendationQualifies(recommendation) {
+			t.Fatalf("expected keep decision not to qualify even for escalation action")
 		}
 	})
 }

--- a/internal/api/aws_privilege_escalation_test.go
+++ b/internal/api/aws_privilege_escalation_test.go
@@ -329,4 +329,29 @@ func TestAWSPrivilegeEscalationFindingsRespectsExplicitDenyOnPassRole(t *testing
 			t.Fatalf("expected passrole escalation type when only passrole allow remains, got %+v", findings[0].EscalationType)
 		}
 	})
+
+	t.Run("wildcard deny target suppresses matching passrole finding", func(t *testing.T) {
+		passRole := AWSIAMPassRoleRelationshipInventoryResult{
+			Records: []AWSIAMPassRoleRelationshipRecord{
+				allowRecord,
+				{
+					FromNodeID:         sourceNode,
+					ToNodeID:           targetNode,
+					SourceRoleARN:      "arn:aws:iam::123456789012:role/source",
+					TargetResource:     "*",
+					TargetWildcardKind: "all",
+					ActionExpression:   "iam:PassRole",
+					Effect:             "Deny",
+					PolicyName:         "DenyPassAll",
+					StatementSid:       "PassDeniedAll",
+					CollectedAt:        now,
+					Confidence:         0.88,
+				},
+			},
+		}
+		findings := awsPrivilegeEscalationFindings(passRole, AWSKMSDecryptReachabilityInventoryResult{}, AWSSecretsManagerMetadataInventoryResult{}, AWSLeastPrivilegeResult{}, AWSBlastRadiusResult{}, now)
+		if len(findings) != 0 {
+			t.Fatalf("expected wildcard deny to suppress passrole finding, got %+v", findings)
+		}
+	})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3155,6 +3155,41 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"findings": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/privilege-escalation", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPrivilegeEscalation(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPrivilegeEscalationRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			Identity:       strings.TrimSpace(c.Query("identity")),
+			Target:         strings.TrimSpace(c.Query("target")),
+			EscalationType: strings.TrimSpace(c.Query("escalation_type")),
+			Severity:       strings.TrimSpace(c.Query("severity")),
+			Status:         strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws privilege escalation request"})
+			default:
+				logger.Error("get aws privilege escalation",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws privilege escalation"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"findings": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1368,6 +1368,51 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS privilege escalation findings with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        findings: {
+          status: 'ready',
+          summary: { total_findings: 0, filtered_findings: 0 },
+          findings: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectPrivilegeEscalation(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'security-admin',
+        target: '*',
+        escalationType: 'passrole_unscoped_trust_path',
+        severity: 'critical',
+        status: 'action_required'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/privilege-escalation?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=security-admin&target=*&escalation_type=passrole_unscoped_trust_path&severity=critical&status=action_required'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3238,6 +3238,122 @@ export type AWSIdentitySprawlQuery = {
   status?: string;
 };
 
+// AWSPrivilegeEscalation* types describe Wave 6.05 escalation paths composed
+// from PassRole, policy attachment, trust, admin-equivalence, KMS/secrets, and
+// cross-account graph evidence.
+export type AWSPrivilegeEscalationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSPrivilegeEscalationFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSPrivilegeEscalationType =
+  | 'passrole_service_escalation'
+  | 'passrole_wildcard_escalation'
+  | 'passrole_unscoped_trust_path'
+  | 'policy_attachment_escalation'
+  | 'kms_admin_equivalence'
+  | 'secrets_admin_equivalence'
+  | 'cross_account_escalation_path'
+  | string;
+export type AWSPrivilegeEscalationFindingStatus = 'review' | 'action_required' | string;
+
+export type AWSPrivilegeEscalationRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSPrivilegeEscalationFinding = {
+  finding_id: string;
+  calculation_version: string;
+  escalation_type: AWSPrivilegeEscalationType;
+  severity: string;
+  status: AWSPrivilegeEscalationFindingStatus;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  target_node_id?: string;
+  target_label: string;
+  display_name: string;
+  rationale: string;
+  exploitability: string;
+  runtime_context: string;
+  policy_sources?: string[];
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSPrivilegeEscalationSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  escalation_type_counts: Record<string, number>;
+  critical_count: number;
+  high_count: number;
+  cross_account_path_count: number;
+  passrole_path_count: number;
+  admin_equivalent_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+};
+
+export type AWSPrivilegeEscalationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSPrivilegeEscalationStatus;
+  fixture_state?: AWSPrivilegeEscalationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSPrivilegeEscalationSummary;
+  findings: AWSPrivilegeEscalationFinding[];
+  relationships: AWSPrivilegeEscalationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSPrivilegeEscalationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSPrivilegeEscalationFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  target?: string;
+  escalationType?: AWSPrivilegeEscalationType;
+  severity?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -6497,6 +6613,27 @@ export const apiClient = {
         owner: query?.owner,
         cluster: query?.cluster,
         finding_type: query?.findingType,
+        severity: query?.severity,
+        status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectPrivilegeEscalation(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSPrivilegeEscalationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ findings: AWSPrivilegeEscalationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/privilege-escalation${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        target: query?.target,
+        escalation_type: query?.escalationType,
         severity: query?.severity,
         status: query?.status
       })}`,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3382,6 +3382,84 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getPrivilegeEscalation = vi.spyOn(api.apiClient, 'getAWSProjectPrivilegeEscalation').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [
+          {
+            finding_id: 'aws-privilege-escalation:security-admin',
+            calculation_version: 'aws-privilege-escalation-engine-v1',
+            escalation_type: 'passrole_unscoped_trust_path',
+            severity: 'critical',
+            status: 'action_required',
+            score: 92,
+            confidence: 0.92,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:identity:security-admin',
+            principal_arn: 'arn:aws:iam::123456789012:role/security-admin',
+            target_node_id: '*',
+            target_label: '*',
+            display_name: 'security-admin',
+            rationale: 'Role can pass any role without iam:PassedToService scoping.',
+            exploitability: 'high',
+            runtime_context: 'static PassRole grant',
+            policy_sources: ['PassAny'],
+            impacted_nodes: ['aws:identity:security-admin', '*'],
+            impacted_path: [
+              { node_id: 'aws:identity:security-admin', node_type: 'identity', label: 'security-admin' },
+              { node_id: '*', node_type: 'iam_role', label: '*' }
+            ],
+            evidence: [
+              {
+                source: 'iam_passrole_relationship',
+                evidence_ref: 'evidence://passrole/security-admin',
+                label: 'IAM PassRole relationship',
+                confidence: 0.92,
+                observed_at: '2026-06-21T12:00:00Z',
+                relationship: 'can_pass_role'
+              }
+            ],
+            next_action: 'Constrain iam:PassRole to specific approved role ARNs and iam:PassedToService conditions.',
+            remediation_case: {
+              case_id: 'aws-privilege-escalation-preview:security-admin',
+              title: 'PassRole review',
+              recommended_action: 'Constrain iam:PassRole.',
+              approval_required: true,
+              blocking_evidence: ['evidence://passrole/security-admin'],
+              impacted_node_count: 2,
+              estimated_risk_drop: 40,
+              breakage_prediction: 'unknown',
+              read_only_projection: true
+            },
+            created_at: '2026-06-21T12:00:00Z',
+            updated_at: '2026-06-21T12:00:00Z'
+          }
+        ],
+        summary: {
+          total_findings: 1,
+          filtered_findings: 1,
+          critical_count: 1,
+          high_count: 0,
+          passrole_path_count: 1,
+          admin_equivalent_count: 0,
+          cross_account_path_count: 0,
+          relationship_count: 1,
+          highest_score: 92,
+          average_confidence_pct: 92,
+          remediation_preview_count: 1,
+          severity_counts: { critical: 1 },
+          status_counts: { action_required: 1 },
+          escalation_type_counts: { passrole_unscoped_trust_path: 1 }
+        },
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
 
     const { ProductAWSRuntimePage } = await import('./productShell');
 
@@ -3403,7 +3481,15 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText(/Identity sprawl could not be calculated/i)).toBeInTheDocument();
     expect(screen.getByText(/live identity-bearing inventory is unavailable/i)).toBeInTheDocument();
     expect(screen.queryByText(/No identity sprawl detected/i)).not.toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS privilege escalation findings' })).toBeInTheDocument();
+    expect(screen.getByText(/Passrole unscoped trust path/i)).toBeInTheDocument();
     expect(getLeastPrivilege).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getPrivilegeEscalation).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -63,6 +63,8 @@ import {
   type AWSUnusedDormantAccessResult,
   type AWSIdentitySprawlFinding,
   type AWSIdentitySprawlResult,
+  type AWSPrivilegeEscalationFinding,
+  type AWSPrivilegeEscalationResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10695,6 +10697,134 @@ function awsIdentitySprawlEvidenceLabel(finding: AWSIdentitySprawlFinding): stri
   return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
 }
 
+function awsPrivilegeEscalationStage(finding: AWSPrivilegeEscalationFinding): AWSCapabilityStage {
+  if (finding.status === 'action_required' || finding.severity === 'critical') {
+    return 'not-available';
+  }
+  if (finding.severity === 'high') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsPrivilegeEscalationLabel(finding: AWSPrivilegeEscalationFinding): string {
+  return `${formatTokenLabel(finding.escalation_type)} · score ${finding.score}`;
+}
+
+function awsPrivilegeEscalationPathLabel(finding: AWSPrivilegeEscalationFinding): string {
+  const labels = finding.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
+  if (labels.length >= 2) {
+    return labels.slice(0, 3).join(' -> ');
+  }
+  return finding.target_label || finding.target_node_id || '-';
+}
+
+function awsPrivilegeEscalationEvidenceLabel(finding: AWSPrivilegeEscalationFinding): string {
+  const sources = finding.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function AWSPrivilegeEscalationContent({
+  findings,
+  loading,
+  error,
+  onRetry
+}: {
+  findings: AWSPrivilegeEscalationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = findings?.findings ?? [];
+  const summaryLine = findings
+    ? `${findings.summary.critical_count} critical · ${findings.summary.passrole_path_count} PassRole · ${findings.summary.admin_equivalent_count} admin-equivalent · ${findings.summary.cross_account_path_count} cross-account`
+    : '';
+  const emptyState = findings
+    ? findings.status === 'blocked'
+      ? {
+          eyebrow: 'Permission required',
+          title: 'Privilege escalation analysis needs read-only evidence access',
+          body: findings.failure_reasons[0] ?? 'Privilege escalation paths cannot be calculated until read-only AWS evidence is available.'
+        }
+      : findings.status === 'degraded'
+        ? {
+            eyebrow: 'Evidence incomplete',
+            title: 'Privilege escalation paths are incomplete',
+            body:
+              findings.failure_reasons[0] ??
+              findings.remediation_hints[0] ??
+              'Some source evidence is unavailable, so Identrail cannot prove whether all escalation paths are covered yet.'
+          }
+        : {
+            eyebrow: 'No escalation paths',
+            title: 'No privilege escalation paths detected',
+            body: 'No PassRole, admin-equivalent, policy attachment, trust, or cross-account paths matched this scope.'
+          }
+    : null;
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS privilege escalation findings">
+      <h3>AWS privilege escalation paths</h3>
+      <p className="idt-app-kicker">
+        Ranked escalation paths across PassRole, policy attachment, trust, admin-equivalent KMS/secrets grants, and
+        cross-account graph evidence.{summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load privilege escalation findings"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating privilege escalation paths"
+          body="Identrail is ranking metadata-only escalation paths from IAM, resource policy, runtime, and graph evidence."
+        />
+      ) : null}
+      {!error && !loading && findings && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={emptyState?.eyebrow ?? 'No escalation paths'}
+          title={emptyState?.title ?? 'No privilege escalation paths detected'}
+          body={emptyState?.body ?? 'No PassRole, admin-equivalent, policy attachment, trust, or cross-account paths matched this scope.'}
+        />
+      ) : null}
+      {!error && !loading && findings && findings.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {findings.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS privilege escalation findings"
+          rows={rows}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsPrivilegeEscalationLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.principal_arn || row.display_name || row.identity_node_id },
+            { key: 'target', header: 'Target', render: (row) => row.target_label || row.target_node_id || '-' },
+            { key: 'path', header: 'Path', render: (row) => awsPrivilegeEscalationPathLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsPrivilegeEscalationEvidenceLabel(row) },
+            {
+              key: 'exploitability',
+              header: 'Exploitability',
+              render: (row) => (
+                <AWSInventoryPill
+                  stage={awsPrivilegeEscalationStage(row)}
+                  label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.exploitability)}`}
+                />
+              )
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function AWSIdentitySprawlContent({
   findings,
   loading,
@@ -11415,6 +11545,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [identitySprawlLoading, setIdentitySprawlLoading] = useState(false);
   const [identitySprawlError, setIdentitySprawlError] = useState('');
   const identitySprawlRequestRef = useRef(0);
+  const [privilegeEscalation, setPrivilegeEscalation] = useState<AWSPrivilegeEscalationResult | null>(null);
+  const [privilegeEscalationLoading, setPrivilegeEscalationLoading] = useState(false);
+  const [privilegeEscalationError, setPrivilegeEscalationError] = useState('');
+  const privilegeEscalationRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11814,6 +11948,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadIdentitySprawl]);
 
+  const loadPrivilegeEscalation = useCallback(async () => {
+    const requestID = ++privilegeEscalationRequestRef.current;
+    setPrivilegeEscalation(null);
+    setPrivilegeEscalationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setPrivilegeEscalationLoading(false);
+      return;
+    }
+    setPrivilegeEscalationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectPrivilegeEscalation(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== privilegeEscalationRequestRef.current) {
+        return;
+      }
+      setPrivilegeEscalation(response.findings);
+    } catch (error) {
+      if (requestID !== privilegeEscalationRequestRef.current) {
+        return;
+      }
+      setPrivilegeEscalationError(formatAPIError(error, 'Unable to load AWS privilege escalation findings.'));
+    } finally {
+      if (requestID === privilegeEscalationRequestRef.current) {
+        setPrivilegeEscalationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadPrivilegeEscalation();
+    return () => {
+      privilegeEscalationRequestRef.current += 1;
+    };
+  }, [loadPrivilegeEscalation]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -11961,6 +12143,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={identitySprawlLoading}
             error={identitySprawlError}
             onRetry={loadIdentitySprawl}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSPrivilegeEscalationContent
+            findings={privilegeEscalation}
+            loading={privilegeEscalationLoading}
+            error={privilegeEscalationError}
+            onRetry={loadPrivilegeEscalation}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
## Summary

- Adds the AWS privilege escalation path engine for Issue #1525, composing PassRole, KMS, Secrets Manager, least-privilege, and blast-radius evidence into ranked read-only findings.
- Exposes the new authorized REST endpoint, OpenAPI contract, TypeScript API client, and runtime page table.
- Documents the engine contract, read-only guarantees, filters, failure states, and validation path.

## Tests

- `go test ./internal/api`
- `npm run test -- api/client.test.ts -t "AWS privilege escalation" --run`
- `npm run test -- productShell.test.tsx -t "translates AWS runtime filter aliases" --run`
- `npm run build`

## AI disclosure

No

Closes #1525

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a read-only AWS privilege escalation engine that composes PassRole, KMS (including live grants), Secrets Manager, least‑privilege, and blast‑radius metadata into ranked findings, exposed via a new API and runtime UI. Addresses #1525 with stable IDs, relationships, remediation previews, and explicit Deny handling for PassRole, KMS, and Secrets Manager without mutating AWS.

- **New Features**
  - Authorized endpoint GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/privilege-escalation with filters: connector_id, fixture_state, account_id, region, identity, target, escalation_type, severity, status.
  - Engine emits ranked findings for PassRole service/wildcard/unscoped paths, policy‑attachment escalation, KMS/Secrets admin equivalence, cross‑account paths; includes stable IDs, score/confidence, relationships, and read‑only remediation previews. Ingests live KMS grants.
  - OpenAPI spec and runtime auth policy updated; route added.
  - TypeScript client `getAWSProjectPrivilegeEscalation(...)` added with tests.
  - Runtime page shows an “AWS privilege escalation paths” panel with summary, evidence, and actions.
  - Docs added for engine contract, guarantees, filters, failure states, and validation.

- **Bug Fixes**
  - Relationship graph omits edges to wildcard PassRole targets to avoid non‑concrete nodes.
  - Honors explicit Deny iam:PassRole, including wildcard PassRole denies during filtering, to prevent false positives.
  - Fixes KMS privilege escalation deny handling so explicit Deny in key policies and live grants correctly suppresses admin‑equivalence findings.
  - Honors Secrets Manager explicit Deny and wildcard read actions to prevent admin‑equivalence false positives.

<sup>Written for commit 83a38ca2da1605514f1a3aaea1db0091fc733259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

