### PR TITLE
Implement AWS AI agent risk engine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS collector details: `aws-collector.md`
 - AWS account/region fan-out worker: `aws-account-region-fanout-worker.md`
 - AWS AI agent identities: `aws-ai-agent-identities.md`
+- AWS AI agent risk engine: `aws-ai-agent-risk-engine.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-ai-agent-risk-engine.md
+++ b/docs/aws-ai-agent-risk-engine.md
@@ -16,9 +16,10 @@ The engine emits `AWSAIAgentRiskFinding` records for these risk types:
   degraded ownership coverage.
 - **`external_credential_exposure`** - an agent references external provider
   credential metadata or secret-permission equivalence evidence.
-- **`undeclared_tool_runtime`**, **`backing_role_mismatch`**, and
-  **`declared_unused_tool`** - runtime/tool-call correlation found an
-  undeclared tool, role drift, or declared-but-unused tool surface.
+- **`undeclared_tool_runtime`**, **`backing_role_mismatch`**,
+  **`declared_unused_tool`**, and **`runtime_tool_anomaly`** -
+  runtime/tool-call correlation found an undeclared tool, role drift,
+  a declared-but-unused tool surface, or another runtime caveat.
 - **`backing_role_scope`** - least-privilege analysis found removable or
   review-required scope on the agent backing role.
 

--- a/docs/aws-ai-agent-risk-engine.md
+++ b/docs/aws-ai-agent-risk-engine.md
@@ -1,0 +1,109 @@
+# AWS AI agent risk engine
+
+Issue #1528 (Wave 6.08) adds a metadata-only engine that turns AWS AI agent
+inventory, runtime/tool-call evidence, secret-permission equivalence, and
+least-privilege role-scope signals into ranked, explainable risk findings.
+
+## What it produces
+
+The engine emits `AWSAIAgentRiskFinding` records for these risk types:
+
+- **`broad_tool_access`** - an agent or gateway declares a wide tool/action
+  surface.
+- **`sensitive_data_reachability`** - an agent can reach memory, browser,
+  code-interpreter, storage, or KMS-backed capability metadata.
+- **`ownerless_agent`** - an agent has no accountable owner metadata or has
+  degraded ownership coverage.
+- **`external_credential_exposure`** - an agent references external provider
+  credential metadata or secret-permission equivalence evidence.
+- **`undeclared_tool_runtime`**, **`backing_role_mismatch`**, and
+  **`declared_unused_tool`** - runtime/tool-call correlation found an
+  undeclared tool, role drift, or declared-but-unused tool surface.
+- **`backing_role_scope`** - least-privilege analysis found removable or
+  review-required scope on the agent backing role.
+
+Each finding carries a stable id, calculation version, severity, score,
+confidence, agent identity, backing role, provider, tools, sensitive resources,
+rationale, impacted path, evidence refs, source signals, next action, and
+read-only remediation case preview.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-risk`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `agent_id` | agent id, agent name, node id, or backing-role search |
+| `risk_type` | one of the finding types above |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `action_required`, `review`, or `monitor` |
+| `evidence` | `runtime-backed`, `inventory-backed`, `secret-backed`, or evidence text search |
+| `search` | free-text search across agent, role, provider, evidence, rationale, and resources |
+
+Response shape: `{ "findings": AWSAIAgentRiskResult }` with summary, ranked
+findings, graph relationships, caveats, failure reasons, remediation hints,
+evidence links, coverage gaps, diagnostics, and standard
+tenant/workspace/project issue metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays secret values, prompt text,
+completions, tool inputs or outputs, browser pages, code-interpreter output,
+database rows, object contents, or customer payloads. It only composes:
+
+- AI agent identity, tool, capability, credential-reference, and runtime-role
+  metadata
+- CloudTrail event ids, redacted runtime action metadata, and correlation
+  statuses
+- secret-permission equivalence finding refs and provider classifications
+- least-privilege recommendation refs for backing roles
+
+## AWS permissions
+
+This capability adds no live mutation and does not require payload-reading
+permissions. It reuses read-only metadata permissions from AI agent identity
+inventory, runtime event correlation, secret-permission equivalence, and
+least-privilege recommendation sources.
+
+Do not grant permissions that read prompts, invocations, memory records,
+browser pages, code-interpreter output, database rows, object contents, or
+secret values for this issue.
+
+## Failure handling
+
+- **Ready**: source engines are available and no blocking diagnostics were
+  emitted.
+- **Degraded**: at least one source is partial, empty because live evidence is
+  unavailable, capability-limited, or produced retryable diagnostics. Retained
+  evidence remains visible.
+- **Blocked**: required source evidence is permission denied. The response has
+  zero deterministic findings plus diagnostics and failure reasons.
+
+Unknown, unsupported, partial, degraded, and permission-denied evidence remains
+explicit and is not treated as proof that an agent is safe.
+
+## App surface
+
+The AWS Runtime app surface renders the **AWS AI agent risk engine** panel with
+ranked findings, agent/backing-role context, scope, confidence, evidence,
+severity/status, and next action. Operators can inspect the decision without
+reading logs or database rows.
+
+## Live validation
+
+1. Confirm blockers #1512, #1520, and #1527 are closed.
+2. Run AI agent identities, agent runtime access, least privilege, and
+   secret-permission equivalence with `fixture_state=success`.
+3. Run the AI agent risk endpoint with `fixture_state=success` and confirm
+   broad-tool, sensitive-capability, external-credential, runtime, and
+   backing-role findings are ranked.
+4. Filter by `risk_type=external_credential_exposure`, `agent_id`,
+   `evidence=runtime-backed`, and `search` to verify deterministic drill-down.
+5. Run `fixture_state=permission_denied`, `empty`, `degraded`, and
+   `partial_failure` and confirm blocked/degraded states are explicit.
+6. Confirm the AWS Runtime app panel renders success, empty, degraded,
+   permission-denied, and partial-failure states without exposing payloads or
+   secret values.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -569,6 +569,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-risk
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -4925,6 +4930,89 @@ paths:
                     $ref: "#/components/schemas/AWSAgentRuntimeAccessResult"
         "400":
           description: Invalid AWS agent runtime access request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-risk:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS AI agent risk findings
+      operationId: getAWSProjectAIAgentRisk
+      description: Calculates ranked, explainable AWS AI agent risk findings by composing metadata-only AI agent inventory, runtime/tool-call correlation, secret-permission equivalence, and least-privilege backing-role evidence. Findings carry stable IDs, calculation version, severity, confidence, rationale, impacted graph path, evidence refs, source signals, and read-only remediation previews. Secret values, prompts, completions, tool payloads, browser pages, code-interpreter output, database rows, object contents, and customer payloads are never read or returned.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent id, name, node id, or backing-role search.
+        - in: query
+          name: risk_type
+          schema:
+            type: string
+            enum: [broad_tool_access, sensitive_data_reachability, ownerless_agent, external_credential_exposure, undeclared_tool_runtime, backing_role_mismatch, declared_unused_tool, backing_role_scope]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: evidence
+          schema: { type: string }
+          description: Optional evidence filter such as runtime-backed, inventory-backed, secret-backed, or evidence text search.
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across agent, role, provider, resource, evidence, and rationale fields.
+      responses:
+        "200":
+          description: AWS AI agent risk finding contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    type: object
+        "400":
+          description: Invalid AWS AI agent risk request
           content:
             application/json:
               schema:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4982,7 +4982,7 @@ paths:
           name: risk_type
           schema:
             type: string
-            enum: [broad_tool_access, sensitive_data_reachability, ownerless_agent, external_credential_exposure, undeclared_tool_runtime, backing_role_mismatch, declared_unused_tool, backing_role_scope]
+            enum: [broad_tool_access, sensitive_data_reachability, ownerless_agent, external_credential_exposure, undeclared_tool_runtime, backing_role_mismatch, declared_unused_tool, backing_role_scope, runtime_tool_anomaly]
         - in: query
           name: severity
           schema:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5010,7 +5010,7 @@ paths:
                 type: object
                 properties:
                   findings:
-                    type: object
+                    $ref: "#/components/schemas/AWSAIAgentRiskResult"
         "400":
           description: Invalid AWS AI agent risk request
           content:
