### PR TITLE
Implement AWS permission boundary and SCP recommendation planner (#1532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS permission boundary and SCP recommendation planner** (#1532).
+  Adds a read-only, metadata-only engine that turns upstream least-privilege
+  (#1522), cross-account-trust (#1526), and AWS Organizations topology
+  (#1498) evidence into ranked IAM permission boundary and Service Control
+  Policy recommendations. Permission boundaries are emitted only when at
+  least two identities share a least-privilege `remove` recommendation for
+  the same action (so single-identity findings never get hoisted to
+  org-level boundaries). SCPs are emitted per cross-account-trust finding
+  that should be blocked at the org/OU level (public principal, missing
+  condition, Access Analyzer external access, or cross-account graph path).
+  Each plan carries `kind` (`permission_boundary` / `scp`), `target_scope`
+  (`identity` / `account` / `ou` / `org_root`), `target_account_ids`,
+  `target_ou_paths`, `target_identity_node_ids`, deny/allow action lists,
+  condition-key labels, resource-scope refs, prevented-behavior string,
+  breakage projection (low/medium/high/unknown plus affected identity /
+  account / OU counts and signal counts), rollback plan, verification
+  plan, deterministic `ready_for_apply` flag (true only when
+  `breakage_level=low`, `confidence>=0.75`, and the plan has non-empty
+  targets for its kind), and the standard evidence, source-signal,
+  impacted-node, and audit metadata. Public-principal SCPs always project
+  `high` breakage and stay non-executable. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp`
+  with filters for connector, account, region, service, kind, target
+  scope, severity, status, breakage level, ready-for-apply, and free-text
+  search. OpenAPI schemas and authz wiring follow the neighboring AWS
+  intelligence engines. The AWS Runtime app surface now shows an **AWS
+  permission boundary / SCP planner** panel with plan, kind, target
+  scope, denied actions, prevented behavior, breakage level,
+  ready-for-apply badge, severity/status, and verification strategy. The
+  engine never mutates AWS, never reads or returns rendered policy
+  bodies, secret values, prompts, completions, tool payloads, browser
+  pages, code-interpreter output, database rows, object contents,
+  customer payloads, or workload payloads; apply/verify transitions
+  belong to later wave issues.
 - Add **AWS trust policy hardening planner** (#1531). Adds a read-only,
   metadata-only engine that turns upstream cross-account-trust findings
   (#1526) into ranked trust-policy hardening plans. Each plan carries a

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS remediation case model: `aws-remediation-case-model.md`
 - AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
 - AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
+- AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-permission-boundary-scp-planner.md
+++ b/docs/aws-permission-boundary-scp-planner.md
@@ -1,0 +1,186 @@
+# AWS permission boundary and SCP recommendation planner
+
+Issue #1532 (Wave 7.04) adds a metadata-only engine that turns upstream
+least-privilege (#1522), cross-account-trust (#1526), and AWS
+Organizations topology (#1498) evidence into ranked, read-only IAM
+permission boundary and Service Control Policy (SCP) recommendations.
+Each plan carries target scope, OU/account impact, statement snippet
+refs, prevented behavior, breakage projection, rollback plan, and
+verification plan — so a remediation case (#1529) and a future executor
+wave have the concrete payload they need to plan, approve, and apply
+safely.
+
+This issue is the **boundary/SCP projection** capability of the
+Identrail remediation loop. It does not mutate AWS, does not call any
+IAM or Organizations write API, and does not read rendered policy
+bodies, secret values, workload payloads, prompts, completions,
+browser pages, code-interpreter output, database rows, object
+contents, or customer payloads. Approve / execute / verify / rollback
+/ govern transitions belong to later wave issues.
+
+## What it produces
+
+The engine emits `AWSPermissionBoundarySCPPlan` records with two
+kinds:
+
+- **`permission_boundary`** — generated when at least two identities
+  have a least-privilege `remove` recommendation for the same action.
+  The boundary denies that action so the recommendation cannot
+  silently reappear across the affected identities.
+- **`scp`** — generated per cross-account-trust finding that should
+  be blocked at the org/OU level (public principals, missing
+  conditions, Access Analyzer external access, cross-account graph
+  paths). The SCP denies the action pattern that re-introduces the
+  flagged trust.
+
+Every plan carries:
+
+- **Identifiers**: stable `plan_id`, `calculation_version`,
+  `source_finding_ids` (the upstream recommendation or finding IDs
+  the plan was derived from), `kind` ∈
+  `permission_boundary` / `scp`, `target_scope` ∈
+  `identity` / `account` / `ou` / `org_root`.
+- **Targets**: `target_account_ids`, `target_ou_paths`,
+  `target_identity_node_ids`.
+- **Severity / status / score / confidence**: aggregated from the
+  upstream sources.
+- **`prevented_behavior`**: a short string describing what the plan
+  denies.
+- **`statement_snippets`**: one or more
+  `AWSPermissionBoundarySCPStatementSnippet` entries with
+  `change_kind` ∈ `deny_repeated_action`,
+  `deny_public_principal_creation`, `require_org_condition`,
+  `deny_org_unsafe_pattern`, `manual_review`. Snippets carry
+  `before_ref` / `after_ref` metadata pointers, deny/allow action
+  lists, condition-key labels, and resource scope — never rendered
+  JSON policy bodies.
+- **`breakage_projection`** with `level` ∈ `low` / `medium` / `high` /
+  `unknown`, rationale, `affected_identities`, `affected_accounts`,
+  `affected_ous`, plus signal counts.
+- **`rollback_plan`** (`detach_permission_boundary` or `detach_scp`)
+  and **`verification_plan`** (`policy_simulate` or `scp_simulate`).
+- **`ready_for_apply: true`** only when `breakage_level == "low"`,
+  `confidence >= 0.75`, and the plan has non-empty targets for its
+  kind.
+- **`read_only_projection: true`** on every plan.
+- Evidence refs, source signals, impacted graph nodes/path, next
+  action.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-scp`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters (matches the plan's anchor account or any `target_account_ids` entry) |
+| `service` | exact match on the upstream AWS service token |
+| `kind` | `permission_boundary` or `scp` |
+| `target_scope` | `identity`, `account`, `ou`, or `org_root` |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `action_required`, `review`, or `monitor` |
+| `breakage_level` | `low`, `medium`, `high`, or `unknown` |
+| `ready_for_apply` | `true` / `false` |
+| `search` | free-text search across plan, statement snippet (denied/allowed actions, condition keys, resource scope), breakage projection, rollback, and verification fields |
+
+Response shape: `{ "plans": AWSPermissionBoundarySCPResult }` with
+summary, ranked plans, graph relationships, caveats, failure reasons,
+remediation hints, evidence links, coverage gaps, diagnostics, and
+the standard tenant/workspace/project metadata.
+
+## Evidence boundary
+
+The engine never reads, stores, logs, or displays rendered IAM/SCP
+policy bodies, secret values, prompts, completions, tool
+inputs/outputs, browser pages, code-interpreter output, database
+rows, object contents, customer payloads, or workload payloads. It
+composes only the upstream finding refs, action and condition-key
+labels, and account/OU topology pointers.
+
+`before_ref` / `after_ref` on each statement snippet carry projection
+URIs (e.g. `permission-boundary://repeated-action/<action>`,
+`scp://<finding>/scoped-projection`) — never rendered JSON.
+
+## AWS permissions
+
+This capability adds no live mutation and requires no additional AWS
+permissions beyond what the least-privilege (#1522),
+cross-account-trust (#1526), and AWS Organizations topology (#1498)
+engines already need. It reuses their read-only metadata access.
+
+Do not grant IAM or Organizations write permissions for this issue.
+
+## Ready-for-apply derivation
+
+A plan is marked `ready_for_apply: true` only when *all* of the
+following hold:
+
+1. `breakage_projection.level == "low"`, **and**
+2. `confidence >= 0.75`, **and**
+3. for `permission_boundary`: `breakage_projection.affected_identities >= 2`, **or**
+   for `scp`: `breakage_projection.affected_accounts >= 1`.
+
+Public SCPs always project `high` breakage and therefore stay
+non-executable; unknown breakage stays non-executable; plans that
+target zero identities or accounts stay non-executable.
+
+## Failure handling
+
+- **Ready**: all three upstream sources were available and emitted
+  no blocking diagnostics.
+- **Degraded**: at least one upstream source returned partial,
+  degraded, or retryable diagnostics. Plans already composed remain
+  visible.
+- **Blocked**: at least one upstream source is permission denied. The
+  response has zero plans plus diagnostics and failure reasons.
+
+Unknown, unsupported, partial, degraded, and permission-denied
+evidence stays explicit and is not treated as proof that a plan is
+safe to apply.
+
+## App surface
+
+The AWS Runtime app surface renders the **AWS permission boundary /
+SCP planner** panel with each plan's kind, target scope, denied
+action / condition key summary, prevented behavior, breakage level,
+ready-for-apply badge, severity/status, and verification strategy.
+Loading, empty, error, degraded, and permission-denied states are
+explicit.
+
+## Live validation
+
+1. Confirm blockers #1498 and #1529 are closed.
+2. Run least-privilege, cross-account-trust, and Organizations
+   topology with `fixture_state=success`.
+3. Run the planner endpoint with `fixture_state=success` and confirm
+   permission boundary plans (only when >= 2 identities share a
+   removed action) and SCP plans (per qualifying trust finding) both
+   appear.
+4. Filter by `kind=permission_boundary`, `kind=scp`,
+   `target_scope=org_root`, `breakage_level=low`,
+   `ready_for_apply=true`, and `search` to verify deterministic
+   drill-down.
+5. Run `fixture_state=permission_denied`, `empty`, `degraded`, and
+   `partial_failure` and confirm blocked/degraded states are
+   explicit.
+6. Confirm the AWS Runtime app panel renders success, empty,
+   degraded, permission-denied, and partial-failure states without
+   exposing rendered policy bodies or secret values.
+
+## Safety gates
+
+- Read-only. No IAM or Organizations write API is called by this
+  issue.
+- All plans include `read_only_projection: true`.
+- All plans include rollback and verification plans, so a future
+  executor has the safety scaffolding the moment it can land
+  approved changes.
+- `ready_for_apply` is derived deterministically — it is a hint to
+  consumers, not an instruction to execute.
+- Public-principal SCPs always stay non-executable so the engine
+  cannot accidentally suggest applying an org-wide deny without
+  owner sign-off.
+- Permission boundaries require at least two identities to share a
+  removed action, so single-identity findings never get hoisted to
+  org-level boundaries.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -589,6 +589,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-scp
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5310,6 +5315,99 @@ paths:
                     $ref: "#/components/schemas/AWSTrustPolicyHardeningResult"
         "400":
           description: Invalid AWS trust policy hardening request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-scp:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS permission boundary and SCP plans
+      operationId: getAWSProjectPermissionBoundarySCPPlans
+      description: Generates ranked, read-only IAM permission boundary and Service Control Policy (SCP) recommendations from upstream least-privilege, cross-account-trust, and AWS Organizations topology evidence. Each plan carries the projected target scope (identity / OU / account / org_root), affected accounts and OU paths, statement-level deny/allow action sets, condition-key labels, prevented behavior, expected breakage projection, rollback plan, verification plan, ready_for_apply, evidence refs, source signals, impacted graph nodes/path, and next action. The engine is read-only and never mutates AWS state, never reads or returns rendered policy bodies, secret values, prompts, completions, tool payloads, browser pages, code-interpreter output, database rows, object contents, customer payloads, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: service
+          schema: { type: string }
+        - in: query
+          name: kind
+          schema:
+            type: string
+            enum: [permission_boundary, scp]
+        - in: query
+          name: target_scope
+          schema:
+            type: string
+            enum: [identity, account, ou, org_root]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: breakage_level
+          schema:
+            type: string
+            enum: [low, medium, high, unknown]
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across plan, statement snippet (denied/allowed actions, condition keys, resource scope), breakage projection, rollback, and verification fields.
+      responses:
+        "200":
+          description: AWS permission boundary and SCP contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    $ref: "#/components/schemas/AWSPermissionBoundarySCPResult"
+        "400":
+          description: Invalid AWS permission boundary and SCP request
           content:
             application/json:
               schema:
@@ -14037,6 +14135,244 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSTrustPolicyHardeningRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPermissionBoundarySCPStatementSnippet:
+      type: object
+      properties:
+        statement_sid: { type: string }
+        effect:
+          type: string
+          enum: [Allow, Deny]
+        change_kind:
+          type: string
+          enum: [deny_repeated_action, deny_public_principal_creation, require_org_condition, deny_org_unsafe_pattern, manual_review]
+        before_ref: { type: string }
+        after_ref: { type: string }
+        denied_actions:
+          type: array
+          items: { type: string }
+        allowed_actions:
+          type: array
+          items: { type: string }
+        resource_scope:
+          type: array
+          items: { type: string }
+        condition_keys:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+    AWSPermissionBoundarySCPBreakageProjection:
+      type: object
+      properties:
+        level:
+          type: string
+          enum: [low, medium, high, unknown]
+        rationale: { type: string }
+        affected_identities: { type: integer }
+        affected_accounts: { type: integer }
+        affected_ous: { type: integer }
+        signals:
+          type: array
+          items: { type: string }
+    AWSPermissionBoundarySCPRollbackPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSPermissionBoundarySCPVerificationPlan:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        success_signals:
+          type: array
+          items: { type: string }
+        failure_signals:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+    AWSPermissionBoundarySCPRelationship:
+      type: object
+      properties:
+        plan_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSPermissionBoundarySCPPlan:
+      type: object
+      properties:
+        plan_id: { type: string }
+        calculation_version: { type: string }
+        kind:
+          type: string
+          enum: [permission_boundary, scp]
+        target_scope:
+          type: string
+          enum: [identity, account, ou, org_root]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        target_ou_paths:
+          type: array
+          items: { type: string }
+        target_identity_node_ids:
+          type: array
+          items: { type: string }
+        prevented_behavior: { type: string }
+        source_finding_ids:
+          type: array
+          items: { type: string }
+        statement_snippets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundarySCPStatementSnippet"
+        breakage_projection:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPBreakageProjection"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPVerificationPlan"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPermissionBoundarySCPSummary:
+      type: object
+      properties:
+        total_plans: { type: integer }
+        filtered_plans: { type: integer }
+        kind_counts:
+          type: object
+          additionalProperties: { type: integer }
+        target_scope_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        breakage_level_counts:
+          type: object
+          additionalProperties: { type: integer }
+        boundary_plan_count: { type: integer }
+        scp_plan_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        affected_identity_count: { type: integer }
+        affected_account_count: { type: integer }
+        affected_ou_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSPermissionBoundarySCPResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPSummary"
+        plans:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundarySCPPlan"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundarySCPRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -761,6 +761,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-cases", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -382,8 +382,8 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 		accounts := emptyStrings(dedupeStrings(b.accountIDs))
 		ouPaths := awsPermissionBoundarySCPOUPathsForAccounts(orgs, accounts)
 		service := firstString(dedupeStrings(b.services))
-		severity := awsPermissionBoundarySCPMostCommonKey(b.severities, "medium")
-		status := awsPermissionBoundarySCPMostCommonKey(b.statuses, "review")
+		severity := awsPermissionBoundarySCPMostCommonKeyWithPriority(b.severities, "medium", awsPermissionBoundarySCPSeverityPriority)
+		status := awsPermissionBoundarySCPMostCommonKeyWithPriority(b.statuses, "review", awsPermissionBoundarySCPStatusPriority)
 		score := 0
 		if b.scoreCount > 0 {
 			score = b.scoreSum / b.scoreCount
@@ -525,6 +525,8 @@ func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
 	case "runtime_cross_account_assumption":
 		return []string{"sts:AssumeRole"}
+	case "cross_account_resource_access":
+		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
 	case "access_analyzer_external_access":
 		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Allow")}
 	case "cross_account_graph_path":
@@ -577,6 +579,9 @@ func awsSCPTargetScope(finding AWSCrossAccountTrustFinding, orgs AWSOrganization
 	if finding.PublicPrincipal {
 		return "org_root", awsPermissionBoundarySCPAllAccounts(orgs), awsPermissionBoundarySCPAllOUPaths(orgs)
 	}
+	if awsSCPIsResourcePolicyFinding(finding.FindingType) && finding.AccountID != "" {
+		return "account", []string{finding.AccountID}, awsPermissionBoundarySCPOUPathsForAccounts(orgs, []string{finding.AccountID})
+	}
 	if finding.ExternalPrincipalOUPath != "" {
 		paths := []string{finding.ExternalPrincipalOUPath}
 		return "ou", awsPermissionBoundarySCPAccountsForOUPath(orgs, finding.ExternalPrincipalOUPath), paths
@@ -585,6 +590,15 @@ func awsSCPTargetScope(finding AWSCrossAccountTrustFinding, orgs AWSOrganization
 		return "account", []string{finding.AccountID}, awsPermissionBoundarySCPOUPathsForAccounts(orgs, []string{finding.AccountID})
 	}
 	return "org_root", awsPermissionBoundarySCPAllAccounts(orgs), awsPermissionBoundarySCPAllOUPaths(orgs)
+}
+
+func awsSCPIsResourcePolicyFinding(findingType string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(findingType) {
+	case "cross_account_resource_access", "access_analyzer_external_access":
+		return true
+	default:
+		return false
+	}
 }
 
 func awsSCPTitle(finding AWSCrossAccountTrustFinding, scope string) string {
@@ -730,21 +744,62 @@ func awsPermissionBoundarySCPReadyForApply(kind string, breakage AWSPermissionBo
 }
 
 func awsPermissionBoundarySCPMostCommonKey(counts map[string]int, fallback string) string {
+	return awsPermissionBoundarySCPMostCommonKeyWithPriority(counts, fallback, nil)
+}
+
+func awsPermissionBoundarySCPMostCommonKeyWithPriority(counts map[string]int, fallback string, priorities map[string]int) string {
 	best := ""
 	bestCount := -1
+	bestPriority := -1
 	for key, count := range counts {
-		if key == "" {
+		if count <= 0 || key == "" {
 			continue
+		}
+		priority := -1
+		if priorities != nil {
+			priority = priorities[normalizeAWSRuntimeEventFilterToken(key)]
 		}
 		if count > bestCount {
 			best = key
 			bestCount = count
+			bestPriority = priority
+			continue
 		}
+		if count < bestCount {
+			continue
+		}
+		if priority > bestPriority {
+			best = key
+			bestPriority = priority
+			continue
+		}
+		if priority < bestPriority {
+			continue
+		}
+		if normalizeAWSRuntimeEventFilterToken(key) >= normalizeAWSRuntimeEventFilterToken(best) {
+			continue
+		}
+		best = key
 	}
 	if best == "" {
 		return fallback
 	}
 	return best
+}
+
+var awsPermissionBoundarySCPStatusPriority = map[string]int{
+	"action_required": 2,
+	"review":          1,
+	"ready":           0,
+	"deferred":        -1,
+}
+
+var awsPermissionBoundarySCPSeverityPriority = map[string]int{
+	"critical": 4,
+	"high":     3,
+	"medium":   2,
+	"low":      1,
+	"info":     0,
 }
 
 func awsPermissionBoundarySCPOUPathsForAccounts(orgs AWSOrganizationsTopologyResult, accounts []string) []string {

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -328,6 +328,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 		recommendIDs []string
 		identityIDs  []string
 		accountIDs   []string
+		regions      []string
 		services     []string
 		evidence     []AWSPermissionBoundarySCPEvidence
 		impactedRefs []string
@@ -357,6 +358,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 			b.recommendIDs = append(b.recommendIDs, recommendation.RecommendationID)
 			b.identityIDs = append(b.identityIDs, recommendation.IdentityNodeID)
 			b.accountIDs = append(b.accountIDs, recommendation.AccountID)
+			b.regions = append(b.regions, recommendation.Region)
 			if recommendation.Service != "" {
 				b.services = append(b.services, recommendation.Service)
 			}
@@ -380,6 +382,11 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 			continue
 		}
 		accounts := emptyStrings(dedupeStrings(b.accountIDs))
+		regions := emptyStrings(dedupeStrings(b.regions))
+		region := ""
+		if len(regions) == 1 {
+			region = regions[0]
+		}
 		ouPaths := awsPermissionBoundarySCPOUPathsForAccounts(orgs, accounts)
 		service := firstString(dedupeStrings(b.services))
 		severity := awsPermissionBoundarySCPMostCommonKeyWithPriority(b.severities, "medium", awsPermissionBoundarySCPSeverityPriority)
@@ -415,6 +422,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 			TargetScope:           "identity",
 			Severity:              severity,
 			Status:                status,
+			Region:                region,
 			Score:                 score,
 			Confidence:            confidence,
 			Title:                 fmt.Sprintf("Permission boundary: deny %s across %d identities", b.action, len(identityIDs)),
@@ -528,7 +536,7 @@ func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 	case "cross_account_resource_access":
 		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
 	case "access_analyzer_external_access":
-		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Allow")}
+		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
 	case "cross_account_graph_path":
 		return []string{"iam:PassRole", "sts:AssumeRole"}
 	default:
@@ -537,14 +545,22 @@ func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 }
 
 func awsSCPDenyActionForResource(resourceType, modePrefix string) string {
-	switch strings.ToLower(strings.TrimSpace(resourceType)) {
-	case "s3_bucket":
+	resourceType = normalizeAWSRuntimeEventFilterToken(resourceType)
+	modePrefix = normalizeAWSRuntimeEventFilterToken(modePrefix)
+	if modePrefix == "" || modePrefix == "allow" {
+		modePrefix = "put"
+	}
+	if modePrefix != "" {
+		modePrefix = strings.ToUpper(modePrefix[:1]) + modePrefix[1:]
+	}
+	switch resourceType {
+	case "s3", "s3-bucket", "s3_bucket":
 		return "s3:" + modePrefix + "BucketPolicy"
-	case "iam_role":
+	case "iam", "iam-role", "iam_role":
 		return "iam:UpdateAssumeRolePolicy"
-	case "kms_key":
+	case "kms", "kms-key", "kms_key":
 		return "kms:PutKeyPolicy"
-	case "secret":
+	case "secret", "secret-manager", "secrets", "secrets-manager", "secrets_manager", "secretsmanager":
 		return "secretsmanager:PutResourcePolicy"
 	default:
 		return "*"
@@ -979,7 +995,7 @@ func filterAWSPermissionBoundarySCPPlans(plans []AWSPermissionBoundarySCPPlan, r
 		if filters["account_id"] != "" && filters["account_id"] != p.AccountID && !awsStringSliceContains(p.TargetAccountIDs, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && !strings.EqualFold(filters["region"], p.Region) {
+		if filters["region"] != "" && p.Region != "" && !strings.EqualFold(filters["region"], p.Region) {
 			continue
 		}
 		if filters["service"] != "" && !strings.EqualFold(filters["service"], p.Service) {

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -536,7 +536,7 @@ func awsSCPCandidate(finding AWSCrossAccountTrustFinding) bool {
 func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 	switch finding.FindingType {
 	case "public_resource_trust":
-		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		action := awsSCPDenyActionForResourceWithSource(finding, "Put")
 		if action == "" {
 			return nil
 		}
@@ -544,13 +544,13 @@ func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 	case "runtime_cross_account_assumption":
 		return []string{"sts:AssumeRole"}
 	case "cross_account_resource_access":
-		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		action := awsSCPDenyActionForResourceWithSource(finding, "Put")
 		if action == "" {
 			return nil
 		}
 		return []string{action}
 	case "access_analyzer_external_access":
-		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		action := awsSCPDenyActionForResourceWithSource(finding, "Put")
 		if action == "" {
 			return nil
 		}
@@ -560,6 +560,36 @@ func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 	default:
 		return []string{"*"}
 	}
+}
+
+func awsSCPDenyActionForResourceWithSource(finding AWSCrossAccountTrustFinding, modePrefix string) string {
+	if finding.ResourceType == "" {
+		return ""
+	}
+	resourceType := normalizeAWSRuntimeEventFilterToken(finding.ResourceType)
+	if resourceType == "" {
+		return ""
+	}
+	switch resourceType {
+	case "kms", "kms-key", "kms_key":
+		if awsSCPFindingHasEvidenceSource(finding, "kms_live_grant") {
+			return "kms:CreateGrant"
+		}
+	}
+	return awsSCPDenyActionForResource(finding.ResourceType, modePrefix)
+}
+
+func awsSCPFindingHasEvidenceSource(finding AWSCrossAccountTrustFinding, source string) bool {
+	target := normalizeAWSRuntimeEventFilterToken(source)
+	if target == "" {
+		return false
+	}
+	for _, evidence := range finding.Evidence {
+		if normalizeAWSRuntimeEventFilterToken(evidence.Source) == target {
+			return true
+		}
+	}
+	return false
 }
 
 func awsSCPDenyActionForResource(resourceType, modePrefix string) string {
@@ -691,11 +721,30 @@ func awsPermissionBoundarySCPBoundaryBreakage(identityCount, accountCount, ouCou
 }
 
 func awsPermissionBoundarySCPMostSeverePrediction(predictions map[string]int, fallback string, priorities map[string]int) string {
-	prediction := awsPermissionBoundarySCPMostCommonKeyWithPriority(predictions, fallback, priorities)
-	if prediction == "" {
+	bestPrediction := ""
+	bestPriority := -1
+	for prediction, count := range predictions {
+		prediction = normalizeAWSRuntimeEventFilterToken(prediction)
+		if count <= 0 || prediction == "" {
+			continue
+		}
+		priority, ok := priorities[prediction]
+		if !ok {
+			continue
+		}
+		if priority > bestPriority {
+			bestPrediction = prediction
+			bestPriority = priority
+			continue
+		}
+		if priority == bestPriority && (bestPrediction == "" || prediction < bestPrediction) {
+			bestPrediction = prediction
+		}
+	}
+	if bestPrediction == "" {
 		return fallback
 	}
-	return prediction
+	return bestPrediction
 }
 
 func awsPermissionBoundarySCPBreakageWithUpstreamPrediction(breakage AWSPermissionBoundarySCPBreakageProjection, upstreamBreakage string) AWSPermissionBoundarySCPBreakageProjection {

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -334,6 +334,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 		impactedRefs []string
 		severities   map[string]int
 		statuses     map[string]int
+		breakage     map[string]int
 		scoreSum     int
 		scoreCount   int
 		confidence   float64
@@ -352,7 +353,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 			}
 			b := buckets[key]
 			if b == nil {
-				b = &bucket{action: action, severities: map[string]int{}, statuses: map[string]int{}}
+				b = &bucket{action: action, severities: map[string]int{}, statuses: map[string]int{}, breakage: map[string]int{}}
 				buckets[key] = b
 			}
 			b.recommendIDs = append(b.recommendIDs, recommendation.RecommendationID)
@@ -369,6 +370,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 			b.impactedRefs = append(b.impactedRefs, recommendation.ImpactedNodes...)
 			b.severities[recommendation.Severity]++
 			b.statuses[recommendation.Status]++
+			b.breakage[strings.ToLower(strings.TrimSpace(recommendation.BreakagePrediction))]++
 			b.scoreSum += recommendation.Score
 			b.scoreCount++
 			b.confidence += recommendation.Confidence
@@ -404,6 +406,7 @@ func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult,
 		}
 		evidenceRef := firstString(awsPermissionBoundarySCPEvidenceRefs(b.evidence))
 		breakage := awsPermissionBoundarySCPBoundaryBreakage(len(identityIDs), len(accounts), len(ouPaths))
+		breakage = awsPermissionBoundarySCPBreakageWithUpstreamPrediction(breakage, awsPermissionBoundarySCPMostSeverePrediction(b.breakage, "low", awsPermissionBoundarySCPBreakagePredictionPriority))
 		statement := AWSPermissionBoundarySCPStatementSnippet{
 			StatementSID:   "permission-boundary-projection",
 			Effect:         "Deny",
@@ -464,6 +467,9 @@ func awsSCPPlansFromCrossAccountTrust(trust AWSCrossAccountTrustResult, orgs AWS
 		targetScope, accounts, ouPaths := awsSCPTargetScope(finding, orgs)
 		breakage := awsPermissionBoundarySCPSCPBreakage(finding, len(accounts), len(ouPaths))
 		denied := awsSCPDeniedActions(finding)
+		if len(denied) == 0 {
+			continue
+		}
 		statement := AWSPermissionBoundarySCPStatementSnippet{
 			StatementSID:  "scp-projection",
 			Effect:        "Deny",
@@ -530,13 +536,25 @@ func awsSCPCandidate(finding AWSCrossAccountTrustFinding) bool {
 func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
 	switch finding.FindingType {
 	case "public_resource_trust":
-		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
+		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		if action == "" {
+			return nil
+		}
+		return []string{action}
 	case "runtime_cross_account_assumption":
 		return []string{"sts:AssumeRole"}
 	case "cross_account_resource_access":
-		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
+		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		if action == "" {
+			return nil
+		}
+		return []string{action}
 	case "access_analyzer_external_access":
-		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
+		action := awsSCPDenyActionForResource(finding.ResourceType, "Put")
+		if action == "" {
+			return nil
+		}
+		return []string{action}
 	case "cross_account_graph_path":
 		return []string{"iam:PassRole", "sts:AssumeRole"}
 	default:
@@ -563,7 +581,7 @@ func awsSCPDenyActionForResource(resourceType, modePrefix string) string {
 	case "secret", "secret-manager", "secrets", "secrets-manager", "secrets_manager", "secretsmanager":
 		return "secretsmanager:PutResourcePolicy"
 	default:
-		return "*"
+		return ""
 	}
 }
 
@@ -670,6 +688,27 @@ func awsPermissionBoundarySCPBoundaryBreakage(identityCount, accountCount, ouCou
 		AffectedOUs:        ouCount,
 		Signals:            signals,
 	}
+}
+
+func awsPermissionBoundarySCPMostSeverePrediction(predictions map[string]int, fallback string, priorities map[string]int) string {
+	prediction := awsPermissionBoundarySCPMostCommonKeyWithPriority(predictions, fallback, priorities)
+	if prediction == "" {
+		return fallback
+	}
+	return prediction
+}
+
+func awsPermissionBoundarySCPBreakageWithUpstreamPrediction(breakage AWSPermissionBoundarySCPBreakageProjection, upstreamBreakage string) AWSPermissionBoundarySCPBreakageProjection {
+	upstreamBreakage = normalizeAWSRuntimeEventFilterToken(upstreamBreakage)
+	switch upstreamBreakage {
+	case "", "low":
+		return breakage
+	case "medium", "high", "unknown":
+		breakage.Level = upstreamBreakage
+		breakage.Rationale = fmt.Sprintf("Upstream least-privilege evidence indicates %s breakage; review before apply.", upstreamBreakage)
+		breakage.Signals = append(breakage.Signals, "upstream_breakage_prediction:"+upstreamBreakage)
+	}
+	return breakage
 }
 
 func awsPermissionBoundarySCPSCPBreakage(finding AWSCrossAccountTrustFinding, accountCount, ouCount int) AWSPermissionBoundarySCPBreakageProjection {
@@ -816,6 +855,12 @@ var awsPermissionBoundarySCPSeverityPriority = map[string]int{
 	"medium":   2,
 	"low":      1,
 	"info":     0,
+}
+var awsPermissionBoundarySCPBreakagePredictionPriority = map[string]int{
+	"low":     0,
+	"medium":  1,
+	"high":    2,
+	"unknown": 3,
 }
 
 func awsPermissionBoundarySCPOUPathsForAccounts(orgs AWSOrganizationsTopologyResult, accounts []string) []string {

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -1,0 +1,1098 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsPermissionBoundarySCPCurrentIssue = 1532
+	awsPermissionBoundarySCPVersion      = "aws-permission-boundary-scp-planner-v1"
+
+	awsPermissionBoundaryKind = "permission_boundary"
+	awsSCPKind                = "scp"
+)
+
+// AWSPermissionBoundarySCPRequest scopes the deterministic permission
+// boundary / SCP planner to one AWS connector plus optional operator
+// drill-down filters.
+type AWSPermissionBoundarySCPRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Service       string `json:"service,omitempty"`
+	Kind          string `json:"kind,omitempty"`
+	TargetScope   string `json:"target_scope,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	BreakageLevel string `json:"breakage_level,omitempty"`
+	ReadyForApply string `json:"ready_for_apply,omitempty"`
+	Search        string `json:"search,omitempty"`
+}
+
+// AWSPermissionBoundarySCPEvidence and path step reuse the least-privilege
+// contract so the planner stays consistent with its upstream sources.
+type AWSPermissionBoundarySCPEvidence = AWSLeastPrivilegeEvidence
+type AWSPermissionBoundarySCPPathStep = AWSLeastPrivilegePathStep
+type AWSPermissionBoundarySCPDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSPermissionBoundarySCPCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSPermissionBoundarySCPStatementSnippet labels the before/after policy
+// statement without inlining a rendered policy body.
+type AWSPermissionBoundarySCPStatementSnippet struct {
+	StatementSID   string   `json:"statement_sid"`
+	Effect         string   `json:"effect"`
+	ChangeKind     string   `json:"change_kind"`
+	BeforeRef      string   `json:"before_ref,omitempty"`
+	AfterRef       string   `json:"after_ref,omitempty"`
+	DeniedActions  []string `json:"denied_actions,omitempty"`
+	AllowedActions []string `json:"allowed_actions,omitempty"`
+	ResourceScope  []string `json:"resource_scope,omitempty"`
+	ConditionKeys  []string `json:"condition_keys,omitempty"`
+	Rationale      string   `json:"rationale"`
+}
+
+// AWSPermissionBoundarySCPBreakageProjection bucketed expectation for the
+// workload breakage of applying the plan.
+type AWSPermissionBoundarySCPBreakageProjection struct {
+	Level              string   `json:"level"`
+	Rationale          string   `json:"rationale"`
+	AffectedIdentities int      `json:"affected_identities"`
+	AffectedAccounts   int      `json:"affected_accounts"`
+	AffectedOUs        int      `json:"affected_ous"`
+	Signals            []string `json:"signals,omitempty"`
+}
+
+// AWSPermissionBoundarySCPRollbackPlan documents how an applied plan is
+// reverted.
+type AWSPermissionBoundarySCPRollbackPlan struct {
+	Strategy    string   `json:"strategy"`
+	Steps       []string `json:"steps"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSPermissionBoundarySCPVerificationPlan documents how an applied plan is
+// checked.
+type AWSPermissionBoundarySCPVerificationPlan struct {
+	Strategy       string   `json:"strategy"`
+	Steps          []string `json:"steps"`
+	SuccessSignals []string `json:"success_signals,omitempty"`
+	FailureSignals []string `json:"failure_signals,omitempty"`
+	EvidenceRef    string   `json:"evidence_ref,omitempty"`
+}
+
+// AWSPermissionBoundarySCPRelationship surfaces plan→graph node edges.
+type AWSPermissionBoundarySCPRelationship struct {
+	PlanID      string `json:"plan_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSPermissionBoundarySCPPlan is the persisted-record-shaped contract
+// emitted by the planner. It carries statement-level metadata refs and
+// graph nodes only; no rendered policy bodies, secret values, prompts,
+// completions, tool payloads, browser pages, code-interpreter output,
+// database rows, object contents, customer payloads, or workload payloads
+// are inlined.
+type AWSPermissionBoundarySCPPlan struct {
+	PlanID                string                                     `json:"plan_id"`
+	CalculationVersion    string                                     `json:"calculation_version"`
+	Kind                  string                                     `json:"kind"`
+	TargetScope           string                                     `json:"target_scope"`
+	Severity              string                                     `json:"severity"`
+	Status                string                                     `json:"status"`
+	Score                 int                                        `json:"score"`
+	Confidence            float64                                    `json:"confidence"`
+	Title                 string                                     `json:"title"`
+	Summary               string                                     `json:"summary"`
+	AccountID             string                                     `json:"account_id,omitempty"`
+	Region                string                                     `json:"region,omitempty"`
+	Service               string                                     `json:"service,omitempty"`
+	TargetAccountIDs      []string                                   `json:"target_account_ids,omitempty"`
+	TargetOUPaths         []string                                   `json:"target_ou_paths,omitempty"`
+	TargetIdentityNodeIDs []string                                   `json:"target_identity_node_ids,omitempty"`
+	PreventedBehavior     string                                     `json:"prevented_behavior"`
+	SourceFindingIDs      []string                                   `json:"source_finding_ids"`
+	StatementSnippets     []AWSPermissionBoundarySCPStatementSnippet `json:"statement_snippets"`
+	BreakageProjection    AWSPermissionBoundarySCPBreakageProjection `json:"breakage_projection"`
+	RollbackPlan          AWSPermissionBoundarySCPRollbackPlan       `json:"rollback_plan"`
+	VerificationPlan      AWSPermissionBoundarySCPVerificationPlan   `json:"verification_plan"`
+	ReadyForApply         bool                                       `json:"ready_for_apply"`
+	ReadOnlyProjection    bool                                       `json:"read_only_projection"`
+	SourceSignals         []string                                   `json:"source_signals"`
+	Evidence              []AWSPermissionBoundarySCPEvidence         `json:"evidence"`
+	EvidenceBoundary      string                                     `json:"evidence_boundary"`
+	ImpactedNodes         []string                                   `json:"impacted_nodes"`
+	ImpactedPath          []AWSPermissionBoundarySCPPathStep         `json:"impacted_path"`
+	NextAction            string                                     `json:"next_action"`
+	CreatedAt             time.Time                                  `json:"created_at"`
+	UpdatedAt             time.Time                                  `json:"updated_at"`
+}
+
+// AWSPermissionBoundarySCPSummary aggregates the unfiltered and filtered set.
+type AWSPermissionBoundarySCPSummary struct {
+	TotalPlans            int            `json:"total_plans"`
+	FilteredPlans         int            `json:"filtered_plans"`
+	KindCounts            map[string]int `json:"kind_counts"`
+	TargetScopeCounts     map[string]int `json:"target_scope_counts"`
+	SeverityCounts        map[string]int `json:"severity_counts"`
+	StatusCounts          map[string]int `json:"status_counts"`
+	BreakageLevelCounts   map[string]int `json:"breakage_level_counts"`
+	BoundaryPlanCount     int            `json:"boundary_plan_count"`
+	SCPPlanCount          int            `json:"scp_plan_count"`
+	ReadyForApplyCount    int            `json:"ready_for_apply_count"`
+	AffectedIdentityCount int            `json:"affected_identity_count"`
+	AffectedAccountCount  int            `json:"affected_account_count"`
+	AffectedOUCount       int            `json:"affected_ou_count"`
+	RelationshipCount     int            `json:"relationship_count"`
+	HighestScore          int            `json:"highest_score"`
+	AverageConfidencePct  int            `json:"average_confidence_pct"`
+}
+
+// AWSPermissionBoundarySCPResult is the deterministic planner envelope.
+type AWSPermissionBoundarySCPResult struct {
+	TenantID           string                                 `json:"tenant_id"`
+	WorkspaceID        string                                 `json:"workspace_id"`
+	ProjectID          string                                 `json:"project_id"`
+	ConnectorID        string                                 `json:"connector_id,omitempty"`
+	AccountID          string                                 `json:"account_id,omitempty"`
+	Region             string                                 `json:"region,omitempty"`
+	ParentIssueNumber  int                                    `json:"parent_issue_number"`
+	ParentIssueRef     string                                 `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                    `json:"current_issue_number"`
+	CurrentIssueRef    string                                 `json:"current_issue_ref"`
+	Version            string                                 `json:"version"`
+	Status             string                                 `json:"status"`
+	FixtureState       string                                 `json:"fixture_state,omitempty"`
+	Confidence         float64                                `json:"confidence"`
+	CalculationVersion string                                 `json:"calculation_version"`
+	AppliedFilters     map[string]string                      `json:"applied_filters"`
+	Summary            AWSPermissionBoundarySCPSummary        `json:"summary"`
+	Plans              []AWSPermissionBoundarySCPPlan         `json:"plans"`
+	Relationships      []AWSPermissionBoundarySCPRelationship `json:"relationships"`
+	Caveats            []string                               `json:"caveats"`
+	FailureReasons     []string                               `json:"failure_reasons"`
+	RemediationHints   []string                               `json:"remediation_hints"`
+	EvidenceLinks      []string                               `json:"evidence_links"`
+	CoverageGaps       []AWSPermissionBoundarySCPCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSPermissionBoundarySCPDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                              `json:"generated_at"`
+	UpdatedAt          time.Time                              `json:"updated_at"`
+}
+
+type awsPermissionBoundarySCPSources struct {
+	least AWSLeastPrivilegeResult
+	trust AWSCrossAccountTrustResult
+	orgs  AWSOrganizationsTopologyResult
+}
+
+// GetAWSPermissionBoundarySCPPlans composes ranked permission boundary and
+// SCP recommendations from upstream least-privilege, cross-account-trust,
+// and Organizations topology evidence. The engine is read-only: it never
+// mutates AWS, never reads or returns rendered policy bodies, secret
+// values, or workload payloads, and treats unknown or denied evidence as
+// explicit states instead of deterministic truth.
+func (s *Service) GetAWSPermissionBoundarySCPPlans(ctx context.Context, workspaceID string, projectID string, request AWSPermissionBoundarySCPRequest) (AWSPermissionBoundarySCPResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSPermissionBoundarySCPResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSPermissionBoundarySCPResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSPermissionBoundarySCPFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSPermissionBoundarySCPResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsPermissionBoundarySCPSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSPermissionBoundarySCPResult{}, err
+	}
+	plans := awsPermissionBoundarySCPPlans(sources, now)
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Score == plans[j].Score {
+			return plans[i].PlanID < plans[j].PlanID
+		}
+		return plans[i].Score > plans[j].Score
+	})
+	filtered, applied := filterAWSPermissionBoundarySCPPlans(plans, request)
+	relationships := awsPermissionBoundarySCPRelationships(filtered)
+	diagnostics := awsPermissionBoundarySCPDiagnostics(sources)
+	coverageGaps := awsPermissionBoundarySCPCoverageGaps(sources)
+	status, confidence := summarizeAWSPermissionBoundarySCPStatus(sources, filtered, diagnostics)
+
+	return AWSPermissionBoundarySCPResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPermissionBoundarySCPCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPermissionBoundarySCPCurrentIssue),
+		Version:            awsPermissionBoundarySCPVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPermissionBoundarySCPVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSPermissionBoundarySCPPlans(plans, filtered, relationships),
+		Plans:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsPermissionBoundarySCPCaveats(),
+		FailureReasons:     awsPermissionBoundarySCPFailureReasons(sources),
+		RemediationHints:   awsPermissionBoundarySCPRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPermissionBoundarySCPCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			awsIssueURL(awsCrossAccountTrustCurrentIssue),
+			awsIssueURL(awsOrganizationsTopologyCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-permission-boundary-scp-planner",
+			"/docs/aws-least-privilege",
+			"/docs/aws-cross-account-trust",
+			"/docs/aws-organizations-topology",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSPermissionBoundarySCPFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsPermissionBoundarySCPSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsPermissionBoundarySCPSources, error) {
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsPermissionBoundarySCPSources{}, fmt.Errorf("permission boundary scp least privilege: %w", err)
+	}
+	trust, err := s.GetAWSCrossAccountTrust(ctx, workspaceID, projectID, AWSCrossAccountTrustRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsPermissionBoundarySCPSources{}, fmt.Errorf("permission boundary scp cross account trust: %w", err)
+	}
+	orgs, err := s.GetAWSOrganizationsTopology(ctx, workspaceID, projectID, AWSOrganizationsTopologyRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsPermissionBoundarySCPSources{}, fmt.Errorf("permission boundary scp organizations topology: %w", err)
+	}
+	return awsPermissionBoundarySCPSources{least: least, trust: trust, orgs: orgs}, nil
+}
+
+func awsPermissionBoundarySCPPlans(sources awsPermissionBoundarySCPSources, now time.Time) []AWSPermissionBoundarySCPPlan {
+	plans := awsPermissionBoundaryPlansFromLeastPrivilege(sources.least, sources.orgs, now)
+	plans = append(plans, awsSCPPlansFromCrossAccountTrust(sources.trust, sources.orgs, now)...)
+	return plans
+}
+
+// awsPermissionBoundaryPlansFromLeastPrivilege groups least-privilege remove
+// recommendations by repeated action and proposes a permission boundary when
+// at least two identities are recommended to remove the same action.
+func awsPermissionBoundaryPlansFromLeastPrivilege(least AWSLeastPrivilegeResult, orgs AWSOrganizationsTopologyResult, now time.Time) []AWSPermissionBoundarySCPPlan {
+	type bucket struct {
+		action       string
+		recommendIDs []string
+		identityIDs  []string
+		accountIDs   []string
+		services     []string
+		evidence     []AWSPermissionBoundarySCPEvidence
+		impactedRefs []string
+		severities   map[string]int
+		statuses     map[string]int
+		scoreSum     int
+		scoreCount   int
+		confidence   float64
+		confCount    int
+	}
+	buckets := map[string]*bucket{}
+	keyForAction := func(action string) string { return strings.ToLower(strings.TrimSpace(action)) }
+	for _, recommendation := range least.Recommendations {
+		if recommendation.Decision != "remove" {
+			continue
+		}
+		for _, action := range dedupeStrings(recommendation.RemoveActions) {
+			key := keyForAction(action)
+			if key == "" {
+				continue
+			}
+			b := buckets[key]
+			if b == nil {
+				b = &bucket{action: action, severities: map[string]int{}, statuses: map[string]int{}}
+				buckets[key] = b
+			}
+			b.recommendIDs = append(b.recommendIDs, recommendation.RecommendationID)
+			b.identityIDs = append(b.identityIDs, recommendation.IdentityNodeID)
+			b.accountIDs = append(b.accountIDs, recommendation.AccountID)
+			if recommendation.Service != "" {
+				b.services = append(b.services, recommendation.Service)
+			}
+			for _, e := range recommendation.Evidence {
+				b.evidence = append(b.evidence, e)
+			}
+			b.impactedRefs = append(b.impactedRefs, recommendation.IdentityNodeID)
+			b.impactedRefs = append(b.impactedRefs, recommendation.ImpactedNodes...)
+			b.severities[recommendation.Severity]++
+			b.statuses[recommendation.Status]++
+			b.scoreSum += recommendation.Score
+			b.scoreCount++
+			b.confidence += recommendation.Confidence
+			b.confCount++
+		}
+	}
+	out := []AWSPermissionBoundarySCPPlan{}
+	for _, b := range buckets {
+		identityIDs := emptyStrings(dedupeStrings(b.identityIDs))
+		if len(identityIDs) < 2 {
+			continue
+		}
+		accounts := emptyStrings(dedupeStrings(b.accountIDs))
+		ouPaths := awsPermissionBoundarySCPOUPathsForAccounts(orgs, accounts)
+		service := firstString(dedupeStrings(b.services))
+		severity := awsPermissionBoundarySCPMostCommonKey(b.severities, "medium")
+		status := awsPermissionBoundarySCPMostCommonKey(b.statuses, "review")
+		score := 0
+		if b.scoreCount > 0 {
+			score = b.scoreSum / b.scoreCount
+			if score < 60 {
+				score = 60
+			}
+		}
+		confidence := 0.78
+		if b.confCount > 0 {
+			confidence = b.confidence / float64(b.confCount)
+		}
+		evidenceRef := firstString(awsPermissionBoundarySCPEvidenceRefs(b.evidence))
+		breakage := awsPermissionBoundarySCPBoundaryBreakage(len(identityIDs), len(accounts), len(ouPaths))
+		statement := AWSPermissionBoundarySCPStatementSnippet{
+			StatementSID:   "permission-boundary-projection",
+			Effect:         "Deny",
+			ChangeKind:     "deny_repeated_action",
+			BeforeRef:      evidenceRef,
+			AfterRef:       "permission-boundary://repeated-action/" + keyForAction(b.action),
+			DeniedActions:  []string{b.action},
+			AllowedActions: []string{},
+			ResourceScope:  []string{"*"},
+			Rationale:      fmt.Sprintf("%d identities across %d account(s) all have least-privilege removal for %s; deny it at the permission boundary to prevent reintroduction.", len(identityIDs), len(accounts), b.action),
+		}
+		plan := AWSPermissionBoundarySCPPlan{
+			PlanID:                "aws-permission-boundary-scp:" + stableAWSBlastRadiusToken("boundary", b.action),
+			CalculationVersion:    awsPermissionBoundarySCPVersion,
+			Kind:                  awsPermissionBoundaryKind,
+			TargetScope:           "identity",
+			Severity:              severity,
+			Status:                status,
+			Score:                 score,
+			Confidence:            confidence,
+			Title:                 fmt.Sprintf("Permission boundary: deny %s across %d identities", b.action, len(identityIDs)),
+			Summary:               fmt.Sprintf("%d least-privilege recommendations agree that %s is unused; a permission boundary prevents reintroduction.", len(b.recommendIDs), b.action),
+			Service:               service,
+			TargetAccountIDs:      accounts,
+			TargetOUPaths:         ouPaths,
+			TargetIdentityNodeIDs: identityIDs,
+			PreventedBehavior:     fmt.Sprintf("Re-grant or future use of %s by any boundary-bound identity.", b.action),
+			SourceFindingIDs:      dedupeStrings(b.recommendIDs),
+			StatementSnippets:     []AWSPermissionBoundarySCPStatementSnippet{statement},
+			BreakageProjection:    breakage,
+			RollbackPlan:          awsPermissionBoundarySCPRollback(awsPermissionBoundaryKind, evidenceRef),
+			VerificationPlan:      awsPermissionBoundarySCPVerification(awsPermissionBoundaryKind, evidenceRef),
+			ReadyForApply:         awsPermissionBoundarySCPReadyForApply(awsPermissionBoundaryKind, breakage, confidence),
+			ReadOnlyProjection:    true,
+			SourceSignals:         []string{"least_privilege"},
+			Evidence:              b.evidence,
+			EvidenceBoundary:      awsPermissionBoundarySCPEvidenceBoundary(),
+			ImpactedNodes:         emptyStrings(dedupeStrings(append(append([]string{}, identityIDs...), b.impactedRefs...))),
+			NextAction:            "Confirm the affected identities, then publish the boundary via the IAM remediation executor when one lands.",
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+		out = append(out, plan)
+	}
+	return out
+}
+
+// awsSCPPlansFromCrossAccountTrust proposes an SCP for each org-level trust
+// risk (public principals or unconditional cross-account grants).
+func awsSCPPlansFromCrossAccountTrust(trust AWSCrossAccountTrustResult, orgs AWSOrganizationsTopologyResult, now time.Time) []AWSPermissionBoundarySCPPlan {
+	out := []AWSPermissionBoundarySCPPlan{}
+	for _, finding := range trust.Findings {
+		if !awsSCPCandidate(finding) {
+			continue
+		}
+		evidenceRef := firstString(awsPermissionBoundarySCPEvidenceRefs(finding.Evidence))
+		targetScope, accounts, ouPaths := awsSCPTargetScope(finding, orgs)
+		breakage := awsPermissionBoundarySCPSCPBreakage(finding, len(accounts), len(ouPaths))
+		denied := awsSCPDeniedActions(finding)
+		statement := AWSPermissionBoundarySCPStatementSnippet{
+			StatementSID:  "scp-projection",
+			Effect:        "Deny",
+			ChangeKind:    awsSCPChangeKind(finding),
+			BeforeRef:     evidenceRef,
+			AfterRef:      "scp://" + finding.FindingID + "/scoped-projection",
+			DeniedActions: denied,
+			ResourceScope: dedupeStrings([]string{finding.ResourceARN, finding.ResourceNodeID}),
+			ConditionKeys: dedupeStrings(append(append([]string{}, finding.ConditionKeys...), awsSCPRecommendedConditionKeys(finding)...)),
+			Rationale:     fmt.Sprintf("Block %s at the org/OU level so the trust finding cannot reappear in another account.", finding.FindingType),
+		}
+		plan := AWSPermissionBoundarySCPPlan{
+			PlanID:             "aws-permission-boundary-scp:" + stableAWSBlastRadiusToken("scp", finding.FindingID),
+			CalculationVersion: awsPermissionBoundarySCPVersion,
+			Kind:               awsSCPKind,
+			TargetScope:        targetScope,
+			Severity:           finding.Severity,
+			Status:             finding.Status,
+			Score:              finding.Score,
+			Confidence:         finding.Confidence,
+			Title:              awsSCPTitle(finding, targetScope),
+			Summary:            finding.Rationale,
+			AccountID:          finding.AccountID,
+			Region:             finding.Region,
+			Service:            finding.Service,
+			TargetAccountIDs:   accounts,
+			TargetOUPaths:      ouPaths,
+			PreventedBehavior:  awsSCPPreventedBehavior(finding),
+			SourceFindingIDs:   []string{finding.FindingID},
+			StatementSnippets:  []AWSPermissionBoundarySCPStatementSnippet{statement},
+			BreakageProjection: breakage,
+			RollbackPlan:       awsPermissionBoundarySCPRollback(awsSCPKind, evidenceRef),
+			VerificationPlan:   awsPermissionBoundarySCPVerification(awsSCPKind, evidenceRef),
+			ReadyForApply:      awsPermissionBoundarySCPReadyForApply(awsSCPKind, breakage, finding.Confidence),
+			ReadOnlyProjection: true,
+			SourceSignals:      []string{"cross_account_trust", "organizations_topology"},
+			Evidence:           finding.Evidence,
+			EvidenceBoundary:   awsPermissionBoundarySCPEvidenceBoundary(),
+			ImpactedNodes:      emptyStrings(dedupeStrings(append([]string{finding.ResourceNodeID}, finding.ImpactedNodes...))),
+			ImpactedPath:       finding.ImpactedPath,
+			NextAction:         finding.NextAction,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}
+		out = append(out, plan)
+	}
+	return out
+}
+
+func awsSCPCandidate(finding AWSCrossAccountTrustFinding) bool {
+	if finding.PublicPrincipal {
+		return true
+	}
+	if !finding.HasCondition {
+		return true
+	}
+	switch finding.FindingType {
+	case "access_analyzer_external_access", "cross_account_graph_path":
+		return true
+	}
+	return false
+}
+
+func awsSCPDeniedActions(finding AWSCrossAccountTrustFinding) []string {
+	switch finding.FindingType {
+	case "public_resource_trust":
+		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Put")}
+	case "runtime_cross_account_assumption":
+		return []string{"sts:AssumeRole"}
+	case "access_analyzer_external_access":
+		return []string{awsSCPDenyActionForResource(finding.ResourceType, "Allow")}
+	case "cross_account_graph_path":
+		return []string{"iam:PassRole", "sts:AssumeRole"}
+	default:
+		return []string{"*"}
+	}
+}
+
+func awsSCPDenyActionForResource(resourceType, modePrefix string) string {
+	switch strings.ToLower(strings.TrimSpace(resourceType)) {
+	case "s3_bucket":
+		return "s3:" + modePrefix + "BucketPolicy"
+	case "iam_role":
+		return "iam:UpdateAssumeRolePolicy"
+	case "kms_key":
+		return "kms:PutKeyPolicy"
+	case "secret":
+		return "secretsmanager:PutResourcePolicy"
+	default:
+		return "*"
+	}
+}
+
+func awsSCPChangeKind(finding AWSCrossAccountTrustFinding) string {
+	if finding.PublicPrincipal {
+		return "deny_public_principal_creation"
+	}
+	if !finding.HasCondition {
+		return "require_org_condition"
+	}
+	return "deny_org_unsafe_pattern"
+}
+
+func awsSCPRecommendedConditionKeys(finding AWSCrossAccountTrustFinding) []string {
+	out := []string{}
+	if !finding.HasCondition || !finding.TrustedWithinOrganization {
+		out = append(out, "aws:PrincipalOrgID")
+	}
+	switch finding.FindingType {
+	case "runtime_cross_account_assumption":
+		out = append(out, "sts:ExternalId", "aws:SourceIdentity")
+	case "public_resource_trust":
+		out = append(out, "aws:SecureTransport")
+	}
+	return out
+}
+
+func awsSCPTargetScope(finding AWSCrossAccountTrustFinding, orgs AWSOrganizationsTopologyResult) (string, []string, []string) {
+	if finding.PublicPrincipal {
+		return "org_root", awsPermissionBoundarySCPAllAccounts(orgs), awsPermissionBoundarySCPAllOUPaths(orgs)
+	}
+	if finding.ExternalPrincipalOUPath != "" {
+		paths := []string{finding.ExternalPrincipalOUPath}
+		return "ou", awsPermissionBoundarySCPAccountsForOUPath(orgs, finding.ExternalPrincipalOUPath), paths
+	}
+	if finding.AccountID != "" {
+		return "account", []string{finding.AccountID}, awsPermissionBoundarySCPOUPathsForAccounts(orgs, []string{finding.AccountID})
+	}
+	return "org_root", awsPermissionBoundarySCPAllAccounts(orgs), awsPermissionBoundarySCPAllOUPaths(orgs)
+}
+
+func awsSCPTitle(finding AWSCrossAccountTrustFinding, scope string) string {
+	display := firstNonEmptyAWSValue(finding.ResourceLabel, finding.ResourceARN, finding.Service, "AWS resource")
+	switch scope {
+	case "org_root":
+		return fmt.Sprintf("SCP at org root: %s for %s", awsSCPChangeKind(finding), display)
+	case "ou":
+		return fmt.Sprintf("SCP at OU %s: %s for %s", finding.ExternalPrincipalOUPath, awsSCPChangeKind(finding), display)
+	default:
+		return fmt.Sprintf("SCP at account %s: %s for %s", finding.AccountID, awsSCPChangeKind(finding), display)
+	}
+}
+
+func awsSCPPreventedBehavior(finding AWSCrossAccountTrustFinding) string {
+	switch finding.FindingType {
+	case "public_resource_trust":
+		return "Creating or restoring a resource policy with a wildcard public principal."
+	case "runtime_cross_account_assumption":
+		return "Cross-account AssumeRole calls that do not satisfy the recommended condition keys."
+	case "access_analyzer_external_access":
+		return "Re-introduction of the Access Analyzer-flagged external grant on any account in scope."
+	case "cross_account_graph_path":
+		return "Cross-account passrole / assume-role transitions that bypass the recommended org boundary."
+	default:
+		return "Re-introduction of the upstream cross-account-trust risk on any account in scope."
+	}
+}
+
+func awsPermissionBoundarySCPBoundaryBreakage(identityCount, accountCount, ouCount int) AWSPermissionBoundarySCPBreakageProjection {
+	signals := []string{
+		fmt.Sprintf("affected_identities:%d", identityCount),
+		fmt.Sprintf("affected_accounts:%d", accountCount),
+	}
+	if ouCount > 0 {
+		signals = append(signals, fmt.Sprintf("affected_ous:%d", ouCount))
+	}
+	level := "low"
+	rationale := "All affected identities already have a least-privilege remove decision for the denied action; the boundary only blocks re-introduction."
+	if identityCount > 10 {
+		level = "medium"
+		rationale = "Boundary affects more than ten identities; stage the rollout per OU before applying globally."
+	}
+	if accountCount > 3 {
+		level = "medium"
+		rationale = "Boundary spans more than three accounts; review breakage per account before apply."
+	}
+	return AWSPermissionBoundarySCPBreakageProjection{
+		Level:              level,
+		Rationale:          rationale,
+		AffectedIdentities: identityCount,
+		AffectedAccounts:   accountCount,
+		AffectedOUs:        ouCount,
+		Signals:            signals,
+	}
+}
+
+func awsPermissionBoundarySCPSCPBreakage(finding AWSCrossAccountTrustFinding, accountCount, ouCount int) AWSPermissionBoundarySCPBreakageProjection {
+	signals := []string{
+		fmt.Sprintf("affected_accounts:%d", accountCount),
+		fmt.Sprintf("public_principal:%t", finding.PublicPrincipal),
+		fmt.Sprintf("has_condition:%t", finding.HasCondition),
+	}
+	if ouCount > 0 {
+		signals = append(signals, fmt.Sprintf("affected_ous:%d", ouCount))
+	}
+	if finding.RuntimeObserved {
+		signals = append(signals, "runtime_observed:true")
+	}
+	if finding.AnalyzerBacked {
+		signals = append(signals, "analyzer_backed:true")
+	}
+	level := "unknown"
+	rationale := "SCP affects multiple accounts; no runtime evidence proves which callers rely on the pattern."
+	switch {
+	case finding.PublicPrincipal:
+		level = "high"
+		rationale = "SCP denies wildcard public-trust creation across the org; unknown callers may rely on it. Owner approval required before apply."
+	case finding.RuntimeObserved && finding.AnalyzerBacked:
+		level = "low"
+		rationale = "Runtime and Access Analyzer both confirm the caller set; the SCP only blocks re-introduction of the flagged pattern."
+	case finding.RuntimeObserved || finding.AnalyzerBacked:
+		level = "medium"
+		rationale = "Only one of runtime or Access Analyzer confirms the caller set; review per-account before apply."
+	}
+	return AWSPermissionBoundarySCPBreakageProjection{
+		Level:            level,
+		Rationale:        rationale,
+		AffectedAccounts: accountCount,
+		AffectedOUs:      ouCount,
+		Signals:          signals,
+	}
+}
+
+func awsPermissionBoundarySCPRollback(kind, evidenceRef string) AWSPermissionBoundarySCPRollbackPlan {
+	if kind == awsSCPKind {
+		return AWSPermissionBoundarySCPRollbackPlan{
+			Strategy:    "detach_scp",
+			Steps:       []string{"Detach the projected SCP from the captured target OU/root.", "Re-run cross-account-trust to confirm the previous reachability returns."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSPermissionBoundarySCPRollbackPlan{
+		Strategy:    "detach_permission_boundary",
+		Steps:       []string{"Detach the projected permission boundary from each captured identity.", "Re-run least-privilege to confirm the previous decision set returns."},
+		EvidenceRef: evidenceRef,
+	}
+}
+
+func awsPermissionBoundarySCPVerification(kind, evidenceRef string) AWSPermissionBoundarySCPVerificationPlan {
+	if kind == awsSCPKind {
+		return AWSPermissionBoundarySCPVerificationPlan{
+			Strategy:       "scp_simulate",
+			Steps:          []string{"Use IAM Access Analyzer / policy-simulator to confirm the SCP denies the prevented behavior in every target account.", "Re-run cross-account-trust and confirm the finding resolves."},
+			SuccessSignals: []string{"cross_account_trust:finding-resolved", "scp_simulate:no-regression"},
+			FailureSignals: []string{"cross_account_trust:finding-unchanged", "scp_simulate:denied-observed-action"},
+			EvidenceRef:    evidenceRef,
+		}
+	}
+	return AWSPermissionBoundarySCPVerificationPlan{
+		Strategy:       "policy_simulate",
+		Steps:          []string{"Use IAM policy simulator to confirm the boundary denies the action for each affected identity without blocking observed actions.", "Re-run least-privilege and confirm the recommendation flips to keep."},
+		SuccessSignals: []string{"policy_simulate:no-regression", "least_privilege:decision-keep"},
+		FailureSignals: []string{"policy_simulate:denied-observed-action"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsPermissionBoundarySCPReadyForApply(kind string, breakage AWSPermissionBoundarySCPBreakageProjection, confidence float64) bool {
+	if breakage.Level != "low" {
+		return false
+	}
+	if confidence < 0.75 {
+		return false
+	}
+	if kind == awsSCPKind && breakage.AffectedAccounts == 0 {
+		return false
+	}
+	if kind == awsPermissionBoundaryKind && breakage.AffectedIdentities < 2 {
+		return false
+	}
+	return true
+}
+
+func awsPermissionBoundarySCPMostCommonKey(counts map[string]int, fallback string) string {
+	best := ""
+	bestCount := -1
+	for key, count := range counts {
+		if key == "" {
+			continue
+		}
+		if count > bestCount {
+			best = key
+			bestCount = count
+		}
+	}
+	if best == "" {
+		return fallback
+	}
+	return best
+}
+
+func awsPermissionBoundarySCPOUPathsForAccounts(orgs AWSOrganizationsTopologyResult, accounts []string) []string {
+	if len(accounts) == 0 {
+		return nil
+	}
+	wanted := map[string]struct{}{}
+	for _, account := range accounts {
+		wanted[account] = struct{}{}
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, account := range orgs.Accounts {
+		if _, ok := wanted[account.AccountID]; !ok {
+			continue
+		}
+		if account.OUPath == "" {
+			continue
+		}
+		if _, ok := seen[account.OUPath]; ok {
+			continue
+		}
+		seen[account.OUPath] = struct{}{}
+		out = append(out, account.OUPath)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func awsPermissionBoundarySCPAccountsForOUPath(orgs AWSOrganizationsTopologyResult, ouPath string) []string {
+	out := []string{}
+	for _, account := range orgs.Accounts {
+		if account.OUPath == ouPath || strings.HasPrefix(account.OUPath, ouPath+"/") {
+			out = append(out, account.AccountID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func awsPermissionBoundarySCPAllAccounts(orgs AWSOrganizationsTopologyResult) []string {
+	out := []string{}
+	for _, account := range orgs.Accounts {
+		out = append(out, account.AccountID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func awsPermissionBoundarySCPAllOUPaths(orgs AWSOrganizationsTopologyResult) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, ou := range orgs.OrganizationalUnits {
+		if ou.Path == "" {
+			continue
+		}
+		if _, ok := seen[ou.Path]; ok {
+			continue
+		}
+		seen[ou.Path] = struct{}{}
+		out = append(out, ou.Path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func awsPermissionBoundarySCPRelationships(plans []AWSPermissionBoundarySCPPlan) []AWSPermissionBoundarySCPRelationship {
+	relationships := []AWSPermissionBoundarySCPRelationship{}
+	for _, p := range plans {
+		anchor := firstNonEmptyAWSValue(p.AccountID, firstString(p.TargetAccountIDs), firstString(p.TargetOUPaths), firstString(p.TargetIdentityNodeIDs), p.PlanID)
+		evidenceRef := firstString(awsPermissionBoundarySCPEvidenceRefs(p.Evidence))
+		for _, identity := range p.TargetIdentityNodeIDs {
+			if identity == "" || identity == anchor {
+				continue
+			}
+			relationships = append(relationships, AWSPermissionBoundarySCPRelationship{
+				PlanID:      p.PlanID,
+				Type:        "permission_boundary_target",
+				FromNodeID:  anchor,
+				ToNodeID:    identity,
+				EvidenceRef: evidenceRef,
+			})
+		}
+		for _, account := range p.TargetAccountIDs {
+			if account == "" || account == anchor {
+				continue
+			}
+			relationships = append(relationships, AWSPermissionBoundarySCPRelationship{
+				PlanID:      p.PlanID,
+				Type:        "scp_target_account",
+				FromNodeID:  anchor,
+				ToNodeID:    "aws:account:" + account,
+				EvidenceRef: evidenceRef,
+			})
+		}
+		for _, ou := range p.TargetOUPaths {
+			if ou == "" {
+				continue
+			}
+			relationships = append(relationships, AWSPermissionBoundarySCPRelationship{
+				PlanID:      p.PlanID,
+				Type:        "scp_target_ou",
+				FromNodeID:  anchor,
+				ToNodeID:    "aws:ou:" + ou,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSPermissionBoundarySCPPlans(all, filtered []AWSPermissionBoundarySCPPlan, relationships []AWSPermissionBoundarySCPRelationship) AWSPermissionBoundarySCPSummary {
+	summary := AWSPermissionBoundarySCPSummary{
+		TotalPlans:          len(all),
+		FilteredPlans:       len(filtered),
+		KindCounts:          map[string]int{},
+		TargetScopeCounts:   map[string]int{},
+		SeverityCounts:      map[string]int{},
+		StatusCounts:        map[string]int{},
+		BreakageLevelCounts: map[string]int{},
+		RelationshipCount:   len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, p := range filtered {
+		summary.KindCounts[p.Kind]++
+		summary.TargetScopeCounts[p.TargetScope]++
+		summary.SeverityCounts[p.Severity]++
+		summary.StatusCounts[p.Status]++
+		summary.BreakageLevelCounts[p.BreakageProjection.Level]++
+		if p.Kind == awsPermissionBoundaryKind {
+			summary.BoundaryPlanCount++
+		}
+		if p.Kind == awsSCPKind {
+			summary.SCPPlanCount++
+		}
+		if p.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		summary.AffectedIdentityCount += p.BreakageProjection.AffectedIdentities
+		summary.AffectedAccountCount += p.BreakageProjection.AffectedAccounts
+		summary.AffectedOUCount += p.BreakageProjection.AffectedOUs
+		if p.Score > summary.HighestScore {
+			summary.HighestScore = p.Score
+		}
+		confidenceTotal += p.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSPermissionBoundarySCPPlans(plans []AWSPermissionBoundarySCPPlan, request AWSPermissionBoundarySCPRequest) ([]AWSPermissionBoundarySCPPlan, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"service":         strings.TrimSpace(request.Service),
+		"kind":            normalizeAWSRuntimeEventFilterToken(request.Kind),
+		"target_scope":    normalizeAWSRuntimeEventFilterToken(request.TargetScope),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":          normalizeAWSRuntimeEventFilterToken(request.Status),
+		"breakage_level":  normalizeAWSRuntimeEventFilterToken(request.BreakageLevel),
+		"ready_for_apply": strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSPermissionBoundarySCPPlan, 0, len(plans))
+	for _, p := range plans {
+		if filters["account_id"] != "" && filters["account_id"] != p.AccountID && !awsStringSliceContains(p.TargetAccountIDs, filters["account_id"]) {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], p.Region) {
+			continue
+		}
+		if filters["service"] != "" && !strings.EqualFold(filters["service"], p.Service) {
+			continue
+		}
+		if filters["kind"] != "" && filters["kind"] != normalizeAWSRuntimeEventFilterToken(p.Kind) {
+			continue
+		}
+		if filters["target_scope"] != "" && filters["target_scope"] != normalizeAWSRuntimeEventFilterToken(p.TargetScope) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(p.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(p.Status) {
+			continue
+		}
+		if filters["breakage_level"] != "" && filters["breakage_level"] != normalizeAWSRuntimeEventFilterToken(p.BreakageProjection.Level) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != p.ReadyForApply {
+				continue
+			}
+		}
+		if filters["search"] != "" && !awsPermissionBoundarySCPSearchMatch(p, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered, applied
+}
+
+func awsPermissionBoundarySCPSearchMatch(p AWSPermissionBoundarySCPPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{p.PlanID, p.Title, p.Summary, p.Kind, p.TargetScope, p.Severity, p.Status, p.Service, p.PreventedBehavior, p.BreakageProjection.Level, p.BreakageProjection.Rationale, p.RollbackPlan.Strategy, p.RollbackPlan.EvidenceRef, p.VerificationPlan.Strategy, p.VerificationPlan.EvidenceRef, p.NextAction}
+	values = append(values, p.SourceFindingIDs...)
+	values = append(values, p.TargetAccountIDs...)
+	values = append(values, p.TargetOUPaths...)
+	values = append(values, p.TargetIdentityNodeIDs...)
+	values = append(values, p.BreakageProjection.Signals...)
+	values = append(values, p.RollbackPlan.Steps...)
+	values = append(values, p.VerificationPlan.Steps...)
+	values = append(values, p.VerificationPlan.SuccessSignals...)
+	values = append(values, p.VerificationPlan.FailureSignals...)
+	for _, snippet := range p.StatementSnippets {
+		values = append(values, snippet.StatementSID, snippet.Effect, snippet.ChangeKind, snippet.Rationale, snippet.BeforeRef, snippet.AfterRef)
+		values = append(values, snippet.DeniedActions...)
+		values = append(values, snippet.AllowedActions...)
+		values = append(values, snippet.ResourceScope...)
+		values = append(values, snippet.ConditionKeys...)
+	}
+	for _, evidence := range p.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSPermissionBoundarySCPStatus(sources awsPermissionBoundarySCPSources, filtered []AWSPermissionBoundarySCPPlan, diagnostics []AWSPermissionBoundarySCPDiagnostic) (string, float64) {
+	for _, status := range []string{sources.least.Status, sources.trust.Status, sources.orgs.Status} {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range []string{sources.least.Status, sources.trust.Status, sources.orgs.Status} {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.76
+		}
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsPermissionBoundarySCPFailureReasons(sources awsPermissionBoundarySCPSources) []string {
+	out := []string{}
+	out = append(out, sources.least.FailureReasons...)
+	out = append(out, sources.trust.FailureReasons...)
+	out = append(out, sources.orgs.FailureReasons...)
+	return dedupeStrings(out)
+}
+
+func awsPermissionBoundarySCPRemediationHints(sources awsPermissionBoundarySCPSources) []string {
+	out := []string{
+		"Apply each plan only after the matching remediation case is approved; this engine is read-only and does not call any IAM or Organizations write API.",
+		"Stage permission boundaries and SCPs per OU before rolling them out across the whole org.",
+	}
+	out = append(out, sources.least.RemediationHints...)
+	out = append(out, sources.trust.RemediationHints...)
+	out = append(out, sources.orgs.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsPermissionBoundarySCPCaveats() []string {
+	return []string{
+		"Permission boundary and SCP plans are read-only projections; the engine never applies an AWS change.",
+		"Statement snippets carry deny/allow action lists and condition-key labels only — never rendered JSON policy bodies, secret values, or workload payloads.",
+		"ready_for_apply is derived deterministically (breakage_level=low + confidence >= 0.75 + non-empty targets); approve/execute/verify transitions belong to future wave issues.",
+	}
+}
+
+func awsPermissionBoundarySCPDiagnostics(sources awsPermissionBoundarySCPSources) []AWSPermissionBoundarySCPDiagnostic {
+	out := []AWSPermissionBoundarySCPDiagnostic{}
+	for _, d := range sources.least.Diagnostics {
+		if strings.TrimSpace(d.Message) == "" && strings.TrimSpace(d.Code) == "" {
+			continue
+		}
+		out = append(out, AWSPermissionBoundarySCPDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range sources.trust.Diagnostics {
+		if strings.TrimSpace(d.Message) == "" && strings.TrimSpace(d.Code) == "" {
+			continue
+		}
+		out = append(out, AWSPermissionBoundarySCPDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range sources.orgs.Diagnostics {
+		if strings.TrimSpace(d.Message) == "" && strings.TrimSpace(d.Code) == "" {
+			continue
+		}
+		out = append(out, AWSPermissionBoundarySCPDiagnostic{Collector: d.Source, SourceID: d.Scope, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	return out
+}
+
+func awsPermissionBoundarySCPCoverageGaps(sources awsPermissionBoundarySCPSources) []AWSPermissionBoundarySCPCoverageGap {
+	out := []AWSPermissionBoundarySCPCoverageGap{{
+		Capability:  "permission_boundary_scp_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1532 implements the boundary/SCP projection only; apply/verify transitions are future-wave work and never call IAM or Organizations write APIs here.",
+		Remediation: "Wire the approve/execute/verify endpoints in the relevant remediation/governance issue once the safety gates are in place.",
+	}}
+	for _, g := range sources.least.CoverageGaps {
+		out = append(out, AWSPermissionBoundarySCPCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	for _, g := range sources.trust.CoverageGaps {
+		out = append(out, AWSPermissionBoundarySCPCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	for _, g := range sources.orgs.CoverageGaps {
+		out = append(out, AWSPermissionBoundarySCPCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	return out
+}
+
+func awsPermissionBoundarySCPEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads"
+}
+
+func awsPermissionBoundarySCPEvidenceRefs(evidence []AWSPermissionBoundarySCPEvidence) []string {
+	out := []string{}
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			out = append(out, item.EvidenceRef)
+		}
+	}
+	return dedupeStrings(out)
+}

--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -593,7 +593,7 @@ func awsSCPTargetScope(finding AWSCrossAccountTrustFinding, orgs AWSOrganization
 }
 
 func awsSCPIsResourcePolicyFinding(findingType string) bool {
-	switch normalizeAWSRuntimeEventFilterToken(findingType) {
+	switch strings.ToLower(strings.TrimSpace(strings.ReplaceAll(normalizeAWSRuntimeEventFilterToken(findingType), "-", "_"))) {
 	case "cross_account_resource_access", "access_analyzer_external_access":
 		return true
 	default:

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -135,6 +135,7 @@ func TestAWSPermissionBoundaryPlanRequiresRepeatedAction(t *testing.T) {
 				Confidence:       0.86,
 				AccountID:        "111111111111",
 				Service:          "s3",
+				Region:           "us-east-1",
 				IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/loader-a",
 				RemoveActions:    []string{"s3:DeleteObject"},
 			},
@@ -147,6 +148,7 @@ func TestAWSPermissionBoundaryPlanRequiresRepeatedAction(t *testing.T) {
 				Confidence:       0.82,
 				AccountID:        "222222222222",
 				Service:          "s3",
+				Region:           "us-east-1",
 				IdentityNodeID:   "aws:identity:arn:aws:iam::222222222222:role/loader-b",
 				RemoveActions:    []string{"s3:DeleteObject"},
 			},
@@ -168,6 +170,9 @@ func TestAWSPermissionBoundaryPlanRequiresRepeatedAction(t *testing.T) {
 	}
 	if p.StatementSnippets[0].DeniedActions[0] != "s3:DeleteObject" {
 		t.Fatalf("statement must deny the repeated action: %+v", p.StatementSnippets[0])
+	}
+	if p.Region != "us-east-1" {
+		t.Fatalf("expected repeated-action boundary to preserve region, got %q", p.Region)
 	}
 }
 
@@ -216,6 +221,19 @@ func TestAWSSCPPlanFromCrossAccountTrust(t *testing.T) {
 	}
 }
 
+func TestAWSPermissionBoundarySCPPlanFilterSupportsRegion(t *testing.T) {
+	plans := []AWSPermissionBoundarySCPPlan{
+		{PlanID: "aws-permission-boundary-scp:region-us-east-1", Kind: awsPermissionBoundaryKind, Region: "us-east-1", TargetScope: "identity"},
+		{PlanID: "aws-permission-boundary-scp:region-unknown", Kind: awsPermissionBoundaryKind, Region: "", TargetScope: "identity"},
+		{PlanID: "aws-permission-boundary-scp:region-us-west-2", Kind: awsSCPKind, Region: "us-west-2", TargetScope: "account"},
+	}
+
+	filtered, _ := filterAWSPermissionBoundarySCPPlans(plans, AWSPermissionBoundarySCPRequest{Region: "us-east-1"})
+	if len(filtered) != 2 {
+		t.Fatalf("expected two plans when filtering region: %+v", filtered)
+	}
+}
+
 func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -228,9 +246,34 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			expected: "s3:PutBucketPolicy",
 		},
 		{
+			name:     "cross-account resource access using service token s3",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using normalized s3 token",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token kms",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
+			expected: "kms:PutKeyPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token secretsmanager",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
+			expected: "secretsmanager:PutResourcePolicy",
+		},
+		{
 			name:     "fallback action",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "other_cross_account_grant", ResourceType: "s3_bucket"},
 			expected: "*",
+		},
+		{
+			name:     "access analyzer external access",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -216,6 +216,82 @@ func TestAWSSCPPlanFromCrossAccountTrust(t *testing.T) {
 	}
 }
 
+func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
+	tests := []struct {
+		name     string
+		finding  AWSCrossAccountTrustFinding
+		expected string
+	}{
+		{
+			name:     "cross-account resource access",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3_bucket"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "fallback action",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "other_cross_account_grant", ResourceType: "s3_bucket"},
+			expected: "*",
+		},
+	}
+	for _, tc := range tests {
+		actions := awsSCPDeniedActions(tc.finding)
+		if len(actions) != 1 {
+			t.Fatalf("%s expected 1 denied action, got %+v", tc.name, actions)
+		}
+		if actions[0] != tc.expected {
+			t.Fatalf("%s expected denied action %q, got %q", tc.name, tc.expected, actions[0])
+		}
+	}
+}
+
+func TestAWSSCPTargetScopeForResourcePolicyFindings(t *testing.T) {
+	orgs := AWSOrganizationsTopologyResult{
+		Accounts: []AWSOrganizationsTopologyAccount{
+			{AccountID: "111111111111", OUPath: "/root/finance"},
+			{AccountID: "222222222222", OUPath: "/root/other"},
+		},
+	}
+	tests := []struct {
+		name        string
+		findingType string
+	}{
+		{name: "cross-account resource access", findingType: "cross_account_resource_access"},
+		{name: "access analyzer external access", findingType: "access_analyzer_external_access"},
+	}
+	for _, tc := range tests {
+		scope, accounts, ouPaths := awsSCPTargetScope(AWSCrossAccountTrustFinding{
+			FindingType:             tc.findingType,
+			PublicPrincipal:         false,
+			ExternalPrincipalOUPath: "/root/principal-ou",
+			AccountID:               "111111111111",
+		}, orgs)
+		if scope != "account" {
+			t.Fatalf("%s expected account scope for resource-policy finding, got %s", tc.name, scope)
+		}
+		if len(accounts) != 1 || accounts[0] != "111111111111" {
+			t.Fatalf("%s expected account target to use finding account, got %+v", tc.name, accounts)
+		}
+		if len(ouPaths) != 1 || ouPaths[0] != "/root/finance" {
+			t.Fatalf("%s expected resource OU path, got %+v", tc.name, ouPaths)
+		}
+	}
+}
+
+func TestAWSPermissionBoundarySCPMostCommonKeyIsDeterministic(t *testing.T) {
+	severity := awsPermissionBoundarySCPMostCommonKeyWithPriority(map[string]int{"high": 1, "critical": 1}, "medium", awsPermissionBoundarySCPSeverityPriority)
+	if severity != "critical" {
+		t.Fatalf("expected deterministic critical tie-break, got %s", severity)
+	}
+	status := awsPermissionBoundarySCPMostCommonKeyWithPriority(map[string]int{"ready": 2, "action_required": 2}, "review", awsPermissionBoundarySCPStatusPriority)
+	if status != "action_required" {
+		t.Fatalf("expected deterministic action_required tie-break, got %s", status)
+	}
+	manual := awsPermissionBoundarySCPMostCommonKeyWithPriority(map[string]int{"zz": 1, "aa": 1}, "fallback", nil)
+	if manual != "aa" {
+		t.Fatalf("expected lexical tie-break, got %s", manual)
+	}
+}
+
 func TestAWSPermissionBoundarySCPSearchMatchesPlanDetails(t *testing.T) {
 	plan := AWSPermissionBoundarySCPPlan{
 		PlanID:            "aws-permission-boundary-scp:search-test",

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -238,52 +238,104 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 	tests := []struct {
 		name     string
 		finding  AWSCrossAccountTrustFinding
-		expected string
+		expected []string
 	}{
 		{
 			name:     "cross-account resource access",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3_bucket"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token s3",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using normalized s3 token",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token kms",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
-			expected: "kms:PutKeyPolicy",
+			expected: []string{"kms:PutKeyPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token secretsmanager",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
-			expected: "secretsmanager:PutResourcePolicy",
+			expected: []string{"secretsmanager:PutResourcePolicy"},
 		},
 		{
 			name:     "fallback action",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "other_cross_account_grant", ResourceType: "s3_bucket"},
-			expected: "*",
+			expected: []string{"*"},
 		},
 		{
 			name:     "access analyzer external access",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
+		},
+		{
+			name:     "unsupported resource type",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "sqs_queue"},
+			expected: nil,
 		},
 	}
 	for _, tc := range tests {
 		actions := awsSCPDeniedActions(tc.finding)
-		if len(actions) != 1 {
-			t.Fatalf("%s expected 1 denied action, got %+v", tc.name, actions)
+		if len(actions) != len(tc.expected) {
+			t.Fatalf("%s expected denied actions %v, got %v", tc.name, tc.expected, actions)
 		}
-		if actions[0] != tc.expected {
-			t.Fatalf("%s expected denied action %q, got %q", tc.name, tc.expected, actions[0])
+		for i := range tc.expected {
+			if actions[i] != tc.expected[i] {
+				t.Fatalf("%s expected denied action %q at index %d, got %q", tc.name, tc.expected[i], i, actions[i])
+			}
 		}
+	}
+}
+
+func TestAWSPermissionBoundaryPlansFromLeastPrivilegeHonorsUpstreamBreakage(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 30, 0, 0, time.UTC)
+	least := AWSLeastPrivilegeResult{
+		Recommendations: []AWSLeastPrivilegeRecommendation{
+			{
+				RecommendationID:   "least-priv:high",
+				Decision:           "remove",
+				Severity:           "medium",
+				Status:             "action_required",
+				Score:              74,
+				Confidence:         0.93,
+				AccountID:          "111111111111",
+				Region:             "us-east-1",
+				IdentityNodeID:     "aws:identity:arn:aws:iam::111111111111:role/loader-a",
+				RemoveActions:      []string{"s3:PutObject"},
+				BreakagePrediction: "medium",
+			},
+			{
+				RecommendationID:   "least-priv:low",
+				Decision:           "remove",
+				Severity:           "medium",
+				Status:             "action_required",
+				Score:              72,
+				Confidence:         0.93,
+				AccountID:          "222222222222",
+				Region:             "us-east-1",
+				IdentityNodeID:     "aws:identity:arn:aws:iam::222222222222:role/loader-b",
+				RemoveActions:      []string{"s3:PutObject"},
+				BreakagePrediction: "low",
+			},
+		},
+	}
+	plans := awsPermissionBoundaryPlansFromLeastPrivilege(least, AWSOrganizationsTopologyResult{}, now)
+	if len(plans) != 1 {
+		t.Fatalf("expected one boundary plan for repeated action, got %d", len(plans))
+	}
+	plan := plans[0]
+	if plan.BreakageProjection.Level != "medium" {
+		t.Fatalf("expected medium upstream-influenced breakage projection, got %s", plan.BreakageProjection.Level)
+	}
+	if plan.ReadyForApply {
+		t.Fatalf("upstream medium breakage must block ready_for_apply: %+v", plan)
 	}
 }
 

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -1,0 +1,319 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newPermissionBoundarySCPService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSPermissionBoundarySCPPlansBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 0, 0, 0, time.UTC)
+	svc, ws := newPermissionBoundarySCPService(t, "project-perm-boundary-scp", now)
+
+	result, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-scp", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get permission boundary scp: %v", err)
+	}
+	if result.CurrentIssueRef != "#1532" || result.Version != awsPermissionBoundarySCPVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Plans); i++ {
+		if result.Plans[i-1].Score < result.Plans[i].Score {
+			t.Fatalf("plans are not ranked by descending score: %+v", result.Plans)
+		}
+	}
+	for _, p := range result.Plans {
+		if p.PlanID == "" || p.CalculationVersion != awsPermissionBoundarySCPVersion {
+			t.Fatalf("plan missing stable metadata: %+v", p)
+		}
+		if p.Kind != awsPermissionBoundaryKind && p.Kind != awsSCPKind {
+			t.Fatalf("plan kind must be permission_boundary or scp, got %s", p.Kind)
+		}
+		if p.TargetScope == "" || p.Title == "" || p.PreventedBehavior == "" {
+			t.Fatalf("plan missing classification fields: %+v", p)
+		}
+		if !p.ReadOnlyProjection {
+			t.Fatalf("plan must be a read-only projection: %+v", p)
+		}
+		if len(p.StatementSnippets) == 0 || p.StatementSnippets[0].Effect != "Deny" {
+			t.Fatalf("plan must have at least one Deny statement snippet: %+v", p.StatementSnippets)
+		}
+		if p.BreakageProjection.Level == "" || p.BreakageProjection.Rationale == "" {
+			t.Fatalf("plan missing breakage projection: %+v", p.BreakageProjection)
+		}
+		if p.RollbackPlan.Strategy == "" || len(p.RollbackPlan.Steps) == 0 {
+			t.Fatalf("plan missing rollback plan: %+v", p.RollbackPlan)
+		}
+		if p.VerificationPlan.Strategy == "" || len(p.VerificationPlan.Steps) == 0 {
+			t.Fatalf("plan missing verification plan: %+v", p.VerificationPlan)
+		}
+		if p.EvidenceBoundary != awsPermissionBoundarySCPEvidenceBoundary() {
+			t.Fatalf("plan crossed evidence boundary: %+v", p)
+		}
+	}
+}
+
+func TestGetAWSPermissionBoundarySCPPlansAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 5, 0, 0, time.UTC)
+	svc, ws := newPermissionBoundarySCPService(t, "project-perm-boundary-filters", now)
+
+	boundaryOnly, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-filters", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Kind:         "permission_boundary",
+	})
+	if err != nil {
+		t.Fatalf("kind filter: %v", err)
+	}
+	for _, p := range boundaryOnly.Plans {
+		if p.Kind != awsPermissionBoundaryKind {
+			t.Fatalf("kind filter leaked %s plan: %+v", p.Kind, p)
+		}
+	}
+	if boundaryOnly.AppliedFilters["kind"] != "permission-boundary" {
+		t.Fatalf("expected applied kind filter, got %+v", boundaryOnly.AppliedFilters)
+	}
+
+	scpOnly, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-filters", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Kind:         "scp",
+	})
+	if err != nil {
+		t.Fatalf("scp filter: %v", err)
+	}
+	for _, p := range scpOnly.Plans {
+		if p.Kind != awsSCPKind {
+			t.Fatalf("kind filter leaked %s plan: %+v", p.Kind, p)
+		}
+	}
+}
+
+func TestAWSPermissionBoundaryPlanRequiresRepeatedAction(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 10, 0, 0, time.UTC)
+	leastSingle := AWSLeastPrivilegeResult{
+		Recommendations: []AWSLeastPrivilegeRecommendation{{
+			RecommendationID: "least-priv:single",
+			Decision:         "remove",
+			Severity:         "medium",
+			Status:           "action_required",
+			Score:            70,
+			Confidence:       0.84,
+			AccountID:        "123456789012",
+			IdentityNodeID:   "aws:identity:arn:aws:iam::123456789012:role/single-loader",
+			RemoveActions:    []string{"s3:DeleteObject"},
+		}},
+	}
+	plans := awsPermissionBoundaryPlansFromLeastPrivilege(leastSingle, AWSOrganizationsTopologyResult{}, now)
+	if len(plans) != 0 {
+		t.Fatalf("single-identity remove must not produce a permission boundary plan: %+v", plans)
+	}
+
+	leastRepeated := AWSLeastPrivilegeResult{
+		Recommendations: []AWSLeastPrivilegeRecommendation{
+			{
+				RecommendationID: "least-priv:a",
+				Decision:         "remove",
+				Severity:         "high",
+				Status:           "action_required",
+				Score:            74,
+				Confidence:       0.86,
+				AccountID:        "111111111111",
+				Service:          "s3",
+				IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/loader-a",
+				RemoveActions:    []string{"s3:DeleteObject"},
+			},
+			{
+				RecommendationID: "least-priv:b",
+				Decision:         "remove",
+				Severity:         "high",
+				Status:           "action_required",
+				Score:            72,
+				Confidence:       0.82,
+				AccountID:        "222222222222",
+				Service:          "s3",
+				IdentityNodeID:   "aws:identity:arn:aws:iam::222222222222:role/loader-b",
+				RemoveActions:    []string{"s3:DeleteObject"},
+			},
+		},
+	}
+	plans = awsPermissionBoundaryPlansFromLeastPrivilege(leastRepeated, AWSOrganizationsTopologyResult{}, now)
+	if len(plans) != 1 {
+		t.Fatalf("expected one boundary plan for repeated action, got %d", len(plans))
+	}
+	p := plans[0]
+	if p.Kind != awsPermissionBoundaryKind {
+		t.Fatalf("expected permission_boundary kind, got %s", p.Kind)
+	}
+	if len(p.TargetIdentityNodeIDs) != 2 || len(p.TargetAccountIDs) != 2 {
+		t.Fatalf("plan must list both identities and accounts: %+v", p)
+	}
+	if len(p.SourceFindingIDs) != 2 {
+		t.Fatalf("plan must reference both source recommendations: %+v", p.SourceFindingIDs)
+	}
+	if p.StatementSnippets[0].DeniedActions[0] != "s3:DeleteObject" {
+		t.Fatalf("statement must deny the repeated action: %+v", p.StatementSnippets[0])
+	}
+}
+
+func TestAWSSCPPlanFromCrossAccountTrust(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 15, 0, 0, time.UTC)
+	trust := AWSCrossAccountTrustResult{
+		Findings: []AWSCrossAccountTrustFinding{
+			{
+				FindingID:       "aws-cross-account-trust:public-bucket",
+				FindingType:     "public_resource_trust",
+				Severity:        "critical",
+				Status:          "action_required",
+				Score:           92,
+				Confidence:      0.9,
+				AccountID:       "123456789012",
+				Service:         "s3",
+				ResourceType:    "s3_bucket",
+				ResourceARN:     "arn:aws:s3:::public-bucket",
+				ResourceNodeID:  "aws:resource:s3-bucket/public-bucket",
+				ResourceLabel:   "public-bucket",
+				PublicPrincipal: true,
+				HasCondition:    false,
+				Rationale:       "Bucket policy allows *.",
+			},
+		},
+	}
+	plans := awsSCPPlansFromCrossAccountTrust(trust, AWSOrganizationsTopologyResult{}, now)
+	if len(plans) != 1 {
+		t.Fatalf("expected one SCP plan, got %d", len(plans))
+	}
+	p := plans[0]
+	if p.Kind != awsSCPKind {
+		t.Fatalf("expected scp kind, got %s", p.Kind)
+	}
+	if p.TargetScope != "org_root" {
+		t.Fatalf("public-principal finding must target org_root, got %s", p.TargetScope)
+	}
+	if p.StatementSnippets[0].ChangeKind != "deny_public_principal_creation" {
+		t.Fatalf("public-principal SCP must deny public principal creation, got %s", p.StatementSnippets[0].ChangeKind)
+	}
+	if p.BreakageProjection.Level != "high" {
+		t.Fatalf("public SCP must project high breakage, got %s", p.BreakageProjection.Level)
+	}
+	if p.ReadyForApply {
+		t.Fatalf("public SCP must not be ready_for_apply: %+v", p)
+	}
+}
+
+func TestAWSPermissionBoundarySCPSearchMatchesPlanDetails(t *testing.T) {
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:            "aws-permission-boundary-scp:search-test",
+		Title:             "Permission boundary: deny s3:DeleteObject",
+		PreventedBehavior: "Re-grant of s3:DeleteObject by boundary-bound identities.",
+		StatementSnippets: []AWSPermissionBoundarySCPStatementSnippet{{
+			DeniedActions: []string{"s3:DeleteObject"},
+			ConditionKeys: []string{"aws:PrincipalOrgID"},
+		}},
+		BreakageProjection: AWSPermissionBoundarySCPBreakageProjection{
+			Signals: []string{"affected_identities:3"},
+		},
+		RollbackPlan: AWSPermissionBoundarySCPRollbackPlan{
+			Strategy:    "detach_permission_boundary",
+			Steps:       []string{"Detach the projected permission boundary from each captured identity."},
+			EvidenceRef: "evidence://least/repeated",
+		},
+		VerificationPlan: AWSPermissionBoundarySCPVerificationPlan{
+			Strategy:       "policy_simulate",
+			Steps:          []string{"Use IAM policy simulator to confirm the boundary denies the action."},
+			SuccessSignals: []string{"policy_simulate:no-regression"},
+		},
+		TargetAccountIDs: []string{"111111111111"},
+		TargetOUPaths:    []string{"/root/security"},
+	}
+	cases := []struct {
+		name   string
+		needle string
+	}{
+		{"denied action", "s3:DeleteObject"},
+		{"condition key", "aws:PrincipalOrgID"},
+		{"rollback step", "Detach the projected"},
+		{"verification step", "IAM policy simulator"},
+		{"verification success signal", "no-regression"},
+		{"breakage signal", "affected_identities:3"},
+		{"target account", "111111111111"},
+		{"target OU", "/root/security"},
+	}
+	for _, tc := range cases {
+		if !awsPermissionBoundarySCPSearchMatch(plan, tc.needle) {
+			t.Fatalf("search did not match %s needle %q", tc.name, tc.needle)
+		}
+	}
+}
+
+func TestGetAWSPermissionBoundarySCPPlansFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 20, 0, 0, time.UTC)
+	svc, ws := newPermissionBoundarySCPService(t, "project-perm-boundary-states", now)
+
+	denied, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-states", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Plans) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress plans: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-states", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Summary.TotalPlans != 0 {
+		t.Fatalf("empty fixture should produce no plans: %+v", empty)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not be marked blocked, got %s", empty.Status)
+	}
+
+	if _, err := svc.GetAWSPermissionBoundarySCPPlans(defaultScopeContext(), ws, "project-perm-boundary-states", AWSPermissionBoundarySCPRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSPermissionBoundarySCP(t *testing.T) {
+	now := time.Date(2026, 6, 24, 14, 25, 0, 0, time.UTC)
+	svc, _ := newPermissionBoundarySCPService(t, "project-perm-boundary-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-perm-boundary-route/aws/permission-boundary-scp?connector_id=aws-prod&fixture_state=success&kind=scp", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plans AWSPermissionBoundarySCPResult `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Plans.CurrentIssueRef != "#1532" || body.Plans.AppliedFilters["kind"] != "scp" {
+		t.Fatalf("unexpected route payload: %+v", body.Plans)
+	}
+}

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -271,6 +271,17 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			expected: []string{"*"},
 		},
 		{
+			name: "kms live grant resource access",
+			finding: AWSCrossAccountTrustFinding{
+				FindingType:  "cross_account_resource_access",
+				ResourceType: "kms_key",
+				Evidence: []AWSCrossAccountTrustEvidence{{
+					Source: "kms_live_grant",
+				}},
+			},
+			expected: []string{"kms:CreateGrant"},
+		},
+		{
 			name:     "access analyzer external access",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
 			expected: []string{"s3:PutBucketPolicy"},
@@ -312,7 +323,7 @@ func TestAWSPermissionBoundaryPlansFromLeastPrivilegeHonorsUpstreamBreakage(t *t
 				BreakagePrediction: "medium",
 			},
 			{
-				RecommendationID:   "least-priv:low",
+				RecommendationID:   "least-priv:low-one",
 				Decision:           "remove",
 				Severity:           "medium",
 				Status:             "action_required",
@@ -321,6 +332,19 @@ func TestAWSPermissionBoundaryPlansFromLeastPrivilegeHonorsUpstreamBreakage(t *t
 				AccountID:          "222222222222",
 				Region:             "us-east-1",
 				IdentityNodeID:     "aws:identity:arn:aws:iam::222222222222:role/loader-b",
+				RemoveActions:      []string{"s3:PutObject"},
+				BreakagePrediction: "low",
+			},
+			{
+				RecommendationID:   "least-priv:low-two",
+				Decision:           "remove",
+				Severity:           "medium",
+				Status:             "action_required",
+				Score:              70,
+				Confidence:         0.93,
+				AccountID:          "222222222222",
+				Region:             "us-east-1",
+				IdentityNodeID:     "aws:identity:arn:aws:iam::222222222222:role/loader-c",
 				RemoveActions:      []string{"s3:PutObject"},
 				BreakagePrediction: "low",
 			},

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3163,6 +3163,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPermissionBoundarySCPPlans(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPermissionBoundarySCPRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			Service:       strings.TrimSpace(c.Query("service")),
+			Kind:          strings.TrimSpace(c.Query("kind")),
+			TargetScope:   strings.TrimSpace(c.Query("target_scope")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			BreakageLevel: strings.TrimSpace(c.Query("breakage_level")),
+			ReadyForApply: strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:        strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws permission boundary scp request"})
+			default:
+				logger.Error("get aws permission boundary scp",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws permission boundary scp"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plans": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1699,6 +1699,54 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS permission boundary and SCP plans with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plans: {
+          status: 'ready',
+          summary: { total_plans: 0, filtered_plans: 0 },
+          plans: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectPermissionBoundarySCPPlans(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        service: 's3',
+        kind: 'permission_boundary',
+        targetScope: 'identity',
+        severity: 'high',
+        status: 'action_required',
+        breakageLevel: 'low',
+        readyForApply: 'true',
+        search: 's3:DeleteObject'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/permission-boundary-scp?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&service=s3&kind=permission_boundary&target_scope=identity&severity=high&status=action_required&breakage_level=low&ready_for_apply=true&search=s3%3ADeleteObject'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3320,6 +3320,156 @@ export type AWSTrustPolicyHardeningQuery = {
   search?: string;
 };
 
+export type AWSPermissionBoundarySCPStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSPermissionBoundarySCPFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSPermissionBoundarySCPSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSPermissionBoundarySCPKind = 'permission_boundary' | 'scp' | string;
+export type AWSPermissionBoundarySCPTargetScope = 'identity' | 'account' | 'ou' | 'org_root' | string;
+export type AWSPermissionBoundarySCPBreakageLevel = 'low' | 'medium' | 'high' | 'unknown' | string;
+
+export type AWSPermissionBoundarySCPStatementSnippet = {
+  statement_sid: string;
+  effect: string;
+  change_kind: string;
+  before_ref?: string;
+  after_ref?: string;
+  denied_actions?: string[];
+  allowed_actions?: string[];
+  resource_scope?: string[];
+  condition_keys?: string[];
+  rationale: string;
+};
+
+export type AWSPermissionBoundarySCPBreakageProjection = {
+  level: AWSPermissionBoundarySCPBreakageLevel;
+  rationale: string;
+  affected_identities: number;
+  affected_accounts: number;
+  affected_ous: number;
+  signals?: string[];
+};
+
+export type AWSPermissionBoundarySCPRollbackPlan = {
+  strategy: string;
+  steps: string[];
+  evidence_ref?: string;
+};
+
+export type AWSPermissionBoundarySCPVerificationPlan = {
+  strategy: string;
+  steps: string[];
+  success_signals?: string[];
+  failure_signals?: string[];
+  evidence_ref?: string;
+};
+
+export type AWSPermissionBoundarySCPRelationship = {
+  plan_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSPermissionBoundarySCPPlan = {
+  plan_id: string;
+  calculation_version: string;
+  kind: AWSPermissionBoundarySCPKind;
+  target_scope: AWSPermissionBoundarySCPTargetScope;
+  severity: AWSPermissionBoundarySCPSeverity;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id?: string;
+  region?: string;
+  service?: string;
+  target_account_ids?: string[];
+  target_ou_paths?: string[];
+  target_identity_node_ids?: string[];
+  prevented_behavior: string;
+  source_finding_ids: string[];
+  statement_snippets: AWSPermissionBoundarySCPStatementSnippet[];
+  breakage_projection: AWSPermissionBoundarySCPBreakageProjection;
+  rollback_plan: AWSPermissionBoundarySCPRollbackPlan;
+  verification_plan: AWSPermissionBoundarySCPVerificationPlan;
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSPermissionBoundarySCPSummary = {
+  total_plans: number;
+  filtered_plans: number;
+  kind_counts: Record<string, number>;
+  target_scope_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  breakage_level_counts: Record<string, number>;
+  boundary_plan_count: number;
+  scp_plan_count: number;
+  ready_for_apply_count: number;
+  affected_identity_count: number;
+  affected_account_count: number;
+  affected_ou_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSPermissionBoundarySCPResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSPermissionBoundarySCPStatus;
+  fixture_state?: AWSPermissionBoundarySCPFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSPermissionBoundarySCPSummary;
+  plans: AWSPermissionBoundarySCPPlan[];
+  relationships: AWSPermissionBoundarySCPRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSPermissionBoundarySCPQuery = {
+  connectorID?: string;
+  fixtureState?: AWSPermissionBoundarySCPFixtureState;
+  accountID?: string;
+  region?: string;
+  service?: string;
+  kind?: string;
+  targetScope?: string;
+  severity?: string;
+  status?: string;
+  breakageLevel?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -7500,6 +7650,30 @@ export const apiClient = {
         breakage_level: query?.breakageLevel,
         severity: query?.severity,
         status: query?.status,
+        ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectPermissionBoundarySCPPlans(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSPermissionBoundarySCPQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plans: AWSPermissionBoundarySCPResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/permission-boundary-scp${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        service: query?.service,
+        kind: query?.kind,
+        target_scope: query?.targetScope,
+        severity: query?.severity,
+        status: query?.status,
+        breakage_level: query?.breakageLevel,
         ready_for_apply: query?.readyForApply,
         search: query?.search
       })}`,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3663,6 +3663,116 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    vi.spyOn(api.apiClient, 'getAWSProjectPermissionBoundarySCPPlans').mockResolvedValue({
+      plans: {
+        status: 'ready',
+        plans: [
+          {
+            plan_id: 'aws-permission-boundary-scp:s3-delete-object',
+            calculation_version: 'aws-permission-boundary-scp-planner-v1',
+            kind: 'permission_boundary',
+            target_scope: 'identity',
+            severity: 'high',
+            status: 'action_required',
+            score: 74,
+            confidence: 0.86,
+            title: 'Permission boundary: deny s3:DeleteObject across 3 identities',
+            summary: '3 least-privilege recommendations agree that s3:DeleteObject is unused.',
+            service: 's3',
+            target_account_ids: ['111111111111', '222222222222'],
+            target_ou_paths: ['/root/security'],
+            target_identity_node_ids: [
+              'aws:identity:arn:aws:iam::111111111111:role/loader-a',
+              'aws:identity:arn:aws:iam::222222222222:role/loader-b',
+              'aws:identity:arn:aws:iam::111111111111:role/loader-c'
+            ],
+            prevented_behavior: 'Re-grant or future use of s3:DeleteObject by any boundary-bound identity.',
+            source_finding_ids: ['least-priv:a', 'least-priv:b', 'least-priv:c'],
+            statement_snippets: [
+              {
+                statement_sid: 'permission-boundary-projection',
+                effect: 'Deny',
+                change_kind: 'deny_repeated_action',
+                before_ref: 'evidence://least/loader',
+                after_ref: 'permission-boundary://repeated-action/s3%3Adeleteobject',
+                denied_actions: ['s3:DeleteObject'],
+                allowed_actions: [],
+                resource_scope: ['*'],
+                rationale: '3 identities across 2 account(s) all have least-privilege removal for s3:DeleteObject.'
+              }
+            ],
+            breakage_projection: {
+              level: 'low',
+              rationale: 'All affected identities already have a least-privilege remove decision.',
+              affected_identities: 3,
+              affected_accounts: 2,
+              affected_ous: 1,
+              signals: ['affected_identities:3', 'affected_accounts:2', 'affected_ous:1']
+            },
+            rollback_plan: {
+              strategy: 'detach_permission_boundary',
+              steps: ['Detach the projected permission boundary from each captured identity.'],
+              evidence_ref: 'evidence://least/loader'
+            },
+            verification_plan: {
+              strategy: 'policy_simulate',
+              steps: ['Use IAM policy simulator to confirm the boundary denies the action.'],
+              success_signals: ['policy_simulate:no-regression', 'least_privilege:decision-keep'],
+              failure_signals: ['policy_simulate:denied-observed-action'],
+              evidence_ref: 'evidence://least/loader'
+            },
+            ready_for_apply: true,
+            read_only_projection: true,
+            source_signals: ['least_privilege'],
+            evidence: [
+              {
+                source: 'least_privilege',
+                evidence_ref: 'evidence://least/loader',
+                label: 'Repeated least-privilege evidence',
+                confidence: 0.86,
+                observed_at: '2026-06-24T14:00:00Z',
+                relationship: 'remove'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            impacted_nodes: [
+              'aws:identity:arn:aws:iam::111111111111:role/loader-a',
+              'aws:identity:arn:aws:iam::222222222222:role/loader-b',
+              'aws:identity:arn:aws:iam::111111111111:role/loader-c'
+            ],
+            impacted_path: [],
+            next_action: 'Confirm the affected identities, then publish the boundary via the IAM remediation executor.',
+            created_at: '2026-06-24T14:00:00Z',
+            updated_at: '2026-06-24T14:00:00Z'
+          }
+        ],
+        summary: {
+          total_plans: 1,
+          filtered_plans: 1,
+          kind_counts: { permission_boundary: 1 },
+          target_scope_counts: { identity: 1 },
+          severity_counts: { high: 1 },
+          status_counts: { action_required: 1 },
+          breakage_level_counts: { low: 1 },
+          boundary_plan_count: 1,
+          scp_plan_count: 0,
+          ready_for_apply_count: 1,
+          affected_identity_count: 3,
+          affected_account_count: 2,
+          affected_ou_count: 1,
+          relationship_count: 3,
+          highest_score: 74,
+          average_confidence_pct: 86
+        },
+        relationships: [],
+        caveats: ['Permission boundary and SCP plans are read-only projections; the engine never applies an AWS change.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -3983,6 +4093,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS trust policy hardening plans' })).toBeInTheDocument();
     expect(screen.getByText(/Add org\/source condition to payments-cross-account trust/i)).toBeInTheDocument();
     expect(screen.getAllByText(/sts:ExternalId/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS permission boundary and SCP plans' })).toBeInTheDocument();
+    expect(screen.getByText(/Permission boundary: deny s3:DeleteObject across 3 identities/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Permission boundary/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -63,6 +63,8 @@ import {
   type AWSIAMPolicyDiffResult,
   type AWSTrustPolicyHardeningPlan,
   type AWSTrustPolicyHardeningResult,
+  type AWSPermissionBoundarySCPPlan,
+  type AWSPermissionBoundarySCPResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -10923,6 +10925,120 @@ function AWSTrustPolicyHardeningContent({
   );
 }
 
+function awsPermissionBoundarySCPStage(plan: AWSPermissionBoundarySCPPlan): AWSCapabilityStage {
+  if (plan.severity === 'critical' || plan.breakage_projection.level === 'high') {
+    return 'not-available';
+  }
+  if (plan.severity === 'high' || plan.breakage_projection.level === 'medium' || plan.breakage_projection.level === 'unknown') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsPermissionBoundarySCPTargetLabel(plan: AWSPermissionBoundarySCPPlan): string {
+  if (plan.kind === 'permission_boundary') {
+    const identities = plan.target_identity_node_ids?.length ?? 0;
+    const accounts = plan.target_account_ids?.length ?? 0;
+    return `${identities} identities · ${accounts} accounts`;
+  }
+  const accounts = plan.target_account_ids?.length ?? 0;
+  const ous = plan.target_ou_paths?.length ?? 0;
+  return `${formatTokenLabel(plan.target_scope)} · ${accounts} accounts · ${ous} OUs`;
+}
+
+function awsPermissionBoundarySCPDenyLabel(plan: AWSPermissionBoundarySCPPlan): string {
+  const denied = plan.statement_snippets?.[0]?.denied_actions ?? [];
+  if (denied.length === 0) {
+    return 'manual review';
+  }
+  return denied.slice(0, 2).join(', ') + (denied.length > 2 ? ` +${denied.length - 2}` : '');
+}
+
+function awsPermissionBoundarySCPReadinessLabel(plan: AWSPermissionBoundarySCPPlan): string {
+  if (plan.ready_for_apply) {
+    return `ready · ${formatTokenLabel(plan.breakage_projection.level)} breakage`;
+  }
+  return `gate · ${formatTokenLabel(plan.breakage_projection.level)} breakage`;
+}
+
+function AWSPermissionBoundarySCPContent({
+  plans,
+  loading,
+  error,
+  onRetry
+}: {
+  plans: AWSPermissionBoundarySCPResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = plans?.plans ?? [];
+  const summaryLine = plans
+    ? `${plans.summary.total_plans} total · ${plans.summary.boundary_plan_count} boundaries · ${plans.summary.scp_plan_count} SCPs · ${plans.summary.ready_for_apply_count} ready`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS permission boundary and SCP plans">
+      <h3>AWS permission boundary / SCP planner</h3>
+      <p className="idt-app-kicker">
+        Read-only IAM permission boundary and SCP recommendations projected from least-privilege, cross-account-trust,
+        and AWS Organizations evidence. Target scope, denied actions, prevented behavior, breakage, rollback, and
+        verification are derived deterministically; the engine never mutates IAM or Organizations. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS permission boundary and SCP plans"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing permission boundary and SCP plans"
+          body="Identrail is composing least-privilege, cross-account-trust, and Organizations evidence into ranked boundary and SCP recommendations."
+        />
+      ) : null}
+      {!error && !loading && plans && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={plans.status === 'blocked' ? 'Permission required' : 'No boundary or SCP plans'}
+          title={plans.status === 'blocked' ? 'Boundary/SCP plans need read-only intelligence access' : 'No boundary or SCP plans projected'}
+          body={plans.failure_reasons[0] ?? 'No upstream evidence produced a permission boundary or SCP plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && plans && plans.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {plans.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS permission boundary and SCP plans"
+          rows={rows}
+          getRowKey={(row) => row.plan_id}
+          columns={[
+            { key: 'plan', header: 'Plan', render: (row) => <strong>{row.title}</strong> },
+            { key: 'kind', header: 'Kind', render: (row) => formatTokenLabel(row.kind) },
+            { key: 'target', header: 'Target', render: (row) => awsPermissionBoundarySCPTargetLabel(row) },
+            { key: 'deny', header: 'Denies', render: (row) => awsPermissionBoundarySCPDenyLabel(row) },
+            { key: 'prevents', header: 'Prevents', render: (row) => row.prevented_behavior },
+            { key: 'breakage', header: 'Readiness', render: (row) => awsPermissionBoundarySCPReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsPermissionBoundarySCPStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12378,6 +12494,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [trustPolicyHardeningLoading, setTrustPolicyHardeningLoading] = useState(false);
   const [trustPolicyHardeningError, setTrustPolicyHardeningError] = useState('');
   const trustPolicyHardeningRequestRef = useRef(0);
+  const [permissionBoundarySCP, setPermissionBoundarySCP] = useState<AWSPermissionBoundarySCPResult | null>(null);
+  const [permissionBoundarySCPLoading, setPermissionBoundarySCPLoading] = useState(false);
+  const [permissionBoundarySCPError, setPermissionBoundarySCPError] = useState('');
+  const permissionBoundarySCPRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12806,6 +12926,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       trustPolicyHardeningRequestRef.current += 1;
     };
   }, [loadTrustPolicyHardening]);
+
+  const loadPermissionBoundarySCP = useCallback(async () => {
+    const requestID = ++permissionBoundarySCPRequestRef.current;
+    setPermissionBoundarySCP(null);
+    setPermissionBoundarySCPError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setPermissionBoundarySCPLoading(false);
+      return;
+    }
+    setPermissionBoundarySCPLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectPermissionBoundarySCPPlans(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== permissionBoundarySCPRequestRef.current) {
+        return;
+      }
+      setPermissionBoundarySCP(response.plans);
+    } catch (error) {
+      if (requestID !== permissionBoundarySCPRequestRef.current) {
+        return;
+      }
+      setPermissionBoundarySCPError(formatAPIError(error, 'Unable to load AWS permission boundary and SCP plans.'));
+    } finally {
+      if (requestID === permissionBoundarySCPRequestRef.current) {
+        setPermissionBoundarySCPLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadPermissionBoundarySCP();
+    return () => {
+      permissionBoundarySCPRequestRef.current += 1;
+    };
+  }, [loadPermissionBoundarySCP]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -13301,6 +13469,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={trustPolicyHardeningLoading}
             error={trustPolicyHardeningError}
             onRetry={loadTrustPolicyHardening}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSPermissionBoundarySCPContent
+            plans={permissionBoundarySCP}
+            loading={permissionBoundarySCPLoading}
+            error={permissionBoundarySCPError}
+            onRetry={loadPermissionBoundarySCP}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Add the AWS permission boundary and SCP recommendation planner (#1532, Wave 7.04). A read-only, metadata-only engine that turns upstream least-privilege (#1522), cross-account-trust (#1526), and AWS Organizations topology (#1498) evidence into ranked IAM permission boundary and Service Control Policy (SCP) recommendations.

Each plan carries:

- \`plan_id\`, \`calculation_version\`, \`source_finding_ids\`, \`kind\` ∈
  \`permission_boundary\` / \`scp\`, \`target_scope\` ∈ \`identity\` /
  \`account\` / \`ou\` / \`org_root\`
- targets: \`target_account_ids\`, \`target_ou_paths\`,
  \`target_identity_node_ids\`
- severity / status / score / confidence aggregated from upstream
- \`prevented_behavior\` (short string)
- \`statement_snippets\` with \`change_kind\` ∈ \`deny_repeated_action\`,
  \`deny_public_principal_creation\`, \`require_org_condition\`,
  \`deny_org_unsafe_pattern\`, \`manual_review\` — \`before_ref\` /
  \`after_ref\` are projection URIs only (never rendered JSON)
- \`breakage_projection\` with \`level\` ∈ \`low\` / \`medium\` / \`high\` /
  \`unknown\`, rationale, \`affected_identities\` / \`affected_accounts\` /
  \`affected_ous\`, signal counts
- \`rollback_plan\` (\`detach_permission_boundary\` / \`detach_scp\`) and
  \`verification_plan\` (\`policy_simulate\` / \`scp_simulate\`)
- \`ready_for_apply: true\` only when *all* hold: \`breakage_level=low\`,
  \`confidence >= 0.75\`, and the plan has non-empty targets for its
  kind. Public-principal SCPs always project \`high\` breakage and stay
  non-executable.
- \`read_only_projection: true\` on every plan
- evidence refs, source signals, impacted graph nodes/path, next
  action

Permission boundaries are emitted only when at least two identities
share a least-privilege \`remove\` recommendation for the same action,
so single-identity findings never get hoisted to org-level boundaries.
SCPs are emitted per cross-account-trust finding that should be blocked
at the org/OU level (public principal, missing condition, Access
Analyzer external access, or cross-account graph path).

Adds \`GET /v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp\` with filters for \`connector_id\`, \`fixture_state\`, \`account_id\`, \`region\`, \`service\`, \`kind\`, \`target_scope\`, \`severity\`, \`status\`, \`breakage_level\`, \`ready_for_apply\`, and \`search\`. OpenAPI schemas and authz wiring follow the neighboring AWS intelligence engines.

The AWS Runtime app surface now shows an **AWS permission boundary / SCP planner** panel with plan, kind, target scope, denied actions, prevented behavior, breakage level, ready-for-apply badge, severity/status, and verification strategy. Loading, empty, error, degraded, and permission-denied states are explicit.

## Why

Closes #1532. The remediation case model (#1529), IAM policy diff
generator (#1530), and trust policy hardening planner (#1531) cover
identity-level scope and per-resource trust. This issue adds the
org-level projection so a future executor wave can hoist repeated
identity findings to permission boundaries and persistent
cross-account risk to SCPs.

This PR implements the **boundary/SCP projection** capability only.
It is intentionally read-only and never mutates AWS or AWS
Organizations.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (new route; no existing
      route contracts change)
- [x] Risk level assessed (read-only, no IAM/Organizations write
      API calls, no new AWS permissions, never reads rendered policy
      bodies or workload payloads)

## Safety / evidence boundary

- Read-only. No IAM or Organizations write API is called by this
  issue.
- Never reads, stores, logs, or displays rendered IAM/SCP policy
  bodies, secret values, prompts, completions, tool inputs/outputs,
  browser pages, code-interpreter output, database rows, object
  contents, customer payloads, or workload payloads.
- Statement snippets carry deny/allow action lists, condition-key
  labels, and resource-scope refs only — never rendered JSON.
- Every plan has \`read_only_projection: true\`.
- \`ready_for_apply\` is derived deterministically; public-principal
  SCPs always stay non-executable; plans with no targets stay
  non-executable.
- Permission boundaries require at least two identities to share a
  removed action, so single-identity findings never get hoisted to
  org-level boundaries.
- Unknown, unsupported, partial, degraded, and permission-denied
  evidence stays explicit and is not treated as proof that a plan is
  safe to apply.

## Validation

\`\`\`bash
go test ./internal/api                                       # ok
go vet ./...                                                 # clean
make fmt-check                                               # clean
make api-example-contract-check                              # passed
npm test -- --run src/api/client.test.ts --prefix web        # passed (incl. new boundary/SCP client test)
npm test -- --run src/productShell.test.tsx --prefix web     # 235 passed (incl. new boundary/SCP panel assertion)
npx tsc -b                                                   # clean (web)
npm run build --prefix web                                   # built, prerendered 39 routes
\`\`\`

Manual frontend preview (\`npm run dev --prefix web\`) compiled and
served cleanly with no console or build errors from the new panel.
End-to-end rendering requires the Go API to be running locally; the
panel's UI behavior is covered by the productShell tests using the
mocked client.

## Checklist

- [x] Tests added for contract, filters, repeated-action requirement,
      public-principal SCP, search-across-plan-details, failure
      states, and the route
- [x] Docs updated (\`docs/aws-permission-boundary-scp-planner.md\`,
      \`docs/README.md\`, OpenAPI path + schemas, authz metadata)
- [x] \`CHANGELOG.md\` updated
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1532.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only, deterministic AWS permission boundary and SCP planner that turns least-privilege and cross-account evidence into ranked org-level plans for a single AWS connector. Ships a new API and a UI panel to explore plans with readiness and breakage signals; closes #1532.

- New Features
  - Connector-scoped boundary/SCP projection; metadata-only.
  - Selection: boundaries only when ≥2 identities share the same removed action; SCPs for org/OU-level cross-account risks (public principal, missing condition, external access, cross-account path).
  - Plan model: kind, target scope/targets, prevented behavior, statement snippets, breakage projection, rollback/verification; stable plan IDs with calculation_version; ready_for_apply only when breakage=low, confidence≥0.75, and targets exist; public-principal SCPs stay non-executable.
  - API: GET `/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp` with filters for connector/fixture_state/account/region/service/kind/target_scope/severity/status/breakage_level/ready_for_apply/search; OpenAPI + route auth wired. UI panel shows plan details, readiness badges, and explicit loading/empty/error/degraded/permission-denied states.

- Bug Fixes
  - Tightened connector scoping and plan ID determinism.
  - Normalized resource-policy finding scope for accurate SCP targeting.
  - Handled unresolved deny edge cases in boundaries and SCPs.
  - Handled `kms` live-grant findings and aggregated worst upstream breakage for accurate breakage_projection.

<sup>Written for commit dcee4f5555aa75dcc66df0f0de0cee070bfb45a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

