### PR TITLE
Implement AWS cross-account trust engine

### DIFF
--- a/docs/aws-cross-account-trust-engine.md
+++ b/docs/aws-cross-account-trust-engine.md
@@ -1,0 +1,86 @@
+# AWS cross-account trust and external access engine
+
+Issue #1526 (Wave 6.06) adds a metadata-only engine that turns normalized AWS
+trust, resource-policy, runtime, Organizations, Access Analyzer, and graph
+evidence into ranked external-access findings.
+
+## What it produces
+
+The engine emits `AWSCrossAccountTrustFinding` records for these finding types:
+
+- **`public_resource_trust`** - a resource policy or grant trusts a wildcard or
+  public principal.
+- **`cross_account_resource_access`** - a resource policy or grant trusts a
+  principal from another account.
+- **`runtime_cross_account_assumption`** - CloudTrail runtime evidence observed
+  STS `AssumeRole` crossing account boundaries.
+- **`access_analyzer_external_access`** - least-privilege reasoning preserved an
+  Access Analyzer external-access signal for owner review.
+- **`cross_account_graph_path`** - blast-radius graph evidence found a
+  cross-account edge in an impacted path.
+
+Each finding carries a stable finding id, calculation version, severity, score,
+confidence, account/region context, service/resource context, external
+principal account and OU context when available, condition keys, evidence
+references, impacted graph path, hardening direction, and read-only
+`remediation_case` preview.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/cross-account-trust`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | scope filters |
+| `service` | filter by AWS service such as `s3`, `kms`, `secretsmanager`, `sqs`, `sns`, `dynamodb`, `rds`, or `sts` |
+| `principal` | external principal ARN, account id, or OU path search |
+| `resource` | resource ARN, graph node id, or display label search |
+| `finding_type` | one of the finding types above |
+| `severity` | `critical`, `high`, `medium`, `low` |
+| `status` | `review`, `action_required`, or source status |
+| `ou` | external principal OU path search when Organizations topology knows the account |
+
+Response shape: `{ "findings": AWSCrossAccountTrustResult }` with summary,
+ranked findings, graph relationships, caveats, failure reasons, remediation
+hints, evidence links, coverage gaps, diagnostics, and standard
+tenant/workspace/project issue metadata.
+
+## Read-only guarantees
+
+The engine performs no AWS mutations and does not read secret values, KMS
+plaintext, object bodies, database rows, prompts, completions, browser pages, or
+customer payloads. It only composes metadata and evidence references from
+read-only upstream collectors.
+
+Remediation output is a planning preview. It can tell an operator which
+principal, resource, condition, and graph path need review, but it does not
+change AWS or Identrail state.
+
+## Failure handling
+
+- **Ready**: source engines are available and no blocking diagnostics were
+  emitted.
+- **Degraded**: at least one source is partial, capability-limited, or produced
+  diagnostics. Existing partial evidence remains visible.
+- **Blocked**: every source required for the calculation is permission denied.
+  The result has `confidence=0`, no findings, diagnostics, and failure reasons.
+
+Unknown, degraded, unsupported, and permission-denied evidence lowers confidence
+and must not be interpreted as absence of external access.
+
+## Live validation
+
+1. Confirm issue blockers #1498 and #1517 are closed.
+2. Run the Organizations, resource reachability, runtime events,
+   least-privilege, and blast-radius endpoints with `fixture_state=success`.
+3. Run the cross-account trust endpoint with `fixture_state=success` and confirm
+   public and cross-account findings are ranked.
+4. Filter by `service=kms`, `principal=partner-ingest`, and
+   `finding_type=cross_account_resource_access` to verify deterministic
+   drill-down behavior.
+5. Run `fixture_state=permission_denied` and confirm `status=blocked`, zero
+   findings, diagnostics, and failure reasons.
+6. Confirm the AWS Runtime app page renders the `AWS cross-account trust` panel
+   without exposing secret values or customer payload data.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -594,6 +594,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/cross-account-trust
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-passrole-relationships
     action: tenancy.read
     resource_type: project
@@ -5318,6 +5323,92 @@ paths:
                     $ref: "#/components/schemas/AWSPrivilegeEscalationResult"
         "400":
           description: Invalid AWS privilege escalation request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/cross-account-trust:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS cross-account trust findings
+      operationId: getAWSProjectCrossAccountTrust
+      description: Ranked, explainable external-access decisions composed from read-only Organizations, resource policy, runtime STS, Access Analyzer, least-privilege, and graph evidence. The engine emits stable finding IDs, graph paths, evidence pointers, confidence, status, hardening direction, and read-only remediation previews; it does not mutate AWS resources or read secret values, plaintext, prompts, completions, object bodies, database rows, browser pages, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the calculation.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: service
+          schema: { type: string }
+          description: Filter by AWS service such as s3, kms, secretsmanager, sqs, sns, dynamodb, rds, or sts.
+        - in: query
+          name: principal
+          schema: { type: string }
+          description: Filter by external principal ARN, account id, or OU path.
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Filter by resource ARN, graph node id, or display label.
+        - in: query
+          name: finding_type
+          schema:
+            type: string
+            enum: [cross_account_resource_access, public_resource_trust, runtime_cross_account_assumption, access_analyzer_external_access, cross_account_graph_path]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [review, action_required]
+        - in: query
+          name: ou
+          schema: { type: string }
+          description: Filter by Organizations OU path for the external principal account when known.
+      responses:
+        "200":
+          description: AWS cross-account trust findings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    $ref: "#/components/schemas/AWSCrossAccountTrustResult"
+        "400":
+          description: Invalid AWS cross-account trust request
           content:
             application/json:
               schema:
@@ -13011,6 +13102,156 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPrivilegeEscalationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSCrossAccountTrustRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSCrossAccountTrustFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        finding_type:
+          type: string
+          enum: [cross_account_resource_access, public_resource_trust, runtime_cross_account_assumption, access_analyzer_external_access, cross_account_graph_path]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status: { type: string }
+        score: { type: integer }
+        confidence: { type: number }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        resource_type: { type: string }
+        resource_arn: { type: string }
+        resource_node_id: { type: string }
+        resource_label: { type: string }
+        external_principal_arn: { type: string }
+        external_principal_account: { type: string }
+        external_principal_ou_path: { type: string }
+        trusted_within_organization: { type: boolean }
+        public_principal: { type: boolean }
+        has_condition: { type: boolean }
+        condition_keys:
+          type: array
+          items: { type: string }
+        policy_sources:
+          type: array
+          items: { type: string }
+        runtime_observed: { type: boolean }
+        analyzer_backed: { type: boolean }
+        rationale: { type: string }
+        hardening_direction: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSCrossAccountTrustSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        finding_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        service_counts:
+          type: object
+          additionalProperties: { type: integer }
+        critical_count: { type: integer }
+        high_count: { type: integer }
+        public_principal_count: { type: integer }
+        cross_account_grant_count: { type: integer }
+        runtime_observed_count: { type: integer }
+        analyzer_backed_count: { type: integer }
+        unconditional_grant_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+    AWSCrossAccountTrustResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status: { type: string }
+        fixture_state: { type: string }
+        confidence: { type: number }
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSCrossAccountTrustSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCrossAccountTrustFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCrossAccountTrustRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -762,6 +762,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/identity-sprawl", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/privilege-escalation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/cross-account-trust", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -200,13 +200,18 @@ func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID strin
 	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
-	sourceFixtureState := fixtureState
+	fixtureBackedSourceState := fixtureState
+	runtimeFixtureState := fixtureState
+	responseFixtureState := fixtureState
+	suppressRuntimeFixtures := false
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
-		sourceFixtureState = ""
+		fixtureBackedSourceState = "empty"
+		runtimeFixtureState = ""
+		responseFixtureState = ""
+		suppressRuntimeFixtures = true
 	}
-	suppressRuntimeFixtures := strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected
 
-	sources, err := s.awsCrossAccountTrustSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState, suppressRuntimeFixtures)
+	sources, err := s.awsCrossAccountTrustSourceSignals(ctx, workspaceID, projectID, connectorID, fixtureBackedSourceState, runtimeFixtureState, suppressRuntimeFixtures)
 	if err != nil {
 		return AWSCrossAccountTrustResult{}, err
 	}
@@ -236,7 +241,7 @@ func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID strin
 		CurrentIssueRef:    awsIssueRef(awsCrossAccountTrustCurrentIssue),
 		Version:            awsCrossAccountTrustVersion,
 		Status:             status,
-		FixtureState:       sourceFixtureState,
+		FixtureState:       responseFixtureState,
 		Confidence:         confidence,
 		CalculationVersion: awsCrossAccountTrustVersion,
 		AppliedFilters:     applied,
@@ -278,40 +283,40 @@ func normalizeAWSCrossAccountTrustFixtureState(requested string, connection AWSC
 	}
 }
 
-func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string, suppressRuntimeFixtures bool) (awsCrossAccountTrustSources, error) {
-	organizations, err := s.GetAWSOrganizationsTopology(ctx, workspaceID, projectID, AWSOrganizationsTopologyRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureBackedSourceState string, runtimeFixtureState string, suppressRuntimeFixtures bool) (awsCrossAccountTrustSources, error) {
+	organizations, err := s.GetAWSOrganizationsTopology(ctx, workspaceID, projectID, AWSOrganizationsTopologyRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust organizations topology: %w", err)
 	}
-	s3, err := s.GetAWSS3BucketReachabilityInventory(ctx, workspaceID, projectID, AWSS3BucketReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	s3, err := s.GetAWSS3BucketReachabilityInventory(ctx, workspaceID, projectID, AWSS3BucketReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust s3 reachability: %w", err)
 	}
-	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust kms reachability: %w", err)
 	}
-	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust secrets metadata: %w", err)
 	}
-	sqsSNS, err := s.GetAWSSQSSNSReachabilityInventory(ctx, workspaceID, projectID, AWSSQSSNSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	sqsSNS, err := s.GetAWSSQSSNSReachabilityInventory(ctx, workspaceID, projectID, AWSSQSSNSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust sqs/sns reachability: %w", err)
 	}
-	dynamoRDS, err := s.GetAWSDynamoDBRDSReachabilityInventory(ctx, workspaceID, projectID, AWSDynamoDBRDSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	dynamoRDS, err := s.GetAWSDynamoDBRDSReachabilityInventory(ctx, workspaceID, projectID, AWSDynamoDBRDSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust dynamodb/rds reachability: %w", err)
 	}
-	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "sts-session", SuppressFixtureRecords: suppressRuntimeFixtures})
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: runtimeFixtureState, EventType: "sts-session", SuppressFixtureRecords: suppressRuntimeFixtures})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust runtime events: %w", err)
 	}
-	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust least privilege: %w", err)
 	}
-	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureBackedSourceState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust blast radius: %w", err)
 	}

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -160,16 +160,26 @@ type awsCrossAccountTrustGrantInput struct {
 	effect            string
 	actions           []string
 	capabilities      []string
+	notAction         bool
 	conditionKeys     []string
 	hasCondition      bool
 	publicPrincipal   bool
 	crossAccount      bool
 	wildcardPrincipal bool
 	statementSid      string
+	denyGrants        []awsCrossAccountTrustExplicitDenyGrant
 	evidenceRef       string
 	confidence        float64
 	observedAt        time.Time
 	status            string
+}
+
+type awsCrossAccountTrustExplicitDenyGrant struct {
+	principalARN      string
+	wildcardPrincipal bool
+	actions           []string
+	capabilities      []string
+	notAction         bool
 }
 
 func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID string, projectID string, request AWSCrossAccountTrustRequest) (AWSCrossAccountTrustResult, error) {
@@ -310,42 +320,47 @@ func awsCrossAccountTrustFindings(sources awsCrossAccountTrustSources, now time.
 	accounts := awsCrossAccountTrustOrganizationAccounts(sources.organizations)
 	findings := []AWSCrossAccountTrustFinding{}
 	for _, record := range sources.s3.Records {
+		denyGrants := awsCrossAccountTrustDenyGrantsFromS3(record.IdentityGrants)
 		for _, grant := range record.IdentityGrants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "s3_bucket_reachability", service: "s3", resourceType: "s3_bucket", resourceARN: record.BucketARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.BucketName, record.BucketARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "s3_bucket_reachability", service: "s3", resourceType: "s3_bucket", resourceARN: record.BucketARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.BucketName, record.BucketARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, notAction: grant.NotAction, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 	}
 	for _, record := range sources.kms.Records {
+		denyGrants := awsCrossAccountTrustDenyGrantsFromKMS(record.IdentityGrants)
 		for _, grant := range record.IdentityGrants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "kms_decrypt_reachability", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "kms_decrypt_reachability", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, notAction: grant.NotAction, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 		for _, grant := range record.Grants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "kms_live_grant", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.GranteePrincipal, effect: "Allow", actions: grant.Operations, capabilities: grant.Capabilities, conditionKeys: append(append([]string{}, grant.EncryptionContextKeys...), grant.EncryptionContextSubsetKeys...), hasCondition: grant.HasConstraints, crossAccount: grant.IsCrossAccount, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "kms_live_grant", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.GranteePrincipal, effect: "Allow", actions: grant.Operations, capabilities: grant.Capabilities, conditionKeys: append(append([]string{}, grant.EncryptionContextKeys...), grant.EncryptionContextSubsetKeys...), hasCondition: grant.HasConstraints, crossAccount: grant.IsCrossAccount, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 	}
 	for _, record := range sources.secrets.Records {
+		denyGrants := awsCrossAccountTrustDenyGrantsFromSecrets(record.IdentityGrants)
 		for _, grant := range record.IdentityGrants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "secrets_manager_metadata", service: "secretsmanager", resourceType: "secret", resourceARN: record.SecretARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.SecretName, record.SecretARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "secrets_manager_metadata", service: "secretsmanager", resourceType: "secret", resourceARN: record.SecretARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.SecretName, record.SecretARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 	}
 	for _, record := range sources.sqsSNS.Records {
+		denyGrants := awsCrossAccountTrustDenyGrantsFromSQSSNS(record.IdentityGrants)
 		for _, grant := range record.IdentityGrants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "sqs_sns_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "sqs_sns_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, notAction: grant.NotAction, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 	}
 	for _, record := range sources.dynamoRDS.Records {
+		denyGrants := awsCrossAccountTrustDenyGrantsFromDynamoRDS(record.IdentityGrants)
 		for _, grant := range record.IdentityGrants {
 			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
-				source: "dynamodb_rds_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+				source: "dynamodb_rds_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, notAction: grant.NotAction, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, denyGrants: denyGrants, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
 			}, accounts, now)...)
 		}
 	}
@@ -369,6 +384,9 @@ func awsCrossAccountTrustFindings(sources awsCrossAccountTrustSources, now time.
 
 func awsCrossAccountTrustFindingFromGrant(input awsCrossAccountTrustGrantInput, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) []AWSCrossAccountTrustFinding {
 	if !strings.EqualFold(firstNonEmptyAWSValue(input.effect, "Allow"), "Allow") {
+		return nil
+	}
+	if awsCrossAccountTrustGrantHasExplicitDeny(input) {
 		return nil
 	}
 	input.publicPrincipal = input.publicPrincipal || input.wildcardPrincipal || strings.TrimSpace(input.principalARN) == "*"
@@ -440,6 +458,157 @@ func awsCrossAccountTrustFindingFromGrant(input awsCrossAccountTrustGrantInput, 
 		UpdatedAt:       now,
 	}
 	return []AWSCrossAccountTrustFinding{finding}
+}
+
+func awsCrossAccountTrustGrantHasExplicitDeny(input awsCrossAccountTrustGrantInput) bool {
+	if input.notAction {
+		return false
+	}
+	for _, deny := range input.denyGrants {
+		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(input.principalARN, deny.principalARN, deny.wildcardPrincipal) {
+			continue
+		}
+		if awsCrossAccountTrustActionsFullyDenied(input.service, input.actions, input.capabilities, deny.actions, deny.capabilities, deny.notAction) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsCrossAccountTrustActionsFullyDenied(service string, allowActions []string, allowCapabilities []string, denyActions []string, denyCapabilities []string, denyNotAction bool) bool {
+	allow := awsCrossAccountTrustNormalizePolicyActions(service, allowActions, allowCapabilities)
+	deny := awsCrossAccountTrustNormalizePolicyActions(service, denyActions, denyCapabilities)
+	if len(allow) == 0 {
+		return len(deny) == 0 || (denyNotAction && !awsCrossAccountTrustActionCoveredByAny("", deny))
+	}
+	for _, action := range allow {
+		if denyNotAction {
+			if awsCrossAccountTrustActionCoveredByAny(action, deny) {
+				return false
+			}
+			continue
+		}
+		if !awsCrossAccountTrustActionCoveredByAny(action, deny) {
+			return false
+		}
+	}
+	return true
+}
+
+func awsCrossAccountTrustNormalizePolicyActions(service string, actions []string, capabilities []string) []string {
+	out := []string{}
+	normalizedService := normalizeAWSRuntimeEventFilterToken(service)
+	appendAction := func(action string) {
+		trimmed := strings.ToLower(strings.TrimSpace(action))
+		if trimmed == "" {
+			return
+		}
+		out = append(out, trimmed)
+		if normalizedService != "" && !strings.Contains(trimmed, ":") {
+			out = append(out, normalizedService+":"+trimmed)
+		}
+	}
+	for _, action := range actions {
+		appendAction(action)
+	}
+	for _, capability := range capabilities {
+		appendAction(capability)
+	}
+	return dedupeStrings(out)
+}
+
+func awsCrossAccountTrustActionCoveredByAny(action string, patterns []string) bool {
+	for _, pattern := range patterns {
+		trimmedPattern := strings.ToLower(strings.TrimSpace(pattern))
+		trimmedAction := strings.ToLower(strings.TrimSpace(action))
+		if trimmedPattern == "" {
+			continue
+		}
+		if trimmedAction == "" {
+			return trimmedPattern == "*"
+		}
+		if awsActionPatternMatches(trimmedPattern, trimmedAction) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsCrossAccountTrustDenyGrantsFromS3(grants []AWSS3IdentityGrant) []awsCrossAccountTrustExplicitDenyGrant {
+	out := []awsCrossAccountTrustExplicitDenyGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, awsCrossAccountTrustExplicitDenyGrant{
+				principalARN:      grant.PrincipalARN,
+				wildcardPrincipal: grant.WildcardPrincipal,
+				actions:           grant.Actions,
+				notAction:         grant.NotAction,
+			})
+		}
+	}
+	return out
+}
+
+func awsCrossAccountTrustDenyGrantsFromKMS(grants []AWSKMSIdentityGrant) []awsCrossAccountTrustExplicitDenyGrant {
+	out := []awsCrossAccountTrustExplicitDenyGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, awsCrossAccountTrustExplicitDenyGrant{
+				principalARN:      grant.PrincipalARN,
+				wildcardPrincipal: grant.WildcardPrincipal,
+				actions:           grant.Actions,
+				capabilities:      grant.Capabilities,
+				notAction:         grant.NotAction,
+			})
+		}
+	}
+	return out
+}
+
+func awsCrossAccountTrustDenyGrantsFromSecrets(grants []AWSSecretsManagerIdentityGrant) []awsCrossAccountTrustExplicitDenyGrant {
+	out := []awsCrossAccountTrustExplicitDenyGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, awsCrossAccountTrustExplicitDenyGrant{
+				principalARN:      grant.PrincipalARN,
+				wildcardPrincipal: grant.WildcardPrincipal,
+				actions:           grant.Actions,
+			})
+		}
+	}
+	return out
+}
+
+func awsCrossAccountTrustDenyGrantsFromSQSSNS(grants []AWSSQSSNSIdentityGrant) []awsCrossAccountTrustExplicitDenyGrant {
+	out := []awsCrossAccountTrustExplicitDenyGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, awsCrossAccountTrustExplicitDenyGrant{
+				principalARN:      grant.PrincipalARN,
+				wildcardPrincipal: grant.WildcardPrincipal,
+				actions:           grant.Actions,
+				capabilities:      grant.Capabilities,
+				notAction:         grant.NotAction,
+			})
+		}
+	}
+	return out
+}
+
+func awsCrossAccountTrustDenyGrantsFromDynamoRDS(grants []AWSDynamoDBRDSIdentityGrant) []awsCrossAccountTrustExplicitDenyGrant {
+	out := []awsCrossAccountTrustExplicitDenyGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, awsCrossAccountTrustExplicitDenyGrant{
+				principalARN:      grant.PrincipalARN,
+				wildcardPrincipal: grant.WildcardPrincipal,
+				actions:           grant.Actions,
+				capabilities:      grant.Capabilities,
+				notAction:         grant.NotAction,
+			})
+		}
+	}
+	return out
 }
 
 func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventRecord, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -180,6 +180,7 @@ type awsCrossAccountTrustExplicitDenyGrant struct {
 	actions           []string
 	capabilities      []string
 	notAction         bool
+	hasCondition      bool
 }
 
 func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID string, projectID string, request AWSCrossAccountTrustRequest) (AWSCrossAccountTrustResult, error) {
@@ -465,6 +466,9 @@ func awsCrossAccountTrustGrantHasExplicitDeny(input awsCrossAccountTrustGrantInp
 		return false
 	}
 	for _, deny := range input.denyGrants {
+		if deny.hasCondition {
+			continue
+		}
 		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(input.principalARN, deny.principalARN, deny.wildcardPrincipal) {
 			continue
 		}
@@ -543,6 +547,7 @@ func awsCrossAccountTrustDenyGrantsFromS3(grants []AWSS3IdentityGrant) []awsCros
 				wildcardPrincipal: grant.WildcardPrincipal,
 				actions:           grant.Actions,
 				notAction:         grant.NotAction,
+				hasCondition:      grant.HasCondition || len(grant.ConditionKeys) > 0,
 			})
 		}
 	}
@@ -559,6 +564,7 @@ func awsCrossAccountTrustDenyGrantsFromKMS(grants []AWSKMSIdentityGrant) []awsCr
 				actions:           grant.Actions,
 				capabilities:      grant.Capabilities,
 				notAction:         grant.NotAction,
+				hasCondition:      grant.HasCondition || len(grant.ConditionKeys) > 0,
 			})
 		}
 	}
@@ -573,6 +579,7 @@ func awsCrossAccountTrustDenyGrantsFromSecrets(grants []AWSSecretsManagerIdentit
 				principalARN:      grant.PrincipalARN,
 				wildcardPrincipal: grant.WildcardPrincipal,
 				actions:           grant.Actions,
+				hasCondition:      grant.HasCondition || len(grant.ConditionKeys) > 0,
 			})
 		}
 	}
@@ -589,6 +596,7 @@ func awsCrossAccountTrustDenyGrantsFromSQSSNS(grants []AWSSQSSNSIdentityGrant) [
 				actions:           grant.Actions,
 				capabilities:      grant.Capabilities,
 				notAction:         grant.NotAction,
+				hasCondition:      grant.HasCondition || len(grant.ConditionKeys) > 0,
 			})
 		}
 	}
@@ -605,6 +613,7 @@ func awsCrossAccountTrustDenyGrantsFromDynamoRDS(grants []AWSDynamoDBRDSIdentity
 				actions:           grant.Actions,
 				capabilities:      grant.Capabilities,
 				notAction:         grant.NotAction,
+				hasCondition:      grant.HasCondition || len(grant.ConditionKeys) > 0,
 			})
 		}
 	}

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -291,7 +291,7 @@ func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspa
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust dynamodb/rds reachability: %w", err)
 	}
-	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "api-call"})
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "sts-session"})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust runtime events: %w", err)
 	}

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -1,0 +1,958 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsCrossAccountTrustCurrentIssue = 1526
+	awsCrossAccountTrustVersion      = "aws-cross-account-trust-engine-v1"
+)
+
+// AWSCrossAccountTrustRequest scopes the read-only external-access reasoning
+// engine to an AWS connector and optional operator drill-down filters.
+type AWSCrossAccountTrustRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Service      string `json:"service,omitempty"`
+	Principal    string `json:"principal,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	FindingType  string `json:"finding_type,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+	OU           string `json:"ou,omitempty"`
+}
+
+type AWSCrossAccountTrustEvidence = AWSLeastPrivilegeEvidence
+type AWSCrossAccountTrustPathStep = AWSLeastPrivilegePathStep
+type AWSCrossAccountTrustRemediationCasePreview = AWSLeastPrivilegeRemediationCasePreview
+type AWSCrossAccountTrustDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSCrossAccountTrustCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSCrossAccountTrustRelationship lets graph consumers join a finding back to
+// the external principal, affected resource, and source evidence.
+type AWSCrossAccountTrustRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSCrossAccountTrustFinding is the deterministic, metadata-only decision
+// shape for public principals, cross-account grants, Access Analyzer external
+// access, runtime STS assumptions, and cross-account graph paths.
+type AWSCrossAccountTrustFinding struct {
+	FindingID                 string                                     `json:"finding_id"`
+	CalculationVersion        string                                     `json:"calculation_version"`
+	FindingType               string                                     `json:"finding_type"`
+	Severity                  string                                     `json:"severity"`
+	Status                    string                                     `json:"status"`
+	Score                     int                                        `json:"score"`
+	Confidence                float64                                    `json:"confidence"`
+	AccountID                 string                                     `json:"account_id"`
+	Region                    string                                     `json:"region"`
+	Service                   string                                     `json:"service"`
+	ResourceType              string                                     `json:"resource_type"`
+	ResourceARN               string                                     `json:"resource_arn,omitempty"`
+	ResourceNodeID            string                                     `json:"resource_node_id,omitempty"`
+	ResourceLabel             string                                     `json:"resource_label"`
+	ExternalPrincipalARN      string                                     `json:"external_principal_arn,omitempty"`
+	ExternalPrincipalAccount  string                                     `json:"external_principal_account,omitempty"`
+	ExternalPrincipalOUPath   string                                     `json:"external_principal_ou_path,omitempty"`
+	TrustedWithinOrganization bool                                       `json:"trusted_within_organization"`
+	PublicPrincipal           bool                                       `json:"public_principal"`
+	HasCondition              bool                                       `json:"has_condition"`
+	ConditionKeys             []string                                   `json:"condition_keys,omitempty"`
+	PolicySources             []string                                   `json:"policy_sources,omitempty"`
+	RuntimeObserved           bool                                       `json:"runtime_observed"`
+	AnalyzerBacked            bool                                       `json:"analyzer_backed"`
+	Rationale                 string                                     `json:"rationale"`
+	HardeningDirection        string                                     `json:"hardening_direction"`
+	ImpactedNodes             []string                                   `json:"impacted_nodes"`
+	ImpactedPath              []AWSCrossAccountTrustPathStep             `json:"impacted_path"`
+	Evidence                  []AWSCrossAccountTrustEvidence             `json:"evidence"`
+	NextAction                string                                     `json:"next_action"`
+	RemediationCase           AWSCrossAccountTrustRemediationCasePreview `json:"remediation_case"`
+	CreatedAt                 time.Time                                  `json:"created_at"`
+	UpdatedAt                 time.Time                                  `json:"updated_at"`
+}
+
+type AWSCrossAccountTrustSummary struct {
+	TotalFindings           int            `json:"total_findings"`
+	FilteredFindings        int            `json:"filtered_findings"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	FindingTypeCounts       map[string]int `json:"finding_type_counts"`
+	ServiceCounts           map[string]int `json:"service_counts"`
+	CriticalCount           int            `json:"critical_count"`
+	HighCount               int            `json:"high_count"`
+	PublicPrincipalCount    int            `json:"public_principal_count"`
+	CrossAccountGrantCount  int            `json:"cross_account_grant_count"`
+	RuntimeObservedCount    int            `json:"runtime_observed_count"`
+	AnalyzerBackedCount     int            `json:"analyzer_backed_count"`
+	UnconditionalGrantCount int            `json:"unconditional_grant_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+	RemediationPreviewCount int            `json:"remediation_preview_count"`
+}
+
+// AWSCrossAccountTrustResult is the deterministic cross-account trust envelope.
+type AWSCrossAccountTrustResult struct {
+	TenantID           string                             `json:"tenant_id"`
+	WorkspaceID        string                             `json:"workspace_id"`
+	ProjectID          string                             `json:"project_id"`
+	ConnectorID        string                             `json:"connector_id,omitempty"`
+	AccountID          string                             `json:"account_id,omitempty"`
+	Region             string                             `json:"region,omitempty"`
+	ParentIssueNumber  int                                `json:"parent_issue_number"`
+	ParentIssueRef     string                             `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                `json:"current_issue_number"`
+	CurrentIssueRef    string                             `json:"current_issue_ref"`
+	Version            string                             `json:"version"`
+	Status             string                             `json:"status"`
+	FixtureState       string                             `json:"fixture_state,omitempty"`
+	Confidence         float64                            `json:"confidence"`
+	CalculationVersion string                             `json:"calculation_version"`
+	AppliedFilters     map[string]string                  `json:"applied_filters"`
+	Summary            AWSCrossAccountTrustSummary        `json:"summary"`
+	Findings           []AWSCrossAccountTrustFinding      `json:"findings"`
+	Relationships      []AWSCrossAccountTrustRelationship `json:"relationships"`
+	Caveats            []string                           `json:"caveats"`
+	FailureReasons     []string                           `json:"failure_reasons"`
+	RemediationHints   []string                           `json:"remediation_hints"`
+	EvidenceLinks      []string                           `json:"evidence_links"`
+	CoverageGaps       []AWSCrossAccountTrustCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSCrossAccountTrustDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                          `json:"generated_at"`
+	UpdatedAt          time.Time                          `json:"updated_at"`
+}
+
+type awsCrossAccountTrustSources struct {
+	organizations AWSOrganizationsTopologyResult
+	s3            AWSS3BucketReachabilityInventoryResult
+	kms           AWSKMSDecryptReachabilityInventoryResult
+	secrets       AWSSecretsManagerMetadataInventoryResult
+	sqsSNS        AWSSQSSNSReachabilityInventoryResult
+	dynamoRDS     AWSDynamoDBRDSReachabilityInventoryResult
+	runtime       AWSRuntimeEventResult
+	least         AWSLeastPrivilegeResult
+	blast         AWSBlastRadiusResult
+}
+
+type awsCrossAccountTrustGrantInput struct {
+	source            string
+	service           string
+	resourceType      string
+	resourceARN       string
+	resourceNodeID    string
+	resourceLabel     string
+	accountID         string
+	region            string
+	principalARN      string
+	effect            string
+	actions           []string
+	capabilities      []string
+	conditionKeys     []string
+	hasCondition      bool
+	publicPrincipal   bool
+	crossAccount      bool
+	wildcardPrincipal bool
+	statementSid      string
+	evidenceRef       string
+	confidence        float64
+	observedAt        time.Time
+	status            string
+}
+
+func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID string, projectID string, request AWSCrossAccountTrustRequest) (AWSCrossAccountTrustResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSCrossAccountTrustResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSCrossAccountTrustResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSCrossAccountTrustFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSCrossAccountTrustResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsCrossAccountTrustSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSCrossAccountTrustResult{}, err
+	}
+	findings := awsCrossAccountTrustFindings(sources, now)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSCrossAccountTrustFindings(findings, request)
+	relationships := awsCrossAccountTrustRelationships(filtered)
+	diagnostics := awsCrossAccountTrustDiagnostics(sources)
+	coverageGaps := awsCrossAccountTrustCoverageGaps(sources)
+	status, confidence := summarizeAWSCrossAccountTrustStatus(sources, diagnostics)
+
+	return AWSCrossAccountTrustResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsCrossAccountTrustCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsCrossAccountTrustCurrentIssue),
+		Version:            awsCrossAccountTrustVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsCrossAccountTrustVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSCrossAccountTrust(findings, filtered, relationships),
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsCrossAccountTrustCaveats(),
+		FailureReasons:     awsCrossAccountTrustFailureReasons(sources),
+		RemediationHints:   awsCrossAccountTrustRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsCrossAccountTrustCurrentIssue),
+			awsIssueURL(awsOrganizationsTopologyCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			"/docs/aws-cross-account-trust-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSCrossAccountTrustFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsCrossAccountTrustSources, error) {
+	organizations, err := s.GetAWSOrganizationsTopology(ctx, workspaceID, projectID, AWSOrganizationsTopologyRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust organizations topology: %w", err)
+	}
+	s3, err := s.GetAWSS3BucketReachabilityInventory(ctx, workspaceID, projectID, AWSS3BucketReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust s3 reachability: %w", err)
+	}
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust kms reachability: %w", err)
+	}
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust secrets metadata: %w", err)
+	}
+	sqsSNS, err := s.GetAWSSQSSNSReachabilityInventory(ctx, workspaceID, projectID, AWSSQSSNSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust sqs/sns reachability: %w", err)
+	}
+	dynamoRDS, err := s.GetAWSDynamoDBRDSReachabilityInventory(ctx, workspaceID, projectID, AWSDynamoDBRDSReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust dynamodb/rds reachability: %w", err)
+	}
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "api-call"})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust runtime events: %w", err)
+	}
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust least privilege: %w", err)
+	}
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust blast radius: %w", err)
+	}
+	return awsCrossAccountTrustSources{organizations: organizations, s3: s3, kms: kms, secrets: secrets, sqsSNS: sqsSNS, dynamoRDS: dynamoRDS, runtime: runtime, least: least, blast: blast}, nil
+}
+
+func awsCrossAccountTrustFindings(sources awsCrossAccountTrustSources, now time.Time) []AWSCrossAccountTrustFinding {
+	accounts := awsCrossAccountTrustOrganizationAccounts(sources.organizations)
+	findings := []AWSCrossAccountTrustFinding{}
+	for _, record := range sources.s3.Records {
+		for _, grant := range record.IdentityGrants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "s3_bucket_reachability", service: "s3", resourceType: "s3_bucket", resourceARN: record.BucketARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.BucketName, record.BucketARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+	}
+	for _, record := range sources.kms.Records {
+		for _, grant := range record.IdentityGrants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "kms_decrypt_reachability", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+		for _, grant := range record.Grants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "kms_live_grant", service: "kms", resourceType: "kms_key", resourceARN: record.KeyARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.Description, firstString(record.Aliases), record.KeyARN, record.KeyID), accountID: record.AccountID, region: record.Region, principalARN: grant.GranteePrincipal, effect: "Allow", actions: grant.Operations, capabilities: grant.Capabilities, conditionKeys: append(append([]string{}, grant.EncryptionContextKeys...), grant.EncryptionContextSubsetKeys...), hasCondition: grant.HasConstraints, crossAccount: grant.IsCrossAccount, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+	}
+	for _, record := range sources.secrets.Records {
+		for _, grant := range record.IdentityGrants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "secrets_manager_metadata", service: "secretsmanager", resourceType: "secret", resourceARN: record.SecretARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.SecretName, record.SecretARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+	}
+	for _, record := range sources.sqsSNS.Records {
+		for _, grant := range record.IdentityGrants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "sqs_sns_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+	}
+	for _, record := range sources.dynamoRDS.Records {
+		for _, grant := range record.IdentityGrants {
+			findings = append(findings, awsCrossAccountTrustFindingFromGrant(awsCrossAccountTrustGrantInput{
+				source: "dynamodb_rds_reachability", service: record.Service, resourceType: record.ResourceType, resourceARN: record.ResourceARN, resourceNodeID: record.FromNodeID, resourceLabel: firstNonEmptyAWSValue(record.ResourceName, record.ResourceARN), accountID: record.AccountID, region: record.Region, principalARN: grant.PrincipalARN, effect: grant.Effect, actions: grant.Actions, capabilities: grant.Capabilities, conditionKeys: grant.ConditionKeys, hasCondition: grant.HasCondition, publicPrincipal: grant.IsPublic, crossAccount: grant.IsCrossAccount, wildcardPrincipal: grant.WildcardPrincipal, statementSid: grant.StatementSid, evidenceRef: record.EvidenceRef, confidence: record.Confidence, observedAt: record.CollectedAt, status: record.Status,
+			}, accounts, now)...)
+		}
+	}
+	for _, record := range sources.runtime.Records {
+		if finding, ok := awsCrossAccountTrustFindingFromRuntimeAssumption(record, accounts, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+	for _, recommendation := range sources.least.Recommendations {
+		if finding, ok := awsCrossAccountTrustFindingFromLeastPrivilege(recommendation, accounts, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+	for _, finding := range sources.blast.Findings {
+		if trustFinding, ok := awsCrossAccountTrustFindingFromBlastRadius(finding, accounts, now); ok {
+			findings = append(findings, trustFinding)
+		}
+	}
+	return awsCrossAccountTrustDedupeFindings(findings)
+}
+
+func awsCrossAccountTrustFindingFromGrant(input awsCrossAccountTrustGrantInput, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) []AWSCrossAccountTrustFinding {
+	if !strings.EqualFold(firstNonEmptyAWSValue(input.effect, "Allow"), "Allow") {
+		return nil
+	}
+	input.publicPrincipal = input.publicPrincipal || input.wildcardPrincipal || strings.TrimSpace(input.principalARN) == "*"
+	input.crossAccount = input.crossAccount || awsCrossAccountTrustPrincipalIsExternal(input.principalARN, input.accountID)
+	if !input.publicPrincipal && !input.crossAccount {
+		return nil
+	}
+	kind := "cross_account_resource_access"
+	score := 78
+	if input.publicPrincipal {
+		kind = "public_resource_trust"
+		score = 88
+	}
+	if !input.hasCondition {
+		score += 8
+	}
+	score = clampBlastRadiusScore(score)
+	principalAccount := awsCrossAccountTrustPrincipalAccount(input.principalARN)
+	accountContext := accounts[principalAccount]
+	status := "review"
+	if score >= 88 {
+		status = "action_required"
+	}
+	principalLabel := firstNonEmptyAWSValue(shortAWSARN(input.principalARN), input.principalARN, "public principal")
+	resourceLabel := firstNonEmptyAWSValue(input.resourceLabel, input.resourceARN, input.resourceNodeID)
+	evidenceRef := firstNonEmptyAWSValue(input.evidenceRef, fmt.Sprintf("%s://%s", input.source, stableAWSBlastRadiusToken(input.resourceARN, input.principalARN)))
+	policySources := dedupeStrings(append(append([]string{}, input.actions...), input.capabilities...))
+	if input.statementSid != "" {
+		policySources = append(policySources, input.statementSid)
+	}
+	nextAction := "Confirm the external principal owner, then restrict the resource policy to approved account, principal, condition, and organization boundaries."
+	if input.publicPrincipal {
+		nextAction = "Remove wildcard public trust or add a narrow principal plus required condition before approving downstream remediation."
+	}
+	finding := AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:" + stableAWSBlastRadiusToken(kind, input.resourceARN, input.principalARN, strings.Join(policySources, ",")),
+		CalculationVersion:        awsCrossAccountTrustVersion,
+		FindingType:               kind,
+		Severity:                  awsPrivilegeEscalationSeverity(score),
+		Status:                    status,
+		Score:                     score,
+		Confidence:                minFloat(firstNonZeroFloat(input.confidence, 0.86), 0.94),
+		AccountID:                 input.accountID,
+		Region:                    input.region,
+		Service:                   firstNonEmptyAWSValue(input.service, serviceFromAWSAction(firstString(input.actions))),
+		ResourceType:              input.resourceType,
+		ResourceARN:               input.resourceARN,
+		ResourceNodeID:            input.resourceNodeID,
+		ResourceLabel:             resourceLabel,
+		ExternalPrincipalARN:      input.principalARN,
+		ExternalPrincipalAccount:  principalAccount,
+		ExternalPrincipalOUPath:   accountContext.OUPath,
+		TrustedWithinOrganization: accountContext.AccountID != "",
+		PublicPrincipal:           input.publicPrincipal,
+		HasCondition:              input.hasCondition,
+		ConditionKeys:             dedupeStrings(input.conditionKeys),
+		PolicySources:             policySources,
+		Rationale:                 fmt.Sprintf("%s %q trusts %s through %s with condition=%t.", strings.ToUpper(firstNonEmptyAWSValue(input.service, "resource")), resourceLabel, principalLabel, strings.Join(policySources, ", "), input.hasCondition),
+		HardeningDirection:        awsCrossAccountTrustHardeningDirection(input.publicPrincipal, input.hasCondition, accountContext.AccountID != ""),
+		ImpactedNodes:             dedupeStrings([]string{awsIdentityNodeIDForAPI(input.principalARN), input.resourceNodeID}),
+		ImpactedPath: []AWSCrossAccountTrustPathStep{
+			awsLeastPrivilegePathStep(awsIdentityNodeIDForAPI(input.principalARN), "external_principal", principalLabel, principalAccount, input.region),
+			awsLeastPrivilegePathStep(input.resourceNodeID, input.resourceType, resourceLabel, input.accountID, input.region),
+		},
+		Evidence:        []AWSCrossAccountTrustEvidence{{Source: input.source, EvidenceRef: evidenceRef, Label: "External resource trust", Confidence: input.confidence, ObservedAt: input.observedAt, Relationship: kind}},
+		NextAction:      nextAction,
+		RemediationCase: awsCrossAccountTrustRemediationCase(kind, status, score, awsIdentityNodeIDForAPI(input.principalARN), []string{evidenceRef}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	return []AWSCrossAccountTrustFinding{finding}
+}
+
+func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventRecord, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {
+	if !strings.EqualFold(record.Action, "sts:AssumeRole") && !strings.EqualFold(record.EventName, "AssumeRole") {
+		return AWSCrossAccountTrustFinding{}, false
+	}
+	targetARN := firstNonEmptyAWSValue(record.Session.AssumedRoleARN, record.TargetResourceARN)
+	targetAccount := awsCrossAccountTrustPrincipalAccount(targetARN)
+	actorAccount := awsCrossAccountTrustPrincipalAccount(firstNonEmptyAWSValue(record.Session.OriginalActorARN, record.ActorPrincipalARN))
+	if targetAccount == "" || actorAccount == "" || targetAccount == actorAccount {
+		return AWSCrossAccountTrustFinding{}, false
+	}
+	accountContext := accounts[actorAccount]
+	score := 82
+	if record.Session.SourceIdentity == "" {
+		score += 6
+	}
+	score = clampBlastRadiusScore(score)
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))
+	principal := firstNonEmptyAWSValue(record.Session.OriginalActorARN, record.ActorPrincipalARN)
+	return AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:" + stableAWSBlastRadiusToken("runtime_cross_account_assumption", record.EventID, principal, targetARN),
+		CalculationVersion:        awsCrossAccountTrustVersion,
+		FindingType:               "runtime_cross_account_assumption",
+		Severity:                  awsPrivilegeEscalationSeverity(score),
+		Status:                    awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:                     score,
+		Confidence:                minFloat(record.Confidence, 0.92),
+		AccountID:                 targetAccount,
+		Region:                    record.Region,
+		Service:                   "sts",
+		ResourceType:              "iam_role",
+		ResourceARN:               targetARN,
+		ResourceNodeID:            firstNonEmptyAWSValue(record.ResourceNodeID, awsIdentityNodeIDForAPI(targetARN)),
+		ResourceLabel:             firstNonEmptyAWSValue(shortAWSARN(targetARN), targetARN),
+		ExternalPrincipalARN:      principal,
+		ExternalPrincipalAccount:  actorAccount,
+		ExternalPrincipalOUPath:   accountContext.OUPath,
+		TrustedWithinOrganization: accountContext.AccountID != "",
+		HasCondition:              record.Session.SourceIdentity != "",
+		ConditionKeys:             awsCrossAccountTrustRuntimeConditionKeys(record),
+		RuntimeObserved:           true,
+		Rationale:                 fmt.Sprintf("Runtime evidence shows %s assuming %s across accounts.", firstNonEmptyAWSValue(shortAWSARN(principal), principal), firstNonEmptyAWSValue(shortAWSARN(targetARN), targetARN)),
+		HardeningDirection:        "Review trust policy principal scope, source identity, external ID, and session-tag requirements for this observed cross-account assumption.",
+		ImpactedNodes:             dedupeStrings([]string{awsIdentityNodeIDForAPI(principal), awsIdentityNodeIDForAPI(targetARN)}),
+		ImpactedPath: []AWSCrossAccountTrustPathStep{
+			awsLeastPrivilegePathStep(awsIdentityNodeIDForAPI(principal), "external_principal", firstNonEmptyAWSValue(shortAWSARN(principal), principal), actorAccount, record.Region),
+			awsLeastPrivilegePathStep(awsIdentityNodeIDForAPI(targetARN), "iam_role", firstNonEmptyAWSValue(shortAWSARN(targetARN), targetARN), targetAccount, record.Region),
+		},
+		Evidence:        []AWSCrossAccountTrustEvidence{{Source: "runtime_events", EvidenceRef: evidenceRef, Label: "Observed STS AssumeRole", Confidence: record.Confidence, ObservedAt: record.ObservedAt, Relationship: "runtime_cross_account_assumption"}},
+		NextAction:      "Confirm the session owner and add required trust-policy conditions before approving automated hardening.",
+		RemediationCase: awsCrossAccountTrustRemediationCase("runtime-cross-account-assumption", "action_required", score, awsIdentityNodeIDForAPI(principal), []string{evidenceRef}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}, true
+}
+
+func awsCrossAccountTrustFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {
+	if normalizeAWSRuntimeEventFilterToken(recommendation.RecommendationType) != "review-external-access" {
+		return AWSCrossAccountTrustFinding{}, false
+	}
+	principalAccount := awsCrossAccountTrustPrincipalAccount(recommendation.PrincipalARN)
+	accountContext := accounts[principalAccount]
+	evidenceRef := firstString(awsCrossAccountTrustEvidenceRefs([]AWSCrossAccountTrustEvidence(recommendation.Evidence)))
+	if evidenceRef == "" {
+		evidenceRef = "least-privilege://" + recommendation.RecommendationID
+	}
+	score := clampBlastRadiusScore(recommendation.Score + 4)
+	return AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:" + stableAWSBlastRadiusToken("access_analyzer_external_access", recommendation.RecommendationID),
+		CalculationVersion:        awsCrossAccountTrustVersion,
+		FindingType:               "access_analyzer_external_access",
+		Severity:                  awsPrivilegeEscalationSeverity(score),
+		Status:                    recommendation.Status,
+		Score:                     score,
+		Confidence:                recommendation.Confidence,
+		AccountID:                 recommendation.AccountID,
+		Region:                    recommendation.Region,
+		Service:                   recommendation.Service,
+		ResourceType:              firstNonEmptyAWSValue(recommendation.Service, "resource"),
+		ResourceARN:               recommendation.ResourceARN,
+		ResourceNodeID:            recommendation.ResourceNodeID,
+		ResourceLabel:             firstNonEmptyAWSValue(recommendation.ResourceARN, recommendation.ResourceNodeID, recommendation.Service),
+		ExternalPrincipalARN:      recommendation.PrincipalARN,
+		ExternalPrincipalAccount:  principalAccount,
+		ExternalPrincipalOUPath:   accountContext.OUPath,
+		TrustedWithinOrganization: accountContext.AccountID != "",
+		PolicySources:             recommendation.GrantedActions,
+		AnalyzerBacked:            true,
+		Rationale:                 recommendation.Rationale,
+		HardeningDirection:        "Validate Access Analyzer scope and expected external principal, then narrow or remove the external-access grant.",
+		ImpactedNodes:             recommendation.ImpactedNodes,
+		ImpactedPath:              []AWSCrossAccountTrustPathStep(recommendation.ImpactedPath),
+		Evidence:                  []AWSCrossAccountTrustEvidence(recommendation.Evidence),
+		NextAction:                recommendation.NextAction,
+		RemediationCase:           awsCrossAccountTrustRemediationCase("access-analyzer-external-access", recommendation.Status, score, recommendation.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:                 now,
+		UpdatedAt:                 now,
+	}, true
+}
+
+func awsCrossAccountTrustFindingFromBlastRadius(finding AWSBlastRadiusFinding, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {
+	if len(finding.CrossAccountEdges) == 0 {
+		return AWSCrossAccountTrustFinding{}, false
+	}
+	principalAccount := awsCrossAccountTrustPrincipalAccount(finding.PrincipalARN)
+	accountContext := accounts[principalAccount]
+	evidenceRef := firstEvidenceRef(finding.Evidence)
+	score := clampBlastRadiusScore(finding.Score + 3)
+	return AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:" + stableAWSBlastRadiusToken("cross_account_graph_path", finding.FindingID),
+		CalculationVersion:        awsCrossAccountTrustVersion,
+		FindingType:               "cross_account_graph_path",
+		Severity:                  awsPrivilegeEscalationSeverity(score),
+		Status:                    finding.Status,
+		Score:                     score,
+		Confidence:                finding.Confidence,
+		AccountID:                 finding.AccountID,
+		Region:                    finding.Region,
+		Service:                   firstNonEmptyAWSValue(serviceFromAWSAction(firstString(finding.RuntimeActions)), "aws"),
+		ResourceType:              "graph_path",
+		ResourceNodeID:            lastString(finding.ImpactedNodes),
+		ResourceLabel:             firstNonEmptyAWSValue(lastString(finding.ImpactedNodes), finding.RiskType),
+		ExternalPrincipalARN:      finding.PrincipalARN,
+		ExternalPrincipalAccount:  principalAccount,
+		ExternalPrincipalOUPath:   accountContext.OUPath,
+		TrustedWithinOrganization: accountContext.AccountID != "",
+		RuntimeObserved:           true,
+		Rationale:                 finding.Rationale,
+		HardeningDirection:        "Review the cross-account graph edge and narrow the upstream trust, resource grant, or runtime path that created it.",
+		ImpactedNodes:             finding.ImpactedNodes,
+		ImpactedPath:              awsCrossAccountTrustPathFromBlastRadius(finding.ImpactedPath),
+		Evidence:                  awsCrossAccountTrustEvidenceFromBlastRadius(finding.Evidence),
+		NextAction:                finding.NextAction,
+		RemediationCase:           awsCrossAccountTrustRemediationCase("cross-account-graph-path", finding.Status, score, finding.IdentityNodeID, []string{evidenceRef}),
+		CreatedAt:                 now,
+		UpdatedAt:                 now,
+	}, true
+}
+
+func awsCrossAccountTrustDedupeFindings(findings []AWSCrossAccountTrustFinding) []AWSCrossAccountTrustFinding {
+	seen := map[string]AWSCrossAccountTrustFinding{}
+	for _, finding := range findings {
+		if finding.FindingID == "" {
+			continue
+		}
+		if existing, ok := seen[finding.FindingID]; ok && existing.Score >= finding.Score {
+			continue
+		}
+		seen[finding.FindingID] = finding
+	}
+	out := make([]AWSCrossAccountTrustFinding, 0, len(seen))
+	for _, finding := range seen {
+		out = append(out, finding)
+	}
+	return out
+}
+
+func filterAWSCrossAccountTrustFindings(findings []AWSCrossAccountTrustFinding, request AWSCrossAccountTrustRequest) ([]AWSCrossAccountTrustFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id":   strings.TrimSpace(request.AccountID),
+		"region":       strings.TrimSpace(request.Region),
+		"service":      normalizeAWSRuntimeEventFilterToken(request.Service),
+		"principal":    strings.TrimSpace(request.Principal),
+		"resource":     strings.TrimSpace(request.Resource),
+		"finding_type": normalizeAWSRuntimeEventFilterToken(request.FindingType),
+		"severity":     normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":       normalizeAWSRuntimeEventFilterToken(request.Status),
+		"ou":           strings.TrimSpace(request.OU),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	filtered := make([]AWSCrossAccountTrustFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && !awsRuntimeEventMatchesAny(filters["account_id"], finding.AccountID) {
+			continue
+		}
+		if filters["region"] != "" && !awsRuntimeEventMatchesAny(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["service"] != "" && normalizeAWSRuntimeEventFilterToken(finding.Service) != filters["service"] {
+			continue
+		}
+		if filters["principal"] != "" && !awsRuntimeEventMatchesAny(filters["principal"], finding.ExternalPrincipalARN, finding.ExternalPrincipalAccount, finding.ExternalPrincipalOUPath) {
+			continue
+		}
+		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], finding.ResourceARN, finding.ResourceNodeID, finding.ResourceLabel) {
+			continue
+		}
+		if filters["finding_type"] != "" && normalizeAWSRuntimeEventFilterToken(finding.FindingType) != filters["finding_type"] {
+			continue
+		}
+		if filters["severity"] != "" && normalizeAWSRuntimeEventFilterToken(finding.Severity) != filters["severity"] {
+			continue
+		}
+		if filters["status"] != "" && normalizeAWSRuntimeEventFilterToken(finding.Status) != filters["status"] {
+			continue
+		}
+		if filters["ou"] != "" && !awsRuntimeEventMatchesAny(filters["ou"], finding.ExternalPrincipalOUPath) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, filters
+}
+
+func awsCrossAccountTrustRelationships(findings []AWSCrossAccountTrustFinding) []AWSCrossAccountTrustRelationship {
+	relationships := []AWSCrossAccountTrustRelationship{}
+	for _, finding := range findings {
+		evidenceRef := firstString(awsCrossAccountTrustEvidenceRefs(finding.Evidence))
+		for i := 1; i < len(finding.ImpactedPath); i++ {
+			from := strings.TrimSpace(finding.ImpactedPath[i-1].NodeID)
+			to := strings.TrimSpace(finding.ImpactedPath[i].NodeID)
+			if from == "" || to == "" || from == "*" || to == "*" {
+				continue
+			}
+			relationships = append(relationships, AWSCrossAccountTrustRelationship{FindingID: finding.FindingID, Type: "cross_account_trust_path", FromNodeID: from, ToNodeID: to, EvidenceRef: evidenceRef})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSCrossAccountTrust(allFindings []AWSCrossAccountTrustFinding, filtered []AWSCrossAccountTrustFinding, relationships []AWSCrossAccountTrustRelationship) AWSCrossAccountTrustSummary {
+	severityCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	typeCounts := map[string]int{}
+	serviceCounts := map[string]int{}
+	totalConfidence := 0.0
+	highest := 0
+	publicCount := 0
+	runtimeCount := 0
+	analyzerCount := 0
+	unconditionalCount := 0
+	for _, finding := range filtered {
+		severityCounts[finding.Severity]++
+		statusCounts[finding.Status]++
+		typeCounts[finding.FindingType]++
+		serviceCounts[finding.Service]++
+		totalConfidence += finding.Confidence
+		if finding.Score > highest {
+			highest = finding.Score
+		}
+		if finding.PublicPrincipal {
+			publicCount++
+		}
+		if finding.RuntimeObserved {
+			runtimeCount++
+		}
+		if finding.AnalyzerBacked {
+			analyzerCount++
+		}
+		if !finding.HasCondition && (finding.FindingType == "cross_account_resource_access" || finding.FindingType == "public_resource_trust") {
+			unconditionalCount++
+		}
+	}
+	avg := 0
+	if len(filtered) > 0 {
+		avg = int((totalConfidence / float64(len(filtered))) * 100)
+	}
+	return AWSCrossAccountTrustSummary{
+		TotalFindings:           len(allFindings),
+		FilteredFindings:        len(filtered),
+		SeverityCounts:          severityCounts,
+		StatusCounts:            statusCounts,
+		FindingTypeCounts:       typeCounts,
+		ServiceCounts:           serviceCounts,
+		CriticalCount:           severityCounts["critical"],
+		HighCount:               severityCounts["high"],
+		PublicPrincipalCount:    publicCount,
+		CrossAccountGrantCount:  typeCounts["cross_account_resource_access"],
+		RuntimeObservedCount:    runtimeCount,
+		AnalyzerBackedCount:     analyzerCount,
+		UnconditionalGrantCount: unconditionalCount,
+		RelationshipCount:       len(relationships),
+		HighestScore:            highest,
+		AverageConfidencePct:    avg,
+		RemediationPreviewCount: len(filtered),
+	}
+}
+
+func summarizeAWSCrossAccountTrustStatus(sources awsCrossAccountTrustSources, diagnostics []AWSCrossAccountTrustDiagnostic) (string, float64) {
+	if awsCrossAccountTrustSourcesAreEmptyFixtures(sources) && len(diagnostics) == 0 {
+		return "ready", 0.9
+	}
+	statuses := []string{sources.organizations.Status, sources.s3.Status, sources.kms.Status, sources.secrets.Status, sources.sqsSNS.Status, sources.dynamoRDS.Status, sources.runtime.Status, sources.least.Status, sources.blast.Status}
+	blocked := 0
+	for _, status := range statuses {
+		switch normalizeAWSRuntimeEventFilterToken(status) {
+		case "blocked", "permission-denied":
+			blocked++
+		case "degraded", "partial-failure", "capability-unavailable":
+			return "degraded", 0.68
+		}
+	}
+	if blocked == len(statuses) {
+		return "blocked", 0
+	}
+	if blocked > 0 || len(diagnostics) > 0 {
+		return "degraded", 0.72
+	}
+	return "ready", 0.9
+}
+
+func awsCrossAccountTrustSourcesAreEmptyFixtures(sources awsCrossAccountTrustSources) bool {
+	states := []string{
+		sources.organizations.FixtureState,
+		sources.s3.FixtureState,
+		sources.kms.FixtureState,
+		sources.secrets.FixtureState,
+		sources.sqsSNS.FixtureState,
+		sources.dynamoRDS.FixtureState,
+		sources.runtime.FixtureState,
+		sources.least.FixtureState,
+		sources.blast.FixtureState,
+	}
+	for _, state := range states {
+		if normalizeAWSRuntimeEventFilterToken(state) != "empty" {
+			return false
+		}
+	}
+	return true
+}
+
+func awsCrossAccountTrustDiagnostics(sources awsCrossAccountTrustSources) []AWSCrossAccountTrustDiagnostic {
+	out := []AWSCrossAccountTrustDiagnostic{}
+	for _, diagnostic := range sources.organizations.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Source, SourceID: diagnostic.Scope, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.least.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range sources.blast.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range sources.runtime.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.s3.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.kms.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.secrets.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.sqsSNS.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	for _, diagnostic := range sources.dynamoRDS.Diagnostics {
+		out = append(out, AWSCrossAccountTrustDiagnostic{Collector: diagnostic.Collector, SourceID: diagnostic.SourceID, Code: diagnostic.Code, Message: diagnostic.Message, Remediation: diagnostic.Remediation, Retryable: diagnostic.Retryable})
+	}
+	return out
+}
+
+func awsCrossAccountTrustCoverageGaps(sources awsCrossAccountTrustSources) []AWSCrossAccountTrustCoverageGap {
+	out := []AWSCrossAccountTrustCoverageGap{{
+		Capability:  "raw_trust_policy_simulation",
+		Status:      "planned_downstream",
+		Reason:      "This engine reasons over normalized trust, resource-policy, runtime, Organizations, Access Analyzer, and graph evidence; it does not execute AWS mutations or policy simulation.",
+		Remediation: "Use the trust-policy hardening planner for approved remediation previews after this engine identifies candidate external access.",
+	}}
+	for _, gap := range sources.least.CoverageGaps {
+		out = append(out, AWSCrossAccountTrustCoverageGap(gap))
+	}
+	for _, gap := range sources.blast.CoverageGaps {
+		out = append(out, AWSCrossAccountTrustCoverageGap(gap))
+	}
+	for _, gap := range sources.runtime.CoverageGaps {
+		out = append(out, AWSCrossAccountTrustCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	return out
+}
+
+func awsCrossAccountTrustCaveats() []string {
+	return []string{
+		"Cross-account trust findings are inferred from metadata-only Organizations, resource policy, Access Analyzer, runtime, and graph evidence.",
+		"Unknown, unsupported, permission-denied, and partially failed evidence lowers confidence and is never treated as proof that external access is absent.",
+		"Remediation cases are read-only previews; this engine does not mutate trust policies, resource policies, SCPs, or customer payloads.",
+	}
+}
+
+func awsCrossAccountTrustFailureReasons(sources awsCrossAccountTrustSources) []string {
+	return emptyStrings(dedupeStrings(append(append(append(append(append(append(append(sources.organizations.FailureReasons, sources.s3.FailureReasons...), sources.kms.FailureReasons...), sources.secrets.FailureReasons...), sources.sqsSNS.FailureReasons...), sources.dynamoRDS.FailureReasons...), sources.runtime.FailureReasons...), append(sources.least.FailureReasons, sources.blast.FailureReasons...)...)))
+}
+
+func awsCrossAccountTrustRemediationHints(sources awsCrossAccountTrustSources) []string {
+	hints := append(append(append(append(append(append(append(sources.organizations.RemediationHints, sources.s3.RemediationHints...), sources.kms.RemediationHints...), sources.secrets.RemediationHints...), sources.sqsSNS.RemediationHints...), sources.dynamoRDS.RemediationHints...), sources.runtime.RemediationHints...), append(sources.least.RemediationHints, sources.blast.RemediationHints...)...)
+	hints = append(hints, "Review external principals against approved account, OU, external ID, and runtime-use evidence before creating trust-policy hardening cases.")
+	return emptyStrings(dedupeStrings(hints))
+}
+
+func awsCrossAccountTrustRemediationCase(kind, status string, score int, identityNodeID string, evidence []string) AWSCrossAccountTrustRemediationCasePreview {
+	return AWSCrossAccountTrustRemediationCasePreview{
+		CaseID:             "aws-cross-account-trust-preview:" + stableAWSBlastRadiusToken(kind, identityNodeID),
+		Title:              fmt.Sprintf("%s trust hardening", formatAWSBlastRadiusLabel(kind)),
+		RecommendedAction:  "Create an owner-approved trust/resource-policy hardening preview; do not mutate AWS until the external principal and evidence boundary are confirmed.",
+		ApprovalRequired:   status == "action_required" || score >= 72,
+		BlockingEvidence:   evidence,
+		ImpactedNodeCount:  1,
+		EstimatedRiskDrop:  minInt(score, 35),
+		BreakagePrediction: "unknown",
+		ReadOnlyProjection: true,
+	}
+}
+
+func awsCrossAccountTrustHardeningDirection(publicPrincipal, hasCondition, trustedWithinOrg bool) string {
+	switch {
+	case publicPrincipal && !hasCondition:
+		return "Replace wildcard trust with explicit principals and required conditions such as organization, external ID, source ARN, or source account."
+	case publicPrincipal:
+		return "Confirm every condition is expected, then replace wildcard trust with explicit approved principals where possible."
+	case trustedWithinOrg && !hasCondition:
+		return "Constrain same-organization external access to approved OU/account paths and add source-account or external-ID conditions."
+	case !hasCondition:
+		return "Add an external ID or equivalent source condition and narrow the principal to the approved external account or role."
+	default:
+		return "Validate the existing conditions and remove any unused external principal or action scope."
+	}
+}
+
+func awsCrossAccountTrustOrganizationAccounts(topology AWSOrganizationsTopologyResult) map[string]AWSOrganizationsTopologyAccount {
+	accounts := map[string]AWSOrganizationsTopologyAccount{}
+	for _, account := range topology.Accounts {
+		if strings.TrimSpace(account.AccountID) != "" {
+			accounts[account.AccountID] = account
+		}
+	}
+	return accounts
+}
+
+func awsCrossAccountTrustPrincipalIsExternal(principalARN string, ownerAccountID string) bool {
+	accountID := awsCrossAccountTrustPrincipalAccount(principalARN)
+	return accountID != "" && ownerAccountID != "" && accountID != ownerAccountID
+}
+
+func awsCrossAccountTrustPrincipalAccount(principalARN string) string {
+	parts := strings.Split(strings.TrimSpace(principalARN), ":")
+	if len(parts) > 4 && len(parts[4]) == 12 {
+		return parts[4]
+	}
+	token := strings.TrimSpace(principalARN)
+	if len(token) == 12 {
+		allDigits := true
+		for _, r := range token {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			return token
+		}
+	}
+	return ""
+}
+
+func awsCrossAccountTrustRuntimeConditionKeys(record AWSRuntimeEventRecord) []string {
+	keys := []string{}
+	if strings.TrimSpace(record.Session.SourceIdentity) != "" {
+		keys = append(keys, "sts:SourceIdentity")
+	}
+	if len(record.Session.SessionTagKeys) > 0 {
+		keys = append(keys, "aws:PrincipalTag")
+	}
+	return dedupeStrings(keys)
+}
+
+func awsCrossAccountTrustPathFromBlastRadius(path []AWSBlastRadiusPathStep) []AWSCrossAccountTrustPathStep {
+	out := make([]AWSCrossAccountTrustPathStep, 0, len(path))
+	for _, step := range path {
+		out = append(out, AWSCrossAccountTrustPathStep{
+			NodeID:    step.NodeID,
+			NodeType:  step.NodeType,
+			Label:     step.Label,
+			AccountID: step.AccountID,
+			Region:    step.Region,
+		})
+	}
+	return out
+}
+
+func awsCrossAccountTrustEvidenceFromBlastRadius(evidence []AWSBlastRadiusEvidence) []AWSCrossAccountTrustEvidence {
+	out := make([]AWSCrossAccountTrustEvidence, 0, len(evidence))
+	for _, item := range evidence {
+		out = append(out, AWSCrossAccountTrustEvidence{
+			Source:       item.Source,
+			EvidenceRef:  item.EvidenceRef,
+			Label:        item.Label,
+			Confidence:   item.Confidence,
+			ObservedAt:   item.ObservedAt,
+			Relationship: item.Relationship,
+		})
+	}
+	return out
+}
+
+func awsCrossAccountTrustEvidenceRefs(evidence []AWSCrossAccountTrustEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		out = append(out, item.EvidenceRef)
+	}
+	return out
+}
+
+func firstNonZeroFloat(values ...float64) float64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -204,8 +204,9 @@ func (s *Service) GetAWSCrossAccountTrust(ctx context.Context, workspaceID strin
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
 		sourceFixtureState = ""
 	}
+	suppressRuntimeFixtures := strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected
 
-	sources, err := s.awsCrossAccountTrustSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	sources, err := s.awsCrossAccountTrustSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState, suppressRuntimeFixtures)
 	if err != nil {
 		return AWSCrossAccountTrustResult{}, err
 	}
@@ -277,7 +278,7 @@ func normalizeAWSCrossAccountTrustFixtureState(requested string, connection AWSC
 	}
 }
 
-func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsCrossAccountTrustSources, error) {
+func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string, suppressRuntimeFixtures bool) (awsCrossAccountTrustSources, error) {
 	organizations, err := s.GetAWSOrganizationsTopology(ctx, workspaceID, projectID, AWSOrganizationsTopologyRequest{ConnectorID: connectorID, FixtureState: fixtureState})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust organizations topology: %w", err)
@@ -302,7 +303,7 @@ func (s *Service) awsCrossAccountTrustSourceSignals(ctx context.Context, workspa
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust dynamodb/rds reachability: %w", err)
 	}
-	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "sts-session"})
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{ConnectorID: connectorID, FixtureState: fixtureState, EventType: "sts-session", SuppressFixtureRecords: suppressRuntimeFixtures})
 	if err != nil {
 		return awsCrossAccountTrustSources{}, fmt.Errorf("cross-account trust runtime events: %w", err)
 	}

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -336,3 +336,20 @@ func TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence(t *testing.T) 
 		t.Fatalf("expected live STS session to produce a runtime cross-account finding, got summary=%+v", result.Summary)
 	}
 }
+
+func TestGetAWSCrossAccountTrustSuppressesRuntimeFixturesForLiveRequests(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 25, 0, 0, time.UTC)
+	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust-no-runtime-fixtures", now)
+
+	result, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust-no-runtime-fixtures", AWSCrossAccountTrustRequest{
+		ConnectorID: "aws-prod",
+	})
+	if err != nil {
+		t.Fatalf("get cross-account trust: %v", err)
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingType == "runtime_cross_account_assumption" {
+			t.Fatalf("live request without CloudTrail ingester should not promote runtime fixtures: %+v", finding)
+		}
+	}
+}

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
 )
 
 func newCrossAccountTrustService(t *testing.T, project string, now time.Time) (*Service, string) {
@@ -171,5 +175,71 @@ func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
 	}
 	if !finding.HasCondition || len(finding.ConditionKeys) == 0 {
 		t.Fatalf("expected SourceIdentity to be surfaced as trust context, got %+v", finding)
+	}
+}
+
+func TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 20, 0, 0, time.UTC)
+	projectID := "project-cross-account-trust-live-runtime"
+	ctx := defaultScopeContext()
+	store := db.NewMemoryStore()
+	seedDefaultProject(t, store, ctx, projectID)
+	seedAWSConnectorForScanTest(t, store, ctx, projectID, "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, projectID, "aws-prod")
+
+	actorARN := "arn:aws:iam::111111111111:role/partner-deployer"
+	targetARN := "arn:aws:iam::222222222222:role/prod-deploy"
+	fake := &fakeCloudTrailIngester{result: AWSCloudTrailIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{{
+			EventID:             "evt-live-cross-account-assume",
+			AccountID:           "222222222222",
+			Region:              "us-east-1",
+			EventType:           "sts-session",
+			EventSource:         "sts.amazonaws.com",
+			EventName:           "AssumeRole",
+			Action:              "sts:AssumeRole",
+			ActorPrincipalARN:   actorARN,
+			ActorPrincipalType:  "assumed_role",
+			ActorIdentityNodeID: awsIdentityNodeIDForAPI(actorARN),
+			Session: AWSRuntimeEventSession{
+				SessionID:        "ASIAEXAMPLESESSION",
+				PrincipalARN:     actorARN,
+				AssumedRoleARN:   targetARN,
+				OriginalActorARN: actorARN,
+				SourceIdentity:   "partner-change-123",
+				StartedAt:        now.Add(-5 * time.Minute),
+			},
+			TargetResourceARN:  targetARN,
+			TargetResourceType: "AWS::IAM::Role",
+			TargetResourceName: "prod-deploy",
+			ResourceNodeID:     awsRuntimeEventResourceNodeID(targetARN, "AWS::IAM::Role"),
+			Owner:              "security",
+			EvidenceCategory:   "cloudtrail",
+			EvidenceRef:        "runtime-evidence://222222222222/us-east-1/evt-live-cross-account-assume",
+			Confidence:         0.9,
+			ObservedAt:         now.Add(-3 * time.Minute),
+			CollectedAt:        now,
+			Status:             "observed",
+			NextAction:         awsRuntimeEventNextAction("sts-session"),
+			RedactionBoundary:  "metadata_only_no_payloads_no_secret_values",
+		}},
+	}}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return fake, nil
+	}
+
+	result, err := svc.GetAWSCrossAccountTrust(ctx, "default", projectID, AWSCrossAccountTrustRequest{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("get cross-account trust: %v", err)
+	}
+	if len(fake.calls) == 0 || fake.calls[0].EventSourceFilter != "sts.amazonaws.com" {
+		t.Fatalf("expected cross-account trust runtime source to request STS sessions, got %+v", fake.calls)
+	}
+	if result.Summary.RuntimeObservedCount == 0 || result.Summary.FindingTypeCounts["runtime_cross_account_assumption"] == 0 {
+		t.Fatalf("expected live STS session to produce a runtime cross-account finding, got summary=%+v", result.Summary)
 	}
 }

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -102,6 +102,77 @@ func TestGetAWSCrossAccountTrustFiltersByTypeServicePrincipalAndResource(t *test
 	}
 }
 
+func TestAWSCrossAccountTrustFindingsSuppressExplicitDenyOverrides(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 7, 0, 0, time.UTC)
+	fullyDeniedPrincipal := "arn:aws:iam::999999999999:role/fully-denied"
+	partiallyDeniedPrincipal := "arn:aws:iam::999999999999:role/partially-denied"
+	publicBucket := "arn:aws:s3:::public-denied"
+	findings := awsCrossAccountTrustFindings(awsCrossAccountTrustSources{
+		s3: AWSS3BucketReachabilityInventoryResult{Records: []AWSS3BucketReachabilityRecord{
+			{
+				AccountID:   "123456789012",
+				Region:      "us-east-1",
+				BucketARN:   "arn:aws:s3:::fully-denied",
+				BucketName:  "fully-denied",
+				FromNodeID:  "aws:s3:fully-denied",
+				EvidenceRef: "aws-evidence://s3/fully-denied",
+				Confidence:  0.9,
+				CollectedAt: now,
+				IdentityGrants: []AWSS3IdentityGrant{
+					{PrincipalARN: fullyDeniedPrincipal, Effect: "Allow", Actions: []string{"s3:GetObject"}, IsCrossAccount: true},
+					{PrincipalARN: fullyDeniedPrincipal, Effect: "Deny", Actions: []string{"s3:GetObject"}},
+				},
+			},
+			{
+				AccountID:   "123456789012",
+				Region:      "us-east-1",
+				BucketARN:   "arn:aws:s3:::partially-denied",
+				BucketName:  "partially-denied",
+				FromNodeID:  "aws:s3:partially-denied",
+				EvidenceRef: "aws-evidence://s3/partially-denied",
+				Confidence:  0.9,
+				CollectedAt: now,
+				IdentityGrants: []AWSS3IdentityGrant{
+					{PrincipalARN: partiallyDeniedPrincipal, Effect: "Allow", Actions: []string{"s3:GetObject", "s3:PutObject"}, IsCrossAccount: true},
+					{PrincipalARN: partiallyDeniedPrincipal, Effect: "Deny", Actions: []string{"s3:GetObject"}},
+				},
+			},
+			{
+				AccountID:   "123456789012",
+				Region:      "us-east-1",
+				BucketARN:   publicBucket,
+				BucketName:  "public-denied",
+				FromNodeID:  "aws:s3:public-denied",
+				EvidenceRef: "aws-evidence://s3/public-denied",
+				Confidence:  0.9,
+				CollectedAt: now,
+				IdentityGrants: []AWSS3IdentityGrant{
+					{PrincipalARN: "*", Effect: "Allow", Actions: []string{"s3:GetObject"}, IsPublic: true, WildcardPrincipal: true},
+					{PrincipalARN: "*", Effect: "Deny", Actions: []string{"s3:*"}, WildcardPrincipal: true},
+				},
+			},
+		}},
+	}, now)
+
+	for _, finding := range findings {
+		if finding.ExternalPrincipalARN == fullyDeniedPrincipal {
+			t.Fatalf("fully denied external grant should not produce a finding: %+v", finding)
+		}
+		if finding.ResourceARN == publicBucket {
+			t.Fatalf("wildcard public grant fully denied by wildcard Deny should not produce a finding: %+v", finding)
+		}
+	}
+	foundPartial := false
+	for _, finding := range findings {
+		if finding.ExternalPrincipalARN == partiallyDeniedPrincipal {
+			foundPartial = true
+		}
+	}
+	if !foundPartial {
+		t.Fatalf("partial Deny should not suppress the remaining allowed cross-account grant: %+v", findings)
+	}
+}
+
 func TestGetAWSCrossAccountTrustFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 21, 13, 10, 0, 0, time.UTC)
 	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust-states", now)

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -106,6 +106,7 @@ func TestAWSCrossAccountTrustFindingsSuppressExplicitDenyOverrides(t *testing.T)
 	now := time.Date(2026, 6, 21, 13, 7, 0, 0, time.UTC)
 	fullyDeniedPrincipal := "arn:aws:iam::999999999999:role/fully-denied"
 	partiallyDeniedPrincipal := "arn:aws:iam::999999999999:role/partially-denied"
+	conditionallyDeniedPrincipal := "arn:aws:iam::999999999999:role/conditionally-denied"
 	publicBucket := "arn:aws:s3:::public-denied"
 	findings := awsCrossAccountTrustFindings(awsCrossAccountTrustSources{
 		s3: AWSS3BucketReachabilityInventoryResult{Records: []AWSS3BucketReachabilityRecord{
@@ -140,6 +141,20 @@ func TestAWSCrossAccountTrustFindingsSuppressExplicitDenyOverrides(t *testing.T)
 			{
 				AccountID:   "123456789012",
 				Region:      "us-east-1",
+				BucketARN:   "arn:aws:s3:::conditionally-denied",
+				BucketName:  "conditionally-denied",
+				FromNodeID:  "aws:s3:conditionally-denied",
+				EvidenceRef: "aws-evidence://s3/conditionally-denied",
+				Confidence:  0.9,
+				CollectedAt: now,
+				IdentityGrants: []AWSS3IdentityGrant{
+					{PrincipalARN: conditionallyDeniedPrincipal, Effect: "Allow", Actions: []string{"s3:GetObject"}, IsCrossAccount: true},
+					{PrincipalARN: conditionallyDeniedPrincipal, Effect: "Deny", Actions: []string{"s3:GetObject"}, HasCondition: true, ConditionKeys: []string{"aws:SecureTransport"}},
+				},
+			},
+			{
+				AccountID:   "123456789012",
+				Region:      "us-east-1",
 				BucketARN:   publicBucket,
 				BucketName:  "public-denied",
 				FromNodeID:  "aws:s3:public-denied",
@@ -163,13 +178,20 @@ func TestAWSCrossAccountTrustFindingsSuppressExplicitDenyOverrides(t *testing.T)
 		}
 	}
 	foundPartial := false
+	foundConditional := false
 	for _, finding := range findings {
 		if finding.ExternalPrincipalARN == partiallyDeniedPrincipal {
 			foundPartial = true
 		}
+		if finding.ExternalPrincipalARN == conditionallyDeniedPrincipal {
+			foundConditional = true
+		}
 	}
 	if !foundPartial {
 		t.Fatalf("partial Deny should not suppress the remaining allowed cross-account grant: %+v", findings)
+	}
+	if !foundConditional {
+		t.Fatalf("conditional Deny should not suppress the cross-account grant outside the denied condition: %+v", findings)
 	}
 }
 

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newCrossAccountTrustService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSCrossAccountTrustBuildsFindingContract(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 0, 0, 0, time.UTC)
+	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust", now)
+
+	result, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust", AWSCrossAccountTrustRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get cross-account trust: %v", err)
+	}
+	if result.CurrentIssueRef != "#1526" || result.Version != awsCrossAccountTrustVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready status, got %q with diagnostics=%+v", result.Status, result.Diagnostics)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected findings summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.PublicPrincipalCount == 0 || result.Summary.CrossAccountGrantCount == 0 {
+		t.Fatalf("expected public and cross-account grant findings: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected graph relationships: %+v", result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 || len(result.EvidenceLinks) == 0 {
+		t.Fatalf("expected caveats, coverage gaps, and evidence links: %+v", result)
+	}
+	for i := 1; i < len(result.Findings); i++ {
+		if result.Findings[i-1].Score < result.Findings[i].Score {
+			t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+		}
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsCrossAccountTrustVersion {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.FindingType == "" || finding.Severity == "" || finding.Status == "" || finding.Rationale == "" {
+			t.Fatalf("finding missing classification fields: %+v", finding)
+		}
+		if finding.Score <= 0 || finding.Confidence <= 0 {
+			t.Fatalf("finding missing score/confidence: %+v", finding)
+		}
+		if finding.ResourceLabel == "" || len(finding.ImpactedPath) < 2 || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing path/evidence fields: %+v", finding)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+	}
+}
+
+func TestGetAWSCrossAccountTrustFiltersByTypeServicePrincipalAndResource(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 5, 0, 0, time.UTC)
+	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust-filters", now)
+
+	kms, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust-filters", AWSCrossAccountTrustRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Service:      "kms",
+		FindingType:  "cross_account_resource_access",
+		Principal:    "partner-ingest",
+		Resource:     "partner-feed",
+	})
+	if err != nil {
+		t.Fatalf("kms filter: %v", err)
+	}
+	if len(kms.Findings) == 0 {
+		t.Fatalf("expected filtered KMS cross-account findings")
+	}
+	for _, finding := range kms.Findings {
+		if finding.Service != "kms" || finding.FindingType != "cross_account_resource_access" {
+			t.Fatalf("filter leaked unrelated finding: %+v", finding)
+		}
+		if !strings.Contains(finding.ExternalPrincipalARN, "partner-ingest") {
+			t.Fatalf("principal filter leaked: %+v", finding)
+		}
+		if !strings.Contains(strings.ToLower(finding.ResourceLabel), "partner") && !strings.Contains(strings.ToLower(finding.ResourceARN), "partner") {
+			t.Fatalf("resource filter leaked: %+v", finding)
+		}
+	}
+	if kms.AppliedFilters["service"] != "kms" || kms.AppliedFilters["finding_type"] != "cross-account-resource-access" {
+		t.Fatalf("expected normalized applied filters, got %+v", kms.AppliedFilters)
+	}
+}
+
+func TestGetAWSCrossAccountTrustFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 10, 0, 0, time.UTC)
+	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust-states", now)
+
+	denied, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust-states", AWSCrossAccountTrustRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || denied.Confidence != 0 || len(denied.Findings) != 0 {
+		t.Fatalf("expected blocked permission-denied state with no findings: %+v", denied)
+	}
+
+	degraded, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust-states", AWSCrossAccountTrustRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "degraded",
+	})
+	if err != nil {
+		t.Fatalf("degraded: %v", err)
+	}
+	if degraded.Status != "degraded" || len(degraded.Diagnostics) == 0 {
+		t.Fatalf("expected degraded status with diagnostics: %+v", degraded)
+	}
+	if len(degraded.Findings) == 0 {
+		t.Fatalf("degraded sources should keep partial external-access evidence visible: %+v", degraded)
+	}
+
+	empty, err := svc.GetAWSCrossAccountTrust(defaultScopeContext(), ws, "project-cross-account-trust-states", AWSCrossAccountTrustRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "ready" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 {
+		t.Fatalf("empty fixture should be a ready no-findings result: %+v", empty)
+	}
+}
+
+func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 15, 0, 0, time.UTC)
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-cross-account-assume",
+		AccountID:           "222222222222",
+		Region:              "us-east-1",
+		EventName:           "AssumeRole",
+		Action:              "sts:AssumeRole",
+		ActorPrincipalARN:   "arn:aws:iam::111111111111:role/partner-deployer",
+		ActorIdentityNodeID: "aws:identity:arn:aws:iam::111111111111:role/partner-deployer",
+		Session: AWSRuntimeEventSession{
+			OriginalActorARN: "arn:aws:iam::111111111111:role/partner-deployer",
+			AssumedRoleARN:   "arn:aws:iam::222222222222:role/prod-deploy",
+			SourceIdentity:   "partner-change-123",
+		},
+		EvidenceRef: "runtime-evidence://evt-cross-account-assume",
+		Confidence:  0.9,
+		ObservedAt:  now,
+	}
+
+	finding, ok := awsCrossAccountTrustFindingFromRuntimeAssumption(record, nil, now)
+	if !ok {
+		t.Fatalf("expected cross-account AssumeRole runtime event to produce finding")
+	}
+	if finding.FindingType != "runtime_cross_account_assumption" || !finding.RuntimeObserved {
+		t.Fatalf("unexpected runtime finding: %+v", finding)
+	}
+	if finding.ExternalPrincipalAccount != "111111111111" || finding.AccountID != "222222222222" {
+		t.Fatalf("expected actor/target accounts to be preserved, got %+v", finding)
+	}
+	if !finding.HasCondition || len(finding.ConditionKeys) == 0 {
+		t.Fatalf("expected SourceIdentity to be surfaced as trust context, got %+v", finding)
+	}
+}

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -337,7 +337,7 @@ func TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence(t *testing.T) 
 	}
 }
 
-func TestGetAWSCrossAccountTrustSuppressesRuntimeFixturesForLiveRequests(t *testing.T) {
+func TestGetAWSCrossAccountTrustSuppressesFixturesForLiveRequests(t *testing.T) {
 	now := time.Date(2026, 6, 21, 13, 25, 0, 0, time.UTC)
 	svc, ws := newCrossAccountTrustService(t, "project-cross-account-trust-no-runtime-fixtures", now)
 
@@ -346,6 +346,12 @@ func TestGetAWSCrossAccountTrustSuppressesRuntimeFixturesForLiveRequests(t *test
 	})
 	if err != nil {
 		t.Fatalf("get cross-account trust: %v", err)
+	}
+	if result.FixtureState != "" {
+		t.Fatalf("live request should not report an explicit fixture state, got %q", result.FixtureState)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("live request without live trust sources should not promote fixture findings: %+v", result.Findings)
 	}
 	for _, finding := range result.Findings {
 		if finding.FindingType == "runtime_cross_account_assumption" {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3190,6 +3190,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"findings": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/cross-account-trust", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSCrossAccountTrust(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSCrossAccountTrustRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			Principal:    strings.TrimSpace(c.Query("principal")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			FindingType:  strings.TrimSpace(c.Query("finding_type")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			OU:           strings.TrimSpace(c.Query("ou")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws cross-account trust request"})
+			default:
+				logger.Error("get aws cross-account trust",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws cross-account trust"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"findings": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1413,6 +1413,53 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS cross-account trust findings with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        findings: {
+          status: 'ready',
+          summary: { total_findings: 0, filtered_findings: 0 },
+          findings: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectCrossAccountTrust(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        service: 'kms',
+        principal: 'partner-ingest',
+        resource: 'partner-feed',
+        findingType: 'cross_account_resource_access',
+        severity: 'high',
+        status: 'review',
+        ou: 'Security'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/cross-account-trust?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&service=kms&principal=partner-ingest&resource=partner-feed&finding_type=cross_account_resource_access&severity=high&status=review&ou=Security'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3354,6 +3354,132 @@ export type AWSPrivilegeEscalationQuery = {
   status?: string;
 };
 
+// AWSCrossAccountTrust* types describe Wave 6.06 external access decisions
+// composed from Organizations, resource-policy, runtime, Access Analyzer, and
+// graph evidence.
+export type AWSCrossAccountTrustStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSCrossAccountTrustFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSCrossAccountTrustFindingType =
+  | 'cross_account_resource_access'
+  | 'public_resource_trust'
+  | 'runtime_cross_account_assumption'
+  | 'access_analyzer_external_access'
+  | 'cross_account_graph_path'
+  | string;
+
+export type AWSCrossAccountTrustRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSCrossAccountTrustFinding = {
+  finding_id: string;
+  calculation_version: string;
+  finding_type: AWSCrossAccountTrustFindingType;
+  severity: string;
+  status: string;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  service: string;
+  resource_type: string;
+  resource_arn?: string;
+  resource_node_id?: string;
+  resource_label: string;
+  external_principal_arn?: string;
+  external_principal_account?: string;
+  external_principal_ou_path?: string;
+  trusted_within_organization: boolean;
+  public_principal: boolean;
+  has_condition: boolean;
+  condition_keys?: string[];
+  policy_sources?: string[];
+  runtime_observed: boolean;
+  analyzer_backed: boolean;
+  rationale: string;
+  hardening_direction: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSCrossAccountTrustSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  finding_type_counts: Record<string, number>;
+  service_counts: Record<string, number>;
+  critical_count: number;
+  high_count: number;
+  public_principal_count: number;
+  cross_account_grant_count: number;
+  runtime_observed_count: number;
+  analyzer_backed_count: number;
+  unconditional_grant_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+};
+
+export type AWSCrossAccountTrustResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSCrossAccountTrustStatus;
+  fixture_state?: AWSCrossAccountTrustFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSCrossAccountTrustSummary;
+  findings: AWSCrossAccountTrustFinding[];
+  relationships: AWSCrossAccountTrustRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSCrossAccountTrustQuery = {
+  connectorID?: string;
+  fixtureState?: AWSCrossAccountTrustFixtureState;
+  accountID?: string;
+  region?: string;
+  service?: string;
+  principal?: string;
+  resource?: string;
+  findingType?: AWSCrossAccountTrustFindingType;
+  severity?: string;
+  status?: string;
+  ou?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -6636,6 +6762,29 @@ export const apiClient = {
         escalation_type: query?.escalationType,
         severity: query?.severity,
         status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectCrossAccountTrust(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSCrossAccountTrustQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ findings: AWSCrossAccountTrustResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/cross-account-trust${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        service: query?.service,
+        principal: query?.principal,
+        resource: query?.resource,
+        finding_type: query?.findingType,
+        severity: query?.severity,
+        status: query?.status,
+        ou: query?.ou
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3460,6 +3460,93 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getCrossAccountTrust = vi.spyOn(api.apiClient, 'getAWSProjectCrossAccountTrust').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [
+          {
+            finding_id: 'aws-cross-account-trust:partner-feed',
+            calculation_version: 'aws-cross-account-trust-engine-v1',
+            finding_type: 'cross_account_resource_access',
+            severity: 'high',
+            status: 'review',
+            score: 86,
+            confidence: 0.9,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'kms',
+            resource_type: 'kms_key',
+            resource_arn: 'arn:aws:kms:us-east-1:123456789012:key/partner-feed',
+            resource_node_id: 'aws:resource:kms-key/partner-feed',
+            resource_label: 'partner-feed',
+            external_principal_arn: 'arn:aws:iam::999999999999:role/partner-ingest',
+            external_principal_account: '999999999999',
+            trusted_within_organization: false,
+            public_principal: false,
+            has_condition: false,
+            policy_sources: ['kms:Decrypt'],
+            runtime_observed: false,
+            analyzer_backed: false,
+            rationale: 'KMS key trusts a partner role without condition scoping.',
+            hardening_direction: 'Add external ID or source conditions.',
+            impacted_nodes: ['aws:identity:arn:aws:iam::999999999999:role/partner-ingest', 'aws:resource:kms-key/partner-feed'],
+            impacted_path: [
+              { node_id: 'aws:identity:arn:aws:iam::999999999999:role/partner-ingest', node_type: 'external_principal', label: 'partner-ingest' },
+              { node_id: 'aws:resource:kms-key/partner-feed', node_type: 'kms_key', label: 'partner-feed' }
+            ],
+            evidence: [
+              {
+                source: 'kms_decrypt_reachability',
+                evidence_ref: 'evidence://kms/partner-feed',
+                label: 'External resource trust',
+                confidence: 0.9,
+                observed_at: '2026-06-21T13:00:00Z',
+                relationship: 'cross_account_resource_access'
+              }
+            ],
+            next_action: 'Confirm the external principal owner before hardening.',
+            remediation_case: {
+              case_id: 'aws-cross-account-trust-preview:partner-feed',
+              title: 'Cross-account trust hardening',
+              recommended_action: 'Create an owner-approved trust hardening preview.',
+              approval_required: true,
+              blocking_evidence: ['evidence://kms/partner-feed'],
+              impacted_node_count: 2,
+              estimated_risk_drop: 35,
+              breakage_prediction: 'unknown',
+              read_only_projection: true
+            },
+            created_at: '2026-06-21T13:00:00Z',
+            updated_at: '2026-06-21T13:00:00Z'
+          }
+        ],
+        summary: {
+          total_findings: 1,
+          filtered_findings: 1,
+          critical_count: 0,
+          high_count: 1,
+          public_principal_count: 0,
+          cross_account_grant_count: 1,
+          runtime_observed_count: 0,
+          analyzer_backed_count: 0,
+          unconditional_grant_count: 1,
+          relationship_count: 1,
+          highest_score: 86,
+          average_confidence_pct: 90,
+          remediation_preview_count: 1,
+          severity_counts: { high: 1 },
+          status_counts: { review: 1 },
+          finding_type_counts: { cross_account_resource_access: 1 },
+          service_counts: { kms: 1 }
+        },
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
 
     const { ProductAWSRuntimePage } = await import('./productShell');
 
@@ -3483,6 +3570,8 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByText(/No identity sprawl detected/i)).not.toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS privilege escalation findings' })).toBeInTheDocument();
     expect(screen.getByText(/Passrole unscoped trust path/i)).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS cross-account trust findings' })).toBeInTheDocument();
+    expect(screen.getByText(/Cross account resource access/i)).toBeInTheDocument();
     expect(getLeastPrivilege).toHaveBeenCalledWith(
       'workspace-a',
       'production',
@@ -3490,6 +3579,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getPrivilegeEscalation).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getCrossAccountTrust).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -65,6 +65,8 @@ import {
   type AWSIdentitySprawlResult,
   type AWSPrivilegeEscalationFinding,
   type AWSPrivilegeEscalationResult,
+  type AWSCrossAccountTrustFinding,
+  type AWSCrossAccountTrustResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10825,6 +10827,139 @@ function AWSPrivilegeEscalationContent({
   );
 }
 
+function awsCrossAccountTrustStage(finding: AWSCrossAccountTrustFinding): AWSCapabilityStage {
+  if (finding.status === 'action_required' || finding.severity === 'critical' || finding.public_principal) {
+    return 'not-available';
+  }
+  if (finding.severity === 'high' || !finding.has_condition) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsCrossAccountTrustLabel(finding: AWSCrossAccountTrustFinding): string {
+  return `${formatTokenLabel(finding.finding_type)} · score ${finding.score}`;
+}
+
+function awsCrossAccountTrustPrincipalLabel(finding: AWSCrossAccountTrustFinding): string {
+  if (finding.public_principal) {
+    return 'Public principal';
+  }
+  return finding.external_principal_arn || finding.external_principal_account || '-';
+}
+
+function awsCrossAccountTrustContextLabel(finding: AWSCrossAccountTrustFinding): string {
+  const condition = finding.has_condition ? `conditioned: ${(finding.condition_keys ?? []).join(', ') || 'yes'}` : 'unconditional';
+  const org = finding.trusted_within_organization
+    ? `org: ${finding.external_principal_ou_path || 'known account'}`
+    : 'external account';
+  return `${formatTokenLabel(finding.service)} · ${condition} · ${org}`;
+}
+
+function AWSCrossAccountTrustContent({
+  findings,
+  loading,
+  error,
+  onRetry
+}: {
+  findings: AWSCrossAccountTrustResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = findings?.findings ?? [];
+  const summaryLine = findings
+    ? `${findings.summary.public_principal_count} public · ${findings.summary.cross_account_grant_count} cross-account · ${findings.summary.runtime_observed_count} runtime-observed · ${findings.summary.analyzer_backed_count} analyzer-backed`
+    : '';
+  const emptyState = findings
+    ? findings.status === 'blocked'
+      ? {
+          eyebrow: 'Permission required',
+          title: 'Cross-account trust analysis needs read-only evidence access',
+          body: findings.failure_reasons[0] ?? 'Cross-account trust cannot be calculated until AWS metadata access is available.'
+        }
+      : findings.status === 'degraded'
+        ? {
+            eyebrow: 'Evidence incomplete',
+            title: 'Cross-account trust findings are incomplete',
+            body:
+              findings.failure_reasons[0] ??
+              findings.remediation_hints[0] ??
+              'Some source evidence is unavailable, so Identrail cannot prove every external access path yet.'
+          }
+        : {
+            eyebrow: 'No external trust',
+            title: 'No cross-account trust findings detected',
+            body: 'No public principals, external resource grants, Access Analyzer findings, or runtime cross-account assumptions matched this scope.'
+          }
+    : null;
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS cross-account trust findings">
+      <h3>AWS cross-account trust</h3>
+      <p className="idt-app-kicker">
+        Ranked external access decisions across Organizations context, resource policies, runtime assumptions, Access
+        Analyzer, and graph evidence.{summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load cross-account trust findings"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating cross-account trust"
+          body="Identrail is ranking metadata-only external access paths from trust, resource policy, runtime, organization, and graph evidence."
+        />
+      ) : null}
+      {!error && !loading && findings && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={emptyState?.eyebrow ?? 'No external trust'}
+          title={emptyState?.title ?? 'No cross-account trust findings detected'}
+          body={
+            emptyState?.body ??
+            'No public principals, external resource grants, Access Analyzer findings, or runtime cross-account assumptions matched this scope.'
+          }
+        />
+      ) : null}
+      {!error && !loading && findings && findings.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {findings.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS cross-account trust findings"
+          rows={rows}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsCrossAccountTrustLabel(row)}</strong> },
+            { key: 'principal', header: 'Principal', render: (row) => awsCrossAccountTrustPrincipalLabel(row) },
+            { key: 'resource', header: 'Resource', render: (row) => row.resource_label || row.resource_arn || row.resource_node_id || '-' },
+            { key: 'context', header: 'Context', render: (row) => awsCrossAccountTrustContextLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => `${formatConfidenceScore(row.confidence)} · ${row.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source)).join(', ') || 'No evidence refs'}` },
+            {
+              key: 'severity',
+              header: 'Risk',
+              render: (row) => (
+                <AWSInventoryPill
+                  stage={awsCrossAccountTrustStage(row)}
+                  label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`}
+                />
+              )
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function AWSIdentitySprawlContent({
   findings,
   loading,
@@ -11549,6 +11684,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [privilegeEscalationLoading, setPrivilegeEscalationLoading] = useState(false);
   const [privilegeEscalationError, setPrivilegeEscalationError] = useState('');
   const privilegeEscalationRequestRef = useRef(0);
+  const [crossAccountTrust, setCrossAccountTrust] = useState<AWSCrossAccountTrustResult | null>(null);
+  const [crossAccountTrustLoading, setCrossAccountTrustLoading] = useState(false);
+  const [crossAccountTrustError, setCrossAccountTrustError] = useState('');
+  const crossAccountTrustRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11996,6 +12135,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadPrivilegeEscalation]);
 