@@ -12823,6 +12823,167 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLeastPrivilegeRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAIAgentRiskRelationship:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAIAgentRiskFinding:
+      type: object
+      properties:
+        finding_id: { type: string }
+        calculation_version: { type: string }
+        risk_type:
+          type: string
+          enum: [broad_tool_access, sensitive_data_reachability, ownerless_agent, external_credential_exposure, undeclared_tool_runtime, backing_role_mismatch, declared_unused_tool, backing_role_scope, runtime_tool_anomaly]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        agent_node_id: { type: string }
+        agent_id: { type: string }
+        agent_name: { type: string }
+        agent_type: { type: string }
+        runtime_role_arn: { type: string }
+        runtime_role_node_id: { type: string }
+        provider: { type: string }
+        tool_names:
+          type: array
+          items: { type: string }
+        capability_names:
+          type: array
+          items: { type: string }
+        sensitive_resources:
+          type: array
+          items: { type: string }
+        source_signals:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        next_action: { type: string }
+        remediation_case:
+          $ref: "#/components/schemas/AWSLeastPrivilegeRemediationCasePreview"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAIAgentRiskSummary:
+      type: object
+      properties:
+        total_findings: { type: integer }
+        filtered_findings: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        risk_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        external_credential_count: { type: integer }
+        broad_tool_access_count: { type: integer }
+        sensitive_reachability_count: { type: integer }
+        ownerless_agent_count: { type: integer }
+        runtime_observed_count: { type: integer }
+        backing_role_scope_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+        remediation_preview_count: { type: integer }
+    AWSAIAgentRiskResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSAIAgentRiskSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentRiskFinding"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAIAgentRiskRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -757,6 +757,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-risk", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -1,0 +1,938 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsAIAgentRiskCurrentIssue = 1528
+	awsAIAgentRiskVersion      = "aws-ai-agent-risk-engine-v1"
+)
+
+// AWSAIAgentRiskRequest scopes the deterministic AI agent risk engine to one
+// AWS connector plus optional operator drill-down filters.
+type AWSAIAgentRiskRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	RiskType     string `json:"risk_type,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Evidence     string `json:"evidence,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSAIAgentRiskEvidence = AWSLeastPrivilegeEvidence
+type AWSAIAgentRiskPathStep = AWSLeastPrivilegePathStep
+type AWSAIAgentRiskRemediationCasePreview = AWSLeastPrivilegeRemediationCasePreview
+type AWSAIAgentRiskDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSAIAgentRiskCoverageGap = AWSLeastPrivilegeCoverageGap
+
+type AWSAIAgentRiskRelationship struct {
+	FindingID   string `json:"finding_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref"`
+}
+
+// AWSAIAgentRiskFinding is the persisted-record-shaped intelligence contract
+// emitted by the AI agent risk engine. It intentionally carries only metadata
+// evidence refs and graph nodes, never prompts, completions, tool payloads,
+// browser pages, code-interpreter output, database rows, object contents, or
+// secret values.
+type AWSAIAgentRiskFinding struct {
+	FindingID          string                               `json:"finding_id"`
+	CalculationVersion string                               `json:"calculation_version"`
+	RiskType           string                               `json:"risk_type"`
+	Severity           string                               `json:"severity"`
+	Status             string                               `json:"status"`
+	Score              int                                  `json:"score"`
+	Confidence         float64                              `json:"confidence"`
+	AccountID          string                               `json:"account_id"`
+	Region             string                               `json:"region"`
+	AgentNodeID        string                               `json:"agent_node_id"`
+	AgentID            string                               `json:"agent_id,omitempty"`
+	AgentName          string                               `json:"agent_name,omitempty"`
+	AgentType          string                               `json:"agent_type,omitempty"`
+	RuntimeRoleARN     string                               `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleNodeID  string                               `json:"runtime_role_node_id,omitempty"`
+	Provider           string                               `json:"provider,omitempty"`
+	ToolNames          []string                             `json:"tool_names,omitempty"`
+	CapabilityNames    []string                             `json:"capability_names,omitempty"`
+	SensitiveResources []string                             `json:"sensitive_resources,omitempty"`
+	SourceSignals      []string                             `json:"source_signals"`
+	Rationale          string                               `json:"rationale"`
+	EvidenceBoundary   string                               `json:"evidence_boundary"`
+	ImpactedNodes      []string                             `json:"impacted_nodes"`
+	ImpactedPath       []AWSAIAgentRiskPathStep             `json:"impacted_path"`
+	Evidence           []AWSAIAgentRiskEvidence             `json:"evidence"`
+	NextAction         string                               `json:"next_action"`
+	RemediationCase    AWSAIAgentRiskRemediationCasePreview `json:"remediation_case"`
+	CreatedAt          time.Time                            `json:"created_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+type AWSAIAgentRiskSummary struct {
+	TotalFindings              int            `json:"total_findings"`
+	FilteredFindings           int            `json:"filtered_findings"`
+	SeverityCounts             map[string]int `json:"severity_counts"`
+	StatusCounts               map[string]int `json:"status_counts"`
+	RiskTypeCounts             map[string]int `json:"risk_type_counts"`
+	ExternalCredentialCount    int            `json:"external_credential_count"`
+	BroadToolAccessCount       int            `json:"broad_tool_access_count"`
+	SensitiveReachabilityCount int            `json:"sensitive_reachability_count"`
+	OwnerlessAgentCount        int            `json:"ownerless_agent_count"`
+	RuntimeObservedCount       int            `json:"runtime_observed_count"`
+	BackingRoleScopeCount      int            `json:"backing_role_scope_count"`
+	RelationshipCount          int            `json:"relationship_count"`
+	HighestScore               int            `json:"highest_score"`
+	AverageConfidencePct       int            `json:"average_confidence_pct"`
+	RemediationPreviewCount    int            `json:"remediation_preview_count"`
+}
+
+type AWSAIAgentRiskResult struct {
+	TenantID           string                       `json:"tenant_id"`
+	WorkspaceID        string                       `json:"workspace_id"`
+	ProjectID          string                       `json:"project_id"`
+	ConnectorID        string                       `json:"connector_id,omitempty"`
+	AccountID          string                       `json:"account_id,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	ParentIssueNumber  int                          `json:"parent_issue_number"`
+	ParentIssueRef     string                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                          `json:"current_issue_number"`
+	CurrentIssueRef    string                       `json:"current_issue_ref"`
+	Version            string                       `json:"version"`
+	Status             string                       `json:"status"`
+	FixtureState       string                       `json:"fixture_state,omitempty"`
+	Confidence         float64                      `json:"confidence"`
+	CalculationVersion string                       `json:"calculation_version"`
+	AppliedFilters     map[string]string            `json:"applied_filters"`
+	Summary            AWSAIAgentRiskSummary        `json:"summary"`
+	Findings           []AWSAIAgentRiskFinding      `json:"findings"`
+	Relationships      []AWSAIAgentRiskRelationship `json:"relationships"`
+	Caveats            []string                     `json:"caveats"`
+	FailureReasons     []string                     `json:"failure_reasons"`
+	RemediationHints   []string                     `json:"remediation_hints"`
+	EvidenceLinks      []string                     `json:"evidence_links"`
+	CoverageGaps       []AWSAIAgentRiskCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSAIAgentRiskDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	UpdatedAt          time.Time                    `json:"updated_at"`
+}
+
+type awsAIAgentRiskSources struct {
+	agents      AWSAIAgentIdentityInventoryResult
+	runtime     AWSAgentRuntimeAccessResult
+	least       AWSLeastPrivilegeResult
+	equivalence AWSSecretPermissionEquivalenceResult
+}
+
+func (s *Service) GetAWSAIAgentRisk(ctx context.Context, workspaceID string, projectID string, request AWSAIAgentRiskRequest) (AWSAIAgentRiskResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAIAgentRiskResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAIAgentRiskResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSAIAgentRiskFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAIAgentRiskResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsAIAgentRiskSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSAIAgentRiskResult{}, err
+	}
+	findings := awsAIAgentRiskFindings(sources, now)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Score == findings[j].Score {
+			return findings[i].FindingID < findings[j].FindingID
+		}
+		return findings[i].Score > findings[j].Score
+	})
+	filtered, applied := filterAWSAIAgentRiskFindings(findings, request)
+	relationships := awsAIAgentRiskRelationships(filtered)
+	diagnostics := awsAIAgentRiskDiagnostics(sources)
+	coverageGaps := awsAIAgentRiskCoverageGaps(sources)
+	status, confidence := summarizeAWSAIAgentRiskStatus(sources, filtered, diagnostics)
+
+	return AWSAIAgentRiskResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAIAgentRiskCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAIAgentRiskCurrentIssue),
+		Version:            awsAIAgentRiskVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsAIAgentRiskVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSAIAgentRisk(findings, filtered, relationships),
+		Findings:           filtered,
+		Relationships:      relationships,
+		Caveats:            awsAIAgentRiskCaveats(),
+		FailureReasons:     awsAIAgentRiskFailureReasons(sources),
+		RemediationHints:   awsAIAgentRiskRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAIAgentRiskCurrentIssue),
+			awsIssueURL(awsAIAgentIdentityCurrentIssue),
+			awsIssueURL(awsAgentRuntimeAccessCurrentIssue),
+			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),
+			"/docs/aws-ai-agent-risk-engine",
+			"/docs/aws-ai-agent-identities",
+			"/docs/aws-agent-runtime-access",
+			"/docs/aws-secret-permission-equivalence-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSAIAgentRiskFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsAIAgentRiskSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsAIAgentRiskSources, error) {
+	agents, err := s.GetAWSAIAgentIdentityInventory(ctx, workspaceID, projectID, AWSAIAgentIdentityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsAIAgentRiskSources{}, fmt.Errorf("ai agent risk identity inventory: %w", err)
+	}
+	runtime, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsAIAgentRiskSources{}, fmt.Errorf("ai agent risk runtime access: %w", err)
+	}
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsAIAgentRiskSources{}, fmt.Errorf("ai agent risk least privilege: %w", err)
+	}
+	equivalence, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsAIAgentRiskSources{}, fmt.Errorf("ai agent risk secret permission equivalence: %w", err)
+	}
+	return awsAIAgentRiskSources{agents: agents, runtime: runtime, least: least, equivalence: equivalence}, nil
+}
+
+func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSAIAgentRiskFinding {
+	findings := []AWSAIAgentRiskFinding{}
+	agentByRuntimeRole := map[string]AWSAIAgentIdentityRecord{}
+	for _, agent := range sources.agents.Records {
+		agentByRuntimeRole[strings.ToLower(strings.TrimSpace(agent.RuntimeRoleNodeID))] = agent
+		agentByRuntimeRole[strings.ToLower(strings.TrimSpace(awsIdentityNodeIDForAPI(agent.RuntimeRoleARN)))] = agent
+		findings = append(findings, awsAIAgentRiskFindingsFromAgent(agent, now)...)
+	}
+	for _, record := range sources.runtime.Records {
+		if finding, ok := awsAIAgentRiskFindingFromRuntime(record, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+	for _, finding := range sources.equivalence.Findings {
+		if derived, ok := awsAIAgentRiskFindingFromSecretEquivalence(finding, now); ok {
+			findings = append(findings, derived)
+		}
+	}
+	for _, recommendation := range sources.least.Recommendations {
+		if derived, ok := awsAIAgentRiskFindingFromLeastPrivilege(recommendation, agentByRuntimeRole, now); ok {
+			findings = append(findings, derived)
+		}
+	}
+	return awsAIAgentRiskDedupeFindings(findings)
+}
+
+func awsAIAgentRiskFindingsFromAgent(agent AWSAIAgentIdentityRecord, now time.Time) []AWSAIAgentRiskFinding {
+	findings := []AWSAIAgentRiskFinding{}
+	toolCount := len(dedupeStrings(append(append([]string{}, agent.ToolNames...), agent.AllowedActions...)))
+	if toolCount >= 3 || strings.EqualFold(agent.AgentType, "agent_gateway") {
+		score := clampBlastRadiusScore(58 + toolCount*5)
+		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("broad-tool-access", agent.AgentNodeID, strings.Join(agent.ToolNames, ",")),
+			CalculationVersion: awsAIAgentRiskVersion,
+			RiskType:           "broad_tool_access",
+			Severity:           awsPrivilegeEscalationSeverity(score),
+			Status:             awsPrivilegeEscalationFindingStatus(score, agent.Confidence),
+			Score:              score,
+			Confidence:         minFloat(firstNonZeroFloat(agent.Confidence, 0.78), 0.92),
+			AccountID:          agent.AccountID,
+			Region:             agent.Region,
+			AgentNodeID:        agent.AgentNodeID,
+			AgentID:            agent.AgentID,
+			AgentName:          agent.AgentName,
+			AgentType:          agent.AgentType,
+			RuntimeRoleARN:     agent.RuntimeRoleARN,
+			RuntimeRoleNodeID:  agent.RuntimeRoleNodeID,
+			Provider:           agent.Provider,
+			ToolNames:          agent.ToolNames,
+			CapabilityNames:    agent.CapabilityNames,
+			SourceSignals:      []string{"ai_agent_identities"},
+			Rationale:          fmt.Sprintf("%s exposes %d declared tools or allowed actions, which increases agent action surface even before runtime use is observed.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), toolCount),
+			EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+			ImpactedNodes:      awsAIAgentRiskImpactedNodes(agent.AgentNodeID, agent.RuntimeRoleNodeID),
+			ImpactedPath:       awsAIAgentRiskAgentPath(agent, "tool_surface", fmt.Sprintf("%d declared tools/actions", toolCount)),
+			Evidence:           []AWSAIAgentRiskEvidence{{Source: "ai_agent_identities", EvidenceRef: agent.EvidenceRef, Label: "Declared agent tool surface", Confidence: agent.Confidence, ObservedAt: agent.CollectedAt, Relationship: "declares_tools"}},
+			NextAction:         "Review tool ownership and split or scope broad agent tool access before generating remediation diffs.",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}))
+	}
+
+	sensitive := awsAIAgentRiskSensitiveResources(agent)
+	if len(sensitive) > 0 {
+		score := 62 + len(sensitive)*6
+		if agent.BrowserEnabled || agent.CodeInterpreterEnabled {
+			score += 8
+		}
+		score = clampBlastRadiusScore(score)
+		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("sensitive-data-reachability", agent.AgentNodeID, strings.Join(sensitive, ",")),
+			CalculationVersion: awsAIAgentRiskVersion,
+			RiskType:           "sensitive_data_reachability",
+			Severity:           awsPrivilegeEscalationSeverity(score),
+			Status:             awsPrivilegeEscalationFindingStatus(score, agent.Confidence),
+			Score:              score,
+			Confidence:         minFloat(firstNonZeroFloat(agent.Confidence, 0.76), 0.9),
+			AccountID:          agent.AccountID,
+			Region:             agent.Region,
+			AgentNodeID:        agent.AgentNodeID,
+			AgentID:            agent.AgentID,
+			AgentName:          agent.AgentName,
+			AgentType:          agent.AgentType,
+			RuntimeRoleARN:     agent.RuntimeRoleARN,
+			RuntimeRoleNodeID:  agent.RuntimeRoleNodeID,
+			Provider:           agent.Provider,
+			ToolNames:          agent.ToolNames,
+			CapabilityNames:    agent.CapabilityNames,
+			SensitiveResources: sensitive,
+			SourceSignals:      []string{"ai_agent_identities"},
+			Rationale:          fmt.Sprintf("%s can reach sensitive agent capabilities or resource references: %s.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), strings.Join(sensitive, ", ")),
+			EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+			ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agent.AgentNodeID, agent.RuntimeRoleNodeID}, sensitive...)...),
+			ImpactedPath:       awsAIAgentRiskAgentPath(agent, "sensitive_resource", strings.Join(sensitive, ", ")),
+			Evidence:           []AWSAIAgentRiskEvidence{{Source: "ai_agent_identities", EvidenceRef: agent.EvidenceRef, Label: "Sensitive capability metadata", Confidence: agent.Confidence, ObservedAt: agent.CollectedAt, Relationship: "can_reach_sensitive_agent_capability"}},
+			NextAction:         "Validate capability owners and restrict memory, browser, code-interpreter, storage, or KMS reachability to approved agents.",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}))
+	}
+
+	if awsAIAgentRiskOwnerless(agent) {
+		score := 70
+		if strings.EqualFold(agent.Status, "degraded") || strings.EqualFold(agent.CoverageStatus, "degraded") {
+			score += 8
+		}
+		score = clampBlastRadiusScore(score)
+		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("ownerless-agent", agent.AgentNodeID),
+			CalculationVersion: awsAIAgentRiskVersion,
+			RiskType:           "ownerless_agent",
+			Severity:           awsPrivilegeEscalationSeverity(score),
+			Status:             "review",
+			Score:              score,
+			Confidence:         minFloat(firstNonZeroFloat(agent.Confidence, 0.7), 0.88),
+			AccountID:          agent.AccountID,
+			Region:             agent.Region,
+			AgentNodeID:        agent.AgentNodeID,
+			AgentID:            agent.AgentID,
+			AgentName:          agent.AgentName,
+			AgentType:          agent.AgentType,
+			RuntimeRoleARN:     agent.RuntimeRoleARN,
+			RuntimeRoleNodeID:  agent.RuntimeRoleNodeID,
+			Provider:           agent.Provider,
+			ToolNames:          agent.ToolNames,
+			CapabilityNames:    agent.CapabilityNames,
+			SourceSignals:      []string{"ai_agent_identities"},
+			Rationale:          fmt.Sprintf("%s has no owner tag or has degraded ownership coverage, so remediation and approval cannot be routed deterministically.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID)),
+			EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+			ImpactedNodes:      awsAIAgentRiskImpactedNodes(agent.AgentNodeID, agent.RuntimeRoleNodeID),
+			ImpactedPath:       awsAIAgentRiskAgentPath(agent, "owner", "missing owner"),
+			Evidence:           []AWSAIAgentRiskEvidence{{Source: "ai_agent_identities", EvidenceRef: agent.EvidenceRef, Label: "Agent ownership metadata", Confidence: agent.Confidence, ObservedAt: agent.CollectedAt, Relationship: "missing_owner"}},
+			NextAction:         "Assign an accountable owner before remediation case creation or policy diff generation.",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}))
+	}
+
+	for _, ref := range agent.ProviderKeyReferences {
+		if !awsAIAgentProviderIsExternalAI(ref.Provider) {
+			continue
+		}
+		score := 78
+		if !ref.Resolved {
+			score += 4
+		}
+		score = clampBlastRadiusScore(score)
+		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agent.AgentNodeID, ref.Provider, ref.ReferenceName),
+			CalculationVersion: awsAIAgentRiskVersion,
+			RiskType:           "external_credential_exposure",
+			Severity:           awsPrivilegeEscalationSeverity(score),
+			Status:             awsPrivilegeEscalationFindingStatus(score, ref.Confidence),
+			Score:              score,
+			Confidence:         minFloat(firstNonZeroFloat(ref.Confidence, agent.Confidence, 0.78), 0.92),
+			AccountID:          agent.AccountID,
+			Region:             agent.Region,
+			AgentNodeID:        agent.AgentNodeID,
+			AgentID:            agent.AgentID,
+			AgentName:          agent.AgentName,
+			AgentType:          agent.AgentType,
+			RuntimeRoleARN:     agent.RuntimeRoleARN,
+			RuntimeRoleNodeID:  agent.RuntimeRoleNodeID,
+			Provider:           ref.Provider,
+			ToolNames:          agent.ToolNames,
+			CapabilityNames:    agent.CapabilityNames,
+			SensitiveResources: []string{ref.TargetNodeID},
+			SourceSignals:      []string{"ai_agent_identities"},
+			Rationale:          fmt.Sprintf("%s references %s provider credential metadata via %s; the key value is not collected.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), formatAWSBlastRadiusLabel(ref.Provider), firstNonEmptyAWSValue(ref.ReferenceName, ref.ReferenceKind)),
+			EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+			ImpactedNodes:      awsAIAgentRiskImpactedNodes(agent.AgentNodeID, agent.RuntimeRoleNodeID, ref.TargetNodeID),
+			ImpactedPath:       awsAIAgentRiskAgentPath(agent, "provider_key_reference", firstNonEmptyAWSValue(ref.ReferenceName, ref.TargetNodeID)),
+			Evidence:           []AWSAIAgentRiskEvidence{{Source: "ai_agent_identities", EvidenceRef: ref.EvidenceRef, Label: "Agent provider-key metadata", Confidence: ref.Confidence, ObservedAt: agent.CollectedAt, Relationship: "references_external_provider_key"}},
+			NextAction:         "Rotate or scope the external provider credential and restrict every AWS identity that can read its reference.",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}))
+	}
+	return findings
+}
+
+func awsAIAgentRiskFindingFromRuntime(record AWSAgentRuntimeAccessRecord, now time.Time) (AWSAIAgentRiskFinding, bool) {
+	if record.Status == "confirmed" && !awsStringSliceContains(record.Caveats, "observed_backing_role_differs_from_declared") && !awsStringSliceContains(record.Caveats, "observed_tool_call_failed") {
+		return AWSAIAgentRiskFinding{}, false
+	}
+	riskType := "runtime_tool_anomaly"
+	score := 66
+	switch record.Status {
+	case "observed_without_declaration":
+		riskType = "undeclared_tool_runtime"
+		score = 80
+	case "declared_unused":
+		riskType = "declared_unused_tool"
+		score = 58
+	}
+	if awsStringSliceContains(record.Caveats, "observed_backing_role_differs_from_declared") {
+		riskType = "backing_role_mismatch"
+		score += 8
+	}
+	if awsStringSliceContains(record.Caveats, "observed_tool_call_failed") {
+		score += 4
+	}
+	score = clampBlastRadiusScore(score)
+	target := firstString(record.TargetResourceNodeIDs)
+	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken(riskType, record.CorrelationID),
+		CalculationVersion: awsAIAgentRiskVersion,
+		RiskType:           riskType,
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             awsPrivilegeEscalationFindingStatus(score, record.Confidence),
+		Score:              score,
+		Confidence:         minFloat(firstNonZeroFloat(record.Confidence, 0.68), 0.9),
+		AccountID:          record.AccountID,
+		Region:             record.Region,
+		AgentNodeID:        record.AgentNodeID,
+		AgentID:            record.AgentID,
+		AgentName:          record.AgentName,
+		AgentType:          record.AgentType,
+		RuntimeRoleARN:     firstString(record.BackingRoleARNs),
+		RuntimeRoleNodeID:  firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode),
+		ToolNames:          []string{record.ToolName},
+		SensitiveResources: []string{target},
+		SourceSignals:      []string{"agent_runtime_access"},
+		Rationale:          fmt.Sprintf("Runtime correlation for %s/%s returned status=%s with caveats %s.", firstNonEmptyAWSValue(record.AgentName, record.AgentID), firstNonEmptyAWSValue(record.ToolName, "agent invocation"), record.Status, strings.Join(record.Caveats, ", ")),
+		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+		ImpactedNodes:      awsAIAgentRiskImpactedNodes(record.AgentNodeID, firstString(record.BackingRoleNodeIDs), target),
+		ImpactedPath: []AWSAIAgentRiskPathStep{
+			awsLeastPrivilegePathStep(record.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(record.AgentName, record.AgentID), record.AccountID, record.Region),
+			awsLeastPrivilegePathStep(firstNonEmptyAWSValue(target, firstString(record.TargetResourceARNs), record.ToolTargetRef), "runtime_target", firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef, target), record.AccountID, record.Region),
+		},
+		Evidence:   []AWSAIAgentRiskEvidence{{Source: "agent_runtime_access", EvidenceRef: record.EvidenceRef, Label: "Agent runtime/tool-call correlation", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction: record.NextAction,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}), true
+}
+
+func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquivalenceFinding, now time.Time) (AWSAIAgentRiskFinding, bool) {
+	if strings.TrimSpace(finding.AgentID) == "" && !strings.Contains(finding.EquivalenceType, "agent") {
+		return AWSAIAgentRiskFinding{}, false
+	}
+	score := clampBlastRadiusScore(finding.Score + 4)
+	agentNode := firstNonEmptyAWSValue(awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath), finding.AgentID, finding.IdentityNodeID)
+	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("secret-equivalence", finding.FindingID),
+		CalculationVersion: awsAIAgentRiskVersion,
+		RiskType:           "external_credential_exposure",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             finding.Status,
+		Score:              score,
+		Confidence:         minFloat(finding.Confidence, 0.92),
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		AgentNodeID:        agentNode,
+		AgentID:            finding.AgentID,
+		AgentName:          finding.AgentName,
+		RuntimeRoleARN:     finding.PrincipalARN,
+		RuntimeRoleNodeID:  finding.IdentityNodeID,
+		Provider:           finding.Provider,
+		SensitiveResources: []string{finding.SecretNodeID, finding.SecretARN},
+		SourceSignals:      []string{"secret_permission_equivalence"},
+		Rationale:          finding.Rationale,
+		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+		ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agentNode, finding.IdentityNodeID, finding.SecretNodeID}, finding.ImpactedNodes...)...),
+		ImpactedPath:       finding.ImpactedPath,
+		Evidence:           finding.Evidence,
+		NextAction:         finding.NextAction,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}), true
+}
+
+func awsAIAgentRiskFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, agents map[string]AWSAIAgentIdentityRecord, now time.Time) (AWSAIAgentRiskFinding, bool) {
+	agent, ok := agents[strings.ToLower(strings.TrimSpace(recommendation.IdentityNodeID))]
+	if !ok {
+		return AWSAIAgentRiskFinding{}, false
+	}
+	if recommendation.Decision == "keep" {
+		return AWSAIAgentRiskFinding{}, false
+	}
+	score := clampBlastRadiusScore(recommendation.Score + 3)
+	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("backing-role-scope", recommendation.RecommendationID),
+		CalculationVersion: awsAIAgentRiskVersion,
+		RiskType:           "backing_role_scope",
+		Severity:           awsPrivilegeEscalationSeverity(score),
+		Status:             recommendation.Status,
+		Score:              score,
+		Confidence:         minFloat(recommendation.Confidence, 0.9),
+		AccountID:          recommendation.AccountID,
+		Region:             recommendation.Region,
+		AgentNodeID:        agent.AgentNodeID,
+		AgentID:            agent.AgentID,
+		AgentName:          agent.AgentName,
+		AgentType:          agent.AgentType,
+		RuntimeRoleARN:     agent.RuntimeRoleARN,
+		RuntimeRoleNodeID:  recommendation.IdentityNodeID,
+		Provider:           agent.Provider,
+		ToolNames:          agent.ToolNames,
+		CapabilityNames:    agent.CapabilityNames,
+		SensitiveResources: []string{recommendation.ResourceNodeID, recommendation.ResourceARN},
+		SourceSignals:      []string{"least_privilege"},
+		Rationale:          fmt.Sprintf("The backing role for %s has least-privilege decision=%s for %s; agent risk inherits that role scope.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), recommendation.Decision, recommendation.DisplayName),
+		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+		ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agent.AgentNodeID, recommendation.IdentityNodeID, recommendation.ResourceNodeID}, recommendation.ImpactedNodes...)...),
+		ImpactedPath:       append([]AWSAIAgentRiskPathStep{awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region)}, recommendation.ImpactedPath...),
+		Evidence:           recommendation.Evidence,
+		NextAction:         recommendation.NextAction,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}), true
+}
+
+func awsAIAgentRiskFinding(finding AWSAIAgentRiskFinding) AWSAIAgentRiskFinding {
+	finding.ToolNames = dedupeStrings(finding.ToolNames)
+	finding.CapabilityNames = dedupeStrings(finding.CapabilityNames)
+	finding.SensitiveResources = dedupeStrings(finding.SensitiveResources)
+	finding.SourceSignals = dedupeStrings(finding.SourceSignals)
+	finding.ImpactedNodes = awsAIAgentRiskImpactedNodes(finding.ImpactedNodes...)
+	evidenceRefs := []string{}
+	for _, evidence := range finding.Evidence {
+		if evidence.EvidenceRef != "" {
+			evidenceRefs = append(evidenceRefs, evidence.EvidenceRef)
+		}
+	}
+	finding.RemediationCase = AWSAIAgentRiskRemediationCasePreview{
+		CaseID:             "aws-ai-agent-risk-preview:" + stableAWSBlastRadiusToken(finding.RiskType, finding.AgentNodeID, finding.FindingID),
+		Title:              fmt.Sprintf("%s AI agent risk review", formatAWSBlastRadiusLabel(finding.RiskType)),
+		RecommendedAction:  finding.NextAction,
+		ApprovalRequired:   finding.Severity == "critical" || finding.Severity == "high",
+		BlockingEvidence:   dedupeStrings(evidenceRefs),
+		ImpactedNodeCount:  len(finding.ImpactedNodes),
+		EstimatedRiskDrop:  minInt(finding.Score, 40),
+		BreakagePrediction: "unknown",
+		ReadOnlyProjection: true,
+	}
+	return finding
+}
+
+func awsAIAgentRiskDedupeFindings(findings []AWSAIAgentRiskFinding) []AWSAIAgentRiskFinding {
+	seen := map[string]AWSAIAgentRiskFinding{}
+	order := []string{}
+	for _, finding := range findings {
+		key := finding.FindingID
+		if key == "" {
+			continue
+		}
+		if existing, ok := seen[key]; ok {
+			if finding.Score > existing.Score {
+				seen[key] = finding
+			}
+			continue
+		}
+		seen[key] = finding
+		order = append(order, key)
+	}
+	out := make([]AWSAIAgentRiskFinding, 0, len(order))
+	for _, key := range order {
+		out = append(out, seen[key])
+	}
+	return out
+}
+
+func filterAWSAIAgentRiskFindings(findings []AWSAIAgentRiskFinding, request AWSAIAgentRiskRequest) ([]AWSAIAgentRiskFinding, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"agent_id":   strings.TrimSpace(request.AgentID),
+		"risk_type":  normalizeAWSRuntimeEventFilterToken(request.RiskType),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
+		"evidence":   strings.TrimSpace(request.Evidence),
+		"search":     strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSAIAgentRiskFinding, 0, len(findings))
+	for _, finding := range findings {
+		if filters["account_id"] != "" && filters["account_id"] != finding.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], finding.Region) {
+			continue
+		}
+		if filters["risk_type"] != "" && filters["risk_type"] != normalizeAWSRuntimeEventFilterToken(finding.RiskType) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(finding.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(finding.Status) {
+			continue
+		}
+		if filters["agent_id"] != "" && !strings.Contains(strings.ToLower(finding.AgentNodeID+" "+finding.AgentID+" "+finding.AgentName+" "+finding.RuntimeRoleARN), strings.ToLower(filters["agent_id"])) {
+			continue
+		}
+		if filters["evidence"] != "" && !awsAIAgentRiskEvidenceFilterMatch(finding, filters["evidence"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsAIAgentRiskSearchFilterMatch(finding, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered, applied
+}
+
+func awsAIAgentRiskEvidenceFilterMatch(finding AWSAIAgentRiskFinding, evidenceFilter string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(evidenceFilter) {
+	case "runtime-backed":
+		return awsStringSliceContains(finding.SourceSignals, "agent_runtime_access") || awsStringSliceContains(finding.SourceSignals, "least_privilege")
+	case "inventory-backed":
+		return awsStringSliceContains(finding.SourceSignals, "ai_agent_identities")
+	case "secret-backed":
+		return awsStringSliceContains(finding.SourceSignals, "secret_permission_equivalence")
+	default:
+		for _, item := range finding.Evidence {
+			if awsRuntimeEventMatchesAny(evidenceFilter, item.Source, item.Label, item.EvidenceRef, item.Relationship) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func awsAIAgentRiskSearchFilterMatch(finding AWSAIAgentRiskFinding, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	values := []string{finding.FindingID, finding.RiskType, finding.Severity, finding.Status, finding.AgentNodeID, finding.AgentID, finding.AgentName, finding.AgentType, finding.RuntimeRoleARN, finding.RuntimeRoleNodeID, finding.Provider, finding.Rationale, finding.NextAction}
+	values = append(values, finding.ToolNames...)
+	values = append(values, finding.CapabilityNames...)
+	values = append(values, finding.SensitiveResources...)
+	values = append(values, finding.SourceSignals...)
+	values = append(values, finding.ImpactedNodes...)
+	for _, item := range finding.Evidence {
+		values = append(values, item.Source, item.EvidenceRef, item.Label, item.Relationship)
+	}
+	for _, item := range values {
+		if strings.Contains(strings.ToLower(item), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsAIAgentRiskRelationships(findings []AWSAIAgentRiskFinding) []AWSAIAgentRiskRelationship {
+	relationships := []AWSAIAgentRiskRelationship{}
+	for _, finding := range findings {
+		if finding.AgentNodeID == "" {
+			continue
+		}
+		for _, nodeID := range finding.ImpactedNodes {
+			if nodeID == "" || nodeID == finding.AgentNodeID {
+				continue
+			}
+			relationships = append(relationships, AWSAIAgentRiskRelationship{
+				FindingID:   finding.FindingID,
+				Type:        "ai_agent_risk_path",
+				FromNodeID:  finding.AgentNodeID,
+				ToNodeID:    nodeID,
+				EvidenceRef: firstString(awsAIAgentRiskEvidenceRefs(finding.Evidence)),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSAIAgentRisk(allFindings []AWSAIAgentRiskFinding, filtered []AWSAIAgentRiskFinding, relationships []AWSAIAgentRiskRelationship) AWSAIAgentRiskSummary {
+	summary := AWSAIAgentRiskSummary{
+		TotalFindings:     len(allFindings),
+		FilteredFindings:  len(filtered),
+		SeverityCounts:    map[string]int{},
+		StatusCounts:      map[string]int{},
+		RiskTypeCounts:    map[string]int{},
+		RelationshipCount: len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, finding := range filtered {
+		summary.SeverityCounts[finding.Severity]++
+		summary.StatusCounts[finding.Status]++
+		summary.RiskTypeCounts[finding.RiskType]++
+		if finding.Score > summary.HighestScore {
+			summary.HighestScore = finding.Score
+		}
+		confidenceTotal += finding.Confidence
+		switch finding.RiskType {
+		case "external_credential_exposure":
+			summary.ExternalCredentialCount++
+		case "broad_tool_access":
+			summary.BroadToolAccessCount++
+		case "sensitive_data_reachability":
+			summary.SensitiveReachabilityCount++
+		case "ownerless_agent":
+			summary.OwnerlessAgentCount++
+		case "backing_role_scope":
+			summary.BackingRoleScopeCount++
+		}
+		if awsStringSliceContains(finding.SourceSignals, "agent_runtime_access") || awsStringSliceContains(finding.SourceSignals, "least_privilege") {
+			summary.RuntimeObservedCount++
+		}
+		if finding.RemediationCase.CaseID != "" {
+			summary.RemediationPreviewCount++
+		}
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func summarizeAWSAIAgentRiskStatus(sources awsAIAgentRiskSources, filtered []AWSAIAgentRiskFinding, diagnostics []AWSAIAgentRiskDiagnostic) (string, float64) {
+	statuses := []string{sources.agents.Status, sources.runtime.Status, sources.least.Status, sources.equivalence.Status}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.76
+		}
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.84
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsAIAgentRiskFailureReasons(sources awsAIAgentRiskSources) []string {
+	out := []string{}
+	for _, messages := range [][]string{
+		sources.agents.FailureReasons,
+		sources.runtime.FailureReasons,
+		sources.least.FailureReasons,
+		sources.equivalence.FailureReasons,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsAIAgentRiskRemediationHints(sources awsAIAgentRiskSources) []string {
+	out := []string{"Treat broad tools, external provider keys, sensitive agent capabilities, and backing-role scope as one agent risk decision until an owner approves remediation."}
+	for _, messages := range [][]string{
+		sources.agents.RemediationHints,
+		sources.runtime.RemediationHints,
+		sources.least.RemediationHints,
+		sources.equivalence.RemediationHints,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsAIAgentRiskCaveats() []string {
+	return []string{
+		"AI agent risk is inferred from metadata-only inventory, tool-call correlation, least-privilege, and secret-permission evidence.",
+		"The engine never reads, stores, logs, or displays secret values, prompts, completions, browser pages, code-interpreter output, database rows, object contents, or tool payloads.",
+		"Unknown, denied, unsupported, degraded, and partial evidence stays explicit instead of becoming deterministic truth.",
+	}
+}
+
+func awsAIAgentRiskDiagnostics(sources awsAIAgentRiskSources) []AWSAIAgentRiskDiagnostic {
+	out := []AWSAIAgentRiskDiagnostic{}
+	appendDiag := func(collector, sourceID, code, message, remediation string, retryable bool) {
+		if strings.TrimSpace(message) == "" && strings.TrimSpace(code) == "" {
+			return
+		}
+		out = append(out, AWSAIAgentRiskDiagnostic{Collector: collector, SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: retryable})
+	}
+	for _, d := range sources.agents.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.runtime.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.least.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.equivalence.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	return out
+}
+
+func awsAIAgentRiskCoverageGaps(sources awsAIAgentRiskSources) []AWSAIAgentRiskCoverageGap {
+	out := []AWSAIAgentRiskCoverageGap{{
+		Capability:  "agent_payload_collection",
+		Status:      "unsupported",
+		Reason:      "Prompts, completions, browser pages, code-interpreter output, database rows, object contents, tool payloads, and secret values are intentionally excluded.",
+		Remediation: "Use metadata evidence refs and owner-approved follow-up collection only when a future issue explicitly permits it.",
+	}}
+	appendGap := func(capability, status, reason, remediation string) {
+		out = append(out, AWSAIAgentRiskCoverageGap{Capability: capability, Status: status, Reason: reason, Remediation: remediation})
+	}
+	for _, g := range sources.agents.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.runtime.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.least.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.equivalence.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	return out
+}
+
+func awsAIAgentRiskSensitiveResources(agent AWSAIAgentIdentityRecord) []string {
+	resources := []string{}
+	if agent.MemoryEnabled {
+		resources = append(resources, "agent_memory")
+	}
+	if agent.BrowserEnabled {
+		resources = append(resources, "browser")
+	}
+	if agent.CodeInterpreterEnabled {
+		resources = append(resources, "code_interpreter")
+	}
+	resources = append(resources, agent.MemoryStoreRefs...)
+	resources = append(resources, agent.StorageReferenceRefs...)
+	if agent.EncryptionKeyARN != "" {
+		resources = append(resources, agent.EncryptionKeyARN)
+	}
+	return dedupeStrings(resources)
+}
+
+func awsAIAgentRiskOwnerless(agent AWSAIAgentIdentityRecord) bool {
+	if owner := strings.TrimSpace(agent.Tags["owner"]); owner != "" {
+		return false
+	}
+	return true
+}
+
+func awsAIAgentRiskAgentPath(agent AWSAIAgentIdentityRecord, targetType string, targetLabel string) []AWSAIAgentRiskPathStep {
+	return []AWSAIAgentRiskPathStep{
+		awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region),
+		awsLeastPrivilegePathStep(firstNonEmptyAWSValue(agent.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(agent.RuntimeRoleARN)), "runtime_role", firstNonEmptyAWSValue(shortAWSARN(agent.RuntimeRoleARN), agent.RuntimeRoleName), agent.AccountID, agent.Region),
+		awsLeastPrivilegePathStep(targetLabel, targetType, targetLabel, agent.AccountID, agent.Region),
+	}
+}
+
+func awsAIAgentRiskImpactedNodes(values ...string) []string {
+	return emptyStrings(dedupeStrings(values))
+}
+
+func awsAIAgentRiskEvidenceRefs(evidence []AWSAIAgentRiskEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			out = append(out, item.EvidenceRef)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func awsAIAgentRiskAgentNodeFromPath(path []AWSSecretPermissionEquivalencePathStep) string {
+	for _, step := range path {
+		if strings.EqualFold(step.NodeType, "ai_agent") && strings.TrimSpace(step.NodeID) != "" {
+			return step.NodeID
+		}
+	}
+	return ""
+}
+
+func awsAIAgentRiskEvidenceBoundary() string {
+	return "metadata_only_no_secret_values_no_prompts_no_completions_no_tool_payloads"
+}

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -407,13 +407,14 @@ func awsAIAgentRiskFindingsFromAgent(agent AWSAIAgentIdentityRecord, now time.Ti
 		if !awsAIAgentProviderIsExternalAI(ref.Provider) {
 			continue
 		}
+		secretRef := firstNonEmptyAWSValue(ref.TargetNodeID, ref.ReferenceName, ref.Reference)
 		score := 78
 		if !ref.Resolved {
 			score += 4
 		}
 		score = clampBlastRadiusScore(score)
 		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
-			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agent.AgentNodeID, ref.Provider, ref.ReferenceName),
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agent.AgentNodeID, ref.Provider, secretRef),
 			CalculationVersion: awsAIAgentRiskVersion,
 			RiskType:           "external_credential_exposure",
 			Severity:           awsPrivilegeEscalationSeverity(score),
@@ -508,8 +509,9 @@ func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquiv
 	}
 	score := clampBlastRadiusScore(finding.Score + 4)
 	agentNode := firstNonEmptyAWSValue(awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath), finding.AgentID, finding.IdentityNodeID)
+	secretRef := firstNonEmptyAWSValue(finding.SecretNodeID, finding.SecretARN, firstString(finding.ImpactedNodes), finding.IdentityNodeID)
 	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
-		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("secret-equivalence", finding.FindingID),
+		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agentNode, finding.Provider, secretRef),
 		CalculationVersion: awsAIAgentRiskVersion,
 		RiskType:           "external_credential_exposure",
 		Severity:           awsPrivilegeEscalationSeverity(score),
@@ -612,14 +614,12 @@ func awsAIAgentRiskDedupeFindings(findings []AWSAIAgentRiskFinding) []AWSAIAgent
 	seen := map[string]AWSAIAgentRiskFinding{}
 	order := []string{}
 	for _, finding := range findings {
-		key := finding.FindingID
-		if key == "" {
+		if finding.FindingID == "" {
 			continue
 		}
+		key := strings.ToLower(strings.TrimSpace(finding.FindingID))
 		if existing, ok := seen[key]; ok {
-			if finding.Score > existing.Score {
-				seen[key] = finding
-			}
+			seen[key] = awsAIAgentRiskMergeFindings(existing, finding)
 			continue
 		}
 		seen[key] = finding
@@ -630,6 +630,26 @@ func awsAIAgentRiskDedupeFindings(findings []AWSAIAgentRiskFinding) []AWSAIAgent
 		out = append(out, seen[key])
 	}
 	return out
+}
+
+func awsAIAgentRiskMergeFindings(existing, incoming AWSAIAgentRiskFinding) AWSAIAgentRiskFinding {
+	merged := existing
+	if incoming.Score > merged.Score {
+		merged = incoming
+	}
+	if incoming.Confidence > merged.Confidence {
+		merged.Confidence = incoming.Confidence
+	}
+	merged.SourceSignals = dedupeStrings(append(merged.SourceSignals, incoming.SourceSignals...))
+	merged.ToolNames = dedupeStrings(append(merged.ToolNames, incoming.ToolNames...))
+	merged.CapabilityNames = dedupeStrings(append(merged.CapabilityNames, incoming.CapabilityNames...))
+	merged.SensitiveResources = dedupeStrings(append(merged.SensitiveResources, incoming.SensitiveResources...))
+	merged.Evidence = append(append([]AWSAIAgentRiskEvidence{}, merged.Evidence...), incoming.Evidence...)
+	merged.ImpactedNodes = awsAIAgentRiskImpactedNodes(append(merged.ImpactedNodes, incoming.ImpactedNodes...)...)
+	if merged.Status == "" {
+		merged.Status = incoming.Status
+	}
+	return awsAIAgentRiskFinding(merged)
 }
 
 func filterAWSAIAgentRiskFindings(findings []AWSAIAgentRiskFinding, request AWSAIAgentRiskRequest) ([]AWSAIAgentRiskFinding, map[string]string) {

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -254,10 +254,15 @@ func (s *Service) awsAIAgentRiskSourceSignals(ctx context.Context, workspaceID, 
 
 func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSAIAgentRiskFinding {
 	findings := []AWSAIAgentRiskFinding{}
-	agentByRuntimeRole := map[string]AWSAIAgentIdentityRecord{}
+	agentsByRuntimeRole := map[string][]AWSAIAgentIdentityRecord{}
 	for _, agent := range sources.agents.Records {
-		agentByRuntimeRole[strings.ToLower(strings.TrimSpace(agent.RuntimeRoleNodeID))] = agent
-		agentByRuntimeRole[strings.ToLower(strings.TrimSpace(awsIdentityNodeIDForAPI(agent.RuntimeRoleARN)))] = agent
+		for _, roleKey := range []string{agent.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(agent.RuntimeRoleARN)} {
+			normalizedRoleKey := strings.ToLower(strings.TrimSpace(roleKey))
+			if normalizedRoleKey == "" {
+				continue
+			}
+			agentsByRuntimeRole[normalizedRoleKey] = appendAWSAIAgentRiskRoleAgent(agentsByRuntimeRole[normalizedRoleKey], agent)
+		}
 		findings = append(findings, awsAIAgentRiskFindingsFromAgent(agent, now)...)
 	}
 	for _, record := range sources.runtime.Records {
@@ -271,11 +276,19 @@ func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSA
 		}
 	}
 	for _, recommendation := range sources.least.Recommendations {
-		if derived, ok := awsAIAgentRiskFindingFromLeastPrivilege(recommendation, agentByRuntimeRole, now); ok {
-			findings = append(findings, derived)
-		}
+		findings = append(findings, awsAIAgentRiskFindingsFromLeastPrivilege(recommendation, agentsByRuntimeRole, now)...)
 	}
 	return awsAIAgentRiskDedupeFindings(findings)
+}
+
+func appendAWSAIAgentRiskRoleAgent(agents []AWSAIAgentIdentityRecord, candidate AWSAIAgentIdentityRecord) []AWSAIAgentIdentityRecord {
+	candidateKey := firstNonEmptyAWSValue(candidate.AgentNodeID, candidate.AgentID, candidate.AgentARN)
+	for _, agent := range agents {
+		if firstNonEmptyAWSValue(agent.AgentNodeID, agent.AgentID, agent.AgentARN) == candidateKey {
+			return agents
+		}
+	}
+	return append(agents, candidate)
 }
 
 func awsAIAgentRiskFindingsFromAgent(agent AWSAIAgentIdentityRecord, now time.Time) []AWSAIAgentRiskFinding {
@@ -524,45 +537,49 @@ func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquiv
 	}), true
 }
 
-func awsAIAgentRiskFindingFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, agents map[string]AWSAIAgentIdentityRecord, now time.Time) (AWSAIAgentRiskFinding, bool) {
-	agent, ok := agents[strings.ToLower(strings.TrimSpace(recommendation.IdentityNodeID))]
-	if !ok {
-		return AWSAIAgentRiskFinding{}, false
-	}
+func awsAIAgentRiskFindingsFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, agents map[string][]AWSAIAgentIdentityRecord, now time.Time) []AWSAIAgentRiskFinding {
 	if recommendation.Decision == "keep" {
-		return AWSAIAgentRiskFinding{}, false
+		return nil
 	}
+	affectedAgents := agents[strings.ToLower(strings.TrimSpace(recommendation.IdentityNodeID))]
+	if len(affectedAgents) == 0 {
+		return nil
+	}
+	findings := make([]AWSAIAgentRiskFinding, 0, len(affectedAgents))
 	score := clampBlastRadiusScore(recommendation.Score + 3)
-	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
-		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("backing-role-scope", recommendation.RecommendationID),
-		CalculationVersion: awsAIAgentRiskVersion,
-		RiskType:           "backing_role_scope",
-		Severity:           awsPrivilegeEscalationSeverity(score),
-		Status:             recommendation.Status,
-		Score:              score,
-		Confidence:         minFloat(recommendation.Confidence, 0.9),
-		AccountID:          recommendation.AccountID,
-		Region:             recommendation.Region,
-		AgentNodeID:        agent.AgentNodeID,
-		AgentID:            agent.AgentID,
-		AgentName:          agent.AgentName,
-		AgentType:          agent.AgentType,
-		RuntimeRoleARN:     agent.RuntimeRoleARN,
-		RuntimeRoleNodeID:  recommendation.IdentityNodeID,
-		Provider:           agent.Provider,
-		ToolNames:          agent.ToolNames,
-		CapabilityNames:    agent.CapabilityNames,
-		SensitiveResources: []string{recommendation.ResourceNodeID, recommendation.ResourceARN},
-		SourceSignals:      []string{"least_privilege"},
-		Rationale:          fmt.Sprintf("The backing role for %s has least-privilege decision=%s for %s; agent risk inherits that role scope.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), recommendation.Decision, recommendation.DisplayName),
-		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
-		ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agent.AgentNodeID, recommendation.IdentityNodeID, recommendation.ResourceNodeID}, recommendation.ImpactedNodes...)...),
-		ImpactedPath:       append([]AWSAIAgentRiskPathStep{awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region)}, recommendation.ImpactedPath...),
-		Evidence:           recommendation.Evidence,
-		NextAction:         recommendation.NextAction,
-		CreatedAt:          now,
-		UpdatedAt:          now,
-	}), true
+	for _, agent := range affectedAgents {
+		findings = append(findings, awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
+			FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("backing-role-scope", recommendation.RecommendationID, agent.AgentNodeID),
+			CalculationVersion: awsAIAgentRiskVersion,
+			RiskType:           "backing_role_scope",
+			Severity:           awsPrivilegeEscalationSeverity(score),
+			Status:             recommendation.Status,
+			Score:              score,
+			Confidence:         minFloat(recommendation.Confidence, 0.9),
+			AccountID:          recommendation.AccountID,
+			Region:             recommendation.Region,
+			AgentNodeID:        agent.AgentNodeID,
+			AgentID:            agent.AgentID,
+			AgentName:          agent.AgentName,
+			AgentType:          agent.AgentType,
+			RuntimeRoleARN:     agent.RuntimeRoleARN,
+			RuntimeRoleNodeID:  recommendation.IdentityNodeID,
+			Provider:           agent.Provider,
+			ToolNames:          agent.ToolNames,
+			CapabilityNames:    agent.CapabilityNames,
+			SensitiveResources: []string{recommendation.ResourceNodeID, recommendation.ResourceARN},
+			SourceSignals:      []string{"least_privilege"},
+			Rationale:          fmt.Sprintf("The backing role for %s has least-privilege decision=%s for %s; agent risk inherits that role scope.", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), recommendation.Decision, recommendation.DisplayName),
+			EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
+			ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agent.AgentNodeID, recommendation.IdentityNodeID, recommendation.ResourceNodeID}, recommendation.ImpactedNodes...)...),
+			ImpactedPath:       append([]AWSAIAgentRiskPathStep{awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(agent.AgentName, agent.AgentID), agent.AccountID, agent.Region)}, recommendation.ImpactedPath...),
+			Evidence:           recommendation.Evidence,
+			NextAction:         recommendation.NextAction,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}))
+	}
+	return findings
 }
 
 func awsAIAgentRiskFinding(finding AWSAIAgentRiskFinding) AWSAIAgentRiskFinding {

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -633,6 +633,13 @@ func awsAIAgentRiskDedupeFindings(findings []AWSAIAgentRiskFinding) []AWSAIAgent
 }
 
 func awsAIAgentRiskMergeFindings(existing, incoming AWSAIAgentRiskFinding) AWSAIAgentRiskFinding {
+	mergedSourceSignals := dedupeStrings(append(append([]string{}, existing.SourceSignals...), incoming.SourceSignals...))
+	mergedToolNames := dedupeStrings(append(append([]string{}, existing.ToolNames...), incoming.ToolNames...))
+	mergedCapabilityNames := dedupeStrings(append(append([]string{}, existing.CapabilityNames...), incoming.CapabilityNames...))
+	mergedSensitiveResources := dedupeStrings(append(append([]string{}, existing.SensitiveResources...), incoming.SensitiveResources...))
+	mergedEvidence := append(append([]AWSAIAgentRiskEvidence{}, existing.Evidence...), incoming.Evidence...)
+	mergedImpactedNodes := awsAIAgentRiskImpactedNodes(append(append([]string{}, existing.ImpactedNodes...), incoming.ImpactedNodes...)...)
+
 	merged := existing
 	if incoming.Score > merged.Score {
 		merged = incoming
@@ -640,12 +647,12 @@ func awsAIAgentRiskMergeFindings(existing, incoming AWSAIAgentRiskFinding) AWSAI
 	if incoming.Confidence > merged.Confidence {
 		merged.Confidence = incoming.Confidence
 	}
-	merged.SourceSignals = dedupeStrings(append(merged.SourceSignals, incoming.SourceSignals...))
-	merged.ToolNames = dedupeStrings(append(merged.ToolNames, incoming.ToolNames...))
-	merged.CapabilityNames = dedupeStrings(append(merged.CapabilityNames, incoming.CapabilityNames...))
-	merged.SensitiveResources = dedupeStrings(append(merged.SensitiveResources, incoming.SensitiveResources...))
-	merged.Evidence = append(append([]AWSAIAgentRiskEvidence{}, merged.Evidence...), incoming.Evidence...)
-	merged.ImpactedNodes = awsAIAgentRiskImpactedNodes(append(merged.ImpactedNodes, incoming.ImpactedNodes...)...)
+	merged.SourceSignals = mergedSourceSignals
+	merged.ToolNames = mergedToolNames
+	merged.CapabilityNames = mergedCapabilityNames
+	merged.SensitiveResources = mergedSensitiveResources
+	merged.Evidence = mergedEvidence
+	merged.ImpactedNodes = mergedImpactedNodes
 	if merged.Status == "" {
 		merged.Status = incoming.Status
 	}

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -480,6 +480,15 @@ func awsAIAgentRiskFindingFromRuntime(record AWSAgentRuntimeAccessRecord, now ti
 	}
 	score = clampBlastRadiusScore(score)
 	target := firstString(record.TargetResourceNodeIDs)
+	backingRoleNode := firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode)
+	backingRoleARN := firstString(record.BackingRoleARNs)
+	impactedPath := []AWSAIAgentRiskPathStep{
+		awsLeastPrivilegePathStep(record.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(record.AgentName, record.AgentID), record.AccountID, record.Region),
+	}
+	if backingRoleNode != "" {
+		impactedPath = append(impactedPath, awsLeastPrivilegePathStep(backingRoleNode, "backing_role", firstNonEmptyAWSValue(shortAWSARN(backingRoleARN), backingRoleARN, backingRoleNode), record.AccountID, record.Region))
+	}
+	impactedPath = append(impactedPath, awsLeastPrivilegePathStep(firstNonEmptyAWSValue(target, firstString(record.TargetResourceARNs), record.ToolTargetRef), "runtime_target", firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef, target), record.AccountID, record.Region))
 	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
 		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken(riskType, record.CorrelationID),
 		CalculationVersion: awsAIAgentRiskVersion,
@@ -494,22 +503,19 @@ func awsAIAgentRiskFindingFromRuntime(record AWSAgentRuntimeAccessRecord, now ti
 		AgentID:            record.AgentID,
 		AgentName:          record.AgentName,
 		AgentType:          record.AgentType,
-		RuntimeRoleARN:     firstString(record.BackingRoleARNs),
-		RuntimeRoleNodeID:  firstNonEmptyAWSValue(firstString(record.BackingRoleNodeIDs), record.DeclaredBackingRoleNode),
+		RuntimeRoleARN:     backingRoleARN,
+		RuntimeRoleNodeID:  backingRoleNode,
 		ToolNames:          []string{record.ToolName},
 		SensitiveResources: []string{target},
 		SourceSignals:      []string{"agent_runtime_access"},
 		Rationale:          fmt.Sprintf("Runtime correlation for %s/%s returned status=%s with caveats %s.", firstNonEmptyAWSValue(record.AgentName, record.AgentID), firstNonEmptyAWSValue(record.ToolName, "agent invocation"), record.Status, strings.Join(record.Caveats, ", ")),
 		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
-		ImpactedNodes:      awsAIAgentRiskImpactedNodes(record.AgentNodeID, firstString(record.BackingRoleNodeIDs), target),
-		ImpactedPath: []AWSAIAgentRiskPathStep{
-			awsLeastPrivilegePathStep(record.AgentNodeID, "ai_agent", firstNonEmptyAWSValue(record.AgentName, record.AgentID), record.AccountID, record.Region),
-			awsLeastPrivilegePathStep(firstNonEmptyAWSValue(target, firstString(record.TargetResourceARNs), record.ToolTargetRef), "runtime_target", firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef, target), record.AccountID, record.Region),
-		},
-		Evidence:   []AWSAIAgentRiskEvidence{{Source: "agent_runtime_access", EvidenceRef: record.EvidenceRef, Label: "Agent runtime/tool-call correlation", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
-		NextAction: record.NextAction,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		ImpactedNodes:      awsAIAgentRiskImpactedNodes(record.AgentNodeID, backingRoleNode, target),
+		ImpactedPath:       impactedPath,
+		Evidence:           []AWSAIAgentRiskEvidence{{Source: "agent_runtime_access", EvidenceRef: record.EvidenceRef, Label: "Agent runtime/tool-call correlation", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
+		NextAction:         record.NextAction,
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}), true
 }
 

--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -255,6 +255,7 @@ func (s *Service) awsAIAgentRiskSourceSignals(ctx context.Context, workspaceID, 
 func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSAIAgentRiskFinding {
 	findings := []AWSAIAgentRiskFinding{}
 	agentsByRuntimeRole := map[string][]AWSAIAgentIdentityRecord{}
+	agentNodeByID := map[string]string{}
 	for _, agent := range sources.agents.Records {
 		for _, roleKey := range []string{agent.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(agent.RuntimeRoleARN)} {
 			normalizedRoleKey := strings.ToLower(strings.TrimSpace(roleKey))
@@ -262,6 +263,15 @@ func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSA
 				continue
 			}
 			agentsByRuntimeRole[normalizedRoleKey] = appendAWSAIAgentRiskRoleAgent(agentsByRuntimeRole[normalizedRoleKey], agent)
+		}
+		for _, agentKey := range []string{agent.AgentID, agent.AgentARN, agent.AgentNodeID} {
+			normalizedAgentKey := strings.ToLower(strings.TrimSpace(agentKey))
+			if normalizedAgentKey == "" || agent.AgentNodeID == "" {
+				continue
+			}
+			if _, ok := agentNodeByID[normalizedAgentKey]; !ok {
+				agentNodeByID[normalizedAgentKey] = agent.AgentNodeID
+			}
 		}
 		findings = append(findings, awsAIAgentRiskFindingsFromAgent(agent, now)...)
 	}
@@ -271,7 +281,7 @@ func awsAIAgentRiskFindings(sources awsAIAgentRiskSources, now time.Time) []AWSA
 		}
 	}
 	for _, finding := range sources.equivalence.Findings {
-		if derived, ok := awsAIAgentRiskFindingFromSecretEquivalence(finding, now); ok {
+		if derived, ok := awsAIAgentRiskFindingFromSecretEquivalence(finding, agentNodeByID, now); ok {
 			findings = append(findings, derived)
 		}
 	}
@@ -503,12 +513,18 @@ func awsAIAgentRiskFindingFromRuntime(record AWSAgentRuntimeAccessRecord, now ti
 	}), true
 }
 
-func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquivalenceFinding, now time.Time) (AWSAIAgentRiskFinding, bool) {
+func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquivalenceFinding, agentNodeByID map[string]string, now time.Time) (AWSAIAgentRiskFinding, bool) {
 	if strings.TrimSpace(finding.AgentID) == "" && !strings.Contains(finding.EquivalenceType, "agent") {
 		return AWSAIAgentRiskFinding{}, false
 	}
 	score := clampBlastRadiusScore(finding.Score + 4)
-	agentNode := firstNonEmptyAWSValue(awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath), finding.AgentID, finding.IdentityNodeID)
+	agentNode := awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath)
+	if agentNode == "" {
+		agentNode = awsAIAgentRiskResolveAgentNode(finding.AgentID, agentNodeByID)
+	}
+	if agentNode == "" {
+		return AWSAIAgentRiskFinding{}, false
+	}
 	secretRef := firstNonEmptyAWSValue(finding.SecretNodeID, finding.SecretARN, firstString(finding.ImpactedNodes), finding.IdentityNodeID)
 	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
 		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agentNode, finding.Provider, secretRef),
@@ -975,6 +991,14 @@ func awsAIAgentRiskAgentNodeFromPath(path []AWSSecretPermissionEquivalencePathSt
 		}
 	}
 	return ""
+}
+
+func awsAIAgentRiskResolveAgentNode(agentID string, agentNodeByID map[string]string) string {
+	key := strings.ToLower(strings.TrimSpace(agentID))
+	if key == "" {
+		return ""
+	}
+	return agentNodeByID[key]
 }
 
 func awsAIAgentRiskEvidenceBoundary() string {

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAIAgentRiskService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSAIAgentRiskBuildsFindingContract(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	svc, ws := newAIAgentRiskService(t, "project-ai-agent-risk", now)
+
+	result, err := svc.GetAWSAIAgentRisk(defaultScopeContext(), ws, "project-ai-agent-risk", AWSAIAgentRiskRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get ai agent risk: %v", err)
+	}
+	if result.CurrentIssueRef != "#1528" || result.Version != awsAIAgentRiskVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Findings) == 0 || result.Summary.TotalFindings != len(result.Findings) {
+		t.Fatalf("expected finding summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.ExternalCredentialCount == 0 || result.Summary.BroadToolAccessCount == 0 || result.Summary.SensitiveReachabilityCount == 0 {
+		t.Fatalf("expected external credential, broad tool, and sensitive reachability findings: %+v", result.Summary)
+	}
+	if result.Summary.RuntimeObservedCount == 0 || result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected runtime-backed counts and graph relationships: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if result.Summary.RemediationPreviewCount == 0 || len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected remediation previews, caveats, and coverage gaps: summary=%+v caveats=%v gaps=%v", result.Summary, result.Caveats, result.CoverageGaps)
+	}
+	for i := 1; i < len(result.Findings); i++ {
+		if result.Findings[i-1].Score < result.Findings[i].Score {
+			t.Fatalf("findings are not ranked by descending score: %+v", result.Findings)
+		}
+	}
+	for _, finding := range result.Findings {
+		if finding.FindingID == "" || finding.CalculationVersion != awsAIAgentRiskVersion {
+			t.Fatalf("finding missing stable metadata: %+v", finding)
+		}
+		if finding.RiskType == "" || finding.Severity == "" || finding.Status == "" || finding.Rationale == "" {
+			t.Fatalf("finding missing classification fields: %+v", finding)
+		}
+		if finding.Score <= 0 || finding.Confidence <= 0 || finding.AgentNodeID == "" || len(finding.ImpactedPath) < 2 || len(finding.Evidence) == 0 {
+			t.Fatalf("finding missing score, confidence, path, or evidence: %+v", finding)
+		}
+		if finding.EvidenceBoundary != "metadata_only_no_secret_values_no_prompts_no_completions_no_tool_payloads" {
+			t.Fatalf("finding crossed evidence boundary: %+v", finding)
+		}
+		if strings.Contains(strings.ToLower(finding.Rationale), "secret value") && !strings.Contains(strings.ToLower(finding.Rationale), "not collected") {
+			t.Fatalf("rationale must not imply secret value collection: %s", finding.Rationale)
+		}
+		if finding.RemediationCase.CaseID == "" || !finding.RemediationCase.ReadOnlyProjection {
+			t.Fatalf("finding missing read-only remediation preview: %+v", finding.RemediationCase)
+		}
+	}
+}
+
+func TestGetAWSAIAgentRiskFilters(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 5, 0, 0, time.UTC)
+	svc, ws := newAIAgentRiskService(t, "project-ai-agent-risk-filters", now)
+
+	external, err := svc.GetAWSAIAgentRisk(defaultScopeContext(), ws, "project-ai-agent-risk-filters", AWSAIAgentRiskRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		RiskType:     "external_credential_exposure",
+		Search:       "support",
+	})
+	if err != nil {
+		t.Fatalf("risk/search filter: %v", err)
+	}
+	if len(external.Findings) == 0 {
+		t.Fatalf("expected external credential exposure findings")
+	}
+	for _, finding := range external.Findings {
+		if finding.RiskType != "external_credential_exposure" || !strings.Contains(strings.ToLower(finding.AgentName+" "+finding.Rationale), "support") {
+			t.Fatalf("risk/search filter leaked: %+v", finding)
+		}
+	}
+	if external.AppliedFilters["risk_type"] != "external-credential-exposure" || external.AppliedFilters["search"] != "support" {
+		t.Fatalf("expected applied filters, got %+v", external.AppliedFilters)
+	}
+
+	runtimeBacked, err := svc.GetAWSAIAgentRisk(defaultScopeContext(), ws, "project-ai-agent-risk-filters", AWSAIAgentRiskRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Evidence:     "runtime-backed",
+	})
+	if err != nil {
+		t.Fatalf("runtime evidence filter: %v", err)
+	}
+	if len(runtimeBacked.Findings) == 0 {
+		t.Fatalf("expected runtime-backed agent risk findings")
+	}
+	for _, finding := range runtimeBacked.Findings {
+		if !awsStringSliceContains(finding.SourceSignals, "agent_runtime_access") && !awsStringSliceContains(finding.SourceSignals, "least_privilege") {
+			t.Fatalf("runtime-backed filter leaked: %+v", finding)
+		}
+	}
+}
+
+func TestAWSAIAgentRiskIdentifiesOwnerlessAgent(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 10, 0, 0, time.UTC)
+	agent := awsAIAgentFixtureRecord("123456789012", "us-east-1", "custom_agent", "ownerless-agent", "agent-ownerless", "arn:aws:lambda:us-east-1:123456789012:function:ownerless-agent", "arn:aws:iam::123456789012:role/ownerless-agent", now, func(r *AWSAIAgentIdentityRecord) {
+		r.Tags = map[string]string{}
+	})
+
+	findings := awsAIAgentRiskFindingsFromAgent(agent, now)
+	hasOwnerless := false
+	for _, finding := range findings {
+		if finding.RiskType == "ownerless_agent" {
+			hasOwnerless = true
+			if finding.Status != "review" || finding.RemediationCase.CaseID == "" {
+				t.Fatalf("ownerless finding missing review/remediation metadata: %+v", finding)
+			}
+		}
+	}
+	if !hasOwnerless {
+		t.Fatalf("expected ownerless agent finding, got %+v", findings)
+	}
+}
+
+func TestGetAWSAIAgentRiskFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 15, 0, 0, time.UTC)
+	svc, ws := newAIAgentRiskService(t, "project-ai-agent-risk-states", now)
+
+	denied, err := svc.GetAWSAIAgentRisk(defaultScopeContext(), ws, "project-ai-agent-risk-states", AWSAIAgentRiskRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Findings) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress deterministic findings: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSAIAgentRisk(defaultScopeContext(), ws, "project-ai-agent-risk-states", AWSAIAgentRiskRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || len(empty.Findings) != 0 || empty.Summary.TotalFindings != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should be explicit degraded no-evidence state: %+v", empty)
+	}
+}
+
+func TestRouterAWSAIAgentRisk(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 20, 0, 0, time.UTC)
+	svc, _ := newAIAgentRiskService(t, "project-ai-agent-risk-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-ai-agent-risk-route/aws/ai-agent-risk?connector_id=aws-prod&fixture_state=success&risk_type=external_credential_exposure", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Findings AWSAIAgentRiskResult `json:"findings"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Findings.CurrentIssueRef != "#1528" || body.Findings.AppliedFilters["risk_type"] != "external-credential-exposure" || len(body.Findings.Findings) == 0 {
+		t.Fatalf("unexpected route payload: %+v", body.Findings)
+	}
+}

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -200,20 +200,15 @@ func TestAWSAIAgentRiskDedupesExternalCredentialExposureAcrossSources(t *testing
 		"arn:aws:iam::123456789012:role/support-agent",
 		now,
 		func(r *AWSAIAgentIdentityRecord) {
-			r.ProviderKeyReferences = []AWSAIAgentProviderKeyReference{{
-				ReferenceName: "support-openai-key",
-				ReferenceKind: "secret",
-				Reference:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:support-openai-key",
-				TargetNodeID:  "aws:resource:secrets-manager-secret/support-openai-key",
-				Provider:      "openai",
-				Resolved:      true,
-				Confidence:    0.94,
-				EvidenceRef:   "evidence://agent/support-agent/provider-key",
-			}}
+			r.CredentialReferenceRefs = []string{"OPENAI_API_KEY=secretsmanager:prod/support/openai-key"}
 		},
 	)
