### PR TITLE
Handle federated STS trust sessions

### DIFF
--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -632,8 +632,16 @@ func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventReco
 	}
 	targetARN := firstNonEmptyAWSValue(record.Session.AssumedRoleARN, record.TargetResourceARN)
 	targetAccount := awsCrossAccountTrustPrincipalAccount(targetARN)
-	actorAccount := awsCrossAccountTrustPrincipalAccount(firstNonEmptyAWSValue(record.Session.OriginalActorARN, record.ActorPrincipalARN))
-	if targetAccount == "" || actorAccount == "" || targetAccount == actorAccount {
+	principal := firstNonEmptyAWSValue(record.Session.OriginalActorARN, record.ActorPrincipalARN)
+	actorAccount := awsCrossAccountTrustPrincipalAccount(principal)
+	if targetAccount == "" || principal == "" {
+		return AWSCrossAccountTrustFinding{}, false
+	}
+	if actorAccount == "" {
+		if !awsCrossAccountTrustRuntimeAllowsAccountlessActor(record) {
+			return AWSCrossAccountTrustFinding{}, false
+		}
+	} else if targetAccount == actorAccount {
 		return AWSCrossAccountTrustFinding{}, false
 	}
 	accountContext := accounts[actorAccount]
@@ -643,7 +651,6 @@ func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventReco
 	}
 	score = clampBlastRadiusScore(score)
 	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))
-	principal := firstNonEmptyAWSValue(record.Session.OriginalActorARN, record.ActorPrincipalARN)
 	return AWSCrossAccountTrustFinding{
 		FindingID:                 "aws-cross-account-trust:" + stableAWSBlastRadiusToken("runtime_cross_account_assumption", record.EventID, principal, targetARN),
 		CalculationVersion:        awsCrossAccountTrustVersion,
@@ -679,6 +686,12 @@ func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventReco
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}, true
+}
+
+func awsCrossAccountTrustRuntimeAllowsAccountlessActor(record AWSRuntimeEventRecord) bool {
+	action := strings.ToLower(strings.TrimSpace(record.Action))
+	eventName := strings.ToLower(strings.TrimSpace(record.EventName))
+	return strings.Contains(action, "assumerolewithwebidentity") || strings.Contains(eventName, "assumerolewithwebidentity")
 }
 
 func awsCrossAccountTrustFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -627,7 +627,7 @@ func awsCrossAccountTrustDenyGrantsFromDynamoRDS(grants []AWSDynamoDBRDSIdentity
 }
 
 func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventRecord, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {
-	if !strings.EqualFold(record.Action, "sts:AssumeRole") && !strings.EqualFold(record.EventName, "AssumeRole") {
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.Action)), "sts:assumerole") && !strings.HasPrefix(strings.ToLower(strings.TrimSpace(record.EventName)), "assumerole") {
 		return AWSCrossAccountTrustFinding{}, false
 	}
 	targetARN := firstNonEmptyAWSValue(record.Session.AssumedRoleARN, record.TargetResourceARN)

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -691,7 +691,10 @@ func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventReco
 func awsCrossAccountTrustRuntimeAllowsAccountlessActor(record AWSRuntimeEventRecord) bool {
 	action := strings.ToLower(strings.TrimSpace(record.Action))
 	eventName := strings.ToLower(strings.TrimSpace(record.EventName))
-	return strings.Contains(action, "assumerolewithwebidentity") || strings.Contains(eventName, "assumerolewithwebidentity")
+	return strings.Contains(action, "assumerolewithsaml") ||
+		strings.Contains(eventName, "assumerolewithsaml") ||
+		strings.Contains(action, "assumerolewithwebidentity") ||
+		strings.Contains(eventName, "assumerolewithwebidentity")
 }
 
 func awsCrossAccountTrustFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {

--- a/internal/api/aws_cross_account_trust.go
+++ b/internal/api/aws_cross_account_trust.go
@@ -642,7 +642,10 @@ func awsCrossAccountTrustFindingFromRuntimeAssumption(record AWSRuntimeEventReco
 			return AWSCrossAccountTrustFinding{}, false
 		}
 	} else if targetAccount == actorAccount {
-		return AWSCrossAccountTrustFinding{}, false
+		if !awsCrossAccountTrustRuntimeAllowsSameAccountProviderARN(record, principal) {
+			return AWSCrossAccountTrustFinding{}, false
+		}
+		actorAccount = ""
 	}
 	accountContext := accounts[actorAccount]
 	score := 82
