### PR TITLE
Implement AWS trust policy hardening planner (#1531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS trust policy hardening planner** (#1531). Adds a read-only,
+  metadata-only engine that turns upstream cross-account-trust findings
+  (#1526) into ranked trust-policy hardening plans. Each plan carries a
+  hardening direction (`remove_public_principal`,
+  `add_org_or_source_condition`, `scope_to_known_external_principal`,
+  `tighten_existing_condition`), principal-change intent (before/after
+  principal identifiers, `public_principal_removed` flag), condition
+  recommendations (`aws:PrincipalOrgID`, `aws:PrincipalAccount`,
+  `sts:ExternalId`, `aws:SourceIdentity`, `aws:SourceArn`,
+  `aws:SecureTransport` per finding type, never duplicating an existing
+  condition), before/after statement snippet refs, affected callers (with
+  org / runtime / Access Analyzer attribution), expected breakage
+  projection (low/medium/high/unknown plus rationale and signals),
+  rollback plan, verification plan, deterministic `ready_for_apply` flag
+  (true only when the principal is not public, breakage is low, at least
+  one condition is recommended, and confidence >= 0.80), and the standard
+  evidence, source-signal, impacted-node, and audit metadata. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening`
+  with filters for connector, account, region, service, resource,
+  principal, hardening direction, breakage level, severity, status,
+  ready-for-apply, and free-text search. OpenAPI schemas and authz wiring
+  follow the neighboring AWS intelligence engines. The AWS Runtime app
+  surface now shows an **AWS trust policy hardening planner** panel with
+  resource, hardening direction, principal change, condition
+  recommendation count, breakage level, ready-for-apply, severity/status,
+  and verification strategy. The engine never mutates AWS, never reads or
+  returns rendered policy bodies, secret values, prompts, completions,
+  tool payloads, browser pages, code-interpreter output, database rows,
+  object contents, customer payloads, or workload payloads;
+  apply/verify transitions belong to later wave issues.
 - Add **AWS IAM policy least-privilege diff generator** (#1530). Adds a
   read-only, metadata-only engine that turns least-privilege recommendations
   (#1522) into ranked IAM policy diffs. Each diff carries statement-level

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS AI agent risk engine: `aws-ai-agent-risk-engine.md`
 - AWS remediation case model: `aws-remediation-case-model.md`
 - AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
+- AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-trust-policy-hardening-planner.md
+++ b/docs/aws-trust-policy-hardening-planner.md
@@ -1,0 +1,170 @@
+# AWS trust policy hardening planner
+
+Issue #1531 (Wave 7.03) adds a metadata-only engine that turns upstream
+cross-account-trust findings (#1526) into ranked, read-only trust-policy
+hardening plans. Each plan carries the projected principal change,
+condition recommendations, before/after statement snippet refs, affected
+callers, expected breakage projection, rollback plan, and verification
+plan — so a remediation case (#1529) and a future executor wave have the
+concrete payload they need to plan, approve, and apply safely.
+
+This issue is the **trust-policy projection** capability of the
+Identrail remediation loop. It does not mutate AWS, does not call any
+IAM write API, and does not read rendered policy bodies, secret values,
+workload payloads, prompts, completions, browser pages, code-interpreter
+output, database rows, object contents, or customer payloads.
+Approve / execute / verify / rollback / govern transitions belong to
+later wave issues.
+
+## What it produces
+
+The engine emits `AWSTrustPolicyHardeningPlan` records, one per upstream
+cross-account-trust finding. Every plan carries:
+
+- **Identifiers**: stable `plan_id`, `calculation_version`, and the
+  `source_finding_id` it was generated from.
+- **`hardening_direction`** ∈ `remove_public_principal`,
+  `add_org_or_source_condition`, `scope_to_known_external_principal`,
+  `tighten_existing_condition`.
+- **Severity / status / score / confidence**: inherited from the
+  upstream finding.
+- **Resource context**: account, region, service, resource type,
+  resource node, resource ARN, resource label.
+- **Trust shape flags**: `public_principal`,
+  `trusted_within_organization`, `runtime_observed`, `analyzer_backed`.
+- **`principal_change`** with `before_principals`, `after_principals`,
+  `public_principal_removed`, and a rationale.
+- **`condition_recommendations`**: list of
+  `{operator, key, value, rationale, evidence_ref}` — the engine
+  recommends `aws:PrincipalOrgID`, `aws:PrincipalAccount`,
+  `sts:ExternalId`, `aws:SourceIdentity`, `aws:SourceArn`, or
+  `aws:SecureTransport` depending on the finding type. Conditions
+  already present on the upstream finding are never re-recommended.
+- **`statement_snippets`**: one or more
+  `AWSTrustPolicyStatementSnippet` entries with `change_kind` ∈
+  `public_principal_removed`, `principal_added`, `condition_added`,
+  `principal_and_condition_tightened`, `manual_review`. Snippets
+  carry `before_ref` / `after_ref` metadata refs and condition-key
+  lists only — never rendered JSON policy bodies.
+- **`affected_callers`**: the external principal(s) known to use the
+  trust path, with org / runtime / analyzer attribution.
+- **`breakage_projection`** with `level` ∈ `low`, `medium`, `high`,
+  `unknown`, a rationale, and signal counts.
+- **`rollback_plan`** (`restore_trust_policy`) and
+  **`verification_plan`** (`trust_policy_re_evaluate`).
+- **`ready_for_apply: true`** only when *all* hold: principal is not
+  public, breakage_level is `low`, at least one condition is
+  recommended, and confidence ≥ 0.80.
+- **`read_only_projection: true`** on every plan.
+- Evidence refs, source signals, impacted graph nodes/path, next action.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/trust-policy-hardening`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `service` | exact match on the upstream AWS service token |
+| `resource` | substring search across resource node, ARN, label, type, and service |
+| `principal` | substring search across affected caller and proposed principal lists |
+| `hardening_direction` | one of the directions above |
+| `breakage_level` | `low`, `medium`, `high`, or `unknown` |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `action_required`, `review`, or `monitor` |
+| `ready_for_apply` | `true` / `false` |
+| `search` | free-text search across plan, principal change, condition recommendations, statement snippet, affected caller, breakage projection, rollback, and verification fields |
+
+Response shape: `{ "plans": AWSTrustPolicyHardeningResult }` with
+summary, ranked plans, graph relationships, caveats, failure reasons,
+remediation hints, evidence links, coverage gaps, diagnostics, and the
+standard tenant/workspace/project metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays rendered IAM policy
+bodies, secret values, prompts, completions, tool inputs/outputs,
+browser pages, code-interpreter output, database rows, object
+contents, customer payloads, or workload payloads. It composes only
+the upstream cross-account-trust finding refs, principal identifiers,
+condition-key labels, and runtime/analyzer evidence pointers.
+
+`before_ref` / `after_ref` on each statement snippet carry projection
+URIs (e.g. `trust-policy://<finding>/scoped-projection`) — never
+rendered JSON.
+
+## AWS permissions
+
+This capability adds no live mutation and requires no additional AWS
+permissions beyond what the cross-account-trust engine (#1526) already
+needs. It reuses that engine's read-only metadata access.
+
+Do not grant IAM write permissions for this issue.
+
+## Ready-for-apply derivation
+
+A plan is marked `ready_for_apply: true` only when *all* of the
+following hold:
+
+1. `public_principal == false`, **and**
+2. `breakage_projection.level == "low"` (runtime *and* Access Analyzer
+   both confirm the caller set), **and**
+3. at least one condition is recommended, **and**
+4. `confidence >= 0.80`.
+
+Public principals always stay non-executable; unknown breakage stays
+non-executable; plans with no condition recommendation stay
+non-executable.
+
+## Failure handling
+
+- **Ready**: cross-account-trust was available and emitted no blocking
+  diagnostics.
+- **Degraded**: cross-account-trust returned partial, degraded, or
+  retryable diagnostics. Plans already composed remain visible.
+- **Blocked**: cross-account-trust is permission denied. The response
+  has zero plans plus diagnostics and failure reasons.
+
+Unknown, unsupported, partial, degraded, and permission-denied
+evidence stays explicit and is not treated as proof that a plan is
+safe to apply.
+
+## App surface
+
+The AWS Runtime app surface renders the **AWS trust policy hardening
+planner** panel with each plan's resource, hardening direction,
+principal change, condition recommendation count, breakage level,
+ready-for-apply flag, verification strategy, and evidence refs.
+Loading, empty, error, degraded, and permission-denied states are
+explicit.
+
+## Live validation
+
+1. Confirm blockers #1526 and #1529 are closed.
+2. Run cross-account-trust with `fixture_state=success`.
+3. Run the trust-policy hardening endpoint with `fixture_state=success`
+   and confirm plans appear for public, cross-account, and runtime
+   assumption findings.
+4. Filter by `hardening_direction=remove_public_principal`,
+   `breakage_level=low`, `ready_for_apply=true`, and `search` to verify
+   deterministic drill-down.
+5. Run `fixture_state=permission_denied`, `empty`, `degraded`, and
+   `partial_failure` and confirm blocked/degraded states are explicit.
+6. Confirm the AWS Runtime app panel renders success, empty, degraded,
+   permission-denied, and partial-failure states without exposing
+   rendered policy bodies or secret values.
+
+## Safety gates
+
+- Read-only. No IAM write API is called by this issue.
+- All plans include `read_only_projection: true`.
+- All plans include rollback and verification plans, so a future
+  executor has the safety scaffolding the moment it can land approved
+  changes.
+- `ready_for_apply` is derived deterministically — it is a hint to
+  consumers, not an instruction to execute.
+- Conditions already present on the upstream finding are never
+  re-recommended, so the planner cannot accidentally suggest
+  duplicate or weaker conditions.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -584,6 +584,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/trust-policy-hardening
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5209,6 +5214,102 @@ paths:
                     $ref: "#/components/schemas/AWSIAMPolicyDiffResult"
         "400":
           description: Invalid AWS IAM policy diff request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/trust-policy-hardening:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS trust policy hardening plans
+      operationId: getAWSProjectTrustPolicyHardeningPlans
+      description: Generates ranked, read-only trust-policy hardening plans from upstream cross-account-trust findings. Plans carry stable IDs, calculation version, hardening direction, severity/status/score/confidence, principal change intent, condition recommendations, before/after statement snippet refs, affected callers, expected breakage projection, rollback plan, verification plan, ready_for_apply, evidence refs, source signals, impacted graph nodes/path, and next action. The engine is read-only and never mutates AWS state, never reads or returns rendered policy bodies, secret values, prompts, completions, tool payloads, browser pages, code-interpreter output, database rows, object contents, customer payloads, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: service
+          schema: { type: string }
+        - in: query
+          name: resource
+          schema: { type: string }
+          description: Optional substring search across resource node, ARN, label, type, and service.
+        - in: query
+          name: principal
+          schema: { type: string }
+          description: Optional substring search across affected caller and proposed principal lists.
+        - in: query
+          name: hardening_direction
+          schema:
+            type: string
+            enum: [remove_public_principal, add_org_or_source_condition, scope_to_known_external_principal, tighten_existing_condition]
+        - in: query
+          name: breakage_level
+          schema:
+            type: string
+            enum: [low, medium, high, unknown]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across plan, principal change, condition recommendations, statement snippet, affected caller, breakage projection, rollback, and verification fields.
+      responses:
+        "200":
+          description: AWS trust policy hardening contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    $ref: "#/components/schemas/AWSTrustPolicyHardeningResult"
+        "400":
+          description: Invalid AWS trust policy hardening request
           content:
             application/json:
               schema:
@@ -13672,6 +13773,270 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSIAMPolicyDiffRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSTrustPolicyPrincipalChange:
+      type: object
+      properties:
+        before_principals:
+          type: array
+          items: { type: string }
+        after_principals:
+          type: array
+          items: { type: string }
+        public_principal_removed: { type: boolean }
+        rationale: { type: string }
+    AWSTrustPolicyConditionRecommendation:
+      type: object
+      properties:
+        operator: { type: string }
+        key: { type: string }
+        value: { type: string }
+        rationale: { type: string }
+        evidence_ref: { type: string }
+    AWSTrustPolicyStatementSnippet:
+      type: object
+      properties:
+        statement_sid: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        change_kind:
+          type: string
+          enum: [public_principal_removed, principal_added, condition_added, principal_and_condition_tightened, manual_review]
+        before_ref: { type: string }
+        after_ref: { type: string }
+        condition_before:
+          type: array
+          items: { type: string }
+        condition_after:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+    AWSTrustPolicyAffectedCaller:
+      type: object
+      properties:
+        principal_arn: { type: string }
+        principal_account_id: { type: string }
+        ou_path: { type: string }
+        trusted_within_organization: { type: boolean }
+        runtime_observed: { type: boolean }
+        analyzer_backed: { type: boolean }
+        evidence_ref: { type: string }
+    AWSTrustPolicyHardeningBreakageProjection:
+      type: object
+      properties:
+        level:
+          type: string
+          enum: [low, medium, high, unknown]
+        rationale: { type: string }
+        signals:
+          type: array
+          items: { type: string }
+    AWSTrustPolicyHardeningRollbackPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSTrustPolicyHardeningVerificationPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        success_signals:
+          type: array
+          items: { type: string }
+        failure_signals:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSTrustPolicyHardeningRelationship:
+      type: object
+      properties:
+        plan_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSTrustPolicyHardeningPlan:
+      type: object
+      properties:
+        plan_id: { type: string }
+        calculation_version: { type: string }
+        source_finding_id: { type: string }
+        finding_type: { type: string }
+        hardening_direction:
+          type: string
+          enum: [remove_public_principal, add_org_or_source_condition, scope_to_known_external_principal, tighten_existing_condition]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        resource_type: { type: string }
+        resource_node_id: { type: string }
+        resource_arn: { type: string }
+        resource_label: { type: string }
+        public_principal: { type: boolean }
+        trusted_within_organization: { type: boolean }
+        runtime_observed: { type: boolean }
+        analyzer_backed: { type: boolean }
+        principal_change:
+          $ref: "#/components/schemas/AWSTrustPolicyPrincipalChange"
+        condition_recommendations:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSTrustPolicyConditionRecommendation"
+        statement_snippets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSTrustPolicyStatementSnippet"
+        affected_callers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSTrustPolicyAffectedCaller"
+        breakage_projection:
+          $ref: "#/components/schemas/AWSTrustPolicyHardeningBreakageProjection"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSTrustPolicyHardeningRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSTrustPolicyHardeningVerificationPlan"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSTrustPolicyHardeningSummary:
+      type: object
+      properties:
+        total_plans: { type: integer }
+        filtered_plans: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        finding_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        hardening_direction_counts:
+          type: object
+          additionalProperties: { type: integer }
+        breakage_level_counts:
+          type: object
+          additionalProperties: { type: integer }
+        public_principal_count: { type: integer }
+        cross_account_count: { type: integer }
+        conditioned_count: { type: integer }
+        runtime_observed_count: { type: integer }
+        analyzer_backed_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        manual_review_count: { type: integer }
+        affected_caller_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSTrustPolicyHardeningResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSTrustPolicyHardeningSummary"
+        plans:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSTrustPolicyHardeningPlan"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSTrustPolicyHardeningRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -760,6 +760,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-risk", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_trust_policy_hardening.go
+++ b/internal/api/aws_trust_policy_hardening.go
@@ -1,0 +1,970 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsTrustPolicyHardeningCurrentIssue = 1531
+	awsTrustPolicyHardeningVersion      = "aws-trust-policy-hardening-planner-v1"
+)
+
+// AWSTrustPolicyHardeningRequest scopes the deterministic trust-policy
+// hardening planner to one AWS connector plus optional operator drill-down
+// filters.
+type AWSTrustPolicyHardeningRequest struct {
+	ConnectorID        string `json:"connector_id,omitempty"`
+	FixtureState       string `json:"fixture_state,omitempty"`
+	AccountID          string `json:"account_id,omitempty"`
+	Region             string `json:"region,omitempty"`
+	Service            string `json:"service,omitempty"`
+	Resource           string `json:"resource,omitempty"`
+	Principal          string `json:"principal,omitempty"`
+	HardeningDirection string `json:"hardening_direction,omitempty"`
+	BreakageLevel      string `json:"breakage_level,omitempty"`
+	Severity           string `json:"severity,omitempty"`
+	Status             string `json:"status,omitempty"`
+	ReadyForApply      string `json:"ready_for_apply,omitempty"`
+	Search             string `json:"search,omitempty"`
+}
+
+// AWSTrustPolicyHardeningEvidence and path step reuse the least-privilege
+// contract so the planner stays consistent with its upstream source.
+type AWSTrustPolicyHardeningEvidence = AWSLeastPrivilegeEvidence
+type AWSTrustPolicyHardeningPathStep = AWSLeastPrivilegePathStep
+type AWSTrustPolicyHardeningDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSTrustPolicyHardeningCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSTrustPolicyPrincipalChange is the read-only before/after intent for the
+// `Principal` element of a trust policy statement. It carries identifier
+// metadata only — never a rendered JSON principal block.
+type AWSTrustPolicyPrincipalChange struct {
+	BeforePrincipals       []string `json:"before_principals,omitempty"`
+	AfterPrincipals        []string `json:"after_principals,omitempty"`
+	PublicPrincipalRemoved bool     `json:"public_principal_removed"`
+	Rationale              string   `json:"rationale"`
+}
+
+// AWSTrustPolicyConditionRecommendation describes a single condition the
+// planner is recommending be added to the trust statement. The value carries
+// a placeholder/identifier — never a rendered secret or workload payload.
+type AWSTrustPolicyConditionRecommendation struct {
+	Operator    string `json:"operator"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Rationale   string `json:"rationale"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSTrustPolicyStatementSnippet labels the before/after trust statement
+// without inlining a rendered policy body.
+type AWSTrustPolicyStatementSnippet struct {
+	StatementSID    string   `json:"statement_sid"`
+	Effect          string   `json:"effect"`
+	ChangeKind      string   `json:"change_kind"`
+	BeforeRef       string   `json:"before_ref,omitempty"`
+	AfterRef        string   `json:"after_ref,omitempty"`
+	ConditionBefore []string `json:"condition_before,omitempty"`
+	ConditionAfter  []string `json:"condition_after,omitempty"`
+	Rationale       string   `json:"rationale"`
+}
+
+// AWSTrustPolicyAffectedCaller is one external principal known to use the
+// trust path. Identifiers only — no secrets, no rendered policy bodies, no
+// workload payloads.
+type AWSTrustPolicyAffectedCaller struct {
+	PrincipalARN       string `json:"principal_arn"`
+	PrincipalAccountID string `json:"principal_account_id,omitempty"`
+	OUPath             string `json:"ou_path,omitempty"`
+	TrustedWithinOrg   bool   `json:"trusted_within_organization"`
+	RuntimeObserved    bool   `json:"runtime_observed"`
+	AnalyzerBacked     bool   `json:"analyzer_backed"`
+	EvidenceRef        string `json:"evidence_ref,omitempty"`
+}
+
+// AWSTrustPolicyHardeningBreakageProjection bucketed expectation for the
+// workload breakage of applying the plan.
+type AWSTrustPolicyHardeningBreakageProjection struct {
+	Level     string   `json:"level"`
+	Rationale string   `json:"rationale"`
+	Signals   []string `json:"signals,omitempty"`
+}
+
+// AWSTrustPolicyHardeningRollbackPlan documents how an applied plan is
+// reverted.
+type AWSTrustPolicyHardeningRollbackPlan struct {
+	Strategy    string   `json:"strategy"`
+	Steps       []string `json:"steps"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSTrustPolicyHardeningVerificationPlan documents how an applied plan is
+// checked.
+type AWSTrustPolicyHardeningVerificationPlan struct {
+	Strategy       string   `json:"strategy"`
+	Steps          []string `json:"steps"`
+	SuccessSignals []string `json:"success_signals,omitempty"`
+	FailureSignals []string `json:"failure_signals,omitempty"`
+	EvidenceRef    string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSTrustPolicyHardeningRelationship surfaces plan→graph node edges so the
+// app and downstream graph consumers can show why a plan touches a node.
+type AWSTrustPolicyHardeningRelationship struct {
+	PlanID      string `json:"plan_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSTrustPolicyHardeningPlan is the persisted-record-shaped contract
+// emitted by the planner. It carries statement-level metadata refs and
+// graph nodes only; no rendered policy bodies, secret values, prompts,
+// completions, tool payloads, browser pages, code-interpreter output,
+// database rows, object contents, customer payloads, or workload payloads
+// are inlined.
+type AWSTrustPolicyHardeningPlan struct {
+	PlanID                    string                                    `json:"plan_id"`
+	CalculationVersion        string                                    `json:"calculation_version"`
+	SourceFindingID           string                                    `json:"source_finding_id"`
+	FindingType               string                                    `json:"finding_type"`
+	HardeningDirection        string                                    `json:"hardening_direction"`
+	Severity                  string                                    `json:"severity"`
+	Status                    string                                    `json:"status"`
+	Score                     int                                       `json:"score"`
+	Confidence                float64                                   `json:"confidence"`
+	Title                     string                                    `json:"title"`
+	Summary                   string                                    `json:"summary"`
+	AccountID                 string                                    `json:"account_id"`
+	Region                    string                                    `json:"region"`
+	Service                   string                                    `json:"service,omitempty"`
+	ResourceType              string                                    `json:"resource_type,omitempty"`
+	ResourceNodeID            string                                    `json:"resource_node_id,omitempty"`
+	ResourceARN               string                                    `json:"resource_arn,omitempty"`
+	ResourceLabel             string                                    `json:"resource_label,omitempty"`
+	PublicPrincipal           bool                                      `json:"public_principal"`
+	TrustedWithinOrganization bool                                      `json:"trusted_within_organization"`
+	RuntimeObserved           bool                                      `json:"runtime_observed"`
+	AnalyzerBacked            bool                                      `json:"analyzer_backed"`
+	PrincipalChange           AWSTrustPolicyPrincipalChange             `json:"principal_change"`
+	ConditionRecommendations  []AWSTrustPolicyConditionRecommendation   `json:"condition_recommendations"`
+	StatementSnippets         []AWSTrustPolicyStatementSnippet          `json:"statement_snippets"`
+	AffectedCallers           []AWSTrustPolicyAffectedCaller            `json:"affected_callers"`
+	BreakageProjection        AWSTrustPolicyHardeningBreakageProjection `json:"breakage_projection"`
+	RollbackPlan              AWSTrustPolicyHardeningRollbackPlan       `json:"rollback_plan"`
+	VerificationPlan          AWSTrustPolicyHardeningVerificationPlan   `json:"verification_plan"`
+	ReadyForApply             bool                                      `json:"ready_for_apply"`
+	ReadOnlyProjection        bool                                      `json:"read_only_projection"`
+	SourceSignals             []string                                  `json:"source_signals"`
+	Evidence                  []AWSTrustPolicyHardeningEvidence         `json:"evidence"`
+	EvidenceBoundary          string                                    `json:"evidence_boundary"`
+	ImpactedNodes             []string                                  `json:"impacted_nodes"`
+	ImpactedPath              []AWSTrustPolicyHardeningPathStep         `json:"impacted_path"`
+	NextAction                string                                    `json:"next_action"`
+	CreatedAt                 time.Time                                 `json:"created_at"`
+	UpdatedAt                 time.Time                                 `json:"updated_at"`
+}
+
+// AWSTrustPolicyHardeningSummary aggregates the unfiltered and filtered set.
+type AWSTrustPolicyHardeningSummary struct {
+	TotalPlans               int            `json:"total_plans"`
+	FilteredPlans            int            `json:"filtered_plans"`
+	SeverityCounts           map[string]int `json:"severity_counts"`
+	StatusCounts             map[string]int `json:"status_counts"`
+	FindingTypeCounts        map[string]int `json:"finding_type_counts"`
+	HardeningDirectionCounts map[string]int `json:"hardening_direction_counts"`
+	BreakageLevelCounts      map[string]int `json:"breakage_level_counts"`
+	PublicPrincipalCount     int            `json:"public_principal_count"`
+	CrossAccountCount        int            `json:"cross_account_count"`
+	ConditionedCount         int            `json:"conditioned_count"`
+	RuntimeObservedCount     int            `json:"runtime_observed_count"`
+	AnalyzerBackedCount      int            `json:"analyzer_backed_count"`
+	ReadyForApplyCount       int            `json:"ready_for_apply_count"`
+	ManualReviewCount        int            `json:"manual_review_count"`
+	AffectedCallerCount      int            `json:"affected_caller_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+}
+
+// AWSTrustPolicyHardeningResult is the deterministic planner envelope.
+type AWSTrustPolicyHardeningResult struct {
+	TenantID           string                                `json:"tenant_id"`
+	WorkspaceID        string                                `json:"workspace_id"`
+	ProjectID          string                                `json:"project_id"`
+	ConnectorID        string                                `json:"connector_id,omitempty"`
+	AccountID          string                                `json:"account_id,omitempty"`
+	Region             string                                `json:"region,omitempty"`
+	ParentIssueNumber  int                                   `json:"parent_issue_number"`
+	ParentIssueRef     string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                   `json:"current_issue_number"`
+	CurrentIssueRef    string                                `json:"current_issue_ref"`
+	Version            string                                `json:"version"`
+	Status             string                                `json:"status"`
+	FixtureState       string                                `json:"fixture_state,omitempty"`
+	Confidence         float64                               `json:"confidence"`
+	CalculationVersion string                                `json:"calculation_version"`
+	AppliedFilters     map[string]string                     `json:"applied_filters"`
+	Summary            AWSTrustPolicyHardeningSummary        `json:"summary"`
+	Plans              []AWSTrustPolicyHardeningPlan         `json:"plans"`
+	Relationships      []AWSTrustPolicyHardeningRelationship `json:"relationships"`
+	Caveats            []string                              `json:"caveats"`
+	FailureReasons     []string                              `json:"failure_reasons"`
+	RemediationHints   []string                              `json:"remediation_hints"`
+	EvidenceLinks      []string                              `json:"evidence_links"`
+	CoverageGaps       []AWSTrustPolicyHardeningCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSTrustPolicyHardeningDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                             `json:"generated_at"`
+	UpdatedAt          time.Time                             `json:"updated_at"`
+}
+
+type awsTrustPolicyHardeningSources struct {
+	trust AWSCrossAccountTrustResult
+}
+
+// GetAWSTrustPolicyHardeningPlans composes ranked trust-policy hardening
+// plans from upstream cross-account-trust findings. The engine is read-only:
+// it never mutates AWS, never reads or returns rendered policy bodies, secret
+// values, or workload payloads, and treats unknown or denied evidence as
+// explicit states instead of deterministic truth.
+func (s *Service) GetAWSTrustPolicyHardeningPlans(ctx context.Context, workspaceID string, projectID string, request AWSTrustPolicyHardeningRequest) (AWSTrustPolicyHardeningResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSTrustPolicyHardeningResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSTrustPolicyHardeningResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSTrustPolicyHardeningFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSTrustPolicyHardeningResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsTrustPolicyHardeningSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSTrustPolicyHardeningResult{}, err
+	}
+	plans := awsTrustPolicyHardeningPlans(sources, now)
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Score == plans[j].Score {
+			return plans[i].PlanID < plans[j].PlanID
+		}
+		return plans[i].Score > plans[j].Score
+	})
+	filtered, applied := filterAWSTrustPolicyHardeningPlans(plans, request)
+	relationships := awsTrustPolicyHardeningRelationships(filtered)
+	diagnostics := awsTrustPolicyHardeningDiagnostics(sources)
+	coverageGaps := awsTrustPolicyHardeningCoverageGaps(sources)
+	status, confidence := summarizeAWSTrustPolicyHardeningStatus(sources, filtered, diagnostics)
+
+	return AWSTrustPolicyHardeningResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsTrustPolicyHardeningCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsTrustPolicyHardeningCurrentIssue),
+		Version:            awsTrustPolicyHardeningVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsTrustPolicyHardeningVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSTrustPolicyHardeningPlans(plans, filtered, relationships),
+		Plans:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsTrustPolicyHardeningCaveats(),
+		FailureReasons:     awsTrustPolicyHardeningFailureReasons(sources),
+		RemediationHints:   awsTrustPolicyHardeningRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsTrustPolicyHardeningCurrentIssue),
+			awsIssueURL(awsCrossAccountTrustCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-trust-policy-hardening-planner",
+			"/docs/aws-cross-account-trust",
+			"/docs/aws-remediation-case-model",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSTrustPolicyHardeningFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsTrustPolicyHardeningSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsTrustPolicyHardeningSources, error) {
+	trust, err := s.GetAWSCrossAccountTrust(ctx, workspaceID, projectID, AWSCrossAccountTrustRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsTrustPolicyHardeningSources{}, fmt.Errorf("trust policy hardening cross account trust: %w", err)
+	}
+	return awsTrustPolicyHardeningSources{trust: trust}, nil
+}
+
+func awsTrustPolicyHardeningPlans(sources awsTrustPolicyHardeningSources, now time.Time) []AWSTrustPolicyHardeningPlan {
+	plans := []AWSTrustPolicyHardeningPlan{}
+	for _, finding := range sources.trust.Findings {
+		if plan, ok := awsTrustPolicyHardeningPlanFromFinding(finding, now); ok {
+			plans = append(plans, plan)
+		}
+	}
+	return plans
+}
+
+func awsTrustPolicyHardeningPlanFromFinding(finding AWSCrossAccountTrustFinding, now time.Time) (AWSTrustPolicyHardeningPlan, bool) {
+	if finding.FindingID == "" {
+		return AWSTrustPolicyHardeningPlan{}, false
+	}
+	planID := "aws-trust-policy-hardening:" + stableAWSBlastRadiusToken("trust-hardening", finding.FindingID)
+	evidenceRef := firstString(awsTrustPolicyHardeningEvidenceRefs(finding.Evidence))
+	direction := strings.TrimSpace(finding.HardeningDirection)
+	if direction == "" {
+		direction = awsTrustPolicyHardeningDirection(finding)
+	}
+	principalChange := awsTrustPolicyHardeningPrincipalChange(finding)
+	conditions := awsTrustPolicyHardeningConditions(finding, evidenceRef)
+	statements := awsTrustPolicyHardeningStatementSnippets(finding, principalChange, conditions, evidenceRef)
+	callers := awsTrustPolicyHardeningAffectedCallers(finding, evidenceRef)
+	breakage := awsTrustPolicyHardeningBreakage(finding, callers)
+	rollback := awsTrustPolicyHardeningRollback(finding, evidenceRef)
+	verification := awsTrustPolicyHardeningVerification(finding, evidenceRef)
+	readyForApply := awsTrustPolicyHardeningReadyForApply(finding, breakage, conditions)
+	title := awsTrustPolicyHardeningTitle(finding, direction)
+	plan := AWSTrustPolicyHardeningPlan{
+		PlanID:                    planID,
+		CalculationVersion:        awsTrustPolicyHardeningVersion,
+		SourceFindingID:           finding.FindingID,
+		FindingType:               finding.FindingType,
+		HardeningDirection:        direction,
+		Severity:                  finding.Severity,
+		Status:                    finding.Status,
+		Score:                     finding.Score,
+		Confidence:                finding.Confidence,
+		Title:                     title,
+		Summary:                   finding.Rationale,
+		AccountID:                 finding.AccountID,
+		Region:                    finding.Region,
+		Service:                   finding.Service,
+		ResourceType:              finding.ResourceType,
+		ResourceNodeID:            finding.ResourceNodeID,
+		ResourceARN:               finding.ResourceARN,
+		ResourceLabel:             finding.ResourceLabel,
+		PublicPrincipal:           finding.PublicPrincipal,
+		TrustedWithinOrganization: finding.TrustedWithinOrganization,
+		RuntimeObserved:           finding.RuntimeObserved,
+		AnalyzerBacked:            finding.AnalyzerBacked,
+		PrincipalChange:           principalChange,
+		ConditionRecommendations:  conditions,
+		StatementSnippets:         statements,
+		AffectedCallers:           callers,
+		BreakageProjection:        breakage,
+		RollbackPlan:              rollback,
+		VerificationPlan:          verification,
+		ReadyForApply:             readyForApply,
+		ReadOnlyProjection:        true,
+		SourceSignals:             []string{"cross_account_trust"},
+		Evidence:                  finding.Evidence,
+		EvidenceBoundary:          awsTrustPolicyHardeningEvidenceBoundary(),
+		ImpactedNodes:             emptyStrings(dedupeStrings(append([]string{finding.ResourceNodeID}, finding.ImpactedNodes...))),
+		ImpactedPath:              finding.ImpactedPath,
+		NextAction:                finding.NextAction,
+		CreatedAt:                 now,
+		UpdatedAt:                 now,
+	}
+	return plan, true
+}
+
+func awsTrustPolicyHardeningDirection(finding AWSCrossAccountTrustFinding) string {
+	if finding.PublicPrincipal {
+		return "remove_public_principal"
+	}
+	if !finding.HasCondition {
+		return "add_org_or_source_condition"
+	}
+	if !finding.TrustedWithinOrganization {
+		return "scope_to_known_external_principal"
+	}
+	return "tighten_existing_condition"
+}
+
+func awsTrustPolicyHardeningPrincipalChange(finding AWSCrossAccountTrustFinding) AWSTrustPolicyPrincipalChange {
+	if finding.PublicPrincipal {
+		afterPrincipals := []string{}
+		if finding.ExternalPrincipalARN != "" {
+			afterPrincipals = append(afterPrincipals, finding.ExternalPrincipalARN)
+		}
+		if len(afterPrincipals) == 0 && finding.ExternalPrincipalAccount != "" {
+			afterPrincipals = append(afterPrincipals, "arn:aws:iam::"+finding.ExternalPrincipalAccount+":root")
+		}
+		if len(afterPrincipals) == 0 {
+			afterPrincipals = []string{"owner-approved-principal-arn"}
+		}
+		return AWSTrustPolicyPrincipalChange{
+			BeforePrincipals:       []string{"*"},
+			AfterPrincipals:        afterPrincipals,
+			PublicPrincipalRemoved: true,
+			Rationale:              "Replace wildcard public principal with an explicit, owner-approved external principal ARN.",
+		}
+	}
+	if finding.ExternalPrincipalARN == "" {
+		return AWSTrustPolicyPrincipalChange{
+			Rationale: "Principal is already explicit; the plan focuses on adding boundary conditions instead of narrowing the principal.",
+		}
+	}
+	return AWSTrustPolicyPrincipalChange{
+		BeforePrincipals: []string{finding.ExternalPrincipalARN},
+		AfterPrincipals:  []string{finding.ExternalPrincipalARN},
+		Rationale:        "Keep the explicit external principal and harden the statement via additional conditions below.",
+	}
+}
+
+func awsTrustPolicyHardeningConditions(finding AWSCrossAccountTrustFinding, evidenceRef string) []AWSTrustPolicyConditionRecommendation {
+	out := []AWSTrustPolicyConditionRecommendation{}
+	existing := map[string]struct{}{}
+	for _, key := range finding.ConditionKeys {
+		existing[strings.ToLower(strings.TrimSpace(key))] = struct{}{}
+	}
+	addCondition := func(operator, key, value, rationale string) {
+		if _, ok := existing[strings.ToLower(key)]; ok {
+			return
+		}
+		out = append(out, AWSTrustPolicyConditionRecommendation{
+			Operator:    operator,
+			Key:         key,
+			Value:       value,
+			Rationale:   rationale,
+			EvidenceRef: evidenceRef,
+		})
+	}
+	if finding.TrustedWithinOrganization {
+		addCondition("StringEquals", "aws:PrincipalOrgID", "<owner-approved-org-id>", "Restrict the trust statement to principals inside the approved AWS organization.")
+	}
+	if !finding.TrustedWithinOrganization && finding.ExternalPrincipalAccount != "" {
+		addCondition("StringEquals", "aws:PrincipalAccount", finding.ExternalPrincipalAccount, "Pin the cross-account grant to the known external account id.")
+	}
+	switch finding.FindingType {
+	case "runtime_cross_account_assumption":
+		addCondition("StringEquals", "sts:ExternalId", "<owner-approved-external-id>", "Require a shared sts:ExternalId for cross-account role assumption to mitigate confused-deputy risk.")
+		addCondition("StringEquals", "aws:SourceIdentity", "<workload-identity>", "Require an aws:SourceIdentity claim from the calling workload so audit logs preserve attribution.")
+	case "access_analyzer_external_access":
+		addCondition("ArnEquals", "aws:SourceArn", "<owner-approved-source-arn>", "Pin Access Analyzer-flagged external access to an explicit source ARN.")
+	case "public_resource_trust":
+		addCondition("Bool", "aws:SecureTransport", "true", "Require TLS for any remaining public access to the resource.")
+	case "cross_account_graph_path":
+		addCondition("StringEquals", "aws:PrincipalOrgID", "<owner-approved-org-id>", "Restrict the cross-account graph path to principals inside the approved AWS organization.")
+	}
+	if !finding.HasCondition && len(out) == 0 {
+		addCondition("StringEquals", "aws:PrincipalOrgID", "<owner-approved-org-id>", "Trust statement carries no condition; bound the principal scope before approving downstream remediation.")
+	}
+	return out
+}
+
+func awsTrustPolicyHardeningStatementSnippets(finding AWSCrossAccountTrustFinding, principal AWSTrustPolicyPrincipalChange, conditions []AWSTrustPolicyConditionRecommendation, evidenceRef string) []AWSTrustPolicyStatementSnippet {
+	statement := AWSTrustPolicyStatementSnippet{
+		StatementSID:    "trust-policy-hardening-projection",
+		Effect:          "Allow",
+		ChangeKind:      "principal_and_condition_tightened",
+		BeforeRef:       evidenceRef,
+		AfterRef:        "trust-policy://" + finding.FindingID + "/scoped-projection",
+		ConditionBefore: finding.ConditionKeys,
+		ConditionAfter:  awsTrustPolicyHardeningProjectedConditionKeys(finding.ConditionKeys, conditions),
+	}
+	switch {
+	case principal.PublicPrincipalRemoved:
+		statement.ChangeKind = "public_principal_removed"
+		statement.Rationale = "Remove the wildcard public principal and add the recommended condition boundary."
+	case len(conditions) > 0 && len(principal.AfterPrincipals) > 0 && len(principal.BeforePrincipals) == 0:
+		statement.ChangeKind = "principal_added"
+		statement.Rationale = "Add an explicit principal and a condition boundary in place of the implicit/public trust."
+	case len(conditions) > 0:
+		statement.ChangeKind = "condition_added"
+		statement.Rationale = "Keep the explicit principal and add the recommended condition boundary."
+	default:
+		statement.ChangeKind = "manual_review"
+		statement.Rationale = "Trust path needs manual review: no automatic condition recommendation matched this finding."
+	}
+	return []AWSTrustPolicyStatementSnippet{statement}
+}
+
+func awsTrustPolicyHardeningProjectedConditionKeys(existing []string, conditions []AWSTrustPolicyConditionRecommendation) []string {
+	out := make([]string, 0, len(existing)+len(conditions))
+	seen := map[string]struct{}{}
+	for _, key := range existing {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		out = append(out, trimmed)
+	}
+	for _, condition := range conditions {
+		lower := strings.ToLower(condition.Key)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		out = append(out, condition.Key)
+	}
+	return out
+}
+
+func awsTrustPolicyHardeningAffectedCallers(finding AWSCrossAccountTrustFinding, evidenceRef string) []AWSTrustPolicyAffectedCaller {
+	if finding.ExternalPrincipalARN == "" {
+		return nil
+	}
+	return []AWSTrustPolicyAffectedCaller{{
+		PrincipalARN:       finding.ExternalPrincipalARN,
+		PrincipalAccountID: finding.ExternalPrincipalAccount,
+		OUPath:             finding.ExternalPrincipalOUPath,
+		TrustedWithinOrg:   finding.TrustedWithinOrganization,
+		RuntimeObserved:    finding.RuntimeObserved,
+		AnalyzerBacked:     finding.AnalyzerBacked,
+		EvidenceRef:        evidenceRef,
+	}}
+}
+
+func awsTrustPolicyHardeningBreakage(finding AWSCrossAccountTrustFinding, callers []AWSTrustPolicyAffectedCaller) AWSTrustPolicyHardeningBreakageProjection {
+	signals := []string{}
+	if finding.RuntimeObserved {
+		signals = append(signals, "runtime_observed:true")
+	}
+	if finding.AnalyzerBacked {
+		signals = append(signals, "analyzer_backed:true")
+	}
+	if finding.HasCondition {
+		signals = append(signals, "existing_condition:true")
+	}
+	if len(callers) > 0 {
+		signals = append(signals, fmt.Sprintf("affected_callers:%d", len(callers)))
+	}
+	if finding.PublicPrincipal {
+		return AWSTrustPolicyHardeningBreakageProjection{
+			Level:     "high",
+			Rationale: "Public principal: unknown callers may depend on the wildcard trust. Owner approval is required before applying.",
+			Signals:   signals,
+		}
+	}
+	if !finding.RuntimeObserved && !finding.AnalyzerBacked {
+		return AWSTrustPolicyHardeningBreakageProjection{
+			Level:     "unknown",
+			Rationale: "No runtime or Access Analyzer evidence proves which callers rely on this trust; manual breakage review required.",
+			Signals:   signals,
+		}
+	}
+	if finding.RuntimeObserved && finding.AnalyzerBacked {
+		return AWSTrustPolicyHardeningBreakageProjection{
+			Level:     "low",
+			Rationale: "Runtime correlation and Access Analyzer both confirm the known caller set; condition boundary should not break new callers.",
+			Signals:   signals,
+		}
+	}
+	return AWSTrustPolicyHardeningBreakageProjection{
+		Level:     "medium",
+		Rationale: "Only one of runtime or Access Analyzer confirms the caller set; review affected callers before apply.",
+		Signals:   signals,
+	}
+}
+
+func awsTrustPolicyHardeningRollback(finding AWSCrossAccountTrustFinding, evidenceRef string) AWSTrustPolicyHardeningRollbackPlan {
+	if finding.PublicPrincipal {
+		return AWSTrustPolicyHardeningRollbackPlan{
+			Strategy:    "restore_trust_policy",
+			Steps:       []string{"Restore the previous trust policy from the captured before_ref.", "Re-run cross-account-trust to confirm the wildcard principal returns.", "Document the rollback in the remediation case audit trail."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSTrustPolicyHardeningRollbackPlan{
+		Strategy:    "restore_trust_policy",
+		Steps:       []string{"Restore the previous trust statement from the captured before_ref.", "Re-run cross-account-trust to confirm the previous principal/condition set."},
+		EvidenceRef: evidenceRef,
+	}
+}
+
+func awsTrustPolicyHardeningVerification(finding AWSCrossAccountTrustFinding, evidenceRef string) AWSTrustPolicyHardeningVerificationPlan {
+	steps := []string{"Re-run cross-account-trust after the change and confirm the finding's severity drops or it disappears."}
+	successSignals := []string{"cross_account_trust:finding-resolved"}
+	failureSignals := []string{"cross_account_trust:finding-unchanged"}
+	switch finding.FindingType {
+	case "runtime_cross_account_assumption":
+		steps = append(steps, "Watch the next runtime correlation window for an STS AssumeRole failure from any caller that does not satisfy the new sts:ExternalId / aws:SourceIdentity condition.")
+		failureSignals = append(failureSignals, "agent_runtime_access:assume-role-denied-unexpected")
+	case "access_analyzer_external_access":
+		steps = append(steps, "Wait one Access Analyzer scan cycle and confirm the analyzer finding clears.")
+		successSignals = append(successSignals, "access_analyzer:finding-cleared")
+	case "public_resource_trust":
+		steps = append(steps, "Re-run resource-policy reachability to confirm no public principal path remains.")
+		successSignals = append(successSignals, "blast_radius:no-public-principal")
+	}
+	return AWSTrustPolicyHardeningVerificationPlan{
+		Strategy:       "trust_policy_re_evaluate",
+		Steps:          steps,
+		SuccessSignals: successSignals,
+		FailureSignals: failureSignals,
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsTrustPolicyHardeningReadyForApply(finding AWSCrossAccountTrustFinding, breakage AWSTrustPolicyHardeningBreakageProjection, conditions []AWSTrustPolicyConditionRecommendation) bool {
+	if finding.PublicPrincipal {
+		return false
+	}
+	if breakage.Level != "low" {
+		return false
+	}
+	if len(conditions) == 0 {
+		return false
+	}
+	if finding.Confidence < 0.8 {
+		return false
+	}
+	return true
+}
+
+func awsTrustPolicyHardeningTitle(finding AWSCrossAccountTrustFinding, direction string) string {
+	display := firstNonEmptyAWSValue(finding.ResourceLabel, finding.ResourceARN, finding.ResourceNodeID, finding.Service)
+	switch direction {
+	case "remove_public_principal":
+		return fmt.Sprintf("Remove public trust on %s", display)
+	case "add_org_or_source_condition":
+		return fmt.Sprintf("Add org/source condition to %s trust", display)
+	case "scope_to_known_external_principal":
+		return fmt.Sprintf("Scope %s trust to known external principal", display)
+	case "tighten_existing_condition":
+		return fmt.Sprintf("Tighten existing trust condition on %s", display)
+	default:
+		return fmt.Sprintf("Harden trust policy on %s", display)
+	}
+}
+
+func awsTrustPolicyHardeningRelationships(plans []AWSTrustPolicyHardeningPlan) []AWSTrustPolicyHardeningRelationship {
+	relationships := []AWSTrustPolicyHardeningRelationship{}
+	for _, p := range plans {
+		from := firstNonEmptyAWSValue(p.ResourceNodeID, p.ResourceARN)
+		if from == "" {
+			continue
+		}
+		for _, target := range p.ImpactedNodes {
+			if target == "" || target == from {
+				continue
+			}
+			relationships = append(relationships, AWSTrustPolicyHardeningRelationship{
+				PlanID:      p.PlanID,
+				Type:        "trust_policy_hardening_path",
+				FromNodeID:  from,
+				ToNodeID:    target,
+				EvidenceRef: firstString(awsTrustPolicyHardeningEvidenceRefs(p.Evidence)),
+			})
+		}
+		for _, caller := range p.AffectedCallers {
+			if caller.PrincipalARN == "" || caller.PrincipalARN == from {
+				continue
+			}
+			relationships = append(relationships, AWSTrustPolicyHardeningRelationship{
+				PlanID:      p.PlanID,
+				Type:        "trust_policy_hardening_affected_caller",
+				FromNodeID:  from,
+				ToNodeID:    caller.PrincipalARN,
+				EvidenceRef: caller.EvidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSTrustPolicyHardeningPlans(all, filtered []AWSTrustPolicyHardeningPlan, relationships []AWSTrustPolicyHardeningRelationship) AWSTrustPolicyHardeningSummary {
+	summary := AWSTrustPolicyHardeningSummary{
+		TotalPlans:               len(all),
+		FilteredPlans:            len(filtered),
+		SeverityCounts:           map[string]int{},
+		StatusCounts:             map[string]int{},
+		FindingTypeCounts:        map[string]int{},
+		HardeningDirectionCounts: map[string]int{},
+		BreakageLevelCounts:      map[string]int{},
+		RelationshipCount:        len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, p := range filtered {
+		summary.SeverityCounts[p.Severity]++
+		summary.StatusCounts[p.Status]++
+		summary.FindingTypeCounts[p.FindingType]++
+		summary.HardeningDirectionCounts[p.HardeningDirection]++
+		summary.BreakageLevelCounts[p.BreakageProjection.Level]++
+		if p.PublicPrincipal {
+			summary.PublicPrincipalCount++
+		}
+		if !p.TrustedWithinOrganization {
+			summary.CrossAccountCount++
+		}
+		if len(p.ConditionRecommendations) > 0 {
+			summary.ConditionedCount++
+		}
+		if p.RuntimeObserved {
+			summary.RuntimeObservedCount++
+		}
+		if p.AnalyzerBacked {
+			summary.AnalyzerBackedCount++
+		}
+		if p.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		for _, snippet := range p.StatementSnippets {
+			if snippet.ChangeKind == "manual_review" {
+				summary.ManualReviewCount++
+			}
+		}
+		summary.AffectedCallerCount += len(p.AffectedCallers)
+		if p.Score > summary.HighestScore {
+			summary.HighestScore = p.Score
+		}
+		confidenceTotal += p.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSTrustPolicyHardeningPlans(plans []AWSTrustPolicyHardeningPlan, request AWSTrustPolicyHardeningRequest) ([]AWSTrustPolicyHardeningPlan, map[string]string) {
+	filters := map[string]string{
+		"account_id":          strings.TrimSpace(request.AccountID),
+		"region":              strings.TrimSpace(request.Region),
+		"service":             strings.TrimSpace(request.Service),
+		"resource":            strings.TrimSpace(request.Resource),
+		"principal":           strings.TrimSpace(request.Principal),
+		"hardening_direction": normalizeAWSRuntimeEventFilterToken(request.HardeningDirection),
+		"breakage_level":      normalizeAWSRuntimeEventFilterToken(request.BreakageLevel),
+		"severity":            normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":              normalizeAWSRuntimeEventFilterToken(request.Status),
+		"ready_for_apply":     strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":              strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSTrustPolicyHardeningPlan, 0, len(plans))
+	for _, p := range plans {
+		if filters["account_id"] != "" && filters["account_id"] != p.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], p.Region) {
+			continue
+		}
+		if filters["service"] != "" && !strings.EqualFold(filters["service"], p.Service) {
+			continue
+		}
+		if filters["hardening_direction"] != "" && filters["hardening_direction"] != normalizeAWSRuntimeEventFilterToken(p.HardeningDirection) {
+			continue
+		}
+		if filters["breakage_level"] != "" && filters["breakage_level"] != normalizeAWSRuntimeEventFilterToken(p.BreakageProjection.Level) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(p.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(p.Status) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != p.ReadyForApply {
+				continue
+			}
+		}
+		if filters["resource"] != "" && !awsTrustPolicyHardeningResourceMatch(p, filters["resource"]) {
+			continue
+		}
+		if filters["principal"] != "" && !awsTrustPolicyHardeningPrincipalMatch(p, filters["principal"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsTrustPolicyHardeningSearchMatch(p, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered, applied
+}
+
+func awsTrustPolicyHardeningResourceMatch(p AWSTrustPolicyHardeningPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	hay := strings.ToLower(strings.Join([]string{p.ResourceNodeID, p.ResourceARN, p.ResourceLabel, p.ResourceType, p.Service}, " "))
+	return strings.Contains(hay, needle)
+}
+
+func awsTrustPolicyHardeningPrincipalMatch(p AWSTrustPolicyHardeningPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{}
+	for _, caller := range p.AffectedCallers {
+		values = append(values, caller.PrincipalARN, caller.PrincipalAccountID, caller.OUPath)
+	}
+	values = append(values, p.PrincipalChange.BeforePrincipals...)
+	values = append(values, p.PrincipalChange.AfterPrincipals...)
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsTrustPolicyHardeningSearchMatch(p AWSTrustPolicyHardeningPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{p.PlanID, p.Title, p.Summary, p.SourceFindingID, p.FindingType, p.HardeningDirection, p.Severity, p.Status, p.Service, p.ResourceType, p.ResourceNodeID, p.ResourceARN, p.ResourceLabel, p.BreakageProjection.Level, p.BreakageProjection.Rationale, p.RollbackPlan.Strategy, p.RollbackPlan.EvidenceRef, p.VerificationPlan.Strategy, p.VerificationPlan.EvidenceRef, p.NextAction, p.PrincipalChange.Rationale}
+	values = append(values, p.PrincipalChange.BeforePrincipals...)
+	values = append(values, p.PrincipalChange.AfterPrincipals...)
+	values = append(values, p.BreakageProjection.Signals...)
+	values = append(values, p.RollbackPlan.Steps...)
+	values = append(values, p.VerificationPlan.Steps...)
+	values = append(values, p.VerificationPlan.SuccessSignals...)
+	values = append(values, p.VerificationPlan.FailureSignals...)
+	for _, condition := range p.ConditionRecommendations {
+		values = append(values, condition.Operator, condition.Key, condition.Value, condition.Rationale, condition.EvidenceRef)
+	}
+	for _, snippet := range p.StatementSnippets {
+		values = append(values, snippet.StatementSID, snippet.Effect, snippet.ChangeKind, snippet.Rationale, snippet.BeforeRef, snippet.AfterRef)
+		values = append(values, snippet.ConditionBefore...)
+		values = append(values, snippet.ConditionAfter...)
+	}
+	for _, caller := range p.AffectedCallers {
+		values = append(values, caller.PrincipalARN, caller.PrincipalAccountID, caller.OUPath, caller.EvidenceRef)
+	}
+	for _, evidence := range p.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSTrustPolicyHardeningStatus(sources awsTrustPolicyHardeningSources, filtered []AWSTrustPolicyHardeningPlan, diagnostics []AWSTrustPolicyHardeningDiagnostic) (string, float64) {
+	if sources.trust.Status == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sources.trust.Status == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.76
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsTrustPolicyHardeningFailureReasons(sources awsTrustPolicyHardeningSources) []string {
+	return dedupeStrings(append([]string{}, sources.trust.FailureReasons...))
+}
+
+func awsTrustPolicyHardeningRemediationHints(sources awsTrustPolicyHardeningSources) []string {
+	out := []string{
+		"Apply each plan only after the matching remediation case is approved; this engine is read-only and does not call any IAM write API.",
+		"Pair each plan with its rollback and verification plan before scheduling execution.",
+	}
+	out = append(out, sources.trust.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsTrustPolicyHardeningCaveats() []string {
+	return []string{
+		"Trust policy hardening plans are read-only projections; the engine never applies an AWS change.",
+		"Principal and condition snippets carry identifier metadata only — never rendered JSON policy bodies, secret values, or workload payloads.",
+		"ready_for_apply is derived deterministically (non-public principal + breakage_level=low + at least one condition recommendation + confidence >= 0.80); approve/execute/verify transitions belong to future wave issues.",
+	}
+}
+
+func awsTrustPolicyHardeningDiagnostics(sources awsTrustPolicyHardeningSources) []AWSTrustPolicyHardeningDiagnostic {
+	out := []AWSTrustPolicyHardeningDiagnostic{}
+	for _, d := range sources.trust.Diagnostics {
+		if strings.TrimSpace(d.Message) == "" && strings.TrimSpace(d.Code) == "" {
+			continue
+		}
+		out = append(out, AWSTrustPolicyHardeningDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	return out
+}
+
+func awsTrustPolicyHardeningCoverageGaps(sources awsTrustPolicyHardeningSources) []AWSTrustPolicyHardeningCoverageGap {
+	out := []AWSTrustPolicyHardeningCoverageGap{{
+		Capability:  "trust_policy_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1531 implements the trust policy hardening projection only; apply/verify transitions are future-wave work and never call IAM write APIs here.",
+		Remediation: "Wire the approve/execute/verify endpoints in the relevant remediation/governance issue once the safety gates are in place.",
+	}}
+	for _, g := range sources.trust.CoverageGaps {
+		out = append(out, AWSTrustPolicyHardeningCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	return out
+}
+
+func awsTrustPolicyHardeningEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads"
+}
+
+func awsTrustPolicyHardeningEvidenceRefs(evidence []AWSTrustPolicyHardeningEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			out = append(out, item.EvidenceRef)
+		}
+	}
+	return dedupeStrings(out)
+}

--- a/internal/api/aws_trust_policy_hardening_test.go
+++ b/internal/api/aws_trust_policy_hardening_test.go
@@ -1,0 +1,323 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newTrustPolicyHardeningService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSTrustPolicyHardeningPlansBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	svc, ws := newTrustPolicyHardeningService(t, "project-trust-policy-hardening", now)
+
+	result, err := svc.GetAWSTrustPolicyHardeningPlans(defaultScopeContext(), ws, "project-trust-policy-hardening", AWSTrustPolicyHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get trust policy hardening: %v", err)
+	}
+	if result.CurrentIssueRef != "#1531" || result.Version != awsTrustPolicyHardeningVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Plans) == 0 || result.Summary.TotalPlans != len(result.Plans) {
+		t.Fatalf("expected plan summary to match payload: %+v", result.Summary)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Plans); i++ {
+		if result.Plans[i-1].Score < result.Plans[i].Score {
+			t.Fatalf("plans are not ranked by descending score: %+v", result.Plans)
+		}
+	}
+	for _, p := range result.Plans {
+		if p.PlanID == "" || p.CalculationVersion != awsTrustPolicyHardeningVersion || p.SourceFindingID == "" {
+			t.Fatalf("plan missing stable metadata: %+v", p)
+		}
+		if p.FindingType == "" || p.HardeningDirection == "" || p.Severity == "" || p.Status == "" || p.Title == "" {
+			t.Fatalf("plan missing classification fields: %+v", p)
+		}
+		if !p.ReadOnlyProjection {
+			t.Fatalf("plan must be a read-only projection: %+v", p)
+		}
+		if len(p.StatementSnippets) == 0 {
+			t.Fatalf("plan missing statement snippets: %+v", p)
+		}
+		if p.BreakageProjection.Level == "" || p.BreakageProjection.Rationale == "" {
+			t.Fatalf("plan missing breakage projection: %+v", p.BreakageProjection)
+		}
+		if p.RollbackPlan.Strategy == "" || len(p.RollbackPlan.Steps) == 0 {
+			t.Fatalf("plan missing rollback plan: %+v", p.RollbackPlan)
+		}
+		if p.VerificationPlan.Strategy == "" || len(p.VerificationPlan.Steps) == 0 {
+			t.Fatalf("plan missing verification plan: %+v", p.VerificationPlan)
+		}
+		if p.EvidenceBoundary != awsTrustPolicyHardeningEvidenceBoundary() {
+			t.Fatalf("plan crossed evidence boundary: %+v", p)
+		}
+	}
+}
+
+func TestGetAWSTrustPolicyHardeningPlansAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC)
+	svc, ws := newTrustPolicyHardeningService(t, "project-trust-policy-filters", now)
+
+	highOnly, err := svc.GetAWSTrustPolicyHardeningPlans(defaultScopeContext(), ws, "project-trust-policy-filters", AWSTrustPolicyHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "high",
+	})
+	if err != nil {
+		t.Fatalf("severity filter: %v", err)
+	}
+	for _, p := range highOnly.Plans {
+		if p.Severity != "high" {
+			t.Fatalf("severity filter leaked %s plan: %+v", p.Severity, p)
+		}
+	}
+	if highOnly.AppliedFilters["severity"] != "high" {
+		t.Fatalf("expected applied severity filter, got %+v", highOnly.AppliedFilters)
+	}
+}
+
+func TestAWSTrustPolicyHardeningPlanFromFinding(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 10, 0, 0, time.UTC)
+
+	public := AWSCrossAccountTrustFinding{
+		FindingID:            "aws-cross-account-trust:public-bucket",
+		CalculationVersion:   "aws-cross-account-trust-engine-v1",
+		FindingType:          "public_resource_trust",
+		Severity:             "critical",
+		Status:               "action_required",
+		Score:                92,
+		Confidence:           0.9,
+		AccountID:            "123456789012",
+		Region:               "us-east-1",
+		Service:              "s3",
+		ResourceType:         "s3_bucket",
+		ResourceARN:          "arn:aws:s3:::public-bucket",
+		ResourceNodeID:       "aws:resource:s3-bucket/public-bucket",
+		ResourceLabel:        "public-bucket",
+		ExternalPrincipalARN: "",
+		PublicPrincipal:      true,
+		HasCondition:         false,
+		ConditionKeys:        nil,
+		Rationale:            "Bucket policy allows *.",
+		HardeningDirection:   "",
+	}
+	p, ok := awsTrustPolicyHardeningPlanFromFinding(public, now)
+	if !ok {
+		t.Fatalf("expected plan for public principal")
+	}
+	if p.HardeningDirection != "remove_public_principal" {
+		t.Fatalf("expected remove_public_principal direction, got %s", p.HardeningDirection)
+	}
+	if !p.PrincipalChange.PublicPrincipalRemoved {
+		t.Fatalf("public principal change must mark PublicPrincipalRemoved: %+v", p.PrincipalChange)
+	}
+	if len(p.PrincipalChange.AfterPrincipals) == 0 {
+		t.Fatalf("public principal change must propose an explicit after_principal: %+v", p.PrincipalChange)
+	}
+	if p.ReadyForApply {
+		t.Fatalf("public principal plan must not be ready_for_apply: %+v", p)
+	}
+	if p.BreakageProjection.Level != "high" {
+		t.Fatalf("public principal plan must project high breakage, got %s", p.BreakageProjection.Level)
+	}
+
+	knownCaller := AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:known-caller",
+		CalculationVersion:        "aws-cross-account-trust-engine-v1",
+		FindingType:               "runtime_cross_account_assumption",
+		Severity:                  "high",
+		Status:                    "action_required",
+		Score:                     78,
+		Confidence:                0.88,
+		AccountID:                 "123456789012",
+		Region:                    "us-east-1",
+		Service:                   "iam",
+		ResourceType:              "iam_role",
+		ResourceARN:               "arn:aws:iam::123456789012:role/payments-cross-account",
+		ResourceNodeID:            "aws:identity:arn:aws:iam::123456789012:role/payments-cross-account",
+		ResourceLabel:             "payments-cross-account",
+		ExternalPrincipalARN:      "arn:aws:iam::555555555555:role/billing-runner",
+		ExternalPrincipalAccount:  "555555555555",
+		TrustedWithinOrganization: false,
+		HasCondition:              false,
+		RuntimeObserved:           true,
+		AnalyzerBacked:            true,
+		Rationale:                 "Runtime AssumeRole observed without sts:ExternalId.",
+	}
+	plan, ok := awsTrustPolicyHardeningPlanFromFinding(knownCaller, now)
+	if !ok {
+		t.Fatalf("expected plan for known caller finding")
+	}
+	if plan.PublicPrincipal {
+		t.Fatalf("known-caller plan must not be flagged public")
+	}
+	if plan.BreakageProjection.Level != "low" {
+		t.Fatalf("runtime + analyzer-backed plan should project low breakage, got %s", plan.BreakageProjection.Level)
+	}
+	if !plan.ReadyForApply {
+		t.Fatalf("known-caller plan with conditions and low breakage must be ready_for_apply: %+v", plan)
+	}
+	var sawExternalID, sawSourceIdentity, sawAccount bool
+	for _, condition := range plan.ConditionRecommendations {
+		switch condition.Key {
+		case "sts:ExternalId":
+			sawExternalID = true
+		case "aws:SourceIdentity":
+			sawSourceIdentity = true
+		case "aws:PrincipalAccount":
+			sawAccount = true
+		}
+	}
+	if !sawExternalID || !sawSourceIdentity || !sawAccount {
+		t.Fatalf("runtime_cross_account_assumption plan must recommend sts:ExternalId, aws:SourceIdentity, and aws:PrincipalAccount conditions: %+v", plan.ConditionRecommendations)
+	}
+	if len(plan.AffectedCallers) != 1 || plan.AffectedCallers[0].PrincipalARN != knownCaller.ExternalPrincipalARN {
+		t.Fatalf("expected one affected caller equal to the external principal: %+v", plan.AffectedCallers)
+	}
+
+	unknown := knownCaller
+	unknown.FindingID = "aws-cross-account-trust:unknown"
+	unknown.RuntimeObserved = false
+	unknown.AnalyzerBacked = false
+	unknownPlan, ok := awsTrustPolicyHardeningPlanFromFinding(unknown, now)
+	if !ok {
+		t.Fatalf("expected plan for unknown-caller finding")
+	}
+	if unknownPlan.BreakageProjection.Level != "unknown" {
+		t.Fatalf("no runtime/analyzer evidence must project unknown breakage, got %s", unknownPlan.BreakageProjection.Level)
+	}
+	if unknownPlan.ReadyForApply {
+		t.Fatalf("unknown-breakage plan must not be ready_for_apply: %+v", unknownPlan)
+	}
+
+	existingCondition := knownCaller
+	existingCondition.FindingID = "aws-cross-account-trust:existing-condition"
+	existingCondition.ConditionKeys = []string{"sts:ExternalId", "aws:SourceIdentity", "aws:PrincipalAccount"}
+	existingPlan, ok := awsTrustPolicyHardeningPlanFromFinding(existingCondition, now)
+	if !ok {
+		t.Fatalf("expected plan for existing-condition finding")
+	}
+	for _, condition := range existingPlan.ConditionRecommendations {
+		switch condition.Key {
+		case "sts:ExternalId", "aws:SourceIdentity", "aws:PrincipalAccount":
+			t.Fatalf("planner should not re-recommend an already-present condition: %+v", condition)
+		}
+	}
+}
+
+func TestAWSTrustPolicyHardeningSearchMatchesPlanDetails(t *testing.T) {
+	plan := AWSTrustPolicyHardeningPlan{
+		PlanID: "aws-trust-policy-hardening:search-test",
+		Title:  "Harden trust on payments-cross-account",
+		ConditionRecommendations: []AWSTrustPolicyConditionRecommendation{{
+			Operator:  "StringEquals",
+			Key:       "sts:ExternalId",
+			Value:     "<owner-approved-external-id>",
+			Rationale: "Require sts:ExternalId for cross-account assumption.",
+		}},
+		StatementSnippets: []AWSTrustPolicyStatementSnippet{{
+			ConditionBefore: []string{"aws:SourceVpce"},
+			ConditionAfter:  []string{"aws:SourceVpce", "sts:ExternalId"},
+		}},
+		BreakageProjection: AWSTrustPolicyHardeningBreakageProjection{
+			Signals: []string{"runtime_observed:true"},
+		},
+		RollbackPlan: AWSTrustPolicyHardeningRollbackPlan{
+			Steps:       []string{"Restore the previous trust statement from the captured before_ref."},
+			EvidenceRef: "evidence://trust/known",
+		},
+		VerificationPlan: AWSTrustPolicyHardeningVerificationPlan{
+			Steps:          []string{"Re-run cross-account-trust and confirm the finding resolves."},
+			SuccessSignals: []string{"cross_account_trust:finding-resolved"},
+			FailureSignals: []string{"agent_runtime_access:assume-role-denied-unexpected"},
+		},
+		AffectedCallers: []AWSTrustPolicyAffectedCaller{{PrincipalARN: "arn:aws:iam::555555555555:role/billing-runner"}},
+	}
+	cases := []struct {
+		name   string
+		needle string
+	}{
+		{"condition key", "sts:ExternalId"},
+		{"rollback step", "before_ref"},
+		{"verification success signal", "finding-resolved"},
+		{"verification failure signal", "assume-role-denied-unexpected"},
+		{"breakage signal", "runtime_observed:true"},
+		{"affected caller", "billing-runner"},
+	}
+	for _, tc := range cases {
+		if !awsTrustPolicyHardeningSearchMatch(plan, tc.needle) {
+			t.Fatalf("search did not match %s needle %q", tc.name, tc.needle)
+		}
+	}
+}
+
+func TestGetAWSTrustPolicyHardeningPlansFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 20, 0, 0, time.UTC)
+	svc, ws := newTrustPolicyHardeningService(t, "project-trust-policy-states", now)
+
+	denied, err := svc.GetAWSTrustPolicyHardeningPlans(defaultScopeContext(), ws, "project-trust-policy-states", AWSTrustPolicyHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Plans) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress plans: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSTrustPolicyHardeningPlans(defaultScopeContext(), ws, "project-trust-policy-states", AWSTrustPolicyHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Summary.TotalPlans != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty fixture should produce no plans and explicit failure reasons: %+v", empty)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not be marked blocked, got %s", empty.Status)
+	}
+
+	if _, err := svc.GetAWSTrustPolicyHardeningPlans(defaultScopeContext(), ws, "project-trust-policy-states", AWSTrustPolicyHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSTrustPolicyHardening(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 25, 0, 0, time.UTC)
+	svc, _ := newTrustPolicyHardeningService(t, "project-trust-policy-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-trust-policy-route/aws/trust-policy-hardening?connector_id=aws-prod&fixture_state=success&severity=high", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plans AWSTrustPolicyHardeningResult `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Plans.CurrentIssueRef != "#1531" || body.Plans.AppliedFilters["severity"] != "high" {
+		t.Fatalf("unexpected route payload: %+v", body.Plans)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3124,6 +3124,45 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"diffs": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSTrustPolicyHardeningPlans(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSTrustPolicyHardeningRequest{
+			ConnectorID:        strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:       strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:          strings.TrimSpace(c.Query("account_id")),
+			Region:             strings.TrimSpace(c.Query("region")),
+			Service:            strings.TrimSpace(c.Query("service")),
+			Resource:           strings.TrimSpace(c.Query("resource")),
+			Principal:          strings.TrimSpace(c.Query("principal")),
+			HardeningDirection: strings.TrimSpace(c.Query("hardening_direction")),
+			BreakageLevel:      strings.TrimSpace(c.Query("breakage_level")),
+			Severity:           strings.TrimSpace(c.Query("severity")),
+			Status:             strings.TrimSpace(c.Query("status")),
+			ReadyForApply:      strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:             strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws trust policy hardening request"})
+			default:
+				logger.Error("get aws trust policy hardening",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws trust policy hardening"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plans": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1650,6 +1650,55 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS trust policy hardening plans with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plans: {
+          status: 'ready',
+          summary: { total_plans: 0, filtered_plans: 0 },
+          plans: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectTrustPolicyHardeningPlans(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        service: 'iam',
+        resource: 'payments-cross-account',
+        principal: 'billing-runner',
+        hardeningDirection: 'add_org_or_source_condition',
+        breakageLevel: 'low',
+        severity: 'high',
+        status: 'action_required',
+        readyForApply: 'true',
+        search: 'sts:ExternalId'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/trust-policy-hardening?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&service=iam&resource=payments-cross-account&principal=billing-runner&hardening_direction=add_org_or_source_condition&breakage_level=low&severity=high&status=action_required&ready_for_apply=true&search=sts%3AExternalId'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3136,6 +3136,190 @@ export type AWSIAMPolicyDiffQuery = {
   search?: string;
 };
 
+export type AWSTrustPolicyHardeningStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSTrustPolicyHardeningFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSTrustPolicyHardeningSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSTrustPolicyHardeningDirection =
+  | 'remove_public_principal'
+  | 'add_org_or_source_condition'
+  | 'scope_to_known_external_principal'
+  | 'tighten_existing_condition'
+  | string;
+export type AWSTrustPolicyHardeningBreakageLevel = 'low' | 'medium' | 'high' | 'unknown' | string;
+
+export type AWSTrustPolicyPrincipalChange = {
+  before_principals?: string[];
+  after_principals?: string[];
+  public_principal_removed: boolean;
+  rationale: string;
+};
+
+export type AWSTrustPolicyConditionRecommendation = {
+  operator: string;
+  key: string;
+  value: string;
+  rationale: string;
+  evidence_ref?: string;
+};
+
+export type AWSTrustPolicyStatementSnippet = {
+  statement_sid: string;
+  effect: string;
+  change_kind: string;
+  before_ref?: string;
+  after_ref?: string;
+  condition_before?: string[];
+  condition_after?: string[];
+  rationale: string;
+};
+
+export type AWSTrustPolicyAffectedCaller = {
+  principal_arn: string;
+  principal_account_id?: string;
+  ou_path?: string;
+  trusted_within_organization: boolean;
+  runtime_observed: boolean;
+  analyzer_backed: boolean;
+  evidence_ref?: string;
+};
+
+export type AWSTrustPolicyHardeningBreakageProjection = {
+  level: AWSTrustPolicyHardeningBreakageLevel;
+  rationale: string;
+  signals?: string[];
+};
+
+export type AWSTrustPolicyHardeningRollbackPlan = {
+  strategy: string;
+  steps: string[];
+  evidence_ref?: string;
+};
+
+export type AWSTrustPolicyHardeningVerificationPlan = {
+  strategy: string;
+  steps: string[];
+  success_signals?: string[];
+  failure_signals?: string[];
+  evidence_ref?: string;
+};
+
+export type AWSTrustPolicyHardeningRelationship = {
+  plan_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSTrustPolicyHardeningPlan = {
+  plan_id: string;
+  calculation_version: string;
+  source_finding_id: string;
+  finding_type: string;
+  hardening_direction: AWSTrustPolicyHardeningDirection;
+  severity: AWSTrustPolicyHardeningSeverity;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  service?: string;
+  resource_type?: string;
+  resource_node_id?: string;
+  resource_arn?: string;
+  resource_label?: string;
+  public_principal: boolean;
+  trusted_within_organization: boolean;
+  runtime_observed: boolean;
+  analyzer_backed: boolean;
+  principal_change: AWSTrustPolicyPrincipalChange;
+  condition_recommendations: AWSTrustPolicyConditionRecommendation[];
+  statement_snippets: AWSTrustPolicyStatementSnippet[];
+  affected_callers: AWSTrustPolicyAffectedCaller[];
+  breakage_projection: AWSTrustPolicyHardeningBreakageProjection;
+  rollback_plan: AWSTrustPolicyHardeningRollbackPlan;
+  verification_plan: AWSTrustPolicyHardeningVerificationPlan;
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSTrustPolicyHardeningSummary = {
+  total_plans: number;
+  filtered_plans: number;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  finding_type_counts: Record<string, number>;
+  hardening_direction_counts: Record<string, number>;
+  breakage_level_counts: Record<string, number>;
+  public_principal_count: number;
+  cross_account_count: number;
+  conditioned_count: number;
+  runtime_observed_count: number;
+  analyzer_backed_count: number;
+  ready_for_apply_count: number;
+  manual_review_count: number;
+  affected_caller_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSTrustPolicyHardeningResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSTrustPolicyHardeningStatus;
+  fixture_state?: AWSTrustPolicyHardeningFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSTrustPolicyHardeningSummary;
+  plans: AWSTrustPolicyHardeningPlan[];
+  relationships: AWSTrustPolicyHardeningRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSTrustPolicyHardeningQuery = {
+  connectorID?: string;
+  fixtureState?: AWSTrustPolicyHardeningFixtureState;
+  accountID?: string;
+  region?: string;
+  service?: string;
+  resource?: string;
+  principal?: string;
+  hardeningDirection?: string;
+  breakageLevel?: string;
+  severity?: string;
+  status?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -7291,6 +7475,31 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         breakage_level: query?.breakageLevel,
+        ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectTrustPolicyHardeningPlans(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSTrustPolicyHardeningQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plans: AWSTrustPolicyHardeningResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/trust-policy-hardening${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        service: query?.service,
+        resource: query?.resource,
+        principal: query?.principal,
+        hardening_direction: query?.hardeningDirection,
+        breakage_level: query?.breakageLevel,
+        severity: query?.severity,
+        status: query?.status,
         ready_for_apply: query?.readyForApply,
         search: query?.search
       })}`,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3518,6 +3518,151 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    vi.spyOn(api.apiClient, 'getAWSProjectTrustPolicyHardeningPlans').mockResolvedValue({
+      plans: {
+        status: 'ready',
+        plans: [
+          {
+            plan_id: 'aws-trust-policy-hardening:payments-cross-account',
+            calculation_version: 'aws-trust-policy-hardening-planner-v1',
+            source_finding_id: 'aws-cross-account-trust:payments-cross-account',
+            finding_type: 'runtime_cross_account_assumption',
+            hardening_direction: 'add_org_or_source_condition',
+            severity: 'high',
+            status: 'action_required',
+            score: 84,
+            confidence: 0.88,
+            title: 'Add org/source condition to payments-cross-account trust',
+            summary: 'Runtime AssumeRole observed without sts:ExternalId.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'iam',
+            resource_type: 'iam_role',
+            resource_node_id: 'aws:identity:arn:aws:iam::123456789012:role/payments-cross-account',
+            resource_arn: 'arn:aws:iam::123456789012:role/payments-cross-account',
+            resource_label: 'payments-cross-account',
+            public_principal: false,
+            trusted_within_organization: false,
+            runtime_observed: true,
+            analyzer_backed: true,
+            principal_change: {
+              before_principals: ['arn:aws:iam::555555555555:role/billing-runner'],
+              after_principals: ['arn:aws:iam::555555555555:role/billing-runner'],
+              public_principal_removed: false,
+              rationale: 'Keep the explicit external principal and harden via conditions.'
+            },
+            condition_recommendations: [
+              {
+                operator: 'StringEquals',
+                key: 'sts:ExternalId',
+                value: '<owner-approved-external-id>',
+                rationale: 'Require shared external id for cross-account assumption.',
+                evidence_ref: 'evidence://trust/payments-cross-account'
+              },
+              {
+                operator: 'StringEquals',
+                key: 'aws:SourceIdentity',
+                value: '<workload-identity>',
+                rationale: 'Preserve workload attribution in audit logs.'
+              }
+            ],
+            statement_snippets: [
+              {
+                statement_sid: 'trust-policy-hardening-projection',
+                effect: 'Allow',
+                change_kind: 'condition_added',
+                before_ref: 'evidence://trust/payments-cross-account',
+                after_ref: 'trust-policy://payments/scoped-projection',
+                condition_before: [],
+                condition_after: ['sts:ExternalId', 'aws:SourceIdentity'],
+                rationale: 'Keep the explicit principal and add the recommended condition boundary.'
+              }
+            ],
+            affected_callers: [
+              {
+                principal_arn: 'arn:aws:iam::555555555555:role/billing-runner',
+                principal_account_id: '555555555555',
+                trusted_within_organization: false,
+                runtime_observed: true,
+                analyzer_backed: true,
+                evidence_ref: 'evidence://trust/payments-cross-account'
+              }
+            ],
+            breakage_projection: {
+              level: 'low',
+              rationale: 'Runtime correlation and Access Analyzer both confirm the caller set.',
+              signals: ['runtime_observed:true', 'analyzer_backed:true', 'affected_callers:1']
+            },
+            rollback_plan: {
+              strategy: 'restore_trust_policy',
+              steps: ['Restore the previous trust statement from the captured before_ref.'],
+              evidence_ref: 'evidence://trust/payments-cross-account'
+            },
+            verification_plan: {
+              strategy: 'trust_policy_re_evaluate',
+              steps: ['Re-run cross-account-trust.'],
+              success_signals: ['cross_account_trust:finding-resolved'],
+              failure_signals: ['cross_account_trust:finding-unchanged'],
+              evidence_ref: 'evidence://trust/payments-cross-account'
+            },
+            ready_for_apply: true,
+            read_only_projection: true,
+            source_signals: ['cross_account_trust'],
+            evidence: [
+              {
+                source: 'cross_account_trust',
+                evidence_ref: 'evidence://trust/payments-cross-account',
+                label: 'Cross-account trust evidence',
+                confidence: 0.88,
+                observed_at: '2026-06-24T10:00:00Z',
+                relationship: 'cross_account_assumption'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            impacted_nodes: ['aws:identity:arn:aws:iam::123456789012:role/payments-cross-account'],
+            impacted_path: [],
+            next_action: 'Confirm caller, then apply the condition boundary via the trust-policy executor.',
+            created_at: '2026-06-24T10:00:00Z',
+            updated_at: '2026-06-24T10:00:00Z'
+          }
+        ],
+        summary: {
+          total_plans: 1,
+          filtered_plans: 1,
+          severity_counts: { high: 1 },
+          status_counts: { action_required: 1 },
+          finding_type_counts: { runtime_cross_account_assumption: 1 },
+          hardening_direction_counts: { add_org_or_source_condition: 1 },
+          breakage_level_counts: { low: 1 },
+          public_principal_count: 0,
+          cross_account_count: 1,
+          conditioned_count: 1,
+          runtime_observed_count: 1,
+          analyzer_backed_count: 1,
+          ready_for_apply_count: 1,
+          manual_review_count: 0,
+          affected_caller_count: 1,
+          relationship_count: 1,
+          highest_score: 84,
+          average_confidence_pct: 88
+        },
+        relationships: [
+          {
+            plan_id: 'aws-trust-policy-hardening:payments-cross-account',
+            type: 'trust_policy_hardening_affected_caller',
+            from_node_id: 'aws:identity:arn:aws:iam::123456789012:role/payments-cross-account',
+            to_node_id: 'arn:aws:iam::555555555555:role/billing-runner',
+            evidence_ref: 'evidence://trust/payments-cross-account'
+          }
+        ],
+        caveats: ['Trust policy hardening plans are read-only projections; the engine never applies an AWS change.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -3835,6 +3980,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS IAM policy diffs' })).toBeInTheDocument();
     expect(screen.getByText(/Scope data-loader: remove 2 action\(s\)/i)).toBeInTheDocument();
     expect(screen.getAllByText(/ready · Low breakage/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS trust policy hardening plans' })).toBeInTheDocument();
+    expect(screen.getByText(/Add org\/source condition to payments-cross-account trust/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/sts:ExternalId/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -61,6 +61,8 @@ import {
   type AWSRemediationCaseResult,
   type AWSIAMPolicyDiff,
   type AWSIAMPolicyDiffResult,
+  type AWSTrustPolicyHardeningPlan,
+  type AWSTrustPolicyHardeningResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -10804,6 +10806,123 @@ function AWSIAMPolicyDiffContent({
   );
 }
 
+function awsTrustPolicyHardeningStage(plan: AWSTrustPolicyHardeningPlan): AWSCapabilityStage {
+  if (plan.public_principal || plan.severity === 'critical' || plan.breakage_projection.level === 'high') {
+    return 'not-available';
+  }
+  if (plan.severity === 'high' || plan.breakage_projection.level === 'medium' || plan.breakage_projection.level === 'unknown') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsTrustPolicyHardeningPrincipalLabel(plan: AWSTrustPolicyHardeningPlan): string {
+  if (plan.principal_change.public_principal_removed) {
+    return 'public → explicit';
+  }
+  const after = plan.principal_change.after_principals ?? [];
+  if (after.length === 0) {
+    return 'principal unchanged';
+  }
+  return after.slice(0, 2).join(', ') + (after.length > 2 ? ` +${after.length - 2}` : '');
+}
+
+function awsTrustPolicyHardeningConditionsLabel(plan: AWSTrustPolicyHardeningPlan): string {
+  const conditions = plan.condition_recommendations ?? [];
+  if (conditions.length === 0) {
+    return 'manual review';
+  }
+  return conditions
+    .slice(0, 2)
+    .map((condition) => condition.key)
+    .join(', ') + (conditions.length > 2 ? ` +${conditions.length - 2}` : '');
+}
+
+function awsTrustPolicyHardeningReadinessLabel(plan: AWSTrustPolicyHardeningPlan): string {
+  if (plan.ready_for_apply) {
+    return `ready · ${formatTokenLabel(plan.breakage_projection.level)} breakage`;
+  }
+  return `gate · ${formatTokenLabel(plan.breakage_projection.level)} breakage`;
+}
+
+function AWSTrustPolicyHardeningContent({
+  plans,
+  loading,
+  error,
+  onRetry
+}: {
+  plans: AWSTrustPolicyHardeningResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = plans?.plans ?? [];
+  const summaryLine = plans
+    ? `${plans.summary.total_plans} total · ${plans.summary.ready_for_apply_count} ready · ${plans.summary.public_principal_count} public · ${plans.summary.cross_account_count} cross-account`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS trust policy hardening plans">
+      <h3>AWS trust policy hardening planner</h3>
+      <p className="idt-app-kicker">
+        Read-only trust-policy hardening plans projected from cross-account-trust evidence. Principal narrowing,
+        condition recommendations, affected callers, breakage projection, rollback, and verification are derived
+        deterministically; the engine never mutates IAM. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS trust policy hardening plans"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Projecting trust policy hardening plans"
+          body="Identrail is composing cross-account-trust evidence into principal-narrowing and condition recommendations."
+        />
+      ) : null}
+      {!error && !loading && plans && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={plans.status === 'blocked' ? 'Permission required' : 'No trust policy hardening plans'}
+          title={plans.status === 'blocked' ? 'Trust policy hardening needs read-only cross-account-trust evidence' : 'No trust policy hardening plans projected'}
+          body={plans.failure_reasons[0] ?? 'No upstream cross-account-trust findings produced a plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && plans && plans.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {plans.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS trust policy hardening plans"
+          rows={rows}
+          getRowKey={(row) => row.plan_id}
+          columns={[
+            { key: 'plan', header: 'Plan', render: (row) => <strong>{row.title}</strong> },
+            { key: 'resource', header: 'Resource', render: (row) => row.resource_label || row.resource_arn || row.resource_node_id || '-' },
+            { key: 'direction', header: 'Direction', render: (row) => formatTokenLabel(row.hardening_direction) },
+            { key: 'principals', header: 'Principal', render: (row) => awsTrustPolicyHardeningPrincipalLabel(row) },
+            { key: 'conditions', header: 'Conditions', render: (row) => awsTrustPolicyHardeningConditionsLabel(row) },
+            { key: 'breakage', header: 'Readiness', render: (row) => awsTrustPolicyHardeningReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsTrustPolicyHardeningStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12255,6 +12374,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [iamPolicyDiffsLoading, setIAMPolicyDiffsLoading] = useState(false);
   const [iamPolicyDiffsError, setIAMPolicyDiffsError] = useState('');
   const iamPolicyDiffsRequestRef = useRef(0);
+  const [trustPolicyHardening, setTrustPolicyHardening] = useState<AWSTrustPolicyHardeningResult | null>(null);
+  const [trustPolicyHardeningLoading, setTrustPolicyHardeningLoading] = useState(false);
+  const [trustPolicyHardeningError, setTrustPolicyHardeningError] = useState('');
+  const trustPolicyHardeningRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12635,6 +12758,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       iamPolicyDiffsRequestRef.current += 1;
     };
   }, [loadIAMPolicyDiffs]);
+
+  const loadTrustPolicyHardening = useCallback(async () => {
+    const requestID = ++trustPolicyHardeningRequestRef.current;
+    setTrustPolicyHardening(null);
+    setTrustPolicyHardeningError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setTrustPolicyHardeningLoading(false);
+      return;
+    }
+    setTrustPolicyHardeningLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectTrustPolicyHardeningPlans(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== trustPolicyHardeningRequestRef.current) {
+        return;
+      }
+      setTrustPolicyHardening(response.plans);
+    } catch (error) {
+      if (requestID !== trustPolicyHardeningRequestRef.current) {
+        return;
+      }
+      setTrustPolicyHardeningError(formatAPIError(error, 'Unable to load AWS trust policy hardening plans.'));
+    } finally {
+      if (requestID === trustPolicyHardeningRequestRef.current) {
+        setTrustPolicyHardeningLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadTrustPolicyHardening();
+    return () => {
+      trustPolicyHardeningRequestRef.current += 1;
+    };
+  }, [loadTrustPolicyHardening]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -13122,6 +13293,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={iamPolicyDiffsLoading}
             error={iamPolicyDiffsError}
             onRetry={loadIAMPolicyDiffs}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSTrustPolicyHardeningContent
+            plans={trustPolicyHardening}
+            loading={trustPolicyHardeningLoading}
+            error={trustPolicyHardeningError}
+            onRetry={loadTrustPolicyHardening}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Add the AWS trust policy hardening planner (#1531, Wave 7.03). A read-only,
metadata-only engine that turns upstream cross-account-trust findings
(#1526) into ranked trust-policy hardening plans the remediation case
model (#1529) and a future executor wave can plan, approve, and apply.

Each plan carries:

- `plan_id`, `calculation_version`, `source_finding_id`, `finding_type`
- `hardening_direction` ∈ `remove_public_principal`,
  `add_org_or_source_condition`, `scope_to_known_external_principal`,
  `tighten_existing_condition`
- severity, status, score, confidence (inherited from the upstream
  finding)
- resource context (account, region, service, type, node, ARN, label)
- trust shape flags: `public_principal`,
  `trusted_within_organization`, `runtime_observed`, `analyzer_backed`
- `principal_change` with `before_principals`, `after_principals`,
  `public_principal_removed`, rationale
- `condition_recommendations`:
  `{operator, key, value, rationale, evidence_ref}` —
  `aws:PrincipalOrgID`, `aws:PrincipalAccount`, `sts:ExternalId`,
  `aws:SourceIdentity`, `aws:SourceArn`, `aws:SecureTransport`
  depending on the finding type; conditions already present on the
  upstream finding are never re-recommended
- `statement_snippets` with `change_kind` ∈ `public_principal_removed`,
  `principal_added`, `condition_added`,
  `principal_and_condition_tightened`, `manual_review` — `before_ref` /
  `after_ref` carry projection URIs only, never rendered JSON
- `affected_callers` with org / runtime / Access Analyzer attribution
- `breakage_projection` with `level` ∈ `low` / `medium` / `high` /
  `unknown`, rationale, and signal counts
- `rollback_plan` (`restore_trust_policy`) and `verification_plan`
  (`trust_policy_re_evaluate`)
- `ready_for_apply: true` only when *all* hold: principal is not
  public, breakage_level is `low`, at least one condition is
  recommended, confidence ≥ 0.80
- `read_only_projection: true` on every plan
- evidence refs, source signals, impacted graph nodes/path, next action

Adds GET /v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening
with filters for `connector_id`, `fixture_state`, `account_id`,
`region`, `service`, `resource`, `principal`, `hardening_direction`,
`breakage_level`, `severity`, `status`, `ready_for_apply`, and
`search`. OpenAPI schemas and authz wiring follow the neighboring AWS
intelligence engines.

The AWS Runtime app surface now shows an **AWS trust policy hardening
planner** panel with resource, hardening direction, principal change,
condition recommendation count, breakage level, ready-for-apply badge,
severity/status, and verification strategy. Loading, empty, error,
degraded, and permission-denied states are explicit.

## Why

Closes #1531. The remediation case model (#1529) and the IAM policy
diff generator (#1530) cover IAM scope; this issue adds the
trust-policy projection so a future executor wave can land safe
principal-narrowing and condition-tightening changes on resource
policies and role trust policies.

This PR implements the **trust-policy projection** capability only.
It is intentionally read-only and never mutates AWS. Apply / verify /
rollback / govern transitions belong to later wave issues.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (new route; no existing route
      contracts change)
- [x] Risk level assessed (read-only, no IAM write API calls, no new AWS
      permissions, never reads rendered policy bodies or workload
      payloads)

## Safety / evidence boundary

- Read-only. No IAM write API is called by this issue.
- Never reads, stores, logs, or displays rendered IAM policy bodies,
  secret values, prompts, completions, tool inputs/outputs, browser
  pages, code-interpreter output, database rows, object contents,
  customer payloads, or workload payloads.
- Principal and condition snippets carry identifier metadata only.
- Every plan has `read_only_projection: true`.
- `ready_for_apply` is derived deterministically (non-public principal
  + breakage_level=low + at least one condition recommendation +
  confidence>=0.80); it is a consumer hint, not an instruction to
  execute.
- Conditions already present on the upstream finding are never
  re-recommended.
- Public principals always stay non-executable.
- Unknown, unsupported, partial, degraded, and permission-denied
  evidence stays explicit and is not treated as proof that a plan is
  safe to apply.

## Validation

\`\`\`bash
go test ./internal/api                                       # ok
go vet ./...                                                 # clean
make fmt-check                                               # clean
make api-example-contract-check                              # passed
npm test -- --run src/api/client.test.ts --prefix web        # passed (incl. new trust client test)
npm test -- --run src/productShell.test.tsx --prefix web     # 234 passed (incl. new trust panel assertion)
npx tsc -b                                                   # clean (web)
npm run build --prefix web                                   # built, prerendered 39 routes
\`\`\`

Manual frontend preview (\`npm run dev --prefix web\`) compiled and
served cleanly with no console or build errors from the new panel.
End-to-end rendering requires the Go API to be running locally; the
panel's UI behavior is covered by the productShell tests using the
mocked client.

## Checklist

- [x] Tests added for contract, filters, principal-narrowing variants
      (public / known caller / unknown caller / existing condition),
      free-text search across plan details, failure states, and the
      route
- [x] Docs updated (\`docs/aws-trust-policy-hardening-planner.md\`,
      \`docs/README.md\`, OpenAPI path + schemas, authz metadata)
- [x] \`CHANGELOG.md\` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1531.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AWS trust policy hardening planner that turns cross-account-trust findings into ranked, read-only hardening plans, with a new API route and UI panel. Implements #1531 and prepares payloads the remediation case flow can approve and apply safely later.

- **New Features**
  - New GET route: `/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening` with filters like `connector_id`, `account_id`, `region`, `service`, `resource`, `principal`, `hardening_direction`, `breakage_level`, `severity`, `status`, `ready_for_apply`, and `search`.
  - Each plan includes hardening direction, principal change, condition recommendations, affected callers, breakage projection, rollback/verification steps, and evidence refs.
  - `ready_for_apply` is set only when the principal is non-public, breakage is low, at least one condition is recommended, and confidence ≥ 0.80.
  - Read-only by design: no IAM write calls and no rendered policy bodies are read or returned.
  - UI: new “AWS trust policy hardening planner” panel showing resource, direction, principal change, condition count, breakage level, `ready_for_apply`, severity/status, and verification strategy; with explicit loading/empty/error/degraded/permission states.
  - OpenAPI schemas, authz wiring, docs, and tests added.

<sup>Written for commit 2445233a2261845e8972c2bdc7d82bd83c4472a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