+	if len(agent.ProviderKeyReferences) == 0 {
+		t.Fatalf("fixture should derive ProviderKeyReferences from CredentialReferenceRefs: %+v", agent)
+	}
+	ref := agent.ProviderKeyReferences[0]
 	providerFinding := AWSSecretPermissionEquivalenceFinding{
-		FindingID:             "aws-secret-permission-equivalence:agent-provider-key-support-agent-support-openai-key",
+		FindingID:             "aws-secret-permission-equivalence:agent-provider-key-support-agent-openai",
 		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
 		EquivalenceType:       "agent_provider_key_equivalence",
 		Severity:              "high",
@@ -226,20 +221,19 @@ func TestAWSAIAgentRiskDedupesExternalCredentialExposureAcrossSources(t *testing
 		PrincipalARN:          agent.RuntimeRoleARN,
 		AgentID:               agent.AgentID,
 		AgentName:             agent.AgentName,
-		SecretNodeID:          "aws:resource:secrets-manager-secret/support-openai-key",
-		SecretARN:             "arn:aws:secretsmanager:us-east-1:123456789012:secret:support-openai-key",
-		SecretLabel:           "support-openai-key",
-		Provider:              "openai",
-		ProviderKeyReference:  "support-openai-key",
+		SecretNodeID:          ref.TargetNodeID,
+		SecretLabel:           ref.ReferenceName,
+		Provider:              ref.Provider,
+		ProviderKeyReference:  ref.ReferenceName,
 		EquivalentPermissions: []string{"read"},
 		SourceSignals:         []string{"secret_permission_equivalence"},
 		Rationale:             "Agent has a provider key reference that can authorize OpenAI API access.",
 		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
-		ImpactedNodes:         []string{agent.RuntimeRoleNodeID, agent.AgentNodeID, "aws:resource:secrets-manager-secret/support-openai-key"},
+		ImpactedNodes:         []string{agent.RuntimeRoleNodeID, agent.AgentNodeID, ref.TargetNodeID},
 		ImpactedPath: []AWSAIAgentRiskPathStep{
 			awsLeastPrivilegePathStep(agent.RuntimeRoleNodeID, "identity", "support-agent-role", agent.AccountID, agent.Region),
 			awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", "support-agent", agent.AccountID, agent.Region),
-			awsLeastPrivilegePathStep("aws:resource:secrets-manager-secret/support-openai-key", "permission_bearing_secret", "support-openai-key", agent.AccountID, agent.Region),
+			awsLeastPrivilegePathStep(ref.TargetNodeID, "permission_bearing_secret", ref.ReferenceName, agent.AccountID, agent.Region),
 		},
 		Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "secret_permission_equivalence", EvidenceRef: "evidence://agent/support-agent/provider-key"}},
 		NextAction: "Rotate or scope the provider key reference and role path.",