+  const loadCrossAccountTrust = useCallback(async () => {
+    const requestID = ++crossAccountTrustRequestRef.current;
+    setCrossAccountTrust(null);
+    setCrossAccountTrustError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setCrossAccountTrustLoading(false);
+      return;
+    }
+    setCrossAccountTrustLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectCrossAccountTrust(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== crossAccountTrustRequestRef.current) {
+        return;
+      }
+      setCrossAccountTrust(response.findings);
+    } catch (error) {
+      if (requestID !== crossAccountTrustRequestRef.current) {
+        return;
+      }
+      setCrossAccountTrustError(formatAPIError(error, 'Unable to load AWS cross-account trust findings.'));
+    } finally {
+      if (requestID === crossAccountTrustRequestRef.current) {
+        setCrossAccountTrustLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadCrossAccountTrust();
+    return () => {
+      crossAccountTrustRequestRef.current += 1;
+    };
+  }, [loadCrossAccountTrust]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -12151,6 +12338,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={privilegeEscalationLoading}
             error={privilegeEscalationError}
             onRetry={loadPrivilegeEscalation}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSCrossAccountTrustContent
+            findings={crossAccountTrust}
+            loading={crossAccountTrustLoading}
+            error={crossAccountTrustError}
+            onRetry={loadCrossAccountTrust}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
## Summary
- add the AWS cross-account trust engine with deterministic findings, severity/confidence/rationale, evidence, impacted nodes, organization context, and calculation versioning
- wire the read-only API route, route authorization metadata, OpenAPI contract, TypeScript client, and Runtime UI table
- document live validation, fixture behavior, failure states, and hardening guidance for issue #1526

## Tests
- go test ./internal/api
- npm --prefix web test -- --run src/api/client.test.ts -t 'cross-account trust'
- npm --prefix web test -- --run src/productShell.test.tsx -t 'translates AWS runtime filter aliases before querying runtime events'
- npm --prefix web run build

AI disclosure: No

Closes #1526.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AWS cross-account trust engine that ranks external-access risk from resource policies, Organizations, runtime, Access Analyzer, and graph evidence. Exposes a read-only API and UI table to review findings, fulfilling #1526 with deterministic scoring and versioned calculations.

- **New Features**
  - Engine emits `AWSCrossAccountTrustFinding` for: `public_resource_trust`, `cross_account_resource_access`, `runtime_cross_account_assumption`, `access_analyzer_external_access`, `cross_account_graph_path`.
  - Each finding includes severity, score, confidence, rationale, evidence refs, impacted nodes, org context, and `calculation_version` (`aws-cross-account-trust-engine-v1`).
  - New GET route: `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/cross-account-trust` with filters: `connector_id`, `fixture_state`, `account_id`, `region`, `service`, `principal`, `resource`, `finding_type`, `severity`, `status`, `ou`. Authorized via `tenancy.read`.
  - OpenAPI updated; new typed client models and `getAWSProjectCrossAccountTrust` in `web/src/api/client.ts`; tests added.
  - Runtime UI adds a cross-account trust table with stage labels and concise rows; product shell tests cover rendering and data flow.
  - Docs cover engine behavior, live validation, fixtures, failure states, and hardening guidance.

- **Bug Fixes**
  - Fixed STS runtime source for `runtime_cross_account_assumption` findings to attribute the correct source principal.
  - Respect explicit Deny in trust evaluation to avoid overstating external access.
  - Preserve conditional Deny trust findings so they are visible for review.
  - Suppress fixture trust sources (including runtime) in live mode to avoid synthetic evidence influencing results.

<sup>Written for commit 964d2e96bfdecd9991d07efcf283acadb5ae6c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

