### PR TITLE
Implement AWS secret-permission equivalence engine

### DIFF
--- a/docs/aws-risk-engine.md
+++ b/docs/aws-risk-engine.md
@@ -39,6 +39,12 @@ The AWS risk engine evaluates normalized identities and graph relationships to p
 
 The Wave 6.01 blast-radius engine is documented in [aws-blast-radius-engine.md](aws-blast-radius-engine.md). It composes existing AWS runtime and reachability signals into ranked, explainable identity findings with impacted paths, evidence references, confidence, calculation version, and read-only remediation previews.
 
+The Wave 6.07 secret-to-permission equivalence engine is documented in
+[aws-secret-permission-equivalence-engine.md](aws-secret-permission-equivalence-engine.md).
+It treats readable secrets, provider keys, and KMS-backed credentials as
+permission-bearing capabilities while preserving the metadata-only evidence
+boundary.
+
 ## Tunables
 
 - `WithStaleAfter(duration)`

--- a/docs/aws-secret-permission-equivalence-engine.md
+++ b/docs/aws-secret-permission-equivalence-engine.md
@@ -1,0 +1,112 @@
+# AWS secret-to-permission equivalence engine
+
+Issue #1527 (Wave 6.07) adds a metadata-only engine that treats readable
+secrets, provider keys, and KMS-backed credentials as permission-bearing
+capabilities. It composes credential-reference, Secrets Manager, KMS, runtime,
+agent, blast-radius, and privilege-escalation evidence into ranked findings.
+
+## What it produces
+
+The engine emits `AWSSecretPermissionEquivalenceFinding` records for these
+equivalence types:
+
+- **`workload_provider_key_equivalence`** - a workload references an external
+  provider key or credential-bearing secret.
+- **`secret_read_policy_equivalence`** - a principal can read a
+  permission-bearing Secrets Manager secret through resource-policy metadata.
+- **`kms_decrypt_secret_equivalence`** - a principal can decrypt a KMS key that
+  protects a permission-bearing secret.
+- **`kms_live_grant_secret_equivalence`** - a live KMS grant can decrypt a key
+  protecting a permission-bearing secret.
+- **`runtime_secret_access_equivalence`** - runtime evidence observed
+  Secrets Manager or KMS access to a credential-bearing resource.
+- **`agent_provider_key_equivalence`** - an AWS AI agent has a provider-key
+  reference, so control of the agent runtime can imply provider permissions.
+- **`blast_radius_secret_equivalence`** - blast-radius evidence includes
+  credential-bearing secret or KMS paths.
+- **`admin_equivalent_secret_permission`** - privilege-escalation evidence found
+  secret or KMS admin/read equivalence.
+
+Each finding carries a stable finding id, calculation version, severity, score,
+confidence, provider, equivalent permissions, implied AWS actions when known,
+impacted nodes, impacted path, rationale, evidence references, explicit
+metadata-only evidence boundary, and read-only `remediation_case` preview.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-permission-equivalence`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | scope filters |
+| `identity` | principal ARN, workload id/name, agent id/name, or identity-node search |
+| `secret` | secret ARN, graph node id, display label, or provider-key reference search |
+| `provider` | provider classification such as `openai`, `anthropic`, `github`, `database`, `slack`, `webhook`, or `aws_secret` |
+| `equivalence_type` | one of the finding types above |
+| `severity` | `critical`, `high`, `medium`, `low` |
+| `status` | `review`, `action_required`, or source status |
+
+Response shape: `{ "findings": AWSSecretPermissionEquivalenceResult }` with
+summary, ranked findings, graph relationships, caveats, failure reasons,
+remediation hints, evidence links, coverage gaps, diagnostics, and standard
+tenant/workspace/project issue metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays secret values, KMS plaintext,
+prompt text, completions, browser pages, code-interpreter output, object
+contents, database rows, or customer payloads. It only composes metadata:
+
+- credential reference names, source markers, and resolved secret references
+- Secrets Manager metadata, resource-policy grants, and KMS key ids
+- KMS policy and live-grant metadata
+- CloudTrail event ids and resource/action metadata
+- AI agent provider-key references and runtime role metadata
+- upstream blast-radius and privilege-escalation evidence references
+
+## AWS permissions
+
+This capability adds no new AWS permissions. It reuses the read-only collectors
+from credential-reference mapping, Secrets Manager metadata, KMS decrypt
+reachability, runtime events, AI agent identity inventory, blast-radius
+intelligence, and privilege-escalation reasoning.
+
+## Failure handling
+
+- **Ready**: source engines are available and no blocking diagnostics were
+  emitted.
+- **Degraded**: at least one source is partial, empty because runtime evidence
+  is unavailable, capability-limited, or produced retryable diagnostics. Partial
+  evidence remains visible.
+- **Blocked**: required source evidence is permission denied. The result has no
+  deterministic findings, diagnostics, and failure reasons.
+
+Unknown, unresolved, degraded, unsupported, partial, and permission-denied
+evidence stays explicit. It must not be treated as deterministic proof that a
+secret is safe or unused.
+
+## App surface
+
+The AWS Runtime and AWS Findings app surfaces render the
+`AWS secret-to-permission equivalence` panel. Operators can see ranked findings
+with identity, secret label, equivalent permission, impacted path, confidence,
+evidence, risk status, and next action without reading logs or database rows.
+
+## Live validation
+
+1. Confirm issue blockers #1496, #1518, and #1521 are closed.
+2. Run the credential references, Secrets Manager metadata, KMS reachability,
+   Secrets/KMS runtime access, AI agent identities, blast-radius, and privilege
+   escalation endpoints with `fixture_state=success`.
+3. Run the secret-permission endpoint with `fixture_state=success` and confirm
+   provider-key, secret-policy, KMS-backed, runtime, agent, blast-radius, and
+   admin-equivalence findings are ranked.
+4. Filter by `provider=openai`, `equivalence_type=agent_provider_key_equivalence`,
+   `identity`, and `secret` to verify deterministic drill-down behavior.
+5. Run `fixture_state=permission_denied` and confirm `status=blocked`, zero
+   findings, diagnostics, and failure reasons.
+6. Confirm the AWS app panel renders success, empty/degraded,
+   permission-denied, and partial-failure states without exposing secret values
+   or customer payload data.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -594,6 +594,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-permission-equivalence
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/cross-account-trust
     action: tenancy.read
     resource_type: project
@@ -5323,6 +5328,88 @@ paths:
                     $ref: "#/components/schemas/AWSPrivilegeEscalationResult"
         "400":
           description: Invalid AWS privilege escalation request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-permission-equivalence:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS secret-to-permission equivalence findings
+      operationId: getAWSProjectSecretPermissionEquivalence
+      description: Ranked, explainable findings for identities, workloads, and agents that can read permission-bearing secrets or provider keys and therefore inherit the secret's external or cloud permissions. The engine composes read-only credential-reference, Secrets Manager metadata, KMS decrypt reachability, runtime access, AI agent identity, blast-radius, and privilege-escalation evidence. It emits stable finding IDs, equivalent permissions, graph paths, evidence pointers, confidence, status, and read-only remediation previews without reading secret values, plaintext, prompts, completions, object bodies, browser pages, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope the calculation.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Filter by principal ARN, workload ID, agent ID, identity node ID, or display name.
+        - in: query
+          name: secret
+          schema: { type: string }
+          description: Filter by secret ARN, secret node ID, provider key reference, or secret label.
+        - in: query
+          name: provider
+          schema: { type: string }
+          description: Filter by provider token such as openai, anthropic, aws_secret, secrets_manager, or ssm.
+        - in: query
+          name: equivalence_type
+          schema:
+            type: string
+            enum: [workload_provider_key_equivalence, secret_read_policy_equivalence, kms_decrypt_secret_equivalence, kms_live_grant_secret_equivalence, runtime_secret_access_equivalence, agent_provider_key_equivalence, blast_radius_secret_equivalence, admin_equivalent_secret_permission]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [review, action_required, monitor]
+      responses:
+        "200":
+          description: AWS secret-to-permission equivalence findings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    $ref: "#/components/schemas/AWSSecretPermissionEquivalenceResult"
+        "400":
+          description: Invalid AWS secret-to-permission equivalence request
           content:
             application/json:
               schema:
@@ -13102,6 +13189,161 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPrivilegeEscalationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretPermissionEquivalenceRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSSecretPermissionEquivalenceFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        equivalence_type:
+          type: string
+          enum: [workload_provider_key_equivalence, secret_read_policy_equivalence, kms_decrypt_secret_equivalence, kms_live_grant_secret_equivalence, runtime_secret_access_equivalence, agent_provider_key_equivalence, blast_radius_secret_equivalence, admin_equivalent_secret_permission]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [review, action_required, monitor]
+        score: { type: integer }
+        confidence: { type: number }
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        workload_id: { type: string }
+        workload_name: { type: string }
+        agent_id: { type: string }
+        agent_name: { type: string }
+        secret_node_id: { type: string }
+        secret_arn: { type: string }
+        secret_label: { type: string }
+        provider: { type: string }
+        provider_key_reference: { type: string }
+        equivalent_permissions:
+          type: array
+          items: { type: string }
+        implied_actions:
+          type: array
+          items: { type: string }
+        source_signals:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretPermissionEquivalenceSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        equivalence_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        provider_counts:
+          type: object
+          additionalProperties: { type: integer }
+        external_provider_key_count: { type: integer }
+        aws_managed_secret_count: { type: integer }
+        runtime_observed_count: { type: integer }
+        kms_backed_count: { type: integer }
+        unresolved_reference_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+    AWSSecretPermissionEquivalenceResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence: { type: number }
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSSecretPermissionEquivalenceSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretPermissionEquivalenceFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretPermissionEquivalenceRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -13252,6 +13252,7 @@ components:
         secret_label: { type: string }
         provider: { type: string }
         provider_key_reference: { type: string }
+        unresolved_reference: { type: boolean }
         equivalent_permissions:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -763,6 +763,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/identity-sprawl", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/privilege-escalation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/cross-account-trust", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-permission-equivalence", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-bucket-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/kms-decrypt-reachability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_privilege_escalation.go
+++ b/internal/api/aws_privilege_escalation.go
@@ -325,6 +325,7 @@ func awsPrivilegeEscalationPassRoleIsDenied(record AWSIAMPassRoleRelationshipRec
 }
 
 func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIdentityGrant, denyGrants []AWSKMSIdentityGrant) bool {
+	allowActions := awsPrivilegeEscalationNormalizeKMSGrantActions(allowGrant.Actions, allowGrant.Capabilities)
 	for _, deny := range denyGrants {
 		if !strings.EqualFold(deny.Effect, "Deny") {
 			continue
@@ -332,7 +333,7 @@ func awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant AWSKMSIden
 		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(allowGrant.PrincipalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
 			continue
 		}
-		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowGrant.Actions, deny.Actions) {
+		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(allowActions, deny.Actions) {
 			return true
 		}
 	}
@@ -343,7 +344,7 @@ func awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant AWSKMSGrant, denyGr
 	if strings.TrimSpace(grant.GranteePrincipal) == "" {
 		return false
 	}
-	allowActions := awsPrivilegeEscalationNormalizeKMSLiveGrantActions(grant.Operations, grant.Capabilities)
+	allowActions := awsPrivilegeEscalationNormalizeKMSGrantActions(grant.Operations, grant.Capabilities)
 	allowGrant := AWSKMSIdentityGrant{
 		PrincipalARN:  grant.GranteePrincipal,
 		PrincipalType: grant.GranteePrincipalType,
@@ -352,9 +353,9 @@ func awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant AWSKMSGrant, denyGr
 	return awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(allowGrant, denyGrants)
 }
 
-func awsPrivilegeEscalationNormalizeKMSLiveGrantActions(operations, capabilities []string) []string {
-	out := make([]string, 0, len(operations)+len(capabilities))
-	for _, action := range append(append([]string{}, operations...), capabilities...) {
+func awsPrivilegeEscalationNormalizeKMSGrantActions(actions, capabilities []string) []string {
+	out := make([]string, 0, len(actions)+len(capabilities))
+	for _, action := range append(append([]string{}, actions...), capabilities...) {
 		trimmed := strings.ToLower(strings.TrimSpace(action))
 		if trimmed == "" {
 			continue

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -1,0 +1,1225 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsSecretPermissionEquivalenceCurrentIssue = 1527
+	awsSecretPermissionEquivalenceVersion      = "aws-secret-permission-equivalence-engine-v1"
+)
+
+// AWSSecretPermissionEquivalenceRequest scopes the metadata-only
+// secret-to-permission calculation to one AWS connector and optional drill-down
+// filters.
+type AWSSecretPermissionEquivalenceRequest struct {
+	ConnectorID     string `json:"connector_id,omitempty"`
+	FixtureState    string `json:"fixture_state,omitempty"`
+	AccountID       string `json:"account_id,omitempty"`
+	Region          string `json:"region,omitempty"`
+	Identity        string `json:"identity,omitempty"`
+	Secret          string `json:"secret,omitempty"`
+	Provider        string `json:"provider,omitempty"`
+	EquivalenceType string `json:"equivalence_type,omitempty"`
+	Severity        string `json:"severity,omitempty"`
+	Status          string `json:"status,omitempty"`
+}
+
+type AWSSecretPermissionEquivalenceEvidence = AWSLeastPrivilegeEvidence
+type AWSSecretPermissionEquivalencePathStep = AWSLeastPrivilegePathStep
+type AWSSecretPermissionEquivalenceRemediationCasePreview = AWSLeastPrivilegeRemediationCasePreview
+type AWSSecretPermissionEquivalenceDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSSecretPermissionEquivalenceCoverageGap = AWSLeastPrivilegeCoverageGap
+
+type AWSSecretPermissionEquivalenceRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSSecretPermissionEquivalenceFinding is the operator-visible decision shape
+// for identities or workloads that can read a credential-bearing secret and
+// therefore inherit the secret's external or cloud permissions.
+type AWSSecretPermissionEquivalenceFinding struct {
+	FindingID             string                                               `json:"finding_id"`
+	CalculationVersion    string                                               `json:"calculation_version"`
+	EquivalenceType       string                                               `json:"equivalence_type"`
+	Severity              string                                               `json:"severity"`
+	Status                string                                               `json:"status"`
+	Score                 int                                                  `json:"score"`
+	Confidence            float64                                              `json:"confidence"`
+	AccountID             string                                               `json:"account_id"`
+	Region                string                                               `json:"region"`
+	IdentityNodeID        string                                               `json:"identity_node_id"`
+	PrincipalARN          string                                               `json:"principal_arn,omitempty"`
+	WorkloadID            string                                               `json:"workload_id,omitempty"`
+	WorkloadName          string                                               `json:"workload_name,omitempty"`
+	AgentID               string                                               `json:"agent_id,omitempty"`
+	AgentName             string                                               `json:"agent_name,omitempty"`
+	SecretNodeID          string                                               `json:"secret_node_id"`
+	SecretARN             string                                               `json:"secret_arn,omitempty"`
+	SecretLabel           string                                               `json:"secret_label"`
+	Provider              string                                               `json:"provider"`
+	ProviderKeyReference  string                                               `json:"provider_key_reference,omitempty"`
+	EquivalentPermissions []string                                             `json:"equivalent_permissions"`
+	ImpliedActions        []string                                             `json:"implied_actions,omitempty"`
+	SourceSignals         []string                                             `json:"source_signals"`
+	Rationale             string                                               `json:"rationale"`
+	EvidenceBoundary      string                                               `json:"evidence_boundary"`
+	ImpactedNodes         []string                                             `json:"impacted_nodes"`
+	ImpactedPath          []AWSSecretPermissionEquivalencePathStep             `json:"impacted_path"`
+	Evidence              []AWSSecretPermissionEquivalenceEvidence             `json:"evidence"`
+	NextAction            string                                               `json:"next_action"`
+	RemediationCase       AWSSecretPermissionEquivalenceRemediationCasePreview `json:"remediation_case"`
+	CreatedAt             time.Time                                            `json:"created_at"`
+	UpdatedAt             time.Time                                            `json:"updated_at"`
+}
+
+type AWSSecretPermissionEquivalenceSummary struct {
+	TotalFindings            int            `json:"total_findings"`
+	FilteredFindings         int            `json:"filtered_findings"`
+	SeverityCounts           map[string]int `json:"severity_counts"`
+	StatusCounts             map[string]int `json:"status_counts"`
+	EquivalenceTypeCounts    map[string]int `json:"equivalence_type_counts"`
+	ProviderCounts           map[string]int `json:"provider_counts"`
+	ExternalProviderKeyCount int            `json:"external_provider_key_count"`
+	AWSManagedSecretCount    int            `json:"aws_managed_secret_count"`
+	RuntimeObservedCount     int            `json:"runtime_observed_count"`
+	KMSBackedCount           int            `json:"kms_backed_count"`
+	UnresolvedReferenceCount int            `json:"unresolved_reference_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+	RemediationPreviewCount  int            `json:"remediation_preview_count"`
+}
+
+type AWSSecretPermissionEquivalenceResult struct {
+	TenantID           string                                       `json:"tenant_id"`
+	WorkspaceID        string                                       `json:"workspace_id"`
+	ProjectID          string                                       `json:"project_id"`
+	ConnectorID        string                                       `json:"connector_id,omitempty"`
+	AccountID          string                                       `json:"account_id,omitempty"`
+	Region             string                                       `json:"region,omitempty"`
+	ParentIssueNumber  int                                          `json:"parent_issue_number"`
+	ParentIssueRef     string                                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                          `json:"current_issue_number"`
+	CurrentIssueRef    string                                       `json:"current_issue_ref"`
+	Version            string                                       `json:"version"`
+	Status             string                                       `json:"status"`
+	FixtureState       string                                       `json:"fixture_state,omitempty"`
+	Confidence         float64                                      `json:"confidence"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	AppliedFilters     map[string]string                            `json:"applied_filters"`
+	Summary            AWSSecretPermissionEquivalenceSummary        `json:"summary"`
+	Findings           []AWSSecretPermissionEquivalenceFinding      `json:"findings"`
+	Relationships      []AWSSecretPermissionEquivalenceRelationship `json:"relationships"`
+	Caveats            []string                                     `json:"caveats"`
+	FailureReasons     []string                                     `json:"failure_reasons"`
+	RemediationHints   []string                                     `json:"remediation_hints"`
+	EvidenceLinks      []string                                     `json:"evidence_links"`
+	CoverageGaps       []AWSSecretPermissionEquivalenceCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSSecretPermissionEquivalenceDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                    `json:"generated_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+type awsSecretPermissionEquivalenceSources struct {
+	credentials AWSCredentialReferencesInventoryResult
+	secrets     AWSSecretsManagerMetadataInventoryResult
+	kms         AWSKMSDecryptReachabilityInventoryResult
+	runtime     AWSSecretsKMSRuntimeAccessResult
+	agents      AWSAIAgentIdentityInventoryResult
+	blast       AWSBlastRadiusResult
+	escalation  AWSPrivilegeEscalationResult
+}
+
+func (s *Service) GetAWSSecretPermissionEquivalence(ctx context.Context, workspaceID string, projectID string, request AWSSecretPermissionEquivalenceRequest) (AWSSecretPermissionEquivalenceResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSecretPermissionEquivalenceResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSSecretPermissionEquivalenceResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSSecretPermissionEquivalenceFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSecretPermissionEquivalenceResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsSecretPermissionEquivalenceSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSSecretPermissionEquivalenceResult{}, err
+	}
+	findings := awsSecretPermissionEquivalenceFindings(sources, now)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSSecretPermissionEquivalenceFindings(findings, request)
+	relationships := awsSecretPermissionEquivalenceRelationships(filtered)
+	diagnostics := awsSecretPermissionEquivalenceDiagnostics(sources)
+	coverageGaps := awsSecretPermissionEquivalenceCoverageGaps(sources)
+	status, confidence := summarizeAWSSecretPermissionEquivalenceStatus(sources, filtered, diagnostics)
+
+	return AWSSecretPermissionEquivalenceResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsSecretPermissionEquivalenceCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsSecretPermissionEquivalenceCurrentIssue),
+		Version:            awsSecretPermissionEquivalenceVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsSecretPermissionEquivalenceVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSSecretPermissionEquivalence(findings, filtered, relationships),
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsSecretPermissionEquivalenceCaveats(),
+		FailureReasons:     awsSecretPermissionEquivalenceFailureReasons(sources),
+		RemediationHints:   awsSecretPermissionEquivalenceRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),
+			awsIssueURL(awsCredentialReferencesCurrentIssue),
+			awsIssueURL(awsSecretsKMSRuntimeAccessCurrentIssue),
+			awsIssueURL(awsBlastRadiusCurrentIssue),
+			awsIssueURL(awsPrivilegeEscalationCurrentIssue),
+			"/docs/aws-secret-permission-equivalence-engine",
+			"/docs/aws-credential-references",
+			"/docs/aws-secrets-kms-runtime-access",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSSecretPermissionEquivalenceFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsSecretPermissionEquivalenceSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsSecretPermissionEquivalenceSources, error) {
+	credentials, err := s.GetAWSCredentialReferencesInventory(ctx, workspaceID, projectID, AWSCredentialReferencesInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence credential references: %w", err)
+	}
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence secrets metadata: %w", err)
+	}
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence kms reachability: %w", err)
+	}
+	runtime, err := s.GetAWSSecretsKMSRuntimeAccess(ctx, workspaceID, projectID, AWSSecretsKMSRuntimeAccessRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence runtime access: %w", err)
+	}
+	agents, err := s.GetAWSAIAgentIdentityInventory(ctx, workspaceID, projectID, AWSAIAgentIdentityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence ai agent inventory: %w", err)
+	}
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence blast radius: %w", err)
+	}
+	escalation, err := s.GetAWSPrivilegeEscalation(ctx, workspaceID, projectID, AWSPrivilegeEscalationRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretPermissionEquivalenceSources{}, fmt.Errorf("secret permission equivalence privilege escalation: %w", err)
+	}
+	return awsSecretPermissionEquivalenceSources{credentials: credentials, secrets: secrets, kms: kms, runtime: runtime, agents: agents, blast: blast, escalation: escalation}, nil
+}
+
+func awsSecretPermissionEquivalenceFindings(sources awsSecretPermissionEquivalenceSources, now time.Time) []AWSSecretPermissionEquivalenceFinding {
+	findings := []AWSSecretPermissionEquivalenceFinding{}
+	secretByARN, secretByNode, secretsByKMS := awsSecretPermissionSecretIndexes(sources.secrets)
+	for _, record := range sources.credentials.Records {
+		if finding, ok := awsSecretPermissionFindingFromCredentialReference(record, secretByARN, secretByNode, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+	for _, secret := range sources.secrets.Records {
+		denyGrants := awsSecretPermissionSecretDenyGrants(secret.IdentityGrants)
+		for _, grant := range secret.IdentityGrants {
+			if finding, ok := awsSecretPermissionFindingFromSecretGrant(secret, grant, denyGrants, now); ok {
+				findings = append(findings, finding)
+			}
+		}
+	}
+	for _, key := range sources.kms.Records {
+		for _, secret := range secretsByKMS[strings.ToLower(strings.TrimSpace(key.KeyARN))] {
+			denyGrants := awsSecretPermissionKMSDenyGrants(key.IdentityGrants)
+			for _, grant := range key.IdentityGrants {
+				if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, grant, denyGrants, now); ok {
+					findings = append(findings, finding)
+				}
+			}
+			for _, grant := range key.Grants {
+				if finding, ok := awsSecretPermissionFindingFromKMSLiveGrant(key, secret, grant, denyGrants, now); ok {
+					findings = append(findings, finding)
+				}
+			}
+		}
+	}
+	for _, record := range sources.runtime.Records {
+		if finding, ok := awsSecretPermissionFindingFromRuntime(record, secretByARN, secretByNode, secretsByKMS, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+	for _, agent := range sources.agents.Records {
+		findings = append(findings, awsSecretPermissionFindingsFromAgent(agent, secretByARN, secretByNode, now)...)
+	}
+	for _, finding := range sources.blast.Findings {
+		if derived, ok := awsSecretPermissionFindingFromBlastRadius(finding, now); ok {
+			findings = append(findings, derived)
+		}
+	}
+	for _, finding := range sources.escalation.Findings {
+		if derived, ok := awsSecretPermissionFindingFromPrivilegeEscalation(finding, now); ok {
+			findings = append(findings, derived)
+		}
+	}
+	return awsSecretPermissionDedupeFindings(findings)
+}
+
+func awsSecretPermissionFindingFromCredentialReference(record AWSCredentialReferenceRecord, secretByARN map[string]AWSSecretsManagerMetadataRecord, secretByNode map[string]AWSSecretsManagerMetadataRecord, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	provider := awsSecretPermissionProvider(record.Provider, record.ReferenceName, record.Reference, record.Sensitivity)
+	if !awsSecretPermissionProviderIsPermissionBearing(provider, record.Sensitivity) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	secret := awsSecretPermissionSecretForCredentialReference(record, secretByARN, secretByNode)
+	secretNodeID := firstNonEmptyAWSValue(record.TargetNodeID, secret.FromNodeID, "aws:credential-reference:"+stableAWSBlastRadiusToken(record.WorkloadID, record.ReferenceName))
+	secretLabel := firstNonEmptyAWSValue(secret.SecretName, record.ReferenceName, record.ReferenceKind, "credential reference")
+	score := awsSecretPermissionProviderScore(provider)
+	if record.Resolved {
+		score += 6
+	}
+	if record.Unresolved {
+		score -= 8
+	}
+	score = clampBlastRadiusScore(score)
+	confidence := minFloat(firstNonZeroFloat(record.Confidence, record.ProviderConfidence, 0.72), 0.95)
+	if record.Unresolved {
+		confidence = minFloat(confidence, 0.78)
+	}
+	identity := firstNonEmptyAWSValue(record.WorkloadID, record.ResourceID)
+	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, record.ReferenceName, record.Reference)
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("credential", record.WorkloadID, record.TargetNodeID, provider, record.ReferenceName),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "workload_provider_key_equivalence",
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsSecretPermissionFindingStatus(score, confidence, record.Unresolved),
+		Score:                 score,
+		Confidence:            confidence,
+		AccountID:             record.AccountID,
+		Region:                record.Region,
+		IdentityNodeID:        identity,
+		WorkloadID:            record.WorkloadID,
+		WorkloadName:          record.WorkloadName,
+		SecretNodeID:          secretNodeID,
+		SecretARN:             secret.SecretARN,
+		SecretLabel:           secretLabel,
+		Provider:              provider,
+		ProviderKeyReference:  record.ReferenceName,
+		EquivalentPermissions: awsSecretPermissionProviderPermissions(provider),
+		SourceSignals:         []string{"credential_references"},
+		Rationale:             fmt.Sprintf("%s references %s credential metadata for %s; the engine treats the referenced credential as permission-bearing without reading its value.", firstNonEmptyAWSValue(record.WorkloadName, record.WorkloadID), formatAWSBlastRadiusLabel(provider), secretLabel),
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         dedupeStrings([]string{identity, secretNodeID}),
+		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+			awsLeastPrivilegePathStep(identity, record.ResourceType, firstNonEmptyAWSValue(record.WorkloadName, record.WorkloadID), record.AccountID, record.Region),
+			awsLeastPrivilegePathStep(secretNodeID, "permission_bearing_secret", secretLabel, record.AccountID, record.Region),
+		},
+		Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "credential_references", EvidenceRef: evidenceRef, Label: "Credential reference metadata", Confidence: confidence, ObservedAt: record.CollectedAt, Relationship: "uses_permission_bearing_secret"}},
+		NextAction: awsSecretPermissionNextAction(provider, record.Unresolved),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}), true
+}
+
+func awsSecretPermissionFindingFromSecretGrant(secret AWSSecretsManagerMetadataRecord, grant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	if !strings.EqualFold(firstNonEmptyAWSValue(grant.Effect, "Allow"), "Allow") {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	if awsSecretPermissionSecretGrantDenied(grant, denyGrants) || !awsSecretPermissionSecretGrantCanRead(grant) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	provider := awsSecretPermissionProvider("", secret.SecretName, secret.SecretARN, secret.SensitivityClassification)
+	if !awsSecretPermissionProviderIsPermissionBearing(provider, secret.SensitivityClassification) && !secret.Sensitive {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := 68
+	if grant.IsCrossAccount || secret.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if grant.IsPublic || grant.WildcardPrincipal || secret.ExposureClassification == "public" {
+		score += 14
+	}
+	if !grant.HasCondition {
+		score += 5
+	}
+	score = clampBlastRadiusScore(score)
+	principal := firstNonEmptyAWSValue(grant.PrincipalARN, "wildcard-principal")
+	identity := awsIdentityNodeIDForAPI(principal)
+	secretLabel := firstNonEmptyAWSValue(secret.SecretName, secret.SecretARN)
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("secret-grant", principal, secret.SecretARN, strings.Join(grant.Actions, ",")),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "secret_read_policy_equivalence",
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsPrivilegeEscalationFindingStatus(score, secret.Confidence),
+		Score:                 score,
+		Confidence:            minFloat(firstNonZeroFloat(secret.Confidence, 0.82), 0.92),
+		AccountID:             secret.AccountID,
+		Region:                secret.Region,
+		IdentityNodeID:        identity,
+		PrincipalARN:          principal,
+		SecretNodeID:          secret.FromNodeID,
+		SecretARN:             secret.SecretARN,
+		SecretLabel:           secretLabel,
+		Provider:              provider,
+		EquivalentPermissions: awsSecretPermissionProviderPermissions(provider),
+		ImpliedActions:        grant.Actions,
+		SourceSignals:         []string{"secrets_manager_metadata"},
+		Rationale:             fmt.Sprintf("%s can read permission-bearing secret metadata %s through actions %s; secret values remain outside the evidence boundary.", firstNonEmptyAWSValue(shortAWSARN(principal), principal), secretLabel, strings.Join(grant.Actions, ", ")),
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         dedupeStrings([]string{identity, secret.FromNodeID}),
+		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+			awsLeastPrivilegePathStep(identity, "identity", firstNonEmptyAWSValue(shortAWSARN(principal), principal), secret.AccountID, secret.Region),
+			awsLeastPrivilegePathStep(secret.FromNodeID, "permission_bearing_secret", secretLabel, secret.AccountID, secret.Region),
+		},
+		Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "secrets_manager_metadata", EvidenceRef: secret.EvidenceRef, Label: "Secrets Manager read grant", Confidence: secret.Confidence, ObservedAt: secret.CollectedAt, Relationship: "can_read_permission_bearing_secret"}},
+		NextAction: "Validate the secret owner and restrict GetSecretValue/resource-policy access before using downstream remediation.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}), true
+}
+
+func awsSecretPermissionFindingFromKMSGrant(key AWSKMSDecryptReachabilityRecord, secret AWSSecretsManagerMetadataRecord, grant AWSKMSIdentityGrant, denyGrants []AWSKMSIdentityGrant, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	if !strings.EqualFold(firstNonEmptyAWSValue(grant.Effect, "Allow"), "Allow") {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	if awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(grant, denyGrants) || !awsSecretPermissionKMSGrantCanDecrypt(grant.Actions, grant.Capabilities) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := 64
+	if grant.IsCrossAccount || key.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if grant.IsPublic || grant.WildcardPrincipal || key.ExposureClassification == "public" {
+		score += 14
+	}
+	score = clampBlastRadiusScore(score)
+	principal := firstNonEmptyAWSValue(grant.PrincipalARN, "wildcard-principal")
+	return awsSecretPermissionKMSFinding(key, secret, principal, grant.Actions, grant.Capabilities, grant.HasCondition, score, minFloat(key.Confidence, 0.86), "kms_decrypt_secret_equivalence", "kms_decrypt_reachability", now)
+}
+
+func awsSecretPermissionFindingFromKMSLiveGrant(key AWSKMSDecryptReachabilityRecord, secret AWSSecretsManagerMetadataRecord, grant AWSKMSGrant, denyGrants []AWSKMSIdentityGrant, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	if strings.TrimSpace(grant.GranteePrincipal) == "" || !awsSecretPermissionKMSGrantCanDecrypt(grant.Operations, grant.Capabilities) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	if awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant, denyGrants) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := 66
+	if grant.IsCrossAccount || key.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if !grant.HasConstraints {
+		score += 5
+	}
+	return awsSecretPermissionKMSFinding(key, secret, grant.GranteePrincipal, grant.Operations, grant.Capabilities, grant.HasConstraints, clampBlastRadiusScore(score), minFloat(key.Confidence, 0.88), "kms_live_grant_secret_equivalence", "kms_live_grant", now)
+}
+
+func awsSecretPermissionKMSFinding(key AWSKMSDecryptReachabilityRecord, secret AWSSecretsManagerMetadataRecord, principal string, actions []string, capabilities []string, conditioned bool, score int, confidence float64, equivalenceType string, source string, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	provider := awsSecretPermissionProvider("", secret.SecretName, secret.SecretARN, secret.SensitivityClassification)
+	if !awsSecretPermissionProviderIsPermissionBearing(provider, secret.SensitivityClassification) && !secret.Sensitive {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	identity := awsIdentityNodeIDForAPI(principal)
+	secretLabel := firstNonEmptyAWSValue(secret.SecretName, secret.SecretARN)
+	policySources := dedupeStrings(append(append([]string{}, actions...), capabilities...))
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken(equivalenceType, principal, key.KeyARN, secret.SecretARN),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       equivalenceType,
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsPrivilegeEscalationFindingStatus(score, confidence),
+		Score:                 score,
+		Confidence:            confidence,
+		AccountID:             secret.AccountID,
+		Region:                secret.Region,
+		IdentityNodeID:        identity,
+		PrincipalARN:          principal,
+		SecretNodeID:          secret.FromNodeID,
+		SecretARN:             secret.SecretARN,
+		SecretLabel:           secretLabel,
+		Provider:              provider,
+		EquivalentPermissions: awsSecretPermissionProviderPermissions(provider),
+		ImpliedActions:        policySources,
+		SourceSignals:         []string{source, "secrets_manager_metadata"},
+		Rationale:             fmt.Sprintf("%s can use KMS permissions %s on %s, which protects permission-bearing secret %s; conditioned=%t.", firstNonEmptyAWSValue(shortAWSARN(principal), principal), strings.Join(policySources, ", "), firstNonEmptyAWSValue(key.Description, key.KeyID), secretLabel, conditioned),
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         dedupeStrings([]string{identity, key.FromNodeID, secret.FromNodeID}),
+		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+			awsLeastPrivilegePathStep(identity, "identity", firstNonEmptyAWSValue(shortAWSARN(principal), principal), secret.AccountID, secret.Region),
+			awsLeastPrivilegePathStep(key.FromNodeID, "kms_key", firstNonEmptyAWSValue(key.Description, key.KeyARN), key.AccountID, key.Region),
+			awsLeastPrivilegePathStep(secret.FromNodeID, "permission_bearing_secret", secretLabel, secret.AccountID, secret.Region),
+		},
+		Evidence: []AWSSecretPermissionEquivalenceEvidence{
+			{Source: source, EvidenceRef: key.EvidenceRef, Label: "KMS decrypt/admin reachability", Confidence: key.Confidence, ObservedAt: key.CollectedAt, Relationship: "can_decrypt_secret_key"},
+			{Source: "secrets_manager_metadata", EvidenceRef: secret.EvidenceRef, Label: "Secret KMS metadata", Confidence: secret.Confidence, ObservedAt: secret.CollectedAt, Relationship: "protects_permission_bearing_secret"},
+		},
+		NextAction: "Validate the secret/KMS owner boundary and remove broad decrypt grants before treating this credential as controlled.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}), true
+}
+
+func awsSecretPermissionFindingFromRuntime(record AWSSecretsKMSRuntimeAccessRecord, secretByARN map[string]AWSSecretsManagerMetadataRecord, secretByNode map[string]AWSSecretsManagerMetadataRecord, secretsByKMS map[string][]AWSSecretsManagerMetadataRecord, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	if record.Status == "granted_unused" {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	secret, ok := awsSecretPermissionSecretForRuntime(record, secretByARN, secretByNode, secretsByKMS)
+	provider := awsSecretPermissionProvider("", firstNonEmptyAWSValue(secret.SecretName, record.ResourceName), firstNonEmptyAWSValue(secret.SecretARN, record.ResourceARN), secret.SensitivityClassification)
+	if !ok && record.ResourceKind == "kms_key" {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	if !awsSecretPermissionProviderIsPermissionBearing(provider, secret.SensitivityClassification) && !secret.Sensitive && record.ResourceKind != "secret" {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := 76
+	if record.Status == "observed_without_grant" {
+		score += 10
+	}
+	if record.CrossAccount {
+		score += 8
+	}
+	score = clampBlastRadiusScore(score)
+	secretNode := firstNonEmptyAWSValue(secret.FromNodeID, record.ResourceNodeID)
+	secretARN := firstNonEmptyAWSValue(secret.SecretARN, record.ResourceARN)
+	secretLabel := firstNonEmptyAWSValue(secret.SecretName, record.ResourceName, record.ResourceARN)
+	principal := firstNonEmptyAWSValue(record.PrincipalARN, record.IdentityNodeID)
+	identity := firstNonEmptyAWSValue(record.IdentityNodeID, awsIdentityNodeIDForAPI(principal))
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("runtime", record.CorrelationID, secretARN),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "runtime_secret_access_equivalence",
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:                 score,
+		Confidence:            minFloat(record.Confidence, 0.94),
+		AccountID:             record.AccountID,
+		Region:                record.Region,
+		IdentityNodeID:        identity,
+		PrincipalARN:          record.PrincipalARN,
+		AgentID:               record.AgentID,
+		SecretNodeID:          secretNode,
+		SecretARN:             secretARN,
+		SecretLabel:           secretLabel,
+		Provider:              provider,
+		EquivalentPermissions: awsSecretPermissionProviderPermissions(provider),
+		ImpliedActions:        record.Actions,
+		SourceSignals:         []string{"secrets_kms_runtime_access"},
+		Rationale:             fmt.Sprintf("Runtime evidence observed %s accessing permission-bearing %s %s with status=%s.", firstNonEmptyAWSValue(shortAWSARN(principal), principal), formatAWSBlastRadiusLabel(record.ResourceKind), secretLabel, record.Status),
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         dedupeStrings([]string{identity, secretNode}),
+		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+			awsLeastPrivilegePathStep(identity, "identity", firstNonEmptyAWSValue(shortAWSARN(principal), principal), record.AccountID, record.Region),
+			awsLeastPrivilegePathStep(secretNode, "permission_bearing_secret", secretLabel, record.AccountID, record.Region),
+		},
+		Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "secrets_kms_runtime_access", EvidenceRef: record.EvidenceRef, Label: "Observed secret/KMS runtime access", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: "observed_permission_bearing_secret_access"}},
+		NextAction: "Confirm this runtime access is expected, then rotate or scope the credential and its reader identity as one permission boundary.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}), true
+}
+
+func awsSecretPermissionFindingsFromAgent(agent AWSAIAgentIdentityRecord, secretByARN map[string]AWSSecretsManagerMetadataRecord, secretByNode map[string]AWSSecretsManagerMetadataRecord, now time.Time) []AWSSecretPermissionEquivalenceFinding {
+	findings := []AWSSecretPermissionEquivalenceFinding{}
+	for _, ref := range agent.ProviderKeyReferences {
+		provider := awsSecretPermissionProvider(ref.Provider, ref.ReferenceName, ref.Reference, ref.Sensitivity)
+		if !awsSecretPermissionProviderIsPermissionBearing(provider, ref.Sensitivity) {
+			continue
+		}
+		secret := awsSecretPermissionSecretForAgentReference(ref, secretByARN, secretByNode)
+		secretNode := firstNonEmptyAWSValue(ref.TargetNodeID, secret.FromNodeID, "aws:credential-reference:"+stableAWSBlastRadiusToken(agent.AgentID, ref.ReferenceName))
+		secretLabel := firstNonEmptyAWSValue(secret.SecretName, ref.ReferenceName, ref.ReferenceKind, "provider key reference")
+		score := awsSecretPermissionProviderScore(provider) + 8
+		if !ref.Resolved {
+			score -= 8
+		}
+		score = clampBlastRadiusScore(score)
+		confidence := minFloat(firstNonZeroFloat(ref.Confidence, agent.Confidence, 0.78), 0.94)
+		if !ref.Resolved {
+			confidence = minFloat(confidence, 0.8)
+		}
+		identity := firstNonEmptyAWSValue(agent.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(agent.RuntimeRoleARN), agent.AgentNodeID)
+		findings = append(findings, awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+			FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("agent-provider-key", agent.AgentID, secretNode, provider),
+			CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+			EquivalenceType:       "agent_provider_key_equivalence",
+			Severity:              awsPrivilegeEscalationSeverity(score),
+			Status:                awsSecretPermissionFindingStatus(score, confidence, !ref.Resolved),
+			Score:                 score,
+			Confidence:            confidence,
+			AccountID:             agent.AccountID,
+			Region:                agent.Region,
+			IdentityNodeID:        identity,
+			PrincipalARN:          agent.RuntimeRoleARN,
+			AgentID:               agent.AgentID,
+			AgentName:             agent.AgentName,
+			SecretNodeID:          secretNode,
+			SecretARN:             secret.SecretARN,
+			SecretLabel:           secretLabel,
+			Provider:              provider,
+			ProviderKeyReference:  ref.ReferenceName,
+			EquivalentPermissions: awsSecretPermissionProviderPermissions(provider),
+			SourceSignals:         []string{"ai_agent_identities"},
+			Rationale:             fmt.Sprintf("Agent %s has a %s provider-key reference; anyone controlling the agent runtime can inherit that provider permission without Identrail reading the key value.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), formatAWSBlastRadiusLabel(provider)),
+			EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+			ImpactedNodes:         dedupeStrings([]string{identity, agent.AgentNodeID, secretNode}),
+			ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+				awsLeastPrivilegePathStep(identity, "identity", firstNonEmptyAWSValue(shortAWSARN(agent.RuntimeRoleARN), agent.RuntimeRoleName, agent.AgentName), agent.AccountID, agent.Region),
+				awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region),
+				awsLeastPrivilegePathStep(secretNode, "permission_bearing_secret", secretLabel, agent.AccountID, agent.Region),
+			},
+			Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "ai_agent_identities", EvidenceRef: firstNonEmptyAWSValue(ref.EvidenceRef, agent.EvidenceRef), Label: "Agent provider-key metadata", Confidence: confidence, ObservedAt: agent.CollectedAt, Relationship: "agent_uses_permission_bearing_secret"}},
+			NextAction: awsSecretPermissionNextAction(provider, !ref.Resolved),
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}))
+	}
+	return findings
+}
+
+func awsSecretPermissionFindingFromBlastRadius(finding AWSBlastRadiusFinding, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	if !awsSecretPermissionBlastFindingUsesSecret(finding) {
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := clampBlastRadiusScore(finding.Score + 4)
+	target := firstNonEmptyAWSValue(lastString(finding.SensitiveNodes), lastString(finding.ImpactedNodes), finding.IdentityNodeID)
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("blast-radius", finding.FindingID),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "blast_radius_secret_equivalence",
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsPrivilegeEscalationFindingStatus(score, finding.Confidence),
+		Score:                 score,
+		Confidence:            minFloat(finding.Confidence, 0.9),
+		AccountID:             finding.AccountID,
+		Region:                finding.Region,
+		IdentityNodeID:        finding.IdentityNodeID,
+		PrincipalARN:          finding.PrincipalARN,
+		SecretNodeID:          target,
+		SecretLabel:           target,
+		Provider:              "aws_secret",
+		EquivalentPermissions: awsSecretPermissionProviderPermissions("aws_secret"),
+		ImpliedActions:        finding.RuntimeActions,
+		SourceSignals:         []string{"blast_radius"},
+		Rationale:             fmt.Sprintf("Blast-radius intelligence includes permission-bearing secret or KMS evidence on %s with score %d.", finding.DisplayName, finding.Score),
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         finding.ImpactedNodes,
+		ImpactedPath:          []AWSSecretPermissionEquivalencePathStep(awsPrivilegeEscalationPathFromBlastRadius(finding.ImpactedPath)),
+		Evidence:              []AWSSecretPermissionEquivalenceEvidence(awsPrivilegeEscalationEvidenceFromBlastRadius(finding.Evidence)),
+		NextAction:            "Use the blast-radius path to decide whether the secret reader identity and credential owner need separate remediation cases.",
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}), true
+}
+
+func awsSecretPermissionFindingFromPrivilegeEscalation(finding AWSPrivilegeEscalationFinding, now time.Time) (AWSSecretPermissionEquivalenceFinding, bool) {
+	switch finding.EscalationType {
+	case "secrets_admin_equivalence", "kms_admin_equivalence":
+	default:
+		return AWSSecretPermissionEquivalenceFinding{}, false
+	}
+	score := clampBlastRadiusScore(finding.Score + 3)
+	target := firstNonEmptyAWSValue(finding.TargetNodeID, finding.TargetLabel)
+	return awsSecretPermissionFinding(AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:" + stableAWSBlastRadiusToken("privilege-escalation", finding.FindingID),
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "admin_equivalent_secret_permission",
+		Severity:              awsPrivilegeEscalationSeverity(score),
+		Status:                awsPrivilegeEscalationFindingStatus(score, finding.Confidence),
+		Score:                 score,
+		Confidence:            minFloat(finding.Confidence, 0.88),
+		AccountID:             finding.AccountID,
+		Region:                finding.Region,
+		IdentityNodeID:        finding.IdentityNodeID,
+		PrincipalARN:          finding.PrincipalARN,
+		SecretNodeID:          target,
+		SecretLabel:           firstNonEmptyAWSValue(finding.TargetLabel, target),
+		Provider:              "aws_secret",
+		EquivalentPermissions: awsSecretPermissionProviderPermissions("aws_secret"),
+		ImpliedActions:        finding.PolicySources,
+		SourceSignals:         []string{"privilege_escalation"},
+		Rationale:             "Privilege-escalation reasoning found admin or read equivalence over a secret/KMS resource; this engine exposes the secret-as-permission decision directly.",
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         finding.ImpactedNodes,
+		ImpactedPath:          []AWSSecretPermissionEquivalencePathStep(finding.ImpactedPath),
+		Evidence:              []AWSSecretPermissionEquivalenceEvidence(finding.Evidence),
+		NextAction:            "Review this alongside the privilege-escalation case and scope the secret or key grant before remediation.",
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}), true
+}
+
+func awsSecretPermissionFinding(finding AWSSecretPermissionEquivalenceFinding) AWSSecretPermissionEquivalenceFinding {
+	finding.Provider = firstNonEmptyAWSValue(finding.Provider, "generic_secret")
+	finding.EquivalentPermissions = dedupeStrings(finding.EquivalentPermissions)
+	finding.ImpliedActions = dedupeStrings(finding.ImpliedActions)
+	finding.SourceSignals = dedupeStrings(finding.SourceSignals)
+	finding.ImpactedNodes = dedupeStrings(finding.ImpactedNodes)
+	evidenceRefs := awsSecretPermissionEvidenceRefs(finding.Evidence)
+	finding.RemediationCase = AWSSecretPermissionEquivalenceRemediationCasePreview{
+		CaseID:             "aws-secret-permission-equivalence-preview:" + stableAWSBlastRadiusToken(finding.EquivalenceType, finding.IdentityNodeID, finding.SecretNodeID),
+		Title:              fmt.Sprintf("%s secret-permission review", formatAWSBlastRadiusLabel(finding.EquivalenceType)),
+		RecommendedAction:  finding.NextAction,
+		ApprovalRequired:   finding.Severity == "critical" || finding.Severity == "high",
+		BlockingEvidence:   evidenceRefs,
+		ImpactedNodeCount:  len(finding.ImpactedNodes),
+		EstimatedRiskDrop:  minInt(finding.Score, 42),
+		BreakagePrediction: "unknown",
+		ReadOnlyProjection: true,
+	}
+	return finding
+}
+
+func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermissionEquivalenceFinding, request AWSSecretPermissionEquivalenceRequest) ([]AWSSecretPermissionEquivalenceFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id":       strings.TrimSpace(request.AccountID),
+		"region":           strings.TrimSpace(request.Region),
+		"identity":         strings.TrimSpace(request.Identity),
+		"secret":           strings.TrimSpace(request.Secret),
+		"provider":         normalizeAWSRuntimeEventFilterToken(request.Provider),
+		"equivalence_type": normalizeAWSRuntimeEventFilterToken(request.EquivalenceType),
+		"severity":         normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":           normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSSecretPermissionEquivalenceFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && filters["account_id"] != finding.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["provider"] != "" && filters["provider"] != normalizeAWSRuntimeEventFilterToken(finding.Provider) {
+			continue
+		}
+		if filters["equivalence_type"] != "" && filters["equivalence_type"] != normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(finding.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
+			continue
+		}
+		if filters["identity"] != "" && !strings.Contains(strings.ToLower(finding.IdentityNodeID+" "+finding.PrincipalARN+" "+finding.WorkloadID+" "+finding.AgentID), strings.ToLower(filters["identity"])) {
+			continue
+		}
+		if filters["secret"] != "" && !strings.Contains(strings.ToLower(finding.SecretNodeID+" "+finding.SecretARN+" "+finding.SecretLabel+" "+finding.ProviderKeyReference), strings.ToLower(filters["secret"])) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, applied
+}
+
+func awsSecretPermissionEquivalenceRelationships(findings []AWSSecretPermissionEquivalenceFinding) []AWSSecretPermissionEquivalenceRelationship {
+	relationships := []AWSSecretPermissionEquivalenceRelationship{}
+	for _, finding := range findings {
+		if finding.IdentityNodeID == "" || finding.SecretNodeID == "" {
+			continue
+		}
+		relationships = append(relationships, AWSSecretPermissionEquivalenceRelationship{
+			FindingID:   finding.FindingID,
+			Type:        "secret_permission_equivalence",
+			FromNodeID:  finding.IdentityNodeID,
+			ToNodeID:    finding.SecretNodeID,
+			EvidenceRef: firstString(awsSecretPermissionEvidenceRefs(finding.Evidence)),
+		})
+	}
+	return relationships
+}
+
+func summarizeAWSSecretPermissionEquivalence(allFindings []AWSSecretPermissionEquivalenceFinding, filtered []AWSSecretPermissionEquivalenceFinding, relationships []AWSSecretPermissionEquivalenceRelationship) AWSSecretPermissionEquivalenceSummary {
+	summary := AWSSecretPermissionEquivalenceSummary{
+		TotalFindings:         len(allFindings),
+		FilteredFindings:      len(filtered),
+		SeverityCounts:        map[string]int{},
+		StatusCounts:          map[string]int{},
+		EquivalenceTypeCounts: map[string]int{},
+		ProviderCounts:        map[string]int{},
+		RelationshipCount:     len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, finding := range filtered {
+		summary.SeverityCounts[finding.Severity]++
+		summary.StatusCounts[finding.Status]++
+		summary.EquivalenceTypeCounts[finding.EquivalenceType]++
+		summary.ProviderCounts[finding.Provider]++
+		if finding.Score > summary.HighestScore {
+			summary.HighestScore = finding.Score
+		}
+		confidenceTotal += finding.Confidence
+		if awsSecretPermissionProviderIsExternal(finding.Provider) {
+			summary.ExternalProviderKeyCount++
+		}
+		if finding.Provider == "aws_secret" || finding.Provider == credentialProviderSecretsManager || finding.Provider == credentialProviderSSM {
+			summary.AWSManagedSecretCount++
+		}
+		if awsStringSliceContains(finding.SourceSignals, "secrets_kms_runtime_access") {
+			summary.RuntimeObservedCount++
+		}
+		if strings.Contains(finding.EquivalenceType, "kms") {
+			summary.KMSBackedCount++
+		}
+		if strings.Contains(finding.Status, "review") && strings.Contains(strings.ToLower(finding.Rationale), "unresolved") {
+			summary.UnresolvedReferenceCount++
+		}
+		if finding.RemediationCase.CaseID != "" {
+			summary.RemediationPreviewCount++
+		}
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func summarizeAWSSecretPermissionEquivalenceStatus(sources awsSecretPermissionEquivalenceSources, filtered []AWSSecretPermissionEquivalenceFinding, diagnostics []AWSSecretPermissionEquivalenceDiagnostic) (string, float64) {
+	statuses := []string{sources.credentials.Status, sources.secrets.Status, sources.kms.Status, sources.runtime.Status, sources.agents.Status, sources.blast.Status, sources.escalation.Status}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.76
+		}
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.84
+	}
+	return awsPlatformDependencyStatusReady, 0.91
+}
+
+func awsSecretPermissionEquivalenceFailureReasons(sources awsSecretPermissionEquivalenceSources) []string {
+	out := []string{}
+	for _, messages := range [][]string{
+		sources.credentials.FailureReasons,
+		sources.secrets.FailureReasons,
+		sources.kms.FailureReasons,
+		sources.runtime.FailureReasons,
+		sources.agents.FailureReasons,
+		sources.blast.FailureReasons,
+		sources.escalation.FailureReasons,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsSecretPermissionEquivalenceRemediationHints(sources awsSecretPermissionEquivalenceSources) []string {
+	out := []string{"Treat every readable provider key, AWS secret, and decryptable KMS-backed credential as permission-bearing until the owner rotates or scopes it."}
+	for _, messages := range [][]string{
+		sources.credentials.RemediationHints,
+		sources.secrets.RemediationHints,
+		sources.kms.RemediationHints,
+		sources.runtime.RemediationHints,
+		sources.agents.RemediationHints,
+		sources.blast.RemediationHints,
+		sources.escalation.RemediationHints,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsSecretPermissionEquivalenceCaveats() []string {
+	return []string{
+		"Secret-to-permission equivalence is inferred from metadata-only references, resource policies, KMS grants, runtime access, and graph evidence.",
+		"The engine never reads, stores, logs, or displays secret values, prompts, completions, object contents, or customer payloads.",
+		"Unknown, denied, unsupported, degraded, and partial evidence stays explicit instead of becoming deterministic truth.",
+	}
+}
+
+func awsSecretPermissionEquivalenceDiagnostics(sources awsSecretPermissionEquivalenceSources) []AWSSecretPermissionEquivalenceDiagnostic {
+	out := []AWSSecretPermissionEquivalenceDiagnostic{}
+	appendDiag := func(collector, sourceID, code, message, remediation string, retryable bool) {
+		if strings.TrimSpace(message) == "" && strings.TrimSpace(code) == "" {
+			return
+		}
+		out = append(out, AWSSecretPermissionEquivalenceDiagnostic{Collector: collector, SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: retryable})
+	}
+	for _, d := range sources.credentials.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.secrets.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.kms.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.runtime.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.agents.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.blast.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.escalation.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	return out
+}
+
+func awsSecretPermissionEquivalenceCoverageGaps(sources awsSecretPermissionEquivalenceSources) []AWSSecretPermissionEquivalenceCoverageGap {
+	out := []AWSSecretPermissionEquivalenceCoverageGap{{
+		Capability:  "secret_value_collection",
+		Status:      "unsupported",
+		Reason:      "Secret values are intentionally excluded; the engine uses metadata, policies, grants, references, runtime event IDs, and graph evidence only.",
+		Remediation: "Use the owning secret manager and approved rotation workflow to inspect or rotate values outside Identrail.",
+	}}
+	appendGap := func(capability, status, reason, remediation string) {
+		out = append(out, AWSSecretPermissionEquivalenceCoverageGap{Capability: capability, Status: status, Reason: reason, Remediation: remediation})
+	}
+	for _, g := range sources.credentials.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.secrets.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.kms.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.runtime.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.agents.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.blast.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.escalation.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	return out
+}
+
+func awsSecretPermissionSecretIndexes(secrets AWSSecretsManagerMetadataInventoryResult) (map[string]AWSSecretsManagerMetadataRecord, map[string]AWSSecretsManagerMetadataRecord, map[string][]AWSSecretsManagerMetadataRecord) {
+	byARN := map[string]AWSSecretsManagerMetadataRecord{}
+	byNode := map[string]AWSSecretsManagerMetadataRecord{}
+	byKMS := map[string][]AWSSecretsManagerMetadataRecord{}
+	for _, secret := range secrets.Records {
+		if secret.SecretARN != "" {
+			byARN[strings.ToLower(secret.SecretARN)] = secret
+		}
+		if secret.FromNodeID != "" {
+			byNode[strings.ToLower(secret.FromNodeID)] = secret
+		}
+		if secret.KMSKeyARN != "" {
+			key := strings.ToLower(strings.TrimSpace(secret.KMSKeyARN))
+			byKMS[key] = append(byKMS[key], secret)
+		}
+	}
+	return byARN, byNode, byKMS
+}
+
+func awsSecretPermissionSecretForCredentialReference(record AWSCredentialReferenceRecord, byARN map[string]AWSSecretsManagerMetadataRecord, byNode map[string]AWSSecretsManagerMetadataRecord) AWSSecretsManagerMetadataRecord {
+	if secret, ok := byNode[strings.ToLower(strings.TrimSpace(record.TargetNodeID))]; ok {
+		return secret
+	}
+	for arn, secret := range byARN {
+		if strings.Contains(strings.ToLower(record.Reference), arn) {
+			return secret
+		}
+	}
+	return AWSSecretsManagerMetadataRecord{}
+}
+
+func awsSecretPermissionSecretForAgentReference(ref AWSAIAgentProviderKeyReference, byARN map[string]AWSSecretsManagerMetadataRecord, byNode map[string]AWSSecretsManagerMetadataRecord) AWSSecretsManagerMetadataRecord {
+	if secret, ok := byNode[strings.ToLower(strings.TrimSpace(ref.TargetNodeID))]; ok {
+		return secret
+	}
+	for arn, secret := range byARN {
+		if strings.Contains(strings.ToLower(ref.Reference), arn) {
+			return secret
+		}
+	}
+	return AWSSecretsManagerMetadataRecord{}
+}
+
+func awsSecretPermissionSecretForRuntime(record AWSSecretsKMSRuntimeAccessRecord, byARN map[string]AWSSecretsManagerMetadataRecord, byNode map[string]AWSSecretsManagerMetadataRecord, byKMS map[string][]AWSSecretsManagerMetadataRecord) (AWSSecretsManagerMetadataRecord, bool) {
+	if secret, ok := byNode[strings.ToLower(strings.TrimSpace(record.ResourceNodeID))]; ok {
+		return secret, true
+	}
+	if secret, ok := byARN[strings.ToLower(strings.TrimSpace(record.ResourceARN))]; ok {
+		return secret, true
+	}
+	if strings.EqualFold(record.ResourceKind, "kms_key") {
+		secrets := byKMS[strings.ToLower(strings.TrimSpace(record.ResourceARN))]
+		if len(secrets) > 0 {
+			return secrets[0], true
+		}
+	}
+	return AWSSecretsManagerMetadataRecord{}, false
+}
+
+func awsSecretPermissionSecretDenyGrants(grants []AWSSecretsManagerIdentityGrant) []AWSSecretsManagerIdentityGrant {
+	out := []AWSSecretsManagerIdentityGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, grant)
+		}
+	}
+	return out
+}
+
+func awsSecretPermissionKMSDenyGrants(grants []AWSKMSIdentityGrant) []AWSKMSIdentityGrant {
+	out := []AWSKMSIdentityGrant{}
+	for _, grant := range grants {
+		if strings.EqualFold(grant.Effect, "Deny") {
+			out = append(out, grant)
+		}
+	}
+	return out
+}
+
+func awsSecretPermissionSecretGrantDenied(grant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant) bool {
+	for _, deny := range denyGrants {
+		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(grant.PrincipalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
+			continue
+		}
+		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(grant.Actions, deny.Actions) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretPermissionSecretGrantCanRead(grant AWSSecretsManagerIdentityGrant) bool {
+	for _, action := range grant.Actions {
+		action = strings.ToLower(strings.TrimSpace(action))
+		if action == "*" || awsActionPatternMatches(action, "secretsmanager:getsecretvalue") || awsActionPatternMatches(action, "secretsmanager:*") {
+			return true
+		}
+		if strings.Contains(action, "getsecretvalue") || strings.Contains(action, "batchgetsecretvalue") || strings.Contains(action, "replicatesecrettoregions") {
+			return true
+		}
+	}
+	return len(grant.Actions) == 0 && grant.WildcardPrincipal
+}
+
+func awsSecretPermissionKMSGrantCanDecrypt(actions []string, capabilities []string) bool {
+	for _, action := range append(append([]string{}, actions...), capabilities...) {
+		action = strings.ToLower(strings.TrimSpace(action))
+		if action == "*" || action == "decrypt" || action == "kms:decrypt" || strings.Contains(action, "decrypt") || strings.Contains(action, "admin") || strings.Contains(action, "manage") {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretPermissionProvider(provider, name, ref, sensitivity string) string {
+	provider = normalizeAWSRuntimeEventFilterToken(provider)
+	if provider != "" && provider != "generic" {
+		return provider
+	}
+	haystack := strings.ToLower(strings.Join([]string{name, ref, sensitivity}, " "))
+	switch {
+	case strings.Contains(haystack, "openai"):
+		return credentialProviderOpenAI
+	case strings.Contains(haystack, "anthropic") || strings.Contains(haystack, "claude"):
+		return credentialProviderAnthropic
+	case strings.Contains(haystack, "bedrock"):
+		return credentialProviderBedrock
+	case strings.Contains(haystack, "github") || strings.Contains(haystack, "ghp_"):
+		return credentialProviderGitHub
+	case strings.Contains(haystack, "slack"):
+		return credentialProviderSlack
+	case strings.Contains(haystack, "database") || strings.Contains(haystack, "db_") || strings.Contains(haystack, "connection"):
+		return credentialProviderDatabase
+	case strings.Contains(haystack, "webhook"):
+		return credentialProviderWebhook
+	case strings.Contains(haystack, "secretsmanager") || strings.Contains(haystack, "secret"):
+		return "aws_secret"
+	default:
+		return credentialProviderGeneric
+	}
+}
+
+func awsSecretPermissionProviderIsPermissionBearing(provider string, sensitivity string) bool {
+	if awsSecretPermissionProviderIsExternal(provider) || provider == "aws_secret" || provider == credentialProviderSecretsManager || provider == credentialProviderSSM {
+		return true
+	}
+	sensitivity = strings.ToLower(strings.TrimSpace(sensitivity))
+	return strings.Contains(sensitivity, "api_key") || strings.Contains(sensitivity, "token") || strings.Contains(sensitivity, "credential") || strings.Contains(sensitivity, "secret")
+}
+
+func awsSecretPermissionProviderIsExternal(provider string) bool {
+	switch provider {
+	case credentialProviderOpenAI, credentialProviderAnthropic, credentialProviderBedrock, credentialProviderGitHub, credentialProviderSlack, credentialProviderDatabase, credentialProviderWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
+func awsSecretPermissionProviderScore(provider string) int {
+	switch provider {
+	case credentialProviderOpenAI, credentialProviderAnthropic, credentialProviderBedrock:
+		return 72
+	case credentialProviderGitHub:
+		return 74
+	case credentialProviderDatabase:
+		return 70
+	case credentialProviderSlack, credentialProviderWebhook:
+		return 62
+	case "aws_secret", credentialProviderSecretsManager, credentialProviderSSM:
+		return 66
+	default:
+		return 58
+	}
+}
+
+func awsSecretPermissionProviderPermissions(provider string) []string {
+	switch provider {
+	case credentialProviderOpenAI:
+		return []string{"openai:api_request", "openai:model_inference"}
+	case credentialProviderAnthropic:
+		return []string{"anthropic:api_request", "anthropic:model_inference"}
+	case credentialProviderBedrock:
+		return []string{"bedrock:InvokeModel", "bedrock:InvokeAgent"}
+	case credentialProviderGitHub:
+		return []string{"github:api_request", "github:repository_access"}
+	case credentialProviderSlack:
+		return []string{"slack:api_request", "slack:webhook_post"}
+	case credentialProviderDatabase:
+		return []string{"database:connect", "database:query"}
+	case credentialProviderWebhook:
+		return []string{"webhook:invoke"}
+	case "aws_secret", credentialProviderSecretsManager:
+		return []string{"secretsmanager:GetSecretValue", "credential:use_secret_material"}
+	case credentialProviderSSM:
+		return []string{"ssm:GetParameter", "credential:use_parameter_value"}
+	default:
+		return []string{"credential:use_secret_material"}
+	}
+}
+
+func awsSecretPermissionFindingStatus(score int, confidence float64, unresolved bool) string {
+	if unresolved || confidence < 0.7 {
+		return "review"
+	}
+	return awsPrivilegeEscalationFindingStatus(score, confidence)
+}
+
+func awsSecretPermissionNextAction(provider string, unresolved bool) string {
+	if unresolved {
+		return "Resolve the credential reference to its owning secret store before treating the equivalence as deterministic."
+	}
+	if awsSecretPermissionProviderIsExternal(provider) {
+		return "Rotate or scope the provider credential and restrict every identity that can read it as one permission boundary."
+	}
+	return "Validate the secret owner, reader identities, and KMS boundary before opening a remediation case."
+}
+
+func awsSecretPermissionEvidenceBoundary() string {
+	return "metadata_only_no_secret_values_no_payloads"
+}
+
+func awsSecretPermissionEvidenceRefs(evidence []AWSSecretPermissionEquivalenceEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		out = append(out, item.EvidenceRef)
+	}
+	return dedupeStrings(out)
+}
+
+func awsSecretPermissionBlastFindingUsesSecret(finding AWSBlastRadiusFinding) bool {
+	haystack := strings.ToLower(strings.Join(append(append(append([]string{finding.RiskType}, finding.SensitiveNodes...), finding.RuntimeActions...), finding.AgentToolPaths...), " "))
+	return strings.Contains(haystack, "secret") || strings.Contains(haystack, "kms") || strings.Contains(haystack, "credential")
+}
+
+func awsSecretPermissionDedupeFindings(findings []AWSSecretPermissionEquivalenceFinding) []AWSSecretPermissionEquivalenceFinding {
+	out := []AWSSecretPermissionEquivalenceFinding{}
+	seen := map[string]int{}
+	for _, finding := range findings {
+		key := strings.ToLower(strings.Join([]string{finding.IdentityNodeID, finding.SecretNodeID, finding.Provider, finding.EquivalenceType}, "|"))
+		if idx, ok := seen[key]; ok {
+			if finding.Score > out[idx].Score || (finding.Score == out[idx].Score && len(finding.SourceSignals) > len(out[idx].SourceSignals)) {
+				merged := finding
+				merged.SourceSignals = dedupeStrings(append(merged.SourceSignals, out[idx].SourceSignals...))
+				merged.Evidence = append(merged.Evidence, out[idx].Evidence...)
+				merged.ImpactedNodes = dedupeStrings(append(merged.ImpactedNodes, out[idx].ImpactedNodes...))
+				out[idx] = awsSecretPermissionFinding(merged)
+			}
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, finding)
+	}
+	return out
+}

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -443,7 +443,7 @@ func awsSecretPermissionFindingFromKMSGrant(key AWSKMSDecryptReachabilityRecord,
 	if !strings.EqualFold(firstNonEmptyAWSValue(grant.Effect, "Allow"), "Allow") {
 		return AWSSecretPermissionEquivalenceFinding{}, false
 	}
-	if awsPrivilegeEscalationKMSIdentityGrantHasExplicitDeny(grant, denyGrants) || !awsSecretPermissionKMSGrantCanDecrypt(grant.Actions, grant.Capabilities) {
+	if awsSecretPermissionKMSDenyBlocksDecrypt(grant.PrincipalARN, grant.WildcardPrincipal, denyGrants) || !awsSecretPermissionKMSGrantCanDecrypt(grant.Actions, grant.Capabilities) {
 		return AWSSecretPermissionEquivalenceFinding{}, false
 	}
 	score := 64
@@ -462,7 +462,7 @@ func awsSecretPermissionFindingFromKMSLiveGrant(key AWSKMSDecryptReachabilityRec
 	if strings.TrimSpace(grant.GranteePrincipal) == "" || !awsSecretPermissionKMSGrantCanDecrypt(grant.Operations, grant.Capabilities) {
 		return AWSSecretPermissionEquivalenceFinding{}, false
 	}
-	if awsPrivilegeEscalationKMSLiveGrantHasExplicitDeny(grant, denyGrants) {
+	if awsSecretPermissionKMSDenyBlocksDecrypt(grant.GranteePrincipal, false, denyGrants) {
 		return AWSSecretPermissionEquivalenceFinding{}, false
 	}
 	score := 66
@@ -1146,12 +1146,101 @@ func awsSecretPermissionKMSDenyGrants(grants []AWSKMSIdentityGrant) []AWSKMSIden
 	return out
 }
 
+// awsSecretPermissionSecretReadAPIs is the closed set of secrets-manager read
+// APIs that, on their own, are sufficient to read a secret value.
+var awsSecretPermissionSecretReadAPIs = []string{
+	"secretsmanager:getsecretvalue",
+	"secretsmanager:batchgetsecretvalue",
+}
+
+// awsSecretPermissionSecretGrantReadAPIs returns the concrete read APIs the
+// grant's action list authorizes. A wildcard or secretsmanager:* grant
+// expands to every read API; a narrower grant only contributes the APIs it
+// actually matches. The returned set is what callers must verify is covered
+// by denies before treating the grant as fully suppressed.
+func awsSecretPermissionSecretGrantReadAPIs(grant AWSSecretsManagerIdentityGrant) []string {
+	allowed := map[string]bool{}
+	for _, raw := range grant.Actions {
+		action := strings.ToLower(strings.TrimSpace(raw))
+		if action == "" {
+			continue
+		}
+		if action == "*" {
+			for _, api := range awsSecretPermissionSecretReadAPIs {
+				allowed[api] = true
+			}
+			continue
+		}
+		for _, api := range awsSecretPermissionSecretReadAPIs {
+			if action == api || awsActionPatternMatches(action, api) {
+				allowed[api] = true
+			}
+		}
+	}
+	if len(allowed) == 0 && len(grant.Actions) == 0 && grant.WildcardPrincipal {
+		for _, api := range awsSecretPermissionSecretReadAPIs {
+			allowed[api] = true
+		}
+	}
+	out := make([]string, 0, len(allowed))
+	for api := range allowed {
+		out = append(out, api)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// awsSecretPermissionSecretGrantDenied returns true only when every read API
+// the allow grant authorizes is denied for the same principal. A deny that
+// only covers BatchGetSecretValue must not suppress a finding when
+// GetSecretValue would still be enough to read the secret.
 func awsSecretPermissionSecretGrantDenied(grant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant) bool {
+	readAPIs := awsSecretPermissionSecretGrantReadAPIs(grant)
+	if len(readAPIs) == 0 {
+		return false
+	}
+	for _, api := range readAPIs {
+		if !awsSecretPermissionAnyDenyCoversSecretAction(grant, denyGrants, api) {
+			return false
+		}
+	}
+	return true
+}
+
+func awsSecretPermissionAnyDenyCoversSecretAction(grant AWSSecretsManagerIdentityGrant, denyGrants []AWSSecretsManagerIdentityGrant, action string) bool {
 	for _, deny := range denyGrants {
 		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(grant.PrincipalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
 			continue
 		}
-		if awsPrivilegeEscalationKMSIdentityGrantActionsOverlap(grant.Actions, deny.Actions) {
+		for _, raw := range deny.Actions {
+			da := strings.ToLower(strings.TrimSpace(raw))
+			if da == "" {
+				continue
+			}
+			if da == "*" || da == action || awsActionPatternMatches(da, action) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// awsSecretPermissionKMSDenyBlocksDecrypt returns true only when a deny grant
+// for the same principal denies a decrypt action concretely. A broad allow
+// (kms:*) combined with a deny on an unrelated action (kms:Encrypt) must not
+// suppress the decrypt-equivalence finding because kms:Decrypt remains
+// reachable for the principal.
+func awsSecretPermissionKMSDenyBlocksDecrypt(principalARN string, wildcardPrincipal bool, denyGrants []AWSKMSIdentityGrant) bool {
+	for _, deny := range denyGrants {
+		if !strings.EqualFold(firstNonEmptyAWSValue(deny.Effect, "Deny"), "Deny") {
+			continue
+		}
+		if !awsPrivilegeEscalationIdentityGrantPrincipalsMatch(principalARN, deny.PrincipalARN, deny.WildcardPrincipal) {
+			if !wildcardPrincipal {
+				continue
+			}
+		}
+		if awsSecretPermissionKMSGrantCanDecrypt(deny.Actions, deny.Capabilities) {
 			return true
 		}
 	}

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -77,6 +77,7 @@ type AWSSecretPermissionEquivalenceFinding struct {
 	Evidence              []AWSSecretPermissionEquivalenceEvidence             `json:"evidence"`
 	NextAction            string                                               `json:"next_action"`
 	RemediationCase       AWSSecretPermissionEquivalenceRemediationCasePreview `json:"remediation_case"`
+	UnresolvedReference   bool                                                 `json:"unresolved_reference,omitempty"`
 	CreatedAt             time.Time                                            `json:"created_at"`
 	UpdatedAt             time.Time                                            `json:"updated_at"`
 }
@@ -365,6 +366,7 @@ func awsSecretPermissionFindingFromCredentialReference(record AWSCredentialRefer
 		SourceSignals:         []string{"credential_references"},
 		Rationale:             fmt.Sprintf("%s references %s credential metadata for %s; the engine treats the referenced credential as permission-bearing without reading its value.", firstNonEmptyAWSValue(record.WorkloadName, record.WorkloadID), formatAWSBlastRadiusLabel(provider), secretLabel),
 		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		UnresolvedReference:   record.Unresolved,
 		ImpactedNodes:         dedupeStrings([]string{identity, secretNodeID}),
 		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
 			awsLeastPrivilegePathStep(identity, record.ResourceType, firstNonEmptyAWSValue(record.WorkloadName, record.WorkloadID), record.AccountID, record.Region),
@@ -624,10 +626,11 @@ func awsSecretPermissionFindingsFromAgent(agent AWSAIAgentIdentityRecord, secret
 				awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region),
 				awsLeastPrivilegePathStep(secretNode, "permission_bearing_secret", secretLabel, agent.AccountID, agent.Region),
 			},
-			Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "ai_agent_identities", EvidenceRef: firstNonEmptyAWSValue(ref.EvidenceRef, agent.EvidenceRef), Label: "Agent provider-key metadata", Confidence: confidence, ObservedAt: agent.CollectedAt, Relationship: "agent_uses_permission_bearing_secret"}},
-			NextAction: awsSecretPermissionNextAction(provider, !ref.Resolved),
-			CreatedAt:  now,
-			UpdatedAt:  now,
+			UnresolvedReference: !ref.Resolved,
+			Evidence:            []AWSSecretPermissionEquivalenceEvidence{{Source: "ai_agent_identities", EvidenceRef: firstNonEmptyAWSValue(ref.EvidenceRef, agent.EvidenceRef), Label: "Agent provider-key metadata", Confidence: confidence, ObservedAt: agent.CollectedAt, Relationship: "agent_uses_permission_bearing_secret"}},
+			NextAction:          awsSecretPermissionNextAction(provider, !ref.Resolved),
+			CreatedAt:           now,
+			UpdatedAt:           now,
 		}))
 	}
 	return findings
@@ -766,7 +769,7 @@ func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermission
 		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
 			continue
 		}
-		if filters["identity"] != "" && !strings.Contains(strings.ToLower(finding.IdentityNodeID+" "+finding.PrincipalARN+" "+finding.WorkloadID+" "+finding.AgentID), strings.ToLower(filters["identity"])) {
+		if filters["identity"] != "" && !strings.Contains(strings.ToLower(finding.IdentityNodeID+" "+finding.PrincipalARN+" "+finding.WorkloadID+" "+finding.WorkloadName+" "+finding.AgentID+" "+finding.AgentName), strings.ToLower(filters["identity"])) {
 			continue
 		}
 		if filters["secret"] != "" && !strings.Contains(strings.ToLower(finding.SecretNodeID+" "+finding.SecretARN+" "+finding.SecretLabel+" "+finding.ProviderKeyReference), strings.ToLower(filters["secret"])) {
@@ -826,7 +829,7 @@ func summarizeAWSSecretPermissionEquivalence(allFindings []AWSSecretPermissionEq
 		if strings.Contains(finding.EquivalenceType, "kms") {
 			summary.KMSBackedCount++
 		}
-		if strings.Contains(finding.Status, "review") && strings.Contains(strings.ToLower(finding.Rationale), "unresolved") {
+		if finding.UnresolvedReference {
 			summary.UnresolvedReferenceCount++
 		}
 		if finding.RemediationCase.CaseID != "" {
@@ -1214,6 +1217,7 @@ func awsSecretPermissionDedupeFindings(findings []AWSSecretPermissionEquivalence
 				merged.SourceSignals = dedupeStrings(append(merged.SourceSignals, out[idx].SourceSignals...))
 				merged.Evidence = append(merged.Evidence, out[idx].Evidence...)
 				merged.ImpactedNodes = dedupeStrings(append(merged.ImpactedNodes, out[idx].ImpactedNodes...))
+				merged.UnresolvedReference = merged.UnresolvedReference || out[idx].UnresolvedReference
 				out[idx] = awsSecretPermissionFinding(merged)
 			}
 			continue

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -27,6 +27,8 @@ type AWSSecretPermissionEquivalenceRequest struct {
 	EquivalenceType string `json:"equivalence_type,omitempty"`
 	Severity        string `json:"severity,omitempty"`
 	Status          string `json:"status,omitempty"`
+	Evidence        string `json:"evidence,omitempty"`
+	Search          string `json:"search,omitempty"`
 }
 
 type AWSSecretPermissionEquivalenceEvidence = AWSLeastPrivilegeEvidence
@@ -739,6 +741,8 @@ func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermission
 		"equivalence_type": normalizeAWSRuntimeEventFilterToken(request.EquivalenceType),
 		"severity":         normalizeAWSRuntimeEventFilterToken(request.Severity),
 		"status":           normalizeAWSRuntimeEventFilterToken(request.Status),
+		"evidence":         strings.TrimSpace(request.Evidence),
+		"search":           strings.TrimSpace(request.Search),
 	}
 	for key, value := range filters {
 		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
@@ -775,9 +779,101 @@ func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermission
 		if filters["secret"] != "" && !strings.Contains(strings.ToLower(finding.SecretNodeID+" "+finding.SecretARN+" "+finding.SecretLabel+" "+finding.ProviderKeyReference), strings.ToLower(filters["secret"])) {
 			continue
 		}
+		if filters["evidence"] != "" && !awsSecretPermissionEvidenceFilterMatch(finding, filters["evidence"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsSecretPermissionSearchFilterMatch(finding, filters["search"]) {
+			continue
+		}
 		filtered = append(filtered, finding)
 	}
 	return filtered, applied
+}
+
+func awsSecretPermissionEvidenceFilterMatch(finding AWSSecretPermissionEquivalenceFinding, evidenceFilter string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(evidenceFilter) {
+	case "runtime-backed":
+		return awsSecretPermissionFindingHasRuntimeEvidence(finding)
+	case "inventory-backed":
+		return awsSecretPermissionFindingHasInventoryEvidence(finding)
+	case "unavailable":
+		return len(finding.Evidence) == 0
+	default:
+		for _, item := range finding.Evidence {
+			if awsRuntimeEventMatchesAny(evidenceFilter, item.Source, item.Label, item.EvidenceRef, item.Relationship) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func awsSecretPermissionFindingHasRuntimeEvidence(finding AWSSecretPermissionEquivalenceFinding) bool {
+	for _, item := range finding.Evidence {
+		if strings.EqualFold(strings.TrimSpace(item.Source), "secrets_kms_runtime_access") {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretPermissionFindingHasInventoryEvidence(finding AWSSecretPermissionEquivalenceFinding) bool {
+	for _, item := range finding.Evidence {
+		if strings.EqualFold(strings.TrimSpace(item.Source), "secrets_kms_runtime_access") {
+			continue
+		}
+		if strings.TrimSpace(item.Source) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretPermissionSearchFilterMatch(finding AWSSecretPermissionEquivalenceFinding, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	for _, item := range awsSecretPermissionSearchValues(finding) {
+		if strings.Contains(strings.ToLower(item), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretPermissionSearchValues(finding AWSSecretPermissionEquivalenceFinding) []string {
+	candidates := []string{
+		finding.AccountID,
+		finding.Region,
+		finding.IdentityNodeID,
+		finding.PrincipalARN,
+		finding.WorkloadID,
+		finding.WorkloadName,
+		finding.AgentID,
+		finding.AgentName,
+		finding.SecretNodeID,
+		finding.SecretARN,
+		finding.SecretLabel,
+		finding.Provider,
+		finding.ProviderKeyReference,
+		finding.EquivalenceType,
+		finding.Severity,
+		finding.Status,
+		finding.Rationale,
+		finding.EvidenceBoundary,
+	}
+	candidates = append(candidates, finding.EquivalentPermissions...)
+	candidates = append(candidates, finding.ImpliedActions...)
+	candidates = append(candidates, finding.SourceSignals...)
+	candidates = append(candidates, finding.ImpactedNodes...)
+	for _, item := range finding.Evidence {
+		candidates = append(candidates, item.Source, item.EvidenceRef, item.Label, item.Relationship)
+	}
+	for _, item := range finding.ImpactedPath {
+		candidates = append(candidates, item.NodeID, item.NodeType, item.Label, item.AccountID, item.Region)
+	}
+	return dedupeStrings(candidates)
 }
 
 func awsSecretPermissionEquivalenceRelationships(findings []AWSSecretPermissionEquivalenceFinding) []AWSSecretPermissionEquivalenceRelationship {
@@ -1068,7 +1164,7 @@ func awsSecretPermissionSecretGrantCanRead(grant AWSSecretsManagerIdentityGrant)
 		if action == "*" || awsActionPatternMatches(action, "secretsmanager:getsecretvalue") || awsActionPatternMatches(action, "secretsmanager:*") {
 			return true
 		}
-		if strings.Contains(action, "getsecretvalue") || strings.Contains(action, "batchgetsecretvalue") || strings.Contains(action, "replicatesecrettoregions") {
+		if strings.Contains(action, "getsecretvalue") || strings.Contains(action, "batchgetsecretvalue") {
 			return true
 		}
 	}

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -735,7 +735,7 @@ func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermission
 		"region":           strings.TrimSpace(request.Region),
 		"identity":         strings.TrimSpace(request.Identity),
 		"secret":           strings.TrimSpace(request.Secret),
-		"provider":         normalizeAWSRuntimeEventFilterToken(request.Provider),
+		"provider":         awsSecretPermissionProviderFilterToken(request.Provider),
 		"equivalence_type": normalizeAWSRuntimeEventFilterToken(request.EquivalenceType),
 		"severity":         normalizeAWSRuntimeEventFilterToken(request.Severity),
 		"status":           normalizeAWSRuntimeEventFilterToken(request.Status),
@@ -757,7 +757,7 @@ func filterAWSSecretPermissionEquivalenceFindings(findings []AWSSecretPermission
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
 			continue
 		}
-		if filters["provider"] != "" && filters["provider"] != normalizeAWSRuntimeEventFilterToken(finding.Provider) {
+		if filters["provider"] != "" && filters["provider"] != awsSecretPermissionProviderFilterToken(finding.Provider) {
 			continue
 		}
 		if filters["equivalence_type"] != "" && filters["equivalence_type"] != normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType) {
@@ -1078,7 +1078,7 @@ func awsSecretPermissionSecretGrantCanRead(grant AWSSecretsManagerIdentityGrant)
 func awsSecretPermissionKMSGrantCanDecrypt(actions []string, capabilities []string) bool {
 	for _, action := range append(append([]string{}, actions...), capabilities...) {
 		action = strings.ToLower(strings.TrimSpace(action))
-		if action == "*" || action == "decrypt" || action == "kms:decrypt" || strings.Contains(action, "decrypt") || strings.Contains(action, "admin") || strings.Contains(action, "manage") {
+		if action == "*" || action == "decrypt" || awsActionPatternMatches(action, "kms:decrypt") || strings.Contains(action, "decrypt") || strings.Contains(action, "admin") || strings.Contains(action, "manage") {
 			return true
 		}
 	}
@@ -1125,6 +1125,10 @@ func awsSecretPermissionCanonicalProvider(provider string) string {
 	default:
 		return provider
 	}
+}
+
+func awsSecretPermissionProviderFilterToken(provider string) string {
+	return normalizeAWSRuntimeEventFilterToken(awsSecretPermissionCanonicalProvider(provider))
 }
 
 func awsSecretPermissionProviderIsPermissionBearing(provider string, sensitivity string) bool {

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -1086,7 +1086,7 @@ func awsSecretPermissionKMSGrantCanDecrypt(actions []string, capabilities []stri
 }
 
 func awsSecretPermissionProvider(provider, name, ref, sensitivity string) string {
-	provider = normalizeAWSRuntimeEventFilterToken(provider)
+	provider = awsSecretPermissionCanonicalProvider(provider)
 	if provider != "" && provider != "generic" {
 		return provider
 	}
@@ -1110,6 +1110,20 @@ func awsSecretPermissionProvider(provider, name, ref, sensitivity string) string
 		return "aws_secret"
 	default:
 		return credentialProviderGeneric
+	}
+}
+
+func awsSecretPermissionCanonicalProvider(provider string) string {
+	provider = normalizeAWSRuntimeEventFilterToken(provider)
+	switch provider {
+	case "secretsmanager", "secrets-manager", "aws-secretsmanager", "aws-secrets-manager":
+		return credentialProviderSecretsManager
+	case "ssm", "aws-ssm", "parameter-store", "parameterstore", "ssm-parameter":
+		return credentialProviderSSM
+	case "aws-secret":
+		return "aws_secret"
+	default:
+		return provider
 	}
 }
 

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -1078,7 +1078,7 @@ func awsSecretPermissionSecretGrantCanRead(grant AWSSecretsManagerIdentityGrant)
 func awsSecretPermissionKMSGrantCanDecrypt(actions []string, capabilities []string) bool {
 	for _, action := range append(append([]string{}, actions...), capabilities...) {
 		action = strings.ToLower(strings.TrimSpace(action))
-		if action == "*" || action == "decrypt" || awsActionPatternMatches(action, "kms:decrypt") || strings.Contains(action, "decrypt") || strings.Contains(action, "admin") || strings.Contains(action, "manage") {
+		if action == "*" || action == "decrypt" || awsActionPatternMatches(action, "kms:decrypt") || strings.Contains(action, "decrypt") {
 			return true
 		}
 	}

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -118,6 +118,83 @@ func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
 	}
 }
 
+func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
+	now := time.Date(2026, 6, 22, 8, 50, 0, 0, time.UTC)
+	accountID := "123456789012"
+	region := "us-east-1"
+	roleARN := "arn:aws:iam::123456789012:role/source"
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/99990000-1111-2222-3333-444455556666"
+	key := AWSKMSDecryptReachabilityRecord{
+		AccountID:   accountID,
+		Region:      region,
+		KeyARN:      keyARN,
+		KeyID:       "restricted-key",
+		FromNodeID:  "aws:resource:kms-key/" + keyARN,
+		Confidence:  0.91,
+		EvidenceRef: "evidence://kms/restricted-key",
+		CollectedAt: now,
+	}
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:                       accountID,
+		Region:                          region,
+		SecretARN:                       "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/api/key",
+		SecretName:                      "prod/api/key",
+		KMSKeyARN:                       keyARN,
+		Sensitive:                       true,
+		SensitivityClassification:       "aws_managed_secret",
+		FromNodeID:                      "aws:resource:secrets-manager-secret/prod/api/key",
+		EvidenceRef:                     "evidence://secret/prod-api-key",
+		Confidence:                      0.9,
+		CollectedAt:                     now,
+		SensitivityClassificationSource: "fixture",
+	}
+	allow := AWSKMSIdentityGrant{
+		PrincipalARN: roleARN,
+		Effect:       "Allow",
+		Capabilities: []string{"decrypt"},
+	}
+	deny := []AWSKMSIdentityGrant{{
+		PrincipalARN: roleARN,
+		Effect:       "Deny",
+		Actions:      []string{"kms:Decrypt"},
+	}}
+
+	if _, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, nil, now); !ok {
+		t.Fatalf("expected capability-only KMS decrypt allow to produce a finding without a deny")
+	}
+	if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, deny, now); ok {
+		t.Fatalf("expected explicit deny on kms:Decrypt to suppress capability-only KMS finding, got %+v", finding)
+	}
+}
+
+func TestAWSSecretPermissionProviderCanonicalizesAWSStoreAliases(t *testing.T) {
+	cases := []struct {
+		name           string
+		provider       string
+		wantProvider   string
+		wantPermission string
+	}{
+		{name: "secrets manager compact alias", provider: "secretsmanager", wantProvider: credentialProviderSecretsManager, wantPermission: "secretsmanager:GetSecretValue"},
+		{name: "secrets manager underscored alias", provider: "aws_secrets_manager", wantProvider: credentialProviderSecretsManager, wantPermission: "secretsmanager:GetSecretValue"},
+		{name: "ssm alias", provider: "ssm", wantProvider: credentialProviderSSM, wantPermission: "ssm:GetParameter"},
+		{name: "ssm parameter alias", provider: "ssm_parameter", wantProvider: credentialProviderSSM, wantPermission: "ssm:GetParameter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := awsSecretPermissionProvider(tc.provider, "", "", "generic_secret")
+			if got != tc.wantProvider {
+				t.Fatalf("expected canonical provider %q, got %q", tc.wantProvider, got)
+			}
+			if !awsStringSliceContains(awsSecretPermissionProviderPermissions(got), tc.wantPermission) {
+				t.Fatalf("expected permissions for %q to include %q", got, tc.wantPermission)
+			}
+			if !awsSecretPermissionProviderIsPermissionBearing(got, "") {
+				t.Fatalf("expected %q to remain permission-bearing", got)
+			}
+		})
+	}
+}
+
 func TestGetAWSSecretPermissionEquivalenceFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 21, 13, 10, 0, 0, time.UTC)
 	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-states", now)

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newSecretPermissionEquivalenceService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSSecretPermissionEquivalenceBuildsFindingContract(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 0, 0, 0, time.UTC)
+	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence", now)
+
+	result, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get secret permission equivalence: %v", err)
+	}
+	if result.CurrentIssueRef != "#1527" || result.Version != awsSecretPermissionEquivalenceVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected findings summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.ExternalProviderKeyCount == 0 || result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected provider-key findings and graph relationships: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 || len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected remediation previews, caveats, and coverage gaps: summary=%+v caveats=%v gaps=%v", result.Summary, result.Caveats, result.CoverageGaps)
+	}
+	for i := 1; i < len(result.Findings); i++ {
+		if result.Findings[i-1].Score < result.Findings[i].Score {
+			t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+		}
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsSecretPermissionEquivalenceVersion {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.EquivalenceType == "" || finding.Severity == "" || finding.Status == "" || finding.Rationale == "" {
+			t.Fatalf("finding missing classification fields: %+v", finding)
+		}
+		if finding.Score <= 0 || finding.Confidence <= 0 || len(finding.EquivalentPermissions) == 0 {
+			t.Fatalf("finding missing score/confidence/equivalent permissions: %+v", finding)
+		}
+		if finding.IdentityNodeID == "" || finding.SecretNodeID == "" || finding.SecretLabel == "" || len(finding.ImpactedPath) < 2 || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing path/evidence fields: %+v", finding)
+		}
+		if finding.EvidenceBoundary != "metadata_only_no_secret_values_no_payloads" {
+			t.Fatalf("finding crossed evidence boundary: %+v", finding)
+		}
+		if strings.Contains(strings.ToLower(finding.Rationale), "secret value") && !strings.Contains(strings.ToLower(finding.Rationale), "without reading") {
+			t.Fatalf("rationale must not imply secret value collection: %s", finding.Rationale)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+	}
+}
+
+func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 5, 0, 0, time.UTC)
+	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-filters", now)
+
+	openAI, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence-filters", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Provider:     "openai",
+	})
+	if err != nil {
+		t.Fatalf("provider filter: %v", err)
+	}
+	if len(openAI.Findings) == 0 {
+		t.Fatalf("expected OpenAI provider-key equivalence findings")
+	}
+	for _, finding := range openAI.Findings {
+		if finding.Provider != "openai" {
+			t.Fatalf("provider filter leaked: %+v", finding)
+		}
+	}
+	if openAI.AppliedFilters["provider"] != "openai" {
+		t.Fatalf("expected normalized provider applied filter, got %+v", openAI.AppliedFilters)
+	}
+
+	agent, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence-filters", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:     "aws-prod",
+		FixtureState:    "success",
+		EquivalenceType: "agent_provider_key_equivalence",
+		Identity:        "external-support-agent",
+	})
+	if err != nil {
+		t.Fatalf("agent equivalence filter: %v", err)
+	}
+	if len(agent.Findings) == 0 {
+		t.Fatalf("expected agent provider-key findings")
+	}
+	for _, finding := range agent.Findings {
+		if finding.EquivalenceType != "agent_provider_key_equivalence" {
+			t.Fatalf("equivalence_type filter leaked: %+v", finding)
+		}
+		if !strings.Contains(strings.ToLower(finding.AgentID+" "+finding.AgentName+" "+finding.IdentityNodeID), "external-support-agent") {
+			t.Fatalf("identity filter leaked: %+v", finding)
+		}
+	}
+}
+
+func TestGetAWSSecretPermissionEquivalenceFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 10, 0, 0, time.UTC)
+	svc, ws := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-states", now)
+
+	denied, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence-states", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Findings) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress deterministic findings: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSSecretPermissionEquivalence(defaultScopeContext(), ws, "project-secret-permission-equivalence-states", AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 || empty.Summary.FilteredFindings != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should be explicit degraded no-evidence state: %+v", empty)
+	}
+}
+
+func TestRouterAWSSecretPermissionEquivalence(t *testing.T) {
+	now := time.Date(2026, 6, 21, 13, 15, 0, 0, time.UTC)
+	svc, _ := newSecretPermissionEquivalenceService(t, "project-secret-permission-equivalence-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-secret-permission-equivalence-route/aws/secret-permission-equivalence?connector_id=aws-prod&fixture_state=success&provider=openai", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Findings AWSSecretPermissionEquivalenceResult `json:"findings"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Findings.CurrentIssueRef != "#1527" || body.Findings.AppliedFilters["provider"] != "openai" || len(body.Findings.Findings) == 0 {
+		t.Fatalf("unexpected route payload: %+v", body.Findings)
+	}
+}

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -118,6 +118,29 @@ func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
 	}
 }
 
+func TestAWSSecretPermissionProviderFilterCanonicalizesAWSStoreAliases(t *testing.T) {
+	findings := []AWSSecretPermissionEquivalenceFinding{
+		{FindingID: "ssm", Provider: credentialProviderSSM},
+		{FindingID: "secrets-manager", Provider: credentialProviderSecretsManager},
+	}
+
+	ssm, applied := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Provider: "ssm"})
+	if len(ssm) != 1 || ssm[0].Provider != credentialProviderSSM {
+		t.Fatalf("expected ssm alias to match canonical SSM provider, got findings=%+v applied=%+v", ssm, applied)
+	}
+	if applied["provider"] != "aws-ssm" {
+		t.Fatalf("expected normalized SSM provider filter, got %+v", applied)
+	}
+
+	secretsManager, applied := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Provider: "secrets_manager"})
+	if len(secretsManager) != 1 || secretsManager[0].Provider != credentialProviderSecretsManager {
+		t.Fatalf("expected secrets_manager alias to match canonical Secrets Manager provider, got findings=%+v applied=%+v", secretsManager, applied)
+	}
+	if applied["provider"] != "aws-secrets-manager" {
+		t.Fatalf("expected normalized Secrets Manager provider filter, got %+v", applied)
+	}
+}
+
 func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
 	now := time.Date(2026, 6, 22, 8, 50, 0, 0, time.UTC)
 	accountID := "123456789012"
@@ -161,6 +184,13 @@ func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
 
 	if _, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, nil, now); !ok {
 		t.Fatalf("expected capability-only KMS decrypt allow to produce a finding without a deny")
+	}
+	if _, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, AWSKMSIdentityGrant{
+		PrincipalARN: roleARN,
+		Effect:       "Allow",
+		Actions:      []string{"kms:*"},
+	}, nil, now); !ok {
+		t.Fatalf("expected kms:* KMS grant to produce a decrypt-equivalence finding")
 	}
 	if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, deny, now); ok {
 		t.Fatalf("expected explicit deny on kms:Decrypt to suppress capability-only KMS finding, got %+v", finding)

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -257,6 +257,81 @@ func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
 	if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, deny, now); ok {
 		t.Fatalf("expected explicit deny on kms:Decrypt to suppress capability-only KMS finding, got %+v", finding)
 	}
+
+	unrelatedDeny := []AWSKMSIdentityGrant{{
+		PrincipalARN: roleARN,
+		Effect:       "Deny",
+		Actions:      []string{"kms:Encrypt"},
+	}}
+	if _, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, AWSKMSIdentityGrant{
+		PrincipalARN: roleARN,
+		Effect:       "Allow",
+		Actions:      []string{"kms:*"},
+	}, unrelatedDeny, now); !ok {
+		t.Fatalf("expected kms:* allow with an unrelated kms:Encrypt deny to still emit a decrypt-equivalence finding")
+	}
+
+	liveGrant := AWSKMSGrant{
+		GranteePrincipal: roleARN,
+		Operations:       []string{"Decrypt"},
+	}
+	if _, ok := awsSecretPermissionFindingFromKMSLiveGrant(key, secret, liveGrant, unrelatedDeny, now); !ok {
+		t.Fatalf("expected live KMS decrypt grant to survive an unrelated kms:Encrypt deny")
+	}
+	if finding, ok := awsSecretPermissionFindingFromKMSLiveGrant(key, secret, liveGrant, deny, now); ok {
+		t.Fatalf("expected explicit deny on kms:Decrypt to suppress the live KMS grant finding, got %+v", finding)
+	}
+}
+
+func TestAWSSecretPermissionSecretGrantDeniedRequiresAllReadAPIs(t *testing.T) {
+	allowAll := AWSSecretsManagerIdentityGrant{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Allow",
+		Actions:      []string{"secretsmanager:*"},
+	}
+	denyBatchOnly := []AWSSecretsManagerIdentityGrant{{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Deny",
+		Actions:      []string{"secretsmanager:BatchGetSecretValue"},
+	}}
+	if awsSecretPermissionSecretGrantDenied(allowAll, denyBatchOnly) {
+		t.Fatalf("deny on BatchGetSecretValue alone must not suppress a secretsmanager:* allow that still grants GetSecretValue")
+	}
+
+	denyBothReads := append([]AWSSecretsManagerIdentityGrant{}, denyBatchOnly...)
+	denyBothReads = append(denyBothReads, AWSSecretsManagerIdentityGrant{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Deny",
+		Actions:      []string{"secretsmanager:GetSecretValue"},
+	})
+	if !awsSecretPermissionSecretGrantDenied(allowAll, denyBothReads) {
+		t.Fatalf("denying every concrete read API should suppress a wildcard secrets-manager allow")
+	}
+
+	denyWildcard := []AWSSecretsManagerIdentityGrant{{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Deny",
+		Actions:      []string{"secretsmanager:*"},
+	}}
+	if !awsSecretPermissionSecretGrantDenied(allowAll, denyWildcard) {
+		t.Fatalf("wildcard deny should suppress a wildcard allow")
+	}
+
+	narrowAllow := AWSSecretsManagerIdentityGrant{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Allow",
+		Actions:      []string{"secretsmanager:GetSecretValue"},
+	}
+	if awsSecretPermissionSecretGrantDenied(narrowAllow, denyBatchOnly) {
+		t.Fatalf("a deny on a different read API must not suppress a narrow GetSecretValue allow")
+	}
+	if !awsSecretPermissionSecretGrantDenied(narrowAllow, []AWSSecretsManagerIdentityGrant{{
+		PrincipalARN: "arn:aws:iam::123456789012:role/reader",
+		Effect:       "Deny",
+		Actions:      []string{"secretsmanager:GetSecretValue"},
+	}}) {
+		t.Fatalf("a matching deny on GetSecretValue must suppress a narrow GetSecretValue allow")
+	}
 }
 
 func TestAWSSecretPermissionProviderCanonicalizesAWSStoreAliases(t *testing.T) {

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -192,6 +192,13 @@ func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
 	}, nil, now); !ok {
 		t.Fatalf("expected kms:* KMS grant to produce a decrypt-equivalence finding")
 	}
+	if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, AWSKMSIdentityGrant{
+		PrincipalARN: roleARN,
+		Effect:       "Allow",
+		Capabilities: []string{"admin"},
+	}, nil, now); ok {
+		t.Fatalf("expected admin-only KMS capability to stay out of decrypt-equivalence findings, got %+v", finding)
+	}
 	if finding, ok := awsSecretPermissionFindingFromKMSGrant(key, secret, allow, deny, now); ok {
 		t.Fatalf("expected explicit deny on kms:Decrypt to suppress capability-only KMS finding, got %+v", finding)
 	}

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -141,6 +141,61 @@ func TestAWSSecretPermissionProviderFilterCanonicalizesAWSStoreAliases(t *testin
 	}
 }
 
+func TestAWSSecretPermissionCanReadExcludesReplicationGrant(t *testing.T) {
+	if awsSecretPermissionSecretGrantCanRead(AWSSecretsManagerIdentityGrant{Actions: []string{"secretsmanager:ReplicateSecretToRegions"}}) {
+		t.Fatalf("replicate-only secret grants should not be treated as read access")
+	}
+}
+
+func TestAWSSecretPermissionEquivalenceFiltersEvidenceAndSearch(t *testing.T) {
+	findings := []AWSSecretPermissionEquivalenceFinding{
+		{
+			FindingID:             "runtime-backed",
+			IdentityNodeID:        "arn:aws:iam::123456789012:role/runtime-reader",
+			SecretNodeID:          "secret:runtime",
+			SecretLabel:           "runtime-secret",
+			Evidence:              []AWSSecretPermissionEquivalenceEvidence{{Source: "secrets_kms_runtime_access", Label: "Observed runtime access", EvidenceRef: "runtime://secret-access"}},
+			EquivalentPermissions: []string{"secretsmanager:GetSecretValue"},
+			ImpactedNodes:         []string{"arn:aws:iam::123456789012:role/runtime-reader"},
+		},
+		{
+			FindingID:             "inventory-backed",
+			IdentityNodeID:        "arn:aws:iam::123456789012:role/inventory-reader",
+			SecretNodeID:          "secret:inventory",
+			SecretLabel:           "inventory-secret",
+			Evidence:              []AWSSecretPermissionEquivalenceEvidence{{Source: "secrets_manager_metadata", Label: "Secret metadata", EvidenceRef: "inventory://secret"}},
+			EquivalentPermissions: []string{"secretsmanager:GetSecretValue"},
+			ImpactedNodes:         []string{"arn:aws:iam::123456789012:role/inventory-reader"},
+		},
+		{
+			FindingID:      "unavailable",
+			IdentityNodeID: "arn:aws:iam::123456789012:role/no-evidence",
+			SecretNodeID:   "secret:none",
+			SecretLabel:    "no-evidence-secret",
+		},
+	}
+
+	runtime, _ := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Evidence: "runtime-backed"})
+	if len(runtime) != 1 || runtime[0].FindingID != "runtime-backed" {
+		t.Fatalf("expected only runtime-backed finding, got %+v", runtime)
+	}
+
+	inventory, _ := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Evidence: "inventory-backed"})
+	if len(inventory) != 1 || inventory[0].FindingID != "inventory-backed" {
+		t.Fatalf("expected only inventory-backed finding, got %+v", inventory)
+	}
+
+	unavailable, _ := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Evidence: "unavailable"})
+	if len(unavailable) != 1 || unavailable[0].FindingID != "unavailable" {
+		t.Fatalf("expected only unavailable finding, got %+v", unavailable)
+	}
+
+	search, _ := filterAWSSecretPermissionEquivalenceFindings(findings, AWSSecretPermissionEquivalenceRequest{Search: "inventory-secret"})
+	if len(search) != 1 || search[0].FindingID != "inventory-backed" {
+		t.Fatalf("expected search to match the inventory secret label, got %+v", search)
+	}
+}
+
 func TestAWSSecretPermissionKMSGrantRespectsCapabilityDeny(t *testing.T) {
 	now := time.Date(2026, 6, 22, 8, 50, 0, 0, time.UTC)
 	accountID := "123456789012"

--- a/internal/api/aws_secret_permission_equivalence_test.go
+++ b/internal/api/aws_secret_permission_equivalence_test.go
@@ -39,6 +39,9 @@ func TestGetAWSSecretPermissionEquivalenceBuildsFindingContract(t *testing.T) {
 	if result.Summary.RemediationPreviewCount == 0 || len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
 		t.Fatalf("expected remediation previews, caveats, and coverage gaps: summary=%+v caveats=%v gaps=%v", result.Summary, result.Caveats, result.CoverageGaps)
 	}
+	if result.Summary.UnresolvedReferenceCount == 0 {
+		t.Fatalf("expected unresolved references to be counted from structured finding state: %+v", result.Summary)
+	}
 	for i := 1; i < len(result.Findings); i++ {
 		if result.Findings[i-1].Score < result.Findings[i].Score {
 			t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
@@ -97,7 +100,7 @@ func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
 		ConnectorID:     "aws-prod",
 		FixtureState:    "success",
 		EquivalenceType: "agent_provider_key_equivalence",
-		Identity:        "external-support-agent",
+		Identity:        "support-assistant",
 	})
 	if err != nil {
 		t.Fatalf("agent equivalence filter: %v", err)
@@ -109,7 +112,7 @@ func TestGetAWSSecretPermissionEquivalenceFilters(t *testing.T) {
 		if finding.EquivalenceType != "agent_provider_key_equivalence" {
 			t.Fatalf("equivalence_type filter leaked: %+v", finding)
 		}
-		if !strings.Contains(strings.ToLower(finding.AgentID+" "+finding.AgentName+" "+finding.IdentityNodeID), "external-support-agent") {
+		if !strings.Contains(strings.ToLower(finding.AgentName), "support-assistant") {
 			t.Fatalf("identity filter leaked: %+v", finding)
 		}
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3227,6 +3227,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"findings": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-permission-equivalence", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSecretPermissionEquivalence(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSecretPermissionEquivalenceRequest{
+			ConnectorID:     strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:    strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:       strings.TrimSpace(c.Query("account_id")),
+			Region:          strings.TrimSpace(c.Query("region")),
+			Identity:        strings.TrimSpace(c.Query("identity")),
+			Secret:          strings.TrimSpace(c.Query("secret")),
+			Provider:        strings.TrimSpace(c.Query("provider")),
+			EquivalenceType: strings.TrimSpace(c.Query("equivalence_type")),
+			Severity:        strings.TrimSpace(c.Query("severity")),
+			Status:          strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws secret permission equivalence request"})
+			default:
+				logger.Error("get aws secret permission equivalence",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws secret permission equivalence"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"findings": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-passrole-relationships", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3243,6 +3243,8 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			EquivalenceType: strings.TrimSpace(c.Query("equivalence_type")),
 			Severity:        strings.TrimSpace(c.Query("severity")),
 			Status:          strings.TrimSpace(c.Query("status")),
+			Evidence:        strings.TrimSpace(c.Query("evidence")),
+			Search:          strings.TrimSpace(c.Query("search")),
 		})
 		if err != nil {
 			switch {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1460,6 +1460,52 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS secret-permission equivalence findings with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        findings: {
+          status: 'ready',
+          summary: { total_findings: 0, filtered_findings: 0 },
+          findings: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectSecretPermissionEquivalence(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'case-triage-runtime',
+        secret: 'openai/api-key',
+        provider: 'openai',
+        equivalenceType: 'agent_provider_key_equivalence',
+        severity: 'high',
+        status: 'review'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/secret-permission-equivalence?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=case-triage-runtime&secret=openai%2Fapi-key&provider=openai&equivalence_type=agent_provider_key_equivalence&severity=high&status=review'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1485,6 +1485,8 @@ describe('apiClient', () => {
         secret: 'openai/api-key',
         provider: 'openai',
         equivalenceType: 'agent_provider_key_equivalence',
+        evidence: 'runtime-backed',
+        search: 'role',
         severity: 'high',
         status: 'review'
       },
@@ -1497,7 +1499,7 @@ describe('apiClient', () => {
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain(
-      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/secret-permission-equivalence?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=case-triage-runtime&secret=openai%2Fapi-key&provider=openai&equivalence_type=agent_provider_key_equivalence&severity=high&status=review'
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/secret-permission-equivalence?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=case-triage-runtime&secret=openai%2Fapi-key&provider=openai&equivalence_type=agent_provider_key_equivalence&evidence=runtime-backed&search=role&severity=high&status=review'
     );
     expect(options.method ?? 'GET').toBe('GET');
     const headers = new Headers(options.headers);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3601,6 +3601,8 @@ export type AWSSecretPermissionEquivalenceQuery = {
   secret?: string;
   provider?: string;
   equivalenceType?: AWSSecretPermissionEquivalenceType;
+  evidence?: string;
+  search?: string;
   severity?: string;
   status?: string;
 };

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3529,6 +3529,7 @@ export type AWSSecretPermissionEquivalenceFinding = {
   secret_label: string;
   provider: string;
   provider_key_reference?: string;
+  unresolved_reference?: boolean;
   equivalent_permissions: string[];
   implied_actions?: string[];
   source_signals: string[];

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6932,6 +6932,8 @@ export const apiClient = {
         secret: query?.secret,
         provider: query?.provider,
         equivalence_type: query?.equivalenceType,
+        evidence: query?.evidence,
+        search: query?.search,
         severity: query?.severity,
         status: query?.status
       })}`,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3480,6 +3480,130 @@ export type AWSCrossAccountTrustQuery = {
   ou?: string;
 };
 
+// AWSSecretPermissionEquivalence* types describe Wave 6.07 decisions where a
+// readable secret/provider key is treated as a permission-bearing capability.
+export type AWSSecretPermissionEquivalenceStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSecretPermissionEquivalenceFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+export type AWSSecretPermissionEquivalenceType =
+  | 'workload_provider_key_equivalence'
+  | 'secret_read_policy_equivalence'
+  | 'kms_decrypt_secret_equivalence'
+  | 'kms_live_grant_secret_equivalence'
+  | 'runtime_secret_access_equivalence'
+  | 'agent_provider_key_equivalence'
+  | 'blast_radius_secret_equivalence'
+  | 'admin_equivalent_secret_permission'
+  | string;
+
+export type AWSSecretPermissionEquivalenceRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSSecretPermissionEquivalenceFinding = {
+  finding_id: string;
+  calculation_version: string;
+  equivalence_type: AWSSecretPermissionEquivalenceType;
+  severity: string;
+  status: string;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  workload_id?: string;
+  workload_name?: string;
+  agent_id?: string;
+  agent_name?: string;
+  secret_node_id: string;
+  secret_arn?: string;
+  secret_label: string;
+  provider: string;
+  provider_key_reference?: string;
+  equivalent_permissions: string[];
+  implied_actions?: string[];
+  source_signals: string[];
+  rationale: string;
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSSecretPermissionEquivalenceSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  equivalence_type_counts: Record<string, number>;
+  provider_counts: Record<string, number>;
+  external_provider_key_count: number;
+  aws_managed_secret_count: number;
+  runtime_observed_count: number;
+  kms_backed_count: number;
+  unresolved_reference_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+};
+
+export type AWSSecretPermissionEquivalenceResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSecretPermissionEquivalenceStatus;
+  fixture_state?: AWSSecretPermissionEquivalenceFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSSecretPermissionEquivalenceSummary;
+  findings: AWSSecretPermissionEquivalenceFinding[];
+  relationships: AWSSecretPermissionEquivalenceRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSSecretPermissionEquivalenceQuery = {
+  connectorID?: string;
+  fixtureState?: AWSSecretPermissionEquivalenceFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  secret?: string;
+  provider?: string;
+  equivalenceType?: AWSSecretPermissionEquivalenceType;
+  severity?: string;
+  status?: string;
+};
+
 export type AWSBedrockAgentsInventoryStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBedrockAgentsFixtureState =
   | 'success'
@@ -6785,6 +6909,28 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         ou: query?.ou
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSecretPermissionEquivalence(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSSecretPermissionEquivalenceQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ findings: AWSSecretPermissionEquivalenceResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secret-permission-equivalence${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        secret: query?.secret,
+        provider: query?.provider,
+        equivalence_type: query?.equivalenceType,
+        severity: query?.severity,
+        status: query?.status
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3408,6 +3408,93 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [
+          {
+            finding_id: 'aws-secret-permission-equivalence:openai-agent',
+            calculation_version: 'aws-secret-permission-equivalence-engine-v1',
+            equivalence_type: 'agent_provider_key_equivalence',
+            severity: 'high',
+            status: 'review',
+            score: 82,
+            confidence: 0.9,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:identity:arn:aws:iam::123456789012:role/case-triage-runtime',
+            principal_arn: 'arn:aws:iam::123456789012:role/case-triage-runtime',
+            agent_id: 'case-triage',
+            agent_name: 'case-triage',
+            secret_node_id: 'aws:resource:secrets-manager-secret:openai/api-key',
+            secret_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:openai/api-key',
+            secret_label: 'openai/api-key',
+            provider: 'openai',
+            provider_key_reference: 'OPENAI_API_KEY',
+            equivalent_permissions: ['openai:api_request', 'openai:model_inference'],
+            source_signals: ['ai_agent_identities'],
+            rationale: 'Agent has OpenAI provider-key metadata without exposing the key value.',
+            evidence_boundary: 'metadata_only_no_secret_values_no_payloads',
+            impacted_nodes: [
+              'aws:identity:arn:aws:iam::123456789012:role/case-triage-runtime',
+              'aws:resource:secrets-manager-secret:openai/api-key'
+            ],
+            impacted_path: [
+              { node_id: 'aws:identity:arn:aws:iam::123456789012:role/case-triage-runtime', node_type: 'identity', label: 'case-triage-runtime' },
+              { node_id: 'aws:agent:case-triage', node_type: 'ai_agent', label: 'case-triage' },
+              { node_id: 'aws:resource:secrets-manager-secret:openai/api-key', node_type: 'permission_bearing_secret', label: 'openai/api-key' }
+            ],
+            evidence: [
+              {
+                source: 'ai_agent_identities',
+                evidence_ref: 'evidence://agent/case-triage/openai',
+                label: 'Agent provider-key metadata',
+                confidence: 0.9,
+                observed_at: '2026-06-21T13:30:00Z',
+                relationship: 'agent_uses_permission_bearing_secret'
+              }
+            ],
+            next_action: 'Rotate or scope the provider credential and restrict every identity that can read it.',
+            remediation_case: {
+              case_id: 'aws-secret-permission-equivalence-preview:openai-agent',
+              title: 'Provider key review',
+              recommended_action: 'Restrict secret readers.',
+              approval_required: true,
+              blocking_evidence: ['evidence://agent/case-triage/openai'],
+              impacted_node_count: 2,
+              estimated_risk_drop: 40,
+              breakage_prediction: 'unknown',
+              read_only_projection: true
+            },
+            created_at: '2026-06-21T13:30:00Z',
+            updated_at: '2026-06-21T13:30:00Z'
+          }
+        ],
+        summary: {
+          total_findings: 1,
+          filtered_findings: 1,
+          external_provider_key_count: 1,
+          aws_managed_secret_count: 0,
+          runtime_observed_count: 0,
+          kms_backed_count: 0,
+          unresolved_reference_count: 0,
+          relationship_count: 1,
+          highest_score: 82,
+          average_confidence_pct: 90,
+          remediation_preview_count: 1,
+          severity_counts: { high: 1 },
+          status_counts: { review: 1 },
+          equivalence_type_counts: { agent_provider_key_equivalence: 1 },
+          provider_counts: { openai: 1 }
+        },
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
 
     const { ProductAWSRuntimePage } = await import('./productShell');
 
@@ -3433,6 +3520,8 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/Passrole unscoped trust path/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS cross-account trust findings' })).toBeInTheDocument();
     expect(screen.getByText(/Cross account resource access/i)).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).toBeInTheDocument();
+    expect(screen.getByText(/Agent provider key equivalence/i)).toBeInTheDocument();
     expect(getLeastPrivilege).toHaveBeenCalledWith(
       'workspace-a',
       'production',
@@ -3446,6 +3535,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getCrossAccountTrust).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getSecretPermissionEquivalence).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3582,6 +3582,82 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('passes AWS findings filters to secret-permission equivalence queries', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getSecretPermissionEquivalence = vi.spyOn(api.apiClient, 'getAWSProjectSecretPermissionEquivalence').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [],
+        summary: {
+          external_provider_key_count: 0,
+          aws_managed_secret_count: 0,
+          runtime_observed_count: 0,
+          kms_backed_count: 0
+        },
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
+
+    const { ProductAWSFindingsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/findings?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/findings" element={<ProductAWSFindingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Findings' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Severity' }), { target: { value: 'high' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Account' }), { target: { value: 'connected' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'current' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Remediation' }), { target: { value: 'open' } });
+
+    await waitFor(() =>
+      expect(getSecretPermissionEquivalence).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({
+          connectorID: 'aws-connector-1',
+          accountID: '123456789012',
+          region: 'us-east-1',
+          severity: 'high',
+          status: 'action_required'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('keeps AWS resources inventory metadata-only when no environment exists', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [] });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -355,17 +355,6 @@ const DOMAIN_NAV_ORDER: SourceProvider[] = ['aws', 'github', 'kubernetes'];
 const SHOULD_LOAD_CONNECTOR_BACKEND_FEATURES = FEATURE_CONNECTOR_GITHUB_V2 || FEATURE_CONNECTOR_K8S;
 const SOURCE_STACK: SourceProvider[] = [...SOURCE_ORDER];
 const SCAN_POLICY_TRIGGER_MODES: ScanTriggerMode[] = ['manual', 'scheduled', 'event', 'hybrid'];
-const createDefaultGitHubPATForm = () => ({ displayName: '', baseURL: '', token: '', repositories: '' });
-const createDefaultScanPolicyForm = () => ({
-  policyID: 'default',
-  name: 'Default policy',
-  enabled: true,
-  triggerMode: 'manual' as ScanTriggerMode,
-  cron: '',
-  maxConcurrentScans: '1',
-  historyLimit: '500',
-  maxFindings: '200'
-});
 const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low', 'info'] as const;
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
@@ -1179,15 +1168,6 @@ function normalizeProjectToken(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 64);
-}
-
-function parsePositiveInteger(value: string, label: string): number {
-  const normalized = normalizeValue(value);
-  const parsed = Number.parseInt(normalized, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== normalized) {
-    throw new Error(`${label} must be a positive whole number.`);
-  }
-  return parsed;
 }
 
 function tokenWithNumericSuffix(base: string, suffix: number): string {
@@ -2208,15 +2188,11 @@ export function ProductGitHubCallbackPage() {
 
     const run = async () => {
       if (!state || !Number.isFinite(installationID) || installationID <= 0) {
-        setError(
-          'GitHub did not finish the installation — the installation details were missing from its response. This usually means setup was cancelled before completing. Start the GitHub connection again to retry.'
-        );
+        setError('GitHub did not return a valid installation callback.');
         return;
       }
       if (!code) {
-        setError(
-          'GitHub did not return an authorization code, so we could not verify the installation. Start the GitHub connection again to retry. If this keeps happening, contact support.'
-        );
+        setError('GitHub did not return an authorization code. Please retry the installation.');
         return;
       }
       try {
@@ -2234,10 +2210,7 @@ export function ProductGitHubCallbackPage() {
         }
       } catch (callbackError) {
         if (mounted) {
-          const message =
-            callbackError instanceof Error && callbackError.message.trim()
-              ? callbackError.message
-              : 'We could not complete the GitHub installation. Start the GitHub connection again to retry, and contact support if it persists.';
+          const message = callbackError instanceof Error ? callbackError.message : 'Unable to complete GitHub installation.';
           setError(message);
         }
       }
@@ -2255,7 +2228,7 @@ export function ProductGitHubCallbackPage() {
       <section className="idt-app-shell-screen" role="alert">
         <article className="idt-app-panel idt-app-panel-error">
           <p className="idt-app-kicker">GitHub setup failed</p>
-          <h1>Couldn't finish connecting GitHub</h1>
+          <h1>Unable to complete GitHub</h1>
           <p>{error}</p>
           <Link className="idt-btn idt-btn-primary" to="/app">
             Return to app
@@ -14948,15 +14921,6 @@ const GITHUB_REPOSITORIES_SCANS_LIMIT = 50;
 const GITHUB_REMEDIATION_FINDINGS_LIMIT = 100;
 const GITHUB_MAX_SCAN_PAGE_FETCHES = 50;
 const GITHUB_DOMAIN_DATA_CACHE_LIMIT = 24;
-const GITHUB_ACTIVE_SCAN_POLL_MS = 8000;
-type OneOffRepoScanMode = Extract<NonNullable<RepoScanRequest['scan_mode']>, 'quick' | 'deep'>;
-const ONE_OFF_REPO_SCAN_MODES: OneOffRepoScanMode[] = ['quick', 'deep'];
-const createDefaultOneOffRepoScanForm = () => ({
-  repository: '',
-  scanMode: 'deep' as OneOffRepoScanMode,
-  historyLimit: '500',
-  maxFindings: '200'
-});
 
 type GitHubAvailability = {
   loading: boolean;
@@ -15132,15 +15096,13 @@ async function listRepoScansForSelectedRepositories(
   auth: RequestAuthContext,
   options: { pageLimit?: number; maxPages?: number } = {}
 ): Promise<RepoScanRecord[]> {
-  if (scanLimit <= 0) {
+  if (!selectedRepositories.length || scanLimit <= 0) {
     return [];
   }
 
   const pageLimit = Math.max(scanLimit, options.pageLimit ?? scanLimit);
   const maxPages = Math.max(1, options.maxPages ?? GITHUB_MAX_SCAN_PAGE_FETCHES);
-  const allowed = selectedRepositories.length > 0
-    ? new Set(selectedRepositories.map((repository) => canonicalGitHubRepositoryDisplay(repository).toLowerCase()))
-    : null;
+  const allowed = new Set(selectedRepositories.map((repository) => canonicalGitHubRepositoryDisplay(repository).toLowerCase()));
   const matches: RepoScanRecord[] = [];
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
@@ -15163,7 +15125,7 @@ async function listRepoScansForSelectedRepositories(
     )) as { items: RepoScanRecord[]; next_cursor?: string };
 
     for (const scan of response.items) {
-      if (!allowed || allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase())) {
+      if (allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase())) {
         matches.push(scan);
       }
     }
@@ -15683,6 +15645,14 @@ function GitHubControlCenterBannerView({ banner }: { banner: GitHubControlCenter
   );
 }
 
+function legacyProjectSetupPath(scope: ProductSession, projectID: string | undefined): string {
+  const trimmed = normalizeValue(projectID);
+  if (!trimmed) {
+    return appendSourceQuery(buildProjectsPath(scope), 'github');
+  }
+  return appendSourceQuery(buildProjectPath(scope, trimmed), 'github');
+}
+
 function GitHubUnavailableShell({
   title,
   scope,
@@ -15895,111 +15865,9 @@ export function ProductGitHubConnectPage() {
   const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
   const availability = useGitHubAvailability();
   const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, 0);
-  const scopedEnvironmentID = scope ? `${scope.tenantID}|${scope.workspaceID}|${selectedEnvironmentID}` : selectedEnvironmentID;
-  const scanPolicyRequestRef = useRef(0);
-  const scanPolicySaveRequestRef = useRef(0);
-  const scanPolicyDeleteRequestRef = useRef(0);
-  const selectedScanPolicyScopeRef = useRef(scopedEnvironmentID);
-  const patSubmitRequestRef = useRef(0);
-  const selectedPATScopeRef = useRef(scopedEnvironmentID);
-  const installRequestRef = useRef(0);
-  const selectedInstallScopeRef = useRef(scopedEnvironmentID);
-  selectedScanPolicyScopeRef.current = scopedEnvironmentID;
-  selectedInstallScopeRef.current = scopedEnvironmentID;
   const [installError, setInstallError] = useState('');
   const [installing, setInstalling] = useState(false);
   const [pendingInstallURL, setPendingInstallURL] = useState('');
-  const [enterpriseOpen, setEnterpriseOpen] = useState(false);
-  const [patForm, setPATForm] = useState(createDefaultGitHubPATForm);
-  const [patError, setPATError] = useState('');
-  const [patSuccess, setPATSuccess] = useState('');
-  const [patSubmitting, setPATSubmitting] = useState(false);
-  const [scanPolicies, setScanPolicies] = useState<ScanPolicyRecord[]>([]);
-  const [scanPolicyLoading, setScanPolicyLoading] = useState(false);
-  const [scanPolicyError, setScanPolicyError] = useState('');
-  const [scanPolicySuccess, setScanPolicySuccess] = useState('');
-  const [policySaving, setPolicySaving] = useState(false);
-  const [policyDeletingID, setPolicyDeletingID] = useState('');
-  const [policyForm, setPolicyForm] = useState(createDefaultScanPolicyForm);
-  const loadScanPolicies = useCallback(async () => {
-    if (!scope || !selectedEnvironmentID || !availability.available) {
-      scanPolicyRequestRef.current += 1;
-      setScanPolicies([]);
-      setPolicyForm(createDefaultScanPolicyForm());
-      setScanPolicyLoading(false);
-      return;
-    }
-    const requestID = scanPolicyRequestRef.current + 1;
-    scanPolicyRequestRef.current = requestID;
-    setScanPolicyLoading(true);
-    setScanPolicyError('');
-    setScanPolicies([]);
-    try {
-      const response = await apiClient.listProjectScanPolicies(
-        scope.workspaceID,
-        selectedEnvironmentID,
-        {
-          limit: 50,
-          sort_by: 'updated_at',
-          sort_order: 'desc'
-        },
-        buildProductAuthContext(scope)
-      );
-      if (scanPolicyRequestRef.current !== requestID) {
-        return;
-      }
-      const items = response.items ?? [];
-      setScanPolicies(items);
-      setPolicyForm((current) => {
-        if (items.length === 0) {
-          return createDefaultScanPolicyForm();
-        }
-        const selected = items.find((item) => item.policy_id === current.policyID) ?? items[0];
-        return {
-          policyID: selected.policy_id,
-          name: selected.name,
-          enabled: selected.enabled,
-          triggerMode: selected.trigger_mode,
-          cron: selected.cron ?? '',
-          maxConcurrentScans: String(selected.max_concurrent_scans),
-          historyLimit: String(selected.history_limit),
-          maxFindings: String(selected.max_findings)
-        };
-      });
-    } catch (error) {
-      if (scanPolicyRequestRef.current !== requestID) {
-        return;
-      }
-      setScanPolicies([]);
-      setPolicyForm(createDefaultScanPolicyForm());
-      setScanPolicyError(formatAPIError(error, 'Unable to load scan policies.'));
-    } finally {
-      if (scanPolicyRequestRef.current === requestID) {
-        setScanPolicyLoading(false);
-      }
-    }
-  }, [availability.available, scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
-
-  useEffect(() => {
-    void loadScanPolicies();
-  }, [loadScanPolicies]);
-
-  useEffect(() => {
-    selectedPATScopeRef.current = scopedEnvironmentID;
-    patSubmitRequestRef.current += 1;
-    setPATForm(createDefaultGitHubPATForm());
-    setPATError('');
-    setPATSuccess('');
-    setPATSubmitting(false);
-  }, [scopedEnvironmentID]);
-
-  useEffect(() => {
-    selectedInstallScopeRef.current = scopedEnvironmentID;
-    installRequestRef.current += 1;
-    setInstallError('');
-    setPendingInstallURL('');
-    setInstalling(false);
-  }, [selectedEnvironmentID, scopedEnvironmentID]);
 
   if (!scope) {
     return (
@@ -16051,13 +15919,10 @@ export function ProductGitHubConnectPage() {
   }
 
   const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  const legacyPath = legacyProjectSetupPath(scope, selectedEnvironmentID);
   const repositoriesPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/repositories'), selectedEnvironmentID);
 
   const handleInstall = async () => {
-    const environmentID = selectedEnvironmentID;
-    const installScope = scopedEnvironmentID;
-    const requestID = installRequestRef.current + 1;
-    installRequestRef.current = requestID;
     setInstallError('');
     setPendingInstallURL('');
     setInstalling(true);
@@ -16066,15 +15931,12 @@ export function ProductGitHubConnectPage() {
         typeof window !== 'undefined' ? `${window.location.origin}/app/github/callback` : undefined;
       const response = await apiClient.startGitHubConnector(
         {
-          project_id: environmentID,
+          project_id: selectedEnvironmentID,
           install_account_type: 'any',
           redirect_uri: redirectURI
         },
         buildProductAuthContext(scope)
       );
-      if (installRequestRef.current !== requestID || selectedInstallScopeRef.current !== installScope) {
-        return;
-      }
       const installURL = response.install_url ?? '';
       if (installURL) {
         let opened: Window | null = null;
@@ -16087,173 +15949,9 @@ export function ProductGitHubConnectPage() {
       }
       data.reload();
     } catch (error) {
-      if (installRequestRef.current !== requestID || selectedInstallScopeRef.current !== installScope) {
-        return;
-      }
       setInstallError(formatAPIError(error, 'Unable to start GitHub App installation.'));
     } finally {
-      if (installRequestRef.current === requestID && selectedInstallScopeRef.current === installScope) {
-        setInstalling(false);
-      }
-    }
-  };
-
-  // Self-hosted GitHub Enterprise / restricted environments cannot use the
-  // hosted App install, so they save a personal access token connector here.
-  // This replaces the form that lived on the retired legacy project page.
-  const handleEnterprisePATSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const environmentID = selectedEnvironmentID;
-    const patRequestID = patSubmitRequestRef.current + 1;
-    patSubmitRequestRef.current = patRequestID;
-    setPATSubmitting(true);
-    setPATError('');
-    setPATSuccess('');
-    try {
-      const token = normalizeValue(patForm.token);
-      if (!token) {
-        throw new Error('Enter a GitHub personal access token for the self-hosted fallback.');
-      }
-      await apiClient.upsertGitHubPATConnector(
-        {
-          project_id: environmentID,
-          display_name: normalizeValue(patForm.displayName) || undefined,
-          base_url: normalizeValue(patForm.baseURL) || undefined,
-          token,
-          selected_repositories: parseGitHubRepositories(patForm.repositories)
-        },
-        buildProductAuthContext(scope)
-      );
-      if (patSubmitRequestRef.current !== patRequestID || selectedPATScopeRef.current !== scopedEnvironmentID) {
-        return;
-      }
-      setPATForm((current) => ({ ...current, token: '' }));
-      setPATSuccess('GitHub Enterprise connector validated and saved.');
-      data.reload();
-    } catch (error) {
-      if (patSubmitRequestRef.current !== patRequestID || selectedPATScopeRef.current !== scopedEnvironmentID) {
-        return;
-      }
-      setPATError(formatAPIError(error, 'Unable to save GitHub Enterprise connector.'));
-    } finally {
-      if (patSubmitRequestRef.current === patRequestID && selectedPATScopeRef.current === scopedEnvironmentID) {
-        setPATSubmitting(false);
-      }
-    }
-  };
-
-  const handleScanPolicySubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const environmentID = selectedEnvironmentID;
-    const saveRequestID = scanPolicySaveRequestRef.current + 1;
-    scanPolicySaveRequestRef.current = saveRequestID;
-    setPolicySaving(true);
-    setScanPolicyError('');
-    setScanPolicySuccess('');
-    try {
-      const policyID = normalizeProjectToken(policyForm.policyID);
-      if (!policyID) {
-        throw new Error('Policy ID is required.');
-      }
-      const name = normalizeValue(policyForm.name);
-      if (!name) {
-        throw new Error('Policy name is required.');
-      }
-      const triggerMode = policyForm.triggerMode;
-      const cron = normalizeValue(policyForm.cron);
-      if ((triggerMode === 'scheduled' || triggerMode === 'hybrid') && !cron) {
-        throw new Error('Cron is required when trigger mode is scheduled or hybrid.');
-      }
-      const response = await apiClient.upsertProjectScanPolicy(
-        scope.workspaceID,
-        environmentID,
-        {
-          policy_id: policyID,
-          name,
-          enabled: policyForm.enabled,
-          trigger_mode: triggerMode,
-          cron: cron || undefined,
-          max_concurrent_scans: parsePositiveInteger(policyForm.maxConcurrentScans, 'Max concurrent scans'),
-          history_limit: parsePositiveInteger(policyForm.historyLimit, 'History limit'),
-          max_findings: parsePositiveInteger(policyForm.maxFindings, 'Max findings')
-        },
-        buildProductAuthContext(scope)
-      );
-      if (
-        scanPolicySaveRequestRef.current !== saveRequestID ||
-        selectedScanPolicyScopeRef.current !== scopedEnvironmentID
-      ) {
-        return;
-      }
-      const policy = response.policy;
-      setPolicyForm({
-        policyID: policy.policy_id,
-        name: policy.name,
-        enabled: policy.enabled,
-        triggerMode: policy.trigger_mode,
-        cron: policy.cron ?? '',
-        maxConcurrentScans: String(policy.max_concurrent_scans),
-        historyLimit: String(policy.history_limit),
-        maxFindings: String(policy.max_findings)
-      });
-      setScanPolicySuccess('Scan policy saved.');
-      await loadScanPolicies();
-    } catch (error) {
-      if (
-        scanPolicySaveRequestRef.current !== saveRequestID ||
-        selectedScanPolicyScopeRef.current !== scopedEnvironmentID
-      ) {
-        return;
-      }
-      setScanPolicyError(error instanceof Error ? error.message : 'Unable to save scan policy.');
-    } finally {
-      if (scanPolicySaveRequestRef.current === saveRequestID && selectedScanPolicyScopeRef.current === scopedEnvironmentID) {
-        setPolicySaving(false);
-      }
-    }
-  };
-
-  const handleScanPolicyDelete = async (policyID: string) => {
-    const normalizedPolicyID = normalizeValue(policyID);
-    if (!normalizedPolicyID) {
-      return;
-    }
-    const environmentID = selectedEnvironmentID;
-    const deleteRequestID = scanPolicyDeleteRequestRef.current + 1;
-    scanPolicyDeleteRequestRef.current = deleteRequestID;
-    setPolicyDeletingID(normalizedPolicyID);
-    setScanPolicyError('');
-    setScanPolicySuccess('');
-    try {
-      await apiClient.deleteProjectScanPolicy(
-        scope.workspaceID,
-        environmentID,
-        normalizedPolicyID,
-        buildProductAuthContext(scope)
-      );
-      if (
-        scanPolicyDeleteRequestRef.current !== deleteRequestID ||
-        selectedScanPolicyScopeRef.current !== scopedEnvironmentID
-      ) {
-        return;
-      }
-      setScanPolicySuccess(`Scan policy ${normalizedPolicyID} deleted.`);
-      await loadScanPolicies();
-    } catch (error) {
-      if (
-        scanPolicyDeleteRequestRef.current !== deleteRequestID ||
-        selectedScanPolicyScopeRef.current !== scopedEnvironmentID
-      ) {
-        return;
-      }
-      setScanPolicyError(error instanceof Error ? error.message : 'Unable to delete scan policy.');
-    } finally {
-      if (
-        scanPolicyDeleteRequestRef.current === deleteRequestID &&
-        selectedScanPolicyScopeRef.current === scopedEnvironmentID
-      ) {
-        setPolicyDeletingID('');
-      }
+      setInstalling(false);
     }
   };
 
@@ -16376,13 +16074,9 @@ export function ProductGitHubConnectPage() {
             >
               {installing ? 'Opening install...' : 'Reinstall on GitHub'}
             </button>
-            <button
-              type="button"
-              className="idt-btn idt-btn-ghost"
-              onClick={() => setEnterpriseOpen(true)}
-            >
+            <Link to={legacyPath} className="idt-btn idt-btn-ghost">
               Manage Enterprise / PAT
-            </button>
+            </Link>
             <Link to={basePath} className="idt-btn idt-btn-ghost">
               GitHub home
             </Link>
@@ -16407,261 +16101,10 @@ export function ProductGitHubConnectPage() {
             >
               {installing ? 'Opening install...' : 'Install GitHub App'}
             </button>
-            <button
-              type="button"
-              className="idt-btn idt-btn-dark"
-              onClick={() => setEnterpriseOpen(true)}
-            >
+            <Link to={legacyPath} className="idt-btn idt-btn-dark">
               Manage Enterprise / PAT
-            </button>
+            </Link>
           </footer>
-        </section>
-      ) : null}
-      {showBody ? (
-        <details
-          className="idt-source-advanced idt-source-enterprise-fallback"
-          open={enterpriseOpen}
-          onToggle={(event) => setEnterpriseOpen((event.target as HTMLDetailsElement).open)}
-        >
-          <summary>
-            <span>
-              <strong>GitHub Enterprise fallback</strong>
-              <small>Use only for self-hosted GitHub Server or restricted app-install environments.</small>
-            </span>
-          </summary>
-          <form className="idt-app-form" onSubmit={handleEnterprisePATSubmit}>
-            <div className="idt-source-inline-fields">
-              <label>
-                Enterprise base URL
-                <input
-                  value={patForm.baseURL}
-                  onChange={(event) => setPATForm((current) => ({ ...current, baseURL: event.target.value }))}
-                  placeholder="https://github.company.com"
-                />
-              </label>
-              <label>
-                Display name
-                <input
-                  value={patForm.displayName}
-                  onChange={(event) => setPATForm((current) => ({ ...current, displayName: event.target.value }))}
-                  placeholder="GitHub Enterprise"
-                />
-              </label>
-            </div>
-            <label>
-              Personal access token
-              <input
-                type="password"
-                value={patForm.token}
-                onChange={(event) => setPATForm((current) => ({ ...current, token: event.target.value }))}
-                placeholder="GitHub Enterprise fallback token"
-                required
-              />
-            </label>
-            <label>
-              Repository allowlist
-              <textarea
-                value={patForm.repositories}
-                onChange={(event) => setPATForm((current) => ({ ...current, repositories: event.target.value }))}
-                placeholder="owner/repo, owner/security-platform"
-              />
-            </label>
-            {patError ? <p role="alert">{patError}</p> : null}
-            {patSuccess ? <p>{patSuccess}</p> : null}
-            <button className="idt-btn idt-btn-primary" type="submit" disabled={patSubmitting}>
-              {patSubmitting ? 'Validating...' : 'Save enterprise fallback'}
-            </button>
-          </form>
-        </details>
-      ) : null}
-      {showBody ? (
-        <section className="idt-domain-status-panel idt-source-policy-panel" aria-label="Scan policy management">
-          <header>
-            <div>
-              <p className="idt-app-kicker">Automation policies</p>
-              <h3>Scan policy</h3>
-              <p>Define trigger mode, cadence, and limits for GitHub scans in this environment.</p>
-            </div>
-            <span className="idt-source-status-pill is-warning">Advanced</span>
-          </header>
-
-          {scanPolicyError ? (
-            <p role="alert" className="idt-app-alert idt-app-alert-error">
-              {scanPolicyError}
-            </p>
-          ) : null}
-          {scanPolicySuccess ? (
-            <p role="status" className="idt-app-alert idt-app-alert-success">
-              {scanPolicySuccess}
-            </p>
-          ) : null}
-
-          <div className="idt-source-summary" aria-label="scan policy summary">
-            <article>
-              <span>{scanPolicyLoading ? '...' : scanPolicies.length}</span>
-              <p>Policies</p>
-            </article>
-            <article>
-              <span>{scanPolicies.filter((item) => item.enabled).length}</span>
-              <p>Enabled</p>
-            </article>
-            <article>
-              <span>{policyForm.triggerMode}</span>
-              <p>Editing mode</p>
-            </article>
-          </div>
-
-          {scanPolicies.length > 0 ? (
-            <div className="idt-source-diagnostics">
-              {scanPolicies.map((policy) => (
-                <article key={policy.policy_id}>
-                  <strong>{policy.name}</strong>
-                  <span>{policy.enabled ? 'Enabled' : 'Disabled'}</span>
-                  <p>
-                    {formatScanTriggerModeLabel(policy.trigger_mode)} · concurrency {policy.max_concurrent_scans} ·
-                    history {policy.history_limit} · findings {policy.max_findings}
-                  </p>
-                  <div className="idt-source-inline-fields">
-                    <button
-                      type="button"
-                      className="idt-btn idt-btn-ghost"
-                      disabled={scanPolicyLoading}
-                      onClick={() =>
-                        setPolicyForm({
-                          policyID: policy.policy_id,
-                          name: policy.name,
-                          enabled: policy.enabled,
-                          triggerMode: policy.trigger_mode,
-                          cron: policy.cron ?? '',
-                          maxConcurrentScans: String(policy.max_concurrent_scans),
-                          historyLimit: String(policy.history_limit),
-                          maxFindings: String(policy.max_findings)
-                        })
-                      }
-                    >
-                      Edit
-                    </button>
-                    <button
-                      type="button"
-                      className="idt-btn idt-btn-ghost"
-                      onClick={() => {
-                        void handleScanPolicyDelete(policy.policy_id);
-                      }}
-                      disabled={scanPolicyLoading || policyDeletingID === policy.policy_id}
-                    >
-                      {policyDeletingID === policy.policy_id ? 'Deleting...' : 'Delete'}
-                    </button>
-                  </div>
-                </article>
-              ))}
-            </div>
-          ) : null}
-
-          <form className="idt-app-form" onSubmit={handleScanPolicySubmit}>
-            <div className="idt-source-inline-fields">
-              <label>
-                Policy ID
-                <input
-                  value={policyForm.policyID}
-                  onChange={(event) =>
-                    setPolicyForm((current) => ({ ...current, policyID: normalizeProjectToken(event.target.value) }))
-                  }
-                  placeholder="default"
-                  required
-                />
-              </label>
-              <label>
-                Policy name
-                <input
-                  value={policyForm.name}
-                  onChange={(event) => setPolicyForm((current) => ({ ...current, name: event.target.value }))}
-                  placeholder="Default policy"
-                  required
-                />
-              </label>
-            </div>
-            <div className="idt-source-inline-fields">
-              <label>
-                Trigger mode
-                <select
-                  value={policyForm.triggerMode}
-                  onChange={(event) =>
-                    setPolicyForm((current) => ({ ...current, triggerMode: event.target.value as ScanTriggerMode }))
-                  }
-                >
-                  {SCAN_POLICY_TRIGGER_MODES.map((mode) => (
-                    <option key={mode} value={mode}>
-                      {formatScanTriggerModeLabel(mode)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Enabled
-                <select
-                  value={policyForm.enabled ? 'true' : 'false'}
-                  onChange={(event) =>
-                    setPolicyForm((current) => ({ ...current, enabled: event.target.value === 'true' }))
-                  }
-                >
-                  <option value="true">Enabled</option>
-                  <option value="false">Disabled</option>
-                </select>
-              </label>
-            </div>
-            <p className="idt-form-note">
-              Manual keeps GitHub events from starting scans. Event and hybrid modes allow selected-repository webhooks
-              to queue scans.
-            </p>
-            {policyForm.triggerMode === 'scheduled' || policyForm.triggerMode === 'hybrid' ? (
-              <label>
-                Cron schedule
-                <input
-                  value={policyForm.cron}
-                  onChange={(event) => setPolicyForm((current) => ({ ...current, cron: event.target.value }))}
-                  placeholder="0 * * * *"
-                  required
-                />
-              </label>
-            ) : null}
-            <div className="idt-source-inline-fields">
-              <label>
-                Max concurrent scans
-                <input
-                  inputMode="numeric"
-                  value={policyForm.maxConcurrentScans}
-                  onChange={(event) =>
-                    setPolicyForm((current) => ({ ...current, maxConcurrentScans: event.target.value }))
-                  }
-                  placeholder="1"
-                  required
-                />
-              </label>
-              <label>
-                History limit
-                <input
-                  inputMode="numeric"
-                  value={policyForm.historyLimit}
-                  onChange={(event) => setPolicyForm((current) => ({ ...current, historyLimit: event.target.value }))}
-                  placeholder="500"
-                  required
-                />
-              </label>
-              <label>
-                Max findings
-                <input
-                  inputMode="numeric"
-                  value={policyForm.maxFindings}
-                  onChange={(event) => setPolicyForm((current) => ({ ...current, maxFindings: event.target.value }))}
-                  placeholder="200"
-                  required
-                />
-              </label>
-            </div>
-            <button className="idt-btn idt-btn-primary" type="submit" disabled={policySaving || scanPolicyLoading}>
-              {policySaving ? 'Saving policy...' : 'Save scan policy'}
-            </button>
-          </form>
         </section>
       ) : null}
     </DomainPageShell>
@@ -16693,129 +16136,6 @@ export function ProductGitHubRepositoriesPage() {
   const [scanInfo, setScanInfo] = useState('');
   const [submittingRepository, setSubmittingRepository] = useState('');
   const [cancelingScanID, setCancelingScanID] = useState('');
-  const [oneOffScanForm, setOneOffScanForm] = useState(createDefaultOneOffRepoScanForm);
-  const [oneOffScanSubmitting, setOneOffScanSubmitting] = useState(false);
-  const oneOffScanScopeKey = scope ? `${scope.tenantID}\n${scope.workspaceID}` : '';
-  const oneOffScanRequestRef = useRef(0);
-  const selectedOneOffScanEnvironmentRef = useRef(selectedEnvironmentID);
-  const selectedOneOffScanScopeRef = useRef(oneOffScanScopeKey);
-  const postureRequestRef = useRef(0);
-  selectedOneOffScanEnvironmentRef.current = selectedEnvironmentID;
-  selectedOneOffScanScopeRef.current = oneOffScanScopeKey;
-  const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
-  const selectedRepositoriesKey = selectedRepositories.join('\n');
-  const [postureRepository, setPostureRepository] = useState('');
-  const [githubPosture, setGitHubPosture] = useState<GitHubRepositoryPosture | null>(null);
-  const [githubOrganizationPosture, setGitHubOrganizationPosture] = useState<GitHubOrganizationPosture | null>(null);
-  const [githubPostureLoading, setGitHubPostureLoading] = useState(false);
-  const [githubPostureError, setGitHubPostureError] = useState('');
-  const hasActiveRepositoryScan = data.scans.some((scan) => isActiveScanStatus(scan.status));
-
-  useEffect(() => {
-    const nextRepository = selectedRepositories.includes(postureRepository)
-      ? postureRepository
-      : (selectedRepositories[0] ?? '');
-    if (nextRepository !== postureRepository) {
-      setPostureRepository(nextRepository);
-    }
-  }, [postureRepository, selectedRepositoriesKey]);
-
-  useEffect(() => {
-    selectedOneOffScanEnvironmentRef.current = selectedEnvironmentID;
-    selectedOneOffScanScopeRef.current = oneOffScanScopeKey;
-    oneOffScanRequestRef.current += 1;
-    setOneOffScanForm(createDefaultOneOffRepoScanForm());
-    setOneOffScanSubmitting(false);
-    setScanError('');
-    setScanInfo('');
-  }, [oneOffScanScopeKey, selectedEnvironmentID]);
-
-  useEffect(() => {
-    const connection = data.connection;
-    const repository = canonicalGitHubRepositoryDisplay(postureRepository);
-    const requestID = postureRequestRef.current + 1;
-    postureRequestRef.current = requestID;
-
-    if (
-      !scope ||
-      !selectedEnvironmentID ||
-      !connection?.connected ||
-      connection.provider !== 'github_app' ||
-      !connection.connector_id ||
-      !repository
-    ) {
-      setGitHubPosture(null);
-      setGitHubOrganizationPosture(null);
-      setGitHubPostureLoading(false);
-      setGitHubPostureError('');
-      return undefined;
-    }
-
-    setGitHubPostureLoading(true);
-    setGitHubPostureError('');
-    setGitHubPosture(null);
-    setGitHubOrganizationPosture(null);
-    void apiClient
-      .getGitHubConnectorRepositoryPosture(
-        connection.connector_id,
-        scope.workspaceID,
-        selectedEnvironmentID,
-        repository,
-        buildProductAuthContext(scope)
-      )
-      .then((response) => {
-        if (postureRequestRef.current !== requestID) {
-          return;
-        }
-        setGitHubPosture(response.posture);
-        setGitHubOrganizationPosture(response.organization_posture ?? null);
-      })
-      .catch((error) => {
-        if (postureRequestRef.current !== requestID) {
-          return;
-        }
-        setGitHubPosture(null);
-        setGitHubOrganizationPosture(null);
-        setGitHubPostureError(formatAPIError(error, 'Unable to load GitHub repository posture.'));
-      })
-      .finally(() => {
-        if (postureRequestRef.current === requestID) {
-          setGitHubPostureLoading(false);
-        }
-      });
-
-    return () => {
-      if (postureRequestRef.current === requestID) {
-        postureRequestRef.current += 1;
-      }
-    };
-  }, [
-    data.connection?.connected,
-    data.connection?.connector_id,
-    data.connection?.provider,
-    postureRepository,
-    scope?.tenantID,
-    scope?.workspaceID,
-    selectedEnvironmentID
-  ]);
-
-  useEffect(() => {
-    if (!scope || !selectedEnvironmentID || !availability.available || !data.connection?.connected || !hasActiveRepositoryScan) {
-      return undefined;
-    }
-    const pollID = window.setInterval(() => {
-      data.reload();
-    }, GITHUB_ACTIVE_SCAN_POLL_MS);
-    return () => window.clearInterval(pollID);
-  }, [
-    availability.available,
-    data.connection?.connected,
-    data.reload,
-    hasActiveRepositoryScan,
-    scope?.tenantID,
-    scope?.workspaceID,
-    selectedEnvironmentID
-  ]);
 
   if (!scope) {
     return (
@@ -16868,33 +16188,13 @@ export function ProductGitHubRepositoriesPage() {
 
   const connectPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/connect'), selectedEnvironmentID);
   const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
-  const hasRepositories = selectedRepositories.length > 0;
+  const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
   const rows = buildGitHubRepositoryRows(selectedRepositories, data.scans);
-  const selectedRepositoryScans = hasRepositories
-    ? gitHubScansForSelectedRepositories(data.scans, selectedRepositories)
-    : data.scans;
-  const githubPostureSecureCount = countGitHubPostureChecks(githubPosture, 'secure');
-  const githubPostureAttentionCount = countGitHubPostureChecks(githubPosture, 'insecure');
-  const githubPostureLimitedCount = countGitHubPostureChecks(githubPosture, 'permission_limited');
-  const githubPostureUnavailableCount = countGitHubPostureChecks(githubPosture, 'unavailable');
-  const githubPostureUnsupportedCount = countGitHubPostureChecks(githubPosture, 'unsupported');
-  const githubPostureUnknownCount = countGitHubPostureChecks(githubPosture, 'unknown');
-  const githubPostureNeedsAttentionCount =
-    githubPostureAttentionCount +
-    githubPostureLimitedCount +
-    githubPostureUnavailableCount +
-    githubPostureUnsupportedCount +
-    githubPostureUnknownCount;
-  const githubPostureDetailChecks = githubPosture?.checks.filter((check) => check.state !== 'secure') ?? [];
-  const postureChecksToRender = githubPostureDetailChecks.length > 0 ? githubPostureDetailChecks : (githubPosture?.checks ?? []);
-  const githubOrganizationPostureSecureCount = countGitHubPostureChecks(githubOrganizationPosture, 'secure');
-  const githubOrganizationPostureAttentionCount = countGitHubPostureChecks(githubOrganizationPosture, 'insecure');
-  const githubOrganizationPostureLimitedCount = countGitHubPostureChecks(githubOrganizationPosture, 'permission_limited');
-  const githubOrganizationPostureUnavailableCount = countGitHubPostureChecks(githubOrganizationPosture, 'unavailable');
-  const githubOrganizationPostureChecks = githubOrganizationPosture?.checks.filter((check) => check.state !== 'secure') ?? [];
+  const selectedRepositoryScans = gitHubScansForSelectedRepositories(data.scans, selectedRepositories);
 
   const connected = Boolean(data.connection?.connected);
   const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
+  const hasRepositories = selectedRepositories.length > 0;
 
   const launchScan = async (repository: string) => {
     if (!data.connection?.connected) {
@@ -16919,73 +16219,6 @@ export function ProductGitHubRepositoriesPage() {
       setScanError(formatRepoScanSubmitError(error));
     } finally {
       setSubmittingRepository((current) => (current === repository ? '' : current));
-    }
-  };
-
-  const launchOneOffScan = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!data.connection?.connected) {
-      setScanError('Connect GitHub before queueing a repository scan.');
-      return;
-    }
-    const environmentID = selectedEnvironmentID;
-    const scopeKey = oneOffScanScopeKey;
-    const requestID = oneOffScanRequestRef.current + 1;
-    oneOffScanRequestRef.current = requestID;
-    setScanError('');
-    setScanInfo('');
-    setOneOffScanSubmitting(true);
-    try {
-      const repository = normalizeValue(oneOffScanForm.repository);
-      if (!repository) {
-        throw new Error('Repository is required.');
-      }
-      const request: RepoScanRequest = {
-        repository,
-        scan_mode: oneOffScanForm.scanMode,
-        history_limit: parsePositiveInteger(oneOffScanForm.historyLimit, 'History limit'),
-        max_findings: parsePositiveInteger(oneOffScanForm.maxFindings, 'Max findings')
-      };
-      if (data.connection.provider === 'github_app') {
-        request.project_id = environmentID;
-        if (data.connection.connector_id) {
-          request.connector_id = data.connection.connector_id;
-        }
-      }
-      await apiClient.runRepoScan(request, buildProductAuthContext(scope));
-      if (
-        oneOffScanRequestRef.current !== requestID ||
-        selectedOneOffScanEnvironmentRef.current !== environmentID ||
-        selectedOneOffScanScopeRef.current !== scopeKey
-      ) {
-        return;
-      }
-      setOneOffScanForm((current) => ({ ...current, repository: '' }));
-      setScanInfo(`Repository scan queued for ${repository}.`);
-      data.reload();
-    } catch (error) {
-      if (
-        oneOffScanRequestRef.current !== requestID ||
-        selectedOneOffScanEnvironmentRef.current !== environmentID ||
-        selectedOneOffScanScopeRef.current !== scopeKey
-      ) {
-        return;
-      }
-      setScanError(
-        error instanceof ApiError
-          ? formatRepoScanSubmitError(error)
-          : error instanceof Error
-            ? error.message
-            : formatRepoScanSubmitError(error)
-      );
-    } finally {
-      if (
-        oneOffScanRequestRef.current === requestID &&
-        selectedOneOffScanEnvironmentRef.current === environmentID &&
-        selectedOneOffScanScopeRef.current === scopeKey
-      ) {
-        setOneOffScanSubmitting(false);
-      }
     }
   };
 
@@ -17079,68 +16312,6 @@ export function ProductGitHubRepositoriesPage() {
           nextAction={{ label: 'Select repositories', to: connectPath }}
         />
       ) : null}
-      {showBody && connected ? (
-        <section className="idt-domain-status-panel idt-github-one-off-scan-panel" aria-label="One-off repository scan">
-          <header>
-            <div>
-              <h3>One-off scan</h3>
-              <p>Run a repository scan with explicit depth and finding limits.</p>
-            </div>
-            <span className="idt-source-status-pill is-warning">Advanced</span>
-          </header>
-          <form className="idt-app-form" onSubmit={launchOneOffScan}>
-            <label>
-              Repository
-              <input
-                value={oneOffScanForm.repository}
-                onChange={(event) => setOneOffScanForm((current) => ({ ...current, repository: event.target.value }))}
-                placeholder="owner/repo"
-                required
-              />
-            </label>
-            <div className="idt-source-inline-fields">
-              <label>
-                Scan mode
-                <select
-                  value={oneOffScanForm.scanMode}
-                  onChange={(event) =>
-                    setOneOffScanForm((current) => ({ ...current, scanMode: event.target.value as OneOffRepoScanMode }))
-                  }
-                >
-                  {ONE_OFF_REPO_SCAN_MODES.map((mode) => (
-                    <option key={mode} value={mode}>
-                      {formatTokenLabel(mode)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                History limit
-                <input
-                  inputMode="numeric"
-                  value={oneOffScanForm.historyLimit}
-                  onChange={(event) => setOneOffScanForm((current) => ({ ...current, historyLimit: event.target.value }))}
-                  placeholder="500"
-                  required
-                />
-              </label>
-              <label>
-                Max findings
-                <input
-                  inputMode="numeric"
-                  value={oneOffScanForm.maxFindings}
-                  onChange={(event) => setOneOffScanForm((current) => ({ ...current, maxFindings: event.target.value }))}
-                  placeholder="200"
-                  required
-                />
-              </label>
-            </div>
-            <button className="idt-btn idt-btn-primary" type="submit" disabled={oneOffScanSubmitting || data.loading}>
-              {oneOffScanSubmitting ? 'Queuing scan...' : 'Run scan'}
-            </button>
-          </form>
-        </section>
-      ) : null}
       {showBody && connected && hasRepositories ? (
         <section className="idt-domain-status-panel idt-github-repository-panel" aria-label="Selected repositories">
           <header>
@@ -17201,138 +16372,6 @@ export function ProductGitHubRepositoriesPage() {
         </section>
       ) : null}
       {showBody && connected && hasRepositories ? (
-        <section className="idt-domain-status-panel idt-github-posture-panel" aria-label="Repository posture">
-          <header>
-            <div>
-              <h3>Repository posture</h3>
-              <p>Branch protection, Actions permissions, security settings, and organization posture for a selected repository.</p>
-            </div>
-            {selectedRepositories.length > 1 ? (
-              <label>
-                Repository
-                <select value={postureRepository} onChange={(event) => setPostureRepository(event.target.value)}>
-                  {selectedRepositories.map((repository) => (
-                    <option key={repository} value={repository}>
-                      {repository}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
-          </header>
-          {githubPostureLoading ? (
-            <DomainLoadingState label="Loading repository posture" />
-          ) : githubPostureError ? (
-            <DomainErrorState title="Unable to load repository posture" body={githubPostureError} />
-          ) : githubPosture ? (
-            <>
-              <article className="idt-github-posture-card">
-                <div className="idt-github-posture-card-head">
-                  <div>
-                    <strong>{githubPosture.repository}</strong>
-                    <p>Collected {formatConnectionTime(githubPosture.collected_at)}</p>
-                  </div>
-                  <span className={`idt-source-status-pill is-${githubPostureNeedsAttentionCount > 0 ? 'warning' : 'success'}`}>
-                    {githubPostureNeedsAttentionCount > 0
-                      ? formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')
-                      : 'Secure'}
-                  </span>
-                </div>
-                <dl className="idt-github-posture-stats" aria-label="GitHub posture summary">
-                  <div>
-                    <dt>Secure</dt>
-                    <dd>{githubPostureSecureCount}</dd>
-                  </div>
-                  <div>
-                    <dt>Attention</dt>
-                    <dd>{githubPostureAttentionCount}</dd>
-                  </div>
-                  <div>
-                    <dt>Limited</dt>
-                    <dd>{githubPostureLimitedCount}</dd>
-                  </div>
-                  <div>
-                    <dt>Unavailable</dt>
-                    <dd>{githubPostureUnavailableCount}</dd>
-                  </div>
-                </dl>
-              </article>
-              <details className="idt-source-advanced idt-github-posture-details" open={githubPostureNeedsAttentionCount > 0}>
-                <summary>
-                  <span>
-                    <strong>
-                      {githubPostureNeedsAttentionCount > 0
-                        ? `Review ${formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')}`
-                        : 'Review checks'}
-                    </strong>
-                    <small>
-                      {githubPostureNeedsAttentionCount > 0 ? 'Branch, Actions, security' : 'Collected GitHub signals'}
-                    </small>
-                  </span>
-                </summary>
-                {githubPosture.rate_limit?.remaining !== undefined ? (
-                  <p className="idt-github-posture-rate-limit">
-                    GitHub API remaining {githubPosture.rate_limit.remaining}
-                    {githubPosture.rate_limit.limit ? ` of ${githubPosture.rate_limit.limit}` : ''}
-                  </p>
-                ) : null}
-                <div className="idt-github-posture-checks">
-                  {postureChecksToRender.slice(0, 6).map((check) => (
-                    <article key={check.id}>
-                      <strong>{formatTokenLabel(check.category || check.id)}</strong>
-                      <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
-                        {formatTokenLabel(check.state)}
-                      </span>
-                      <p>{check.summary}</p>
-                      {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
-                    </article>
-                  ))}
-                  {postureChecksToRender.length > 6 ? (
-                    <p>{formatCountLabel(postureChecksToRender.length - 6, 'additional check', 'additional checks')} hidden.</p>
-                  ) : null}
-                  {githubOrganizationPosture ? (
-                    <article>
-                      <strong>Organization posture</strong>
-                      <span>{formatConnectionTime(githubOrganizationPosture.collected_at)}</span>
-                      <p>
-                        {githubOrganizationPostureSecureCount} secure · {githubOrganizationPostureAttentionCount} attention ·{' '}
-                        {githubOrganizationPostureLimitedCount} permission limited · {githubOrganizationPostureUnavailableCount}{' '}
-                        unavailable
-                      </p>
-                    </article>
-                  ) : null}
-                  {githubOrganizationPostureChecks.slice(0, 5).map((check) => (
-                    <article key={`org-${check.id}`}>
-                      <strong>{formatTokenLabel(check.category || check.id)}</strong>
-                      <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
-                        {formatTokenLabel(check.state)}
-                      </span>
-                      <p>{check.summary}</p>
-                      {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
-                    </article>
-                  ))}
-                  {githubOrganizationPostureChecks.length > 5 ? (
-                    <p>
-                      {formatCountLabel(
-                        githubOrganizationPostureChecks.length - 5,
-                        'additional organization check',
-                        'additional organization checks'
-                      )}{' '}
-                      hidden.
-                    </p>
-                  ) : null}
-                </div>
-              </details>
-            </>
-          ) : (
-            <DomainEmptyState
-              title="No repository posture collected yet"
-              body="Posture checks appear here after Identrail can read the selected repository through the GitHub App."
-            />
-          )}
-        </section>
-      ) : null}
-      {showBody && connected ? (
         <section className="idt-domain-status-panel" aria-label="Recent repository scan activity">
           <header>
             <div>
@@ -21121,6 +20160,1967 @@ export function ProductProjectsPage() {
   );
 }
 
+export function ProductProjectDetailPage() {
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  const projectID = normalizeValue(params.projectID ?? '');
+  const location = useLocation();
+  const { features: backendFeatures, loading: backendFeaturesLoading } = useBackendFeatures({
+    enabled: SHOULD_LOAD_CONNECTOR_BACKEND_FEATURES
+  });
+  const refreshSequenceRef = useRef(0);
+  const repoScanSubmitSequenceRef = useRef(0);
+  const githubPostureRequestRef = useRef(0);
+  const sourceAvailability = useMemo(() => buildSourceAvailability(backendFeatures), [backendFeatures]);
+  const selectedSourceFromConnect = useMemo(() => {
+    return normalizeSourceProvider(new URLSearchParams(location.search).get('source'));
+  }, [location.search]);
+  const sourceScope = useMemo(() => {
+    if (!selectedSourceFromConnect || !sourceAvailability[selectedSourceFromConnect]?.visible) {
+      return null;
+    }
+    return selectedSourceFromConnect;
+  }, [selectedSourceFromConnect, sourceAvailability]);
+  const sourceOrder = useMemo(
+    () => (sourceScope ? [sourceScope] : SOURCE_ORDER.filter((provider) => sourceAvailability[provider].visible)),
+    [sourceAvailability, sourceScope]
+  );
+  const actionableSourceOrder = useMemo(
+    () => sourceOrder.filter((provider) => sourceAvailability[provider].available),
+    [sourceAvailability, sourceOrder]
+  );
+
+  const [connections, setConnections] = useState<SourceConnectionMap>({});
+  const [sourceErrors, setSourceErrors] = useState<Partial<Record<SourceProvider, string>>>({});
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [submitting, setSubmitting] = useState<SourceProvider | ''>('');
+  const [selectedSource, setSelectedSource] = useState<SourceProvider>(
+    selectedSourceFromConnect ?? SOURCE_ORDER[0] ?? 'aws'
+  );
+  const [successMessage, setSuccessMessage] = useState('');
+  const [githubStart, setGitHubStart] = useState<GitHubConnectorStartResponse | null>(null);
+  const [githubAppForm, setGitHubAppForm] = useState({
+    displayName: 'Identrail'
+  });
+  const [githubPATForm, setGitHubPATForm] = useState({
+    displayName: 'GitHub Enterprise',
+    baseURL: '',
+    token: '',
+    repositories: ''
+  });
+  const [repoScanForm, setRepoScanForm] = useState({
+    repository: '',
+    historyLimit: '',
+    maxFindings: ''
+  });
+  const [recentRepoScans, setRecentRepoScans] = useState<RepoScanRecord[]>([]);
+  const [repoScanSubmitting, setRepoScanSubmitting] = useState(false);
+  const [repoScanCancelingID, setRepoScanCancelingID] = useState('');
+  const [repoScanError, setRepoScanError] = useState('');
+  const [githubPosture, setGitHubPosture] = useState<GitHubRepositoryPosture | null>(null);
+  const [githubOrganizationPosture, setGitHubOrganizationPosture] = useState<GitHubOrganizationPosture | null>(null);
+  const [githubPostureLoading, setGitHubPostureLoading] = useState(false);
+  const [githubPostureError, setGitHubPostureError] = useState('');
+  const [awsForm, setAWSForm] = useState({
+    roleARN: '',
+    externalID: '',
+    region: 'us-east-1',
+    displayName: '',
+    sessionName: 'identrail-connector-validation',
+    roleName: 'IdentrailReadOnly',
+    stackName: 'identrail-readonly-connector'
+  });
+  const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
+  const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
+  const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
+  const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
+  const [kubernetesForm, setKubernetesForm] = useState({
+    displayName: '',
+    context: '',
+    mode: 'agent' as 'agent' | 'kubeconfig',
+    apiURL: '',
+    kubeconfig: ''
+  });
+  const [kubernetesEnrollment, setKubernetesEnrollment] = useState<KubernetesConnectorStartResponse | null>(null);
+  const [scanPolicies, setScanPolicies] = useState<ScanPolicyRecord[]>([]);
+  const [scanPolicyError, setScanPolicyError] = useState('');
+  const [policySaving, setPolicySaving] = useState(false);
+  const [policyDeletingID, setPolicyDeletingID] = useState('');
+  const scopedEnvironmentKey = scope ? `${scope.tenantID}::${scope.workspaceID}::${projectID}` : '';
+  const scopedEnvironmentKeyRef = useRef(scopedEnvironmentKey);
+  scopedEnvironmentKeyRef.current = scopedEnvironmentKey;
+  const [policyForm, setPolicyForm] = useState({
+    policyID: 'default',
+    name: 'Default policy',
+    enabled: true,
+    triggerMode: 'manual' as ScanTriggerMode,
+    cron: '',
+    maxConcurrentScans: '1',
+    historyLimit: '500',
+    maxFindings: '200'
+  });
+  const githubSelectedRepositories = useMemo(
+    () => uniqueGitHubRepositories(connections.github?.selected_repositories ?? []),
+    [connections.github?.selected_repositories]
+  );
+  const githubSelectedRepositoriesKey = githubSelectedRepositories.join('\n');
+  const githubSelectedRepositoryKeys = useMemo(
+    () => new Set(githubSelectedRepositories.map((repository) => repository.toLowerCase())),
+    [githubSelectedRepositories]
+  );
+  const githubRecentRepoScans = useMemo(() => {
+    if (githubSelectedRepositoryKeys.size === 0) {
+      return [];
+    }
+    return recentRepoScans.filter((scan) =>
+      githubSelectedRepositoryKeys.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase())
+    );
+  }, [githubSelectedRepositoryKeys, recentRepoScans]);
+  const repoScanRepository = normalizeValue(repoScanForm.repository);
+  const effectiveRepoScanRepository = repoScanRepository || githubSelectedRepositories[0] || '';
+  const effectiveRepoScanRepositoryKey = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository).toLowerCase();
+  const githubPostureSecureCount = countGitHubPostureChecks(githubPosture, 'secure');
+  const githubPostureAttentionCount = countGitHubPostureChecks(githubPosture, 'insecure');
+  const githubPostureLimitedCount = countGitHubPostureChecks(githubPosture, 'permission_limited');
+  const githubPostureUnavailableCount = countGitHubPostureChecks(githubPosture, 'unavailable');
+  const githubPostureUnsupportedCount = countGitHubPostureChecks(githubPosture, 'unsupported');
+  const githubPostureUnknownCount = countGitHubPostureChecks(githubPosture, 'unknown');
+  const githubOrganizationPostureSecureCount = countGitHubPostureChecks(githubOrganizationPosture, 'secure');
+  const githubOrganizationPostureAttentionCount = countGitHubPostureChecks(githubOrganizationPosture, 'insecure');
+  const githubOrganizationPostureLimitedCount = countGitHubPostureChecks(githubOrganizationPosture, 'permission_limited');
+  const githubOrganizationPostureUnavailableCount = countGitHubPostureChecks(githubOrganizationPosture, 'unavailable');
+  const githubOrganizationPostureUnsupportedCount = countGitHubPostureChecks(githubOrganizationPosture, 'unsupported');
+  const githubOrganizationPostureUnknownCount = countGitHubPostureChecks(githubOrganizationPosture, 'unknown');
+  const githubPostureAttentionChecks = useMemo(
+    () => githubPosture?.checks.filter((check) => check.state !== 'secure') ?? [],
+    [githubPosture]
+  );
+  const githubPostureDetailChecks =
+    githubPostureAttentionChecks.length > 0 ? githubPostureAttentionChecks : (githubPosture?.checks ?? []);
+  const githubPostureNeedsAttentionCount =
+    githubPostureAttentionCount +
+    githubPostureLimitedCount +
+    githubPostureUnavailableCount +
+    githubPostureUnsupportedCount +
+    githubPostureUnknownCount;
+  const githubOrganizationPostureAttentionChecks = useMemo(
+    () => githubOrganizationPosture?.checks.filter((check) => check.state !== 'secure') ?? [],
+    [githubOrganizationPosture]
+  );
+  const githubOrganizationPostureDetailChecks =
+    githubOrganizationPostureAttentionChecks.length > 0
+      ? githubOrganizationPostureAttentionChecks
+      : (githubOrganizationPosture?.checks ?? []);
+  const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
+  const githubHasActiveSelectedRepoScan =
+    effectiveRepoScanRepositoryKey !== '' &&
+    githubRecentRepoScans.some(
+      (scan) =>
+        isActiveScanStatus(scan.status) &&
+        canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() === effectiveRepoScanRepositoryKey
+    );
+  const repoScanFindingsPath = scope ? buildScopedPath(scope, 'github/findings') : '/app';
+
+  const nextRequestSequence = () => {
+    const nextSequence = refreshSequenceRef.current + 1;
+    refreshSequenceRef.current = nextSequence;
+    return nextSequence;
+  };
+
+  const isStaleRequestSequence = (sequence: number) => refreshSequenceRef.current !== sequence;
+
+  const nextRepoScanSubmitSequence = () => {
+    const nextSequence = repoScanSubmitSequenceRef.current + 1;
+    repoScanSubmitSequenceRef.current = nextSequence;
+    return nextSequence;
+  };
+
+  const isLatestRepoScanSubmitSequence = (sequence: number) => repoScanSubmitSequenceRef.current === sequence;
+
+  const refreshConnections = async (quiet = false) => {
+    const refreshSequence = nextRequestSequence();
+    const requestPolicyScope = scopedEnvironmentKeyRef.current;
+
+    if (backendFeaturesLoading) {
+      setLoading(true);
+      setRefreshing(false);
+      return;
+    }
+
+    if (!scope || !projectID) {
+      setConnections({});
+      setSourceErrors({});
+      setRecentRepoScans([]);
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    if (quiet) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setSourceErrors({});
+    const auth = buildProductAuthContext(scope);
+
+    const results = await Promise.allSettled([
+      sourceAvailability.github.available
+        ? apiClient.getGitHubConnectorStatus(scope.workspaceID, projectID, auth)
+        : Promise.resolve({ connection: undefined as unknown as GitHubConnectionStatus }),
+      apiClient.getAWSProjectConnection(scope.workspaceID, projectID, auth),
+      sourceAvailability.kubernetes.available
+        ? apiClient.getKubernetesConnectorStatus(scope.workspaceID, projectID, auth)
+        : Promise.resolve({ connection: undefined as unknown as KubernetesConnectionStatus }),
+      apiClient.listProjectScanPolicies(
+        scope.workspaceID,
+        projectID,
+        {
+          limit: 50,
+          sort_by: 'updated_at',
+          sort_order: 'desc'
+        },
+        auth
+      ),
+      apiClient.listRepoScans({ limit: 8 }, auth)
+    ]);
+
+    if (isStaleRequestSequence(refreshSequence)) {
+      return;
+    }
+
+    const nextConnections: SourceConnectionMap = {};
+    const nextErrors: Partial<Record<SourceProvider, string>> = {};
+    const [githubResult, awsResult, kubernetesResult, scanPolicyResult, repoScanResult] = results;
+
+    if (githubResult.status === 'fulfilled' && githubResult.value.connection) {
+      nextConnections.github = githubResult.value.connection;
+    } else {
+      if (sourceAvailability.github.available) {
+        nextErrors.github =
+          githubResult.status === 'rejected' && githubResult.reason instanceof Error
+            ? githubResult.reason.message
+            : `Unable to load ${SOURCE_PROFILES.github.name} status.`;
+      }
+    }
+    if (awsResult.status === 'fulfilled') {
+      nextConnections.aws = awsResult.value.connection;
+    } else {
+      nextErrors.aws =
+        awsResult.reason instanceof Error ? awsResult.reason.message : `Unable to load ${SOURCE_PROFILES.aws.name} status.`;
+    }
+    if (kubernetesResult.status === 'fulfilled' && kubernetesResult.value.connection) {
+      nextConnections.kubernetes = kubernetesResult.value.connection;
+    } else {
+      if (sourceAvailability.kubernetes.available) {
+        nextErrors.kubernetes =
+          kubernetesResult.status === 'rejected' && kubernetesResult.reason instanceof Error
+            ? kubernetesResult.reason.message
+            : `Unable to load ${SOURCE_PROFILES.kubernetes.name} status.`;
+      }
+    }
+
+    setConnections(nextConnections);
+    setSourceErrors(nextErrors);
+    if (scanPolicyResult?.status === 'fulfilled') {
+      const isCurrentPolicyScope = scopedEnvironmentKeyRef.current === requestPolicyScope;
+      const items = scanPolicyResult.value.items ?? [];
+      if (isCurrentPolicyScope) {
+        setScanPolicies(items);
+        setScanPolicyError('');
+        setPolicyForm((current) => {
+          if (items.length === 0) {
+            return {
+              policyID: current.policyID || 'default',
+              name: current.name || 'Default policy',
+              enabled: current.enabled,
+              triggerMode: current.triggerMode,
+              cron: current.cron,
+              maxConcurrentScans: current.maxConcurrentScans,
+              historyLimit: current.historyLimit,
+              maxFindings: current.maxFindings
+            };
+          }
+          const selected = items.find((item) => item.policy_id === current.policyID) ?? items[0];
+          return {
+            policyID: selected.policy_id,
+            name: selected.name,
+            enabled: selected.enabled,
+            triggerMode: selected.trigger_mode,
+            cron: selected.cron ?? '',
+            maxConcurrentScans: String(selected.max_concurrent_scans),
+            historyLimit: String(selected.history_limit),
+            maxFindings: String(selected.max_findings)
+          };
+        });
+      }
+    } else if (scanPolicyResult?.status === 'rejected') {
+      if (scopedEnvironmentKeyRef.current === requestPolicyScope) {
+        setScanPolicyError(
+          scanPolicyResult.reason instanceof Error
+            ? scanPolicyResult.reason.message
+            : 'Unable to load scan policies for this source.'
+        );
+        setScanPolicies([]);
+      }
+    }
+    if (repoScanResult?.status === 'fulfilled') {
+      setRecentRepoScans(repoScanResult.value.items ?? []);
+    }
+    setLoading(false);
+    setRefreshing(false);
+  };
+
+  const refreshRecentRepoScans = async (targetScope: ProductSession, mode: 'silent' | 'interactive' = 'silent') => {
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(targetScope);
+      const response = await apiClient.listRepoScans({ limit: 8 }, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRecentRepoScans(response.items ?? []);
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      if (mode === 'interactive') {
+        setRepoScanError(formatAPIError(error, 'Unable to refresh recent repository scans.'));
+      }
+    }
+  };
+
+  useEffect(() => {
+    setConnections({});
+    setSourceErrors({});
+    setScanPolicies([]);
+    setScanPolicyError('');
+    setGitHubPATForm({
+      displayName: 'GitHub Enterprise',
+      baseURL: '',
+      token: '',
+      repositories: ''
+    });
+    setPolicyForm({
+      policyID: 'default',
+      name: 'Default policy',
+      enabled: true,
+      triggerMode: 'manual',
+      cron: '',
+      maxConcurrentScans: '1',
+      historyLimit: '500',
+      maxFindings: '200'
+    });
+    setPolicySaving(false);
+    setPolicyDeletingID('');
+    setSubmitting('');
+    setSuccessMessage('');
+    setGitHubStart(null);
+    setRepoScanForm({ repository: '', historyLimit: '', maxFindings: '' });
+    setRecentRepoScans([]);
+    repoScanSubmitSequenceRef.current += 1;
+    githubPostureRequestRef.current += 1;
+    setRepoScanSubmitting(false);
+    setRepoScanCancelingID('');
+    setRepoScanError('');
+    setGitHubPosture(null);
+    setGitHubPostureLoading(false);
+    setGitHubPostureError('');
+    setAWSCloudFormationStart(null);
+    setAWSPermissionPreview([]);
+    setAWSPermissionTiers([]);
+    setAWSPreviewOpen(false);
+    setAWSForm((current) => ({ ...current, externalID: '' }));
+    if (backendFeaturesLoading) {
+      setLoading(true);
+      return undefined;
+    }
+    void refreshConnections(false);
+
+    return () => {
+      refreshSequenceRef.current += 1;
+    };
+  }, [
+    scope?.tenantID,
+    scope?.workspaceID,
+    projectID,
+    backendFeaturesLoading,
+    sourceAvailability.github.available,
+    sourceAvailability.kubernetes.available
+  ]);
+
+  useEffect(() => {
+    if (backendFeaturesLoading || sourceScope || sourceAvailability[selectedSource]?.available) {
+      return;
+    }
+    setSelectedSource(actionableSourceOrder[0] ?? 'aws');
+  }, [actionableSourceOrder, backendFeaturesLoading, selectedSource, sourceAvailability, sourceScope]);
+
+  useEffect(() => {
+    if (!selectedSourceFromConnect || backendFeaturesLoading) {
+      return;
+    }
+
+    if (sourceAvailability[selectedSourceFromConnect]?.visible) {
+      setSelectedSource(selectedSourceFromConnect);
+    }
+  }, [backendFeaturesLoading, selectedSourceFromConnect, sourceAvailability]);
+
+  useEffect(() => {
+    if (!connections.github?.connected) {
+      return;
+    }
+    setRepoScanForm((current) => {
+      const currentRepository = canonicalGitHubRepositoryDisplay(current.repository);
+      if (
+        currentRepository &&
+        (githubSelectedRepositories.length === 0 ||
+          githubSelectedRepositories.some((repository) => repository.toLowerCase() === currentRepository.toLowerCase()))
+      ) {
+        return current;
+      }
+      return { ...current, repository: githubSelectedRepositories[0] ?? current.repository };
+    });
+  }, [connections.github?.connected, githubSelectedRepositories, githubSelectedRepositoriesKey]);
+
+  useEffect(() => {
+    const connection = connections.github;
+    const repository = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository);
+    const requestID = githubPostureRequestRef.current + 1;
+    githubPostureRequestRef.current = requestID;
+
+    if (
+      !scope ||
+      !projectID ||
+      selectedSource !== 'github' ||
+      !connection?.connected ||
+      connection.provider !== 'github_app' ||
+      !connection.connector_id ||
+      !repository
+    ) {
+      setGitHubPosture(null);
+      setGitHubPostureLoading(false);
+      setGitHubPostureError('');
+      setGitHubOrganizationPosture(null);
+      return undefined;
+    }
+
+    setGitHubPostureLoading(true);
+    setGitHubPostureError('');
+    setGitHubPosture(null);
+    setGitHubOrganizationPosture(null);
+    void apiClient
+      .getGitHubConnectorRepositoryPosture(
+        connection.connector_id,
+        scope.workspaceID,
+        projectID,
+        repository,
+        buildProductAuthContext(scope)
+      )
+      .then((response) => {
+        if (githubPostureRequestRef.current !== requestID) {
+          return;
+        }
+        setGitHubPosture(response.posture);
+        setGitHubOrganizationPosture(response.organization_posture ?? null);
+      })
+      .catch((error) => {
+        if (githubPostureRequestRef.current !== requestID) {
+          return;
+        }
+        setGitHubPosture(null);
+        setGitHubOrganizationPosture(null);
+        setGitHubPostureError(error instanceof Error ? error.message : 'Unable to load GitHub repository posture.');
+      })
+      .finally(() => {
+        if (githubPostureRequestRef.current === requestID) {
+          setGitHubPostureLoading(false);
+        }
+      });
+
+    return () => {
+      if (githubPostureRequestRef.current === requestID) {
+        githubPostureRequestRef.current += 1;
+      }
+    };
+  }, [
+    connections.github?.connected,
+    connections.github?.connector_id,
+    connections.github?.provider,
+    effectiveRepoScanRepository,
+    projectID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedSource
+  ]);
+
+  useEffect(() => {
+    if (!scope || !githubHasActiveRepoScan) {
+      return undefined;
+    }
+    const activeScope = scope;
+    const intervalID = window.setInterval(() => {
+      void refreshRecentRepoScans(activeScope);
+    }, 8000);
+    return () => window.clearInterval(intervalID);
+  }, [githubHasActiveRepoScan, scope?.tenantID, scope?.workspaceID]);
+
+  if (!scope || !projectID) {
+    return <AppShellLoading message="Resolving environment scope" />;
+  }
+
+  if (loading) {
+    return (
+      <AppRouteLoadingState
+        title="Preparing source connections"
+        body="Keeping the environment visible while connector status refreshes."
+      />
+    );
+  }
+
+  const selectedStatus = sourceConnection(connections, selectedSource);
+  const selectedProfile = SOURCE_PROFILES[selectedSource];
+  const selectedAvailability = sourceAvailability[selectedSource] ?? { visible: true, available: true };
+  const selectedUnavailable = !selectedAvailability.available;
+  const sourceScopeProfile = sourceScope ? SOURCE_PROFILES[sourceScope] : null;
+  const sourcePageTitle = sourceScopeProfile ? `Connect ${sourceScopeProfile.name}` : 'Connect environment sources';
+  const sourcePageBody =
+    sourceScopeProfile?.summary ?? 'Install source connections to collect repository, workflow, and cloud identity signals.';
+
+  const handleGitHubStart = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!sourceAvailability.github.available) {
+      setSourceErrors((current) => ({
+        ...current,
+        github: sourceAvailability.github.unavailableMessage ?? 'GitHub connector is not available.'
+      }));
+      return;
+    }
+    setSubmitting('github');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, github: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      const redirectURI =
+        typeof window !== 'undefined' ? `${window.location.origin}/app/github/callback` : undefined;
+      const response = await apiClient.startGitHubConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: projectID,
+          display_name: normalizeValue(githubAppForm.displayName) || undefined,
+          redirect_uri: redirectURI
+        },
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setGitHubStart(response);
+      setConnections((current) => ({ ...current, github: response.connection }));
+      const opened = openGitHubInstallURL(response.install_url);
+      setSuccessMessage(
+        opened
+          ? 'GitHub opened in a new tab. Finish the installation there to complete setup.'
+          : 'GitHub installation is ready. Continue with the GitHub button below.'
+      );
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to start GitHub connection.';
+      setSourceErrors((current) => ({ ...current, github: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const handleGitHubPATSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!sourceAvailability.github.available) {
+      setSourceErrors((current) => ({
+        ...current,
+        github: sourceAvailability.github.unavailableMessage ?? 'GitHub connector is not available.'
+      }));
+      return;
+    }
+    setSubmitting('github');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, github: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    const requestScope = scopedEnvironmentKeyRef.current;
+    try {
+      const token = normalizeValue(githubPATForm.token);
+      if (!token) {
+        throw new Error('Enter a GitHub personal access token for the self-hosted fallback.');
+      }
+      const repositories = parseGitHubRepositories(githubPATForm.repositories);
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.upsertGitHubPATConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: projectID,
+          display_name: normalizeValue(githubPATForm.displayName) || undefined,
+          base_url: normalizeValue(githubPATForm.baseURL) || undefined,
+          token,
+          selected_repositories: repositories
+        },
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      if (scopedEnvironmentKeyRef.current !== requestScope) {
+        return;
+      }
+      setConnections((current) => ({ ...current, github: response.connection }));
+      setGitHubStart(null);
+      setGitHubPATForm((current) => ({ ...current, token: '' }));
+      setSuccessMessage('GitHub Enterprise connector validated and saved.');
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to save GitHub Enterprise connector.';
+      setSourceErrors((current) => ({ ...current, github: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const handleAWSSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting('aws');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, aws: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const roleARN = normalizeValue(awsForm.roleARN);
+      if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
+        throw new Error('Enter a valid IAM role ARN, for example arn:aws:iam::123456789012:role/IdentrailReadOnly.');
+      }
+      const auth = buildProductAuthContext(scope);
+      const payload = {
+          role_arn: roleARN,
+          external_id: normalizeValue(awsForm.externalID) || undefined,
+          region: normalizeValue(awsForm.region) || 'us-east-1',
+          display_name: normalizeValue(awsForm.displayName) || undefined,
+          session_name: normalizeValue(awsForm.sessionName) || undefined
+        };
+      const response =
+        FEATURE_CONNECTOR_AWS && awsCloudFormationStart?.connector_id
+          ? await apiClient.validateAWSConnector(
+              awsCloudFormationStart.connector_id,
+              {
+                workspace_id: scope.workspaceID,
+                project_id: projectID,
+                role_arn: payload.role_arn,
+                external_id: payload.external_id,
+                region: payload.region,
+                session_name: payload.session_name
+              },
+              auth
+            )
+          : await apiClient.upsertAWSProjectConnection(scope.workspaceID, projectID, payload, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setConnections((current) => ({ ...current, aws: response.connection }));
+      setSuccessMessage(
+        response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
+      );
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to validate AWS connection.';
+      setSourceErrors((current) => ({ ...current, aws: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const handleAWSCloudFormationStart = async () => {
+    if (!scope || !projectID) {
+      return;
+    }
+    setSubmitting('aws');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, aws: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.startAWSConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: projectID,
+          display_name: normalizeValue(awsForm.displayName) || undefined,
+          region: normalizeValue(awsForm.region) || 'us-east-1',
+          role_name: normalizeValue(awsForm.roleName) || undefined,
+          stack_name: normalizeValue(awsForm.stackName) || undefined
+        },
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setAWSCloudFormationStart(response);
+      setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
+      setAWSForm((current) => ({ ...current, externalID: response.external_id }));
+      setConnections((current) => ({ ...current, aws: response.connection }));
+      setSuccessMessage('AWS stack launch is ready.');
+      window.open(response.launch_url, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to start AWS connector setup.';
+      setSourceErrors((current) => ({ ...current, aws: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const handleAWSPoll = async () => {
+    if (!scope || !projectID || !awsCloudFormationStart?.connector_id) {
+      return;
+    }
+    setSubmitting('aws');
+    setSourceErrors((current) => ({ ...current, aws: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.pollAWSConnector(
+        awsCloudFormationStart.connector_id,
+        scope.workspaceID,
+        projectID,
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setConnections((current) => ({ ...current, aws: response.connection }));
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to poll AWS connector setup.';
+      setSourceErrors((current) => ({ ...current, aws: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const handleKubernetesSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!sourceAvailability.kubernetes.available) {
+      setSourceErrors((current) => ({
+        ...current,
+        kubernetes: sourceAvailability.kubernetes.unavailableMessage ?? 'Connector disabled.'
+      }));
+      return;
+    }
+    setSubmitting('kubernetes');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, kubernetes: undefined }));
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      if (kubernetesForm.mode === 'kubeconfig') {
+        const response = await apiClient.upsertKubernetesKubeconfigConnector(
+          {
+            workspace_id: scope.workspaceID,
+            project_id: projectID,
+            display_name: normalizeValue(kubernetesForm.displayName) || undefined,
+            context: normalizeValue(kubernetesForm.context) || undefined,
+            kubeconfig: kubernetesForm.kubeconfig
+          },
+          auth
+        );
+        if (isStaleRequestSequence(requestSequence)) {
+          return;
+        }
+        setConnections((current) => ({ ...current, kubernetes: response.connection }));
+        setKubernetesEnrollment(null);
+        setSuccessMessage('Kubeconfig saved.');
+        return;
+      }
+      const response = await apiClient.startKubernetesConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: projectID,
+          display_name: normalizeValue(kubernetesForm.displayName) || undefined,
+          api_url: normalizeValue(kubernetesForm.apiURL) || undefined
+        },
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setConnections((current) => ({ ...current, kubernetes: response.connection }));
+      setKubernetesEnrollment(response);
+      setSuccessMessage('Enrollment token ready.');
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to validate Kubernetes connection.';
+      setSourceErrors((current) => ({ ...current, kubernetes: message }));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
+    }
+  };
+
+  const parsePositiveInteger = (value: string, field: string): number => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`${field} must be a positive integer.`);
+    }
+    return parsed;
+  };
+
+  const parseOptionalPositiveInteger = (value: string, field: string): number | undefined => {
+    const normalized = normalizeValue(value);
+    return normalized ? parsePositiveInteger(normalized, field) : undefined;
+  };
+
+  const handleRepoScanSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!scope) {
+      setRepoScanError('Workspace route context is missing.');
+      return;
+    }
+    if (!connections.github?.connected) {
+      setRepoScanError('Connect GitHub before queueing a repository scan.');
+      return;
+    }
+    const repository = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository);
+    if (!repository) {
+      setRepoScanError('Choose a selected GitHub repository before queueing a scan.');
+      return;
+    }
+    setRepoScanSubmitting(true);
+    setRepoScanError('');
+    setSuccessMessage('');
+    const requestSequence = refreshSequenceRef.current;
+    const submitSequence = nextRepoScanSubmitSequence();
+    try {
+      const githubConnection = connections.github;
+      const request: RepoScanRequest = { repository };
+      if (githubConnection?.provider === 'github_app') {
+        request.project_id = projectID;
+        if (githubConnection.connector_id) {
+          request.connector_id = githubConnection.connector_id;
+        }
+      }
+      const historyLimit = parseOptionalPositiveInteger(repoScanForm.historyLimit, 'History limit');
+      const maxFindings = parseOptionalPositiveInteger(repoScanForm.maxFindings, 'Max findings');
+      if (historyLimit) {
+        request.history_limit = historyLimit;
+      }
+      if (maxFindings) {
+        request.max_findings = maxFindings;
+      }
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.runRepoScan(request, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRecentRepoScans((current) =>
+        [response.repo_scan, ...current.filter((scan) => scan.id !== response.repo_scan.id)].slice(0, 8)
+      );
+      setSuccessMessage(`Repository scan queued for ${canonicalGitHubRepositoryDisplay(response.repo_scan.repository)}.`);
+      void refreshRecentRepoScans(scope);
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRepoScanError(formatRepoScanSubmitError(error));
+    } finally {
+      if (isLatestRepoScanSubmitSequence(submitSequence)) {
+        setRepoScanSubmitting(false);
+      }
+    }
+  };
+
+  const handleRepoScanCancel = async (scan: RepoScanRecord) => {
+    if (!scope) {
+      setRepoScanError('Workspace route context is missing.');
+      return;
+    }
+    if (!isActiveScanStatus(scan.status)) {
+      setRepoScanError('Only queued or running repository scans can be canceled.');
+      return;
+    }
+    setRepoScanCancelingID(scan.id);
+    setRepoScanError('');
+    setSuccessMessage('');
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.cancelRepoScan(scan.id, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRecentRepoScans((current) => current.map((item) => (item.id === response.repo_scan.id ? response.repo_scan : item)));
+      setSuccessMessage(`Repository scan canceled for ${canonicalGitHubRepositoryDisplay(response.repo_scan.repository)}.`);
+      void refreshRecentRepoScans(scope, 'interactive');
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRepoScanError(formatRepoScanCancelError(error));
+    } finally {
+      setRepoScanCancelingID((current) => (current === scan.id ? '' : current));
+    }
+  };
+
+  const handleScanPolicySubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPolicySaving(true);
+    setScanPolicyError('');
+    setSuccessMessage('');
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const policyID = normalizeProjectToken(policyForm.policyID);
+      if (!policyID) {
+        throw new Error('Policy ID is required.');
+      }
+      const name = normalizeValue(policyForm.name);
+      if (!name) {
+        throw new Error('Policy name is required.');
+      }
+      const triggerMode = policyForm.triggerMode;
+      const cron = normalizeValue(policyForm.cron);
+      if ((triggerMode === 'scheduled' || triggerMode === 'hybrid') && !cron) {
+        throw new Error('Cron is required when trigger mode is scheduled or hybrid.');
+      }
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.upsertProjectScanPolicy(
+        scope.workspaceID,
+        projectID,
+        {
+          policy_id: policyID,
+          name,
+          enabled: policyForm.enabled,
+          trigger_mode: triggerMode,
+          cron: cron || undefined,
+          max_concurrent_scans: parsePositiveInteger(policyForm.maxConcurrentScans, 'Max concurrent scans'),
+          history_limit: parsePositiveInteger(policyForm.historyLimit, 'History limit'),
+          max_findings: parsePositiveInteger(policyForm.maxFindings, 'Max findings')
+        },
+        auth
+      );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      const policy = response.policy;
+      setPolicyForm({
+        policyID: policy.policy_id,
+        name: policy.name,
+        enabled: policy.enabled,
+        triggerMode: policy.trigger_mode,
+        cron: policy.cron ?? '',
+        maxConcurrentScans: String(policy.max_concurrent_scans),
+        historyLimit: String(policy.history_limit),
+        maxFindings: String(policy.max_findings)
+      });
+      setSuccessMessage('Scan policy saved.');
+      setPolicySaving(false);
+      void refreshConnections(true);
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setScanPolicyError(error instanceof Error ? error.message : 'Unable to save scan policy.');
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setPolicySaving(false);
+      }
+    }
+  };
+
+  const handleScanPolicyDelete = async (policyID: string) => {
+    const normalizedPolicyID = normalizeValue(policyID);
+    if (!normalizedPolicyID) {
+      return;
+    }
+    setPolicyDeletingID(normalizedPolicyID);
+    setScanPolicyError('');
+    setSuccessMessage('');
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      await apiClient.deleteProjectScanPolicy(scope.workspaceID, projectID, normalizedPolicyID, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setSuccessMessage(`Scan policy ${normalizedPolicyID} deleted.`);
+      setPolicyDeletingID('');
+      void refreshConnections(true);
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setScanPolicyError(error instanceof Error ? error.message : 'Unable to delete scan policy.');
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setPolicyDeletingID('');
+      }
+    }
+  };
+
+  return (
+    <section className={`idt-app-panel idt-source-onboarding${sourceScope ? ' is-source-scoped' : ''}`}>
+      <div className="idt-source-onboarding-header">
+        {sourceScopeProfile ? (
+          <div className="idt-source-onboarding-title-row">
+            <SourceLogoMark provider={selectedSource} className="is-hero" />
+            <div>
+              <h1>{sourcePageTitle}</h1>
+              <p>{sourcePageBody}</p>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <p className="idt-app-kicker">Environment sources</p>
+            <h2>{sourcePageTitle}</h2>
+            <p>
+              {sourcePageBody} Environment <strong>{environmentFallbackLabel(projectID)}</strong>.
+            </p>
+          </div>
+        )}
+        <div className="idt-source-onboarding-actions">
+          {sourceScopeProfile ? (
+            <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
+              {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            className="idt-btn idt-btn-ghost"
+            onClick={() => {
+              void refreshConnections(true);
+            }}
+            disabled={backendFeaturesLoading || refreshing || submitting !== '' || repoScanSubmitting}
+          >
+            {refreshing ? 'Refreshing...' : 'Refresh status'}
+          </button>
+        </div>
+      </div>
+
+      {successMessage ? (
+        <p role="status" className="idt-app-alert idt-app-alert-success">
+          {successMessage}
+        </p>
+      ) : null}
+
+      <div className="idt-source-wizard-grid">
+        {sourceScopeProfile ? null : (
+          <aside className="idt-source-picker" aria-label="Source types">
+            {sourceOrder.map((provider) => {
+              const profile = SOURCE_PROFILES[provider];
+              const status = sourceConnection(connections, provider);
+              const error = sourceErrors[provider];
+              const availability = sourceAvailability[provider];
+              return (
+                <button
+                  key={provider}
+                  type="button"
+                  className={`idt-source-card is-provider-${provider} ${selectedSource === provider ? 'is-selected' : ''} ${
+                    availability.available ? '' : 'is-unavailable'
+                  }`}
+                  aria-pressed={selectedSource === provider}
+                  aria-disabled={!availability.available}
+                  onClick={() => setSelectedSource(provider)}
+                  disabled={!availability.available}
+                >
+                  <span className="idt-source-card-topline">
+                    <span className="idt-source-card-identity">
+                      <SourceLogoMark provider={provider} />
+                      <span>{profile.eyebrow}</span>
+                    </span>
+                    <span className={`idt-source-status-pill is-${sourceAvailabilityTone(availability, status)}`}>
+                      {!availability.available ? 'Unavailable' : error ? 'Needs retry' : connectionLifecycle(status)}
+                    </span>
+                  </span>
+                  <strong>{profile.name}</strong>
+                  <small>{availability.unavailableMessage ?? profile.primarySignal}</small>
+                </button>
+              );
+            })}
+          </aside>
+        )}
+
+        <div className="idt-source-config">
+          {sourceScopeProfile ? null : (
+            <div className="idt-source-config-header">
+              <div className="idt-source-config-title">
+                <SourceLogoMark provider={selectedSource} className="is-hero" />
+                <div>
+                  <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
+                  <h3>{selectedProfile.name}</h3>
+                  <p>{selectedProfile.summary}</p>
+                </div>
+              </div>
+              <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
+                {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
+              </span>
+            </div>
+          )}
+
+          <dl className="idt-source-meta">
+            <div>
+              <dt>Required access</dt>
+              <dd>{selectedProfile.requiredAccess}</dd>
+            </div>
+            <div>
+              <dt>Health</dt>
+              <dd>{selectedUnavailable ? 'unavailable' : connectionHealth(selectedStatus)}</dd>
+            </div>
+            <div>
+              <dt>Last validation</dt>
+              <dd>
+                {selectedStatus && 'last_validated_at' in selectedStatus
+                  ? formatConnectionTime(selectedStatus.last_validated_at)
+                  : formatConnectionTime(selectedStatus?.updated_at)}
+              </dd>
+            </div>
+          </dl>
+
+          {selectedUnavailable ? (
+            <p role="status" className="idt-app-alert">
+              {selectedAvailability.unavailableMessage ?? `${selectedProfile.name} connector is not available.`}
+            </p>
+          ) : sourceErrors[selectedSource] ? (
+            <p role="alert" className="idt-app-alert idt-app-alert-error">
+              {sourceErrors[selectedSource]}
+            </p>
+          ) : null}
+
+          {selectedSource === 'github' && !selectedUnavailable ? (
+            <div className="idt-source-form-stack">
+              <article className="idt-source-install-card idt-source-primary-action">
+                <div className="idt-source-primary-copy">
+                  <p className="idt-app-kicker">Setup</p>
+                  <h4>Install Identrail on GitHub</h4>
+                  <p>Choose the account and repositories to scan.</p>
+                </div>
+                <form className="idt-app-form" onSubmit={handleGitHubStart}>
+                  <label>
+                    Installation name
+                    <input
+                      value={githubAppForm.displayName}
+                      onChange={(event) =>
+                        setGitHubAppForm((current) => ({ ...current, displayName: event.target.value }))
+                      }
+                      placeholder="Identrail"
+                    />
+                  </label>
+                  <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                    {submitting === 'github' ? 'Preparing GitHub...' : 'Install GitHub App'}
+                  </button>
+                </form>
+              </article>
+
+              {githubStart ? (
+                <article className="idt-source-install-card">
+                  <div>
+                    <h4>GitHub did not open?</h4>
+                    <p>
+                      Open the account picker manually. This link expires {formatConnectionTime(githubStart.expires_at)}.
+                    </p>
+                  </div>
+                  <a className="idt-btn idt-btn-dark" href={githubStart.install_url} target="_blank" rel="noreferrer">
+                    Open GitHub
+                  </a>
+                </article>
+              ) : null}
+
+              <details className="idt-source-advanced idt-source-enterprise-fallback">
+                <summary>
+                  <span>
+                    <strong>GitHub Enterprise fallback</strong>
+                    <small>Use only for self-hosted GitHub Server or restricted app-install environments.</small>
+                  </span>
+                </summary>
+                <form className="idt-app-form" onSubmit={handleGitHubPATSubmit}>
+                  <div className="idt-source-inline-fields">
+                    <label>
+                      Enterprise base URL
+                      <input
+                        value={githubPATForm.baseURL}
+                        onChange={(event) => setGitHubPATForm((current) => ({ ...current, baseURL: event.target.value }))}
+                        placeholder="https://github.company.com"
+                      />
+                    </label>
+                    <label>
+                      Display name
+                      <input
+                        value={githubPATForm.displayName}
+                        onChange={(event) =>
+                          setGitHubPATForm((current) => ({ ...current, displayName: event.target.value }))
+                        }
+                        placeholder="GitHub Enterprise"
+                      />
+                    </label>
+                  </div>
+                  <label>
+                    Personal access token
+                    <input
+                      type="password"
+                      value={githubPATForm.token}
+                      onChange={(event) => setGitHubPATForm((current) => ({ ...current, token: event.target.value }))}
+                      placeholder="GitHub Enterprise fallback token"
+                      required
+                    />
+                  </label>
+                  <label>
+                    Repository allowlist
+                    <textarea
+                      value={githubPATForm.repositories}
+                      onChange={(event) =>
+                        setGitHubPATForm((current) => ({ ...current, repositories: event.target.value }))
+                      }
+                      placeholder="owner/repo, owner/security-platform"
+                    />
+                  </label>
+                  <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                    {submitting === 'github' ? 'Validating...' : 'Save enterprise fallback'}
+                  </button>
+                </form>
+              </details>
+
+              {connections.github?.connected ? (
+                <form className="idt-app-form idt-repo-scan-launch" onSubmit={handleRepoScanSubmit}>
+                  <article className="idt-source-install-card idt-repo-scan-launch-card">
+                    <div>
+                      <h4>Run scan</h4>
+                      <p>Scan a selected repository and route results to GitHub findings.</p>
+                    </div>
+                    <Link className="idt-btn idt-btn-ghost" to={repoScanFindingsPath}>
+                      View findings
+                    </Link>
+                  </article>
+
+                  {repoScanError ? (
+                    <article role="alert" className="idt-source-recovery-card">
+                      <strong>Scan could not start</strong>
+                      <p>{repoScanError}</p>
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setRepoScanError('')}>
+                        Dismiss
+                      </button>
+                    </article>
+                  ) : null}
+
+                  <div className="idt-source-inline-fields">
+                    {githubSelectedRepositories.length > 0 ? (
+                      <label>
+                        Repository
+                        <select
+                          value={effectiveRepoScanRepository}
+                          onChange={(event) => {
+                            setRepoScanForm((current) => ({ ...current, repository: event.target.value }));
+                            setRepoScanError('');
+                          }}
+                        >
+                          {githubSelectedRepositories.map((repository) => (
+                            <option key={repository} value={repository}>
+                              {repository}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    ) : (
+                      <label>
+                        Repository
+                        <input
+                          value={repoScanForm.repository}
+                          onChange={(event) => {
+                            setRepoScanForm((current) => ({ ...current, repository: event.target.value }));
+                            setRepoScanError('');
+                          }}
+                          placeholder="owner/repo"
+                          required
+                        />
+                      </label>
+                    )}
+                  </div>
+
+                  <details className="idt-source-advanced idt-scan-limits-details">
+                    <summary>
+                      <span>
+                        <strong>Scan limits</strong>
+                        <small>Optional</small>
+                      </span>
+                    </summary>
+                    <div className="idt-source-inline-fields">
+                      <label>
+                        History limit
+                        <input
+                          inputMode="numeric"
+                          value={repoScanForm.historyLimit}
+                          onChange={(event) => setRepoScanForm((current) => ({ ...current, historyLimit: event.target.value }))}
+                          placeholder="default"
+                        />
+                      </label>
+                      <label>
+                        Max findings
+                        <input
+                          inputMode="numeric"
+                          value={repoScanForm.maxFindings}
+                          onChange={(event) => setRepoScanForm((current) => ({ ...current, maxFindings: event.target.value }))}
+                          placeholder="default"
+                        />
+                      </label>
+                    </div>
+                  </details>
+
+                  <button
+                    className="idt-btn idt-btn-primary"
+                    type="submit"
+                    disabled={
+                      repoScanSubmitting || submitting !== '' || !effectiveRepoScanRepository || githubHasActiveSelectedRepoScan
+                    }
+                  >
+                    {repoScanSubmitting ? 'Queueing...' : githubHasActiveSelectedRepoScan ? 'Scan already active' : 'Queue first scan'}
+                  </button>
+
+                  <div className="idt-source-diagnostics idt-repo-scan-activity" aria-label="recent repository scan activity">
+                    <p>Scan activity</p>
+                    {githubRecentRepoScans.length > 0 ? (
+                      githubRecentRepoScans.map((scan) => (
+                        <article key={scan.id}>
+                          <strong>{canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}</strong>
+                          <span className={`idt-source-status-pill is-${repoScanStatusTone(scan.status)}`}>
+                            {formatTokenLabel(scan.status)}
+                          </span>
+                          <p>
+                            {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
+                          </p>
+                          {scan.error_message ? <small>{scan.error_message}</small> : null}
+                          {isActiveScanStatus(scan.status) ? (
+                            <button
+                              className="idt-btn idt-btn-ghost idt-repo-scan-cancel"
+                              type="button"
+                              disabled={repoScanCancelingID === scan.id || submitting !== ''}
+                              onClick={() => void handleRepoScanCancel(scan)}
+                            >
+                              {repoScanCancelingID === scan.id ? 'Canceling...' : 'Cancel scan'}
+                            </button>
+                          ) : null}
+                        </article>
+                      ))
+                    ) : (
+                      <article>
+                        <strong>No scans yet</strong>
+                        <p>Run the first scan to populate history.</p>
+                      </article>
+                    )}
+                    {githubHasActiveRepoScan ? <p>Refreshing while a scan is queued or running.</p> : null}
+                  </div>
+                </form>
+              ) : null}
+            </div>
+          ) : null}
+
+          {selectedSource === 'aws' && !selectedUnavailable ? (
+            <form className="idt-app-form" onSubmit={handleAWSSubmit}>
+              {FEATURE_CONNECTOR_AWS ? (
+                <article className="idt-source-install-card idt-aws-launch-card">
+                  <div>
+                    <h4>Launch read-only stack</h4>
+                    <p>{awsCloudFormationStart ? 'Stack launch generated.' : 'Generate the read-only role and trust policy.'}</p>
+                  </div>
+                  <div className="idt-source-actions">
+                    <button className="idt-btn idt-btn-dark" type="button" onClick={handleAWSCloudFormationStart} disabled={submitting !== ''}>
+                      {submitting === 'aws' ? 'Preparing...' : 'Launch stack'}
+                    </button>
+                    {awsCloudFormationStart ? (
+                      <a className="idt-btn idt-btn-dark" href={awsCloudFormationStart.launch_url} target="_blank" rel="noreferrer">
+                        Open stack
+                      </a>
+                    ) : null}
+                    {awsPermissionPreview.length > 0 ? (
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
+                        Preview permissions
+                      </button>
+                    ) : null}
+                    {awsCloudFormationStart ? (
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={handleAWSPoll} disabled={submitting !== ''}>
+                        Refresh status
+                      </button>
+                    ) : null}
+                  </div>
+                </article>
+              ) : null}
+              <label>
+                Role ARN
+                <input
+                  value={awsForm.roleARN}
+                  onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                  placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                  required
+                />
+              </label>
+              <div className="idt-source-inline-fields">
+                <label>
+                  External ID
+                  <input
+                    value={awsForm.externalID}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, externalID: event.target.value }))}
+                    placeholder="optional trust-policy guard"
+                  />
+                </label>
+                <label>
+                  Region
+                  <input
+                    value={awsForm.region}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
+                    placeholder="us-east-1"
+                  />
+                </label>
+              </div>
+              <div className="idt-source-inline-fields">
+                {FEATURE_CONNECTOR_AWS ? (
+                  <>
+                    <label>
+                      Role name
+                      <input
+                        value={awsForm.roleName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, roleName: event.target.value }))}
+                        placeholder="IdentrailReadOnly"
+                      />
+                    </label>
+                    <label>
+                      Stack name
+                      <input
+                        value={awsForm.stackName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, stackName: event.target.value }))}
+                        placeholder="identrail-readonly-connector"
+                      />
+                    </label>
+                  </>
+                ) : null}
+                <label>
+                  Display name
+                  <input
+                    value={awsForm.displayName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
+                    placeholder="Production AWS"
+                  />
+                </label>
+                <label>
+                  Session name
+                  <input
+                    value={awsForm.sessionName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, sessionName: event.target.value }))}
+                    placeholder="identrail-connector-validation"
+                  />
+                </label>
+              </div>
+              <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                {submitting === 'aws' ? 'Validating...' : 'Validate and save AWS'}
+              </button>
+            </form>
+          ) : null}
+
+          {selectedSource === 'kubernetes' && !selectedUnavailable ? (
+            <form className="idt-app-form" onSubmit={handleKubernetesSubmit}>
+              <div className="idt-source-inline-fields">
+                <label>
+                  Mode
+                  <select
+                    value={kubernetesForm.mode}
+                    onChange={(event) =>
+                      setKubernetesForm((current) => ({
+                        ...current,
+                        mode: event.target.value === 'kubeconfig' ? 'kubeconfig' : 'agent'
+                      }))
+                    }
+                  >
+                    <option value="agent">Agent</option>
+                    <option value="kubeconfig">Kubeconfig</option>
+                  </select>
+                </label>
+              </div>
+              <div className="idt-source-inline-fields">
+                <label>
+                  Display name
+                  <input
+                    value={kubernetesForm.displayName}
+                    onChange={(event) =>
+                      setKubernetesForm((current) => ({ ...current, displayName: event.target.value }))
+                    }
+                    placeholder="Production cluster"
+                  />
+                </label>
+                {kubernetesForm.mode === 'agent' ? (
+                  <label>
+                    API URL
+                    <input
+                      value={kubernetesForm.apiURL}
+                      onChange={(event) =>
+                        setKubernetesForm((current) => ({ ...current, apiURL: event.target.value }))
+                      }
+                      placeholder="https://api.identrail.com"
+                    />
+                  </label>
+                ) : (
+                  <label>
+                    Kubeconfig context
+                    <input
+                      value={kubernetesForm.context}
+                      onChange={(event) =>
+                        setKubernetesForm((current) => ({ ...current, context: event.target.value }))
+                      }
+                      placeholder="current-context"
+                    />
+                  </label>
+                )}
+              </div>
+              {kubernetesForm.mode === 'kubeconfig' ? (
+                <label>
+                  kubeconfig
+                  <textarea
+                    value={kubernetesForm.kubeconfig}
+                    onChange={(event) =>
+                      setKubernetesForm((current) => ({ ...current, kubeconfig: event.target.value }))
+                    }
+                    placeholder="Paste kubeconfig YAML"
+                    rows={8}
+                  />
+                </label>
+              ) : null}
+              <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                {submitting === 'kubernetes'
+                  ? 'Preparing...'
+                  : kubernetesForm.mode === 'agent'
+                    ? 'Generate token'
+                    : 'Save kubeconfig'}
+              </button>
+              {kubernetesEnrollment ? (
+                <div className="idt-source-diagnostics">
+                  <article>
+                    <strong>Install command</strong>
+                    <span>Expires {formatConnectionTime(kubernetesEnrollment.enrollment_expires_at)}</span>
+                    <p>
+                      <code>{kubernetesEnrollment.helm_command}</code>
+                    </p>
+                  </article>
+                </div>
+              ) : null}
+            </form>
+          ) : null}
+
+          {selectedSource === 'aws' && connections.aws ? (
+            <div className="idt-source-diagnostics">
+              {connections.aws.account_id ? <p>Account {connections.aws.account_id}</p> : null}
+              {connections.aws.principal_arn ? <p>Principal {connections.aws.principal_arn}</p> : null}
+              {connections.aws.permission_checks.map((check) => (
+                <article key={check.name}>
+                  <strong>{check.name}</strong>
+                  <span>{check.passed ? 'Passed' : 'Needs attention'}</span>
+                  <p>{check.message}</p>
+                  {check.remediation ? <small>{check.remediation}</small> : null}
+                </article>
+              ))}
+              {connections.aws.diagnostics.map((diagnostic) => (
+                <article key={diagnostic.code}>
+                  <strong>{diagnostic.code}</strong>
+                  <span>Diagnostic</span>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+
+          {selectedSource === 'kubernetes' && connections.kubernetes ? (
+            <div className="idt-source-diagnostics">
+              {connections.kubernetes.connection_mode ? <p>Mode {connections.kubernetes.connection_mode}</p> : null}
+              {connections.kubernetes.agent_id ? <p>Agent {connections.kubernetes.agent_id}</p> : null}
+              {connections.kubernetes.last_heartbeat_at ? (
+                <p>Last heartbeat {formatConnectionTime(connections.kubernetes.last_heartbeat_at)}</p>
+              ) : null}
+              {connections.kubernetes.cluster ? <p>Cluster {connections.kubernetes.cluster}</p> : null}
+              {connections.kubernetes.server ? <p>Server {connections.kubernetes.server}</p> : null}
+              {connections.kubernetes.permission_checks.map((check) => (
+                <article key={`${check.verb}-${check.resource}-${check.scope}`}>
+                  <strong>
+                    {check.verb} {check.resource}
+                  </strong>
+                  <span>{check.allowed ? 'Allowed' : 'Blocked'}</span>
+                  {check.diagnostic ? <p>{check.diagnostic}</p> : null}
+                  {check.remediation ? <small>{check.remediation}</small> : null}
+                </article>
+              ))}
+              {connections.kubernetes.diagnostics.map((diagnostic) => (
+                <article key={diagnostic.code}>
+                  <strong>{diagnostic.code}</strong>
+                  <span>{diagnostic.severity}</span>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+
+          {selectedSource === 'github' && connections.github ? (
+            <div className="idt-source-diagnostics">
+              <details className="idt-source-advanced idt-source-compact-details idt-source-connection-details">
+                <summary>
+                  <span>
+                    <strong>GitHub installation</strong>
+                    <small>
+                      {githubSelectedRepositories.length > 0
+                        ? formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')
+                        : 'Connected'}
+                    </small>
+                  </span>
+                </summary>
+                <div className="idt-source-connection-body">
+                  <p>
+                    {connections.github.account_login ? `Installed on ${connections.github.account_login}` : 'Installation active'}
+                    {connections.github.installation_id ? ` · Installation ${connections.github.installation_id}` : ''}
+                  </p>
+                  {githubSelectedRepositories.length > 0 ? (
+                    <div className="idt-source-chip-list">
+                      {githubSelectedRepositories.map((repository) => (
+                        <span key={repository}>{repository}</span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </details>
+              {connections.github.webhook_secret_rotation_due_at ? (
+                <p>Webhook rotation due {formatConnectionTime(connections.github.webhook_secret_rotation_due_at)}</p>
+              ) : null}
+              {githubPostureLoading ? (
+                <article>
+                  <strong>{effectiveRepoScanRepository || 'Selected repository'}</strong>
+                  <span>Loading posture</span>
+                  <p>Collecting GitHub repository posture signals.</p>
+                </article>
+              ) : null}
+              {githubPostureError ? (
+                <p role="alert" className="idt-app-alert idt-app-alert-error">
+                  {githubPostureError}
+                </p>
+              ) : null}
+              {githubPosture ? (
+                <>
+                  <article className="idt-github-posture-card">
+                    <div className="idt-github-posture-card-head">
+                      <div>
+                        <strong>Repository posture</strong>
+                        <p>Collected {formatConnectionTime(githubPosture.collected_at)}</p>
+                      </div>
+                      <span className={`idt-source-status-pill is-${githubPostureNeedsAttentionCount > 0 ? 'warning' : 'success'}`}>
+                        {githubPostureNeedsAttentionCount > 0
+                          ? formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')
+                          : 'Secure'}
+                      </span>
+                    </div>
+                    <dl className="idt-github-posture-stats" aria-label="GitHub posture summary">
+                      <div>
+                        <dt>Secure</dt>
+                        <dd>{githubPostureSecureCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Attention</dt>
+                        <dd>{githubPostureAttentionCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Limited</dt>
+                        <dd>{githubPostureLimitedCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Unavailable</dt>
+                        <dd>{githubPostureUnavailableCount}</dd>
+                      </div>
+                    </dl>
+                  </article>
+                  <details className="idt-source-advanced idt-github-posture-details">
+                    <summary>
+                      <span>
+                        <strong>
+                          {githubPostureNeedsAttentionCount > 0
+                            ? `Review ${formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')}`
+                            : 'Review checks'}
+                        </strong>
+                        <small>
+                          {githubPostureNeedsAttentionCount > 0 ? 'Branch, Actions, security' : 'Collected GitHub signals'}
+                        </small>
+                      </span>
+                    </summary>
+                    {githubPosture.rate_limit?.remaining !== undefined ? (
+                      <p className="idt-github-posture-rate-limit">
+                        GitHub API remaining {githubPosture.rate_limit.remaining}
+                        {githubPosture.rate_limit.limit ? ` of ${githubPosture.rate_limit.limit}` : ''}
+                      </p>
+                    ) : null}
+                    <div className="idt-github-posture-checks">
+                      {githubPostureDetailChecks.slice(0, 6).map((check) => (
+                        <article key={check.id}>
+                          <strong>{formatTokenLabel(check.category || check.id)}</strong>
+                          <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
+                            {formatTokenLabel(check.state)}
+                          </span>
+                          <p>{check.summary}</p>
+                          {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
+                        </article>
+                      ))}
+                      {githubPostureDetailChecks.length > 6 ? (
+                        <p>{formatCountLabel(githubPostureDetailChecks.length - 6, 'additional check', 'additional checks')} hidden.</p>
+                      ) : null}
+                      {githubOrganizationPosture ? (
+                        <>
+                          <article>
+                            <strong>Organization posture</strong>
+                            <span>{formatConnectionTime(githubOrganizationPosture.collected_at)}</span>
+                            <p>
+                              {githubOrganizationPostureSecureCount} secure · {githubOrganizationPostureAttentionCount}{' '}
+                              attention · {githubOrganizationPostureLimitedCount} permission limited ·{' '}
+                              {githubOrganizationPostureUnavailableCount} unavailable
+                            </p>
+                            <small>
+                              {githubOrganizationPostureUnsupportedCount} unsupported ·{' '}
+                              {githubOrganizationPostureUnknownCount} unknown
+                            </small>
+                          </article>
+                          {githubOrganizationPostureDetailChecks.slice(0, 5).map((check) => (
+                            <article key={`org-${check.id}`}>
+                              <strong>{formatTokenLabel(check.category || check.id)}</strong>
+                              <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
+                                {formatTokenLabel(check.state)}
+                              </span>
+                              <p>{check.summary}</p>
+                              {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
+                            </article>
+                          ))}
+                          {githubOrganizationPostureDetailChecks.length > 5 ? (
+                            <p>
+                              {formatCountLabel(
+                                githubOrganizationPostureDetailChecks.length - 5,
+                                'additional organization check',
+                                'additional organization checks'
+                              )}{' '}
+                              hidden.
+                            </p>
+                          ) : null}
+                        </>
+                      ) : null}
+                    </div>
+                  </details>
+                </>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <article className="idt-app-panel idt-source-policy-panel">
+        <details>
+          <summary className="idt-source-policy-summary">
+            <div>
+              <p className="idt-app-kicker">Automation policies</p>
+              <h3>Scan policy</h3>
+              <p>Define trigger mode, cadence, and limits for this source.</p>
+            </div>
+            <span className="idt-source-status-pill is-warning">Advanced</span>
+          </summary>
+          <div className="idt-source-policy-body">
+
+        {scanPolicyError ? (
+          <p role="alert" className="idt-app-alert idt-app-alert-error">
+            {scanPolicyError}
+          </p>
+        ) : null}
+
+        <div className="idt-source-summary" aria-label="scan policy summary">
+          <article>
+            <span>{scanPolicies.length}</span>
+            <p>Policies</p>
+          </article>
+          <article>
+            <span>{scanPolicies.filter((item) => item.enabled).length}</span>
+            <p>Enabled</p>
+          </article>
+          <article>
+            <span>{policyForm.triggerMode}</span>
+            <p>Editing mode</p>
+          </article>
+        </div>
+
+        {scanPolicies.length > 0 ? (
+          <div className="idt-source-diagnostics">
+            {scanPolicies.map((policy) => (
+              <article key={policy.policy_id}>
+                <strong>{policy.name}</strong>
+                <span>{policy.enabled ? 'Enabled' : 'Disabled'}</span>
+                <p>
+                  {formatScanTriggerModeLabel(policy.trigger_mode)} · concurrency {policy.max_concurrent_scans} · history{' '}
+                  {policy.history_limit} · findings {policy.max_findings}
+                </p>
+                <div className="idt-source-inline-fields">
+                  <button
+                    type="button"
+                    className="idt-btn idt-btn-ghost"
+                    onClick={() =>
+                      setPolicyForm({
+                        policyID: policy.policy_id,
+                        name: policy.name,
+                        enabled: policy.enabled,
+                        triggerMode: policy.trigger_mode,
+                        cron: policy.cron ?? '',
+                        maxConcurrentScans: String(policy.max_concurrent_scans),
+                        historyLimit: String(policy.history_limit),
+                        maxFindings: String(policy.max_findings)
+                      })
+                    }
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="idt-btn idt-btn-ghost"
+                    onClick={() => {
+                      void handleScanPolicyDelete(policy.policy_id);
+                    }}
+                    disabled={policyDeletingID === policy.policy_id}
+                  >
+                    {policyDeletingID === policy.policy_id ? 'Deleting...' : 'Delete'}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : null}
+
+        <form className="idt-app-form" onSubmit={handleScanPolicySubmit}>
+          <div className="idt-source-inline-fields">
+            <label>
+              Policy ID
+              <input
+                value={policyForm.policyID}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, policyID: normalizeProjectToken(event.target.value) }))}
+                placeholder="default"
+                required
+              />
+            </label>
+            <label>
+              Policy name
+              <input
+                value={policyForm.name}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, name: event.target.value }))}
+                placeholder="Default policy"
+                required
+              />
+            </label>
+          </div>
+          <div className="idt-source-inline-fields">
+            <label>
+              Trigger mode
+              <select
+                value={policyForm.triggerMode}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, triggerMode: event.target.value as ScanTriggerMode }))}
+              >
+                {SCAN_POLICY_TRIGGER_MODES.map((mode) => (
+                  <option key={mode} value={mode}>
+                    {formatScanTriggerModeLabel(mode)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Enabled
+              <select
+                value={policyForm.enabled ? 'true' : 'false'}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, enabled: event.target.value === 'true' }))}
+              >
+                <option value="true">Enabled</option>
+                <option value="false">Disabled</option>
+              </select>
+            </label>
+          </div>
+          <p className="idt-form-note">
+            Manual keeps GitHub events from starting scans. Event and hybrid modes allow selected-repository webhooks to queue scans.
+          </p>
+          {policyForm.triggerMode === 'scheduled' || policyForm.triggerMode === 'hybrid' ? (
+            <label>
+              Cron schedule
+              <input
+                value={policyForm.cron}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, cron: event.target.value }))}
+                placeholder="0 * * * *"
+                required
+              />
+            </label>
+          ) : null}
+          <div className="idt-source-inline-fields">
+            <label>
+              Max concurrent scans
+              <input
+                inputMode="numeric"
+                value={policyForm.maxConcurrentScans}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, maxConcurrentScans: event.target.value }))}
+                placeholder="1"
+                required
+              />
+            </label>
+            <label>
+              History limit
+              <input
+                inputMode="numeric"
+                value={policyForm.historyLimit}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, historyLimit: event.target.value }))}
+                placeholder="500"
+                required
+              />
+            </label>
+            <label>
+              Max findings
+              <input
+                inputMode="numeric"
+                value={policyForm.maxFindings}
+                onChange={(event) => setPolicyForm((current) => ({ ...current, maxFindings: event.target.value }))}
+                placeholder="200"
+                required
+              />
+            </label>
+          </div>
+          <button className="idt-btn idt-btn-primary" type="submit" disabled={policySaving}>
+            {policySaving ? 'Saving policy...' : 'Save scan policy'}
+          </button>
+        </form>
+          </div>
+        </details>
+      </article>
+      <PermissionPreviewModal
+        open={awsPreviewOpen}
+        title="AWS read-only connector policy"
+        items={awsPermissionPreview}
+        tiers={awsPermissionTiers}
+        onClose={() => setAWSPreviewOpen(false)}
+      />
+    </section>
+  );
+}
 
 type GitHubIntelligenceCategory = {
   id: string;
@@ -24024,18 +25024,50 @@ export function ProductAppearanceSettingsPage() {
             </select>
           </label>
 
-          <div className="idt-appearance-behavior-row">
-            <div>
-              <h3>Reduce motion</h3>
-              <p>Reduce animations or match your system</p>
-            </div>
-            <AppearanceSegmentedControl
-              label="Reduce motion"
-              value={preferences.reduceMotion}
-              options={APPEARANCE_MOTION_OPTIONS}
-              onChange={(reduceMotion) => commitPreferences({ reduceMotion })}
-            />
+          <label className="idt-appearance-control-row idt-appearance-slider-row">
+            <span>
+              <strong>Contrast</strong>
+            </span>
+            <span className="idt-appearance-slider">
+              <input
+                aria-label="Contrast"
+                type="range"
+                min="0"
+                max="100"
+                value={preferences.contrast}
+                onChange={(event) => commitPreferences({ contrast: Number(event.target.value) })}
+              />
+              <strong>{preferences.contrast}</strong>
+            </span>
+          </label>
+        </div>
+      </section>
+
+      <section className="idt-settings-card idt-appearance-card idt-appearance-behavior-card">
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Use pointer cursors</h3>
+            <p>Show pointer cursors on interactive controls</p>
           </div>
+          <AppearanceSwitch
+            checked={preferences.pointerCursors}
+            label="Use pointer cursors"
+            onChange={(pointerCursors) => commitPreferences({ pointerCursors })}
+          />
+        </div>
+
+        <div className="idt-appearance-behavior-row">
+          <div>
+            <h3>Reduce motion</h3>
+            <p>Reduce animations or match your system</p>
+          </div>
+          <AppearanceSegmentedControl
+            label="Reduce motion"
+            value={preferences.reduceMotion}
+            options={APPEARANCE_MOTION_OPTIONS}
+            onChange={(reduceMotion) => commitPreferences({ reduceMotion })}
+          />
+        </div>
 
         <label className="idt-appearance-behavior-row">
           <span>
@@ -24054,6 +25086,23 @@ export function ProductAppearanceSettingsPage() {
           </span>
         </label>
 
+        <label className="idt-appearance-behavior-row">
+          <span>
+            <h3>Code font size</h3>
+            <p>Adjust the base size used for code across previews and diffs</p>
+          </span>
+          <span className="idt-appearance-number">
+            <AppearanceNumberInput
+              label="Code font size"
+              min={12}
+              max={22}
+              value={preferences.codeFontSize}
+              onCommit={(codeFontSize) => commitPreferences({ codeFontSize })}
+            />
+            <span>px</span>
+          </span>
+        </label>
+
         <div className="idt-appearance-behavior-row">
           <div>
             <h3>Font smoothing</h3>
@@ -24065,8 +25114,8 @@ export function ProductAppearanceSettingsPage() {
             onChange={(fontSmoothing) => commitPreferences({ fontSmoothing })}
           />
         </div>
-        </div>
       </section>
+
     </section>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -68,6 +68,7 @@ import {
   type AWSCrossAccountTrustFinding,
   type AWSCrossAccountTrustResult,
   type AWSSecretPermissionEquivalenceFinding,
+  type AWSSecretPermissionEquivalenceQuery,
   type AWSSecretPermissionEquivalenceResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
@@ -11508,6 +11509,66 @@ function awsRuntimeEventDisplayFilters(filters: AWSInventoryFilterState): AWSInv
   };
 }
 
+function awsSecretPermissionEquivalenceFilterToken(value: string | undefined): string | undefined {
+  const normalized = normalizeFilterValue(value ?? '');
+  return normalized && normalized !== 'all' ? normalized : undefined;
+}
+
+function awsSecretPermissionEquivalenceStatusFilterToken(value: string | undefined): string | undefined {
+  switch (awsSecretPermissionEquivalenceFilterToken(value)) {
+    case 'open':
+      return 'action_required';
+    case 'queued':
+      return 'review';
+    case 'blocked':
+      return 'action_required';
+    case 'unavailable':
+      return undefined;
+    default:
+      return awsSecretPermissionEquivalenceFilterToken(value);
+  }
+}
+
+function awsSecretPermissionEquivalenceAccountFilterToken(
+  value: string | undefined,
+  connection: AWSConnectionStatus | null
+): string | undefined {
+  switch (awsSecretPermissionEquivalenceFilterToken(value)) {
+    case 'connected':
+      return connection?.account_id || undefined;
+    case 'unknown':
+      return 'unknown';
+    default:
+      return awsSecretPermissionEquivalenceFilterToken(value);
+  }
+}
+
+function awsSecretPermissionEquivalenceRegionFilterToken(
+  value: string | undefined,
+  connection: AWSConnectionStatus | null
+): string | undefined {
+  switch (awsSecretPermissionEquivalenceFilterToken(value)) {
+    case 'current':
+      return connection?.region || undefined;
+    case 'unknown':
+      return 'unknown';
+    default:
+      return awsSecretPermissionEquivalenceFilterToken(value);
+  }
+}
+
+function awsSecretPermissionEquivalenceFindingsQuery(
+  filters: AWSInventoryFilterState,
+  connection: AWSConnectionStatus | null
+): Partial<AWSSecretPermissionEquivalenceQuery> {
+  return {
+    accountID: awsSecretPermissionEquivalenceAccountFilterToken(filters.account, connection),
+    region: awsSecretPermissionEquivalenceRegionFilterToken(filters.region, connection),
+    severity: awsSecretPermissionEquivalenceFilterToken(filters.severity),
+    status: awsSecretPermissionEquivalenceStatusFilterToken(filters.status)
+  };
+}
+
 function AWSGraphExplorerContent({
   connection,
   filters,
@@ -12378,12 +12439,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       return;
     }
     setSecretPermissionEquivalenceLoading(true);
+    const requestFilters = routeID === 'findings' ? awsSecretPermissionEquivalenceFindingsQuery(activeFilters, connection) : {};
     try {
       const response = await apiClient.getAWSProjectSecretPermissionEquivalence(
         scope.workspaceID,
         selectedEnvironmentID,
         {
-          connectorID: connection.connector_id
+          connectorID: connection.connector_id,
+          ...requestFilters
         },
         buildProductAuthContext(scope)
       );
@@ -12406,8 +12469,15 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     scope?.tenantID,
     scope?.workspaceID,
     selectedEnvironmentID,
+    routeID,
+    activeFilters.account,
+    activeFilters.region,
+    activeFilters.severity,
+    activeFilters.status,
     connection?.connected,
-    connection?.connector_id
+    connection?.connector_id,
+    connection?.account_id,
+    connection?.region
   ]);
 
   useEffect(() => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -11537,6 +11537,8 @@ function awsSecretPermissionEquivalenceFindingsQuery(
   return {
     accountID: awsSecretPermissionEquivalenceAccountFilterToken(filters.account, connection),
     region: awsSecretPermissionEquivalenceRegionFilterToken(filters.region, connection),
+    evidence: awsSecretPermissionEquivalenceFilterToken(filters.evidence),
+    search: normalizeFilterValue(filters.search ?? '') || undefined,
     severity: awsSecretPermissionEquivalenceFilterToken(filters.severity),
     status: awsSecretPermissionEquivalenceStatusFilterToken(filters.status)
   };
@@ -12445,7 +12447,9 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     routeID,
     activeFilters.account,
     activeFilters.region,
+    activeFilters.evidence,
     activeFilters.severity,
+    activeFilters.search,
     activeFilters.status,
     connection?.connected,
     connection?.connector_id,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -67,6 +67,8 @@ import {
   type AWSPrivilegeEscalationResult,
   type AWSCrossAccountTrustFinding,
   type AWSCrossAccountTrustResult,
+  type AWSSecretPermissionEquivalenceFinding,
+  type AWSSecretPermissionEquivalenceResult,
   type AWSStepFunctionsStateMachineRoleInventoryResult,
   type AWSStepFunctionsStateMachineRoleRecord,
   type AWSEC2InstanceProfileInventoryResult,
@@ -10987,6 +10989,157 @@ function AWSCrossAccountTrustContent({
   );
 }
 
+function awsSecretPermissionEquivalenceStage(finding: AWSSecretPermissionEquivalenceFinding): AWSCapabilityStage {
+  if (finding.status === 'action_required' || finding.severity === 'critical') {
+    return 'not-available';
+  }
+  if (finding.severity === 'high' || finding.status === 'review') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsSecretPermissionEquivalenceLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
+  return `${formatTokenLabel(finding.equivalence_type)} · score ${finding.score}`;
+}
+
+function awsSecretPermissionEquivalenceIdentityLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
+  return (
+    finding.principal_arn ||
+    finding.agent_name ||
+    finding.agent_id ||
+    finding.workload_name ||
+    finding.workload_id ||
+    finding.identity_node_id
+  );
+}
+
+function awsSecretPermissionEquivalencePathLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
+  const labels = finding.impacted_path.map((step) => step.label || step.node_id).filter(Boolean);
+  if (labels.length >= 2) {
+    return labels.slice(0, 4).join(' -> ');
+  }
+  return finding.secret_label || finding.secret_node_id || '-';
+}
+
+function awsSecretPermissionEquivalenceEvidenceLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
+  const sources = finding.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function awsSecretPermissionEquivalencePermissionLabel(finding: AWSSecretPermissionEquivalenceFinding): string {
+  const permissions = finding.equivalent_permissions ?? [];
+  if (permissions.length === 0) {
+    return formatTokenLabel(finding.provider);
+  }
+  return `${formatTokenLabel(finding.provider)} · ${permissions.slice(0, 2).join(', ')}${permissions.length > 2 ? ` +${permissions.length - 2}` : ''}`;
+}
+
+function AWSSecretPermissionEquivalenceContent({
+  findings,
+  loading,
+  error,
+  onRetry
+}: {
+  findings: AWSSecretPermissionEquivalenceResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = findings?.findings ?? [];
+  const summaryLine = findings
+    ? `${findings.summary.external_provider_key_count} provider keys · ${findings.summary.aws_managed_secret_count} AWS secrets · ${findings.summary.runtime_observed_count} runtime-observed · ${findings.summary.kms_backed_count} KMS-backed`
+    : '';
+  const emptyState = findings
+    ? findings.status === 'blocked'
+      ? {
+          eyebrow: 'Permission required',
+          title: 'Secret-permission analysis needs read-only evidence access',
+          body: findings.failure_reasons[0] ?? 'Secret-to-permission equivalence cannot be calculated until AWS metadata access is available.'
+        }
+      : findings.status === 'degraded'
+        ? {
+            eyebrow: 'Evidence incomplete',
+            title: 'Secret-permission findings are incomplete',
+            body:
+              findings.failure_reasons[0] ??
+              findings.remediation_hints[0] ??
+              'Some source evidence is unavailable, so Identrail cannot prove every credential permission boundary yet.'
+          }
+        : {
+            eyebrow: 'No permission-bearing secrets',
+            title: 'No secret-to-permission equivalence findings detected',
+            body: 'No readable provider keys, AWS secrets, KMS-backed credentials, runtime access, or agent references matched this scope.'
+          }
+    : null;
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS secret-to-permission equivalence findings">
+      <h3>AWS secret-to-permission equivalence</h3>
+      <p className="idt-app-kicker">
+        Ranked decisions that treat readable provider keys, AWS secrets, and decryptable KMS-backed credentials as
+        permission-bearing capabilities.{summaryLine ? ` ${summaryLine}` : ''}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load secret-to-permission equivalence"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating secret-permission equivalence"
+          body="Identrail is ranking metadata-only credential references, secret policies, KMS grants, runtime access, and graph evidence."
+        />
+      ) : null}
+      {!error && !loading && findings && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={emptyState?.eyebrow ?? 'No permission-bearing secrets'}
+          title={emptyState?.title ?? 'No secret-to-permission equivalence findings detected'}
+          body={
+            emptyState?.body ??
+            'No readable provider keys, AWS secrets, KMS-backed credentials, runtime access, or agent references matched this scope.'
+          }
+        />
+      ) : null}
+      {!error && !loading && findings && findings.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {findings.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS secret-to-permission equivalence findings"
+          rows={rows}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsSecretPermissionEquivalenceLabel(row)}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => awsSecretPermissionEquivalenceIdentityLabel(row) },
+            { key: 'secret', header: 'Secret', render: (row) => row.secret_label || row.secret_arn || row.secret_node_id },
+            { key: 'permission', header: 'Equivalent permission', render: (row) => awsSecretPermissionEquivalencePermissionLabel(row) },
+            { key: 'path', header: 'Path', render: (row) => awsSecretPermissionEquivalencePathLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsSecretPermissionEquivalenceEvidenceLabel(row) },
+            {
+              key: 'risk',
+              header: 'Risk',
+              render: (row) => (
+                <AWSInventoryPill
+                  stage={awsSecretPermissionEquivalenceStage(row)}
+                  label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`}
+                />
+              )
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function AWSIdentitySprawlContent({
   findings,
   loading,
@@ -11715,6 +11868,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [crossAccountTrustLoading, setCrossAccountTrustLoading] = useState(false);
   const [crossAccountTrustError, setCrossAccountTrustError] = useState('');
   const crossAccountTrustRequestRef = useRef(0);
+  const [secretPermissionEquivalence, setSecretPermissionEquivalence] = useState<AWSSecretPermissionEquivalenceResult | null>(null);
+  const [secretPermissionEquivalenceLoading, setSecretPermissionEquivalenceLoading] = useState(false);
+  const [secretPermissionEquivalenceError, setSecretPermissionEquivalenceError] = useState('');
+  const secretPermissionEquivalenceRequestRef = useRef(0);
 
   const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
     setActiveFilters(nextFilters);
@@ -11723,6 +11880,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   useEffect(() => {
     setActiveFilters({ ...AWS_RISK_OPERATION_FILTER_DEFAULTS[routeID] });
   }, [routeID]);
+
+  const showSecretPermissionEquivalence = routeID === 'runtime' || routeID === 'findings';
 
   const loadRuntimeEvents = useCallback(async () => {
     const requestID = ++runtimeEventsRequestRef.current;
@@ -12210,6 +12369,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadCrossAccountTrust]);
 
+  const loadSecretPermissionEquivalence = useCallback(async () => {
+    const requestID = ++secretPermissionEquivalenceRequestRef.current;
+    setSecretPermissionEquivalence(null);
+    setSecretPermissionEquivalenceError('');
+    if (!showSecretPermissionEquivalence || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSecretPermissionEquivalenceLoading(false);
+      return;
+    }
+    setSecretPermissionEquivalenceLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSecretPermissionEquivalence(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== secretPermissionEquivalenceRequestRef.current) {
+        return;
+      }
+      setSecretPermissionEquivalence(response.findings);
+    } catch (error) {
+      if (requestID !== secretPermissionEquivalenceRequestRef.current) {
+        return;
+      }
+      setSecretPermissionEquivalenceError(formatAPIError(error, 'Unable to load AWS secret-to-permission equivalence.'));
+    } finally {
+      if (requestID === secretPermissionEquivalenceRequestRef.current) {
+        setSecretPermissionEquivalenceLoading(false);
+      }
+    }
+  }, [
+    showSecretPermissionEquivalence,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadSecretPermissionEquivalence();
+    return () => {
+      secretPermissionEquivalenceRequestRef.current += 1;
+    };
+  }, [loadSecretPermissionEquivalence]);
+
   if (!scope) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
@@ -12373,6 +12580,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={crossAccountTrustLoading}
             error={crossAccountTrustError}
             onRetry={loadCrossAccountTrust}
+          />
+        ) : null}
+        {showSecretPermissionEquivalence ? (
+          <AWSSecretPermissionEquivalenceContent
+            findings={secretPermissionEquivalence}
+            loading={secretPermissionEquivalenceLoading}
+            error={secretPermissionEquivalenceError}
+            onRetry={loadSecretPermissionEquivalence}
           />
         ) : null}
         {routeID === 'graph' ? (


### PR DESCRIPTION
## Summary
- Implemented the metadata-only AWS secret-to-permission equivalence engine for Wave 6.07.
- Added the authenticated API route, OpenAPI contract, TypeScript client method, and AWS runtime/findings UI panel.
- Documented the evidence boundary, failure states, filters, and validation flow.

## Validation
- `go test ./internal/api`
- `npm test -- --run src/productShell.test.tsx --testNamePattern "translates AWS runtime filter aliases"`
- `npm test -- --run src/api/client.test.ts --testNamePattern "secret-permission"`
- `npm run build` from `web` (passes; existing large chunk warning remains)

## AI Assistance Disclosure
No

Closes #1527

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS secret-to-permission equivalence engine (Wave 6.07) with a new API, typed client, and an AWS runtime UI panel that shows ranked findings. Includes full filters (now with `evidence` and text `search`) and refined deny checks for KMS and Secrets Manager; implements #1527.

- **New Features**
  - GET `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-permission-equivalence` with full finding filters (severity, status, stage, score, confidence) plus domain filters and new `evidence` and `search`.
  - TypeScript client `getAWSProjectSecretPermissionEquivalence` with typed models and tests.
  - AWS runtime UI panel shows ranked findings with the same filters; OpenAPI, built-in route auth, and `aws-secret-permission-equivalence-engine.md` docs added.

- **Bug Fixes**
  - Tighten deny checks to relevant actions: only decrypt-related denies suppress KMS decrypt findings, and only concrete read API denies suppress Secrets Manager read findings (prevents hiding valid findings on unrelated denies).
  - Normalize KMS grant action evaluation using capabilities and exclude replicate KMS grants to reduce false positives.
  - Fix KMS decrypt-equivalence review logic, review alias translation, and product shell regressions.

<sup>Written for commit bc5c3960eeabbb47a97137d57aeb598fbd9d1ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