@@ -270,6 +264,76 @@ func TestAWSAIAgentRiskDedupesExternalCredentialExposureAcrossSources(t *testing
 	}
 	if len(finding.Evidence) < 2 {
 		t.Fatalf("expected merged evidence from both sources, got %d: %+v", len(finding.Evidence), finding.Evidence)
+	}
+}
+
+func TestAWSAIAgentRiskRuntimeSecretEquivalenceRequiresAgentNode(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 14, 0, 0, time.UTC)
+	agent := awsAIAgentFixtureRecord(
+		"123456789012",
+		"us-east-1",
+		"custom_agent",
+		"case-triage",
+		"case-triage",
+		"arn:aws:lambda:us-east-1:123456789012:function:case-triage",
+		"arn:aws:iam::123456789012:role/case-triage",
+		now,
+		nil,
+	)
+	runtimeFinding := AWSSecretPermissionEquivalenceFinding{
+		FindingID:          "aws-secret-permission-equivalence:runtime-case-triage-openai",
+		CalculationVersion: awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:    "runtime_secret_access_equivalence",
+		Severity:           "high",
+		Status:             "review",
+		Score:              78,
+		Confidence:         0.88,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		IdentityNodeID:     agent.RuntimeRoleNodeID,
+		PrincipalARN:       agent.RuntimeRoleARN,
+		AgentID:            agent.AgentID,
+		SecretNodeID:       "aws:resource:secrets-manager-secret/case-triage-openai",
+		SecretARN:          "arn:aws:secretsmanager:us-east-1:123456789012:secret:case-triage-openai",
+		SecretLabel:        "case-triage-openai",
+		Provider:           "openai",
+		SourceSignals:      []string{"secrets_kms_runtime_access"},
+		EvidenceBoundary:   awsSecretPermissionEvidenceBoundary(),
+		ImpactedPath: []AWSSecretPermissionEquivalencePathStep{
+			awsLeastPrivilegePathStep(agent.RuntimeRoleNodeID, "identity", "case-triage-role", agent.AccountID, agent.Region),
+			awsLeastPrivilegePathStep("aws:resource:secrets-manager-secret/case-triage-openai", "permission_bearing_secret", "case-triage-openai", agent.AccountID, agent.Region),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	resolved := awsAIAgentRiskFindings(awsAIAgentRiskSources{
+		agents:      AWSAIAgentIdentityInventoryResult{Records: []AWSAIAgentIdentityRecord{agent}},
+		equivalence: AWSSecretPermissionEquivalenceResult{Findings: []AWSSecretPermissionEquivalenceFinding{runtimeFinding}},
+	}, now)
+	var derived *AWSAIAgentRiskFinding
+	for i, finding := range resolved {
+		if finding.RiskType == "external_credential_exposure" {
+			derived = &resolved[i]
+		}
+	}
+	if derived == nil {
+		t.Fatalf("expected external credential finding when agent inventory resolves the runtime AgentID, got %+v", resolved)
+	}
+	if derived.AgentNodeID != agent.AgentNodeID {
+		t.Fatalf("expected AgentNodeID to be the inventory graph node %q, got %q", agent.AgentNodeID, derived.AgentNodeID)
+	}
+	if derived.AgentNodeID == runtimeFinding.AgentID {
+		t.Fatalf("AgentNodeID must not be the raw runtime AgentID string %q", runtimeFinding.AgentID)
+	}
+
+	orphaned := awsAIAgentRiskFindings(awsAIAgentRiskSources{
+		equivalence: AWSSecretPermissionEquivalenceResult{Findings: []AWSSecretPermissionEquivalenceFinding{runtimeFinding}},
+	}, now)
+	for _, finding := range orphaned {
+		if finding.RiskType == "external_credential_exposure" {
+			t.Fatalf("expected runtime secret-equivalence without an ai_agent path or inventory match to be suppressed, got %+v", finding)
+		}
 	}
 }
 

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -267,6 +267,39 @@ func TestAWSAIAgentRiskDedupesExternalCredentialExposureAcrossSources(t *testing
 	}
 }
 
