### PR TITLE
Derive trust-hardening direction as enum when finding carries prose

### DIFF
--- a/internal/api/aws_trust_policy_hardening.go
+++ b/internal/api/aws_trust_policy_hardening.go
@@ -352,10 +352,7 @@ func awsTrustPolicyHardeningPlanFromFinding(finding AWSCrossAccountTrustFinding,
 	}
 	planID := "aws-trust-policy-hardening:" + stableAWSBlastRadiusToken("trust-hardening", finding.FindingID)
 	evidenceRef := firstString(awsTrustPolicyHardeningEvidenceRefs(finding.Evidence))
-	direction := strings.TrimSpace(finding.HardeningDirection)
-	if direction == "" {
-		direction = awsTrustPolicyHardeningDirection(finding)
-	}
+	direction := awsTrustPolicyHardeningDirectionFromFinding(finding)
 	principalChange := awsTrustPolicyHardeningPrincipalChange(finding)
 	conditions := awsTrustPolicyHardeningConditions(finding, evidenceRef)
 	statements := awsTrustPolicyHardeningStatementSnippets(finding, principalChange, conditions, evidenceRef)
@@ -407,6 +404,21 @@ func awsTrustPolicyHardeningPlanFromFinding(finding AWSCrossAccountTrustFinding,
 		UpdatedAt:                 now,
 	}
 	return plan, true
+}
+
+var awsTrustPolicyHardeningDirectionTokens = map[string]struct{}{
+	"remove_public_principal":           {},
+	"add_org_or_source_condition":       {},
+	"scope_to_known_external_principal": {},
+	"tighten_existing_condition":        {},
+}
+
+func awsTrustPolicyHardeningDirectionFromFinding(finding AWSCrossAccountTrustFinding) string {
+	candidate := strings.ToLower(strings.TrimSpace(finding.HardeningDirection))
+	if _, ok := awsTrustPolicyHardeningDirectionTokens[candidate]; ok {
+		return candidate
+	}
+	return awsTrustPolicyHardeningDirection(finding)
 }
 
 func awsTrustPolicyHardeningDirection(finding AWSCrossAccountTrustFinding) string {

--- a/internal/api/aws_trust_policy_hardening_test.go
+++ b/internal/api/aws_trust_policy_hardening_test.go
@@ -135,6 +135,31 @@ func TestAWSTrustPolicyHardeningPlanFromFinding(t *testing.T) {
 		t.Fatalf("public principal plan must project high breakage, got %s", p.BreakageProjection.Level)
 	}
 
+	proseDirection := AWSCrossAccountTrustFinding{
+		FindingID:                 "aws-cross-account-trust:prose-direction",
+		FindingType:               "runtime_cross_account_assumption",
+		Status:                    "action_required",
+		Severity:                  "high",
+		ExternalPrincipalAccount:  "555555555555",
+		ExternalPrincipalARN:      "arn:aws:iam::555555555555:role/billing-runner",
+		TrustedWithinOrganization: false,
+		HasCondition:              true,
+		RuntimeObserved:           true,
+		AnalyzerBacked:            true,
+		HardeningDirection:        "Review trust policy principal scope, source identity, external ID, and session-tag requirements for this observed cross-account assumption.",
+		Rationale:                 "Runtime AssumeRole observed without sts:ExternalId.",
+		ResourceType:              "iam_role",
+		ResourceARN:               "arn:aws:iam::123456789012:role/payments-cross-account",
+		ResourceNodeID:            "aws:identity:arn:aws:iam::123456789012:role/payments-cross-account",
+	}
+	prosePlan, ok := awsTrustPolicyHardeningPlanFromFinding(proseDirection, now)
+	if !ok {
+		t.Fatalf("expected plan for prose direction fallback case")
+	}
+	if prosePlan.HardeningDirection != "scope_to_known_external_principal" {
+		t.Fatalf("expected derived enum direction for prose input, got %s", prosePlan.HardeningDirection)
+	}
+
 	knownCaller := AWSCrossAccountTrustFinding{
 		FindingID:                 "aws-cross-account-trust:known-caller",
 		CalculationVersion:        "aws-cross-account-trust-engine-v1",


### PR DESCRIPTION
## Summary

Follow-up review fix on merged PR [#1673](https://github.com/identrail/identrail/pull/1673) addressing codex P2 review [comment 3466445341](https://github.com/identrail/identrail/pull/1673#discussion_r3466445341).

The cross-account-trust engine emits \`HardeningDirection\` as prose guidance for runtime, Access Analyzer, and graph-path findings (full sentences, not enum tokens). The planner was copying that text verbatim into \`AWSTrustPolicyHardeningPlan.HardeningDirection\`, so the documented enum contract was violated for those plans and \`?hardening_direction=…\` filters never matched.

\`awsTrustPolicyHardeningDirectionFromFinding\` now only accepts a \`HardeningDirection\` from the upstream finding when it is already one of the four enum tokens:

- \`remove_public_principal\`
- \`add_org_or_source_condition\`
- \`scope_to_known_external_principal\`
- \`tighten_existing_condition\`

Anything else falls back to the existing \`awsTrustPolicyHardeningDirection\` deriver, which inspects \`PublicPrincipal\`, \`HasCondition\`, and \`TrustedWithinOrganization\` to pick the right enum.

## Why

Closes review feedback on [#1673](https://github.com/identrail/identrail/pull/1673).

Without this fix the planner returns plans whose \`hardening_direction\` is a full sentence, which:
- violates the OpenAPI enum contract,
- breaks the documented \`?hardening_direction=…\` filter for runtime / Access Analyzer / graph-path findings, and
- breaks the UI badge that calls \`formatTokenLabel\` on the value.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (output shape unchanged; only the field's value contract is tightened)
- [x] Risk level assessed (read-only metadata, no AWS write API)

## Validation

\`\`\`bash
go test ./internal/api                                       # ok
go vet ./...                                                 # clean
make fmt-check                                               # clean
\`\`\`

New regression test \`TestAWSTrustPolicyHardeningPlanFromFinding\` includes a \`proseDirection\` finding whose \`HardeningDirection\` is a sentence; the test asserts the plan's \`HardeningDirection\` is derived as \`scope_to_known_external_principal\` instead of being copied verbatim.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] No docs change needed (contract was already documented as enum; this only enforces it)
- [x] \`CHANGELOG.md\` not updated (this is a behavior-correctness fix to an unreleased entry already covered by #1673's note)
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Refs #1531.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `AWSTrustPolicyHardeningPlan.HardeningDirection` is always an enum token; only accepts known tokens from findings and otherwise derives the value from finding fields. Restores the OpenAPI contract and fixes `?hardening_direction=…` filtering and the UI badge.

- **Bug Fixes**
  - Added `awsTrustPolicyHardeningDirectionFromFinding` to accept only the four enum tokens, otherwise fall back to `awsTrustPolicyHardeningDirection`.
  - Switched plan generation to use this helper, preventing prose from leaking into plans.
  - Added a regression test to cover the prose-direction case.

<sup>Written for commit a72b3ee9b566be5933f2f913ceeaac7d459ea0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

