### PR TITLE
Implement AWS remediation case model (#1529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS remediation case model** (#1529). Adds a read-only, metadata-only
+  engine that composes upstream AI agent risk (#1528), least-privilege
+  (#1522), secret-permission equivalence (#1527), and blast-radius (#1521)
+  findings into ranked, explainable remediation cases. Cases carry a stable
+  `case_id`, source type, lifecycle (`proposed` → `in_review` → `approved`
+  derived deterministically), severity/status/score/confidence, identity and
+  resource context, owner and approval state, a read-only `diff_intent`
+  (before/after refs only — no rendered policy bodies), tradeoffs across
+  breakage, blast radius, observability, and rotation, a rollback plan, a
+  verification plan, source signals, evidence refs, impacted graph nodes/path,
+  next actions, and a deterministic `proposed` audit entry. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases`
+  with filters for connector, account, region, identity, source type,
+  lifecycle, severity, status, approval state, owner-assigned, and free-text
+  search; OpenAPI schemas and authz wiring follow the neighboring AWS
+  intelligence engines. The AWS Runtime app surface now shows an **AWS
+  remediation case model** panel with case, source/lifecycle, identity, diff
+  intent, tradeoffs, owner/approval, severity/status, and verification
+  strategy. The engine never mutates AWS, never reads or returns secret
+  values, prompts, completions, tool payloads, browser pages, code-interpreter
+  output, database rows, object contents, customer payloads, or rendered
+  policy bodies; approve/execute/verify transitions belong to later wave
+  issues.
 - **Per-domain executive reports.** `/v1/enterprise/reports/executive` now
   accepts `?domain=aws|github|kubernetes`; the report aggregates only the
   matching finding source (GitHub = repo findings, AWS / Kubernetes = graph

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS account/region fan-out worker: `aws-account-region-fanout-worker.md`
 - AWS AI agent identities: `aws-ai-agent-identities.md`
 - AWS AI agent risk engine: `aws-ai-agent-risk-engine.md`
+- AWS remediation case model: `aws-remediation-case-model.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-remediation-case-model.md
+++ b/docs/aws-remediation-case-model.md
@@ -1,0 +1,170 @@
+# AWS remediation case model
+
+Issue #1529 (Wave 7.01) adds a metadata-only engine that turns AWS AI agent
+risk, least-privilege, secret-permission equivalence, and blast-radius findings
+into ranked, explainable remediation cases. Cases pair every finding with a
+read-only diff intent, tradeoffs, rollback plan, verification plan, owner and
+approval state, and a deterministic audit trail.
+
+This issue is the **planning** capability of the Identrail remediation loop.
+It does not mutate AWS state, does not call any AWS write API, and does not
+collect prompts, completions, browser pages, code-interpreter output, database
+rows, object contents, secret values, or rendered policy bodies. Approve,
+execute, verify, rollback, and govern transitions belong to later wave
+issues.
+
+## What it produces
+
+The engine emits `AWSRemediationCase` records sourced from four upstream
+intelligence engines:
+
+- `ai_agent_risk` (#1528) - AI agent risk findings
+- `least_privilege` (#1522) - IAM scope recommendations
+- `secret_permission_equivalence` (#1527) - secret/KMS equivalence findings
+- `blast_radius` (#1521) - cross-account / sensitive reachability findings
+
+Every case carries:
+
+- **Identifiers**: stable `case_id`, `calculation_version`, originating
+  `source_type`, and `source_finding_id` for back-reference.
+- **Lifecycle**: one of `proposed`, `in_review`, `approved`, `executed`,
+  `verified`, `closed`, or `rolled_back`. Cases produced by this issue never
+  enter `executed`, `verified`, `closed`, or `rolled_back` - those require a
+  future remediation-executor wave to land.
+- **Severity / status / score / confidence**: inherited from the upstream
+  finding so dashboards stay consistent.
+- **Identity context**: account, region, identity node id, ARN, name, type,
+  provider, owner metadata, and impacted resource node ids.
+- **Approval state**: `not_required`, `pending_owner`, `pending_owner_review`,
+  `pending_approver`, `approved`, or `rejected`. Derivation is deterministic:
+  critical / high severity or risky diff kinds (secret rotation, IAM trust
+  edit, KMS grant edit) require approval; if the upstream finding lacks owner
+  metadata the case is held in `pending_owner` until ownership is assigned.
+- **Diff intent**: one of `iam_policy_diff`, `iam_trust_diff`,
+  `role_scope_diff`, `secret_rotation`, `kms_grant_diff`,
+  `ai_agent_scope_change`, `owner_assignment`, or `manual_review`. The intent
+  carries `before_ref` and `after_ref` metadata pointers but never inlines a
+  rendered policy body, secret value, or workload payload.
+- **Tradeoffs**: one or more operator-visible entries across `breakage_risk`,
+  `observability_impact`, `downstream_blast_radius`, and `rotation_risk` with
+  direction (`improves`, `worsens`, `neutral`) and severity.
+- **Rollback plan**: strategy plus the steps an operator would follow to
+  revert if a future executor lands the diff.
+- **Verification plan**: strategy plus success/failure signals that a future
+  executor or operator would check after applying the diff.
+- **Evidence / source signals**: refs only, never payloads.
+- **Audit trail**: deterministic system-emitted `proposed` event with the
+  case's first evidence ref. Future wave issues append `reviewed`, `approved`,
+  `executed`, `verified`, `closed`, and `rolled_back` rows.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-cases`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `identity` | substring search across identity node, ARN, name, type, or owner |
+| `source_type` | `ai_agent_risk`, `least_privilege`, `secret_permission_equivalence`, or `blast_radius` |
+| `lifecycle` | one of the lifecycle states above |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `action_required`, `review`, or `monitor` |
+| `approval_state` | one of the approval states above |
+| `owner_assigned` | `true`/`false` to restrict to owner-assigned or ownerless cases |
+| `search` | free-text search across case, diff, tradeoff, rollback, verification, evidence, and audit-trail fields |
+
+Response shape: `{ "cases": AWSRemediationCaseResult }` with summary, ranked
+cases, graph relationships, caveats, failure reasons, remediation hints,
+evidence links, coverage gaps, diagnostics, and the standard
+tenant/workspace/project issue metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays secret values, prompt text,
+completions, tool inputs or outputs, browser pages, code-interpreter output,
+database rows, object contents, customer payloads, or rendered policy bodies.
+It only composes:
+
+- AI agent risk findings (already metadata-only)
+- least-privilege recommendations (already metadata-only)
+- secret-permission equivalence findings (already metadata-only)
+- blast-radius findings (already metadata-only)
+
+`before_ref` and `after_ref` on the diff intent are metadata pointers (issue
+URLs, evidence URIs, projection URIs). They never carry rendered diffs.
+
+## AWS permissions
+
+This capability adds no live mutation and requires no additional AWS
+permissions beyond what the upstream intelligence engines already need. It
+reuses their read-only metadata access.
+
+Do not grant permissions that read prompts, invocations, memory records,
+browser pages, code-interpreter output, database rows, object contents, or
+secret values for this issue.
+
+## Lifecycle and approval derivation
+
+Lifecycle is derived deterministically:
+
+| Upstream signal | Lifecycle |
+|---|---|
+| confidence < 0.55 | `proposed` |
+| status = `action_required` AND owner missing | `in_review` |
+| status = `action_required` AND owner assigned AND approval pending | `approved` |
+| status = `review` | `in_review` |
+| status = `monitor` (or anything else) | `proposed` |
+
+Approval is required for `critical`/`high` severity or any of the destructive
+diff kinds (`secret_rotation`, `iam_trust_diff`, `kms_grant_diff`). When
+required but no owner is assigned, the case sits at `pending_owner`;
+otherwise it advances to `pending_approver`.
+
+## Failure handling
+
+- **Ready**: every upstream source was available and emitted no blocking
+  diagnostics.
+- **Degraded**: at least one upstream source was partial, capability-limited,
+  empty because live evidence is unavailable, or produced retryable
+  diagnostics. The cases already composed remain visible.
+- **Blocked**: at least one upstream source is permission denied. The response
+  has zero deterministic cases plus diagnostics and failure reasons.
+
+Unknown, unsupported, partial, degraded, and permission-denied evidence stays
+explicit and is not treated as proof that a case is safe to execute.
+
+## App surface
+
+The AWS Runtime app surface renders the **AWS remediation case model** panel
+with ranked cases, identity / resource context, lifecycle, owner / approval
+state, diff intent, tradeoffs, rollback and verification plans, evidence refs,
+and next actions. Operators can inspect the planned remediation without
+reading logs or database rows.
+
+## Live validation
+
+1. Confirm blockers #1522 and #1528 are closed.
+2. Run AI agent risk, least privilege, secret-permission equivalence, and
+   blast radius with `fixture_state=success`.
+3. Run the remediation case endpoint with `fixture_state=success` and confirm
+   AI agent, least-privilege, secret, and blast-radius source cases are
+   ranked.
+4. Filter by `source_type=least_privilege`, `severity=high`, `owner_assigned`,
+   and `search` to verify deterministic drill-down.
+5. Run `fixture_state=permission_denied`, `empty`, `degraded`, and
+   `partial_failure` and confirm blocked/degraded states are explicit.
+6. Confirm the AWS Runtime app panel renders success, empty, degraded,
+   permission-denied, and partial-failure states without exposing payloads or
+   secret values.
+
+## Safety gates
+
+- Read-only. No AWS write API is called by this issue.
+- All cases include `read_only_projection: true` on the diff intent.
+- All cases include rollback and verification plans, so a future executor has
+  the safety scaffolding the moment it can land approved changes.
+- The deterministic `proposed` audit entry captures the evidence ref that
+  justified case creation so the audit trail begins at the moment of
+  planning, not at execution.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -574,6 +574,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-cases
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5013,6 +5018,100 @@ paths:
                     $ref: "#/components/schemas/AWSAIAgentRiskResult"
         "400":
           description: Invalid AWS AI agent risk request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-cases:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS remediation cases
+      operationId: getAWSProjectRemediationCases
+      description: Composes ranked, explainable remediation cases from upstream AWS AI agent risk, least-privilege, secret-permission equivalence, and blast-radius findings. Cases carry stable IDs, calculation version, lifecycle, severity, confidence, owner/approval state, diff intent (before/after refs only), tradeoffs, rollback plan, verification plan, evidence refs, source signals, and a deterministic audit trail. The engine is read-only and never mutates AWS state, never reads or returns secret values, prompts, completions, tool payloads, browser pages, code-interpreter output, database rows, object contents, customer payloads, or rendered policy bodies.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional substring search across identity node, ARN, name, type, or owner.
+        - in: query
+          name: source_type
+          schema:
+            type: string
+            enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius]
+        - in: query
+          name: lifecycle
+          schema:
+            type: string
+            enum: [proposed, in_review, approved, executed, verified, closed, rolled_back]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: approval_state
+          schema:
+            type: string
+            enum: [not_required, pending_owner, pending_owner_review, pending_approver, approved, rejected]
+        - in: query
+          name: owner_assigned
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across case, diff, tradeoff, rollback, verification, evidence, and audit-trail fields.
+      responses:
+        "200":
+          description: AWS remediation case contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cases:
+                    $ref: "#/components/schemas/AWSRemediationCaseResult"
+        "400":
+          description: Invalid AWS remediation case request
           content:
             application/json:
               schema:
@@ -12984,6 +13083,251 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAIAgentRiskRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationDiffIntent:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [iam_policy_diff, iam_trust_diff, role_scope_diff, secret_rotation, kms_grant_diff, ai_agent_scope_change, owner_assignment, manual_review]
+        before_ref: { type: string }
+        after_ref: { type: string }
+        diff_summary: { type: string }
+        no_op: { type: boolean }
+        read_only_projection: { type: boolean }
+    AWSRemediationTradeoff:
+      type: object
+      properties:
+        dimension:
+          type: string
+          enum: [breakage_risk, observability_impact, downstream_blast_radius, rotation_risk]
+        direction:
+          type: string
+          enum: [improves, worsens, neutral]
+        description: { type: string }
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+    AWSRemediationRollbackPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSRemediationVerificationPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        success_signals:
+          type: array
+          items: { type: string }
+        failure_signals:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSRemediationAuditEntry:
+      type: object
+      properties:
+        event_id: { type: string }
+        actor:
+          type: string
+          enum: [system, owner, approver]
+        event_type:
+          type: string
+          enum: [proposed, reviewed, approved, executed, verified, closed, rolled_back]
+        occurred_at:
+          type: string
+          format: date-time
+        evidence_ref: { type: string }
+        notes: { type: string }
+    AWSRemediationRelationship:
+      type: object
+      properties:
+        case_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSRemediationCase:
+      type: object
+      properties:
+        case_id: { type: string }
+        calculation_version: { type: string }
+        source_type:
+          type: string
+          enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius]
+        source_finding_id: { type: string }
+        lifecycle:
+          type: string
+          enum: [proposed, in_review, approved, executed, verified, closed, rolled_back]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        identity_arn: { type: string }
+        identity_name: { type: string }
+        identity_type: { type: string }
+        provider: { type: string }
+        resource_node_ids:
+          type: array
+          items: { type: string }
+        owner: { type: string }
+        owner_assigned: { type: boolean }
+        approval_required: { type: boolean }
+        approval_state:
+          type: string
+          enum: [not_required, pending_owner, pending_owner_review, pending_approver, approved, rejected]
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_actions:
+          type: array
+          items: { type: string }
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationAuditEntry"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationCaseSummary:
+      type: object
+      properties:
+        total_cases: { type: integer }
+        filtered_cases: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        lifecycle_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        approval_state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        owner_assigned_count: { type: integer }
+        ownerless_count: { type: integer }
+        approval_required_count: { type: integer }
+        read_only_projection_count: { type: integer }
+        rollback_plan_count: { type: integer }
+        verification_plan_count: { type: integer }
+        relationship_count: { type: integer }
+        audit_entry_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSRemediationCaseResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSRemediationCaseSummary"
+        cases:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCase"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -758,6 +758,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/s3-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-risk", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -675,15 +675,21 @@ func awsRemediationLeastPrivilegeDiffKind(recommendation AWSLeastPrivilegeRecomm
 }
 
 func awsRemediationDiffIntentForEquivalence(finding AWSSecretPermissionEquivalenceFinding) AWSRemediationDiffIntent {
-	switch finding.EquivalenceType {
-	case "agent_provider_key_equivalence":
-		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "secret://" + finding.SecretNodeID + "/scoped-projection", DiffSummary: "Rotate the agent provider key reference and scope downstream secret reads.", ReadOnlyProjection: true}
-	case "kms_decrypt_equivalence", "kms_grant_equivalence":
-		return AWSRemediationDiffIntent{Kind: "kms_grant_diff", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "kms://" + finding.SecretNodeID + "/scoped-grants", DiffSummary: "Remove broad KMS decrypt/admin reachability that equates to secret read.", ReadOnlyProjection: true}
-	case "runtime_secret_access_equivalence":
-		return AWSRemediationDiffIntent{Kind: "iam_policy_diff", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "secret://" + finding.SecretNodeID + "/scoped-read", DiffSummary: "Scope the identity's secret read permission to observed access and add monitoring.", ReadOnlyProjection: true}
+	evidenceRef := evidenceRefFromEquivalence(finding)
+	normalized := strings.ToLower(strings.TrimSpace(finding.EquivalenceType))
+	switch {
+	case strings.Contains(normalized, "kms"):
+		return AWSRemediationDiffIntent{Kind: "kms_grant_diff", BeforeRef: evidenceRef, AfterRef: "kms://" + finding.SecretNodeID + "/scoped-grants", DiffSummary: "Remove broad KMS decrypt/admin reachability that equates to secret read.", ReadOnlyProjection: true}
+	case strings.Contains(normalized, "provider_key"):
+		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRef, AfterRef: "secret://" + finding.SecretNodeID + "/scoped-projection", DiffSummary: "Rotate the provider key reference and scope downstream secret reads.", ReadOnlyProjection: true}
+	case strings.Contains(normalized, "admin"):
+		return AWSRemediationDiffIntent{Kind: "iam_policy_diff", BeforeRef: evidenceRef, AfterRef: "secret://" + finding.SecretNodeID + "/scoped-admin", DiffSummary: "Remove the admin-equivalent secret-permission path; keep only scoped read for owner-approved callers.", ReadOnlyProjection: true}
+	case strings.Contains(normalized, "blast_radius"):
+		return AWSRemediationDiffIntent{Kind: "iam_policy_diff", BeforeRef: evidenceRef, AfterRef: "secret://" + finding.SecretNodeID + "/scoped-read", DiffSummary: "Reduce the blast-radius-derived secret reachability to the minimum observed reader set.", ReadOnlyProjection: true}
+	case strings.Contains(normalized, "runtime_secret_access"), strings.Contains(normalized, "secret_read_policy"):
+		return AWSRemediationDiffIntent{Kind: "iam_policy_diff", BeforeRef: evidenceRef, AfterRef: "secret://" + finding.SecretNodeID + "/scoped-read", DiffSummary: "Scope the identity's secret read permission to observed access and add monitoring.", ReadOnlyProjection: true}
 	default:
-		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRefFromEquivalence(finding), DiffSummary: "Rotate or scope the equivalent secret-permission path.", ReadOnlyProjection: true}
+		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRef, DiffSummary: "Rotate or scope the equivalent secret-permission path.", ReadOnlyProjection: true}
 	}
 }
 

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -414,12 +414,22 @@ func awsRemediationCaseFromLeastPrivilege(recommendation AWSLeastPrivilegeRecomm
 	}
 	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("least-privilege", recommendation.RecommendationID)
 	evidenceRef := firstString(awsRemediationEvidenceRefs(recommendation.Evidence))
+	diffKind := awsRemediationLeastPrivilegeDiffKind(recommendation)
+	noOp := recommendation.Decision != "remove"
+	diffSummary := fmt.Sprintf("Decision=%s on %s; remove %d granted action(s) and keep %d observed action(s).", recommendation.Decision, recommendation.DisplayName, len(recommendation.RemoveActions), len(recommendation.KeepActions))
+	if recommendation.Decision == "review" {
+		diffSummary = fmt.Sprintf("Decision=review on %s; least-privilege evidence is not yet conclusive — manual review required before any diff is projected.", recommendation.DisplayName)
+	}
+	afterRef := "least-privilege://" + recommendation.RecommendationID + "/intended-scope"
+	if recommendation.Decision == "review" {
+		afterRef = ""
+	}
 	diff := AWSRemediationDiffIntent{
-		Kind:               awsRemediationLeastPrivilegeDiffKind(recommendation),
+		Kind:               diffKind,
 		BeforeRef:          evidenceRef,
-		AfterRef:           "least-privilege://" + recommendation.RecommendationID + "/intended-scope",
-		DiffSummary:        fmt.Sprintf("Decision=%s on %s; remove %d granted action(s) and keep %d observed action(s).", recommendation.Decision, recommendation.DisplayName, len(recommendation.RemoveActions), len(recommendation.KeepActions)),
-		NoOp:               recommendation.Decision == "keep",
+		AfterRef:           afterRef,
+		DiffSummary:        diffSummary,
+		NoOp:               noOp,
 		ReadOnlyProjection: true,
 	}
 	approvalRequired := awsRemediationApprovalRequired(recommendation.Severity, diff.Kind)
@@ -654,10 +664,14 @@ func awsRemediationDiffIntentForRiskType(riskType string) AWSRemediationDiffInte
 }
 
 func awsRemediationLeastPrivilegeDiffKind(recommendation AWSLeastPrivilegeRecommendation) string {
-	if recommendation.Decision == "remove" {
+	switch recommendation.Decision {
+	case "remove":
 		return "iam_policy_diff"
+	case "review":
+		return "manual_review"
+	default:
+		return "role_scope_diff"
 	}
-	return "role_scope_diff"
 }
 
 func awsRemediationDiffIntentForEquivalence(finding AWSSecretPermissionEquivalenceFinding) AWSRemediationDiffIntent {
@@ -674,16 +688,23 @@ func awsRemediationDiffIntentForEquivalence(finding AWSSecretPermissionEquivalen
 }
 
 func awsRemediationBlastRadiusDiffKind(riskType string) string {
-	switch riskType {
-	case "cross_account_trust", "cross_account_reach":
+	normalized := normalizeAWSRuntimeEventFilterToken(riskType)
+	if strings.Contains(normalized, "cross-account") {
 		return "iam_trust_diff"
-	case "agent_tool_path", "ai_agent_blast_radius":
-		return "ai_agent_scope_change"
-	case "sensitive_resource_reach":
-		return "role_scope_diff"
-	default:
-		return "iam_policy_diff"
 	}
+	if strings.Contains(normalized, "agent-tool-path") || strings.Contains(normalized, "ai-agent") {
+		return "ai_agent_scope_change"
+	}
+	if strings.Contains(normalized, "kms") {
+		return "kms_grant_diff"
+	}
+	if strings.Contains(normalized, "secret") {
+		return "secret_rotation"
+	}
+	if strings.Contains(normalized, "s3-runtime-access") || strings.Contains(normalized, "sensitive-resource-reach") {
+		return "role_scope_diff"
+	}
+	return "iam_policy_diff"
 }
 
 func awsRemediationApprovalRequired(severity, diffKind string) bool {

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -358,7 +358,7 @@ func awsRemediationCaseFromAIAgentRisk(finding AWSAIAgentRiskFinding, now time.T
 	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
 	owner, ownerAssigned := awsRemediationOwnerFromAgent(finding)
 	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, finding.Status)
-	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState, diff)
 	identityType := "ai_agent"
 	identityNodeID := finding.AgentNodeID
 	identityARN := finding.RuntimeRoleARN
@@ -435,7 +435,7 @@ func awsRemediationCaseFromLeastPrivilege(recommendation AWSLeastPrivilegeRecomm
 	approvalRequired := awsRemediationApprovalRequired(recommendation.Severity, diff.Kind)
 	owner, ownerAssigned := "iam-platform", true
 	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, recommendation.Status)
-	lifecycle := awsRemediationLifecycle(recommendation.Status, recommendation.Confidence, ownerAssigned, approvalState)
+	lifecycle := awsRemediationLifecycle(recommendation.Status, recommendation.Confidence, ownerAssigned, approvalState, diff)
 	c := AWSRemediationCase{
 		CaseID:             caseID,
 		CalculationVersion: awsRemediationCaseVersion,
@@ -484,7 +484,7 @@ func awsRemediationCaseFromSecretEquivalence(finding AWSSecretPermissionEquivale
 	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
 	owner, ownerAssigned := awsRemediationOwnerFromEquivalence(finding)
 	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, finding.Status)
-	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState, diff)
 	c := AWSRemediationCase{
 		CaseID:             caseID,
 		CalculationVersion: awsRemediationCaseVersion,
@@ -542,7 +542,7 @@ func awsRemediationCaseFromBlastRadius(finding AWSBlastRadiusFinding, now time.T
 	}
 	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
 	approvalState := awsRemediationApprovalState(approvalRequired, false, finding.Status)
-	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, false, approvalState)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, false, approvalState, diff)
 	c := AWSRemediationCase{
 		CaseID:             caseID,
 		CalculationVersion: awsRemediationCaseVersion,
@@ -732,16 +732,17 @@ func awsRemediationApprovalState(required, ownerAssigned bool, status string) st
 	return "pending_owner_review"
 }
 
-func awsRemediationLifecycle(status string, confidence float64, ownerAssigned bool, approvalState string) string {
+func awsRemediationLifecycle(status string, confidence float64, ownerAssigned bool, approvalState string, diff AWSRemediationDiffIntent) string {
 	if confidence > 0 && confidence < 0.55 {
 		return "proposed"
 	}
+	executable := awsRemediationDiffIsExecutable(diff)
 	switch normalizeAWSRuntimeEventFilterToken(status) {
 	case "action-required":
 		if !ownerAssigned {
 			return "in_review"
 		}
-		if approvalState == "pending_approver" {
+		if executable && approvalState == "pending_approver" {
 			return "approved"
 		}
 		return "in_review"
@@ -751,6 +752,16 @@ func awsRemediationLifecycle(status string, confidence float64, ownerAssigned bo
 		return "proposed"
 	}
 	return "proposed"
+}
+
+func awsRemediationDiffIsExecutable(diff AWSRemediationDiffIntent) bool {
+	if diff.NoOp {
+		return false
+	}
+	if diff.Kind == "manual_review" {
+		return false
+	}
+	return true
 }
 
 func awsRemediationTitleForRiskType(riskType, agentName, agentID string) string {

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -704,10 +704,7 @@ func awsRemediationBlastRadiusDiffKind(riskType string) string {
 	if strings.Contains(normalized, "kms") {
 		return "kms_grant_diff"
 	}
-	if strings.Contains(normalized, "secret") {
-		return "secret_rotation"
-	}
-	if strings.Contains(normalized, "s3-runtime-access") || strings.Contains(normalized, "sensitive-resource-reach") {
+	if strings.Contains(normalized, "secret-runtime-access") || strings.Contains(normalized, "s3-runtime-access") || strings.Contains(normalized, "sensitive-resource-reach") {
 		return "role_scope_diff"
 	}
 	return "iam_policy_diff"
@@ -929,7 +926,14 @@ func awsRemediationVerificationForRiskType(riskType, evidenceRef string) AWSReme
 	}
 }
 
-func awsRemediationVerificationForLeastPrivilege(_ AWSLeastPrivilegeRecommendation, evidenceRef string) AWSRemediationVerificationPlan {
+func awsRemediationVerificationForLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, evidenceRef string) AWSRemediationVerificationPlan {
+	if recommendation.Decision != "remove" {
+		return AWSRemediationVerificationPlan{
+			Strategy:    "manual_review",
+			Steps:       []string{"Least-privilege evidence is inconclusive; no projected diff to simulate.", "Re-run least-privilege after upstream evidence settles into a remove/keep decision."},
+			EvidenceRef: evidenceRef,
+		}
+	}
 	return AWSRemediationVerificationPlan{
 		Strategy:       "policy_simulate",
 		Steps:          []string{"Run IAM policy simulator with observed actions to confirm none regress.", "Re-run least-privilege to confirm the recommendation flips to keep."},

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -1,0 +1,1293 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsRemediationCaseCurrentIssue = 1529
+	awsRemediationCaseVersion      = "aws-remediation-case-model-v1"
+)
+
+// AWSRemediationCaseRequest scopes the deterministic remediation case engine
+// to one AWS connector plus optional operator drill-down filters.
+type AWSRemediationCaseRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Identity      string `json:"identity,omitempty"`
+	SourceType    string `json:"source_type,omitempty"`
+	Lifecycle     string `json:"lifecycle,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	ApprovalState string `json:"approval_state,omitempty"`
+	OwnerAssigned string `json:"owner_assigned,omitempty"`
+	Search        string `json:"search,omitempty"`
+}
+
+// AWSRemediationCaseEvidence and path step reuse the least-privilege contract
+// so the case model stays consistent with upstream intelligence engines.
+type AWSRemediationCaseEvidence = AWSLeastPrivilegeEvidence
+type AWSRemediationCasePathStep = AWSLeastPrivilegePathStep
+type AWSRemediationCaseDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSRemediationCaseCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSRemediationDiffIntent describes the read-only before/after intent of a
+// remediation case. It carries metadata refs only; no policy bodies, secret
+// values, or rendered diffs are inlined.
+type AWSRemediationDiffIntent struct {
+	Kind               string `json:"kind"`
+	BeforeRef          string `json:"before_ref,omitempty"`
+	AfterRef           string `json:"after_ref,omitempty"`
+	DiffSummary        string `json:"diff_summary"`
+	NoOp               bool   `json:"no_op"`
+	ReadOnlyProjection bool   `json:"read_only_projection"`
+}
+
+// AWSRemediationTradeoff explains an operator-visible cost the case introduces
+// (breakage risk, observability impact, etc.).
+type AWSRemediationTradeoff struct {
+	Dimension   string `json:"dimension"`
+	Direction   string `json:"direction"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+}
+
+// AWSRemediationRollbackPlan documents how an executed change can be undone.
+type AWSRemediationRollbackPlan struct {
+	Strategy    string   `json:"strategy"`
+	Steps       []string `json:"steps"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSRemediationVerificationPlan documents how an executed change is verified.
+type AWSRemediationVerificationPlan struct {
+	Strategy       string   `json:"strategy"`
+	Steps          []string `json:"steps"`
+	SuccessSignals []string `json:"success_signals,omitempty"`
+	FailureSignals []string `json:"failure_signals,omitempty"`
+	EvidenceRef    string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSRemediationAuditEntry is a deterministic audit row attached to the case.
+// Because no execution happens in this issue, the only entry is the
+// system-generated proposal event.
+type AWSRemediationAuditEntry struct {
+	EventID     string    `json:"event_id"`
+	Actor       string    `json:"actor"`
+	EventType   string    `json:"event_type"`
+	OccurredAt  time.Time `json:"occurred_at"`
+	EvidenceRef string    `json:"evidence_ref,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+}
+
+// AWSRemediationRelationship surfaces case→graph node edges so the app and
+// downstream graph consumers can show why a case touches a node.
+type AWSRemediationRelationship struct {
+	CaseID      string `json:"case_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSRemediationCase is the persisted-record-shaped contract emitted by the
+// remediation case engine. It intentionally carries only metadata evidence
+// refs and graph nodes; no policy bodies, secret values, prompts,
+// completions, tool payloads, browser pages, code-interpreter output,
+// database rows, object contents, or customer payloads are inlined.
+type AWSRemediationCase struct {
+	CaseID             string                         `json:"case_id"`
+	CalculationVersion string                         `json:"calculation_version"`
+	SourceType         string                         `json:"source_type"`
+	SourceFindingID    string                         `json:"source_finding_id"`
+	Lifecycle          string                         `json:"lifecycle"`
+	Severity           string                         `json:"severity"`
+	Status             string                         `json:"status"`
+	Score              int                            `json:"score"`
+	Confidence         float64                        `json:"confidence"`
+	Title              string                         `json:"title"`
+	Summary            string                         `json:"summary"`
+	AccountID          string                         `json:"account_id"`
+	Region             string                         `json:"region"`
+	IdentityNodeID     string                         `json:"identity_node_id,omitempty"`
+	IdentityARN        string                         `json:"identity_arn,omitempty"`
+	IdentityName       string                         `json:"identity_name,omitempty"`
+	IdentityType       string                         `json:"identity_type,omitempty"`
+	Provider           string                         `json:"provider,omitempty"`
+	ResourceNodeIDs    []string                       `json:"resource_node_ids,omitempty"`
+	Owner              string                         `json:"owner,omitempty"`
+	OwnerAssigned      bool                           `json:"owner_assigned"`
+	ApprovalRequired   bool                           `json:"approval_required"`
+	ApprovalState      string                         `json:"approval_state"`
+	DiffIntent         AWSRemediationDiffIntent       `json:"diff_intent"`
+	Tradeoffs          []AWSRemediationTradeoff       `json:"tradeoffs"`
+	RollbackPlan       AWSRemediationRollbackPlan     `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan `json:"verification_plan"`
+	SourceSignals      []string                       `json:"source_signals"`
+	Evidence           []AWSRemediationCaseEvidence   `json:"evidence"`
+	EvidenceBoundary   string                         `json:"evidence_boundary"`
+	ImpactedNodes      []string                       `json:"impacted_nodes"`
+	ImpactedPath       []AWSRemediationCasePathStep   `json:"impacted_path"`
+	NextActions        []string                       `json:"next_actions"`
+	AuditTrail         []AWSRemediationAuditEntry     `json:"audit_trail"`
+	CreatedAt          time.Time                      `json:"created_at"`
+	UpdatedAt          time.Time                      `json:"updated_at"`
+}
+
+// AWSRemediationCaseSummary aggregates the unfiltered and filtered case set.
+type AWSRemediationCaseSummary struct {
+	TotalCases              int            `json:"total_cases"`
+	FilteredCases           int            `json:"filtered_cases"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	LifecycleCounts         map[string]int `json:"lifecycle_counts"`
+	SourceTypeCounts        map[string]int `json:"source_type_counts"`
+	ApprovalStateCounts     map[string]int `json:"approval_state_counts"`
+	OwnerAssignedCount      int            `json:"owner_assigned_count"`
+	OwnerlessCount          int            `json:"ownerless_count"`
+	ApprovalRequiredCount   int            `json:"approval_required_count"`
+	ReadOnlyProjectionCount int            `json:"read_only_projection_count"`
+	RollbackPlanCount       int            `json:"rollback_plan_count"`
+	VerificationPlanCount   int            `json:"verification_plan_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	AuditEntryCount         int            `json:"audit_entry_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+}
+
+// AWSRemediationCaseResult is the deterministic case-model envelope.
+type AWSRemediationCaseResult struct {
+	TenantID           string                          `json:"tenant_id"`
+	WorkspaceID        string                          `json:"workspace_id"`
+	ProjectID          string                          `json:"project_id"`
+	ConnectorID        string                          `json:"connector_id,omitempty"`
+	AccountID          string                          `json:"account_id,omitempty"`
+	Region             string                          `json:"region,omitempty"`
+	ParentIssueNumber  int                             `json:"parent_issue_number"`
+	ParentIssueRef     string                          `json:"parent_issue_ref"`
+	CurrentIssueNumber int                             `json:"current_issue_number"`
+	CurrentIssueRef    string                          `json:"current_issue_ref"`
+	Version            string                          `json:"version"`
+	Status             string                          `json:"status"`
+	FixtureState       string                          `json:"fixture_state,omitempty"`
+	Confidence         float64                         `json:"confidence"`
+	CalculationVersion string                          `json:"calculation_version"`
+	AppliedFilters     map[string]string               `json:"applied_filters"`
+	Summary            AWSRemediationCaseSummary       `json:"summary"`
+	Cases              []AWSRemediationCase            `json:"cases"`
+	Relationships      []AWSRemediationRelationship    `json:"relationships"`
+	Caveats            []string                        `json:"caveats"`
+	FailureReasons     []string                        `json:"failure_reasons"`
+	RemediationHints   []string                        `json:"remediation_hints"`
+	EvidenceLinks      []string                        `json:"evidence_links"`
+	CoverageGaps       []AWSRemediationCaseCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSRemediationCaseDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                       `json:"generated_at"`
+	UpdatedAt          time.Time                       `json:"updated_at"`
+}
+
+type awsRemediationCaseSources struct {
+	risk        AWSAIAgentRiskResult
+	least       AWSLeastPrivilegeResult
+	equivalence AWSSecretPermissionEquivalenceResult
+	blast       AWSBlastRadiusResult
+}
+
+// GetAWSRemediationCases composes ranked, explainable remediation cases from
+// upstream AI agent risk, least-privilege, secret-permission equivalence, and
+// blast-radius findings. The engine is read-only: it never mutates AWS, never
+// reads secret values or workload payloads, and treats unknown or denied
+// evidence as explicit states instead of deterministic truth.
+func (s *Service) GetAWSRemediationCases(ctx context.Context, workspaceID string, projectID string, request AWSRemediationCaseRequest) (AWSRemediationCaseResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRemediationCaseResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRemediationCaseResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSRemediationCaseFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRemediationCaseResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsRemediationCaseSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSRemediationCaseResult{}, err
+	}
+	cases := awsRemediationCases(sources, now)
+	sort.SliceStable(cases, func(i, j int) bool {
+		if cases[i].Score == cases[j].Score {
+			return cases[i].CaseID < cases[j].CaseID
+		}
+		return cases[i].Score > cases[j].Score
+	})
+	filtered, applied := filterAWSRemediationCases(cases, request)
+	relationships := awsRemediationCaseRelationships(filtered)
+	diagnostics := awsRemediationCaseDiagnostics(sources)
+	coverageGaps := awsRemediationCaseCoverageGaps(sources)
+	status, confidence := summarizeAWSRemediationCaseStatus(sources, filtered, diagnostics)
+
+	return AWSRemediationCaseResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationCaseCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationCaseCurrentIssue),
+		Version:            awsRemediationCaseVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationCaseVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSRemediationCases(cases, filtered, relationships),
+		Cases:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsRemediationCaseCaveats(),
+		FailureReasons:     awsRemediationCaseFailureReasons(sources),
+		RemediationHints:   awsRemediationCaseRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			awsIssueURL(awsAIAgentRiskCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),
+			awsIssueURL(awsBlastRadiusCurrentIssue),
+			"/docs/aws-remediation-case-model",
+			"/docs/aws-ai-agent-risk-engine",
+			"/docs/aws-least-privilege",
+			"/docs/aws-secret-permission-equivalence-engine",
+			"/docs/aws-blast-radius-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSRemediationCaseFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsRemediationCaseSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsRemediationCaseSources, error) {
+	risk, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsRemediationCaseSources{}, fmt.Errorf("remediation case ai agent risk: %w", err)
+	}
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsRemediationCaseSources{}, fmt.Errorf("remediation case least privilege: %w", err)
+	}
+	equivalence, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsRemediationCaseSources{}, fmt.Errorf("remediation case secret permission equivalence: %w", err)
+	}
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsRemediationCaseSources{}, fmt.Errorf("remediation case blast radius: %w", err)
+	}
+	return awsRemediationCaseSources{risk: risk, least: least, equivalence: equivalence, blast: blast}, nil
+}
+
+func awsRemediationCases(sources awsRemediationCaseSources, now time.Time) []AWSRemediationCase {
+	cases := []AWSRemediationCase{}
+	for _, finding := range sources.risk.Findings {
+		if c, ok := awsRemediationCaseFromAIAgentRisk(finding, now); ok {
+			cases = append(cases, c)
+		}
+	}
+	for _, recommendation := range sources.least.Recommendations {
+		if c, ok := awsRemediationCaseFromLeastPrivilege(recommendation, now); ok {
+			cases = append(cases, c)
+		}
+	}
+	for _, finding := range sources.equivalence.Findings {
+		if c, ok := awsRemediationCaseFromSecretEquivalence(finding, now); ok {
+			cases = append(cases, c)
+		}
+	}
+	for _, finding := range sources.blast.Findings {
+		if c, ok := awsRemediationCaseFromBlastRadius(finding, now); ok {
+			cases = append(cases, c)
+		}
+	}
+	return awsRemediationCaseDedupe(cases)
+}
+
+func awsRemediationCaseFromAIAgentRisk(finding AWSAIAgentRiskFinding, now time.Time) (AWSRemediationCase, bool) {
+	if finding.FindingID == "" {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("ai-agent-risk", finding.FindingID)
+	diff := awsRemediationDiffIntentForRiskType(finding.RiskType)
+	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
+	owner, ownerAssigned := awsRemediationOwnerFromAgent(finding)
+	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, finding.Status)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState)
+	identityType := "ai_agent"
+	if strings.HasPrefix(finding.RiskType, "backing_role") {
+		identityType = "iam_role"
+	}
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "ai_agent_risk",
+		SourceFindingID:    finding.FindingID,
+		Lifecycle:          lifecycle,
+		Severity:           finding.Severity,
+		Status:             finding.Status,
+		Score:              finding.Score,
+		Confidence:         finding.Confidence,
+		Title:              awsRemediationTitleForRiskType(finding.RiskType, finding.AgentName, finding.AgentID),
+		Summary:            finding.Rationale,
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		IdentityNodeID:     finding.AgentNodeID,
+		IdentityARN:        firstNonEmptyAWSValue(finding.RuntimeRoleARN),
+		IdentityName:       firstNonEmptyAWSValue(finding.AgentName, finding.AgentID),
+		IdentityType:       identityType,
+		Provider:           finding.Provider,
+		ResourceNodeIDs:    awsRemediationResourceNodes(finding.SensitiveResources, finding.ImpactedNodes, finding.AgentNodeID, finding.RuntimeRoleNodeID),
+		Owner:              owner,
+		OwnerAssigned:      ownerAssigned,
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForRiskType(finding.RiskType, finding.Severity),
+		RollbackPlan:       awsRemediationRollbackForDiff(diff, evidenceRefFromAIAgentRisk(finding)),
+		VerificationPlan:   awsRemediationVerificationForRiskType(finding.RiskType, evidenceRefFromAIAgentRisk(finding)),
+		SourceSignals:      finding.SourceSignals,
+		Evidence:           finding.Evidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      finding.ImpactedNodes,
+		ImpactedPath:       finding.ImpactedPath,
+		NextActions:        awsRemediationNextActionList(finding.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
+func awsRemediationCaseFromLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation, now time.Time) (AWSRemediationCase, bool) {
+	if recommendation.RecommendationID == "" || recommendation.Decision == "keep" {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("least-privilege", recommendation.RecommendationID)
+	evidenceRef := firstString(awsRemediationEvidenceRefs(recommendation.Evidence))
+	diff := AWSRemediationDiffIntent{
+		Kind:               awsRemediationLeastPrivilegeDiffKind(recommendation),
+		BeforeRef:          evidenceRef,
+		AfterRef:           "least-privilege://" + recommendation.RecommendationID + "/intended-scope",
+		DiffSummary:        fmt.Sprintf("Decision=%s on %s; remove %d granted action(s) and keep %d observed action(s).", recommendation.Decision, recommendation.DisplayName, len(recommendation.RemoveActions), len(recommendation.KeepActions)),
+		NoOp:               recommendation.Decision == "keep",
+		ReadOnlyProjection: true,
+	}
+	approvalRequired := awsRemediationApprovalRequired(recommendation.Severity, diff.Kind)
+	owner, ownerAssigned := "iam-platform", true
+	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, recommendation.Status)
+	lifecycle := awsRemediationLifecycle(recommendation.Status, recommendation.Confidence, ownerAssigned, approvalState)
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "least_privilege",
+		SourceFindingID:    recommendation.RecommendationID,
+		Lifecycle:          lifecycle,
+		Severity:           recommendation.Severity,
+		Status:             recommendation.Status,
+		Score:              recommendation.Score,
+		Confidence:         recommendation.Confidence,
+		Title:              fmt.Sprintf("Least-privilege %s for %s", recommendation.Decision, firstNonEmptyAWSValue(recommendation.DisplayName, recommendation.IdentityNodeID)),
+		Summary:            recommendation.Rationale,
+		AccountID:          recommendation.AccountID,
+		Region:             recommendation.Region,
+		IdentityNodeID:     recommendation.IdentityNodeID,
+		IdentityARN:        recommendation.PrincipalARN,
+		IdentityName:       recommendation.DisplayName,
+		IdentityType:       "iam_role",
+		ResourceNodeIDs:    awsRemediationResourceNodes([]string{recommendation.ResourceNodeID}, recommendation.ImpactedNodes, recommendation.IdentityNodeID),
+		Owner:              owner,
+		OwnerAssigned:      ownerAssigned,
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForLeastPrivilege(recommendation),
+		RollbackPlan:       awsRemediationRollbackForDiff(diff, evidenceRef),
+		VerificationPlan:   awsRemediationVerificationForLeastPrivilege(recommendation, evidenceRef),
+		SourceSignals:      []string{"least_privilege"},
+		Evidence:           recommendation.Evidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      recommendation.ImpactedNodes,
+		ImpactedPath:       recommendation.ImpactedPath,
+		NextActions:        awsRemediationNextActionList(recommendation.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
+func awsRemediationCaseFromSecretEquivalence(finding AWSSecretPermissionEquivalenceFinding, now time.Time) (AWSRemediationCase, bool) {
+	if finding.FindingID == "" {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("secret-permission-equivalence", finding.FindingID)
+	diff := awsRemediationDiffIntentForEquivalence(finding)
+	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
+	owner, ownerAssigned := awsRemediationOwnerFromEquivalence(finding)
+	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, finding.Status)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState)
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "secret_permission_equivalence",
+		SourceFindingID:    finding.FindingID,
+		Lifecycle:          lifecycle,
+		Severity:           finding.Severity,
+		Status:             finding.Status,
+		Score:              finding.Score,
+		Confidence:         finding.Confidence,
+		Title:              fmt.Sprintf("Secret-permission equivalence: %s", firstNonEmptyAWSValue(finding.SecretLabel, finding.SecretARN, finding.Provider)),
+		Summary:            finding.Rationale,
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		IdentityNodeID:     finding.IdentityNodeID,
+		IdentityARN:        finding.PrincipalARN,
+		IdentityName:       firstNonEmptyAWSValue(finding.AgentName, finding.AgentID, shortAWSARN(finding.PrincipalARN)),
+		IdentityType:       awsRemediationEquivalenceIdentityType(finding),
+		Provider:           finding.Provider,
+		ResourceNodeIDs:    awsRemediationResourceNodes([]string{finding.SecretNodeID}, finding.ImpactedNodes, finding.IdentityNodeID),
+		Owner:              owner,
+		OwnerAssigned:      ownerAssigned,
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForEquivalence(finding),
+		RollbackPlan:       awsRemediationRollbackForDiff(diff, evidenceRefFromEquivalence(finding)),
+		VerificationPlan:   awsRemediationVerificationForEquivalence(finding, evidenceRefFromEquivalence(finding)),
+		SourceSignals:      finding.SourceSignals,
+		Evidence:           finding.Evidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      finding.ImpactedNodes,
+		ImpactedPath:       finding.ImpactedPath,
+		NextActions:        awsRemediationNextActionList(finding.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
+func awsRemediationCaseFromBlastRadius(finding AWSBlastRadiusFinding, now time.Time) (AWSRemediationCase, bool) {
+	if finding.FindingID == "" {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("blast-radius", finding.FindingID)
+	blastEvidence := awsRemediationEvidenceFromBlastRadius(finding.Evidence)
+	blastEvidenceRef := firstString(awsRemediationEvidenceRefs(blastEvidence))
+	diff := AWSRemediationDiffIntent{
+		Kind:               awsRemediationBlastRadiusDiffKind(finding.RiskType),
+		BeforeRef:          blastEvidenceRef,
+		AfterRef:           "blast-radius://" + finding.FindingID + "/scoped-projection",
+		DiffSummary:        fmt.Sprintf("Restrict %s reachability for %s; review %d impacted node(s) and %d agent/tool path(s).", finding.RiskType, firstNonEmptyAWSValue(finding.DisplayName, finding.IdentityNodeID), len(finding.ImpactedNodes), len(finding.AgentToolPaths)),
+		NoOp:               false,
+		ReadOnlyProjection: true,
+	}
+	approvalRequired := awsRemediationApprovalRequired(finding.Severity, diff.Kind)
+	approvalState := awsRemediationApprovalState(approvalRequired, false, finding.Status)
+	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, false, approvalState)
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "blast_radius",
+		SourceFindingID:    finding.FindingID,
+		Lifecycle:          lifecycle,
+		Severity:           finding.Severity,
+		Status:             finding.Status,
+		Score:              finding.Score,
+		Confidence:         finding.Confidence,
+		Title:              fmt.Sprintf("Blast-radius scope review for %s", firstNonEmptyAWSValue(finding.DisplayName, finding.IdentityNodeID)),
+		Summary:            finding.Rationale,
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		IdentityNodeID:     finding.IdentityNodeID,
+		IdentityARN:        finding.PrincipalARN,
+		IdentityName:       finding.DisplayName,
+		IdentityType:       "iam_identity",
+		ResourceNodeIDs:    awsRemediationResourceNodes(finding.SensitiveNodes, finding.ImpactedNodes, finding.IdentityNodeID),
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForBlastRadius(finding),
+		RollbackPlan:       awsRemediationRollbackForDiff(diff, blastEvidenceRef),
+		VerificationPlan:   awsRemediationVerificationForBlastRadius(blastEvidenceRef),
+		SourceSignals:      []string{"blast_radius"},
+		Evidence:           blastEvidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      finding.ImpactedNodes,
+		ImpactedPath:       awsRemediationPathFromBlastRadius(finding.ImpactedPath),
+		NextActions:        awsRemediationNextActionList(finding.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
+func finalizeAWSRemediationCase(c AWSRemediationCase, now time.Time) AWSRemediationCase {
+	c.SourceSignals = dedupeStrings(c.SourceSignals)
+	c.ImpactedNodes = emptyStrings(dedupeStrings(c.ImpactedNodes))
+	c.ResourceNodeIDs = emptyStrings(dedupeStrings(c.ResourceNodeIDs))
+	c.NextActions = dedupeStrings(c.NextActions)
+	if c.Lifecycle == "" {
+		c.Lifecycle = "proposed"
+	}
+	if c.ApprovalState == "" {
+		c.ApprovalState = "not_required"
+	}
+	if strings.TrimSpace(c.DiffIntent.Kind) == "" {
+		c.DiffIntent.Kind = "manual_review"
+	}
+	c.DiffIntent.ReadOnlyProjection = true
+	c.AuditTrail = []AWSRemediationAuditEntry{{
+		EventID:     c.CaseID + "/proposed",
+		Actor:       "system",
+		EventType:   "proposed",
+		OccurredAt:  now,
+		EvidenceRef: firstString(awsRemediationEvidenceRefs(c.Evidence)),
+		Notes:       fmt.Sprintf("Deterministic case proposed from %s evidence at lifecycle=%s.", c.SourceType, c.Lifecycle),
+	}}
+	return c
+}
+
+func awsRemediationCaseDedupe(cases []AWSRemediationCase) []AWSRemediationCase {
+	seen := map[string]int{}
+	out := []AWSRemediationCase{}
+	for _, c := range cases {
+		key := strings.ToLower(strings.TrimSpace(c.CaseID))
+		if key == "" {
+			continue
+		}
+		if idx, ok := seen[key]; ok {
+			out[idx] = mergeAWSRemediationCase(out[idx], c)
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, c)
+	}
+	return out
+}
+
+func mergeAWSRemediationCase(existing, incoming AWSRemediationCase) AWSRemediationCase {
+	merged := existing
+	if incoming.Score > merged.Score {
+		merged.Score = incoming.Score
+		merged.Severity = incoming.Severity
+		merged.Status = incoming.Status
+		merged.Lifecycle = incoming.Lifecycle
+		merged.Title = incoming.Title
+		merged.Summary = incoming.Summary
+		merged.DiffIntent = incoming.DiffIntent
+	}
+	if incoming.Confidence > merged.Confidence {
+		merged.Confidence = incoming.Confidence
+	}
+	merged.SourceSignals = dedupeStrings(append(append([]string{}, merged.SourceSignals...), incoming.SourceSignals...))
+	merged.Evidence = append(append([]AWSRemediationCaseEvidence{}, merged.Evidence...), incoming.Evidence...)
+	merged.ImpactedNodes = emptyStrings(dedupeStrings(append(merged.ImpactedNodes, incoming.ImpactedNodes...)))
+	merged.ResourceNodeIDs = emptyStrings(dedupeStrings(append(merged.ResourceNodeIDs, incoming.ResourceNodeIDs...)))
+	merged.NextActions = dedupeStrings(append(merged.NextActions, incoming.NextActions...))
+	merged.Tradeoffs = append(merged.Tradeoffs, incoming.Tradeoffs...)
+	merged.AuditTrail = append(merged.AuditTrail, incoming.AuditTrail...)
+	return merged
+}
+
+func awsRemediationDiffIntentForRiskType(riskType string) AWSRemediationDiffIntent {
+	switch riskType {
+	case "external_credential_exposure":
+		return AWSRemediationDiffIntent{Kind: "secret_rotation", DiffSummary: "Rotate or scope the external provider credential and any equivalent secret reference.", ReadOnlyProjection: true}
+	case "broad_tool_access", "sensitive_data_reachability", "declared_unused_tool", "undeclared_tool_runtime", "runtime_tool_anomaly":
+		return AWSRemediationDiffIntent{Kind: "ai_agent_scope_change", DiffSummary: "Narrow the AI agent's tool, capability, and resource surface before rerunning runtime correlation.", ReadOnlyProjection: true}
+	case "ownerless_agent":
+		return AWSRemediationDiffIntent{Kind: "owner_assignment", DiffSummary: "Assign an accountable owner tag and re-evaluate the agent inventory.", NoOp: true, ReadOnlyProjection: true}
+	case "backing_role_scope", "backing_role_mismatch":
+		return AWSRemediationDiffIntent{Kind: "role_scope_diff", DiffSummary: "Scope the agent backing role to observed actions and resources, removing declared-only privileges.", ReadOnlyProjection: true}
+	default:
+		return AWSRemediationDiffIntent{Kind: "manual_review", DiffSummary: "Manual review: no deterministic diff projected for this risk type.", NoOp: true, ReadOnlyProjection: true}
+	}
+}
+
+func awsRemediationLeastPrivilegeDiffKind(recommendation AWSLeastPrivilegeRecommendation) string {
+	if recommendation.Decision == "remove" {
+		return "iam_policy_diff"
+	}
+	return "role_scope_diff"
+}
+
+func awsRemediationDiffIntentForEquivalence(finding AWSSecretPermissionEquivalenceFinding) AWSRemediationDiffIntent {
+	switch finding.EquivalenceType {
+	case "agent_provider_key_equivalence":
+		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "secret://" + finding.SecretNodeID + "/scoped-projection", DiffSummary: "Rotate the agent provider key reference and scope downstream secret reads.", ReadOnlyProjection: true}
+	case "kms_decrypt_equivalence", "kms_grant_equivalence":
+		return AWSRemediationDiffIntent{Kind: "kms_grant_diff", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "kms://" + finding.SecretNodeID + "/scoped-grants", DiffSummary: "Remove broad KMS decrypt/admin reachability that equates to secret read.", ReadOnlyProjection: true}
+	case "runtime_secret_access_equivalence":
+		return AWSRemediationDiffIntent{Kind: "iam_policy_diff", BeforeRef: evidenceRefFromEquivalence(finding), AfterRef: "secret://" + finding.SecretNodeID + "/scoped-read", DiffSummary: "Scope the identity's secret read permission to observed access and add monitoring.", ReadOnlyProjection: true}
+	default:
+		return AWSRemediationDiffIntent{Kind: "secret_rotation", BeforeRef: evidenceRefFromEquivalence(finding), DiffSummary: "Rotate or scope the equivalent secret-permission path.", ReadOnlyProjection: true}
+	}
+}
+
+func awsRemediationBlastRadiusDiffKind(riskType string) string {
+	switch riskType {
+	case "cross_account_trust", "cross_account_reach":
+		return "iam_trust_diff"
+	case "agent_tool_path", "ai_agent_blast_radius":
+		return "ai_agent_scope_change"
+	case "sensitive_resource_reach":
+		return "role_scope_diff"
+	default:
+		return "iam_policy_diff"
+	}
+}
+
+func awsRemediationApprovalRequired(severity, diffKind string) bool {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical", "high":
+		return true
+	}
+	switch diffKind {
+	case "secret_rotation", "iam_trust_diff", "kms_grant_diff":
+		return true
+	}
+	return false
+}
+
+func awsRemediationApprovalState(required, ownerAssigned bool, status string) string {
+	if !required {
+		return "not_required"
+	}
+	if !ownerAssigned {
+		return "pending_owner"
+	}
+	if normalizeAWSRuntimeEventFilterToken(status) == "action-required" {
+		return "pending_approver"
+	}
+	return "pending_owner_review"
+}
+
+func awsRemediationLifecycle(status string, confidence float64, ownerAssigned bool, approvalState string) string {
+	if confidence > 0 && confidence < 0.55 {
+		return "proposed"
+	}
+	switch normalizeAWSRuntimeEventFilterToken(status) {
+	case "action-required":
+		if !ownerAssigned {
+			return "in_review"
+		}
+		if approvalState == "pending_approver" {
+			return "approved"
+		}
+		return "in_review"
+	case "review":
+		return "in_review"
+	case "monitor":
+		return "proposed"
+	}
+	return "proposed"
+}
+
+func awsRemediationTitleForRiskType(riskType, agentName, agentID string) string {
+	display := firstNonEmptyAWSValue(agentName, agentID, "AI agent")
+	switch riskType {
+	case "external_credential_exposure":
+		return "Rotate external credential for " + display
+	case "broad_tool_access":
+		return "Narrow tool surface for " + display
+	case "sensitive_data_reachability":
+		return "Restrict sensitive reachability for " + display
+	case "ownerless_agent":
+		return "Assign owner for " + display
+	case "undeclared_tool_runtime":
+		return "Reconcile undeclared runtime tool for " + display
+	case "declared_unused_tool":
+		return "Retire unused declared tool for " + display
+	case "backing_role_mismatch":
+		return "Reconcile backing role for " + display
+	case "backing_role_scope":
+		return "Scope backing role for " + display
+	case "runtime_tool_anomaly":
+		return "Investigate runtime tool anomaly for " + display
+	default:
+		return "Review AI agent risk for " + display
+	}
+}
+
+func awsRemediationOwnerFromAgent(finding AWSAIAgentRiskFinding) (string, bool) {
+	if strings.EqualFold(finding.RiskType, "ownerless_agent") {
+		return "", false
+	}
+	for _, evidence := range finding.Evidence {
+		if rel := strings.ToLower(evidence.Relationship); rel == "missing_owner" {
+			return "", false
+		}
+	}
+	return "ai-platform", true
+}
+
+func awsRemediationOwnerFromEquivalence(finding AWSSecretPermissionEquivalenceFinding) (string, bool) {
+	if strings.TrimSpace(finding.AgentID) != "" {
+		return "ai-platform", true
+	}
+	return "iam-platform", true
+}
+
+func awsRemediationTradeoffsForRiskType(riskType, severity string) []AWSRemediationTradeoff {
+	out := []AWSRemediationTradeoff{}
+	switch riskType {
+	case "external_credential_exposure":
+		out = append(out,
+			AWSRemediationTradeoff{Dimension: "downstream_blast_radius", Direction: "improves", Description: "Rotating the external key revokes any leaked equivalents and shrinks the agent's external reach.", Severity: severity},
+			AWSRemediationTradeoff{Dimension: "rotation_risk", Direction: "worsens", Description: "Active sessions tied to the previous key fail until callers refresh their credentials.", Severity: "medium"},
+		)
+	case "broad_tool_access", "sensitive_data_reachability", "declared_unused_tool":
+		out = append(out,
+			AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "worsens", Description: "Narrowing tool surface may break flows that depend on declared but unobserved capabilities.", Severity: "medium"},
+			AWSRemediationTradeoff{Dimension: "downstream_blast_radius", Direction: "improves", Description: "Smaller tool surface reduces lateral reach for compromised agents.", Severity: severity},
+		)
+	case "ownerless_agent":
+		out = append(out, AWSRemediationTradeoff{Dimension: "observability_impact", Direction: "improves", Description: "Adding owner metadata routes future approvals deterministically and unblocks downstream cases.", Severity: severity})
+	case "backing_role_mismatch", "backing_role_scope":
+		out = append(out,
+			AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "worsens", Description: "Scoping the role to observed actions may block declared paths that have not been exercised yet.", Severity: "medium"},
+			AWSRemediationTradeoff{Dimension: "downstream_blast_radius", Direction: "improves", Description: "Removing declared-only privileges shrinks the trust surface of the agent backing role.", Severity: severity},
+		)
+	case "undeclared_tool_runtime", "runtime_tool_anomaly":
+		out = append(out, AWSRemediationTradeoff{Dimension: "observability_impact", Direction: "improves", Description: "Reconciling declared and observed tool usage closes runtime evidence gaps.", Severity: severity})
+	}
+	return out
+}
+
+func awsRemediationTradeoffsForLeastPrivilege(recommendation AWSLeastPrivilegeRecommendation) []AWSRemediationTradeoff {
+	out := []AWSRemediationTradeoff{
+		{Dimension: "downstream_blast_radius", Direction: "improves", Description: fmt.Sprintf("Removing %d unused action(s) shrinks the identity's effective reach.", len(recommendation.RemoveActions)), Severity: recommendation.Severity},
+	}
+	if recommendation.BreakagePrediction == "high" || recommendation.BreakagePrediction == "medium" {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "worsens", Description: recommendation.BreakageRationale, Severity: recommendation.BreakagePrediction})
+	} else {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "neutral", Description: "Removed actions have no observed callers in the runtime evidence window.", Severity: "low"})
+	}
+	return out
+}
+
+func awsRemediationTradeoffsForEquivalence(finding AWSSecretPermissionEquivalenceFinding) []AWSRemediationTradeoff {
+	return []AWSRemediationTradeoff{
+		{Dimension: "downstream_blast_radius", Direction: "improves", Description: fmt.Sprintf("Scoping %s reachability removes the equivalent secret-read path across %d impacted node(s).", finding.EquivalenceType, len(finding.ImpactedNodes)), Severity: finding.Severity},
+		{Dimension: "rotation_risk", Direction: "worsens", Description: "Workloads holding the previous secret reference must refresh before the change is complete.", Severity: "medium"},
+	}
+}
+
+func awsRemediationTradeoffsForBlastRadius(finding AWSBlastRadiusFinding) []AWSRemediationTradeoff {
+	return []AWSRemediationTradeoff{
+		{Dimension: "downstream_blast_radius", Direction: "improves", Description: fmt.Sprintf("Restricting %s reduces reachability across %d impacted node(s).", finding.RiskType, len(finding.ImpactedNodes)), Severity: finding.Severity},
+		{Dimension: "observability_impact", Direction: "improves", Description: "Narrower blast radius lets downstream remediation cases run with tighter evidence.", Severity: "medium"},
+	}
+}
+
+func awsRemediationRollbackForDiff(diff AWSRemediationDiffIntent, evidenceRef string) AWSRemediationRollbackPlan {
+	switch diff.Kind {
+	case "iam_policy_diff", "role_scope_diff":
+		return AWSRemediationRollbackPlan{Strategy: "re_attach_policy", Steps: []string{"Re-attach the removed managed policy or inline statement.", "Re-run least-privilege evaluation to confirm restored reach."}, EvidenceRef: evidenceRef}
+	case "iam_trust_diff":
+		return AWSRemediationRollbackPlan{Strategy: "restore_trust_policy", Steps: []string{"Restore the previous trust policy from the captured before_ref.", "Re-run cross-account blast-radius evaluation."}, EvidenceRef: evidenceRef}
+	case "secret_rotation":
+		return AWSRemediationRollbackPlan{Strategy: "re_create_secret_reference", Steps: []string{"Reissue the prior credential or restore the previous reference if the workload regressed.", "Capture rotation evidence in the case audit trail."}, EvidenceRef: evidenceRef}
+	case "kms_grant_diff":
+		return AWSRemediationRollbackPlan{Strategy: "restore_grant", Steps: []string{"Restore the previous KMS grant or key policy statement.", "Re-run KMS-decrypt reachability to confirm the rollback."}, EvidenceRef: evidenceRef}
+	case "ai_agent_scope_change":
+		return AWSRemediationRollbackPlan{Strategy: "re_enable_tool", Steps: []string{"Re-enable the removed tool or capability scope on the AI agent definition.", "Re-run runtime/tool-call correlation."}, EvidenceRef: evidenceRef}
+	case "owner_assignment":
+		return AWSRemediationRollbackPlan{Strategy: "manual_review", Steps: []string{"Owner assignment is a metadata change; remove the owner tag to revert if assigned in error."}, EvidenceRef: evidenceRef}
+	default:
+		return AWSRemediationRollbackPlan{Strategy: "manual_review", Steps: []string{"No deterministic rollback projected; document the manual rollback path before execution."}, EvidenceRef: evidenceRef}
+	}
+}
+
+func awsRemediationVerificationForRiskType(riskType, evidenceRef string) AWSRemediationVerificationPlan {
+	switch riskType {
+	case "external_credential_exposure":
+		return AWSRemediationVerificationPlan{
+			Strategy:       "secret_access_re_evaluate",
+			Steps:          []string{"Confirm the previous credential is revoked.", "Re-run secret-permission equivalence to confirm the agent path is closed."},
+			SuccessSignals: []string{"secret-permission-equivalence:no-equivalence", "agent_runtime_access:no-credential-use"},
+			FailureSignals: []string{"secret-permission-equivalence:still-equivalent"},
+			EvidenceRef:    evidenceRef,
+		}
+	case "broad_tool_access", "sensitive_data_reachability", "declared_unused_tool", "undeclared_tool_runtime", "runtime_tool_anomaly":
+		return AWSRemediationVerificationPlan{
+			Strategy:       "runtime_observe",
+			Steps:          []string{"Re-run agent runtime correlation for the next collection window.", "Confirm the targeted tool is no longer observed or matches the new scope."},
+			SuccessSignals: []string{"agent_runtime_access:scope-matches-declared"},
+			FailureSignals: []string{"agent_runtime_access:undeclared-tool-observed", "agent_runtime_access:declared-unused-tool"},
+			EvidenceRef:    evidenceRef,
+		}
+	case "ownerless_agent":
+		return AWSRemediationVerificationPlan{
+			Strategy:       "inventory_re_evaluate",
+			Steps:          []string{"Re-run agent inventory to confirm owner tag presence."},
+			SuccessSignals: []string{"ai_agent_identities:owner-tag-present"},
+			FailureSignals: []string{"ai_agent_identities:owner-tag-missing"},
+			EvidenceRef:    evidenceRef,
+		}
+	case "backing_role_mismatch", "backing_role_scope":
+		return AWSRemediationVerificationPlan{
+			Strategy:       "least_privilege_re_evaluate",
+			Steps:          []string{"Re-run least-privilege analysis for the backing role.", "Confirm decision flips from remove/review to keep."},
+			SuccessSignals: []string{"least_privilege:decision-keep"},
+			FailureSignals: []string{"least_privilege:decision-remove", "least_privilege:decision-review"},
+			EvidenceRef:    evidenceRef,
+		}
+	default:
+		return AWSRemediationVerificationPlan{
+			Strategy:    "manual_review",
+			Steps:       []string{"No deterministic verification projected; document the manual verification before execution."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+}
+
+func awsRemediationVerificationForLeastPrivilege(_ AWSLeastPrivilegeRecommendation, evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "policy_simulate",
+		Steps:          []string{"Run IAM policy simulator with observed actions to confirm none regress.", "Re-run least-privilege to confirm the recommendation flips to keep."},
+		SuccessSignals: []string{"policy_simulate:no-regression", "least_privilege:decision-keep"},
+		FailureSignals: []string{"policy_simulate:denied-observed-action"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsRemediationVerificationForEquivalence(finding AWSSecretPermissionEquivalenceFinding, evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "secret_access_re_evaluate",
+		Steps:          []string{"Re-run secret-permission equivalence after the change.", "Confirm runtime evidence no longer reports an equivalent reader."},
+		SuccessSignals: []string{"secret-permission-equivalence:no-equivalence"},
+		FailureSignals: []string{"secret-permission-equivalence:still-equivalent", "secrets_kms_runtime_access:still-observed"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsRemediationVerificationForBlastRadius(evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "blast_radius_re_evaluate",
+		Steps:          []string{"Re-run blast-radius for the identity after the change.", "Confirm impacted nodes and cross-account edges drop."},
+		SuccessSignals: []string{"blast_radius:scope-reduced"},
+		FailureSignals: []string{"blast_radius:scope-unchanged"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsRemediationResourceNodes(values ...interface{}) []string {
+	out := []string{}
+	for _, item := range values {
+		switch v := item.(type) {
+		case string:
+			if strings.TrimSpace(v) != "" {
+				out = append(out, v)
+			}
+		case []string:
+			for _, s := range v {
+				if strings.TrimSpace(s) != "" {
+					out = append(out, s)
+				}
+			}
+		}
+	}
+	return emptyStrings(dedupeStrings(out))
+}
+
+func awsRemediationNextActionList(primary string, diff AWSRemediationDiffIntent) []string {
+	out := []string{}
+	if trimmed := strings.TrimSpace(primary); trimmed != "" {
+		out = append(out, trimmed)
+	}
+	if trimmed := strings.TrimSpace(diff.DiffSummary); trimmed != "" {
+		out = append(out, trimmed)
+	}
+	if diff.AfterRef != "" {
+		out = append(out, "Compare against projected after_ref before approval: "+diff.AfterRef)
+	}
+	return dedupeStrings(out)
+}
+
+func awsRemediationCaseRelationships(cases []AWSRemediationCase) []AWSRemediationRelationship {
+	relationships := []AWSRemediationRelationship{}
+	for _, c := range cases {
+		if c.IdentityNodeID == "" && len(c.ResourceNodeIDs) == 0 {
+			continue
+		}
+		fromNode := firstNonEmptyAWSValue(c.IdentityNodeID, firstString(c.ResourceNodeIDs))
+		if fromNode == "" {
+			continue
+		}
+		for _, target := range c.ImpactedNodes {
+			if target == "" || target == fromNode {
+				continue
+			}
+			relationships = append(relationships, AWSRemediationRelationship{
+				CaseID:      c.CaseID,
+				Type:        "remediation_case_path",
+				FromNodeID:  fromNode,
+				ToNodeID:    target,
+				EvidenceRef: firstString(awsRemediationEvidenceRefs(c.Evidence)),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSRemediationCases(all, filtered []AWSRemediationCase, relationships []AWSRemediationRelationship) AWSRemediationCaseSummary {
+	summary := AWSRemediationCaseSummary{
+		TotalCases:          len(all),
+		FilteredCases:       len(filtered),
+		SeverityCounts:      map[string]int{},
+		StatusCounts:        map[string]int{},
+		LifecycleCounts:     map[string]int{},
+		SourceTypeCounts:    map[string]int{},
+		ApprovalStateCounts: map[string]int{},
+		RelationshipCount:   len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, c := range filtered {
+		summary.SeverityCounts[c.Severity]++
+		summary.StatusCounts[c.Status]++
+		summary.LifecycleCounts[c.Lifecycle]++
+		summary.SourceTypeCounts[c.SourceType]++
+		summary.ApprovalStateCounts[c.ApprovalState]++
+		if c.OwnerAssigned {
+			summary.OwnerAssignedCount++
+		} else {
+			summary.OwnerlessCount++
+		}
+		if c.ApprovalRequired {
+			summary.ApprovalRequiredCount++
+		}
+		if c.DiffIntent.ReadOnlyProjection {
+			summary.ReadOnlyProjectionCount++
+		}
+		if len(c.RollbackPlan.Steps) > 0 {
+			summary.RollbackPlanCount++
+		}
+		if len(c.VerificationPlan.Steps) > 0 {
+			summary.VerificationPlanCount++
+		}
+		summary.AuditEntryCount += len(c.AuditTrail)
+		if c.Score > summary.HighestScore {
+			summary.HighestScore = c.Score
+		}
+		confidenceTotal += c.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSRemediationCases(cases []AWSRemediationCase, request AWSRemediationCaseRequest) ([]AWSRemediationCase, map[string]string) {
+	filters := map[string]string{
+		"account_id":     strings.TrimSpace(request.AccountID),
+		"region":         strings.TrimSpace(request.Region),
+		"identity":       strings.TrimSpace(request.Identity),
+		"source_type":    normalizeAWSRuntimeEventFilterToken(request.SourceType),
+		"lifecycle":      normalizeAWSRuntimeEventFilterToken(request.Lifecycle),
+		"severity":       normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":         normalizeAWSRuntimeEventFilterToken(request.Status),
+		"approval_state": normalizeAWSRuntimeEventFilterToken(request.ApprovalState),
+		"owner_assigned": strings.ToLower(strings.TrimSpace(request.OwnerAssigned)),
+		"search":         strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSRemediationCase, 0, len(cases))
+	for _, c := range cases {
+		if filters["account_id"] != "" && filters["account_id"] != c.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], c.Region) {
+			continue
+		}
+		if filters["source_type"] != "" && filters["source_type"] != normalizeAWSRuntimeEventFilterToken(c.SourceType) {
+			continue
+		}
+		if filters["lifecycle"] != "" && filters["lifecycle"] != normalizeAWSRuntimeEventFilterToken(c.Lifecycle) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(c.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(c.Status) {
+			continue
+		}
+		if filters["approval_state"] != "" && filters["approval_state"] != normalizeAWSRuntimeEventFilterToken(c.ApprovalState) {
+			continue
+		}
+		if filters["owner_assigned"] != "" {
+			want := filters["owner_assigned"]
+			if (want == "true" || want == "yes") != c.OwnerAssigned {
+				continue
+			}
+		}
+		if filters["identity"] != "" && !awsRemediationCaseIdentityMatch(c, filters["identity"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsRemediationCaseSearchMatch(c, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered, applied
+}
+
+func awsRemediationCaseIdentityMatch(c AWSRemediationCase, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	hay := strings.ToLower(strings.Join([]string{c.IdentityNodeID, c.IdentityARN, c.IdentityName, c.IdentityType, c.Owner}, " "))
+	return strings.Contains(hay, needle)
+}
+
+func awsRemediationCaseSearchMatch(c AWSRemediationCase, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{c.CaseID, c.Title, c.Summary, c.SourceFindingID, c.SourceType, c.Lifecycle, c.Severity, c.Status, c.ApprovalState, c.IdentityNodeID, c.IdentityARN, c.IdentityName, c.Provider, c.Owner, c.DiffIntent.Kind, c.DiffIntent.DiffSummary, c.DiffIntent.BeforeRef, c.DiffIntent.AfterRef, c.RollbackPlan.Strategy, c.VerificationPlan.Strategy}
+	values = append(values, c.ResourceNodeIDs...)
+	values = append(values, c.SourceSignals...)
+	values = append(values, c.ImpactedNodes...)
+	values = append(values, c.NextActions...)
+	for _, tradeoff := range c.Tradeoffs {
+		values = append(values, tradeoff.Dimension, tradeoff.Direction, tradeoff.Description, tradeoff.Severity)
+	}
+	for _, evidence := range c.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, audit := range c.AuditTrail {
+		values = append(values, audit.EventID, audit.Actor, audit.EventType, audit.Notes, audit.EvidenceRef)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSRemediationCaseStatus(sources awsRemediationCaseSources, filtered []AWSRemediationCase, diagnostics []AWSRemediationCaseDiagnostic) (string, float64) {
+	statuses := []string{sources.risk.Status, sources.least.Status, sources.equivalence.Status, sources.blast.Status}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.76
+		}
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsRemediationCaseFailureReasons(sources awsRemediationCaseSources) []string {
+	out := []string{}
+	for _, messages := range [][]string{
+		sources.risk.FailureReasons,
+		sources.least.FailureReasons,
+		sources.equivalence.FailureReasons,
+		sources.blast.FailureReasons,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsRemediationCaseRemediationHints(sources awsRemediationCaseSources) []string {
+	out := []string{
+		"Approve each remediation case before applying its diff: the engine never mutates AWS state itself.",
+		"Pair every approved case with its rollback and verification plan before scheduling execution.",
+	}
+	for _, messages := range [][]string{
+		sources.risk.RemediationHints,
+		sources.least.RemediationHints,
+		sources.equivalence.RemediationHints,
+		sources.blast.RemediationHints,
+	} {
+		out = append(out, messages...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsRemediationCaseCaveats() []string {
+	return []string{
+		"Remediation cases are read-only projections; the engine never applies an AWS change.",
+		"Diff before/after refs point at metadata evidence, never at rendered policy bodies, secret values, or workload payloads.",
+		"Lifecycle is derived deterministically from upstream finding status, confidence, and owner metadata; approve/execute transitions belong to a future wave issue.",
+	}
+}
+
+func awsRemediationCaseDiagnostics(sources awsRemediationCaseSources) []AWSRemediationCaseDiagnostic {
+	out := []AWSRemediationCaseDiagnostic{}
+	appendDiag := func(collector, sourceID, code, message, remediation string, retryable bool) {
+		if strings.TrimSpace(message) == "" && strings.TrimSpace(code) == "" {
+			return
+		}
+		out = append(out, AWSRemediationCaseDiagnostic{Collector: collector, SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: retryable})
+	}
+	for _, d := range sources.risk.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.least.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.equivalence.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	for _, d := range sources.blast.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
+	return out
+}
+
+func awsRemediationCaseCoverageGaps(sources awsRemediationCaseSources) []AWSRemediationCaseCoverageGap {
+	out := []AWSRemediationCaseCoverageGap{{
+		Capability:  "remediation_execution",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1529 implements the case model only; approve/execute/verify transitions are future-wave work and never mutate AWS here.",
+		Remediation: "Wire the approve/execute/verify endpoints in the relevant remediation/governance issue once the safety gates are in place.",
+	}}
+	appendGap := func(capability, status, reason, remediation string) {
+		out = append(out, AWSRemediationCaseCoverageGap{Capability: capability, Status: status, Reason: reason, Remediation: remediation})
+	}
+	for _, g := range sources.risk.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.least.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.equivalence.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.blast.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	return out
+}
+
+func awsRemediationCaseEvidenceBoundary() string {
+	return "metadata_only_no_secret_values_no_prompts_no_completions_no_tool_payloads_no_rendered_policy_bodies"
+}
+
+func awsRemediationEvidenceRefs(evidence []AWSRemediationCaseEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			out = append(out, item.EvidenceRef)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func evidenceRefFromAIAgentRisk(finding AWSAIAgentRiskFinding) string {
+	return firstString(awsRemediationEvidenceRefs(finding.Evidence))
+}
+
+func evidenceRefFromEquivalence(finding AWSSecretPermissionEquivalenceFinding) string {
+	refs := []string{}
+	for _, e := range finding.Evidence {
+		if strings.TrimSpace(e.EvidenceRef) != "" {
+			refs = append(refs, e.EvidenceRef)
+		}
+	}
+	return firstString(refs)
+}
+
+func awsRemediationEvidenceFromBlastRadius(evidence []AWSBlastRadiusEvidence) []AWSRemediationCaseEvidence {
+	out := make([]AWSRemediationCaseEvidence, 0, len(evidence))
+	for _, item := range evidence {
+		out = append(out, AWSRemediationCaseEvidence{
+			Source:       item.Source,
+			EvidenceRef:  item.EvidenceRef,
+			Label:        item.Label,
+			Confidence:   item.Confidence,
+			ObservedAt:   item.ObservedAt,
+			Relationship: item.Relationship,
+		})
+	}
+	return out
+}
+
+func awsRemediationPathFromBlastRadius(path []AWSBlastRadiusPathStep) []AWSRemediationCasePathStep {
+	out := make([]AWSRemediationCasePathStep, 0, len(path))
+	for _, step := range path {
+		out = append(out, AWSRemediationCasePathStep{
+			NodeID:    step.NodeID,
+			NodeType:  step.NodeType,
+			Label:     step.Label,
+			AccountID: step.AccountID,
+			Region:    step.Region,
+		})
+	}
+	return out
+}
+
+func awsRemediationEquivalenceIdentityType(finding AWSSecretPermissionEquivalenceFinding) string {
+	if strings.TrimSpace(finding.AgentID) != "" {
+		return "ai_agent"
+	}
+	return "iam_identity"
+}

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -360,8 +360,13 @@ func awsRemediationCaseFromAIAgentRisk(finding AWSAIAgentRiskFinding, now time.T
 	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, finding.Status)
 	lifecycle := awsRemediationLifecycle(finding.Status, finding.Confidence, ownerAssigned, approvalState)
 	identityType := "ai_agent"
+	identityNodeID := finding.AgentNodeID
+	identityARN := finding.RuntimeRoleARN
+	identityName := firstNonEmptyAWSValue(finding.AgentName, finding.AgentID)
 	if strings.HasPrefix(finding.RiskType, "backing_role") {
 		identityType = "iam_role"
+		identityNodeID = firstNonEmptyAWSValue(finding.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(finding.RuntimeRoleARN), finding.AgentNodeID)
+		identityName = firstNonEmptyAWSValue(shortAWSARN(finding.RuntimeRoleARN), finding.RuntimeRoleARN, finding.RuntimeRoleNodeID, finding.AgentName, finding.AgentID)
 	}
 	c := AWSRemediationCase{
 		CaseID:             caseID,
@@ -377,9 +382,9 @@ func awsRemediationCaseFromAIAgentRisk(finding AWSAIAgentRiskFinding, now time.T
 		Summary:            finding.Rationale,
 		AccountID:          finding.AccountID,
 		Region:             finding.Region,
-		IdentityNodeID:     finding.AgentNodeID,
-		IdentityARN:        firstNonEmptyAWSValue(finding.RuntimeRoleARN),
-		IdentityName:       firstNonEmptyAWSValue(finding.AgentName, finding.AgentID),
+		IdentityNodeID:     identityNodeID,
+		IdentityARN:        identityARN,
+		IdentityName:       identityName,
 		IdentityType:       identityType,
 		Provider:           finding.Provider,
 		ResourceNodeIDs:    awsRemediationResourceNodes(finding.SensitiveResources, finding.ImpactedNodes, finding.AgentNodeID, finding.RuntimeRoleNodeID),

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -748,7 +748,7 @@ func awsRemediationLifecycle(status string, confidence float64, ownerAssigned bo
 		if !ownerAssigned {
 			return "in_review"
 		}
-		if executable && approvalState == "pending_approver" {
+		if executable && (approvalState == "pending_approver" || approvalState == "not_required" || approvalState == "approved") {
 			return "approved"
 		}
 		return "in_review"

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -1,0 +1,336 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newRemediationCaseService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationCaseService(t, "project-remediation-cases", now)
+
+	result, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-cases", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation cases: %v", err)
+	}
+	if result.CurrentIssueRef != "#1529" || result.Version != awsRemediationCaseVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Cases) == 0 || result.Summary.TotalCases != len(result.Cases) {
+		t.Fatalf("expected case summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.SourceTypeCounts["ai_agent_risk"] == 0 && result.Summary.SourceTypeCounts["least_privilege"] == 0 {
+		t.Fatalf("expected at least one upstream source emitting cases: %+v", result.Summary.SourceTypeCounts)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected relationships and matching count: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Cases); i++ {
+		if result.Cases[i-1].Score < result.Cases[i].Score {
+			t.Fatalf("cases are not ranked by descending score: %+v", result.Cases)
+		}
+	}
+	for _, c := range result.Cases {
+		if c.CaseID == "" || c.CalculationVersion != awsRemediationCaseVersion || c.SourceType == "" || c.SourceFindingID == "" {
+			t.Fatalf("case missing stable metadata: %+v", c)
+		}
+		if c.Lifecycle == "" || c.Severity == "" || c.Status == "" || c.ApprovalState == "" || c.Title == "" {
+			t.Fatalf("case missing classification fields: %+v", c)
+		}
+		if c.DiffIntent.Kind == "" || !c.DiffIntent.ReadOnlyProjection {
+			t.Fatalf("case missing read-only diff intent: %+v", c.DiffIntent)
+		}
+		if len(c.RollbackPlan.Steps) == 0 || c.RollbackPlan.Strategy == "" {
+			t.Fatalf("case missing rollback plan: %+v", c.RollbackPlan)
+		}
+		if len(c.VerificationPlan.Steps) == 0 || c.VerificationPlan.Strategy == "" {
+			t.Fatalf("case missing verification plan: %+v", c.VerificationPlan)
+		}
+		if c.EvidenceBoundary != awsRemediationCaseEvidenceBoundary() {
+			t.Fatalf("case crossed evidence boundary: %+v", c)
+		}
+		if len(c.AuditTrail) == 0 || c.AuditTrail[0].EventType != "proposed" {
+			t.Fatalf("case missing proposed audit entry: %+v", c.AuditTrail)
+		}
+		if strings.Contains(strings.ToLower(c.Summary), "secret value") && !strings.Contains(strings.ToLower(c.Summary), "not collected") {
+			t.Fatalf("summary must not imply secret value collection: %s", c.Summary)
+		}
+	}
+}
+
+func TestGetAWSRemediationCasesAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 5, 0, 0, time.UTC)
+	svc, ws := newRemediationCaseService(t, "project-remediation-case-filters", now)
+
+	leastOnly, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-filters", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		SourceType:   "least_privilege",
+	})
+	if err != nil {
+		t.Fatalf("source filter: %v", err)
+	}
+	if len(leastOnly.Cases) == 0 {
+		t.Fatalf("expected least-privilege cases in the success fixture")
+	}
+	for _, c := range leastOnly.Cases {
+		if c.SourceType != "least_privilege" {
+			t.Fatalf("source filter leaked %s case: %+v", c.SourceType, c)
+		}
+	}
+	if leastOnly.AppliedFilters["source_type"] != "least-privilege" {
+		t.Fatalf("expected applied source_type filter, got %+v", leastOnly.AppliedFilters)
+	}
+
+	highOnly, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-filters", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "high",
+	})
+	if err != nil {
+		t.Fatalf("severity filter: %v", err)
+	}
+	for _, c := range highOnly.Cases {
+		if c.Severity != "high" {
+			t.Fatalf("severity filter leaked %s case: %+v", c.Severity, c)
+		}
+	}
+
+	owned, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-filters", AWSRemediationCaseRequest{
+		ConnectorID:   "aws-prod",
+		FixtureState:  "success",
+		OwnerAssigned: "true",
+	})
+	if err != nil {
+		t.Fatalf("owner filter: %v", err)
+	}
+	for _, c := range owned.Cases {
+		if !c.OwnerAssigned {
+			t.Fatalf("owner filter leaked ownerless case: %+v", c)
+		}
+	}
+
+	search, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-filters", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Search:       "rotation",
+	})
+	if err != nil {
+		t.Fatalf("search filter: %v", err)
+	}
+	if len(search.Cases) == 0 {
+		t.Fatalf("expected rotation cases in the success fixture")
+	}
+}
+
+func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 10, 0, 0, time.UTC)
+	ownerless := AWSAIAgentRiskFinding{
+		FindingID:        "aws-ai-agent-risk:ownerless-test",
+		RiskType:         "ownerless_agent",
+		Severity:         "high",
+		Status:           "action_required",
+		Score:            72,
+		Confidence:       0.82,
+		AccountID:        "123456789012",
+		Region:           "us-east-1",
+		AgentNodeID:      "aws:agent:123456789012:us-east-1:custom_agent/lonely-agent",
+		AgentID:          "lonely-agent",
+		AgentName:        "lonely-agent",
+		AgentType:        "custom_agent",
+		SourceSignals:    []string{"ai_agent_identities"},
+		Rationale:        "lonely-agent has no owner tag.",
+		EvidenceBoundary: awsAIAgentRiskEvidenceBoundary(),
+		ImpactedNodes:    []string{"aws:agent:123456789012:us-east-1:custom_agent/lonely-agent"},
+	}
+	ownerCase, ok := awsRemediationCaseFromAIAgentRisk(ownerless, now)
+	if !ok {
+		t.Fatalf("expected ownerless agent to produce a case")
+	}
+	if ownerCase.OwnerAssigned {
+		t.Fatalf("ownerless agent must not be owner-assigned")
+	}
+	if ownerCase.ApprovalState != "pending_owner" {
+		t.Fatalf("ownerless high-severity case must wait on owner approval: %s", ownerCase.ApprovalState)
+	}
+	if ownerCase.Lifecycle != "in_review" {
+		t.Fatalf("expected in_review lifecycle when owner is missing, got %s", ownerCase.Lifecycle)
+	}
+	if ownerCase.DiffIntent.Kind != "owner_assignment" {
+		t.Fatalf("ownerless agent should propose owner_assignment diff, got %s", ownerCase.DiffIntent.Kind)
+	}
+	if !ownerCase.DiffIntent.NoOp {
+		t.Fatalf("owner assignment diff should be a no-op AWS change: %+v", ownerCase.DiffIntent)
+	}
+
+	rotation := AWSAIAgentRiskFinding{
+		FindingID:        "aws-ai-agent-risk:rotation-test",
+		RiskType:         "external_credential_exposure",
+		Severity:         "critical",
+		Status:           "action_required",
+		Score:            92,
+		Confidence:       0.9,
+		AccountID:        "123456789012",
+		Region:           "us-east-1",
+		AgentNodeID:      "aws:agent:123456789012:us-east-1:custom_agent/billing-agent",
+		AgentID:          "billing-agent",
+		AgentName:        "billing-agent",
+		AgentType:        "custom_agent",
+		Provider:         "openai",
+		SourceSignals:    []string{"ai_agent_identities"},
+		Rationale:        "billing-agent references an openai key.",
+		EvidenceBoundary: awsAIAgentRiskEvidenceBoundary(),
+	}
+	rotationCase, ok := awsRemediationCaseFromAIAgentRisk(rotation, now)
+	if !ok {
+		t.Fatalf("expected rotation case")
+	}
+	if !rotationCase.ApprovalRequired {
+		t.Fatalf("critical secret rotation must require approval: %+v", rotationCase)
+	}
+	if rotationCase.ApprovalState != "pending_approver" {
+		t.Fatalf("owner-assigned critical case must enter pending_approver state, got %s", rotationCase.ApprovalState)
+	}
+	if rotationCase.Lifecycle != "approved" {
+		t.Fatalf("owner-assigned critical action_required case should reach approved lifecycle, got %s", rotationCase.Lifecycle)
+	}
+	if rotationCase.DiffIntent.Kind != "secret_rotation" {
+		t.Fatalf("rotation case should propose secret_rotation diff, got %s", rotationCase.DiffIntent.Kind)
+	}
+	if rotationCase.RollbackPlan.Strategy != "re_create_secret_reference" {
+		t.Fatalf("secret_rotation must use re_create_secret_reference rollback, got %s", rotationCase.RollbackPlan.Strategy)
+	}
+	if rotationCase.VerificationPlan.Strategy != "secret_access_re_evaluate" {
+		t.Fatalf("rotation must use secret_access_re_evaluate verification, got %s", rotationCase.VerificationPlan.Strategy)
+	}
+
+	lowConfidence := rotation
+	lowConfidence.FindingID = "aws-ai-agent-risk:low-confidence"
+	lowConfidence.Confidence = 0.4
+	lowCase, ok := awsRemediationCaseFromAIAgentRisk(lowConfidence, now)
+	if !ok {
+		t.Fatalf("expected low-confidence case")
+	}
+	if lowCase.Lifecycle != "proposed" {
+		t.Fatalf("low-confidence cases must stay proposed, got %s", lowCase.Lifecycle)
+	}
+}
+
+func TestAWSRemediationCaseDedupesAcrossSources(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 15, 0, 0, time.UTC)
+	base := AWSRemediationCase{
+		CaseID:             "aws-remediation-case:duplicate-key",
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "ai_agent_risk",
+		Score:              70,
+		Severity:           "high",
+		Lifecycle:          "in_review",
+		ApprovalState:      "pending_owner",
+		DiffIntent:         AWSRemediationDiffIntent{Kind: "ai_agent_scope_change", ReadOnlyProjection: true},
+		SourceSignals:      []string{"ai_agent_identities"},
+		Evidence:           []AWSRemediationCaseEvidence{{Source: "ai_agent_identities", EvidenceRef: "evidence://agent/a"}},
+		ImpactedNodes:      []string{"aws:agent:1", "aws:identity:role:a"},
+		ResourceNodeIDs:    []string{"aws:agent:1"},
+		AuditTrail:         []AWSRemediationAuditEntry{{EventID: "1", Actor: "system", EventType: "proposed", OccurredAt: now}},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	incoming := base
+	incoming.SourceType = "least_privilege"
+	incoming.Score = 88
+	incoming.Severity = "critical"
+	incoming.Lifecycle = "approved"
+	incoming.DiffIntent = AWSRemediationDiffIntent{Kind: "iam_policy_diff", ReadOnlyProjection: true}
+	incoming.SourceSignals = []string{"least_privilege"}
+	incoming.Evidence = []AWSRemediationCaseEvidence{{Source: "least_privilege", EvidenceRef: "evidence://least/a"}}
+	incoming.AuditTrail = []AWSRemediationAuditEntry{{EventID: "2", Actor: "system", EventType: "proposed", OccurredAt: now}}
+
+	deduped := awsRemediationCaseDedupe([]AWSRemediationCase{base, incoming})
+	if len(deduped) != 1 {
+		t.Fatalf("expected dedupe to keep one case, got %d", len(deduped))
+	}
+	merged := deduped[0]
+	if merged.Score != 88 || merged.Severity != "critical" || merged.Lifecycle != "approved" || merged.DiffIntent.Kind != "iam_policy_diff" {
+		t.Fatalf("higher-score case must win the merge, got %+v", merged)
+	}
+	if !awsStringSliceContains(merged.SourceSignals, "ai_agent_identities") || !awsStringSliceContains(merged.SourceSignals, "least_privilege") {
+		t.Fatalf("merged signals must include both sources: %+v", merged.SourceSignals)
+	}
+	if len(merged.Evidence) != 2 || len(merged.AuditTrail) != 2 {
+		t.Fatalf("merged evidence and audit trail must compose both sources, got evidence=%d audit=%d", len(merged.Evidence), len(merged.AuditTrail))
+	}
+}
+
+func TestGetAWSRemediationCasesFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 20, 0, 0, time.UTC)
+	svc, ws := newRemediationCaseService(t, "project-remediation-case-states", now)
+
+	denied, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-states", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Cases) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress deterministic cases: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-states", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || empty.Summary.TotalCases != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should be explicit degraded no-evidence state: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSRemediationCases(defaultScopeContext(), ws, "project-remediation-case-states", AWSRemediationCaseRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSRemediationCases(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 25, 0, 0, time.UTC)
+	svc, _ := newRemediationCaseService(t, "project-remediation-case-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-remediation-case-route/aws/remediation-cases?connector_id=aws-prod&fixture_state=success&source_type=ai_agent_risk", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Cases AWSRemediationCaseResult `json:"cases"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Cases.CurrentIssueRef != "#1529" || body.Cases.AppliedFilters["source_type"] != "ai-agent-risk" {
+		t.Fatalf("unexpected route payload: %+v", body.Cases)
+	}
+	if len(body.Cases.Cases) == 0 {
+		t.Fatalf("expected ai_agent_risk-sourced cases via the route: %+v", body.Cases)
+	}
+}

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -233,6 +233,45 @@ func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCaseBackingRoleAnchorsOnRole(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 12, 0, 0, time.UTC)
+	backingRole := AWSAIAgentRiskFinding{
+		FindingID:         "aws-ai-agent-risk:backing-role-scope-test",
+		RiskType:          "backing_role_scope",
+		Severity:          "high",
+		Status:            "review",
+		Score:             80,
+		Confidence:        0.86,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/payments-agent",
+		AgentID:           "payments-agent",
+		AgentName:         "payments-agent",
+		AgentType:         "custom_agent",
+		RuntimeRoleARN:    "arn:aws:iam::123456789012:role/payments-agent-task",
+		RuntimeRoleNodeID: "aws:identity:arn:aws:iam::123456789012:role/payments-agent-task",
+		SourceSignals:     []string{"least_privilege"},
+		Rationale:         "Backing role for payments-agent has removable least-privilege scope.",
+		EvidenceBoundary:  awsAIAgentRiskEvidenceBoundary(),
+	}
+	c, ok := awsRemediationCaseFromAIAgentRisk(backingRole, now)
+	if !ok {
+		t.Fatalf("expected backing-role case to be emitted")
+	}
+	if c.IdentityType != "iam_role" {
+		t.Fatalf("expected iam_role identity type, got %s", c.IdentityType)
+	}
+	if c.IdentityNodeID != backingRole.RuntimeRoleNodeID {
+		t.Fatalf("backing-role case must anchor identity_node_id on the role, got %q (want %q)", c.IdentityNodeID, backingRole.RuntimeRoleNodeID)
+	}
+	if c.IdentityARN != backingRole.RuntimeRoleARN {
+		t.Fatalf("backing-role case must anchor identity_arn on the role ARN, got %q (want %q)", c.IdentityARN, backingRole.RuntimeRoleARN)
+	}
+	if strings.Contains(c.IdentityName, "payments-agent") && c.IdentityName == backingRole.AgentName {
+		t.Fatalf("backing-role case identity_name must surface the role, not the agent name, got %q", c.IdentityName)
+	}
+}
+
 func TestAWSRemediationCaseDedupesAcrossSources(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 15, 0, 0, time.UTC)
 	base := AWSRemediationCase{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -272,6 +272,65 @@ func TestAWSRemediationCaseBackingRoleAnchorsOnRole(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCaseLeastPrivilegeReviewIsNonExecutable(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 13, 0, 0, time.UTC)
+	review := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "least-priv:review-pending",
+		CalculationVersion: "aws-least-privilege-v1",
+		Decision:           "review",
+		Severity:           "medium",
+		Status:             "review",
+		Score:              60,
+		Confidence:         0.7,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::123456789012:role/review-role",
+		PrincipalARN:       "arn:aws:iam::123456789012:role/review-role",
+		DisplayName:        "review-role",
+		Rationale:          "Least-privilege evidence is inconclusive; manual review required.",
+		KeepActions:        []string{"s3:GetObject"},
+		ImpactedNodes:      []string{"aws:identity:arn:aws:iam::123456789012:role/review-role"},
+	}
+	c, ok := awsRemediationCaseFromLeastPrivilege(review, now)
+	if !ok {
+		t.Fatalf("expected review case to be emitted")
+	}
+	if c.DiffIntent.Kind != "manual_review" {
+		t.Fatalf("review-decision case must route to manual_review diff kind, got %s", c.DiffIntent.Kind)
+	}
+	if !c.DiffIntent.NoOp {
+		t.Fatalf("review-decision case must be NoOp until the upstream decision is conclusive: %+v", c.DiffIntent)
+	}
+	if c.DiffIntent.AfterRef != "" {
+		t.Fatalf("review-decision case must not project a scoped after_ref, got %q", c.DiffIntent.AfterRef)
+	}
+	if c.RollbackPlan.Strategy != "manual_review" {
+		t.Fatalf("review-decision case must use manual_review rollback, got %s", c.RollbackPlan.Strategy)
+	}
+}
+
+func TestAWSRemediationCaseBlastRadiusDiffKindMatchesEmittedTokens(t *testing.T) {
+	cases := []struct {
+		riskType string
+		want     string
+	}{
+		{"cross-account-secret-runtime-access", "iam_trust_diff"},
+		{"cross-account-s3-runtime-access", "iam_trust_diff"},
+		{"agent-tool-path", "ai_agent_scope_change"},
+		{"undeclared-agent-tool-path", "ai_agent_scope_change"},
+		{"unused-agent-tool-path", "ai_agent_scope_change"},
+		{"agent-tool-path-with-caveats", "ai_agent_scope_change"},
+		{"s3-runtime-access", "role_scope_diff"},
+		{"sensitive-s3-runtime-access", "role_scope_diff"},
+	}
+	for _, tc := range cases {
+		got := awsRemediationBlastRadiusDiffKind(tc.riskType)
+		if got != tc.want {
+			t.Fatalf("awsRemediationBlastRadiusDiffKind(%q) = %q, want %q", tc.riskType, got, tc.want)
+		}
+	}
+}
+
 func TestAWSRemediationCaseDedupesAcrossSources(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 15, 0, 0, time.UTC)
 	base := AWSRemediationCase{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -393,6 +393,12 @@ func TestAWSRemediationCaseLeastPrivilegeReviewIsNonExecutable(t *testing.T) {
 	if c.RollbackPlan.Strategy != "manual_review" {
 		t.Fatalf("review-decision case must use manual_review rollback, got %s", c.RollbackPlan.Strategy)
 	}
+	if c.VerificationPlan.Strategy != "manual_review" {
+		t.Fatalf("review-decision case must use manual_review verification, got %s", c.VerificationPlan.Strategy)
+	}
+	if len(c.VerificationPlan.SuccessSignals) != 0 || len(c.VerificationPlan.FailureSignals) != 0 {
+		t.Fatalf("review-decision verification must not advertise simulatable signals: %+v", c.VerificationPlan)
+	}
 }
 
 func TestAWSRemediationCaseBlastRadiusDiffKindMatchesEmittedTokens(t *testing.T) {
@@ -402,6 +408,7 @@ func TestAWSRemediationCaseBlastRadiusDiffKindMatchesEmittedTokens(t *testing.T)
 	}{
 		{"cross-account-secret-runtime-access", "iam_trust_diff"},
 		{"cross-account-s3-runtime-access", "iam_trust_diff"},
+		{"secret-runtime-access", "role_scope_diff"},
 		{"agent-tool-path", "ai_agent_scope_change"},
 		{"undeclared-agent-tool-path", "ai_agent_scope_change"},
 		{"unused-agent-tool-path", "ai_agent_scope_change"},

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -272,6 +272,41 @@ func TestAWSRemediationCaseBackingRoleAnchorsOnRole(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCaseReachesApprovedWhenApprovalNotRequired(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 35, 0, 0, time.UTC)
+	ready := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "least-priv:ready-medium",
+		CalculationVersion: "aws-least-privilege-v1",
+		Decision:           "remove",
+		Severity:           "medium",
+		Status:             "action_required",
+		Score:              68,
+		Confidence:         0.82,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::123456789012:role/ready-role",
+		PrincipalARN:       "arn:aws:iam::123456789012:role/ready-role",
+		DisplayName:        "ready-role",
+		RemoveActions:      []string{"s3:DeleteObject"},
+		KeepActions:        []string{"s3:GetObject"},
+		Rationale:          "Observed actions exclude the granted s3:DeleteObject permission.",
+		ImpactedNodes:      []string{"aws:identity:arn:aws:iam::123456789012:role/ready-role"},
+	}
+	c, ok := awsRemediationCaseFromLeastPrivilege(ready, now)
+	if !ok {
+		t.Fatalf("expected ready remove case")
+	}
+	if c.ApprovalRequired {
+		t.Fatalf("medium-severity iam_policy_diff should not require approval (severity=%s diff=%+v)", c.Severity, c.DiffIntent)
+	}
+	if c.ApprovalState != "not_required" {
+		t.Fatalf("expected approval_state=not_required, got %s", c.ApprovalState)
+	}
+	if c.Lifecycle != "approved" {
+		t.Fatalf("executable action_required case with no approval gate should reach approved lifecycle, got %s", c.Lifecycle)
+	}
+}
+
 func TestAWSRemediationCaseLeastPrivilegeReviewStaysInReviewLifecycle(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 30, 0, 0, time.UTC)
 	review := AWSLeastPrivilegeRecommendation{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -272,6 +272,57 @@ func TestAWSRemediationCaseBackingRoleAnchorsOnRole(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCaseLeastPrivilegeReviewStaysInReviewLifecycle(t *testing.T) {
+	now := time.Date(2026, 6, 23, 10, 30, 0, 0, time.UTC)
+	review := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "least-priv:review-action-required",
+		CalculationVersion: "aws-least-privilege-v1",
+		Decision:           "review",
+		Severity:           "high",
+		Status:             "action_required",
+		Score:              82,
+		Confidence:         0.86,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::123456789012:role/review-role",
+		PrincipalARN:       "arn:aws:iam::123456789012:role/review-role",
+		DisplayName:        "review-role",
+		Rationale:          "Observed-without-declaration evidence raised status to action_required.",
+		KeepActions:        []string{"s3:GetObject"},
+		ImpactedNodes:      []string{"aws:identity:arn:aws:iam::123456789012:role/review-role"},
+	}
+	c, ok := awsRemediationCaseFromLeastPrivilege(review, now)
+	if !ok {
+		t.Fatalf("expected review case")
+	}
+	if c.Lifecycle == "approved" {
+		t.Fatalf("review-decision case must never advance to approved lifecycle, got %s (status=%s, diff=%+v)", c.Lifecycle, c.Status, c.DiffIntent)
+	}
+	if c.Lifecycle != "in_review" {
+		t.Fatalf("review-decision case with action_required status must stay in_review, got %s", c.Lifecycle)
+	}
+}
+
+func TestAWSRemediationDiffIsExecutable(t *testing.T) {
+	cases := []struct {
+		name string
+		diff AWSRemediationDiffIntent
+		want bool
+	}{
+		{"executable iam_policy_diff", AWSRemediationDiffIntent{Kind: "iam_policy_diff"}, true},
+		{"executable secret_rotation", AWSRemediationDiffIntent{Kind: "secret_rotation"}, true},
+		{"manual review", AWSRemediationDiffIntent{Kind: "manual_review"}, false},
+		{"no-op owner assignment", AWSRemediationDiffIntent{Kind: "owner_assignment", NoOp: true}, false},
+		{"no-op fallthrough", AWSRemediationDiffIntent{Kind: "iam_policy_diff", NoOp: true}, false},
+	}
+	for _, tc := range cases {
+		got := awsRemediationDiffIsExecutable(tc.diff)
+		if got != tc.want {
+			t.Fatalf("awsRemediationDiffIsExecutable(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestAWSRemediationCaseLeastPrivilegeReviewIsNonExecutable(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 13, 0, 0, time.UTC)
 	review := AWSLeastPrivilegeRecommendation{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -382,6 +382,31 @@ func TestAWSRemediationCaseBlastRadiusDiffKindMatchesEmittedTokens(t *testing.T)
 	}
 }
 
+func TestAWSRemediationCaseEquivalenceDiffIntentMatchesEmittedTypes(t *testing.T) {
+	cases := []struct {
+		equivalenceType string
+		wantKind        string
+	}{
+		{"kms_decrypt_secret_equivalence", "kms_grant_diff"},
+		{"kms_live_grant_secret_equivalence", "kms_grant_diff"},
+		{"agent_provider_key_equivalence", "secret_rotation"},
+		{"workload_provider_key_equivalence", "secret_rotation"},
+		{"admin_equivalent_secret_permission", "iam_policy_diff"},
+		{"blast_radius_secret_equivalence", "iam_policy_diff"},
+		{"runtime_secret_access_equivalence", "iam_policy_diff"},
+		{"secret_read_policy_equivalence", "iam_policy_diff"},
+	}
+	for _, tc := range cases {
+		diff := awsRemediationDiffIntentForEquivalence(AWSSecretPermissionEquivalenceFinding{
+			EquivalenceType: tc.equivalenceType,
+			SecretNodeID:    "aws:resource:secrets-manager-secret/test",
+		})
+		if diff.Kind != tc.wantKind {
+			t.Fatalf("awsRemediationDiffIntentForEquivalence(%q) kind = %q, want %q", tc.equivalenceType, diff.Kind, tc.wantKind)
+		}
+	}
+}
+
 func TestAWSRemediationCaseDedupesAcrossSources(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 15, 0, 0, time.UTC)
 	base := AWSRemediationCase{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3048,6 +3048,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"findings": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSRemediationCases(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRemediationCaseRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			Identity:      strings.TrimSpace(c.Query("identity")),
+			SourceType:    strings.TrimSpace(c.Query("source_type")),
+			Lifecycle:     strings.TrimSpace(c.Query("lifecycle")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			ApprovalState: strings.TrimSpace(c.Query("approval_state")),
+			OwnerAssigned: strings.TrimSpace(c.Query("owner_assigned")),
+			Search:        strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws remediation case request"})
+			default:
+				logger.Error("get aws remediation cases",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws remediation cases"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"cases": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1554,6 +1554,54 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS remediation cases with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        cases: {
+          status: 'ready',
+          summary: { total_cases: 0, filtered_cases: 0 },
+          cases: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectRemediationCases(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'case-triage',
+        sourceType: 'ai_agent_risk',
+        lifecycle: 'in_review',
+        severity: 'high',
+        status: 'action_required',
+        approvalState: 'pending_owner',
+        ownerAssigned: 'false',
+        search: 'rotation'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/remediation-cases?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=case-triage&source_type=ai_agent_risk&lifecycle=in_review&severity=high&status=action_required&approval_state=pending_owner&owner_assigned=false&search=rotation'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2806,6 +2806,184 @@ export type AWSAIAgentRiskQuery = {
   search?: string;
 };
 
+export type AWSRemediationCaseStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSRemediationCaseFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSRemediationCaseSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSRemediationCaseLifecycle =
+  | 'proposed'
+  | 'in_review'
+  | 'approved'
+  | 'executed'
+  | 'verified'
+  | 'closed'
+  | 'rolled_back'
+  | string;
+export type AWSRemediationCaseSourceType =
+  | 'ai_agent_risk'
+  | 'least_privilege'
+  | 'secret_permission_equivalence'
+  | 'blast_radius'
+  | string;
+export type AWSRemediationCaseApprovalState =
+  | 'not_required'
+  | 'pending_owner'
+  | 'pending_owner_review'
+  | 'pending_approver'
+  | 'approved'
+  | 'rejected'
+  | string;
+
+export type AWSRemediationDiffIntent = {
+  kind: string;
+  before_ref?: string;
+  after_ref?: string;
+  diff_summary: string;
+  no_op: boolean;
+  read_only_projection: boolean;
+};
+
+export type AWSRemediationTradeoff = {
+  dimension: string;
+  direction: 'improves' | 'worsens' | 'neutral' | string;
+  description: string;
+  severity: string;
+};
+
+export type AWSRemediationRollbackPlan = {
+  strategy: string;
+  steps: string[];
+  evidence_ref?: string;
+};
+
+export type AWSRemediationVerificationPlan = {
+  strategy: string;
+  steps: string[];
+  success_signals?: string[];
+  failure_signals?: string[];
+  evidence_ref?: string;
+};
+
+export type AWSRemediationAuditEntry = {
+  event_id: string;
+  actor: string;
+  event_type: string;
+  occurred_at: string;
+  evidence_ref?: string;
+  notes?: string;
+};
+
+export type AWSRemediationRelationship = {
+  case_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSRemediationCase = {
+  case_id: string;
+  calculation_version: string;
+  source_type: AWSRemediationCaseSourceType;
+  source_finding_id: string;
+  lifecycle: AWSRemediationCaseLifecycle;
+  severity: AWSRemediationCaseSeverity;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  identity_node_id?: string;
+  identity_arn?: string;
+  identity_name?: string;
+  identity_type?: string;
+  provider?: string;
+  resource_node_ids?: string[];
+  owner?: string;
+  owner_assigned: boolean;
+  approval_required: boolean;
+  approval_state: AWSRemediationCaseApprovalState;
+  diff_intent: AWSRemediationDiffIntent;
+  tradeoffs: AWSRemediationTradeoff[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_actions: string[];
+  audit_trail: AWSRemediationAuditEntry[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationCaseSummary = {
+  total_cases: number;
+  filtered_cases: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  lifecycle_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  approval_state_counts: Record<string, number>;
+  owner_assigned_count: number;
+  ownerless_count: number;
+  approval_required_count: number;
+  read_only_projection_count: number;
+  rollback_plan_count: number;
+  verification_plan_count: number;
+  relationship_count: number;
+  audit_entry_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSRemediationCaseResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSRemediationCaseStatus;
+  fixture_state?: AWSRemediationCaseFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSRemediationCaseSummary;
+  cases: AWSRemediationCase[];
+  relationships: AWSRemediationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationCaseQuery = {
+  connectorID?: string;
+  fixtureState?: AWSRemediationCaseFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  sourceType?: string;
+  lifecycle?: string;
+  severity?: string;
+  status?: string;
+  approvalState?: string;
+  ownerAssigned?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -6914,6 +7092,30 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         evidence: query?.evidence,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectRemediationCases(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSRemediationCaseQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ cases: AWSRemediationCaseResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/remediation-cases${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        source_type: query?.sourceType,
+        lifecycle: query?.lifecycle,
+        severity: query?.severity,
+        status: query?.status,
+        approval_state: query?.approvalState,
+        owner_assigned: query?.ownerAssigned,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3288,6 +3288,119 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    vi.spyOn(api.apiClient, 'getAWSProjectRemediationCases').mockResolvedValue({
+      cases: {
+        status: 'ready',
+        cases: [
+          {
+            case_id: 'aws-remediation-case:rotation-test',
+            calculation_version: 'aws-remediation-case-model-v1',
+            source_type: 'ai_agent_risk',
+            source_finding_id: 'aws-ai-agent-risk:support-provider-key',
+            lifecycle: 'approved',
+            severity: 'high',
+            status: 'action_required',
+            score: 86,
+            confidence: 0.9,
+            title: 'Rotate external credential for support-assistant',
+            summary: 'Rotate the Anthropic provider key used by support-assistant.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:agent:external-support-agent',
+            identity_arn: 'arn:aws:iam::123456789012:role/ecs-support-agent-task',
+            identity_name: 'support-assistant',
+            identity_type: 'ai_agent',
+            provider: 'anthropic',
+            resource_node_ids: ['aws:resource:credential-reference:support-anthropic-key'],
+            owner: 'ai-platform',
+            owner_assigned: true,
+            approval_required: true,
+            approval_state: 'pending_approver',
+            diff_intent: {
+              kind: 'secret_rotation',
+              before_ref: 'evidence://agent/support-assistant/anthropic',
+              after_ref: 'secret://aws:resource:credential-reference:support-anthropic-key/scoped-projection',
+              diff_summary: 'Rotate the agent provider key reference and scope downstream secret reads.',
+              no_op: false,
+              read_only_projection: true
+            },
+            tradeoffs: [
+              {
+                dimension: 'downstream_blast_radius',
+                direction: 'improves',
+                description: 'Rotating the external key revokes any leaked equivalents.',
+                severity: 'high'
+              }
+            ],
+            rollback_plan: {
+              strategy: 're_create_secret_reference',
+              steps: ['Reissue the prior credential if the workload regressed.'],
+              evidence_ref: 'evidence://agent/support-assistant/anthropic'
+            },
+            verification_plan: {
+              strategy: 'secret_access_re_evaluate',
+              steps: ['Re-run secret-permission equivalence.'],
+              success_signals: ['secret-permission-equivalence:no-equivalence'],
+              failure_signals: ['secret-permission-equivalence:still-equivalent'],
+              evidence_ref: 'evidence://agent/support-assistant/anthropic'
+            },
+            source_signals: ['ai_agent_identities'],
+            evidence: [
+              {
+                source: 'ai_agent_identities',
+                evidence_ref: 'evidence://agent/support-assistant/anthropic',
+                label: 'Agent provider-key metadata',
+                confidence: 0.9,
+                observed_at: '2026-06-23T09:00:00Z',
+                relationship: 'references_external_provider_key'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_secret_values_no_prompts_no_completions_no_tool_payloads_no_rendered_policy_bodies',
+            impacted_nodes: ['aws:agent:external-support-agent', 'aws:resource:credential-reference:support-anthropic-key'],
+            impacted_path: [],
+            next_actions: ['Rotate the external provider credential and refresh dependent identities.'],
+            audit_trail: [
+              {
+                event_id: 'aws-remediation-case:rotation-test/proposed',
+                actor: 'system',
+                event_type: 'proposed',
+                occurred_at: '2026-06-23T09:00:00Z',
+                evidence_ref: 'evidence://agent/support-assistant/anthropic',
+                notes: 'Deterministic case proposed from ai_agent_risk evidence at lifecycle=approved.'
+              }
+            ],
+            created_at: '2026-06-23T09:00:00Z',
+            updated_at: '2026-06-23T09:00:00Z'
+          }
+        ],
+        summary: {
+          total_cases: 1,
+          filtered_cases: 1,
+          severity_counts: { high: 1 },
+          status_counts: { action_required: 1 },
+          lifecycle_counts: { approved: 1 },
+          source_type_counts: { ai_agent_risk: 1 },
+          approval_state_counts: { pending_approver: 1 },
+          owner_assigned_count: 1,
+          ownerless_count: 0,
+          approval_required_count: 1,
+          read_only_projection_count: 1,
+          rollback_plan_count: 1,
+          verification_plan_count: 1,
+          relationship_count: 0,
+          audit_entry_count: 1,
+          highest_score: 86,
+          average_confidence_pct: 90
+        },
+        relationships: [],
+        caveats: ['Remediation cases are read-only projections; the engine never applies an AWS change.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -3599,6 +3712,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS AI agent risk findings' })).toBeInTheDocument();
     expect(screen.getAllByText(/External credential exposure/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS remediation cases' })).toBeInTheDocument();
+    expect(screen.getByText(/Rotate external credential for support-assistant/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Secret rotation/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -57,6 +57,8 @@ import {
   type AWSAgentRuntimeAccessResult,
   type AWSAIAgentRiskFinding,
   type AWSAIAgentRiskResult,
+  type AWSRemediationCase,
+  type AWSRemediationCaseResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -10578,6 +10580,115 @@ function AWSAIAgentRiskContent({
   );
 }
 
+function awsRemediationCaseStage(remediationCase: AWSRemediationCase): AWSCapabilityStage {
+  if (remediationCase.severity === 'critical' || remediationCase.approval_state === 'pending_approver') {
+    return 'not-available';
+  }
+  if (remediationCase.severity === 'high' || remediationCase.lifecycle === 'in_review') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsRemediationCaseDiffLabel(remediationCase: AWSRemediationCase): string {
+  return `${formatTokenLabel(remediationCase.diff_intent.kind)}${remediationCase.diff_intent.no_op ? ' (no-op)' : ''}`;
+}
+
+function awsRemediationCaseTradeoffLabel(remediationCase: AWSRemediationCase): string {
+  if (!remediationCase.tradeoffs || remediationCase.tradeoffs.length === 0) {
+    return 'none';
+  }
+  return remediationCase.tradeoffs
+    .slice(0, 2)
+    .map((tradeoff) => `${formatTokenLabel(tradeoff.dimension)} ${tradeoff.direction}`)
+    .join(', ') + (remediationCase.tradeoffs.length > 2 ? ` +${remediationCase.tradeoffs.length - 2}` : '');
+}
+
+function awsRemediationCaseOwnerLabel(remediationCase: AWSRemediationCase): string {
+  if (remediationCase.owner_assigned) {
+    return `${remediationCase.owner || 'assigned'} · ${formatTokenLabel(remediationCase.approval_state)}`;
+  }
+  return `ownerless · ${formatTokenLabel(remediationCase.approval_state)}`;
+}
+
+function AWSRemediationCaseContent({
+  cases,
+  loading,
+  error,
+  onRetry
+}: {
+  cases: AWSRemediationCaseResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = cases?.cases ?? [];
+  const summaryLine = cases
+    ? `${cases.summary.total_cases} total · ${cases.summary.approval_required_count} need approval · ${cases.summary.rollback_plan_count} with rollback · ${cases.summary.verification_plan_count} with verification`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS remediation cases">
+      <h3>AWS remediation case model</h3>
+      <p className="idt-app-kicker">
+        Read-only remediation cases composed from AI agent risk, least-privilege, secret-permission equivalence, and
+        blast-radius findings. Diff intent, tradeoffs, rollback, and verification are projected; the engine never
+        mutates AWS state. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS remediation cases"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing remediation cases"
+          body="Identrail is composing metadata-only AI agent risk, least-privilege, secret-permission, and blast-radius evidence into ranked cases."
+        />
+      ) : null}
+      {!error && !loading && cases && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={cases.status === 'blocked' ? 'Permission required' : 'No remediation cases'}
+          title={cases.status === 'blocked' ? 'Remediation cases need read-only intelligence access' : 'No remediation cases proposed'}
+          body={cases.failure_reasons[0] ?? 'No upstream findings produced a remediation case for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && cases && cases.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {cases.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS remediation cases"
+          rows={rows}
+          getRowKey={(row) => row.case_id}
+          columns={[
+            { key: 'case', header: 'Case', render: (row) => <strong>{row.title}</strong> },
+            { key: 'source', header: 'Source', render: (row) => `${formatTokenLabel(row.source_type)} · ${formatTokenLabel(row.lifecycle)}` },
+            { key: 'identity', header: 'Identity', render: (row) => row.identity_name || row.identity_arn || row.identity_node_id || '-' },
+            { key: 'diff', header: 'Diff intent', render: (row) => awsRemediationCaseDiffLabel(row) },
+            { key: 'tradeoffs', header: 'Tradeoffs', render: (row) => awsRemediationCaseTradeoffLabel(row) },
+            { key: 'owner', header: 'Owner / approval', render: (row) => awsRemediationCaseOwnerLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsRemediationCaseStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12021,6 +12132,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [aiAgentRiskLoading, setAIAgentRiskLoading] = useState(false);
   const [aiAgentRiskError, setAIAgentRiskError] = useState('');
   const aiAgentRiskRequestRef = useRef(0);
+  const [remediationCases, setRemediationCases] = useState<AWSRemediationCaseResult | null>(null);
+  const [remediationCasesLoading, setRemediationCasesLoading] = useState(false);
+  const [remediationCasesError, setRemediationCasesError] = useState('');
+  const remediationCasesRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12305,6 +12420,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       aiAgentRiskRequestRef.current += 1;
     };
   }, [loadAIAgentRisk]);
+
+  const loadRemediationCases = useCallback(async () => {
+    const requestID = ++remediationCasesRequestRef.current;
+    setRemediationCases(null);
+    setRemediationCasesError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setRemediationCasesLoading(false);
+      return;
+    }
+    setRemediationCasesLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRemediationCases(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== remediationCasesRequestRef.current) {
+        return;
+      }
+      setRemediationCases(response.cases);
+    } catch (error) {
+      if (requestID !== remediationCasesRequestRef.current) {
+        return;
+      }
+      setRemediationCasesError(formatAPIError(error, 'Unable to load AWS remediation cases.'));
+    } finally {
+      if (requestID === remediationCasesRequestRef.current) {
+        setRemediationCasesLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadRemediationCases();
+    return () => {
+      remediationCasesRequestRef.current += 1;
+    };
+  }, [loadRemediationCases]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -12776,6 +12939,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={aiAgentRiskLoading}
             error={aiAgentRiskError}
             onRetry={loadAIAgentRisk}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSRemediationCaseContent
+            cases={remediationCases}
+            loading={remediationCasesLoading}
+            error={remediationCasesError}
+            onRetry={loadRemediationCases}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Add the AWS remediation case model engine (#1529, Wave 7.01). A read-only,
metadata-only engine that composes upstream AI agent risk (#1528),
least-privilege (#1522), secret-permission equivalence (#1527), and
blast-radius (#1521) findings into ranked, explainable remediation cases.

Each case carries:
- `case_id`, `calculation_version`, `source_type`, `source_finding_id`
- `lifecycle` (`proposed` / `in_review` / `approved` derived deterministically
  from upstream status, confidence, and owner metadata)
- severity / status / score / confidence (inherited from upstream)
- identity context (node id, ARN, name, type, provider, account, region)
- `owner_assigned` and `approval_state` (`not_required` / `pending_owner` /
  `pending_owner_review` / `pending_approver`)
- read-only `diff_intent` with `kind` (one of `iam_policy_diff`,
  `iam_trust_diff`, `role_scope_diff`, `secret_rotation`, `kms_grant_diff`,
  `ai_agent_scope_change`, `owner_assignment`, `manual_review`),
  `before_ref` / `after_ref` metadata pointers (never rendered policy bodies),
  `diff_summary`, `no_op`, and `read_only_projection: true`
- tradeoffs across `breakage_risk`, `observability_impact`,
  `downstream_blast_radius`, and `rotation_risk`
- `rollback_plan` and `verification_plan` with steps + success/failure
  signals
- evidence refs, source signals, impacted graph nodes/path, next actions
- deterministic system-emitted `proposed` audit entry

`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-cases`
returns `{ "cases": AWSRemediationCaseResult }` with summary, ranked cases,
graph relationships, caveats, failure reasons, remediation hints, evidence
links, coverage gaps, diagnostics, and standard tenant/workspace/project
metadata. Filters: `connector_id`, `fixture_state`, `account_id`, `region`,
`identity`, `source_type`, `lifecycle`, `severity`, `status`,
`approval_state`, `owner_assigned`, `search`. Auth policy wires it as
`tenancy.read` like the neighboring intelligence engines.

The AWS Runtime app surface now shows an **AWS remediation case model**
panel with case, source/lifecycle, identity, diff intent, tradeoffs,
owner/approval, severity/status, and verification strategy. Loading,
empty, error, degraded, and permission-denied states are explicit.

## Why

Closes #1529. Operators today translate every intelligence finding into IAM,
trust, secret, key, or IaC changes by hand. The remediation case model gives
each upstream finding a structured plan with diff intent, tradeoffs,
rollback, and verification so a future executor wave can land safely.

This PR implements the **planning** capability only. It is intentionally
read-only and never mutates AWS. Approve/execute/verify/rollback/govern
transitions belong to later wave issues.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (new route, no existing route
      contracts change)
- [x] Risk level assessed (read-only, no AWS write API calls, no new AWS
      permissions, never reads payloads or secret values)

## Safety / evidence boundary

- Read-only. No AWS write API is called by this issue.
- Never reads, stores, logs, or displays secret values, prompts,
  completions, tool inputs/outputs, browser pages, code-interpreter
  output, database rows, object contents, customer payloads, or
  rendered policy bodies.
- `diff_intent.before_ref` and `after_ref` are metadata URIs (issue URLs,
  evidence refs, projection URIs). They never inline rendered diffs.
- Every case has `read_only_projection: true` on the diff intent.
- All cases include rollback and verification plans so a future executor
  has the safety scaffolding the moment it can land approved changes.
- Unknown, unsupported, partial, degraded, and permission-denied evidence
  stays explicit and is not treated as proof that a case is safe to
  execute.

## Validation

```bash
go test ./internal/api                              # ok
go vet ./...                                        # clean
make fmt-check                                      # clean
make api-example-contract-check                     # passed
npm test -- --run src/api/client.test.ts --prefix web   # 63 passed (incl. new remediation cases client test)
npm test -- --run src/productShell.test.tsx --prefix web # 169 passed (incl. new remediation cases table assertion)
npx tsc -b                                          # clean (web)
npm run build --prefix web                          # built, prerendered 39 routes
```

Manual frontend preview (`npm run dev --prefix web`) compiled and served
cleanly with no console or build errors from the new panel. Full
end-to-end rendering requires the Go API to be running; the panel's UI
behavior is covered by the productShell tests using the mocked client.

## Checklist

- [x] Tests added for new contract, filters, lifecycle derivation, dedupe,
      failure states, and the route
- [x] Docs updated (`docs/aws-remediation-case-model.md`, `docs/README.md`,
      OpenAPI schemas)
- [x] `CHANGELOG.md` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1529.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only AWS remediation case model that composes upstream findings into ranked, explainable remediation cases with a new API and Runtime panel. Helps plan safe changes without touching AWS and closes #1529.

- **New Features**
  - New `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-cases` with filters (`connector`, `fixture_state`, `account`, `region`, `identity`, `source_type`, `lifecycle`, `severity`, `status`, `approval_state`, `owner_assigned`, `search`); authorized via `tenancy.read`.
  - Cases include source type; lifecycle (`proposed` → `in_review` → `approved`); severity/status/score/confidence; identity/resource context; owner/approval; read‑only `diff_intent` (before/after refs only); tradeoffs; rollback and verification plans; evidence/graph refs.
  - Deterministic versioning (`aws-remediation-case-model-v1`) and current issue ref; metadata‑only engine that never mutates AWS or exposes secret values or policy bodies.
  - AWS Runtime adds an “AWS remediation case model” panel with case details and explicit loading/empty/error/degraded/permission‑denied states.
  - OpenAPI, docs, tests, and client types updated; web client adds `getAWSProjectRemediationCases`.

- **Bug Fixes**
  - Lifecycle: cap non‑executable cases (`manual_review` or `no_op`) at `in_review`, and auto‑advance executable `action_required` cases with `approval_state=not_required` to `approved`.
  - For `ai_agent_risk` cases with `backing_role_scope` or `backing_role_mismatch`, anchor identity on the IAM role (node id/ARN/name) instead of the agent.
  - Match emitted blast‑radius tokens and route correctly (cross‑account → `iam_trust_diff`, agent paths → `ai_agent_scope_change`); route non‑cross‑account secret runtime access to `role_scope_diff` (reserve `secret_rotation` for credential exposure).
  - Map secret‑permission equivalence types to the right diff kind (e.g., KMS‑backed types → `kms_grant_diff`; explicit branches for admin‑equivalent, blast‑radius, workload‑provider‑key, and secret‑read policy equivalence).
  - For least‑privilege decisions other than `remove`, return a `manual_review` verification plan (no policy simulate) to match non‑executable diffs.

<sup>Written for commit 1c350a10512b96ba168efead4ca26a39d9b63f18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