+func TestAWSAIAgentRiskRuntimeFindingIncludesDeclaredBackingRole(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 16, 0, 0, time.UTC)
+	record := AWSAgentRuntimeAccessRecord{
+		CorrelationID:           "agent-declared-unused",
+		AccountID:               "123456789012",
+		Region:                  "us-east-1",
+		AgentNodeID:             "aws:agent:123456789012:us-east-1:custom_agent/billing-agent",
+		AgentName:               "billing-agent",
+		AgentID:                 "billing-agent",
+		ToolName:                "issue-refund",
+		Status:                  "declared_unused",
+		Confidence:              0.84,
+		DeclaredBackingRoleNode: "aws:identity:role:declared-billing-agent",
+		EvidenceRef:             "agent-evidence://billing-agent/declared-unused",
+	}
+	finding, ok := awsAIAgentRiskFindingFromRuntime(record, now)
+	if !ok {
+		t.Fatalf("expected runtime finding to be emitted for declared_unused status")
+	}
+	if !awsStringSliceContains(finding.ImpactedNodes, record.DeclaredBackingRoleNode) {
+		t.Fatalf("declared backing role must appear in impacted nodes for graph edges: %+v", finding.ImpactedNodes)
+	}
+	var sawBackingRoleStep bool
+	for _, step := range finding.ImpactedPath {
+		if step.NodeType == "backing_role" && step.NodeID == record.DeclaredBackingRoleNode {
+			sawBackingRoleStep = true
+		}
+	}
+	if !sawBackingRoleStep {
+		t.Fatalf("declared backing role must appear as a path step: %+v", finding.ImpactedPath)
+	}
+}
+
 func TestAWSAIAgentRiskRuntimeSecretEquivalenceRequiresAgentNode(t *testing.T) {
 	now := time.Date(2026, 6, 23, 9, 14, 0, 0, time.UTC)
 	agent := awsAIAgentFixtureRecord(

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -133,6 +133,61 @@ func TestAWSAIAgentRiskIdentifiesOwnerlessAgent(t *testing.T) {
 	}
 }
 
+func TestAWSAIAgentRiskFansOutBackingRoleScopeForSharedRoleAgents(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 12, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	agentA := awsAIAgentFixtureRecord("123456789012", "us-east-1", "custom_agent", "support-agent", "support-agent", "arn:aws:lambda:us-east-1:123456789012:function:support-agent", roleARN, now, nil)
+	agentB := awsAIAgentFixtureRecord("123456789012", "us-east-1", "custom_agent", "billing-agent", "billing-agent", "arn:aws:lambda:us-east-1:123456789012:function:billing-agent", roleARN, now, nil)
+	recommendation := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "aws-least-privilege:shared-runtime-role",
+		CalculationVersion: awsLeastPrivilegeVersion,
+		RecommendationType: "static_grant_unused",
+		Decision:           "review",
+		Severity:           "high",
+		Status:             "review",
+		Score:              78,
+		Confidence:         0.88,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		Service:            "secretsmanager",
+		IdentityNodeID:     awsIdentityNodeIDForAPI(roleARN),
+		ResourceNodeID:     "aws:resource:secrets-manager-secret/shared-provider-key",
+		ResourceARN:        "arn:aws:secretsmanager:us-east-1:123456789012:secret:shared-provider-key",
+		DisplayName:        "shared-provider-key",
+		Rationale:          "Shared runtime role can read a provider key.",
+		ImpactedNodes:      []string{awsIdentityNodeIDForAPI(roleARN), "aws:resource:secrets-manager-secret/shared-provider-key"},
+		ImpactedPath: []AWSLeastPrivilegePathStep{
+			awsLeastPrivilegePathStep(awsIdentityNodeIDForAPI(roleARN), "identity", "shared-agent-runtime", "123456789012", "us-east-1"),
+			awsLeastPrivilegePathStep("aws:resource:secrets-manager-secret/shared-provider-key", "secret", "shared-provider-key", "123456789012", "us-east-1"),
+		},
+		Evidence: []AWSLeastPrivilegeEvidence{{
+			Source:      "least_privilege",
+			EvidenceRef: "evidence://least-privilege/shared-runtime-role",
+			Label:       "Least-privilege role-scope decision",
+			Confidence:  0.88,
+			ObservedAt:  now,
+		}},
+		NextAction: "Review the shared role before removing access.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	findings := awsAIAgentRiskFindings(awsAIAgentRiskSources{
+		agents: AWSAIAgentIdentityInventoryResult{Records: []AWSAIAgentIdentityRecord{agentA, agentB}},
+		least:  AWSLeastPrivilegeResult{Recommendations: []AWSLeastPrivilegeRecommendation{recommendation}},
+	}, now)
+
+	backingRoleScopeByAgent := map[string]bool{}
+	for _, finding := range findings {
+		if finding.RiskType == "backing_role_scope" {
+			backingRoleScopeByAgent[finding.AgentID] = true
+		}
+	}
+	if !backingRoleScopeByAgent["support-agent"] || !backingRoleScopeByAgent["billing-agent"] {
+		t.Fatalf("expected backing role scope finding for each shared-role agent, got %+v", backingRoleScopeByAgent)
+	}
+}
+
 func TestGetAWSAIAgentRiskFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 23, 9, 15, 0, 0, time.UTC)
 	svc, ws := newAIAgentRiskService(t, "project-ai-agent-risk-states", now)

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -188,6 +188,91 @@ func TestAWSAIAgentRiskFansOutBackingRoleScopeForSharedRoleAgents(t *testing.T) 
 	}
 }
 
