### PR TITLE
Fix AI agent runtime review follow-ups

### DIFF
--- a/internal/api/aws_ai_agent_risk.go
+++ b/internal/api/aws_ai_agent_risk.go
@@ -458,7 +458,7 @@ func awsAIAgentRiskFindingsFromAgent(agent AWSAIAgentIdentityRecord, now time.Ti
 }
 
 func awsAIAgentRiskFindingFromRuntime(record AWSAgentRuntimeAccessRecord, now time.Time) (AWSAIAgentRiskFinding, bool) {
-	if record.Status == "confirmed" && !awsStringSliceContains(record.Caveats, "observed_backing_role_differs_from_declared") && !awsStringSliceContains(record.Caveats, "observed_tool_call_failed") {
+	if record.Status == "confirmed" && len(normalizeStringList(record.Caveats)) == 0 {
 		return AWSAIAgentRiskFinding{}, false
 	}
 	riskType := "runtime_tool_anomaly"
@@ -524,7 +524,8 @@ func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquiv
 		return AWSAIAgentRiskFinding{}, false
 	}
 	score := clampBlastRadiusScore(finding.Score + 4)
-	agentNode := awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath)
+	pathAgentNode := awsAIAgentRiskAgentNodeFromPath(finding.ImpactedPath)
+	agentNode := pathAgentNode
 	if agentNode == "" {
 		agentNode = awsAIAgentRiskResolveAgentNode(finding.AgentID, agentNodeByID)
 	}
@@ -532,6 +533,10 @@ func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquiv
 		return AWSAIAgentRiskFinding{}, false
 	}
 	secretRef := firstNonEmptyAWSValue(finding.SecretNodeID, finding.SecretARN, firstString(finding.ImpactedNodes), finding.IdentityNodeID)
+	impactedPath := finding.ImpactedPath
+	if pathAgentNode == "" {
+		impactedPath = append([]AWSAIAgentRiskPathStep{awsLeastPrivilegePathStep(agentNode, "ai_agent", firstNonEmptyAWSValue(finding.AgentName, finding.AgentID), finding.AccountID, finding.Region)}, impactedPath...)
+	}
 	return awsAIAgentRiskFinding(AWSAIAgentRiskFinding{
 		FindingID:          "aws-ai-agent-risk:" + stableAWSBlastRadiusToken("external-credential-exposure", agentNode, finding.Provider, secretRef),
 		CalculationVersion: awsAIAgentRiskVersion,
@@ -553,7 +558,7 @@ func awsAIAgentRiskFindingFromSecretEquivalence(finding AWSSecretPermissionEquiv
 		Rationale:          finding.Rationale,
 		EvidenceBoundary:   awsAIAgentRiskEvidenceBoundary(),
 		ImpactedNodes:      awsAIAgentRiskImpactedNodes(append([]string{agentNode, finding.IdentityNodeID, finding.SecretNodeID}, finding.ImpactedNodes...)...),
-		ImpactedPath:       finding.ImpactedPath,
+		ImpactedPath:       impactedPath,
 		Evidence:           finding.Evidence,
 		NextAction:         finding.NextAction,
 		CreatedAt:          now,

--- a/internal/api/aws_ai_agent_risk_test.go
+++ b/internal/api/aws_ai_agent_risk_test.go
@@ -300,6 +300,31 @@ func TestAWSAIAgentRiskRuntimeFindingIncludesDeclaredBackingRole(t *testing.T) {
 	}
 }
 
+func TestAWSAIAgentRiskRuntimeFindingIncludesLineageOnlyCaveat(t *testing.T) {
+	now := time.Date(2026, 6, 23, 9, 17, 0, 0, time.UTC)
+	record := AWSAgentRuntimeAccessRecord{
+		CorrelationID:         "agent-lineage-unresolved",
+		AccountID:             "123456789012",
+		Region:                "us-east-1",
+		AgentNodeID:           "aws:agent:123456789012:us-east-1:custom_agent/support-agent",
+		AgentName:             "support-agent",
+		AgentID:               "support-agent",
+		ToolName:              "lookup-case",
+		Status:                "confirmed",
+		Caveats:               []string{"session_lineage_unresolved"},
+		Confidence:            0.82,
+		TargetResourceNodeIDs: []string{"aws:resource:dynamodb-table/cases"},
+		EvidenceRef:           "agent-evidence://support-agent/lineage-unresolved",
+	}
+	finding, ok := awsAIAgentRiskFindingFromRuntime(record, now)
+	if !ok {
+		t.Fatalf("expected confirmed runtime record with lineage caveat to emit a finding")
+	}
+	if finding.RiskType != "runtime_tool_anomaly" {
+		t.Fatalf("expected lineage-only caveat to use runtime_tool_anomaly, got %q", finding.RiskType)
+	}
+}
+
 func TestAWSAIAgentRiskRuntimeSecretEquivalenceRequiresAgentNode(t *testing.T) {
 	now := time.Date(2026, 6, 23, 9, 14, 0, 0, time.UTC)
 	agent := awsAIAgentFixtureRecord(
@@ -358,6 +383,9 @@ func TestAWSAIAgentRiskRuntimeSecretEquivalenceRequiresAgentNode(t *testing.T) {
 	}
 	if derived.AgentNodeID == runtimeFinding.AgentID {
 		t.Fatalf("AgentNodeID must not be the raw runtime AgentID string %q", runtimeFinding.AgentID)
+	}
+	if len(derived.ImpactedPath) == 0 || derived.ImpactedPath[0].NodeType != "ai_agent" || derived.ImpactedPath[0].NodeID != agent.AgentNodeID {
+		t.Fatalf("expected resolved AI agent to prefix impacted path, got %+v", derived.ImpactedPath)
 	}
 
 	orphaned := awsAIAgentRiskFindings(awsAIAgentRiskSources{


### PR DESCRIPTION
Follow-up to #1669.\n\n## Summary\n- Preserve lineage-only confirmed runtime caveats as runtime_tool_anomaly findings.\n- Prefix inventory-resolved secret-equivalence paths with the resolved AI agent graph node.\n- Add regression coverage for both review cases.\n\n## Tests\n- go test ./internal/api -run 'TestAWSAIAgentRisk(RuntimeFindingIncludesLineageOnlyCaveat|RuntimeSecretEquivalenceRequiresAgentNode)'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime risk review to emit findings for lineage-only caveats and to prefix secret-equivalence paths with the resolved agent node. Includes regression tests.

- **Bug Fixes**
  - Confirmed runtime records with only lineage caveats (e.g., `session_lineage_unresolved`) now produce `runtime_tool_anomaly` findings.
  - Secret-equivalence findings resolve the agent by ID and prefix the impacted path with the `ai_agent` node when missing, preventing orphaned paths.

<sup>Written for commit f200de447c29e689ee0ff8aae740f4d9ae8d1149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