@@ -695,6 +698,18 @@ func awsCrossAccountTrustRuntimeAllowsAccountlessActor(record AWSRuntimeEventRec
 		strings.Contains(eventName, "assumerolewithsaml") ||
 		strings.Contains(action, "assumerolewithwebidentity") ||
 		strings.Contains(eventName, "assumerolewithwebidentity")
+}
+
+func awsCrossAccountTrustRuntimeAllowsSameAccountProviderARN(record AWSRuntimeEventRecord, principal string) bool {
+	if !awsCrossAccountTrustRuntimeAllowsAccountlessActor(record) {
+		return false
+	}
+	parts := strings.SplitN(strings.TrimSpace(principal), ":", 6)
+	if len(parts) < 6 {
+		return false
+	}
+	resource := strings.ToLower(strings.TrimSpace(parts[5]))
+	return strings.HasPrefix(resource, "saml-provider/") || strings.HasPrefix(resource, "oidc-provider/")
 }
 
 func awsCrossAccountTrustFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, accounts map[string]AWSOrganizationsTopologyAccount, now time.Time) (AWSCrossAccountTrustFinding, bool) {

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -277,6 +277,22 @@ func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
 	if _, ok := awsCrossAccountTrustFindingFromRuntimeAssumption(federated, nil, now); !ok {
 		t.Fatalf("expected cross-account federated AssumeRole event to produce finding")
 	}
+
+	webIdentity := record
+	webIdentity.EventID = "evt-cross-account-assume-web-identity"
+	webIdentity.EventName = "AssumeRoleWithWebIdentity"
+	webIdentity.Action = "sts:AssumeRoleWithWebIdentity"
+	webIdentity.ActorPrincipalARN = "accounts.google.com"
+	webIdentity.ActorIdentityNodeID = "aws:identity:accounts.google.com"
+	webIdentity.Session.OriginalActorARN = "accounts.google.com"
+	webIdentity.Session.SourceIdentity = "oidc:alice"
+	finding, ok = awsCrossAccountTrustFindingFromRuntimeAssumption(webIdentity, nil, now)
+	if !ok {
+		t.Fatalf("expected accountless WebIdentity provider to produce runtime finding")
+	}
+	if finding.ExternalPrincipalARN != "accounts.google.com" || finding.ExternalPrincipalAccount != "" {
+		t.Fatalf("expected WebIdentity provider ID without AWS account, got %+v", finding)
+	}
 }
 
 func TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence(t *testing.T) {

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -269,6 +269,14 @@ func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
 	if !finding.HasCondition || len(finding.ConditionKeys) == 0 {
 		t.Fatalf("expected SourceIdentity to be surfaced as trust context, got %+v", finding)
 	}
+
+	federated := record
+	federated.EventID = "evt-cross-account-assume-saml"
+	federated.EventName = "AssumeRoleWithSAML"
+	federated.Action = "sts:AssumeRoleWithSAML"
+	if _, ok := awsCrossAccountTrustFindingFromRuntimeAssumption(federated, nil, now); !ok {
+		t.Fatalf("expected cross-account federated AssumeRole event to produce finding")
+	}
 }
 
 func TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence(t *testing.T) {

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -290,16 +290,16 @@ func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
 	webIdentity.EventID = "evt-cross-account-assume-web-identity"
 	webIdentity.EventName = "AssumeRoleWithWebIdentity"
 	webIdentity.Action = "sts:AssumeRoleWithWebIdentity"
-	webIdentity.ActorPrincipalARN = "accounts.google.com"
-	webIdentity.ActorIdentityNodeID = "aws:identity:accounts.google.com"
-	webIdentity.Session.OriginalActorARN = "accounts.google.com"
+	webIdentity.ActorPrincipalARN = "arn:aws:iam::222222222222:oidc-provider/accounts.google.com"
+	webIdentity.ActorIdentityNodeID = "aws:identity:arn:aws:iam::222222222222:oidc-provider/accounts.google.com"
+	webIdentity.Session.OriginalActorARN = "arn:aws:iam::222222222222:oidc-provider/accounts.google.com"
 	webIdentity.Session.SourceIdentity = "oidc:alice"
 	finding, ok = awsCrossAccountTrustFindingFromRuntimeAssumption(webIdentity, nil, now)
 	if !ok {
-		t.Fatalf("expected accountless WebIdentity provider to produce runtime finding")
+		t.Fatalf("expected same-account WebIdentity provider ARN to produce runtime finding")
 	}
-	if finding.ExternalPrincipalARN != "accounts.google.com" || finding.ExternalPrincipalAccount != "" {
-		t.Fatalf("expected WebIdentity provider ID without AWS account, got %+v", finding)
+	if finding.ExternalPrincipalARN != "arn:aws:iam::222222222222:oidc-provider/accounts.google.com" || finding.ExternalPrincipalAccount != "" {
+		t.Fatalf("expected WebIdentity provider ARN without AWS account attribution, got %+v", finding)
 	}
 }
 

--- a/internal/api/aws_cross_account_trust_test.go
+++ b/internal/api/aws_cross_account_trust_test.go
@@ -274,8 +274,16 @@ func TestAWSCrossAccountTrustRuntimeAssumptionFinding(t *testing.T) {
 	federated.EventID = "evt-cross-account-assume-saml"
 	federated.EventName = "AssumeRoleWithSAML"
 	federated.Action = "sts:AssumeRoleWithSAML"
-	if _, ok := awsCrossAccountTrustFindingFromRuntimeAssumption(federated, nil, now); !ok {
+	federated.ActorPrincipalARN = "saml:namequalifier:corp"
+	federated.ActorIdentityNodeID = "aws:identity:saml:namequalifier:corp"
+	federated.Session.OriginalActorARN = "saml:namequalifier:corp"
+	federated.Session.AssumedRoleARN = "arn:aws:iam::222222222222:role/prod-deploy"
+	finding, ok = awsCrossAccountTrustFindingFromRuntimeAssumption(federated, nil, now)
+	if !ok {
 		t.Fatalf("expected cross-account federated AssumeRole event to produce finding")
+	}
+	if finding.ExternalPrincipalARN != "saml:namequalifier:corp" || finding.ExternalPrincipalAccount != "" {
+		t.Fatalf("expected SAML provider identity without AWS account, got %+v", finding)
 	}
 
 	webIdentity := record

--- a/internal/runtime/cloudtrail/lookup_events.go
+++ b/internal/runtime/cloudtrail/lookup_events.go
@@ -721,6 +721,7 @@ var payloadAllowedKeys = struct {
 	RequestParameters string
 	RoleARN           string
 	RoleSessionName   string
+	PrincipalARN      string
 	Tags              string
 	TransitiveTagKeys string
 	TagKey            string
@@ -743,6 +744,7 @@ var payloadAllowedKeys = struct {
 	RequestParameters: "requestParameters",
 	RoleARN:           "roleArn",
 	RoleSessionName:   "roleSessionName",
+	PrincipalARN:      "principalArn",
 	Tags:              "tags",
 	TransitiveTagKeys: "transitiveTagKeys",
 	TagKey:            "key",
@@ -819,6 +821,9 @@ func normalizeEvent(raw Event, accountID string, region string, collectedAt time
 			base.UserAgent = meta.UserAgent
 			if meta.UserARN != "" {
 				base.ActorPrincipalARN = meta.UserARN
+			}
+			if base.ActorPrincipalARN == "" && isSTSAssumeRoleEvent(base.EventSource, base.EventName) {
+				base.ActorPrincipalARN = meta.RequestPrincipalARN
 			}
 			if meta.UserType != "" {
 				base.ActorPrincipalType = mapPrincipalType(meta.UserType)
@@ -905,7 +910,7 @@ func applySessionLineage(ev *NormalizedEvent, meta extractedMetadata) {
 		return
 	}
 
-	ev.OriginalActorARN = strings.TrimSpace(meta.UserARN)
+	ev.OriginalActorARN = strings.TrimSpace(firstNonEmpty(meta.UserARN, meta.RequestPrincipalARN))
 	if isAssumeRole {
 		if meta.RequestRoleARN != "" {
 			ev.AssumedRoleARN = meta.RequestRoleARN
@@ -957,6 +962,7 @@ type extractedMetadata struct {
 	SessionSourceID     string
 	RequestRoleARN      string
 	RequestSessionName  string
+	RequestPrincipalARN string
 	RequestSourceID     string
 	SessionTagKeys      []string
 	TransitiveTagKeys   []string
@@ -1012,6 +1018,7 @@ func extractAllowedMetadata(raw string, eventSource string, eventName string) (e
 		if err := json.Unmarshal(requestParams, &params); err == nil {
 			out.RequestRoleARN = decodeString(params[payloadAllowedKeys.RoleARN])
 			out.RequestSessionName = decodeString(params[payloadAllowedKeys.RoleSessionName])
+			out.RequestPrincipalARN = decodeString(params[payloadAllowedKeys.PrincipalARN])
 			out.RequestSourceID = decodeString(params[payloadAllowedKeys.SourceIdentity])
 			out.SessionTagKeys = decodeSessionTagKeys(params[payloadAllowedKeys.Tags])
 			out.TransitiveTagKeys = decodeStringSlice(params[payloadAllowedKeys.TransitiveTagKeys])

--- a/internal/runtime/cloudtrail/lookup_events.go
+++ b/internal/runtime/cloudtrail/lookup_events.go
@@ -722,6 +722,7 @@ var payloadAllowedKeys = struct {
 	RoleARN           string
 	RoleSessionName   string
 	PrincipalARN      string
+	ProviderID        string
 	Tags              string
 	TransitiveTagKeys string
 	TagKey            string
@@ -745,6 +746,7 @@ var payloadAllowedKeys = struct {
 	RoleARN:           "roleArn",
 	RoleSessionName:   "roleSessionName",
 	PrincipalARN:      "principalArn",
+	ProviderID:        "providerId",
 	Tags:              "tags",
 	TransitiveTagKeys: "transitiveTagKeys",
 	TagKey:            "key",
@@ -823,7 +825,7 @@ func normalizeEvent(raw Event, accountID string, region string, collectedAt time
 				base.ActorPrincipalARN = meta.UserARN
 			}
 			if base.ActorPrincipalARN == "" && isSTSAssumeRoleEvent(base.EventSource, base.EventName) {
-				base.ActorPrincipalARN = meta.RequestPrincipalARN
+				base.ActorPrincipalARN = firstNonEmpty(meta.RequestPrincipalARN, meta.RequestProviderID)
 			}
 			if meta.UserType != "" {
 				base.ActorPrincipalType = mapPrincipalType(meta.UserType)
@@ -910,7 +912,7 @@ func applySessionLineage(ev *NormalizedEvent, meta extractedMetadata) {
 		return
 	}
 
-	ev.OriginalActorARN = strings.TrimSpace(firstNonEmpty(meta.UserARN, meta.RequestPrincipalARN))
+	ev.OriginalActorARN = strings.TrimSpace(firstNonEmpty(meta.UserARN, meta.RequestPrincipalARN, meta.RequestProviderID))
 	if isAssumeRole {
 		if meta.RequestRoleARN != "" {
 			ev.AssumedRoleARN = meta.RequestRoleARN
@@ -963,6 +965,7 @@ type extractedMetadata struct {
 	RequestRoleARN      string
 	RequestSessionName  string
 	RequestPrincipalARN string
+	RequestProviderID   string
 	RequestSourceID     string
 	SessionTagKeys      []string
 	TransitiveTagKeys   []string
@@ -1019,6 +1022,7 @@ func extractAllowedMetadata(raw string, eventSource string, eventName string) (e
 			out.RequestRoleARN = decodeString(params[payloadAllowedKeys.RoleARN])
 			out.RequestSessionName = decodeString(params[payloadAllowedKeys.RoleSessionName])
 			out.RequestPrincipalARN = decodeString(params[payloadAllowedKeys.PrincipalARN])
+			out.RequestProviderID = decodeString(params[payloadAllowedKeys.ProviderID])
 			out.RequestSourceID = decodeString(params[payloadAllowedKeys.SourceIdentity])
 			out.SessionTagKeys = decodeSessionTagKeys(params[payloadAllowedKeys.Tags])
 			out.TransitiveTagKeys = decodeStringSlice(params[payloadAllowedKeys.TransitiveTagKeys])

--- a/internal/runtime/cloudtrail/lookup_events.go
+++ b/internal/runtime/cloudtrail/lookup_events.go
@@ -711,6 +711,7 @@ var payloadAllowedKeys = struct {
 	UserType          string
 	UserARN           string
 	UserPrincipalID   string
+	IdentityProvider  string
 	SessionContext    string
 	SessionAttributes string
 	SessionIssuer     string
@@ -735,6 +736,7 @@ var payloadAllowedKeys = struct {
 	UserType:          "type",
 	UserARN:           "arn",
 	UserPrincipalID:   "principalId",
+	IdentityProvider:  "identityProvider",
 	SessionContext:    "sessionContext",
 	SessionAttributes: "attributes",
 	SessionIssuer:     "sessionIssuer",
@@ -825,7 +827,7 @@ func normalizeEvent(raw Event, accountID string, region string, collectedAt time
 				base.ActorPrincipalARN = meta.UserARN
 			}
 			if base.ActorPrincipalARN == "" && isSTSAssumeRoleEvent(base.EventSource, base.EventName) {
-				base.ActorPrincipalARN = firstNonEmpty(meta.RequestPrincipalARN, meta.RequestProviderID)
+				base.ActorPrincipalARN = stsAssumeRoleActor(meta, base.EventSource, base.EventName)
 			}
 			if meta.UserType != "" {
 				base.ActorPrincipalType = mapPrincipalType(meta.UserType)
@@ -912,7 +914,7 @@ func applySessionLineage(ev *NormalizedEvent, meta extractedMetadata) {
 		return
 	}
 
-	ev.OriginalActorARN = strings.TrimSpace(firstNonEmpty(meta.UserARN, meta.RequestPrincipalARN, meta.RequestProviderID))
+	ev.OriginalActorARN = strings.TrimSpace(firstNonEmpty(meta.UserARN, stsAssumeRoleActor(meta, ev.EventSource, ev.EventName)))
 	if isAssumeRole {
 		if meta.RequestRoleARN != "" {
 			ev.AssumedRoleARN = meta.RequestRoleARN
@@ -950,6 +952,21 @@ func isSTSAssumeRoleEvent(eventSource string, eventName string) bool {
 	return strings.EqualFold(strings.TrimSpace(eventSource), "sts.amazonaws.com") && strings.HasPrefix(strings.TrimSpace(eventName), "AssumeRole")
 }
 
+func stsAssumeRoleActor(meta extractedMetadata, eventSource string, eventName string) string {
+	if !isSTSAssumeRoleEvent(eventSource, eventName) {
+		return ""
+	}
+	normalizedName := strings.ToLower(strings.TrimSpace(eventName))
+	switch normalizedName {
+	case "assumerolewithsaml":
+		return firstNonEmpty(meta.IdentityProvider, meta.SessionPrincipalID, meta.RequestPrincipalARN)
+	case "assumerolewithwebidentity":
+		return firstNonEmpty(meta.IdentityProvider, meta.RequestProviderID, meta.SessionPrincipalID, meta.RequestPrincipalARN)
+	default:
+		return meta.RequestPrincipalARN
+	}
+}
+
 // extractedMetadata is the small allow-listed slice of CloudTrailEvent
 // JSON the ingester reads. Every field is metadata-only.
 type extractedMetadata struct {
@@ -960,6 +977,7 @@ type extractedMetadata struct {
 	UserARN             string
 	UserType            string
 	SessionPrincipalID  string
+	IdentityProvider    string
 	IssuerARN           string
 	SessionSourceID     string
 	RequestRoleARN      string
@@ -992,6 +1010,7 @@ func extractAllowedMetadata(raw string, eventSource string, eventName string) (e
 			out.UserARN = decodeString(identity[payloadAllowedKeys.UserARN])
 			out.UserType = decodeString(identity[payloadAllowedKeys.UserType])
 			out.SessionPrincipalID = decodeString(identity[payloadAllowedKeys.UserPrincipalID])
+			out.IdentityProvider = decodeString(identity[payloadAllowedKeys.IdentityProvider])
 			if sessionCtx, ok := identity[payloadAllowedKeys.SessionContext]; ok {
 				var session map[string]json.RawMessage
 				if err := json.Unmarshal(sessionCtx, &session); err == nil {

--- a/internal/runtime/cloudtrail/lookup_events_test.go
+++ b/internal/runtime/cloudtrail/lookup_events_test.go
@@ -115,6 +115,20 @@ func cloudTrailFederatedAssumeRoleEventJSON(principalARN string, roleARN string,
 	}`, principalARN, roleARN, roleSessionName, sourceIdentity)
 }
 
+func cloudTrailWebIdentityAssumeRoleEventJSON(providerID string, roleARN string, roleSessionName string, sourceIdentity string) string {
+	return fmt.Sprintf(`{
+		"recipientAccountId": "123456789012",
+		"awsRegion": "us-east-1",
+		"userIdentity": {"type": "WebIdentityUser"},
+		"requestParameters": {
+			"providerId": %q,
+			"roleArn": %q,
+			"roleSessionName": %q,
+			"sourceIdentity": %q
+		}
+	}`, providerID, roleARN, roleSessionName, sourceIdentity)
+}
+
 func cloudTrailTaggedResourceEventJSON(callerARN string, sessionID string, issuerARN string, creation time.Time) string {
 	return fmt.Sprintf(`{
 		"sourceIPAddress": "10.0.0.8",
@@ -295,6 +309,7 @@ func TestIngestResolvesAssumeRoleSourceIdentityLineage(t *testing.T) {
 func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 	now := time.Date(2026, 6, 15, 10, 20, 0, 0, time.UTC)
 	principalARN := "arn:aws:iam::111111111111:saml-provider/ExampleIdP"
+	providerID := "accounts.google.com"
 	targetRole := "arn:aws:iam::123456789012:role/federated-prod"
 	api := &fakeLookupEventsAPI{pages: []LookupEventsPage{{
 		Events: []Event{{
@@ -308,7 +323,7 @@ func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 			EventName:   "AssumeRoleWithWebIdentity",
 			EventSource: "sts.amazonaws.com",
 			EventTime:   now.Add(-2 * time.Minute),
-			RawEvent:    cloudTrailFederatedAssumeRoleEventJSON(principalARN, targetRole, "web-identity-session", "oidc:alice"),
+			RawEvent:    cloudTrailWebIdentityAssumeRoleEventJSON(providerID, targetRole, "web-identity-session", "oidc:alice"),
 		}},
 	}}}
 	ing, _ := newIngester(api, now)
@@ -319,9 +334,14 @@ func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 	if len(result.Events) != 2 {
 		t.Fatalf("expected two normalized events, got %+v", result.Events)
 	}
+	wantActors := map[string]string{
+		"evt-assume-saml":         principalARN,
+		"evt-assume-web-identity": providerID,
+	}
 	for _, event := range result.Events {
-		if event.ActorPrincipalARN != principalARN || event.OriginalActorARN != principalARN {
-			t.Fatalf("expected federated actor lineage from principalArn, got %+v", event)
+		wantActor := wantActors[event.EventID]
+		if event.ActorPrincipalARN != wantActor || event.OriginalActorARN != wantActor {
+			t.Fatalf("expected federated actor lineage from %q, got %+v", wantActor, event)
 		}
 		if event.TargetResourceARN != targetRole || event.AssumedRoleARN != targetRole {
 			t.Fatalf("expected federated target role normalization, got %+v", event)

--- a/internal/runtime/cloudtrail/lookup_events_test.go
+++ b/internal/runtime/cloudtrail/lookup_events_test.go
@@ -101,32 +101,39 @@ func cloudTrailAssumeRoleEventJSON(callerARN string, principalType string, sessi
 	}`, principalType, callerARN, sessionID, sourceIdentity, creation.UTC().Format(time.RFC3339), issuerARN, roleARN, roleSessionName, sourceIdentity)
 }
 
-func cloudTrailFederatedAssumeRoleEventJSON(principalARN string, roleARN string, roleSessionName string, sourceIdentity string) string {
+func cloudTrailFederatedAssumeRoleEventJSON(identityProvider string, principalID string, principalARN string, roleARN string, roleSessionName string, sourceIdentity string) string {
 	return fmt.Sprintf(`{
 		"recipientAccountId": "123456789012",
 		"awsRegion": "us-east-1",
-		"userIdentity": {"type": "FederatedUser"},
+		"userIdentity": {
+			"type": "SAMLUser",
+			"principalId": %q,
+			"identityProvider": %q
+		},
 		"requestParameters": {
 			"principalArn": %q,
 			"roleArn": %q,
 			"roleSessionName": %q,
 			"sourceIdentity": %q
 		}
-	}`, principalARN, roleARN, roleSessionName, sourceIdentity)
+	}`, principalID, identityProvider, principalARN, roleARN, roleSessionName, sourceIdentity)
 }
 
-func cloudTrailWebIdentityAssumeRoleEventJSON(providerID string, roleARN string, roleSessionName string, sourceIdentity string) string {
+func cloudTrailWebIdentityAssumeRoleEventJSON(identityProvider string, principalID string, roleARN string, roleSessionName string, sourceIdentity string) string {
 	return fmt.Sprintf(`{
 		"recipientAccountId": "123456789012",
 		"awsRegion": "us-east-1",
-		"userIdentity": {"type": "WebIdentityUser"},
+		"userIdentity": {
+			"type": "WebIdentityUser",
+			"principalId": %q,
+			"identityProvider": %q
+		},
 		"requestParameters": {
-			"providerId": %q,
 			"roleArn": %q,
 			"roleSessionName": %q,
 			"sourceIdentity": %q
 		}
-	}`, providerID, roleARN, roleSessionName, sourceIdentity)
+	}`, principalID, identityProvider, roleARN, roleSessionName, sourceIdentity)
 }
 
 func cloudTrailTaggedResourceEventJSON(callerARN string, sessionID string, issuerARN string, creation time.Time) string {
@@ -308,22 +315,23 @@ func TestIngestResolvesAssumeRoleSourceIdentityLineage(t *testing.T) {
 
 func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 	now := time.Date(2026, 6, 15, 10, 20, 0, 0, time.UTC)
-	principalARN := "arn:aws:iam::111111111111:saml-provider/ExampleIdP"
-	providerID := "accounts.google.com"
+	samlProvider := "saml:namequalifier:corp"
+	oidcProvider := "accounts.google.com"
 	targetRole := "arn:aws:iam::123456789012:role/federated-prod"
+	samlProviderARN := "arn:aws:iam::123456789012:saml-provider/ExampleIdP"
 	api := &fakeLookupEventsAPI{pages: []LookupEventsPage{{
 		Events: []Event{{
 			EventID:     "evt-assume-saml",
 			EventName:   "AssumeRoleWithSAML",
 			EventSource: "sts.amazonaws.com",
 			EventTime:   now.Add(-3 * time.Minute),
-			RawEvent:    cloudTrailFederatedAssumeRoleEventJSON(principalARN, targetRole, "saml-session", "saml:alice"),
+			RawEvent:    cloudTrailFederatedAssumeRoleEventJSON(samlProvider, "saml:namequalifier:corp:alice", samlProviderARN, targetRole, "saml-session", "saml:alice"),
 		}, {
 			EventID:     "evt-assume-web-identity",
 			EventName:   "AssumeRoleWithWebIdentity",
 			EventSource: "sts.amazonaws.com",
 			EventTime:   now.Add(-2 * time.Minute),
-			RawEvent:    cloudTrailWebIdentityAssumeRoleEventJSON(providerID, targetRole, "web-identity-session", "oidc:alice"),
+			RawEvent:    cloudTrailWebIdentityAssumeRoleEventJSON(oidcProvider, "accounts.google.com:app:user-id", targetRole, "web-identity-session", "oidc:alice"),
 		}},
 	}}}
 	ing, _ := newIngester(api, now)
@@ -335,8 +343,8 @@ func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 		t.Fatalf("expected two normalized events, got %+v", result.Events)
 	}
 	wantActors := map[string]string{
-		"evt-assume-saml":         principalARN,
-		"evt-assume-web-identity": providerID,
+		"evt-assume-saml":         samlProvider,
+		"evt-assume-web-identity": oidcProvider,
 	}
 	for _, event := range result.Events {
 		wantActor := wantActors[event.EventID]

--- a/internal/runtime/cloudtrail/lookup_events_test.go
+++ b/internal/runtime/cloudtrail/lookup_events_test.go
@@ -101,6 +101,20 @@ func cloudTrailAssumeRoleEventJSON(callerARN string, principalType string, sessi
 	}`, principalType, callerARN, sessionID, sourceIdentity, creation.UTC().Format(time.RFC3339), issuerARN, roleARN, roleSessionName, sourceIdentity)
 }
 
+func cloudTrailFederatedAssumeRoleEventJSON(principalARN string, roleARN string, roleSessionName string, sourceIdentity string) string {
+	return fmt.Sprintf(`{
+		"recipientAccountId": "123456789012",
+		"awsRegion": "us-east-1",
+		"userIdentity": {"type": "FederatedUser"},
+		"requestParameters": {
+			"principalArn": %q,
+			"roleArn": %q,
+			"roleSessionName": %q,
+			"sourceIdentity": %q
+		}
+	}`, principalARN, roleARN, roleSessionName, sourceIdentity)
+}
+
 func cloudTrailTaggedResourceEventJSON(callerARN string, sessionID string, issuerARN string, creation time.Time) string {
 	return fmt.Sprintf(`{
 		"sourceIPAddress": "10.0.0.8",
@@ -275,6 +289,46 @@ func TestIngestResolvesAssumeRoleSourceIdentityLineage(t *testing.T) {
 	}
 	if got := strings.Join(event.TransitiveTagKeys, ","); got != "environment,owner" {
 		t.Fatalf("expected sorted transitive tag keys, got %q", got)
+	}
+}
+
+func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
+	now := time.Date(2026, 6, 15, 10, 20, 0, 0, time.UTC)
+	principalARN := "arn:aws:iam::111111111111:saml-provider/ExampleIdP"
+	targetRole := "arn:aws:iam::123456789012:role/federated-prod"
+	api := &fakeLookupEventsAPI{pages: []LookupEventsPage{{
+		Events: []Event{{
+			EventID:     "evt-assume-saml",
+			EventName:   "AssumeRoleWithSAML",
+			EventSource: "sts.amazonaws.com",
+			EventTime:   now.Add(-3 * time.Minute),
+			RawEvent:    cloudTrailFederatedAssumeRoleEventJSON(principalARN, targetRole, "saml-session", "saml:alice"),
+		}, {
+			EventID:     "evt-assume-web-identity",
+			EventName:   "AssumeRoleWithWebIdentity",
+			EventSource: "sts.amazonaws.com",
+			EventTime:   now.Add(-2 * time.Minute),
+			RawEvent:    cloudTrailFederatedAssumeRoleEventJSON(principalARN, targetRole, "web-identity-session", "oidc:alice"),
+		}},
+	}}}
+	ing, _ := newIngester(api, now)
+	result, err := ing.Ingest(context.Background(), IngestRequest{AccountID: "123456789012", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("expected two normalized events, got %+v", result.Events)
+	}
+	for _, event := range result.Events {
+		if event.ActorPrincipalARN != principalARN || event.OriginalActorARN != principalARN {
+			t.Fatalf("expected federated actor lineage from principalArn, got %+v", event)
+		}
+		if event.TargetResourceARN != targetRole || event.AssumedRoleARN != targetRole {
+			t.Fatalf("expected federated target role normalization, got %+v", event)
+		}
+		if event.LineageStatus != "resolved" {
+			t.Fatalf("expected resolved federated lineage, got %+v", event)
+		}
 	}
 }
 

--- a/internal/runtime/cloudtrail/lookup_events_test.go
+++ b/internal/runtime/cloudtrail/lookup_events_test.go
@@ -316,9 +316,9 @@ func TestIngestResolvesAssumeRoleSourceIdentityLineage(t *testing.T) {
 func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 	now := time.Date(2026, 6, 15, 10, 20, 0, 0, time.UTC)
 	samlProvider := "saml:namequalifier:corp"
-	oidcProvider := "accounts.google.com"
 	targetRole := "arn:aws:iam::123456789012:role/federated-prod"
 	samlProviderARN := "arn:aws:iam::123456789012:saml-provider/ExampleIdP"
+	oidcProviderARN := "arn:aws:iam::123456789012:oidc-provider/accounts.google.com"
 	api := &fakeLookupEventsAPI{pages: []LookupEventsPage{{
 		Events: []Event{{
 			EventID:     "evt-assume-saml",
@@ -331,7 +331,7 @@ func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 			EventName:   "AssumeRoleWithWebIdentity",
 			EventSource: "sts.amazonaws.com",
 			EventTime:   now.Add(-2 * time.Minute),
-			RawEvent:    cloudTrailWebIdentityAssumeRoleEventJSON(oidcProvider, "accounts.google.com:app:user-id", targetRole, "web-identity-session", "oidc:alice"),
+			RawEvent:    cloudTrailWebIdentityAssumeRoleEventJSON(oidcProviderARN, "arn:aws:iam::123456789012:oidc-provider/accounts.google.com:app:user-id", targetRole, "web-identity-session", "oidc:alice"),
 		}},
 	}}}
 	ing, _ := newIngester(api, now)
@@ -344,7 +344,7 @@ func TestIngestMapsFederatedAssumeRoleActorLineage(t *testing.T) {
 	}
 	wantActors := map[string]string{
 		"evt-assume-saml":         samlProvider,
-		"evt-assume-web-identity": oidcProvider,
+		"evt-assume-web-identity": oidcProviderARN,
 	}
 	for _, event := range result.Events {
 		wantActor := wantActors[event.EventID]


### PR DESCRIPTION
## Summary
- accept STS `AssumeRole*` runtime events when building cross-account trust findings
- keep the fix scoped to the post-merge review from #1660

## Tests
- go test ./internal/api -run 'TestAWSCrossAccountTrustRuntimeAssumptionFinding|TestGetAWSCrossAccountTrustRequestsSTSSessionRuntimeEvidence' -count=1
- go test ./internal/api

AI disclosure: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand cross-account trust detection and actor lineage for federated STS AssumeRole* sessions. SAML/WebIdentity assumptions now resolve principals and target roles from CloudTrail identity providers, including accountless OIDC and same-account provider ARNs.

- **Bug Fixes**
  - Broaden runtime event matching to include `sts:AssumeRole*`/`AssumeRole*` via trimmed, case-insensitive prefix checks.
  - Map federated actors from `userIdentity.identityProvider`, `requestParameters.principalArn`/`providerId`, and session principal ID; prefer provider ARN when present to preserve evidence, set `ActorPrincipalARN`/`OriginalActorARN`, normalize target roles, and allow accountless actors and same-account provider ARNs (with tests).

<sup>Written for commit 27fdb58812309381fe80456cef3b9bdd24ec82ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

