### PR TITLE
Implement AWS IAM policy least-privilege diff generator (#1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS IAM policy least-privilege diff generator** (#1530). Adds a
+  read-only, metadata-only engine that turns least-privilege recommendations
+  (#1522) into ranked IAM policy diffs. Each diff carries statement-level
+  removed/kept actions, resource scope before/after, an expected breakage
+  projection (`low` / `medium` / `high` / `unknown` plus rationale and
+  signals), a rollback plan, a verification plan, a deterministic
+  `ready_for_apply` flag (true only when `decision=remove` +
+  `breakage_level=low` + `confidence >= 0.75`), and the standard evidence,
+  source-signal, impacted-node, and audit metadata. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs`
+  with filters for connector, account, region, identity, service,
+  decision, severity, status, breakage level, ready-for-apply, and free-text
+  search. OpenAPI schemas and authz wiring follow the neighboring AWS
+  intelligence engines. The AWS Runtime app surface now shows an **AWS IAM
+  policy least-privilege diff** panel with identity, decision, statement
+  change kind, removed/kept counts, breakage level, ready-for-apply,
+  verification strategy, and evidence. The engine never mutates AWS, never
+  reads or returns rendered policy bodies, secret values, prompts,
+  completions, tool payloads, browser pages, code-interpreter output,
+  database rows, object contents, customer payloads, or workload payloads;
+  apply/verify transitions belong to later wave issues.
 - Add **AWS remediation case model** (#1529). Adds a read-only, metadata-only
   engine that composes upstream AI agent risk (#1528), least-privilege
   (#1522), secret-permission equivalence (#1527), and blast-radius (#1521)

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS AI agent identities: `aws-ai-agent-identities.md`
 - AWS AI agent risk engine: `aws-ai-agent-risk-engine.md`
 - AWS remediation case model: `aws-remediation-case-model.md`
+- AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-iam-policy-least-privilege-diff.md
+++ b/docs/aws-iam-policy-least-privilege-diff.md
@@ -1,0 +1,153 @@
+# AWS IAM policy least-privilege diff generator
+
+Issue #1530 (Wave 7.02) adds a metadata-only engine that turns upstream
+least-privilege recommendations (#1522) into ranked, read-only IAM policy
+least-privilege diffs. Each diff carries the projected before/after IAM
+statement, removed/kept actions, resource scope, expected breakage,
+rollback, and verification — so a remediation case (#1529) and a future
+executor wave have the concrete payload they need to plan, approve, and
+apply safely.
+
+This issue is the **diff projection** capability of the Identrail
+remediation loop. It does not mutate AWS, does not call any IAM write
+API, and does not read rendered policy bodies, secret values, workload
+payloads, prompts, completions, browser pages, code-interpreter output,
+database rows, object contents, or customer payloads. Approve, execute,
+verify, rollback, and govern transitions belong to later wave issues.
+
+## What it produces
+
+The engine emits `AWSIAMPolicyDiff` records, one per upstream
+least-privilege recommendation that is not a `keep` decision. Every
+diff carries:
+
+- **Identifiers**: stable `diff_id`, `calculation_version`, and the
+  `source_recommendation_id` it was generated from.
+- **Decision / severity / status / score / confidence**: inherited
+  from the upstream recommendation.
+- **Identity context**: account, region, service, identity node id,
+  ARN, name, plus optional resource node id and ARN.
+- **`statement_changes`**: one or more `AWSIAMPolicyStatementDiff`
+  entries with `change_kind` ∈ {`scope_removed`, `statement_removed`,
+  `manual_review`}, removed/kept actions, resource and condition
+  before/after, and a rationale.
+- **Aggregated action sets**: top-level `removed_actions`,
+  `kept_actions`, `observed_actions`, `granted_actions`.
+- **`resource_scope_before` / `resource_scope_after`**: metadata
+  refs only — empty `resource_scope_after` indicates the statement
+  is removed entirely.
+- **`breakage_projection`** with `level` ∈ {`low`, `medium`, `high`,
+  `unknown`}, rationale, and signal counts. Review-decision diffs
+  always project `unknown`.
+- **`rollback_plan`** (`re_attach_policy` or `manual_review`) and
+  **`verification_plan`** (`policy_simulate` or `manual_review`).
+- **`ready_for_apply`**: `true` only when `decision = remove`,
+  `breakage_projection.level = low`, and `confidence >= 0.75`.
+- **`read_only_projection`: true** on every diff.
+- **Evidence refs / source signals / impacted nodes / impacted path /
+  next action** carried from the upstream recommendation.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-policy-diffs`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `identity` | substring search across identity node, ARN, or name |
+| `service` | exact match on the upstream AWS service token |
+| `decision` | `remove` or `review` (`keep` is suppressed by the engine) |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `action_required`, `review`, or `monitor` |
+| `breakage_level` | `low`, `medium`, `high`, or `unknown` |
+| `ready_for_apply` | `true` / `false` |
+| `search` | free-text search across diff, statement, action, resource, evidence, and plan fields |
+
+Response shape: `{ "diffs": AWSIAMPolicyDiffResult }` with summary,
+ranked diffs, graph relationships, caveats, failure reasons,
+remediation hints, evidence links, coverage gaps, diagnostics, and the
+standard tenant/workspace/project metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays rendered IAM policy
+bodies, secret values, prompts, completions, tool inputs/outputs,
+browser pages, code-interpreter output, database rows, object
+contents, customer payloads, or workload payloads. It composes only
+the upstream least-privilege recommendation refs and counts.
+
+Statement-level `condition_before` and `condition_after` carry
+identifiers (e.g. condition keys / labels) only — never rendered JSON
+condition bodies.
+
+## AWS permissions
+
+This capability adds no live mutation and requires no additional AWS
+permissions beyond what the least-privilege engine (#1522) already
+needs. It reuses that engine's read-only metadata access.
+
+Do not grant IAM write permissions for this issue.
+
+## Ready-for-apply derivation
+
+A diff is marked `ready_for_apply: true` only when *all* of the
+following hold:
+
+1. `decision == "remove"`, and
+2. `breakage_projection.level == "low"`, and
+3. `confidence >= 0.75`.
+
+Any other combination (`review` decisions, medium/high/unknown
+breakage, or sub-0.75 confidence) keeps `ready_for_apply: false` so
+downstream consumers cannot queue uncertain diffs for execution.
+
+## Failure handling
+
+- **Ready**: least-privilege was available and emitted no blocking
+  diagnostics.
+- **Degraded**: least-privilege returned partial / degraded / empty
+  evidence, or produced retryable diagnostics. Diffs already
+  composed remain visible.
+- **Blocked**: least-privilege is permission denied. The response has
+  zero diffs plus diagnostics and failure reasons.
+
+Unknown, unsupported, partial, degraded, and permission-denied
+evidence stays explicit and is not treated as proof that a diff is
+safe to apply.
+
+## App surface
+
+The AWS Runtime app surface renders the **AWS IAM policy
+least-privilege diff** panel with each diff's identity, decision,
+statement change kind, removed/kept action counts, breakage level,
+ready-for-apply flag, verification strategy, and evidence refs.
+Loading, empty, error, degraded, and permission-denied states are
+explicit.
+
+## Live validation
+
+1. Confirm blocker #1529 is closed.
+2. Run least-privilege with `fixture_state=success`.
+3. Run the diff endpoint with `fixture_state=success` and confirm
+   `remove` and `review` diffs appear.
+4. Filter by `decision=remove`, `breakage_level=low`,
+   `ready_for_apply=true`, and `search` to verify deterministic
+   drill-down.
+5. Run `fixture_state=permission_denied`, `empty`, `degraded`, and
+   `partial_failure` and confirm blocked/degraded states are
+   explicit.
+6. Confirm the AWS Runtime app panel renders success, empty,
+   degraded, permission-denied, and partial-failure states without
+   exposing rendered policy bodies or secret values.
+
+## Safety gates
+
+- Read-only. No IAM write API is called by this issue.
+- All diffs include `read_only_projection: true`.
+- All diffs include rollback and verification plans, so a future
+  executor has the safety scaffolding the moment it can land
+  approved changes.
+- `ready_for_apply` is derived deterministically — it is a hint to
+  consumers, not an instruction to execute.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -579,6 +579,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-policy-diffs
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5112,6 +5117,98 @@ paths:
                     $ref: "#/components/schemas/AWSRemediationCaseResult"
         "400":
           description: Invalid AWS remediation case request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iam-policy-diffs:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS IAM policy least-privilege diffs
+      operationId: getAWSProjectIAMPolicyDiffs
+      description: Generates ranked, read-only IAM policy least-privilege diffs from upstream least-privilege recommendations. Diffs carry stable IDs, calculation version, decision/severity/status/confidence, statement-level removed/kept actions, resource scope before/after, expected breakage projection, rollback plan, verification plan, ready_for_apply, evidence refs, source signals, impacted graph nodes/path, and next action. The engine is read-only and never mutates AWS state, never reads or returns rendered policy bodies, secret values, prompts, completions, tool payloads, browser pages, code-interpreter output, database rows, object contents, customer payloads, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+          description: Optional substring search across identity node, ARN, or name.
+        - in: query
+          name: service
+          schema: { type: string }
+        - in: query
+          name: decision
+          schema:
+            type: string
+            enum: [keep, remove, review]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: breakage_level
+          schema:
+            type: string
+            enum: [low, medium, high, unknown]
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across diff, statement, action, resource, evidence, and plan fields.
+      responses:
+        "200":
+          description: AWS IAM policy least-privilege diff contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  diffs:
+                    $ref: "#/components/schemas/AWSIAMPolicyDiffResult"
+        "400":
+          description: Invalid AWS IAM policy diff request
           content:
             application/json:
               schema:
@@ -13328,6 +13425,253 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSRemediationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSIAMPolicyStatementDiff:
+      type: object
+      properties:
+        statement_sid: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        change_kind:
+          type: string
+          enum: [scope_removed, statement_removed, manual_review]
+        removed_actions:
+          type: array
+          items: { type: string }
+        kept_actions:
+          type: array
+          items: { type: string }
+        resource_before:
+          type: array
+          items: { type: string }
+        resource_after:
+          type: array
+          items: { type: string }
+        condition_before:
+          type: array
+          items: { type: string }
+        condition_after:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+    AWSIAMPolicyDiffBreakageProjection:
+      type: object
+      properties:
+        level:
+          type: string
+          enum: [low, medium, high, unknown]
+        rationale: { type: string }
+        signals:
+          type: array
+          items: { type: string }
+    AWSIAMPolicyDiffRollbackPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSIAMPolicyDiffVerificationPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        success_signals:
+          type: array
+          items: { type: string }
+        failure_signals:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSIAMPolicyDiffRelationship:
+      type: object
+      properties:
+        diff_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSIAMPolicyDiff:
+      type: object
+      properties:
+        diff_id: { type: string }
+        calculation_version: { type: string }
+        source_recommendation_id: { type: string }
+        decision:
+          type: string
+          enum: [keep, remove, review]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        identity_node_id: { type: string }
+        identity_arn: { type: string }
+        identity_name: { type: string }
+        resource_node_id: { type: string }
+        resource_arn: { type: string }
+        statement_changes:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPolicyStatementDiff"
+        removed_actions:
+          type: array
+          items: { type: string }
+        kept_actions:
+          type: array
+          items: { type: string }
+        observed_actions:
+          type: array
+          items: { type: string }
+        granted_actions:
+          type: array
+          items: { type: string }
+        resource_scope_before:
+          type: array
+          items: { type: string }
+        resource_scope_after:
+          type: array
+          items: { type: string }
+        breakage_projection:
+          $ref: "#/components/schemas/AWSIAMPolicyDiffBreakageProjection"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSIAMPolicyDiffRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSIAMPolicyDiffVerificationPlan"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSIAMPolicyDiffSummary:
+      type: object
+      properties:
+        total_diffs: { type: integer }
+        filtered_diffs: { type: integer }
+        decision_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        breakage_level_counts:
+          type: object
+          additionalProperties: { type: integer }
+        service_counts:
+          type: object
+          additionalProperties: { type: integer }
+        removed_action_count: { type: integer }
+        kept_action_count: { type: integer }
+        statement_change_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        manual_review_count: { type: integer }
+        no_op_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSIAMPolicyDiffResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSIAMPolicyDiffSummary"
+        diffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPolicyDiff"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIAMPolicyDiffRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -759,6 +759,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-risk", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_iam_policy_diffs.go
+++ b/internal/api/aws_iam_policy_diffs.go
@@ -1,0 +1,749 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsIAMPolicyDiffCurrentIssue = 1530
+	awsIAMPolicyDiffVersion      = "aws-iam-policy-least-privilege-diff-v1"
+)
+
+// AWSIAMPolicyDiffRequest scopes the deterministic IAM policy diff generator
+// to one AWS connector plus optional operator drill-down filters.
+type AWSIAMPolicyDiffRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Identity      string `json:"identity,omitempty"`
+	Service       string `json:"service,omitempty"`
+	Decision      string `json:"decision,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	BreakageLevel string `json:"breakage_level,omitempty"`
+	ReadyForApply string `json:"ready_for_apply,omitempty"`
+	Search        string `json:"search,omitempty"`
+}
+
+// AWSIAMPolicyDiffEvidence and path step reuse the least-privilege contract
+// so the diff generator stays consistent with its upstream source.
+type AWSIAMPolicyDiffEvidence = AWSLeastPrivilegeEvidence
+type AWSIAMPolicyDiffPathStep = AWSLeastPrivilegePathStep
+type AWSIAMPolicyDiffDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSIAMPolicyDiffCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSIAMPolicyStatementDiff is the projected before/after state of a single
+// IAM policy statement. It carries only action/resource/condition refs and
+// labels; the engine never inlines rendered policy bodies, secret values, or
+// workload payloads.
+type AWSIAMPolicyStatementDiff struct {
+	StatementSID    string   `json:"statement_sid"`
+	Effect          string   `json:"effect"`
+	ChangeKind      string   `json:"change_kind"`
+	RemovedActions  []string `json:"removed_actions,omitempty"`
+	KeptActions     []string `json:"kept_actions,omitempty"`
+	ResourceBefore  []string `json:"resource_before,omitempty"`
+	ResourceAfter   []string `json:"resource_after,omitempty"`
+	ConditionBefore []string `json:"condition_before,omitempty"`
+	ConditionAfter  []string `json:"condition_after,omitempty"`
+	Rationale       string   `json:"rationale"`
+}
+
+// AWSIAMPolicyDiffBreakageProjection describes the expected workload
+// breakage of applying the diff. Levels are strictly bucketed.
+type AWSIAMPolicyDiffBreakageProjection struct {
+	Level     string   `json:"level"`
+	Rationale string   `json:"rationale"`
+	Signals   []string `json:"signals,omitempty"`
+}
+
+// AWSIAMPolicyDiffRollbackPlan describes how an applied diff is reverted.
+type AWSIAMPolicyDiffRollbackPlan struct {
+	Strategy    string   `json:"strategy"`
+	Steps       []string `json:"steps"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSIAMPolicyDiffVerificationPlan describes how an applied diff is checked.
+type AWSIAMPolicyDiffVerificationPlan struct {
+	Strategy       string   `json:"strategy"`
+	Steps          []string `json:"steps"`
+	SuccessSignals []string `json:"success_signals,omitempty"`
+	FailureSignals []string `json:"failure_signals,omitempty"`
+	EvidenceRef    string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSIAMPolicyDiffRelationship surfaces diff→graph node edges so the app
+// and downstream graph consumers can show why a diff touches a node.
+type AWSIAMPolicyDiffRelationship struct {
+	DiffID      string `json:"diff_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSIAMPolicyDiff is the persisted-record-shaped contract emitted by the
+// IAM policy least-privilege diff generator. It intentionally carries only
+// statement/action/resource metadata refs and graph nodes; no rendered
+// policy bodies, secret values, prompts, completions, tool payloads,
+// browser pages, code-interpreter output, database rows, object contents,
+// or customer payloads are inlined.
+type AWSIAMPolicyDiff struct {
+	DiffID                 string                             `json:"diff_id"`
+	CalculationVersion     string                             `json:"calculation_version"`
+	SourceRecommendationID string                             `json:"source_recommendation_id"`
+	Decision               string                             `json:"decision"`
+	Severity               string                             `json:"severity"`
+	Status                 string                             `json:"status"`
+	Score                  int                                `json:"score"`
+	Confidence             float64                            `json:"confidence"`
+	Title                  string                             `json:"title"`
+	Summary                string                             `json:"summary"`
+	AccountID              string                             `json:"account_id"`
+	Region                 string                             `json:"region"`
+	Service                string                             `json:"service,omitempty"`
+	IdentityNodeID         string                             `json:"identity_node_id"`
+	IdentityARN            string                             `json:"identity_arn,omitempty"`
+	IdentityName           string                             `json:"identity_name,omitempty"`
+	ResourceNodeID         string                             `json:"resource_node_id,omitempty"`
+	ResourceARN            string                             `json:"resource_arn,omitempty"`
+	StatementChanges       []AWSIAMPolicyStatementDiff        `json:"statement_changes"`
+	RemovedActions         []string                           `json:"removed_actions,omitempty"`
+	KeptActions            []string                           `json:"kept_actions,omitempty"`
+	ObservedActions        []string                           `json:"observed_actions,omitempty"`
+	GrantedActions         []string                           `json:"granted_actions,omitempty"`
+	ResourceScopeBefore    []string                           `json:"resource_scope_before,omitempty"`
+	ResourceScopeAfter     []string                           `json:"resource_scope_after,omitempty"`
+	BreakageProjection     AWSIAMPolicyDiffBreakageProjection `json:"breakage_projection"`
+	RollbackPlan           AWSIAMPolicyDiffRollbackPlan       `json:"rollback_plan"`
+	VerificationPlan       AWSIAMPolicyDiffVerificationPlan   `json:"verification_plan"`
+	ReadyForApply          bool                               `json:"ready_for_apply"`
+	ReadOnlyProjection     bool                               `json:"read_only_projection"`
+	SourceSignals          []string                           `json:"source_signals"`
+	Evidence               []AWSIAMPolicyDiffEvidence         `json:"evidence"`
+	EvidenceBoundary       string                             `json:"evidence_boundary"`
+	ImpactedNodes          []string                           `json:"impacted_nodes"`
+	ImpactedPath           []AWSIAMPolicyDiffPathStep         `json:"impacted_path"`
+	NextAction             string                             `json:"next_action"`
+	CreatedAt              time.Time                          `json:"created_at"`
+	UpdatedAt              time.Time                          `json:"updated_at"`
+}
+
+// AWSIAMPolicyDiffSummary aggregates the unfiltered and filtered diff set.
+type AWSIAMPolicyDiffSummary struct {
+	TotalDiffs           int            `json:"total_diffs"`
+	FilteredDiffs        int            `json:"filtered_diffs"`
+	DecisionCounts       map[string]int `json:"decision_counts"`
+	SeverityCounts       map[string]int `json:"severity_counts"`
+	StatusCounts         map[string]int `json:"status_counts"`
+	BreakageLevelCounts  map[string]int `json:"breakage_level_counts"`
+	ServiceCounts        map[string]int `json:"service_counts"`
+	RemovedActionCount   int            `json:"removed_action_count"`
+	KeptActionCount      int            `json:"kept_action_count"`
+	StatementChangeCount int            `json:"statement_change_count"`
+	ReadyForApplyCount   int            `json:"ready_for_apply_count"`
+	ManualReviewCount    int            `json:"manual_review_count"`
+	NoOpCount            int            `json:"no_op_count"`
+	RelationshipCount    int            `json:"relationship_count"`
+	HighestScore         int            `json:"highest_score"`
+	AverageConfidencePct int            `json:"average_confidence_pct"`
+}
+
+// AWSIAMPolicyDiffResult is the deterministic diff-generator envelope.
+type AWSIAMPolicyDiffResult struct {
+	TenantID           string                         `json:"tenant_id"`
+	WorkspaceID        string                         `json:"workspace_id"`
+	ProjectID          string                         `json:"project_id"`
+	ConnectorID        string                         `json:"connector_id,omitempty"`
+	AccountID          string                         `json:"account_id,omitempty"`
+	Region             string                         `json:"region,omitempty"`
+	ParentIssueNumber  int                            `json:"parent_issue_number"`
+	ParentIssueRef     string                         `json:"parent_issue_ref"`
+	CurrentIssueNumber int                            `json:"current_issue_number"`
+	CurrentIssueRef    string                         `json:"current_issue_ref"`
+	Version            string                         `json:"version"`
+	Status             string                         `json:"status"`
+	FixtureState       string                         `json:"fixture_state,omitempty"`
+	Confidence         float64                        `json:"confidence"`
+	CalculationVersion string                         `json:"calculation_version"`
+	AppliedFilters     map[string]string              `json:"applied_filters"`
+	Summary            AWSIAMPolicyDiffSummary        `json:"summary"`
+	Diffs              []AWSIAMPolicyDiff             `json:"diffs"`
+	Relationships      []AWSIAMPolicyDiffRelationship `json:"relationships"`
+	Caveats            []string                       `json:"caveats"`
+	FailureReasons     []string                       `json:"failure_reasons"`
+	RemediationHints   []string                       `json:"remediation_hints"`
+	EvidenceLinks      []string                       `json:"evidence_links"`
+	CoverageGaps       []AWSIAMPolicyDiffCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSIAMPolicyDiffDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                      `json:"generated_at"`
+	UpdatedAt          time.Time                      `json:"updated_at"`
+}
+
+type awsIAMPolicyDiffSources struct {
+	least AWSLeastPrivilegeResult
+}
+
+// GetAWSIAMPolicyDiffs composes ranked IAM policy least-privilege diffs from
+// least-privilege recommendations. The engine is read-only: it never mutates
+// AWS, never reads or returns rendered policy bodies, secret values, or
+// workload payloads, and treats unknown or denied evidence as explicit
+// states instead of deterministic truth.
+func (s *Service) GetAWSIAMPolicyDiffs(ctx context.Context, workspaceID string, projectID string, request AWSIAMPolicyDiffRequest) (AWSIAMPolicyDiffResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSIAMPolicyDiffResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSIAMPolicyDiffResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSIAMPolicyDiffFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSIAMPolicyDiffResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsIAMPolicyDiffSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSIAMPolicyDiffResult{}, err
+	}
+	diffs := awsIAMPolicyDiffs(sources, now)
+	sort.SliceStable(diffs, func(i, j int) bool {
+		if diffs[i].Score == diffs[j].Score {
+			return diffs[i].DiffID < diffs[j].DiffID
+		}
+		return diffs[i].Score > diffs[j].Score
+	})
+	filtered, applied := filterAWSIAMPolicyDiffs(diffs, request)
+	relationships := awsIAMPolicyDiffRelationships(filtered)
+	diagnostics := awsIAMPolicyDiffDiagnostics(sources)
+	coverageGaps := awsIAMPolicyDiffCoverageGaps(sources)
+	status, confidence := summarizeAWSIAMPolicyDiffStatus(sources, filtered, diagnostics)
+
+	return AWSIAMPolicyDiffResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsIAMPolicyDiffCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsIAMPolicyDiffCurrentIssue),
+		Version:            awsIAMPolicyDiffVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsIAMPolicyDiffVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSIAMPolicyDiffs(diffs, filtered, relationships),
+		Diffs:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsIAMPolicyDiffCaveats(),
+		FailureReasons:     awsIAMPolicyDiffFailureReasons(sources),
+		RemediationHints:   awsIAMPolicyDiffRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsIAMPolicyDiffCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-iam-policy-least-privilege-diff",
+			"/docs/aws-least-privilege",
+			"/docs/aws-remediation-case-model",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSIAMPolicyDiffFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsIAMPolicyDiffSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsIAMPolicyDiffSources, error) {
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsIAMPolicyDiffSources{}, fmt.Errorf("iam policy diff least privilege: %w", err)
+	}
+	return awsIAMPolicyDiffSources{least: least}, nil
+}
+
+func awsIAMPolicyDiffs(sources awsIAMPolicyDiffSources, now time.Time) []AWSIAMPolicyDiff {
+	diffs := []AWSIAMPolicyDiff{}
+	for _, recommendation := range sources.least.Recommendations {
+		if d, ok := awsIAMPolicyDiffFromRecommendation(recommendation, now); ok {
+			diffs = append(diffs, d)
+		}
+	}
+	return diffs
+}
+
+func awsIAMPolicyDiffFromRecommendation(recommendation AWSLeastPrivilegeRecommendation, now time.Time) (AWSIAMPolicyDiff, bool) {
+	if recommendation.RecommendationID == "" || recommendation.Decision == "keep" {
+		return AWSIAMPolicyDiff{}, false
+	}
+	diffID := "aws-iam-policy-diff:" + stableAWSBlastRadiusToken("least-privilege", recommendation.RecommendationID)
+	evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(recommendation.Evidence))
+	resourceBefore := awsIAMPolicyDiffResourceScope(recommendation, "before")
+	resourceAfter := awsIAMPolicyDiffResourceScope(recommendation, "after")
+	statementChanges := awsIAMPolicyStatementChanges(recommendation, resourceBefore, resourceAfter)
+	breakage := awsIAMPolicyDiffBreakage(recommendation)
+	rollback := awsIAMPolicyDiffRollback(recommendation, evidenceRef)
+	verification := awsIAMPolicyDiffVerification(recommendation, evidenceRef)
+	readyForApply := awsIAMPolicyDiffReadyForApply(recommendation, breakage)
+	title := awsIAMPolicyDiffTitle(recommendation)
+	d := AWSIAMPolicyDiff{
+		DiffID:                 diffID,
+		CalculationVersion:     awsIAMPolicyDiffVersion,
+		SourceRecommendationID: recommendation.RecommendationID,
+		Decision:               recommendation.Decision,
+		Severity:               recommendation.Severity,
+		Status:                 recommendation.Status,
+		Score:                  recommendation.Score,
+		Confidence:             recommendation.Confidence,
+		Title:                  title,
+		Summary:                recommendation.Rationale,
+		AccountID:              recommendation.AccountID,
+		Region:                 recommendation.Region,
+		Service:                recommendation.Service,
+		IdentityNodeID:         recommendation.IdentityNodeID,
+		IdentityARN:            recommendation.PrincipalARN,
+		IdentityName:           recommendation.DisplayName,
+		ResourceNodeID:         recommendation.ResourceNodeID,
+		ResourceARN:            recommendation.ResourceARN,
+		StatementChanges:       statementChanges,
+		RemovedActions:         dedupeStrings(recommendation.RemoveActions),
+		KeptActions:            dedupeStrings(recommendation.KeepActions),
+		ObservedActions:        dedupeStrings(recommendation.ObservedActions),
+		GrantedActions:         dedupeStrings(recommendation.GrantedActions),
+		ResourceScopeBefore:    resourceBefore,
+		ResourceScopeAfter:     resourceAfter,
+		BreakageProjection:     breakage,
+		RollbackPlan:           rollback,
+		VerificationPlan:       verification,
+		ReadyForApply:          readyForApply,
+		ReadOnlyProjection:     true,
+		SourceSignals:          []string{"least_privilege"},
+		Evidence:               recommendation.Evidence,
+		EvidenceBoundary:       awsIAMPolicyDiffEvidenceBoundary(),
+		ImpactedNodes:          emptyStrings(dedupeStrings(append([]string{recommendation.IdentityNodeID, recommendation.ResourceNodeID}, recommendation.ImpactedNodes...))),
+		ImpactedPath:           recommendation.ImpactedPath,
+		NextAction:             recommendation.NextAction,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	return d, true
+}
+
+func awsIAMPolicyDiffResourceScope(recommendation AWSLeastPrivilegeRecommendation, phase string) []string {
+	if phase == "before" {
+		return dedupeStrings(emptyStrings([]string{recommendation.ResourceARN, recommendation.ResourceNodeID}))
+	}
+	if recommendation.Decision == "remove" && len(recommendation.KeepActions) == 0 {
+		return []string{}
+	}
+	return dedupeStrings(emptyStrings([]string{recommendation.ResourceARN, recommendation.ResourceNodeID}))
+}
+
+func awsIAMPolicyStatementChanges(recommendation AWSLeastPrivilegeRecommendation, resourceBefore, resourceAfter []string) []AWSIAMPolicyStatementDiff {
+	switch recommendation.Decision {
+	case "remove":
+		statement := AWSIAMPolicyStatementDiff{
+			StatementSID:   "least-privilege-projection",
+			Effect:         "Allow",
+			ChangeKind:     "scope_removed",
+			RemovedActions: dedupeStrings(recommendation.RemoveActions),
+			KeptActions:    dedupeStrings(recommendation.KeepActions),
+			ResourceBefore: resourceBefore,
+			ResourceAfter:  resourceAfter,
+			Rationale:      fmt.Sprintf("Remove %d unused action(s) and keep %d observed action(s) on %s.", len(recommendation.RemoveActions), len(recommendation.KeepActions), recommendation.DisplayName),
+		}
+		if len(recommendation.KeepActions) == 0 {
+			statement.ChangeKind = "statement_removed"
+			statement.Rationale = fmt.Sprintf("All %d granted action(s) on %s are unused; remove the statement entirely.", len(recommendation.RemoveActions), recommendation.DisplayName)
+		}
+		return []AWSIAMPolicyStatementDiff{statement}
+	case "review":
+		return []AWSIAMPolicyStatementDiff{{
+			StatementSID:   "least-privilege-projection",
+			Effect:         "Allow",
+			ChangeKind:     "manual_review",
+			KeptActions:    dedupeStrings(recommendation.KeepActions),
+			ResourceBefore: resourceBefore,
+			ResourceAfter:  resourceBefore,
+			Rationale:      fmt.Sprintf("Least-privilege evidence on %s is not yet conclusive; no statement-level diff is projected.", recommendation.DisplayName),
+		}}
+	}
+	return nil
+}
+
+func awsIAMPolicyDiffBreakage(recommendation AWSLeastPrivilegeRecommendation) AWSIAMPolicyDiffBreakageProjection {
+	level := strings.ToLower(strings.TrimSpace(recommendation.BreakagePrediction))
+	switch level {
+	case "low", "medium", "high":
+	case "":
+		level = "unknown"
+	default:
+		level = "unknown"
+	}
+	signals := []string{}
+	if len(recommendation.ObservedActions) > 0 {
+		signals = append(signals, fmt.Sprintf("observed_actions:%d", len(recommendation.ObservedActions)))
+	}
+	if len(recommendation.RemoveActions) > 0 {
+		signals = append(signals, fmt.Sprintf("removed_actions:%d", len(recommendation.RemoveActions)))
+	}
+	if len(recommendation.KeepActions) > 0 {
+		signals = append(signals, fmt.Sprintf("kept_actions:%d", len(recommendation.KeepActions)))
+	}
+	if recommendation.Decision == "review" {
+		level = "unknown"
+	}
+	rationale := recommendation.BreakageRationale
+	if strings.TrimSpace(rationale) == "" {
+		switch level {
+		case "low":
+			rationale = "Removed actions have no observed callers in the runtime evidence window."
+		case "medium":
+			rationale = "Some removed actions match infrequently observed callers; confirm before apply."
+		case "high":
+			rationale = "Removed actions overlap with recently observed callers; expect breakage."
+		default:
+			rationale = "Runtime evidence is incomplete; manual breakage review required before apply."
+		}
+	}
+	return AWSIAMPolicyDiffBreakageProjection{
+		Level:     level,
+		Rationale: rationale,
+		Signals:   signals,
+	}
+}
+
+func awsIAMPolicyDiffRollback(recommendation AWSLeastPrivilegeRecommendation, evidenceRef string) AWSIAMPolicyDiffRollbackPlan {
+	if recommendation.Decision == "review" {
+		return AWSIAMPolicyDiffRollbackPlan{
+			Strategy:    "manual_review",
+			Steps:       []string{"No projected diff to roll back; rerun least-privilege after evidence settles."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSIAMPolicyDiffRollbackPlan{
+		Strategy:    "re_attach_policy",
+		Steps:       []string{"Re-attach the captured before_ref policy statement.", "Re-run least-privilege to confirm scope returned."},
+		EvidenceRef: evidenceRef,
+	}
+}
+
+func awsIAMPolicyDiffVerification(recommendation AWSLeastPrivilegeRecommendation, evidenceRef string) AWSIAMPolicyDiffVerificationPlan {
+	if recommendation.Decision == "review" {
+		return AWSIAMPolicyDiffVerificationPlan{
+			Strategy:    "manual_review",
+			Steps:       []string{"Least-privilege evidence is inconclusive; no projected diff to simulate.", "Re-run least-privilege after upstream evidence settles into a remove/keep decision."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSIAMPolicyDiffVerificationPlan{
+		Strategy:       "policy_simulate",
+		Steps:          []string{"Run IAM policy simulator against the kept actions to confirm no regression.", "Re-run least-privilege to confirm decision flips to keep."},
+		SuccessSignals: []string{"policy_simulate:no-regression", "least_privilege:decision-keep"},
+		FailureSignals: []string{"policy_simulate:denied-observed-action"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsIAMPolicyDiffReadyForApply(recommendation AWSLeastPrivilegeRecommendation, breakage AWSIAMPolicyDiffBreakageProjection) bool {
+	if recommendation.Decision != "remove" {
+		return false
+	}
+	if breakage.Level != "low" {
+		return false
+	}
+	if recommendation.Confidence < 0.75 {
+		return false
+	}
+	return true
+}
+
+func awsIAMPolicyDiffTitle(recommendation AWSLeastPrivilegeRecommendation) string {
+	display := firstNonEmptyAWSValue(recommendation.DisplayName, recommendation.IdentityNodeID, "IAM identity")
+	switch recommendation.Decision {
+	case "remove":
+		return fmt.Sprintf("Scope %s: remove %d action(s)", display, len(recommendation.RemoveActions))
+	case "review":
+		return fmt.Sprintf("Manual review for %s least-privilege diff", display)
+	default:
+		return fmt.Sprintf("Least-privilege diff for %s", display)
+	}
+}
+
+func awsIAMPolicyDiffRelationships(diffs []AWSIAMPolicyDiff) []AWSIAMPolicyDiffRelationship {
+	relationships := []AWSIAMPolicyDiffRelationship{}
+	for _, d := range diffs {
+		if d.IdentityNodeID == "" {
+			continue
+		}
+		for _, target := range d.ImpactedNodes {
+			if target == "" || target == d.IdentityNodeID {
+				continue
+			}
+			relationships = append(relationships, AWSIAMPolicyDiffRelationship{
+				DiffID:      d.DiffID,
+				Type:        "iam_policy_diff_path",
+				FromNodeID:  d.IdentityNodeID,
+				ToNodeID:    target,
+				EvidenceRef: firstString(awsIAMPolicyDiffEvidenceRefs(d.Evidence)),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSIAMPolicyDiffs(all, filtered []AWSIAMPolicyDiff, relationships []AWSIAMPolicyDiffRelationship) AWSIAMPolicyDiffSummary {
+	summary := AWSIAMPolicyDiffSummary{
+		TotalDiffs:          len(all),
+		FilteredDiffs:       len(filtered),
+		DecisionCounts:      map[string]int{},
+		SeverityCounts:      map[string]int{},
+		StatusCounts:        map[string]int{},
+		BreakageLevelCounts: map[string]int{},
+		ServiceCounts:       map[string]int{},
+		RelationshipCount:   len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, d := range filtered {
+		summary.DecisionCounts[d.Decision]++
+		summary.SeverityCounts[d.Severity]++
+		summary.StatusCounts[d.Status]++
+		summary.BreakageLevelCounts[d.BreakageProjection.Level]++
+		if d.Service != "" {
+			summary.ServiceCounts[d.Service]++
+		}
+		summary.RemovedActionCount += len(d.RemovedActions)
+		summary.KeptActionCount += len(d.KeptActions)
+		summary.StatementChangeCount += len(d.StatementChanges)
+		if d.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		if d.Decision == "review" {
+			summary.ManualReviewCount++
+		}
+		if d.Decision == "remove" && len(d.RemovedActions) == 0 {
+			summary.NoOpCount++
+		}
+		if d.Score > summary.HighestScore {
+			summary.HighestScore = d.Score
+		}
+		confidenceTotal += d.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSIAMPolicyDiffs(diffs []AWSIAMPolicyDiff, request AWSIAMPolicyDiffRequest) ([]AWSIAMPolicyDiff, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"identity":        strings.TrimSpace(request.Identity),
+		"service":         strings.TrimSpace(request.Service),
+		"decision":        normalizeAWSRuntimeEventFilterToken(request.Decision),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":          normalizeAWSRuntimeEventFilterToken(request.Status),
+		"breakage_level":  normalizeAWSRuntimeEventFilterToken(request.BreakageLevel),
+		"ready_for_apply": strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSIAMPolicyDiff, 0, len(diffs))
+	for _, d := range diffs {
+		if filters["account_id"] != "" && filters["account_id"] != d.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], d.Region) {
+			continue
+		}
+		if filters["service"] != "" && !strings.EqualFold(filters["service"], d.Service) {
+			continue
+		}
+		if filters["decision"] != "" && filters["decision"] != normalizeAWSRuntimeEventFilterToken(d.Decision) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(d.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(d.Status) {
+			continue
+		}
+		if filters["breakage_level"] != "" && filters["breakage_level"] != normalizeAWSRuntimeEventFilterToken(d.BreakageProjection.Level) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != d.ReadyForApply {
+				continue
+			}
+		}
+		if filters["identity"] != "" && !awsIAMPolicyDiffIdentityMatch(d, filters["identity"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsIAMPolicyDiffSearchMatch(d, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, d)
+	}
+	return filtered, applied
+}
+
+func awsIAMPolicyDiffIdentityMatch(d AWSIAMPolicyDiff, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	hay := strings.ToLower(strings.Join([]string{d.IdentityNodeID, d.IdentityARN, d.IdentityName}, " "))
+	return strings.Contains(hay, needle)
+}
+
+func awsIAMPolicyDiffSearchMatch(d AWSIAMPolicyDiff, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{d.DiffID, d.Title, d.Summary, d.SourceRecommendationID, d.Service, d.Decision, d.Severity, d.Status, d.IdentityNodeID, d.IdentityARN, d.IdentityName, d.ResourceNodeID, d.ResourceARN, d.BreakageProjection.Level, d.BreakageProjection.Rationale, d.RollbackPlan.Strategy, d.VerificationPlan.Strategy, d.NextAction}
+	values = append(values, d.RemovedActions...)
+	values = append(values, d.KeptActions...)
+	values = append(values, d.ObservedActions...)
+	values = append(values, d.GrantedActions...)
+	values = append(values, d.ResourceScopeBefore...)
+	values = append(values, d.ResourceScopeAfter...)
+	for _, statement := range d.StatementChanges {
+		values = append(values, statement.StatementSID, statement.Effect, statement.ChangeKind, statement.Rationale)
+		values = append(values, statement.RemovedActions...)
+		values = append(values, statement.KeptActions...)
+	}
+	for _, evidence := range d.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSIAMPolicyDiffStatus(sources awsIAMPolicyDiffSources, filtered []AWSIAMPolicyDiff, diagnostics []AWSIAMPolicyDiffDiagnostic) (string, float64) {
+	if sources.least.Status == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sources.least.Status == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.76
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsIAMPolicyDiffFailureReasons(sources awsIAMPolicyDiffSources) []string {
+	return dedupeStrings(append([]string{}, sources.least.FailureReasons...))
+}
+
+func awsIAMPolicyDiffRemediationHints(sources awsIAMPolicyDiffSources) []string {
+	out := []string{
+		"Apply each diff only after the matching remediation case is approved; this engine is read-only and does not call any AWS write API.",
+		"Pair each diff with its rollback and verification plan before scheduling execution.",
+	}
+	out = append(out, sources.least.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsIAMPolicyDiffCaveats() []string {
+	return []string{
+		"IAM policy diffs are read-only projections; the engine never applies an AWS change.",
+		"Statement diffs carry action, resource, and condition refs only — never rendered policy bodies, secret values, or workload payloads.",
+		"ready_for_apply is derived deterministically from decision=remove + breakage_level=low + confidence >= 0.75; approval, execute, and verify transitions belong to future wave issues.",
+	}
+}
+
+func awsIAMPolicyDiffDiagnostics(sources awsIAMPolicyDiffSources) []AWSIAMPolicyDiffDiagnostic {
+	out := []AWSIAMPolicyDiffDiagnostic{}
+	for _, d := range sources.least.Diagnostics {
+		if strings.TrimSpace(d.Message) == "" && strings.TrimSpace(d.Code) == "" {
+			continue
+		}
+		out = append(out, AWSIAMPolicyDiffDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	return out
+}
+
+func awsIAMPolicyDiffCoverageGaps(sources awsIAMPolicyDiffSources) []AWSIAMPolicyDiffCoverageGap {
+	out := []AWSIAMPolicyDiffCoverageGap{{
+		Capability:  "iam_policy_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1530 implements the diff projection only; apply/verify transitions are future-wave work and never call IAM write APIs here.",
+		Remediation: "Wire the approve/execute/verify endpoints in the relevant remediation/governance issue once the safety gates are in place.",
+	}}
+	for _, g := range sources.least.CoverageGaps {
+		out = append(out, AWSIAMPolicyDiffCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	return out
+}
+
+func awsIAMPolicyDiffEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads"
+}
+
+func awsIAMPolicyDiffEvidenceRefs(evidence []AWSIAMPolicyDiffEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			out = append(out, item.EvidenceRef)
+		}
+	}
+	return dedupeStrings(out)
+}

--- a/internal/api/aws_iam_policy_diffs.go
+++ b/internal/api/aws_iam_policy_diffs.go
@@ -648,17 +648,26 @@ func awsIAMPolicyDiffSearchMatch(d AWSIAMPolicyDiff, needle string) bool {
 	if needle == "" {
 		return true
 	}
-	values := []string{d.DiffID, d.Title, d.Summary, d.SourceRecommendationID, d.Service, d.Decision, d.Severity, d.Status, d.IdentityNodeID, d.IdentityARN, d.IdentityName, d.ResourceNodeID, d.ResourceARN, d.BreakageProjection.Level, d.BreakageProjection.Rationale, d.RollbackPlan.Strategy, d.VerificationPlan.Strategy, d.NextAction}
+	values := []string{d.DiffID, d.Title, d.Summary, d.SourceRecommendationID, d.Service, d.Decision, d.Severity, d.Status, d.IdentityNodeID, d.IdentityARN, d.IdentityName, d.ResourceNodeID, d.ResourceARN, d.BreakageProjection.Level, d.BreakageProjection.Rationale, d.RollbackPlan.Strategy, d.RollbackPlan.EvidenceRef, d.VerificationPlan.Strategy, d.VerificationPlan.EvidenceRef, d.NextAction}
 	values = append(values, d.RemovedActions...)
 	values = append(values, d.KeptActions...)
 	values = append(values, d.ObservedActions...)
 	values = append(values, d.GrantedActions...)
 	values = append(values, d.ResourceScopeBefore...)
 	values = append(values, d.ResourceScopeAfter...)
+	values = append(values, d.BreakageProjection.Signals...)
+	values = append(values, d.RollbackPlan.Steps...)
+	values = append(values, d.VerificationPlan.Steps...)
+	values = append(values, d.VerificationPlan.SuccessSignals...)
+	values = append(values, d.VerificationPlan.FailureSignals...)
 	for _, statement := range d.StatementChanges {
 		values = append(values, statement.StatementSID, statement.Effect, statement.ChangeKind, statement.Rationale)
 		values = append(values, statement.RemovedActions...)
 		values = append(values, statement.KeptActions...)
+		values = append(values, statement.ResourceBefore...)
+		values = append(values, statement.ResourceAfter...)
+		values = append(values, statement.ConditionBefore...)
+		values = append(values, statement.ConditionAfter...)
 	}
 	for _, evidence := range d.Evidence {
 		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)

--- a/internal/api/aws_iam_policy_diffs_test.go
+++ b/internal/api/aws_iam_policy_diffs_test.go
@@ -1,0 +1,293 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newIAMPolicyDiffService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSIAMPolicyDiffsBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 0, 0, 0, time.UTC)
+	svc, ws := newIAMPolicyDiffService(t, "project-iam-policy-diffs", now)
+
+	result, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diffs", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get iam policy diffs: %v", err)
+	}
+	if result.CurrentIssueRef != "#1530" || result.Version != awsIAMPolicyDiffVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Diffs) == 0 || result.Summary.TotalDiffs != len(result.Diffs) {
+		t.Fatalf("expected diff summary to match payload: %+v", result.Summary)
+	}
+	if result.Summary.DecisionCounts["remove"] == 0 && result.Summary.DecisionCounts["review"] == 0 {
+		t.Fatalf("expected at least one remove or review decision: %+v", result.Summary.DecisionCounts)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
+		t.Fatalf("expected relationships and matching count: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Diffs); i++ {
+		if result.Diffs[i-1].Score < result.Diffs[i].Score {
+			t.Fatalf("diffs are not ranked by descending score: %+v", result.Diffs)
+		}
+	}
+	for _, d := range result.Diffs {
+		if d.DiffID == "" || d.CalculationVersion != awsIAMPolicyDiffVersion || d.SourceRecommendationID == "" {
+			t.Fatalf("diff missing stable metadata: %+v", d)
+		}
+		if d.Decision == "" || d.Severity == "" || d.Status == "" || d.Title == "" {
+			t.Fatalf("diff missing classification fields: %+v", d)
+		}
+		if !d.ReadOnlyProjection {
+			t.Fatalf("diff must be a read-only projection: %+v", d)
+		}
+		if len(d.StatementChanges) == 0 {
+			t.Fatalf("diff missing statement changes: %+v", d)
+		}
+		if d.BreakageProjection.Level == "" || d.BreakageProjection.Rationale == "" {
+			t.Fatalf("diff missing breakage projection: %+v", d.BreakageProjection)
+		}
+		if d.RollbackPlan.Strategy == "" || len(d.RollbackPlan.Steps) == 0 {
+			t.Fatalf("diff missing rollback plan: %+v", d.RollbackPlan)
+		}
+		if d.VerificationPlan.Strategy == "" || len(d.VerificationPlan.Steps) == 0 {
+			t.Fatalf("diff missing verification plan: %+v", d.VerificationPlan)
+		}
+		if d.EvidenceBoundary != awsIAMPolicyDiffEvidenceBoundary() {
+			t.Fatalf("diff crossed evidence boundary: %+v", d)
+		}
+	}
+}
+
+func TestGetAWSIAMPolicyDiffsAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 5, 0, 0, time.UTC)
+	svc, ws := newIAMPolicyDiffService(t, "project-iam-policy-diff-filters", now)
+
+	removeOnly, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diff-filters", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Decision:     "remove",
+	})
+	if err != nil {
+		t.Fatalf("decision filter: %v", err)
+	}
+	for _, d := range removeOnly.Diffs {
+		if d.Decision != "remove" {
+			t.Fatalf("decision filter leaked %s diff: %+v", d.Decision, d)
+		}
+	}
+	if removeOnly.AppliedFilters["decision"] != "remove" {
+		t.Fatalf("expected applied decision filter, got %+v", removeOnly.AppliedFilters)
+	}
+
+	highSeverity, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diff-filters", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "high",
+	})
+	if err != nil {
+		t.Fatalf("severity filter: %v", err)
+	}
+	for _, d := range highSeverity.Diffs {
+		if d.Severity != "high" {
+			t.Fatalf("severity filter leaked %s diff: %+v", d.Severity, d)
+		}
+	}
+}
+
+func TestAWSIAMPolicyDiffFromRecommendation(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 10, 0, 0, time.UTC)
+
+	remove := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "least-priv:remove-test",
+		CalculationVersion: "aws-least-privilege-v1",
+		Decision:           "remove",
+		Severity:           "medium",
+		Status:             "action_required",
+		Score:              74,
+		Confidence:         0.84,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		Service:            "s3",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::123456789012:role/data-loader",
+		PrincipalARN:       "arn:aws:iam::123456789012:role/data-loader",
+		ResourceNodeID:     "aws:resource:s3-bucket/data-loader",
+		ResourceARN:        "arn:aws:s3:::data-loader",
+		DisplayName:        "data-loader",
+		BreakagePrediction: "low",
+		Rationale:          "Removed actions have no observed callers.",
+		RemoveActions:      []string{"s3:DeleteObject", "s3:DeleteBucket"},
+		KeepActions:        []string{"s3:GetObject"},
+		ObservedActions:    []string{"s3:GetObject"},
+		GrantedActions:     []string{"s3:DeleteObject", "s3:DeleteBucket", "s3:GetObject"},
+		ImpactedNodes:      []string{"aws:identity:arn:aws:iam::123456789012:role/data-loader", "aws:resource:s3-bucket/data-loader"},
+	}
+	d, ok := awsIAMPolicyDiffFromRecommendation(remove, now)
+	if !ok {
+		t.Fatalf("expected diff to be emitted for remove decision")
+	}
+	if len(d.RemovedActions) != 2 || len(d.KeptActions) != 1 {
+		t.Fatalf("unexpected action sets: removed=%v kept=%v", d.RemovedActions, d.KeptActions)
+	}
+	if len(d.StatementChanges) != 1 || d.StatementChanges[0].ChangeKind != "scope_removed" {
+		t.Fatalf("expected scope_removed statement change, got %+v", d.StatementChanges)
+	}
+	if !d.ReadyForApply {
+		t.Fatalf("low-breakage, high-confidence remove diff should be ready_for_apply: %+v", d)
+	}
+	if d.VerificationPlan.Strategy != "policy_simulate" {
+		t.Fatalf("remove diff must use policy_simulate verification, got %s", d.VerificationPlan.Strategy)
+	}
+
+	allRemoved := remove
+	allRemoved.RecommendationID = "least-priv:remove-all"
+	allRemoved.KeepActions = nil
+	allRemoved.ObservedActions = nil
+	allRemovedDiff, ok := awsIAMPolicyDiffFromRecommendation(allRemoved, now)
+	if !ok {
+		t.Fatalf("expected diff for full-remove case")
+	}
+	if allRemovedDiff.StatementChanges[0].ChangeKind != "statement_removed" {
+		t.Fatalf("expected statement_removed change kind when no observed actions remain, got %+v", allRemovedDiff.StatementChanges)
+	}
+	if len(allRemovedDiff.ResourceScopeAfter) != 0 {
+		t.Fatalf("full-remove diff should have empty resource_scope_after, got %+v", allRemovedDiff.ResourceScopeAfter)
+	}
+
+	review := remove
+	review.RecommendationID = "least-priv:review"
+	review.Decision = "review"
+	review.BreakagePrediction = ""
+	reviewDiff, ok := awsIAMPolicyDiffFromRecommendation(review, now)
+	if !ok {
+		t.Fatalf("expected diff for review case")
+	}
+	if reviewDiff.StatementChanges[0].ChangeKind != "manual_review" {
+		t.Fatalf("review diff must use manual_review change kind, got %+v", reviewDiff.StatementChanges)
+	}
+	if reviewDiff.ReadyForApply {
+		t.Fatalf("review diff must never be ready_for_apply: %+v", reviewDiff)
+	}
+	if reviewDiff.VerificationPlan.Strategy != "manual_review" || reviewDiff.RollbackPlan.Strategy != "manual_review" {
+		t.Fatalf("review diff must use manual_review plans: rollback=%s verification=%s", reviewDiff.RollbackPlan.Strategy, reviewDiff.VerificationPlan.Strategy)
+	}
+	if reviewDiff.BreakageProjection.Level != "unknown" {
+		t.Fatalf("review diff must report unknown breakage, got %s", reviewDiff.BreakageProjection.Level)
+	}
+
+	keep := remove
+	keep.RecommendationID = "least-priv:keep"
+	keep.Decision = "keep"
+	if _, ok := awsIAMPolicyDiffFromRecommendation(keep, now); ok {
+		t.Fatalf("keep decision must not produce a diff")
+	}
+}
+
+func TestAWSIAMPolicyDiffReadyForApplyGuards(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 15, 0, 0, time.UTC)
+	base := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "least-priv:ready-test",
+		Decision:           "remove",
+		Severity:           "medium",
+		Status:             "action_required",
+		Score:              72,
+		Confidence:         0.84,
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::123456789012:role/ready-test",
+		PrincipalARN:       "arn:aws:iam::123456789012:role/ready-test",
+		DisplayName:        "ready-test",
+		BreakagePrediction: "low",
+		RemoveActions:      []string{"s3:DeleteObject"},
+		KeepActions:        []string{"s3:GetObject"},
+	}
+	d, _ := awsIAMPolicyDiffFromRecommendation(base, now)
+	if !d.ReadyForApply {
+		t.Fatalf("low-breakage high-confidence remove must be ready_for_apply: %+v", d)
+	}
+
+	highBreakage := base
+	highBreakage.RecommendationID = "least-priv:high-breakage"
+	highBreakage.BreakagePrediction = "high"
+	d2, _ := awsIAMPolicyDiffFromRecommendation(highBreakage, now)
+	if d2.ReadyForApply {
+		t.Fatalf("high-breakage diff must not be ready_for_apply: %+v", d2)
+	}
+
+	lowConf := base
+	lowConf.RecommendationID = "least-priv:low-conf"
+	lowConf.Confidence = 0.6
+	d3, _ := awsIAMPolicyDiffFromRecommendation(lowConf, now)
+	if d3.ReadyForApply {
+		t.Fatalf("low-confidence diff must not be ready_for_apply: %+v", d3)
+	}
+}
+
+func TestGetAWSIAMPolicyDiffsFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 20, 0, 0, time.UTC)
+	svc, ws := newIAMPolicyDiffService(t, "project-iam-policy-diff-states", now)
+
+	denied, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diff-states", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Diffs) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress diffs: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diff-states", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status != "degraded" || empty.Summary.TotalDiffs != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should be explicit degraded no-evidence state: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSIAMPolicyDiffs(defaultScopeContext(), ws, "project-iam-policy-diff-states", AWSIAMPolicyDiffRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSIAMPolicyDiffs(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 25, 0, 0, time.UTC)
+	svc, _ := newIAMPolicyDiffService(t, "project-iam-policy-diff-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-iam-policy-diff-route/aws/iam-policy-diffs?connector_id=aws-prod&fixture_state=success&decision=remove", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Diffs AWSIAMPolicyDiffResult `json:"diffs"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Diffs.CurrentIssueRef != "#1530" || body.Diffs.AppliedFilters["decision"] != "remove" {
+		t.Fatalf("unexpected route payload: %+v", body.Diffs)
+	}
+}

--- a/internal/api/aws_iam_policy_diffs_test.go
+++ b/internal/api/aws_iam_policy_diffs_test.go
@@ -198,6 +198,53 @@ func TestAWSIAMPolicyDiffFromRecommendation(t *testing.T) {
 	}
 }
 
+func TestAWSIAMPolicyDiffSearchMatchesPlanDetails(t *testing.T) {
+	diff := AWSIAMPolicyDiff{
+		DiffID: "aws-iam-policy-diff:search-test",
+		Title:  "Scope sample-role: remove 1 action(s)",
+		BreakageProjection: AWSIAMPolicyDiffBreakageProjection{
+			Level:   "low",
+			Signals: []string{"observed_actions:5"},
+		},
+		RollbackPlan: AWSIAMPolicyDiffRollbackPlan{
+			Strategy:    "re_attach_policy",
+			Steps:       []string{"Re-attach the captured before_ref policy statement."},
+			EvidenceRef: "evidence://least/sample-role",
+		},
+		VerificationPlan: AWSIAMPolicyDiffVerificationPlan{
+			Strategy:       "policy_simulate",
+			Steps:          []string{"Run IAM policy simulator against kept actions to confirm no regression."},
+			SuccessSignals: []string{"policy_simulate:no-regression"},
+			FailureSignals: []string{"policy_simulate:denied-observed-action"},
+			EvidenceRef:    "evidence://least/sample-role",
+		},
+		StatementChanges: []AWSIAMPolicyStatementDiff{{
+			ResourceBefore:  []string{"arn:aws:s3:::bucket-x"},
+			ResourceAfter:   []string{"arn:aws:s3:::bucket-x"},
+			ConditionBefore: []string{"aws:SourceVpce"},
+			ConditionAfter:  []string{"aws:SourceVpce"},
+		}},
+	}
+	cases := []struct {
+		name   string
+		needle string
+	}{
+		{"rollback step", "re-attach"},
+		{"verification step", "simulator"},
+		{"verification success signal", "no-regression"},
+		{"verification failure signal", "denied-observed-action"},
+		{"breakage signal", "observed_actions:5"},
+		{"plan evidence ref", "evidence://least/sample-role"},
+		{"statement resource", "bucket-x"},
+		{"statement condition", "aws:SourceVpce"},
+	}
+	for _, tc := range cases {
+		if !awsIAMPolicyDiffSearchMatch(diff, tc.needle) {
+			t.Fatalf("search did not match %s needle %q", tc.name, tc.needle)
+		}
+	}
+}
+
 func TestAWSIAMPolicyDiffReadyForApplyGuards(t *testing.T) {
 	now := time.Date(2026, 6, 24, 9, 15, 0, 0, time.UTC)
 	base := AWSLeastPrivilegeRecommendation{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3086,6 +3086,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"cases": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSIAMPolicyDiffs(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSIAMPolicyDiffRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			Identity:      strings.TrimSpace(c.Query("identity")),
+			Service:       strings.TrimSpace(c.Query("service")),
+			Decision:      strings.TrimSpace(c.Query("decision")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			BreakageLevel: strings.TrimSpace(c.Query("breakage_level")),
+			ReadyForApply: strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:        strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws iam policy diff request"})
+			default:
+				logger.Error("get aws iam policy diffs",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws iam policy diffs"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"diffs": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1602,6 +1602,54 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS IAM policy least-privilege diffs with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        diffs: {
+          status: 'ready',
+          summary: { total_diffs: 0, filtered_diffs: 0 },
+          diffs: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectIAMPolicyDiffs(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'data-loader',
+        service: 's3',
+        decision: 'remove',
+        severity: 'high',
+        status: 'action_required',
+        breakageLevel: 'low',
+        readyForApply: 'true',
+        search: 's3:DeleteObject'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/iam-policy-diffs?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=data-loader&service=s3&decision=remove&severity=high&status=action_required&breakage_level=low&ready_for_apply=true&search=s3%3ADeleteObject'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2984,6 +2984,158 @@ export type AWSRemediationCaseQuery = {
   search?: string;
 };
 
+export type AWSIAMPolicyDiffStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSIAMPolicyDiffFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSIAMPolicyDiffSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSIAMPolicyDiffDecision = 'keep' | 'remove' | 'review' | string;
+export type AWSIAMPolicyDiffBreakageLevel = 'low' | 'medium' | 'high' | 'unknown' | string;
+
+export type AWSIAMPolicyStatementDiff = {
+  statement_sid: string;
+  effect: string;
+  change_kind: 'scope_removed' | 'statement_removed' | 'manual_review' | string;
+  removed_actions?: string[];
+  kept_actions?: string[];
+  resource_before?: string[];
+  resource_after?: string[];
+  condition_before?: string[];
+  condition_after?: string[];
+  rationale: string;
+};
+
+export type AWSIAMPolicyDiffBreakageProjection = {
+  level: AWSIAMPolicyDiffBreakageLevel;
+  rationale: string;
+  signals?: string[];
+};
+
+export type AWSIAMPolicyDiffRollbackPlan = {
+  strategy: string;
+  steps: string[];
+  evidence_ref?: string;
+};
+
+export type AWSIAMPolicyDiffVerificationPlan = {
+  strategy: string;
+  steps: string[];
+  success_signals?: string[];
+  failure_signals?: string[];
+  evidence_ref?: string;
+};
+
+export type AWSIAMPolicyDiffRelationship = {
+  diff_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSIAMPolicyDiff = {
+  diff_id: string;
+  calculation_version: string;
+  source_recommendation_id: string;
+  decision: AWSIAMPolicyDiffDecision;
+  severity: AWSIAMPolicyDiffSeverity;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  service?: string;
+  identity_node_id: string;
+  identity_arn?: string;
+  identity_name?: string;
+  resource_node_id?: string;
+  resource_arn?: string;
+  statement_changes: AWSIAMPolicyStatementDiff[];
+  removed_actions?: string[];
+  kept_actions?: string[];
+  observed_actions?: string[];
+  granted_actions?: string[];
+  resource_scope_before?: string[];
+  resource_scope_after?: string[];
+  breakage_projection: AWSIAMPolicyDiffBreakageProjection;
+  rollback_plan: AWSIAMPolicyDiffRollbackPlan;
+  verification_plan: AWSIAMPolicyDiffVerificationPlan;
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSIAMPolicyDiffSummary = {
+  total_diffs: number;
+  filtered_diffs: number;
+  decision_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  breakage_level_counts: Record<string, number>;
+  service_counts: Record<string, number>;
+  removed_action_count: number;
+  kept_action_count: number;
+  statement_change_count: number;
+  ready_for_apply_count: number;
+  manual_review_count: number;
+  no_op_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSIAMPolicyDiffResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSIAMPolicyDiffStatus;
+  fixture_state?: AWSIAMPolicyDiffFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSIAMPolicyDiffSummary;
+  diffs: AWSIAMPolicyDiff[];
+  relationships: AWSIAMPolicyDiffRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSIAMPolicyDiffQuery = {
+  connectorID?: string;
+  fixtureState?: AWSIAMPolicyDiffFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  service?: string;
+  decision?: string;
+  severity?: string;
+  status?: string;
+  breakageLevel?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -7116,6 +7268,30 @@ export const apiClient = {
         status: query?.status,
         approval_state: query?.approvalState,
         owner_assigned: query?.ownerAssigned,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectIAMPolicyDiffs(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSIAMPolicyDiffQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ diffs: AWSIAMPolicyDiffResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/iam-policy-diffs${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        service: query?.service,
+        decision: query?.decision,
+        severity: query?.severity,
+        status: query?.status,
+        breakage_level: query?.breakageLevel,
+        ready_for_apply: query?.readyForApply,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3401,6 +3401,123 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    vi.spyOn(api.apiClient, 'getAWSProjectIAMPolicyDiffs').mockResolvedValue({
+      diffs: {
+        status: 'ready',
+        diffs: [
+          {
+            diff_id: 'aws-iam-policy-diff:data-loader-remove',
+            calculation_version: 'aws-iam-policy-least-privilege-diff-v1',
+            source_recommendation_id: 'least-priv:data-loader-remove',
+            decision: 'remove',
+            severity: 'medium',
+            status: 'action_required',
+            score: 74,
+            confidence: 0.86,
+            title: 'Scope data-loader: remove 2 action(s)',
+            summary: 'Remove unused s3 actions from data-loader role.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 's3',
+            identity_node_id: 'aws:identity:arn:aws:iam::123456789012:role/data-loader',
+            identity_arn: 'arn:aws:iam::123456789012:role/data-loader',
+            identity_name: 'data-loader',
+            resource_node_id: 'aws:resource:s3-bucket/data-loader',
+            resource_arn: 'arn:aws:s3:::data-loader',
+            statement_changes: [
+              {
+                statement_sid: 'least-privilege-projection',
+                effect: 'Allow',
+                change_kind: 'scope_removed',
+                removed_actions: ['s3:DeleteObject', 's3:DeleteBucket'],
+                kept_actions: ['s3:GetObject'],
+                resource_before: ['arn:aws:s3:::data-loader'],
+                resource_after: ['arn:aws:s3:::data-loader'],
+                rationale: 'Remove 2 unused action(s) and keep 1 observed action(s) on data-loader.'
+              }
+            ],
+            removed_actions: ['s3:DeleteObject', 's3:DeleteBucket'],
+            kept_actions: ['s3:GetObject'],
+            observed_actions: ['s3:GetObject'],
+            granted_actions: ['s3:DeleteObject', 's3:DeleteBucket', 's3:GetObject'],
+            resource_scope_before: ['arn:aws:s3:::data-loader'],
+            resource_scope_after: ['arn:aws:s3:::data-loader'],
+            breakage_projection: {
+              level: 'low',
+              rationale: 'Removed actions have no observed callers.',
+              signals: ['observed_actions:1', 'removed_actions:2', 'kept_actions:1']
+            },
+            rollback_plan: {
+              strategy: 're_attach_policy',
+              steps: ['Re-attach the captured before_ref policy statement.', 'Re-run least-privilege.'],
+              evidence_ref: 'evidence://least/data-loader'
+            },
+            verification_plan: {
+              strategy: 'policy_simulate',
+              steps: ['Run IAM policy simulator.', 'Re-run least-privilege.'],
+              success_signals: ['policy_simulate:no-regression', 'least_privilege:decision-keep'],
+              failure_signals: ['policy_simulate:denied-observed-action'],
+              evidence_ref: 'evidence://least/data-loader'
+            },
+            ready_for_apply: true,
+            read_only_projection: true,
+            source_signals: ['least_privilege'],
+            evidence: [
+              {
+                source: 'least_privilege',
+                evidence_ref: 'evidence://least/data-loader',
+                label: 'Least-privilege scope recommendation',
+                confidence: 0.86,
+                observed_at: '2026-06-24T09:00:00Z',
+                relationship: 'remove'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            impacted_nodes: [
+              'aws:identity:arn:aws:iam::123456789012:role/data-loader',
+              'aws:resource:s3-bucket/data-loader'
+            ],
+            impacted_path: [],
+            next_action: 'Approve the diff, then apply via the IAM remediation executor.',
+            created_at: '2026-06-24T09:00:00Z',
+            updated_at: '2026-06-24T09:00:00Z'
+          }
+        ],
+        summary: {
+          total_diffs: 1,
+          filtered_diffs: 1,
+          decision_counts: { remove: 1 },
+          severity_counts: { medium: 1 },
+          status_counts: { action_required: 1 },
+          breakage_level_counts: { low: 1 },
+          service_counts: { s3: 1 },
+          removed_action_count: 2,
+          kept_action_count: 1,
+          statement_change_count: 1,
+          ready_for_apply_count: 1,
+          manual_review_count: 0,
+          no_op_count: 0,
+          relationship_count: 1,
+          highest_score: 74,
+          average_confidence_pct: 86
+        },
+        relationships: [
+          {
+            diff_id: 'aws-iam-policy-diff:data-loader-remove',
+            type: 'iam_policy_diff_path',
+            from_node_id: 'aws:identity:arn:aws:iam::123456789012:role/data-loader',
+            to_node_id: 'aws:resource:s3-bucket/data-loader',
+            evidence_ref: 'evidence://least/data-loader'
+          }
+        ],
+        caveats: ['IAM policy diffs are read-only projections; the engine never applies an AWS change.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -3715,6 +3832,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS remediation cases' })).toBeInTheDocument();
     expect(screen.getByText(/Rotate external credential for support-assistant/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Secret rotation/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS IAM policy diffs' })).toBeInTheDocument();
+    expect(screen.getByText(/Scope data-loader: remove 2 action\(s\)/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/ready · Low breakage/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -59,6 +59,8 @@ import {
   type AWSAIAgentRiskResult,
   type AWSRemediationCase,
   type AWSRemediationCaseResult,
+  type AWSIAMPolicyDiff,
+  type AWSIAMPolicyDiffResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -10689,6 +10691,119 @@ function AWSRemediationCaseContent({
   );
 }
 
+function awsIAMPolicyDiffStage(diff: AWSIAMPolicyDiff): AWSCapabilityStage {
+  if (diff.severity === 'critical' || diff.breakage_projection.level === 'high') {
+    return 'not-available';
+  }
+  if (diff.severity === 'high' || diff.breakage_projection.level === 'medium' || diff.decision === 'review') {
+    return 'coming';
+  }
+  if (diff.ready_for_apply) {
+    return 'wired';
+  }
+  return 'wired';
+}
+
+function awsIAMPolicyDiffActionLabel(diff: AWSIAMPolicyDiff): string {
+  const removed = diff.removed_actions?.length ?? 0;
+  const kept = diff.kept_actions?.length ?? 0;
+  return `${removed} removed · ${kept} kept`;
+}
+
+function awsIAMPolicyDiffStatementLabel(diff: AWSIAMPolicyDiff): string {
+  if (!diff.statement_changes || diff.statement_changes.length === 0) {
+    return 'no projection';
+  }
+  return diff.statement_changes
+    .slice(0, 2)
+    .map((statement) => formatTokenLabel(statement.change_kind))
+    .join(', ') + (diff.statement_changes.length > 2 ? ` +${diff.statement_changes.length - 2}` : '');
+}
+
+function awsIAMPolicyDiffReadinessLabel(diff: AWSIAMPolicyDiff): string {
+  if (diff.ready_for_apply) {
+    return `ready · ${formatTokenLabel(diff.breakage_projection.level)} breakage`;
+  }
+  return `gate · ${formatTokenLabel(diff.breakage_projection.level)} breakage`;
+}
+
+function AWSIAMPolicyDiffContent({
+  diffs,
+  loading,
+  error,
+  onRetry
+}: {
+  diffs: AWSIAMPolicyDiffResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = diffs?.diffs ?? [];
+  const summaryLine = diffs
+    ? `${diffs.summary.total_diffs} total · ${diffs.summary.ready_for_apply_count} ready · ${diffs.summary.manual_review_count} manual review · ${diffs.summary.removed_action_count} removed action(s)`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS IAM policy least-privilege diffs">
+      <h3>AWS IAM policy least-privilege diff</h3>
+      <p className="idt-app-kicker">
+        Read-only IAM policy diffs projected from least-privilege evidence. Removed/kept actions, breakage projection,
+        rollback, and verification are all derived deterministically; the engine never mutates IAM. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS IAM policy diffs"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Projecting IAM policy diffs"
+          body="Identrail is composing least-privilege evidence into statement-level removed/kept action projections."
+        />
+      ) : null}
+      {!error && !loading && diffs && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={diffs.status === 'blocked' ? 'Permission required' : 'No IAM policy diffs'}
+          title={diffs.status === 'blocked' ? 'IAM policy diffs need read-only least-privilege evidence' : 'No IAM policy diffs projected'}
+          body={diffs.failure_reasons[0] ?? 'No upstream least-privilege recommendations produced a diff for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && diffs && diffs.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {diffs.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS IAM policy diffs"
+          rows={rows}
+          getRowKey={(row) => row.diff_id}
+          columns={[
+            { key: 'diff', header: 'Diff', render: (row) => <strong>{row.title}</strong> },
+            { key: 'identity', header: 'Identity', render: (row) => row.identity_name || row.identity_arn || row.identity_node_id },
+            { key: 'decision', header: 'Decision', render: (row) => formatTokenLabel(row.decision) },
+            { key: 'actions', header: 'Actions', render: (row) => awsIAMPolicyDiffActionLabel(row) },
+            { key: 'statements', header: 'Statement change', render: (row) => awsIAMPolicyDiffStatementLabel(row) },
+            { key: 'breakage', header: 'Readiness', render: (row) => awsIAMPolicyDiffReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsIAMPolicyDiffStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12136,6 +12251,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [remediationCasesLoading, setRemediationCasesLoading] = useState(false);
   const [remediationCasesError, setRemediationCasesError] = useState('');
   const remediationCasesRequestRef = useRef(0);
+  const [iamPolicyDiffs, setIAMPolicyDiffs] = useState<AWSIAMPolicyDiffResult | null>(null);
+  const [iamPolicyDiffsLoading, setIAMPolicyDiffsLoading] = useState(false);
+  const [iamPolicyDiffsError, setIAMPolicyDiffsError] = useState('');
+  const iamPolicyDiffsRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12468,6 +12587,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       remediationCasesRequestRef.current += 1;
     };
   }, [loadRemediationCases]);
+
+  const loadIAMPolicyDiffs = useCallback(async () => {
+    const requestID = ++iamPolicyDiffsRequestRef.current;
+    setIAMPolicyDiffs(null);
+    setIAMPolicyDiffsError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setIAMPolicyDiffsLoading(false);
+      return;
+    }
+    setIAMPolicyDiffsLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectIAMPolicyDiffs(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== iamPolicyDiffsRequestRef.current) {
+        return;
+      }
+      setIAMPolicyDiffs(response.diffs);
+    } catch (error) {
+      if (requestID !== iamPolicyDiffsRequestRef.current) {
+        return;
+      }
+      setIAMPolicyDiffsError(formatAPIError(error, 'Unable to load AWS IAM policy diffs.'));
+    } finally {
+      if (requestID === iamPolicyDiffsRequestRef.current) {
+        setIAMPolicyDiffsLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadIAMPolicyDiffs();
+    return () => {
+      iamPolicyDiffsRequestRef.current += 1;
+    };
+  }, [loadIAMPolicyDiffs]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -12947,6 +13114,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={remediationCasesLoading}
             error={remediationCasesError}
             onRetry={loadRemediationCases}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSIAMPolicyDiffContent
+            diffs={iamPolicyDiffs}
+            loading={iamPolicyDiffsLoading}
+            error={iamPolicyDiffsError}
+            onRetry={loadIAMPolicyDiffs}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Add the AWS IAM policy least-privilege diff generator (#1530, Wave 7.02).
A read-only, metadata-only engine that turns upstream least-privilege
recommendations (#1522) into ranked IAM policy diffs the remediation case
model (#1529) and a future executor wave can plan, approve, and apply.

Each diff carries:

- `diff_id`, `calculation_version`, and `source_recommendation_id`
- decision (`remove` / `review` — `keep` is suppressed), severity, status,
  score, confidence
- identity context (account, region, service, identity node, ARN, name,
  resource node, resource ARN)
- `statement_changes`: statement-level `AWSIAMPolicyStatementDiff` with
  `change_kind` ∈ `scope_removed` / `statement_removed` / `manual_review`,
  removed/kept actions, resource and condition before/after, rationale
- aggregated `removed_actions` / `kept_actions` / `observed_actions` /
  `granted_actions`, plus `resource_scope_before` / `resource_scope_after`
- `breakage_projection` with `level` ∈ `low` / `medium` / `high` /
  `unknown`, rationale, and signal counts (review-decision diffs always
  project `unknown`)
- `rollback_plan` (`re_attach_policy` or `manual_review`) and
  `verification_plan` (`policy_simulate` or `manual_review`)
- `ready_for_apply: true` only when `decision = remove`,
  `breakage_level = low`, and `confidence >= 0.75`
- `read_only_projection: true` on every diff
- evidence refs, source signals, impacted graph nodes/path, next action

Adds GET /v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs
with filters for `connector_id`, `fixture_state`, `account_id`, `region`,
`identity`, `service`, `decision`, `severity`, `status`, `breakage_level`,
`ready_for_apply`, and `search`. OpenAPI schemas and authz wiring follow
the neighboring AWS intelligence engines.

The AWS Runtime app surface now shows an **AWS IAM policy least-privilege
diff** panel with identity, decision, statement change kind, removed/kept
counts, breakage level, ready-for-apply badge, severity/status, and
verification strategy. Loading, empty, error, degraded, and
permission-denied states are explicit.

## Why

Closes #1530. The remediation case model (#1529) generates the case
envelope but its diff intent only carries before/after refs. This issue
generates the concrete IAM policy diff payload — statement-level
removed/kept actions, resource scope, expected breakage, rollback, and
verification — so a future executor wave has machine-readable diffs to
plan and apply safely.

This PR implements the **diff projection** capability only. It is
intentionally read-only and never mutates AWS. Apply / verify / rollback /
govern transitions belong to later wave issues.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (new route; no existing route
      contracts change)
- [x] Risk level assessed (read-only, no IAM write API calls, no new AWS
      permissions, never reads rendered policy bodies or workload
      payloads)

## Safety / evidence boundary

- Read-only. No IAM write API is called by this issue.
- Never reads, stores, logs, or displays rendered IAM policy bodies,
  secret values, prompts, completions, tool inputs/outputs, browser
  pages, code-interpreter output, database rows, object contents,
  customer payloads, or workload payloads.
- Statement-level `condition_before` and `condition_after` carry
  condition identifiers only — never rendered JSON condition bodies.
- Every diff has `read_only_projection: true`.
- `ready_for_apply` is derived deterministically (decision=remove +
  breakage_level=low + confidence>=0.75); it is a consumer hint, not an
  instruction to execute.
- Unknown, unsupported, partial, degraded, and permission-denied
  evidence stays explicit and is not treated as proof that a diff is
  safe to apply.

## Validation

\`\`\`bash
go test ./internal/api                                       # ok
go vet ./...                                                 # clean
make fmt-check                                               # clean
make api-example-contract-check                              # passed
npm test -- --run src/api/client.test.ts --prefix web        # passed (incl. new diff client test)
npm test -- --run src/productShell.test.tsx --prefix web     # passed (incl. new diff table assertion)
npx tsc -b                                                   # clean (web)
npm run build --prefix web                                   # built, prerendered 39 routes
\`\`\`

Manual frontend preview (\`npm run dev --prefix web\`) compiled and
served cleanly with no console or build errors from the new panel.
End-to-end rendering requires the Go API to be running locally; the
panel's UI behavior is covered by the productShell tests using the
mocked client.

## Checklist

- [x] Tests added for contract, filters, lifecycle/ready-for-apply,
      review-vs-remove statement change kinds, failure states, and the
      route
- [x] Docs updated (\`docs/aws-iam-policy-least-privilege-diff.md\`,
      \`docs/README.md\`, OpenAPI path + schemas, authz metadata)
- [x] \`CHANGELOG.md\` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1530.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a read-only engine that turns least-privilege recommendations into ranked AWS IAM policy diffs, plus a new API and runtime UI to plan safe removals. Aligns with #1530 and expands search to index plan details for better filtering.

- **New Features**
  - Added GET /v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs with filters for connector, fixture state, account, region, identity, service, decision, severity, status, breakage level, ready-for-apply, and search.
  - Diff payload includes statement-level changes (`scope_removed` / `statement_removed` / `manual_review`), removed/kept/observed/granted actions, resource scope before/after, breakage projection (`low` / `medium` / `high` / `unknown`), rollback and verification plans, and deterministic `ready_for_apply`.
  - Search now also indexes rollback/verification steps, success/failure signals, plan evidence refs, breakage signals, and statement resource/condition before/after. Added a regression test to cover these fields.
  - Read-only, metadata-only: never mutates AWS; never returns rendered policy bodies or secrets; every diff sets `read_only_projection: true`. OpenAPI schemas, authz wiring, router handler, and tests for contract, filters, lifecycle, and failure states.
  - AWS Runtime adds an “AWS IAM policy least-privilege diff” panel showing identity, decision, statement change kind, action counts, breakage/readiness, severity/status, and verification strategy, with clear loading/empty/degraded/permission-denied states.

- **Migration**
  - No breaking changes; new route only.
  - Use `ready_for_apply` when `decision=remove` + `breakage_level=low` + `confidence >= 0.75`; pair each diff with its rollback and verification plan before execution.

<sup>Written for commit bd7bb8f1c6e51e57281c173a07c29102fb207bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