+func TestAWSAIAgentRiskDedupesExternalCredentialExposureAcrossSources(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 13, 0, 0, time.UTC)
+	agent := awsAIAgentFixtureRecord(
+		"123456789012",
+		"us-east-1",
+		"custom_agent",
+		"support-agent",
+		"support-agent",
+		"arn:aws:ecs:us-east-1:123456789012:service/prod/support-agent",
+		"arn:aws:iam::123456789012:role/support-agent",
+		now,
+		func(r *AWSAIAgentIdentityRecord) {
+			r.ProviderKeyReferences = []AWSAIAgentProviderKeyReference{{
+				ReferenceName: "support-openai-key",
+				ReferenceKind: "secret",
+				Reference:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:support-openai-key",
+				TargetNodeID:  "aws:resource:secrets-manager-secret/support-openai-key",
+				Provider:      "openai",
+				Resolved:      true,
+				Confidence:    0.94,
+				EvidenceRef:   "evidence://agent/support-agent/provider-key",
+			}}
+		},
+	)
+	providerFinding := AWSSecretPermissionEquivalenceFinding{
+		FindingID:             "aws-secret-permission-equivalence:agent-provider-key-support-agent-support-openai-key",
+		CalculationVersion:    awsSecretPermissionEquivalenceVersion,
+		EquivalenceType:       "agent_provider_key_equivalence",
+		Severity:              "high",
+		Status:                "review",
+		Score:                 84,
+		Confidence:            0.94,
+		AccountID:             "123456789012",
+		Region:                "us-east-1",
+		IdentityNodeID:        agent.RuntimeRoleNodeID,
+		PrincipalARN:          agent.RuntimeRoleARN,
+		AgentID:               agent.AgentID,
+		AgentName:             agent.AgentName,
+		SecretNodeID:          "aws:resource:secrets-manager-secret/support-openai-key",
+		SecretARN:             "arn:aws:secretsmanager:us-east-1:123456789012:secret:support-openai-key",
+		SecretLabel:           "support-openai-key",
+		Provider:              "openai",
+		ProviderKeyReference:  "support-openai-key",
+		EquivalentPermissions: []string{"read"},
+		SourceSignals:         []string{"secret_permission_equivalence"},
+		Rationale:             "Agent has a provider key reference that can authorize OpenAI API access.",
+		EvidenceBoundary:      awsSecretPermissionEvidenceBoundary(),
+		ImpactedNodes:         []string{agent.RuntimeRoleNodeID, agent.AgentNodeID, "aws:resource:secrets-manager-secret/support-openai-key"},
+		ImpactedPath: []AWSAIAgentRiskPathStep{
+			awsLeastPrivilegePathStep(agent.RuntimeRoleNodeID, "identity", "support-agent-role", agent.AccountID, agent.Region),
+			awsLeastPrivilegePathStep(agent.AgentNodeID, "ai_agent", "support-agent", agent.AccountID, agent.Region),
+			awsLeastPrivilegePathStep("aws:resource:secrets-manager-secret/support-openai-key", "permission_bearing_secret", "support-openai-key", agent.AccountID, agent.Region),
+		},
+		Evidence:   []AWSSecretPermissionEquivalenceEvidence{{Source: "secret_permission_equivalence", EvidenceRef: "evidence://agent/support-agent/provider-key"}},
+		NextAction: "Rotate or scope the provider key reference and role path.",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	findings := awsAIAgentRiskFindings(awsAIAgentRiskSources{
+		agents:      AWSAIAgentIdentityInventoryResult{Records: []AWSAIAgentIdentityRecord{agent}},
+		equivalence: AWSSecretPermissionEquivalenceResult{Findings: []AWSSecretPermissionEquivalenceFinding{providerFinding}},
+	}, now)
+
+	externalCredentialFindings := []AWSAIAgentRiskFinding{}
+	for _, finding := range findings {
+		if finding.RiskType == "external_credential_exposure" {
+			externalCredentialFindings = append(externalCredentialFindings, finding)
+		}
+	}
+	if len(externalCredentialFindings) != 1 {
+		t.Fatalf("expected one deduplicated external credential finding, got %d: %+v", len(externalCredentialFindings), externalCredentialFindings)
+	}
+	finding := externalCredentialFindings[0]
+	if !awsStringSliceContains(finding.SourceSignals, "ai_agent_identities") {
+		t.Fatalf("expected identity signal merged into external credential finding: %+v", finding.SourceSignals)
+	}
+	if !awsStringSliceContains(finding.SourceSignals, "secret_permission_equivalence") {
+		t.Fatalf("expected secret-permission signal merged into external credential finding: %+v", finding.SourceSignals)
+	}
+	if len(finding.Evidence) < 2 {
+		t.Fatalf("expected merged evidence from both sources, got %d: %+v", len(finding.Evidence), finding.Evidence)
+	}
+}
+
 func TestGetAWSAIAgentRiskFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 23, 9, 15, 0, 0, time.UTC)
 	svc, ws := newAIAgentRiskService(t, "project-ai-agent-risk-states", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3012,6 +3012,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"correlation": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-risk", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAIAgentRisk(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAIAgentRiskRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			AgentID:      strings.TrimSpace(c.Query("agent_id")),
+			RiskType:     strings.TrimSpace(c.Query("risk_type")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			Evidence:     strings.TrimSpace(c.Query("evidence")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws ai agent risk request"})
+			default:
+				logger.Error("get aws ai agent risk",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws ai agent risk"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"findings": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1508,6 +1508,52 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS AI agent risk findings with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        findings: {
+          status: 'ready',
+          summary: { total_findings: 0, filtered_findings: 0 },
+          findings: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectAIAgentRisk(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        agentID: 'support-assistant',
+        riskType: 'external_credential_exposure',
+        evidence: 'runtime-backed',
+        search: 'anthropic',
+        severity: 'high',
+        status: 'review'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/ai-agent-risk?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&agent_id=support-assistant&risk_type=external_credential_exposure&severity=high&status=review&evidence=runtime-backed&search=anthropic'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2700,6 +2700,112 @@ export type AWSAgentRuntimeAccessQuery = {
   status?: string;
 };
 
+export type AWSAIAgentRiskStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAIAgentRiskFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSAIAgentRiskSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSAIAgentRiskFindingStatus = 'action_required' | 'review' | 'monitor' | string;
+
+export type AWSAIAgentRiskRelationship = {
+  finding_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref: string;
+};
+
+export type AWSAIAgentRiskFinding = {
+  finding_id: string;
+  calculation_version: string;
+  risk_type: string;
+  severity: AWSAIAgentRiskSeverity;
+  status: AWSAIAgentRiskFindingStatus;
+  score: number;
+  confidence: number;
+  account_id: string;
+  region: string;
+  agent_node_id: string;
+  agent_id?: string;
+  agent_name?: string;
+  agent_type?: string;
+  runtime_role_arn?: string;
+  runtime_role_node_id?: string;
+  provider?: string;
+  tool_names?: string[];
+  capability_names?: string[];
+  sensitive_resources?: string[];
+  source_signals: string[];
+  rationale: string;
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  next_action: string;
+  remediation_case: AWSLeastPrivilegeRemediationCasePreview;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSAIAgentRiskSummary = {
+  total_findings: number;
+  filtered_findings: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  risk_type_counts: Record<string, number>;
+  external_credential_count: number;
+  broad_tool_access_count: number;
+  sensitive_reachability_count: number;
+  ownerless_agent_count: number;
+  runtime_observed_count: number;
+  backing_role_scope_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+  remediation_preview_count: number;
+};
+
+export type AWSAIAgentRiskResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAIAgentRiskStatus;
+  fixture_state?: AWSAIAgentRiskFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSAIAgentRiskSummary;
+  findings: AWSAIAgentRiskFinding[];
+  relationships: AWSAIAgentRiskRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSAIAgentRiskQuery = {
+  connectorID?: string;
+  fixtureState?: AWSAIAgentRiskFixtureState;
+  accountID?: string;
+  region?: string;
+  agentID?: string;
+  riskType?: string;
+  severity?: string;
+  status?: string;
+  evidence?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -6787,6 +6893,28 @@ export const apiClient = {
         resource: query?.resource,
         outcome: query?.outcome,
         status: query?.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAIAgentRisk(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSAIAgentRiskQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ findings: AWSAIAgentRiskResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/ai-agent-risk${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        agent_id: query?.agentID,
+        risk_type: query?.riskType,
+        severity: query?.severity,
+        status: query?.status,
+        evidence: query?.evidence,
+        search: query?.search
       })}`,
       auth
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3200,6 +3200,94 @@ describe('Domain-first app routes', () => {
     vi.spyOn(api.apiClient, 'getAWSProjectAgentRuntimeAccess').mockResolvedValue({
       correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
     });
+    const getAIAgentRisk = vi.spyOn(api.apiClient, 'getAWSProjectAIAgentRisk').mockResolvedValue({
+      findings: {
+        status: 'ready',
+        findings: [
+          {
+            finding_id: 'aws-ai-agent-risk:support-provider-key',
+            calculation_version: 'aws-ai-agent-risk-engine-v1',
+            risk_type: 'external_credential_exposure',
+            severity: 'high',
+            status: 'review',
+            score: 86,
+            confidence: 0.9,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            agent_node_id: 'aws:agent:external-support-agent',
+            agent_id: 'external-support-agent',
+            agent_name: 'support-assistant',
+            agent_type: 'external_provider_agent',
+            runtime_role_arn: 'arn:aws:iam::123456789012:role/ecs-support-agent-task',
+            runtime_role_node_id: 'aws:identity:arn:aws:iam::123456789012:role/ecs-support-agent-task',
+            provider: 'anthropic',
+            tool_names: ['support-search'],
+            capability_names: ['tool_use'],
+            sensitive_resources: ['aws:resource:credential-reference:support-anthropic-key'],
+            source_signals: ['ai_agent_identities', 'secret_permission_equivalence'],
+            rationale: 'Agent references Anthropic provider credential metadata without exposing the key value.',
+            evidence_boundary: 'metadata_only_no_secret_values_no_prompts_no_completions_no_tool_payloads',
+            impacted_nodes: [
+              'aws:agent:external-support-agent',
+              'aws:identity:arn:aws:iam::123456789012:role/ecs-support-agent-task',
+              'aws:resource:credential-reference:support-anthropic-key'
+            ],
+            impacted_path: [
+              { node_id: 'aws:agent:external-support-agent', node_type: 'ai_agent', label: 'support-assistant' },
+              { node_id: 'aws:identity:arn:aws:iam::123456789012:role/ecs-support-agent-task', node_type: 'runtime_role', label: 'ecs-support-agent-task' },
+              { node_id: 'aws:resource:credential-reference:support-anthropic-key', node_type: 'provider_key_reference', label: 'ANTHROPIC_API_KEY' }
+            ],
+            evidence: [
+              {
+                source: 'ai_agent_identities',
+                evidence_ref: 'evidence://agent/support-assistant/anthropic',
+                label: 'Agent provider-key metadata',
+                confidence: 0.9,
+                observed_at: '2026-06-23T09:00:00Z',
+                relationship: 'references_external_provider_key'
+              }
+            ],
+            next_action: 'Rotate or scope the external provider credential and restrict every AWS identity that can read its reference.',
+            remediation_case: {
+              case_id: 'aws-ai-agent-risk-preview:support-provider-key',
+              title: 'External credential exposure AI agent risk review',
+              recommended_action: 'Rotate or scope the external provider credential.',
+              approval_required: true,
+              blocking_evidence: ['evidence://agent/support-assistant/anthropic'],
+              impacted_node_count: 3,
+              estimated_risk_drop: 40,
+              breakage_prediction: 'unknown',
+              read_only_projection: true
+            },
+            created_at: '2026-06-23T09:00:00Z',
+            updated_at: '2026-06-23T09:00:00Z'
+          }
+        ],
+        summary: {
+          total_findings: 1,
+          filtered_findings: 1,
+          external_credential_count: 1,
+          broad_tool_access_count: 0,
+          sensitive_reachability_count: 0,
+          ownerless_agent_count: 0,
+          runtime_observed_count: 0,
+          backing_role_scope_count: 0,
+          relationship_count: 1,
+          highest_score: 86,
+          average_confidence_pct: 90,
+          remediation_preview_count: 1,
+          severity_counts: { high: 1 },
+          status_counts: { review: 1 },
+          risk_type_counts: { external_credential_exposure: 1 }
+        },
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -3509,6 +3597,8 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
     expect(await screen.findByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
     expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS AI agent risk findings' })).toBeInTheDocument();
+    expect(screen.getAllByText(/External credential exposure/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();
@@ -3523,6 +3613,12 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS secret-to-permission equivalence findings' })).toBeInTheDocument();
     expect(screen.getByText(/Agent provider key equivalence/i)).toBeInTheDocument();
     expect(getLeastPrivilege).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getAIAgentRisk).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -55,6 +55,8 @@ import {
   type AWSS3RuntimeAccessResult,
   type AWSAgentRuntimeAccessRecord,
   type AWSAgentRuntimeAccessResult,
+  type AWSAIAgentRiskFinding,
+  type AWSAIAgentRiskResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -10469,6 +10471,113 @@ function AWSAgentRuntimeAccessContent({
   );
 }
 
+function awsAIAgentRiskStage(finding: AWSAIAgentRiskFinding): AWSCapabilityStage {
+  if (finding.status === 'action_required' || finding.severity === 'critical') {
+    return 'not-available';
+  }
+  if (finding.severity === 'high') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsAIAgentRiskLabel(finding: AWSAIAgentRiskFinding): string {
+  return `${formatTokenLabel(finding.risk_type)} · score ${finding.score}`;
+}
+
+function awsAIAgentRiskEvidenceLabel(finding: AWSAIAgentRiskFinding): string {
+  const sources = finding.evidence.map((evidence) => evidence.label || formatTokenLabel(evidence.source));
+  return `${formatConfidenceScore(finding.confidence)} · ${sources.join(', ') || 'No evidence refs'}`;
+}
+
+function awsAIAgentRiskScopeLabel(finding: AWSAIAgentRiskFinding): string {
+  const tools = finding.tool_names ?? [];
+  const sensitive = finding.sensitive_resources ?? [];
+  if (tools.length > 0) {
+    return `${tools.slice(0, 3).join(', ')}${tools.length > 3 ? ` +${tools.length - 3}` : ''}`;
+  }
+  if (sensitive.length > 0) {
+    return `${sensitive.slice(0, 2).join(', ')}${sensitive.length > 2 ? ` +${sensitive.length - 2}` : ''}`;
+  }
+  return finding.provider || '-';
+}
+
+function AWSAIAgentRiskContent({
+  findings,
+  loading,
+  error,
+  onRetry
+}: {
+  findings: AWSAIAgentRiskResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = findings?.findings ?? [];
+  const summaryLine = findings
+    ? `${findings.summary.external_credential_count} credential · ${findings.summary.broad_tool_access_count} broad-tool · ${findings.summary.sensitive_reachability_count} sensitive · ${findings.summary.runtime_observed_count} runtime-backed`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS AI agent risk findings">
+      <h3>AWS AI agent risk engine</h3>
+      <p className="idt-app-kicker">
+        Ranked agent risk findings from tool access, external credential exposure, runtime calls, sensitive capabilities,
+        and backing-role scope. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AI agent risk findings"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Calculating AI agent risk"
+          body="Identrail is ranking metadata-only agent inventory, runtime, credential, and role-scope evidence."
+        />
+      ) : null}
+      {!error && !loading && findings && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={findings.status === 'blocked' ? 'Permission required' : 'No agent risk findings'}
+          title={findings.status === 'blocked' ? 'AI agent risk needs read-only evidence access' : 'No AI agent risks detected'}
+          body={findings.failure_reasons[0] ?? 'No broad tools, external credentials, sensitive capabilities, runtime anomalies, or backing-role scope findings matched this environment.'}
+        />
+      ) : null}
+      {!error && !loading && findings && findings.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {findings.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS AI agent risk findings"
+          rows={rows}
+          getRowKey={(row) => row.finding_id}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{awsAIAgentRiskLabel(row)}</strong> },
+            { key: 'agent', header: 'Agent', render: (row) => row.agent_name || row.agent_id || row.agent_node_id },
+            { key: 'role', header: 'Backing role', render: (row) => row.runtime_role_arn || row.runtime_role_node_id || '-' },
+            { key: 'scope', header: 'Scope', render: (row) => awsAIAgentRiskScopeLabel(row) },
+            { key: 'evidence', header: 'Evidence', render: (row) => awsAIAgentRiskEvidenceLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsAIAgentRiskStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -11908,6 +12017,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [agentRuntimeAccessLoading, setAgentRuntimeAccessLoading] = useState(false);
   const [agentRuntimeAccessError, setAgentRuntimeAccessError] = useState('');
   const agentRuntimeAccessRequestRef = useRef(0);
+  const [aiAgentRisk, setAIAgentRisk] = useState<AWSAIAgentRiskResult | null>(null);
+  const [aiAgentRiskLoading, setAIAgentRiskLoading] = useState(false);
+  const [aiAgentRiskError, setAIAgentRiskError] = useState('');
+  const aiAgentRiskRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12144,6 +12257,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       agentRuntimeAccessRequestRef.current += 1;
     };
   }, [loadAgentRuntimeAccess]);
+
+  const loadAIAgentRisk = useCallback(async () => {
+    const requestID = ++aiAgentRiskRequestRef.current;
+    setAIAgentRisk(null);
+    setAIAgentRiskError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAIAgentRiskLoading(false);
+      return;
+    }
+    setAIAgentRiskLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAIAgentRisk(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== aiAgentRiskRequestRef.current) {
+        return;
+      }
+      setAIAgentRisk(response.findings);
+    } catch (error) {
+      if (requestID !== aiAgentRiskRequestRef.current) {
+        return;
+      }
+      setAIAgentRiskError(formatAPIError(error, 'Unable to load AWS AI agent risk findings.'));
+    } finally {
+      if (requestID === aiAgentRiskRequestRef.current) {
+        setAIAgentRiskLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadAIAgentRisk();
+    return () => {
+      aiAgentRiskRequestRef.current += 1;
+    };
+  }, [loadAIAgentRisk]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -12607,6 +12768,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={agentRuntimeAccessLoading}
             error={agentRuntimeAccessError}
             onRetry={loadAgentRuntimeAccess}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSAIAgentRiskContent
+            findings={aiAgentRisk}
+            loading={aiAgentRiskLoading}
+            error={aiAgentRiskError}
+            onRetry={loadAIAgentRisk}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Implements the AWS AI agent risk engine for issue #1528.

- Adds a deterministic `GET /aws/ai-agent-risk` API that composes AI agent inventory, runtime/tool-call correlation, secret-permission equivalence, and least-privilege role-scope evidence into ranked findings.
- Surfaces broad tool access, sensitive capability reachability, ownerless agents, external credential exposure, runtime anomalies, and backing-role scope with stable IDs, confidence, rationale, evidence refs, graph paths, and read-only remediation previews.
- Adds the AWS Runtime app panel, typed web client, OpenAPI/docs entries, and regression tests for API behavior, filtering, failure states, and operator-visible UI.

Closes #1528.

## Validation

- `go test ./internal/api`
- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a metadata‑only AWS AI agent risk engine at `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ai-agent-risk`, adds the Runtime panel and typed web client, and documents response schemas in OpenAPI. Tightens node mapping and carries declared backing roles so relationships render correctly. Fulfills #1528.

- **New Features**
  - API: `getAWSProjectAIAgentRisk` ranks findings with filters (`connector_id`, `agent_id`, `risk_type`, `severity`, `status`, `evidence`, `search`). Findings include stable IDs, confidence, rationale, graph paths, relationships, and read‑only remediation previews.
  - Risk types: `broad_tool_access`, `sensitive_data_reachability`, `ownerless_agent`, `external_credential_exposure`, `undeclared_tool_runtime`, `backing_role_mismatch`, `declared_unused_tool`, `backing_role_scope`, `runtime_tool_anomaly`.
  - Relationships: keeps the declared backing role in impacted nodes and adds a `backing_role` step so role edges render for `declared_unused_tool` even without observed runtime roles.
  - Platform/docs: route registered with auth policy; OpenAPI adds `AWSAIAgentRiskResult/Finding/Summary/Relationship` schemas and points the endpoint response to the result schema; docs at `docs/aws-ai-agent-risk-engine.md`.
  - Web: typed client `getAWSProjectAIAgentRisk`; Runtime page shows the “AWS AI agent risk engine” panel with success/empty/degraded/blocked states; tests cover API, router, client, and UI.

- **Bug Fixes**
  - Deduplicates external credential exposure across identity and secret‑permission equivalence, merging evidence and `source_signals`.
  - Fans out least‑privilege backing‑role scope findings to all agents sharing a runtime role.
  - Preserves merged `source_signals` when de‑duping findings.
  - Requires an `ai_agent` path step or an inventory‑resolved agent node before emitting external‑credential findings; suppresses runtime‑only secret accesses missing inventory; OpenAPI `risk_type` enum now includes `runtime_tool_anomaly`.

<sup>Written for commit 7b8dfa719bec9240145d0fda6e1fe5250a9adddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

