### PR TITLE
Implement AWS secret and key rotation planner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
 - AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
 - AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
+- AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-secret-key-rotation-planner.md
+++ b/docs/aws-secret-key-rotation-planner.md
@@ -1,0 +1,64 @@
+# AWS Secret and Key Rotation Planner
+
+Issue: #1533
+
+The AWS secret/key rotation planner converts metadata-only secret, provider-key,
+KMS, and remediation-case evidence into deterministic rotation workflows. It is
+read-only: it never reads, exposes, logs, rotates, or persists secret values,
+provider key material, rendered policies, prompts, completions, browser pages,
+code-interpreter output, database rows, object contents, customer payloads, or
+workload payloads.
+
+## Endpoint
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation`
+
+Query parameters:
+
+- `connector_id`
+- `fixture_state`
+- `account_id`
+- `region`
+- `rotation_type`: `provider_key`, `secrets_manager_secret`, or `kms_related`
+- `provider`
+- `owner`
+- `severity`
+- `status`
+- `ready_for_apply`
+- `search`
+
+## Planner Inputs
+
+- Secret-permission equivalence findings identify identities or agents that
+  inherit a permission-bearing secret or provider key.
+- Secrets Manager metadata identifies active secrets, rotation posture,
+  workload references, KMS key refs, exposure classification, tags, and evidence
+  refs.
+- KMS decrypt reachability identifies key metadata and grant reachability for
+  KMS-backed rotation cases.
+- Remediation cases provide lifecycle and approval handoff context for linked
+  secret-permission findings.
+
+## Plan Shape
+
+Each plan includes:
+
+- stable `plan_id`, version, status, score, confidence, and issue metadata
+- `rotation_type`, provider, account, region, and owner handoff
+- target secret refs and KMS key refs as metadata only
+- dependent workload refresh order
+- ordered `prepare`, `dry_run`, `apply`, `refresh`, and `verify` steps
+- before/after intent, tradeoffs, rollback, verification, and readiness gates
+- source evidence refs, impacted graph nodes, and relationships
+
+`ready_for_apply` is only a planning signal. Actual rotation must happen in the
+owning provider, Secrets Manager, or KMS workflow after approval. Identrail only
+records metadata evidence links for dry-run, apply, verify, and rollback.
+
+## Safety Boundary
+
+The planner intentionally excludes secret values and customer payloads. Target
+refs use ARNs, node IDs, labels, evidence refs, workload identifiers, and owner
+metadata. Unknown, denied, degraded, and partial evidence remain explicit in
+status, diagnostics, failure reasons, and coverage gaps rather than becoming
+deterministic truth.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -594,6 +594,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5408,6 +5413,89 @@ paths:
                     $ref: "#/components/schemas/AWSPermissionBoundarySCPResult"
         "400":
           description: Invalid AWS permission boundary and SCP request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS secret and key rotation plans
+      operationId: getAWSProjectSecretKeyRotationPlans
+      description: Generates ranked, read-only provider-key, Secrets Manager, and KMS-related rotation workflows from secret-permission equivalence, Secrets Manager metadata, KMS decrypt reachability, and remediation case evidence. Each plan carries owner handoff, target metadata refs, dependent workload refresh order, before/after intent, tradeoffs, rollback, verification, readiness gates, source evidence refs, relationships, and next action. The engine never reads, exposes, logs, rotates, or persists secret values, provider key material, rendered policies, prompts, completions, browser pages, code-interpreter output, database rows, object contents, customer payloads, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: rotation_type
+          schema:
+            type: string
+            enum: [provider_key, secrets_manager_secret, kms_related]
+        - in: query
+          name: provider
+          schema: { type: string }
+        - in: query
+          name: owner
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [action_required, review, monitor]
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS secret and key rotation plan contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    $ref: "#/components/schemas/AWSSecretKeyRotationResult"
+        "400":
+          description: Invalid AWS secret/key rotation request
           content:
             application/json:
               schema:
@@ -14373,6 +14461,237 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPermissionBoundarySCPRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretKeyRotationOwnerHandoff:
+      type: object
+      properties:
+        owner: { type: string }
+        assigned: { type: boolean }
+        approval_state: { type: string }
+        required_actors:
+          type: array
+          items: { type: string }
+        instructions:
+          type: array
+          items: { type: string }
+    AWSSecretKeyRotationTargetRef:
+      type: object
+      properties:
+        ref_type: { type: string }
+        node_id: { type: string }
+        arn: { type: string }
+        label: { type: string }
+        provider: { type: string }
+        metadata_ref: { type: string }
+    AWSSecretKeyRotationWorkload:
+      type: object
+      properties:
+        workload_id: { type: string }
+        workload_name: { type: string }
+        workload_type: { type: string }
+        resource_arn: { type: string }
+        owner: { type: string }
+        refresh_order: { type: integer }
+    AWSSecretKeyRotationStep:
+      type: object
+      properties:
+        order: { type: integer }
+        phase: { type: string }
+        action: { type: string }
+        actor: { type: string }
+        evidence_ref: { type: string }
+        blocks_on:
+          type: array
+          items: { type: string }
+    AWSSecretKeyRotationReadinessGate:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSSecretKeyRotationRelationship:
+      type: object
+      properties:
+        plan_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSSecretKeyRotationPlan:
+      type: object
+      properties:
+        plan_id: { type: string }
+        calculation_version: { type: string }
+        rotation_type:
+          type: string
+          enum: [provider_key, secrets_manager_secret, kms_related]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [action_required, review, monitor]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        provider: { type: string }
+        owner_handoff:
+          $ref: "#/components/schemas/AWSSecretKeyRotationOwnerHandoff"
+        source_finding_ids:
+          type: array
+          items: { type: string }
+        target_secrets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationTargetRef"
+        target_keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationTargetRef"
+        dependent_workloads:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationWorkload"
+        rotation_order:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationStep"
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        readiness_gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationReadinessGate"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSecretKeyRotationSummary:
+      type: object
+      properties:
+        total_plans: { type: integer }
+        filtered_plans: { type: integer }
+        rotation_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        provider_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        owner_assigned_count: { type: integer }
+        ownerless_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        target_secret_count: { type: integer }
+        target_key_count: { type: integer }
+        dependent_workload_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSSecretKeyRotationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSSecretKeyRotationSummary"
+        plans:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationPlan"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSecretKeyRotationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -762,6 +762,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -452,7 +452,8 @@ func awsSecretKeyRotationPlanFromMetadata(secret AWSSecretsManagerMetadataRecord
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}
-	if len(secret.KMSKeyARN) > 0 && len(secretsByKMS[strings.ToLower(secret.KMSKeyARN)]) > 1 {
+	kmsRef := awsSecretKeyRotationKMSRef(secret)
+	if kmsRef != "" && len(secretsByKMS[kmsRef]) > 1 {
 		plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "shared_kms_key", Status: "review", Rationale: "Multiple secrets use the same KMS key; stage rotation and verification per dependent secret."})
 	}
 	return finalizeAWSSecretKeyRotationPlan(plan)
@@ -519,15 +520,17 @@ func awsSecretKeyRotationTargetFromSecret(secret AWSSecretsManagerMetadataRecord
 }
 
 func awsSecretKeyRotationTargetsForKMS(secret AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) []AWSSecretKeyRotationTargetRef {
-	if strings.TrimSpace(secret.KMSKeyARN) == "" {
+	kmsRef := awsSecretKeyRotationKMSRef(secret)
+	if kmsRef == "" {
 		return nil
 	}
-	record := kmsByARN[strings.ToLower(strings.TrimSpace(secret.KMSKeyARN))]
+	record := kmsByARN[kmsRef]
+	arn := firstNonEmptyAWSValue(secret.KMSKeyARN, record.KeyARN)
 	return []AWSSecretKeyRotationTargetRef{{
 		RefType:     "kms_key",
 		NodeID:      record.FromNodeID,
-		ARN:         secret.KMSKeyARN,
-		Label:       firstNonEmptyAWSValue(firstString(record.Aliases), record.KeyID, shortAWSARN(secret.KMSKeyARN), "kms key"),
+		ARN:         arn,
+		Label:       firstNonEmptyAWSValue(firstString(record.Aliases), record.KeyID, secret.KMSKeyID, shortAWSARN(arn), "kms key"),
 		MetadataRef: firstNonEmptyAWSValue(record.EvidenceRef, secret.EvidenceRef),
 	}}
 }
@@ -683,11 +686,26 @@ func awsSecretKeyRotationScoreForSecret(secret AWSSecretsManagerMetadataRecord) 
 func awsSecretKeyRotationKMSIndex(kms AWSKMSDecryptReachabilityInventoryResult) map[string]AWSKMSDecryptReachabilityRecord {
 	out := map[string]AWSKMSDecryptReachabilityRecord{}
 	for _, record := range kms.Records {
-		if record.KeyARN != "" {
-			out[strings.ToLower(strings.TrimSpace(record.KeyARN))] = record
+		for _, ref := range awsSecretKeyRotationKMSRecordRefs(record) {
+			out[ref] = record
 		}
 	}
 	return out
+}
+
+func awsSecretKeyRotationKMSRef(secret AWSSecretsManagerMetadataRecord) string {
+	return strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(secret.KMSKeyARN, secret.KMSKeyID)))
+}
+
+func awsSecretKeyRotationKMSRecordRefs(record AWSKMSDecryptReachabilityRecord) []string {
+	refs := []string{}
+	for _, ref := range append([]string{record.KeyARN, record.KeyID}, record.Aliases...) {
+		ref = strings.ToLower(strings.TrimSpace(ref))
+		if ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return dedupeStrings(refs)
 }
 
 func awsSecretKeyRotationCaseIndex(cases AWSRemediationCaseResult) map[string]AWSRemediationCase {
@@ -703,7 +721,7 @@ func awsSecretKeyRotationCaseIndex(cases AWSRemediationCaseResult) map[string]AW
 func awsSecretKeyRotationTargetNodeIDs(targets []AWSSecretKeyRotationTargetRef) []string {
 	out := []string{}
 	for _, target := range targets {
-		out = append(out, target.NodeID, target.ARN)
+		out = append(out, target.NodeID, target.ARN, target.Label)
 	}
 	return out
 }
@@ -726,10 +744,11 @@ func awsSecretKeyRotationRelationships(plans []AWSSecretKeyRotationPlan) []AWSSe
 			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_targets_secret", FromNodeID: plan.PlanID, ToNodeID: target.NodeID, EvidenceRef: evidenceRef})
 		}
 		for _, target := range plan.TargetKeys {
-			if target.NodeID == "" && target.ARN == "" {
+			toNodeID := firstNonEmptyAWSValue(target.NodeID, target.ARN, target.Label)
+			if toNodeID == "" {
 				continue
 			}
-			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_targets_kms_key", FromNodeID: plan.PlanID, ToNodeID: firstNonEmptyAWSValue(target.NodeID, target.ARN), EvidenceRef: evidenceRef})
+			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_targets_kms_key", FromNodeID: plan.PlanID, ToNodeID: toNodeID, EvidenceRef: evidenceRef})
 		}
 		for _, workload := range plan.DependentWorkloads {
 			if workload.WorkloadID == "" {

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -1,0 +1,960 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsSecretKeyRotationCurrentIssue = 1533
+	awsCredentialRotationVersion     = "aws-credential-rotation-planner-v1"
+)
+
+// AWSSecretKeyRotationRequest scopes the deterministic secret and key
+// rotation planner to one AWS connector plus optional operator drill-down
+// filters.
+type AWSSecretKeyRotationRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	RotationType  string `json:"rotation_type,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	Owner         string `json:"owner,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	ReadyForApply string `json:"ready_for_apply,omitempty"`
+	Search        string `json:"search,omitempty"`
+}
+
+type AWSSecretKeyRotationEvidence = AWSLeastPrivilegeEvidence
+type AWSSecretKeyRotationPathStep = AWSLeastPrivilegePathStep
+type AWSSecretKeyRotationDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSSecretKeyRotationCoverageGap = AWSLeastPrivilegeCoverageGap
+
+type AWSSecretKeyRotationOwnerHandoff struct {
+	Owner          string   `json:"owner"`
+	Assigned       bool     `json:"assigned"`
+	ApprovalState  string   `json:"approval_state"`
+	RequiredActors []string `json:"required_actors,omitempty"`
+	Instructions   []string `json:"instructions,omitempty"`
+}
+
+type AWSSecretKeyRotationTargetRef struct {
+	RefType     string `json:"ref_type"`
+	NodeID      string `json:"node_id,omitempty"`
+	ARN         string `json:"arn,omitempty"`
+	Label       string `json:"label"`
+	Provider    string `json:"provider,omitempty"`
+	MetadataRef string `json:"metadata_ref,omitempty"`
+}
+
+type AWSSecretKeyRotationWorkload struct {
+	WorkloadID   string `json:"workload_id,omitempty"`
+	WorkloadName string `json:"workload_name,omitempty"`
+	WorkloadType string `json:"workload_type,omitempty"`
+	ResourceARN  string `json:"resource_arn,omitempty"`
+	Owner        string `json:"owner,omitempty"`
+	RefreshOrder int    `json:"refresh_order"`
+}
+
+type AWSSecretKeyRotationStep struct {
+	Order       int      `json:"order"`
+	Phase       string   `json:"phase"`
+	Action      string   `json:"action"`
+	Actor       string   `json:"actor,omitempty"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+	BlocksOn    []string `json:"blocks_on,omitempty"`
+}
+
+type AWSSecretKeyRotationReadinessGate struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+type AWSSecretKeyRotationPlan struct {
+	PlanID             string                              `json:"plan_id"`
+	CalculationVersion string                              `json:"calculation_version"`
+	RotationType       string                              `json:"rotation_type"`
+	Severity           string                              `json:"severity"`
+	Status             string                              `json:"status"`
+	Score              int                                 `json:"score"`
+	Confidence         float64                             `json:"confidence"`
+	Title              string                              `json:"title"`
+	Summary            string                              `json:"summary"`
+	AccountID          string                              `json:"account_id"`
+	Region             string                              `json:"region"`
+	Provider           string                              `json:"provider,omitempty"`
+	OwnerHandoff       AWSSecretKeyRotationOwnerHandoff    `json:"owner_handoff"`
+	SourceFindingIDs   []string                            `json:"source_finding_ids"`
+	TargetSecrets      []AWSSecretKeyRotationTargetRef     `json:"target_secrets,omitempty"`
+	TargetKeys         []AWSSecretKeyRotationTargetRef     `json:"target_keys,omitempty"`
+	DependentWorkloads []AWSSecretKeyRotationWorkload      `json:"dependent_workloads,omitempty"`
+	RotationOrder      []AWSSecretKeyRotationStep          `json:"rotation_order"`
+	DiffIntent         AWSRemediationDiffIntent            `json:"diff_intent"`
+	Tradeoffs          []AWSRemediationTradeoff            `json:"tradeoffs"`
+	RollbackPlan       AWSRemediationRollbackPlan          `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan      `json:"verification_plan"`
+	ReadinessGates     []AWSSecretKeyRotationReadinessGate `json:"readiness_gates"`
+	ReadyForApply      bool                                `json:"ready_for_apply"`
+	ReadOnlyProjection bool                                `json:"read_only_projection"`
+	SourceSignals      []string                            `json:"source_signals"`
+	Evidence           []AWSSecretKeyRotationEvidence      `json:"evidence"`
+	EvidenceBoundary   string                              `json:"evidence_boundary"`
+	ImpactedNodes      []string                            `json:"impacted_nodes"`
+	ImpactedPath       []AWSSecretKeyRotationPathStep      `json:"impacted_path"`
+	NextAction         string                              `json:"next_action"`
+	CreatedAt          time.Time                           `json:"created_at"`
+	UpdatedAt          time.Time                           `json:"updated_at"`
+}
+
+type AWSSecretKeyRotationRelationship struct {
+	PlanID      string `json:"plan_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+type AWSSecretKeyRotationSummary struct {
+	TotalPlans             int            `json:"total_plans"`
+	FilteredPlans          int            `json:"filtered_plans"`
+	RotationTypeCounts     map[string]int `json:"rotation_type_counts"`
+	ProviderCounts         map[string]int `json:"provider_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	StatusCounts           map[string]int `json:"status_counts"`
+	OwnerAssignedCount     int            `json:"owner_assigned_count"`
+	OwnerlessCount         int            `json:"ownerless_count"`
+	ReadyForApplyCount     int            `json:"ready_for_apply_count"`
+	TargetSecretCount      int            `json:"target_secret_count"`
+	TargetKeyCount         int            `json:"target_key_count"`
+	DependentWorkloadCount int            `json:"dependent_workload_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+type AWSSecretKeyRotationResult struct {
+	TenantID           string                             `json:"tenant_id"`
+	WorkspaceID        string                             `json:"workspace_id"`
+	ProjectID          string                             `json:"project_id"`
+	ConnectorID        string                             `json:"connector_id,omitempty"`
+	AccountID          string                             `json:"account_id,omitempty"`
+	Region             string                             `json:"region,omitempty"`
+	ParentIssueNumber  int                                `json:"parent_issue_number"`
+	ParentIssueRef     string                             `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                `json:"current_issue_number"`
+	CurrentIssueRef    string                             `json:"current_issue_ref"`
+	Version            string                             `json:"version"`
+	Status             string                             `json:"status"`
+	FixtureState       string                             `json:"fixture_state,omitempty"`
+	Confidence         float64                            `json:"confidence"`
+	CalculationVersion string                             `json:"calculation_version"`
+	AppliedFilters     map[string]string                  `json:"applied_filters"`
+	Summary            AWSSecretKeyRotationSummary        `json:"summary"`
+	Plans              []AWSSecretKeyRotationPlan         `json:"plans"`
+	Relationships      []AWSSecretKeyRotationRelationship `json:"relationships"`
+	Caveats            []string                           `json:"caveats"`
+	FailureReasons     []string                           `json:"failure_reasons"`
+	RemediationHints   []string                           `json:"remediation_hints"`
+	EvidenceLinks      []string                           `json:"evidence_links"`
+	CoverageGaps       []AWSSecretKeyRotationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSSecretKeyRotationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                          `json:"generated_at"`
+	UpdatedAt          time.Time                          `json:"updated_at"`
+}
+
+type awsSecretKeyRotationSources struct {
+	equivalence AWSSecretPermissionEquivalenceResult
+	secrets     AWSSecretsManagerMetadataInventoryResult
+	kms         AWSKMSDecryptReachabilityInventoryResult
+	cases       AWSRemediationCaseResult
+}
+
+// GetAWSSecretKeyRotationPlans composes ranked, read-only rotation workflows
+// from secret-permission equivalence, Secrets Manager metadata, KMS
+// reachability, and remediation case evidence. It never reads, returns,
+// rotates, or persists secret values.
+func (s *Service) GetAWSSecretKeyRotationPlans(ctx context.Context, workspaceID string, projectID string, request AWSSecretKeyRotationRequest) (AWSSecretKeyRotationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSecretKeyRotationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSSecretKeyRotationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSSecretKeyRotationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSecretKeyRotationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsSecretKeyRotationSourceSignals(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSSecretKeyRotationResult{}, err
+	}
+	plans := awsSecretKeyRotationPlans(sources, now)
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Score == plans[j].Score {
+			return plans[i].PlanID < plans[j].PlanID
+		}
+		return plans[i].Score > plans[j].Score
+	})
+	filtered, applied := filterAWSSecretKeyRotationPlans(plans, request)
+	relationships := awsSecretKeyRotationRelationships(filtered)
+	diagnostics := awsSecretKeyRotationDiagnostics(sources)
+	coverageGaps := awsSecretKeyRotationCoverageGaps(sources)
+	status, confidence := summarizeAWSSecretKeyRotationStatus(sources, filtered, diagnostics)
+
+	return AWSSecretKeyRotationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsSecretKeyRotationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsSecretKeyRotationCurrentIssue),
+		Version:            awsCredentialRotationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsCredentialRotationVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSSecretKeyRotationPlans(plans, filtered, relationships),
+		Plans:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsSecretKeyRotationCaveats(),
+		FailureReasons:     awsSecretKeyRotationFailureReasons(sources),
+		RemediationHints:   awsSecretKeyRotationRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSecretKeyRotationCurrentIssue),
+			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),
+			awsIssueURL(awsSecretsManagerMetadataCurrentIssue),
+			awsIssueURL(awsKMSDecryptReachabilityCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-secret-key-rotation-planner",
+			"/docs/aws-secret-permission-equivalence-engine",
+			"/docs/aws-secrets-manager-metadata",
+			"/docs/aws-kms-decrypt-reachability",
+			"/docs/aws-remediation-case-model",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSSecretKeyRotationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsSecretKeyRotationSourceSignals(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsSecretKeyRotationSources, error) {
+	equivalence, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretKeyRotationSources{}, fmt.Errorf("secret key rotation equivalence: %w", err)
+	}
+	secrets, err := s.GetAWSSecretsManagerMetadataInventory(ctx, workspaceID, projectID, AWSSecretsManagerMetadataInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretKeyRotationSources{}, fmt.Errorf("secret key rotation secrets metadata: %w", err)
+	}
+	kms, err := s.GetAWSKMSDecryptReachabilityInventory(ctx, workspaceID, projectID, AWSKMSDecryptReachabilityInventoryRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsSecretKeyRotationSources{}, fmt.Errorf("secret key rotation kms reachability: %w", err)
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{ConnectorID: connectorID, FixtureState: fixtureState, SourceType: "secret_permission_equivalence"})
+	if err != nil {
+		return awsSecretKeyRotationSources{}, fmt.Errorf("secret key rotation remediation cases: %w", err)
+	}
+	return awsSecretKeyRotationSources{equivalence: equivalence, secrets: secrets, kms: kms, cases: cases}, nil
+}
+
+func awsSecretKeyRotationPlans(sources awsSecretKeyRotationSources, now time.Time) []AWSSecretKeyRotationPlan {
+	plans := []AWSSecretKeyRotationPlan{}
+	secretsByARN, secretsByNode, secretsByKMS := awsSecretPermissionSecretIndexes(sources.secrets)
+	kmsByARN := awsSecretKeyRotationKMSIndex(sources.kms)
+	caseByFinding := awsSecretKeyRotationCaseIndex(sources.cases)
+	for _, finding := range sources.equivalence.Findings {
+		if p, ok := awsSecretKeyRotationPlanFromEquivalence(finding, secretsByARN, secretsByNode, kmsByARN, caseByFinding, now); ok {
+			plans = append(plans, p)
+		}
+	}
+	seen := map[string]struct{}{}
+	for _, plan := range plans {
+		for _, target := range plan.TargetSecrets {
+			if target.ARN != "" {
+				seen[strings.ToLower(target.ARN)] = struct{}{}
+			}
+			if target.NodeID != "" {
+				seen[strings.ToLower(target.NodeID)] = struct{}{}
+			}
+		}
+	}
+	for _, secret := range sources.secrets.Records {
+		if strings.TrimSpace(secret.SecretStatus) != "active" || secret.RotationEnabled {
+			continue
+		}
+		if _, ok := seen[strings.ToLower(secret.SecretARN)]; ok {
+			continue
+		}
+		if _, ok := seen[strings.ToLower(secret.FromNodeID)]; ok {
+			continue
+		}
+		plans = append(plans, awsSecretKeyRotationPlanFromMetadata(secret, secretsByKMS, kmsByARN, now))
+	}
+	return plans
+}
+
+func awsSecretKeyRotationPlanFromEquivalence(finding AWSSecretPermissionEquivalenceFinding, secretsByARN, secretsByNode map[string]AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord, caseByFinding map[string]AWSRemediationCase, now time.Time) (AWSSecretKeyRotationPlan, bool) {
+	if finding.FindingID == "" {
+		return AWSSecretKeyRotationPlan{}, false
+	}
+	secret := secretsByNode[strings.ToLower(strings.TrimSpace(finding.SecretNodeID))]
+	if secret.SecretARN == "" && finding.SecretARN != "" {
+		secret = secretsByARN[strings.ToLower(strings.TrimSpace(finding.SecretARN))]
+	}
+	rotationType := awsSecretKeyRotationType(finding, secret)
+	evidenceRef := evidenceRefFromEquivalence(finding)
+	owner, ownerAssigned := awsRemediationOwnerFromEquivalence(finding)
+	approvalState := awsRemediationApprovalState(true, ownerAssigned, finding.Status)
+	diff := AWSRemediationDiffIntent{
+		Kind:               "secret_rotation",
+		BeforeRef:          evidenceRef,
+		AfterRef:           "rotation://" + finding.FindingID + "/new-version-reference",
+		DiffSummary:        fmt.Sprintf("Rotate %s and update dependent workloads; no credential value is read or stored.", firstNonEmptyAWSValue(finding.SecretLabel, finding.SecretARN, finding.Provider)),
+		ReadOnlyProjection: true,
+	}
+	if rotationType == "kms_related" {
+		diff.Kind = "kms_grant_diff"
+		diff.AfterRef = "rotation://" + finding.FindingID + "/kms-scope-and-verify"
+		diff.DiffSummary = "Re-key or scope the KMS-related path before verifying the secret remains readable only by approved workloads."
+	}
+	targetSecrets := []AWSSecretKeyRotationTargetRef{awsSecretKeyRotationTargetFromFinding(finding, secret)}
+	targetKeys := awsSecretKeyRotationTargetsForKMS(secret, kmsByARN)
+	workloads := awsSecretKeyRotationWorkloads(secret, finding)
+	plan := AWSSecretKeyRotationPlan{
+		PlanID:             "aws-secret-key-rotation:" + stableAWSBlastRadiusToken("equivalence", finding.FindingID),
+		CalculationVersion: awsCredentialRotationVersion,
+		RotationType:       rotationType,
+		Severity:           finding.Severity,
+		Status:             finding.Status,
+		Score:              finding.Score,
+		Confidence:         finding.Confidence,
+		Title:              awsSecretKeyRotationTitle(rotationType, firstNonEmptyAWSValue(finding.SecretLabel, secret.SecretName, finding.Provider)),
+		Summary:            finding.Rationale,
+		AccountID:          firstNonEmptyAWSValue(finding.AccountID, secret.AccountID),
+		Region:             firstNonEmptyAWSValue(finding.Region, secret.Region),
+		Provider:           finding.Provider,
+		OwnerHandoff:       awsSecretKeyRotationOwnerHandoff(owner, ownerAssigned, approvalState, rotationType),
+		SourceFindingIDs:   []string{finding.FindingID},
+		TargetSecrets:      targetSecrets,
+		TargetKeys:         targetKeys,
+		DependentWorkloads: workloads,
+		RotationOrder:      awsSecretKeyRotationOrder(rotationType, owner, evidenceRef, workloads),
+		DiffIntent:         diff,
+		Tradeoffs:          awsSecretKeyRotationTradeoffs(rotationType, finding.Severity, len(workloads)),
+		RollbackPlan:       awsSecretKeyRotationRollback(rotationType, evidenceRef),
+		VerificationPlan:   awsSecretKeyRotationVerification(rotationType, evidenceRef),
+		SourceSignals:      dedupeStrings(append([]string{"secret_permission_equivalence"}, finding.SourceSignals...)),
+		Evidence:           finding.Evidence,
+		EvidenceBoundary:   awsSecretKeyRotationEvidenceBoundary(),
+		ImpactedNodes:      emptyStrings(dedupeStrings(append(append([]string{finding.SecretNodeID, finding.IdentityNodeID}, finding.ImpactedNodes...), awsSecretKeyRotationTargetNodeIDs(targetKeys)...))),
+		ImpactedPath:       finding.ImpactedPath,
+		NextAction:         "Assign the owner handoff, execute the rotation outside Identrail, then link dry-run/apply/verify evidence to the remediation case.",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if c, ok := caseByFinding[finding.FindingID]; ok {
+		plan.SourceFindingIDs = dedupeStrings(append(plan.SourceFindingIDs, c.CaseID))
+		plan.OwnerHandoff.Owner = firstNonEmptyAWSValue(plan.OwnerHandoff.Owner, c.Owner)
+		plan.OwnerHandoff.Assigned = plan.OwnerHandoff.Assigned || c.OwnerAssigned
+		plan.OwnerHandoff.ApprovalState = firstNonEmptyAWSValue(c.ApprovalState, plan.OwnerHandoff.ApprovalState)
+		plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "remediation_case", Status: c.Lifecycle, Rationale: "Rotation plan is linked to the remediation case lifecycle."})
+	}
+	return finalizeAWSSecretKeyRotationPlan(plan), true
+}
+
+func awsSecretKeyRotationPlanFromMetadata(secret AWSSecretsManagerMetadataRecord, secretsByKMS map[string][]AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord, now time.Time) AWSSecretKeyRotationPlan {
+	evidenceRef := firstNonEmptyAWSValue(secret.EvidenceRef, "secrets-manager-metadata://"+secret.SecretARN)
+	actualOwner := firstNonEmptyAWSValue(secret.Tags["owner"], secret.OwningService)
+	owner := firstNonEmptyAWSValue(actualOwner, "application-owner")
+	provider := firstNonEmptyAWSValue(secret.OwningService, secret.Service)
+	workloads := awsSecretKeyRotationWorkloads(secret, AWSSecretPermissionEquivalenceFinding{})
+	plan := AWSSecretKeyRotationPlan{
+		PlanID:             "aws-secret-key-rotation:" + stableAWSBlastRadiusToken("secret-metadata", firstNonEmptyAWSValue(secret.SecretARN, secret.SecretName)),
+		CalculationVersion: awsCredentialRotationVersion,
+		RotationType:       "secrets_manager_secret",
+		Severity:           awsSecretKeyRotationSeverityForSecret(secret),
+		Status:             "review",
+		Score:              awsSecretKeyRotationScoreForSecret(secret),
+		Confidence:         secret.Confidence,
+		Title:              awsSecretKeyRotationTitle("secrets_manager_secret", secret.SecretName),
+		Summary:            "Secrets Manager metadata shows an active referenced secret without automatic rotation enabled.",
+		AccountID:          secret.AccountID,
+		Region:             secret.Region,
+		Provider:           provider,
+		OwnerHandoff:       awsSecretKeyRotationOwnerHandoff(owner, strings.TrimSpace(actualOwner) != "", "pending_owner_review", "secrets_manager_secret"),
+		SourceFindingIDs:   []string{firstNonEmptyAWSValue(secret.EvidenceRef, secret.SecretARN)},
+		TargetSecrets:      []AWSSecretKeyRotationTargetRef{awsSecretKeyRotationTargetFromSecret(secret)},
+		TargetKeys:         awsSecretKeyRotationTargetsForKMS(secret, kmsByARN),
+		DependentWorkloads: workloads,
+		RotationOrder:      awsSecretKeyRotationOrder("secrets_manager_secret", owner, evidenceRef, workloads),
+		DiffIntent: AWSRemediationDiffIntent{
+			Kind:               "secret_rotation",
+			BeforeRef:          evidenceRef,
+			AfterRef:           "rotation://" + firstNonEmptyAWSValue(secret.FromNodeID, secret.SecretARN) + "/new-version-reference",
+			DiffSummary:        "Enable or perform owner-approved rotation for the referenced secret and update dependent workloads.",
+			ReadOnlyProjection: true,
+		},
+		Tradeoffs:        awsSecretKeyRotationTradeoffs("secrets_manager_secret", awsSecretKeyRotationSeverityForSecret(secret), len(workloads)),
+		RollbackPlan:     awsSecretKeyRotationRollback("secrets_manager_secret", evidenceRef),
+		VerificationPlan: awsSecretKeyRotationVerification("secrets_manager_secret", evidenceRef),
+		SourceSignals:    []string{"secrets_manager_metadata"},
+		Evidence: []AWSSecretKeyRotationEvidence{{
+			Source:       "secrets_manager_metadata",
+			Label:        secret.SecretName,
+			EvidenceRef:  evidenceRef,
+			Relationship: "secret_requires_rotation_plan",
+		}},
+		EvidenceBoundary: awsSecretKeyRotationEvidenceBoundary(),
+		ImpactedNodes:    emptyStrings(dedupeStrings(append([]string{secret.FromNodeID}, awsSecretKeyRotationTargetNodeIDs(awsSecretKeyRotationTargetsForKMS(secret, kmsByARN))...))),
+		NextAction:       "Confirm the owning service can refresh the new secret version before enabling or executing rotation.",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if len(secret.KMSKeyARN) > 0 && len(secretsByKMS[strings.ToLower(secret.KMSKeyARN)]) > 1 {
+		plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "shared_kms_key", Status: "review", Rationale: "Multiple secrets use the same KMS key; stage rotation and verification per dependent secret."})
+	}
+	return finalizeAWSSecretKeyRotationPlan(plan)
+}
+
+func finalizeAWSSecretKeyRotationPlan(plan AWSSecretKeyRotationPlan) AWSSecretKeyRotationPlan {
+	plan.SourceFindingIDs = dedupeStrings(plan.SourceFindingIDs)
+	plan.SourceSignals = dedupeStrings(plan.SourceSignals)
+	plan.ImpactedNodes = emptyStrings(dedupeStrings(plan.ImpactedNodes))
+	plan.ReadOnlyProjection = true
+	plan.DiffIntent.ReadOnlyProjection = true
+	if plan.Confidence == 0 {
+		plan.Confidence = 0.72
+	}
+	if plan.Status == "" {
+		plan.Status = "review"
+	}
+	plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "no_secret_values", Status: "passed", Rationale: "Plan uses metadata refs only and does not contain secret values."})
+	plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "owner_handoff", Status: awsSecretKeyRotationGateStatus(plan.OwnerHandoff.Assigned), Rationale: "Owner must approve rotation order and workload refresh before apply."})
+	plan.ReadyForApply = plan.OwnerHandoff.Assigned && plan.Confidence >= 0.75 && plan.Severity != "critical" && plan.Status != awsPlatformDependencyStatusBlocked
+	for _, gate := range plan.ReadinessGates {
+		if gate.Status == "blocked" {
+			plan.ReadyForApply = false
+		}
+	}
+	return plan
+}
+
+func awsSecretKeyRotationType(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) string {
+	normalized := normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType)
+	secretRef := strings.ToLower(strings.Join([]string{finding.SecretNodeID, finding.SecretARN, finding.SecretLabel, secret.KMSKeyARN, strings.Join(finding.SourceSignals, " ")}, " "))
+	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") {
+		return "kms_related"
+	}
+	if strings.Contains(normalized, "provider-key") || strings.TrimSpace(finding.Provider) != "" {
+		return "provider_key"
+	}
+	return "secrets_manager_secret"
+}
+
+func awsSecretKeyRotationTargetFromFinding(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) AWSSecretKeyRotationTargetRef {
+	if secret.SecretARN != "" || secret.SecretName != "" {
+		return awsSecretKeyRotationTargetFromSecret(secret)
+	}
+	return AWSSecretKeyRotationTargetRef{
+		RefType:     "secret",
+		NodeID:      finding.SecretNodeID,
+		ARN:         finding.SecretARN,
+		Label:       firstNonEmptyAWSValue(finding.SecretLabel, shortAWSARN(finding.SecretARN), finding.Provider, "secret reference"),
+		Provider:    finding.Provider,
+		MetadataRef: evidenceRefFromEquivalence(finding),
+	}
+}
+
+func awsSecretKeyRotationTargetFromSecret(secret AWSSecretsManagerMetadataRecord) AWSSecretKeyRotationTargetRef {
+	return AWSSecretKeyRotationTargetRef{
+		RefType:     "secret",
+		NodeID:      secret.FromNodeID,
+		ARN:         secret.SecretARN,
+		Label:       firstNonEmptyAWSValue(secret.SecretName, shortAWSARN(secret.SecretARN), "secret reference"),
+		Provider:    firstNonEmptyAWSValue(secret.OwningService, secret.Service),
+		MetadataRef: secret.EvidenceRef,
+	}
+}
+
+func awsSecretKeyRotationTargetsForKMS(secret AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) []AWSSecretKeyRotationTargetRef {
+	if strings.TrimSpace(secret.KMSKeyARN) == "" {
+		return nil
+	}
+	record := kmsByARN[strings.ToLower(strings.TrimSpace(secret.KMSKeyARN))]
+	return []AWSSecretKeyRotationTargetRef{{
+		RefType:     "kms_key",
+		NodeID:      record.FromNodeID,
+		ARN:         secret.KMSKeyARN,
+		Label:       firstNonEmptyAWSValue(firstString(record.Aliases), record.KeyID, shortAWSARN(secret.KMSKeyARN), "kms key"),
+		MetadataRef: firstNonEmptyAWSValue(record.EvidenceRef, secret.EvidenceRef),
+	}}
+}
+
+func awsSecretKeyRotationWorkloads(secret AWSSecretsManagerMetadataRecord, finding AWSSecretPermissionEquivalenceFinding) []AWSSecretKeyRotationWorkload {
+	out := []AWSSecretKeyRotationWorkload{}
+	for idx, ref := range secret.ReferencedBy {
+		out = append(out, AWSSecretKeyRotationWorkload{
+			WorkloadID:   ref.WorkloadID,
+			WorkloadName: ref.WorkloadName,
+			WorkloadType: ref.WorkloadType,
+			ResourceARN:  ref.ResourceARN,
+			Owner:        firstNonEmptyAWSValue(secret.Tags["owner"], secret.OwningService),
+			RefreshOrder: idx + 1,
+		})
+	}
+	findingWorkloadID := firstNonEmptyAWSValue(finding.WorkloadID, finding.AgentID, finding.IdentityNodeID)
+	if findingWorkloadID != "" && !awsSecretKeyRotationHasWorkload(out, findingWorkloadID) {
+		out = append(out, AWSSecretKeyRotationWorkload{
+			WorkloadID:   findingWorkloadID,
+			WorkloadName: firstNonEmptyAWSValue(finding.WorkloadName, finding.AgentName),
+			WorkloadType: firstNonEmptyAWSValue(awsRemediationEquivalenceIdentityType(finding), "workload"),
+			Owner:        "application-owner",
+			RefreshOrder: len(out) + 1,
+		})
+	}
+	return out
+}
+
+func awsSecretKeyRotationHasWorkload(workloads []AWSSecretKeyRotationWorkload, workloadID string) bool {
+	workloadID = strings.TrimSpace(workloadID)
+	if workloadID == "" {
+		return false
+	}
+	for _, workload := range workloads {
+		if strings.EqualFold(strings.TrimSpace(workload.WorkloadID), workloadID) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsSecretKeyRotationOrder(rotationType, owner, evidenceRef string, workloads []AWSSecretKeyRotationWorkload) []AWSSecretKeyRotationStep {
+	actor := firstNonEmptyAWSValue(owner, "application-owner")
+	steps := []AWSSecretKeyRotationStep{
+		{Order: 1, Phase: "prepare", Action: "Confirm owner, maintenance window, dependent workloads, and fallback plan.", Actor: actor, EvidenceRef: evidenceRef},
+		{Order: 2, Phase: "dry_run", Action: "Dry-run the workload refresh path using metadata refs and approved staging credentials outside Identrail.", Actor: actor, EvidenceRef: evidenceRef, BlocksOn: []string{"prepare"}},
+		{Order: 3, Phase: "apply", Action: "Rotate the provider key or Secrets Manager version in the owning system; Identrail does not read or rotate the value.", Actor: actor, EvidenceRef: evidenceRef, BlocksOn: []string{"dry_run"}},
+		{Order: 4, Phase: "refresh", Action: fmt.Sprintf("Refresh %d dependent workload(s) in captured order.", len(workloads)), Actor: actor, EvidenceRef: evidenceRef, BlocksOn: []string{"apply"}},
+		{Order: 5, Phase: "verify", Action: "Re-run metadata and reachability checks; link verification evidence to the case.", Actor: "security", EvidenceRef: evidenceRef, BlocksOn: []string{"refresh"}},
+	}
+	if rotationType == "kms_related" {
+		steps[2].Action = "Re-key or scope the KMS-related path in the owning AWS account; Identrail records only metadata evidence refs."
+	}
+	return steps
+}
+
+func awsSecretKeyRotationOwnerHandoff(owner string, assigned bool, approvalState string, rotationType string) AWSSecretKeyRotationOwnerHandoff {
+	actors := []string{"application-owner", "security-reviewer"}
+	if rotationType == "kms_related" {
+		actors = append(actors, "kms-key-owner")
+	}
+	return AWSSecretKeyRotationOwnerHandoff{
+		Owner:          firstNonEmptyAWSValue(owner, "unassigned"),
+		Assigned:       assigned,
+		ApprovalState:  approvalState,
+		RequiredActors: dedupeStrings(actors),
+		Instructions: []string{
+			"Confirm no dependent workload keeps the previous credential after refresh.",
+			"Attach dry-run, apply, verify, and rollback evidence links to the remediation case.",
+		},
+	}
+}
+
+func awsSecretKeyRotationTradeoffs(rotationType, severity string, workloadCount int) []AWSRemediationTradeoff {
+	out := []AWSRemediationTradeoff{
+		{Dimension: "credential_exposure", Direction: "improves", Description: "Rotation invalidates the previous secret/key reference once dependents are refreshed.", Severity: severity},
+		{Dimension: "workload_refresh", Direction: "worsens", Description: fmt.Sprintf("%d dependent workload(s) must refresh without retaining stale credentials.", workloadCount), Severity: "medium"},
+	}
+	if rotationType == "kms_related" {
+		out = append(out, AWSRemediationTradeoff{Dimension: "kms_reachability", Direction: "improves", Description: "KMS grants/key policy reachability is re-verified after rotation.", Severity: "medium"})
+	}
+	return out
+}
+
+func awsSecretKeyRotationRollback(rotationType, evidenceRef string) AWSRemediationRollbackPlan {
+	if rotationType == "kms_related" {
+		return AWSRemediationRollbackPlan{
+			Strategy:    "restore_previous_kms_reference",
+			Steps:       []string{"Restore the previous KMS key alias/grant metadata in the owning AWS account.", "Re-run KMS decrypt reachability and secret metadata inventory to verify restored access."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSRemediationRollbackPlan{
+		Strategy:    "restore_previous_secret_version",
+		Steps:       []string{"Restore the previous secret version/reference in the owning system if workload refresh regresses.", "Re-run secret-permission equivalence and workload health checks before retrying rotation."},
+		EvidenceRef: evidenceRef,
+	}
+}
+
+func awsSecretKeyRotationVerification(rotationType, evidenceRef string) AWSRemediationVerificationPlan {
+	signals := []string{"secrets_manager_metadata:rotation-recorded", "secret_permission_equivalence:no-equivalent-stale-access"}
+	if rotationType == "kms_related" {
+		signals = append(signals, "kms_decrypt_reachability:scoped")
+	}
+	return AWSRemediationVerificationPlan{
+		Strategy:       "rotation_re_evaluate",
+		Steps:          []string{"Confirm the previous credential/key reference is no longer active for captured workloads.", "Re-run secret-permission equivalence, Secrets Manager metadata, and KMS reachability checks.", "Attach verification evidence links to the remediation case."},
+		SuccessSignals: signals,
+		FailureSignals: []string{"secret_permission_equivalence:stale-reference-observed", "workload_refresh:failed"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsSecretKeyRotationTitle(rotationType, label string) string {
+	switch rotationType {
+	case "provider_key":
+		return fmt.Sprintf("Provider key rotation: %s", firstNonEmptyAWSValue(label, "external provider key"))
+	case "kms_related":
+		return fmt.Sprintf("KMS-backed secret rotation: %s", firstNonEmptyAWSValue(label, "kms-backed secret"))
+	default:
+		return fmt.Sprintf("Secrets Manager rotation: %s", firstNonEmptyAWSValue(label, "secret"))
+	}
+}
+
+func awsSecretKeyRotationSeverityForSecret(secret AWSSecretsManagerMetadataRecord) string {
+	if secret.ExposureClassification == "public" || secret.ExposureClassification == "cross_account" {
+		return "high"
+	}
+	if len(secret.ReferencedBy) > 0 {
+		return "medium"
+	}
+	return "low"
+}
+
+func awsSecretKeyRotationScoreForSecret(secret AWSSecretsManagerMetadataRecord) int {
+	score := 60
+	if len(secret.ReferencedBy) > 0 {
+		score += 10
+	}
+	if secret.ExposureClassification == "cross_account" {
+		score += 12
+	}
+	if secret.ExposureClassification == "public" {
+		score += 18
+	}
+	if score > 95 {
+		return 95
+	}
+	return score
+}
+
+func awsSecretKeyRotationKMSIndex(kms AWSKMSDecryptReachabilityInventoryResult) map[string]AWSKMSDecryptReachabilityRecord {
+	out := map[string]AWSKMSDecryptReachabilityRecord{}
+	for _, record := range kms.Records {
+		if record.KeyARN != "" {
+			out[strings.ToLower(strings.TrimSpace(record.KeyARN))] = record
+		}
+	}
+	return out
+}
+
+func awsSecretKeyRotationCaseIndex(cases AWSRemediationCaseResult) map[string]AWSRemediationCase {
+	out := map[string]AWSRemediationCase{}
+	for _, c := range cases.Cases {
+		if c.SourceFindingID != "" {
+			out[c.SourceFindingID] = c
+		}
+	}
+	return out
+}
+
+func awsSecretKeyRotationTargetNodeIDs(targets []AWSSecretKeyRotationTargetRef) []string {
+	out := []string{}
+	for _, target := range targets {
+		out = append(out, target.NodeID, target.ARN)
+	}
+	return out
+}
+
+func awsSecretKeyRotationGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsSecretKeyRotationRelationships(plans []AWSSecretKeyRotationPlan) []AWSSecretKeyRotationRelationship {
+	out := []AWSSecretKeyRotationRelationship{}
+	for _, plan := range plans {
+		evidenceRef := firstString(awsRemediationEvidenceRefs(plan.Evidence))
+		for _, target := range plan.TargetSecrets {
+			if target.NodeID == "" {
+				continue
+			}
+			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_targets_secret", FromNodeID: plan.PlanID, ToNodeID: target.NodeID, EvidenceRef: evidenceRef})
+		}
+		for _, target := range plan.TargetKeys {
+			if target.NodeID == "" && target.ARN == "" {
+				continue
+			}
+			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_targets_kms_key", FromNodeID: plan.PlanID, ToNodeID: firstNonEmptyAWSValue(target.NodeID, target.ARN), EvidenceRef: evidenceRef})
+		}
+		for _, workload := range plan.DependentWorkloads {
+			if workload.WorkloadID == "" {
+				continue
+			}
+			out = append(out, AWSSecretKeyRotationRelationship{PlanID: plan.PlanID, Type: "rotation_refreshes_workload", FromNodeID: plan.PlanID, ToNodeID: workload.WorkloadID, EvidenceRef: evidenceRef})
+		}
+	}
+	return out
+}
+
+func summarizeAWSSecretKeyRotationPlans(all, filtered []AWSSecretKeyRotationPlan, relationships []AWSSecretKeyRotationRelationship) AWSSecretKeyRotationSummary {
+	summary := AWSSecretKeyRotationSummary{
+		TotalPlans:         len(all),
+		FilteredPlans:      len(filtered),
+		RotationTypeCounts: map[string]int{},
+		ProviderCounts:     map[string]int{},
+		SeverityCounts:     map[string]int{},
+		StatusCounts:       map[string]int{},
+		RelationshipCount:  len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, plan := range filtered {
+		summary.RotationTypeCounts[plan.RotationType]++
+		summary.ProviderCounts[plan.Provider]++
+		summary.SeverityCounts[plan.Severity]++
+		summary.StatusCounts[plan.Status]++
+		if plan.OwnerHandoff.Assigned {
+			summary.OwnerAssignedCount++
+		} else {
+			summary.OwnerlessCount++
+		}
+		if plan.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		summary.TargetSecretCount += len(plan.TargetSecrets)
+		summary.TargetKeyCount += len(plan.TargetKeys)
+		summary.DependentWorkloadCount += len(plan.DependentWorkloads)
+		if plan.Score > summary.HighestScore {
+			summary.HighestScore = plan.Score
+		}
+		confidenceTotal += plan.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSSecretKeyRotationPlans(plans []AWSSecretKeyRotationPlan, request AWSSecretKeyRotationRequest) ([]AWSSecretKeyRotationPlan, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"rotation_type":   normalizeAWSRuntimeEventFilterToken(request.RotationType),
+		"provider":        normalizeAWSRuntimeEventFilterToken(request.Provider),
+		"owner":           normalizeAWSRuntimeEventFilterToken(request.Owner),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":          normalizeAWSRuntimeEventFilterToken(request.Status),
+		"ready_for_apply": strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSSecretKeyRotationPlan, 0, len(plans))
+	for _, plan := range plans {
+		if filters["account_id"] != "" && filters["account_id"] != plan.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], plan.Region) {
+			continue
+		}
+		if filters["rotation_type"] != "" && filters["rotation_type"] != normalizeAWSRuntimeEventFilterToken(plan.RotationType) {
+			continue
+		}
+		if filters["provider"] != "" && filters["provider"] != normalizeAWSRuntimeEventFilterToken(plan.Provider) {
+			continue
+		}
+		if filters["owner"] != "" && filters["owner"] != normalizeAWSRuntimeEventFilterToken(plan.OwnerHandoff.Owner) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(plan.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(plan.Status) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != plan.ReadyForApply {
+				continue
+			}
+		}
+		if filters["search"] != "" && !awsSecretKeyRotationSearchMatch(plan, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, plan)
+	}
+	return filtered, applied
+}
+
+func awsSecretKeyRotationSearchMatch(plan AWSSecretKeyRotationPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	values := []string{plan.PlanID, plan.RotationType, plan.Title, plan.Summary, plan.Provider, plan.OwnerHandoff.Owner, plan.OwnerHandoff.ApprovalState, plan.DiffIntent.Kind, plan.DiffIntent.DiffSummary, plan.RollbackPlan.Strategy, plan.VerificationPlan.Strategy, plan.NextAction}
+	values = append(values, plan.SourceFindingIDs...)
+	values = append(values, plan.SourceSignals...)
+	values = append(values, plan.RollbackPlan.Steps...)
+	values = append(values, plan.VerificationPlan.Steps...)
+	values = append(values, plan.VerificationPlan.SuccessSignals...)
+	values = append(values, plan.VerificationPlan.FailureSignals...)
+	for _, target := range plan.TargetSecrets {
+		values = append(values, target.RefType, target.NodeID, target.ARN, target.Label, target.Provider, target.MetadataRef)
+	}
+	for _, target := range plan.TargetKeys {
+		values = append(values, target.RefType, target.NodeID, target.ARN, target.Label, target.MetadataRef)
+	}
+	for _, workload := range plan.DependentWorkloads {
+		values = append(values, workload.WorkloadID, workload.WorkloadName, workload.WorkloadType, workload.ResourceARN, workload.Owner)
+	}
+	for _, step := range plan.RotationOrder {
+		values = append(values, step.Phase, step.Action, step.Actor, step.EvidenceRef)
+		values = append(values, step.BlocksOn...)
+	}
+	for _, gate := range plan.ReadinessGates {
+		values = append(values, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, evidence := range plan.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSSecretKeyRotationStatus(sources awsSecretKeyRotationSources, filtered []AWSSecretKeyRotationPlan, diagnostics []AWSSecretKeyRotationDiagnostic) (string, float64) {
+	for _, status := range []string{sources.equivalence.Status, sources.secrets.Status, sources.kms.Status, sources.cases.Status} {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range []string{sources.equivalence.Status, sources.secrets.Status, sources.kms.Status, sources.cases.Status} {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.76
+		}
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsSecretKeyRotationFailureReasons(sources awsSecretKeyRotationSources) []string {
+	out := []string{}
+	out = append(out, sources.equivalence.FailureReasons...)
+	out = append(out, sources.secrets.FailureReasons...)
+	out = append(out, sources.kms.FailureReasons...)
+	out = append(out, sources.cases.FailureReasons...)
+	return dedupeStrings(out)
+}
+
+func awsSecretKeyRotationRemediationHints(sources awsSecretKeyRotationSources) []string {
+	out := []string{
+		"Rotation plans are read-only workflow projections; execute rotation only in the owning AWS/provider system after approval.",
+		"Attach dry-run, apply, verify, and rollback evidence links to the linked remediation case.",
+	}
+	out = append(out, sources.equivalence.RemediationHints...)
+	out = append(out, sources.secrets.RemediationHints...)
+	out = append(out, sources.kms.RemediationHints...)
+	out = append(out, sources.cases.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsSecretKeyRotationCaveats() []string {
+	return []string{
+		"Plans never read, expose, log, rotate, or persist secret values; only metadata refs and evidence links are returned.",
+		"ready_for_apply is a deterministic planning signal, not execution approval.",
+		"Provider-key, Secrets Manager, and KMS-related plans must be executed by the owning system and verified after workload refresh.",
+	}
+}
+
+func awsSecretKeyRotationDiagnostics(sources awsSecretKeyRotationSources) []AWSSecretKeyRotationDiagnostic {
+	out := []AWSSecretKeyRotationDiagnostic{}
+	out = append(out, sources.equivalence.Diagnostics...)
+	for _, d := range sources.secrets.Diagnostics {
+		out = append(out, AWSSecretKeyRotationDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range sources.kms.Diagnostics {
+		out = append(out, AWSSecretKeyRotationDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	out = append(out, sources.cases.Diagnostics...)
+	return out
+}
+
+func awsSecretKeyRotationCoverageGaps(sources awsSecretKeyRotationSources) []AWSSecretKeyRotationCoverageGap {
+	out := []AWSSecretKeyRotationCoverageGap{{
+		Capability:  "secret_value_rotation",
+		Status:      "unsupported",
+		Reason:      "Identrail plans workflow order and evidence refs only; it never reads or rotates secret/key material.",
+		Remediation: "Use the owning provider, Secrets Manager, or KMS workflow to perform approved rotation.",
+	}}
+	out = append(out, sources.equivalence.CoverageGaps...)
+	for _, g := range sources.secrets.CoverageGaps {
+		out = append(out, AWSSecretKeyRotationCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	for _, g := range sources.kms.CoverageGaps {
+		out = append(out, AWSSecretKeyRotationCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	out = append(out, sources.cases.CoverageGaps...)
+	return out
+}
+
+func awsSecretKeyRotationEvidenceBoundary() string {
+	return "metadata-only: evidence refs, graph nodes, rotation workflow metadata, owner handoff, and verification links only; no secret values, rendered policy bodies, prompts, completions, payloads, or database rows."
+}

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -488,10 +488,17 @@ func awsSecretKeyRotationType(finding AWSSecretPermissionEquivalenceFinding, sec
 	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") {
 		return "kms_related"
 	}
-	if strings.Contains(normalized, "provider-key") || strings.TrimSpace(finding.Provider) != "" {
+	if awsSecretKeyRotationIsProviderKeyFinding(normalized, finding.Provider) {
 		return "provider_key"
 	}
 	return "secrets_manager_secret"
+}
+
+func awsSecretKeyRotationIsProviderKeyFinding(normalizedEquivalenceType string, provider string) bool {
+	if strings.Contains(normalizedEquivalenceType, "provider-key") {
+		return true
+	}
+	return awsSecretPermissionProviderIsExternal(awsSecretPermissionCanonicalProvider(provider))
 }
 
 func awsSecretKeyRotationTargetFromFinding(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) AWSSecretKeyRotationTargetRef {

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -232,6 +232,56 @@ func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testi
 	}
 }
 
+func TestAWSSecretKeyRotationTypeKeepsAWSNativeSecretFindings(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 13, 0, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:    "123456789012",
+		Region:       "us-east-1",
+		Service:      "secretsmanager",
+		SecretARN:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders/api-key",
+		SecretName:   "orders/api-key",
+		SecretStatus: "active",
+		EvidenceRef:  "evidence://secret/orders",
+		FromNodeID:   "aws:resource:secrets-manager-secret:orders/api-key",
+		Confidence:   0.82,
+	}
+	finding := AWSSecretPermissionEquivalenceFinding{
+		FindingID:       "aws-secret-permission-equivalence:orders-reader",
+		EquivalenceType: "secret_read_policy_equivalence",
+		Severity:        "medium",
+		Status:          "review",
+		Score:           70,
+		Confidence:      0.82,
+		AccountID:       "123456789012",
+		Region:          "us-east-1",
+		IdentityNodeID:  "aws:identity:role/orders-reader",
+		SecretNodeID:    secret.FromNodeID,
+		SecretARN:       secret.SecretARN,
+		SecretLabel:     secret.SecretName,
+		Provider:        "aws_secret",
+		Rationale:       "Role can read permission-bearing Secrets Manager metadata.",
+		Evidence:        []AWSSecretPermissionEquivalenceEvidence{{Source: "secrets_manager_metadata", EvidenceRef: secret.EvidenceRef}},
+	}
+
+	plan, ok := awsSecretKeyRotationPlanFromEquivalence(finding, map[string]AWSSecretsManagerMetadataRecord{strings.ToLower(secret.SecretARN): secret}, map[string]AWSSecretsManagerMetadataRecord{strings.ToLower(secret.FromNodeID): secret}, nil, nil, now)
+	if !ok {
+		t.Fatalf("expected AWS-native secret finding to produce a rotation plan")
+	}
+	if plan.RotationType != "secrets_manager_secret" {
+		t.Fatalf("AWS-native secret finding must stay a secret rotation, got %+v", plan)
+	}
+	filtered, _ := filterAWSSecretKeyRotationPlans([]AWSSecretKeyRotationPlan{plan}, AWSSecretKeyRotationRequest{RotationType: "secrets_manager_secret"})
+	if len(filtered) != 1 {
+		t.Fatalf("secret rotation filter should include AWS-native secret finding plan: %+v", plan)
+	}
+
+	external := finding
+	external.Provider = credentialProviderOpenAI
+	if got := awsSecretKeyRotationType(external, AWSSecretsManagerMetadataRecord{}); got != "provider_key" {
+		t.Fatalf("external provider finding should remain provider_key, got %q", got)
+	}
+}
+
 func hasAWSSecretKeyRotationRelationship(relationships []AWSSecretKeyRotationRelationship, relationshipType string, toNodeID string) bool {
 	for _, relationship := range relationships {
 		if relationship.Type == relationshipType && relationship.ToNodeID == toNodeID {

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -154,6 +154,55 @@ func TestAWSSecretKeyRotationPlanFromMetadataIncludesKMSAndWorkloads(t *testing.
 	}
 }
 
+func TestAWSSecretKeyRotationPlanFromMetadataPreservesKMSKeyID(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 11, 0, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "123456789012",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/api-key",
+		SecretName:    "billing/api-key",
+		KMSKeyID:      "alias/billing-secrets",
+		OwningService: "billing",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/billing",
+		FromNodeID:    "aws:resource:secrets-manager-secret:billing/api-key",
+		Confidence:    0.81,
+		Tags:          map[string]string{"owner": "billing-platform"},
+	}
+	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{
+		secret,
+		{SecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/webhook", KMSKeyID: "alias/billing-secrets"},
+	}})
+	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{{
+		KeyID:       "key-billing",
+		Aliases:     []string{"alias/billing-secrets"},
+		FromNodeID:  "aws:resource:kms-key:key-billing",
+		EvidenceRef: "evidence://kms/billing",
+	}}})
+
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, secretsByKMS, kms, now)
+	if len(plan.TargetKeys) != 1 {
+		t.Fatalf("metadata plan must preserve kms key id target without resolved arn: %+v", plan)
+	}
+	if plan.TargetKeys[0].Label != "alias/billing-secrets" || plan.TargetKeys[0].MetadataRef != "evidence://kms/billing" {
+		t.Fatalf("kms key target should use alias lookup and kms evidence: %+v", plan.TargetKeys[0])
+	}
+	if !awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("expected KMSKeyID-only shared KMS readiness gate: %+v", plan.ReadinessGates)
+	}
+	relationships := awsSecretKeyRotationRelationships([]AWSSecretKeyRotationPlan{plan})
+	if !hasAWSSecretKeyRotationRelationship(relationships, "rotation_targets_kms_key", "aws:resource:kms-key:key-billing") {
+		t.Fatalf("expected KMS target relationship from key id lookup: %+v", relationships)
+	}
+
+	noRecordPlan := awsSecretKeyRotationPlanFromMetadata(secret, secretsByKMS, nil, now)
+	relationships = awsSecretKeyRotationRelationships([]AWSSecretKeyRotationPlan{noRecordPlan})
+	if !hasAWSSecretKeyRotationRelationship(relationships, "rotation_targets_kms_key", "alias/billing-secrets") {
+		t.Fatalf("expected KMS target relationship to fall back to key id: %+v", relationships)
+	}
+}
+
 func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
 	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
 	secret := AWSSecretsManagerMetadataRecord{
@@ -181,6 +230,15 @@ func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testi
 	if plan.Provider != "secretsmanager" {
 		t.Fatalf("metadata plan must populate provider from service fallback, got %q", plan.Provider)
 	}
+}
+
+func hasAWSSecretKeyRotationRelationship(relationships []AWSSecretKeyRotationRelationship, relationshipType string, toNodeID string) bool {
+	for _, relationship := range relationships {
+		if relationship.Type == relationshipType && relationship.ToNodeID == toNodeID {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAWSSecretKeyRotationWorkloadsIncludeFindingConsumer(t *testing.T) {

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -1,0 +1,270 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newSecretKeyRotationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSSecretKeyRotationPlansBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 0, 0, 0, time.UTC)
+	svc, ws := newSecretKeyRotationService(t, "project-secret-key-rotation", now)
+
+	result, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get secret key rotation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1533" || result.Version != awsCredentialRotationVersion || result.Status != "ready" {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Plans) == 0 {
+		t.Fatalf("expected rotation plans: %+v", result)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 || len(result.Relationships) == 0 {
+		t.Fatalf("expected caveats, coverage gaps, and relationships: %+v", result)
+	}
+	for i := 1; i < len(result.Plans); i++ {
+		if result.Plans[i-1].Score < result.Plans[i].Score {
+			t.Fatalf("plans are not ranked by descending score: %+v", result.Plans)
+		}
+	}
+	for _, plan := range result.Plans {
+		if plan.PlanID == "" || plan.CalculationVersion != awsCredentialRotationVersion {
+			t.Fatalf("plan missing stable metadata: %+v", plan)
+		}
+		if plan.RotationType == "" || plan.Title == "" || plan.OwnerHandoff.Owner == "" {
+			t.Fatalf("plan missing classification or owner handoff: %+v", plan)
+		}
+		if len(plan.TargetSecrets) == 0 {
+			t.Fatalf("plan must target at least one secret metadata ref: %+v", plan)
+		}
+		if len(plan.RotationOrder) < 5 {
+			t.Fatalf("plan must include prepare/dry-run/apply/refresh/verify order: %+v", plan.RotationOrder)
+		}
+		if !plan.ReadOnlyProjection || !plan.DiffIntent.ReadOnlyProjection {
+			t.Fatalf("plan must be a read-only projection: %+v", plan)
+		}
+		if plan.RollbackPlan.Strategy == "" || len(plan.RollbackPlan.Steps) == 0 {
+			t.Fatalf("plan missing rollback plan: %+v", plan.RollbackPlan)
+		}
+		if plan.VerificationPlan.Strategy == "" || len(plan.VerificationPlan.SuccessSignals) == 0 {
+			t.Fatalf("plan missing verification plan: %+v", plan.VerificationPlan)
+		}
+		if plan.EvidenceBoundary != awsSecretKeyRotationEvidenceBoundary() {
+			t.Fatalf("plan crossed evidence boundary: %+v", plan)
+		}
+		serialized, err := json.Marshal(plan)
+		if err != nil {
+			t.Fatalf("marshal plan: %v", err)
+		}
+		lower := strings.ToLower(string(serialized))
+		for _, forbidden := range []string{"\"secret_string\"", "\"secret_value\"", "\"private_key\"", "\"access_key_secret\""} {
+			if strings.Contains(lower, forbidden) {
+				t.Fatalf("plan serialized forbidden sensitive payload marker %q: %s", forbidden, lower)
+			}
+		}
+	}
+}
+
+func TestGetAWSSecretKeyRotationPlansAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 5, 0, 0, time.UTC)
+	svc, ws := newSecretKeyRotationService(t, "project-secret-key-rotation-filters", now)
+
+	provider, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation-filters", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		RotationType: "provider_key",
+	})
+	if err != nil {
+		t.Fatalf("provider-key filter: %v", err)
+	}
+	if provider.AppliedFilters["rotation_type"] != "provider-key" {
+		t.Fatalf("expected applied rotation_type filter, got %+v", provider.AppliedFilters)
+	}
+	for _, plan := range provider.Plans {
+		if plan.RotationType != "provider_key" {
+			t.Fatalf("rotation_type filter leaked %s plan: %+v", plan.RotationType, plan)
+		}
+	}
+
+	search, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation-filters", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Search:       "rotation_re_evaluate",
+	})
+	if err != nil {
+		t.Fatalf("search filter: %v", err)
+	}
+	if len(search.Plans) == 0 {
+		t.Fatalf("expected search to match verification strategy")
+	}
+}
+
+func TestAWSSecretKeyRotationPlanFromMetadataIncludesKMSAndWorkloads(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 10, 0, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "123456789012",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:payments/api-key",
+		SecretName:    "payments/api-key",
+		KMSKeyARN:     "arn:aws:kms:us-east-1:123456789012:key/abcd",
+		OwningService: "payments",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/payments",
+		FromNodeID:    "aws:resource:secrets-manager-secret:payments/api-key",
+		Confidence:    0.84,
+		Tags:          map[string]string{"owner": "payments-platform"},
+		ReferencedBy:  []AWSSecretsManagerWorkloadReference{{WorkloadID: "lambda:payments", WorkloadName: "payments-worker", WorkloadType: "lambda"}},
+	}
+	kms := map[string]AWSKMSDecryptReachabilityRecord{
+		strings.ToLower(secret.KMSKeyARN): {
+			KeyARN:      secret.KMSKeyARN,
+			KeyID:       "abcd",
+			Aliases:     []string{"alias/payments"},
+			FromNodeID:  "aws:resource:kms-key:abcd",
+			EvidenceRef: "evidence://kms/abcd",
+		},
+	}
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, map[string][]AWSSecretsManagerMetadataRecord{strings.ToLower(secret.KMSKeyARN): {secret, secret}}, kms, now)
+	if plan.RotationType != "secrets_manager_secret" || len(plan.TargetKeys) != 1 || len(plan.DependentWorkloads) != 1 {
+		t.Fatalf("metadata plan missing kms/workload context: %+v", plan)
+	}
+	if plan.Provider != "payments" {
+		t.Fatalf("metadata plan must expose provider for filters and counts, got %q", plan.Provider)
+	}
+	if plan.OwnerHandoff.Owner != "payments-platform" || !plan.OwnerHandoff.Assigned {
+		t.Fatalf("metadata plan must hand off to tagged owner: %+v", plan.OwnerHandoff)
+	}
+	if len(plan.ReadinessGates) == 0 || !awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("expected shared KMS readiness gate to be searchable: %+v", plan.ReadinessGates)
+	}
+}
+
+func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:    "123456789012",
+		Region:       "us-east-1",
+		Service:      "secretsmanager",
+		SecretARN:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:ownerless/api-key",
+		SecretName:   "ownerless/api-key",
+		SecretStatus: "active",
+		EvidenceRef:  "evidence://secret/ownerless",
+		FromNodeID:   "aws:resource:secrets-manager-secret:ownerless/api-key",
+		Confidence:   0.88,
+	}
+
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, nil, nil, now)
+	if plan.OwnerHandoff.Owner != "application-owner" {
+		t.Fatalf("expected display fallback owner, got %+v", plan.OwnerHandoff)
+	}
+	if plan.OwnerHandoff.Assigned {
+		t.Fatalf("fallback owner label must not count as assigned: %+v", plan.OwnerHandoff)
+	}
+	if plan.ReadyForApply {
+		t.Fatalf("ownerless metadata plan must not become ready_for_apply: %+v", plan)
+	}
+	if plan.Provider != "secretsmanager" {
+		t.Fatalf("metadata plan must populate provider from service fallback, got %q", plan.Provider)
+	}
+}
+
+func TestAWSSecretKeyRotationWorkloadsIncludeFindingConsumer(t *testing.T) {
+	secret := AWSSecretsManagerMetadataRecord{
+		OwningService: "payments",
+		ReferencedBy: []AWSSecretsManagerWorkloadReference{{
+			WorkloadID:   "lambda:payments",
+			WorkloadName: "payments-worker",
+			WorkloadType: "lambda",
+		}},
+	}
+	finding := AWSSecretPermissionEquivalenceFinding{
+		AgentID:        "case-triage",
+		AgentName:      "case-triage",
+		IdentityNodeID: "aws:identity:case-triage-runtime",
+	}
+
+	workloads := awsSecretKeyRotationWorkloads(secret, finding)
+	if len(workloads) != 2 {
+		t.Fatalf("expected metadata and finding workloads, got %+v", workloads)
+	}
+	if workloads[0].WorkloadID != "lambda:payments" || workloads[0].RefreshOrder != 1 {
+		t.Fatalf("metadata workload should stay first: %+v", workloads)
+	}
+	if workloads[1].WorkloadID != "case-triage" || workloads[1].RefreshOrder != 2 {
+		t.Fatalf("finding workload should be appended with next refresh order: %+v", workloads)
+	}
+
+	duplicate := awsSecretKeyRotationWorkloads(secret, AWSSecretPermissionEquivalenceFinding{WorkloadID: "lambda:payments"})
+	if len(duplicate) != 1 {
+		t.Fatalf("duplicate finding workload should not be added twice: %+v", duplicate)
+	}
+}
+
+func TestGetAWSSecretKeyRotationPlansFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 15, 0, 0, time.UTC)
+	svc, ws := newSecretKeyRotationService(t, "project-secret-key-rotation-states", now)
+
+	denied, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation-states", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Plans) != 0 || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress plans: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation-states", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Summary.TotalPlans != 0 || empty.Status == "blocked" {
+		t.Fatalf("empty fixture should produce no non-blocked plans: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSSecretKeyRotationPlans(defaultScopeContext(), ws, "project-secret-key-rotation-states", AWSSecretKeyRotationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSSecretKeyRotation(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 20, 0, 0, time.UTC)
+	svc, _ := newSecretKeyRotationService(t, "project-secret-key-rotation-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-secret-key-rotation-route/aws/secret-key-rotation?connector_id=aws-prod&fixture_state=success&rotation_type=provider_key", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plans AWSSecretKeyRotationResult `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Plans.CurrentIssueRef != "#1533" || body.Plans.AppliedFilters["rotation_type"] != "provider-key" {
+		t.Fatalf("unexpected route payload: %+v", body.Plans)
+	}
+}

--- a/internal/api/aws_secret_permission_equivalence.go
+++ b/internal/api/aws_secret_permission_equivalence.go
@@ -1078,9 +1078,11 @@ func awsSecretPermissionSecretIndexes(secrets AWSSecretsManagerMetadataInventory
 		if secret.FromNodeID != "" {
 			byNode[strings.ToLower(secret.FromNodeID)] = secret
 		}
-		if secret.KMSKeyARN != "" {
-			key := strings.ToLower(strings.TrimSpace(secret.KMSKeyARN))
-			byKMS[key] = append(byKMS[key], secret)
+		for _, ref := range []string{secret.KMSKeyARN, secret.KMSKeyID} {
+			key := strings.ToLower(strings.TrimSpace(ref))
+			if key != "" {
+				byKMS[key] = append(byKMS[key], secret)
+			}
 		}
 	}
 	return byARN, byNode, byKMS

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3201,6 +3201,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSecretKeyRotationPlans(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSecretKeyRotationRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			RotationType:  strings.TrimSpace(c.Query("rotation_type")),
+			Provider:      strings.TrimSpace(c.Query("provider")),
+			Owner:         strings.TrimSpace(c.Query("owner")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			ReadyForApply: strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:        strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws secret key rotation request"})
+			default:
+				logger.Error("get aws secret key rotation",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws secret key rotation plans"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plans": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1747,6 +1747,53 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS secret/key rotation plans with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plans: {
+          status: 'ready',
+          summary: { total_plans: 0, filtered_plans: 0 },
+          plans: []
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectSecretKeyRotationPlans(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        rotationType: 'provider_key',
+        provider: 'openai',
+        owner: 'appsec',
+        severity: 'high',
+        status: 'action_required',
+        readyForApply: 'true',
+        search: 'rotation_re_evaluate'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/secret-key-rotation?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&rotation_type=provider_key&provider=openai&owner=appsec&severity=high&status=action_required&ready_for_apply=true&search=rotation_re_evaluate'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3470,6 +3470,157 @@ export type AWSPermissionBoundarySCPQuery = {
   search?: string;
 };
 
+export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
+
+export type AWSSecretKeyRotationOwnerHandoff = {
+  owner: string;
+  assigned: boolean;
+  approval_state: string;
+  required_actors?: string[];
+  instructions?: string[];
+};
+
+export type AWSSecretKeyRotationTargetRef = {
+  ref_type: string;
+  node_id?: string;
+  arn?: string;
+  label: string;
+  provider?: string;
+  metadata_ref?: string;
+};
+
+export type AWSSecretKeyRotationWorkload = {
+  workload_id?: string;
+  workload_name?: string;
+  workload_type?: string;
+  resource_arn?: string;
+  owner?: string;
+  refresh_order: number;
+};
+
+export type AWSSecretKeyRotationStep = {
+  order: number;
+  phase: string;
+  action: string;
+  actor?: string;
+  evidence_ref?: string;
+  blocks_on?: string[];
+};
+
+export type AWSSecretKeyRotationReadinessGate = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSSecretKeyRotationPlan = {
+  plan_id: string;
+  calculation_version: string;
+  rotation_type: AWSSecretKeyRotationType;
+  severity: string;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  provider?: string;
+  owner_handoff: AWSSecretKeyRotationOwnerHandoff;
+  source_finding_ids: string[];
+  target_secrets?: AWSSecretKeyRotationTargetRef[];
+  target_keys?: AWSSecretKeyRotationTargetRef[];
+  dependent_workloads?: AWSSecretKeyRotationWorkload[];
+  rotation_order: AWSSecretKeyRotationStep[];
+  diff_intent: AWSRemediationDiffIntent;
+  tradeoffs: AWSRemediationTradeoff[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  readiness_gates: AWSSecretKeyRotationReadinessGate[];
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSSecretKeyRotationRelationship = {
+  plan_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSSecretKeyRotationSummary = {
+  total_plans: number;
+  filtered_plans: number;
+  rotation_type_counts: Record<string, number>;
+  provider_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  owner_assigned_count: number;
+  ownerless_count: number;
+  ready_for_apply_count: number;
+  target_secret_count: number;
+  target_key_count: number;
+  dependent_workload_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSSecretKeyRotationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSecretKeyRotationStatus;
+  fixture_state?: AWSSecretKeyRotationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSSecretKeyRotationSummary;
+  plans: AWSSecretKeyRotationPlan[];
+  relationships: AWSSecretKeyRotationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSSecretKeyRotationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSSecretKeyRotationFixtureState;
+  accountID?: string;
+  region?: string;
+  rotationType?: string;
+  provider?: string;
+  owner?: string;
+  severity?: string;
+  status?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -7674,6 +7825,29 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         breakage_level: query?.breakageLevel,
+        ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSecretKeyRotationPlans(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSSecretKeyRotationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plans: AWSSecretKeyRotationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/secret-key-rotation${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        rotation_type: query?.rotationType,
+        provider: query?.provider,
+        owner: query?.owner,
+        severity: query?.severity,
+        status: query?.status,
         ready_for_apply: query?.readyForApply,
         search: query?.search
       })}`,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3773,6 +3773,137 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
+      plans: {
+        status: 'ready',
+        plans: [
+          {
+            plan_id: 'aws-secret-key-rotation:openai-api-key',
+            calculation_version: 'aws-credential-rotation-planner-v1',
+            rotation_type: 'provider_key',
+            severity: 'high',
+            status: 'action_required',
+            score: 88,
+            confidence: 0.9,
+            title: 'Provider key rotation: openai/api-key',
+            summary: 'Rotate the OpenAI provider key and refresh dependent workloads.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            provider: 'openai',
+            owner_handoff: {
+              owner: 'ai-platform',
+              assigned: true,
+              approval_state: 'pending_approver',
+              required_actors: ['application-owner', 'security-reviewer'],
+              instructions: ['Confirm dependent workload refresh.']
+            },
+            source_finding_ids: ['aws-secret-permission-equivalence:openai-agent'],
+            target_secrets: [
+              {
+                ref_type: 'secret',
+                node_id: 'aws:resource:secrets-manager-secret:openai/api-key',
+                arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:openai/api-key',
+                label: 'openai/api-key',
+                provider: 'openai',
+                metadata_ref: 'evidence://agent/case-triage/openai'
+              }
+            ],
+            target_keys: [],
+            dependent_workloads: [
+              {
+                workload_id: 'aws:agent:case-triage',
+                workload_name: 'case-triage',
+                workload_type: 'ai_agent',
+                owner: 'ai-platform',
+                refresh_order: 1
+              }
+            ],
+            rotation_order: [
+              { order: 1, phase: 'prepare', action: 'Confirm owner and fallback.', actor: 'ai-platform' },
+              { order: 2, phase: 'dry_run', action: 'Dry-run workload refresh.', actor: 'ai-platform' },
+              { order: 3, phase: 'apply', action: 'Rotate the provider key outside Identrail.', actor: 'ai-platform' },
+              { order: 4, phase: 'refresh', action: 'Refresh dependent workload.', actor: 'ai-platform' },
+              { order: 5, phase: 'verify', action: 'Re-run metadata checks.', actor: 'security' }
+            ],
+            diff_intent: {
+              kind: 'secret_rotation',
+              before_ref: 'evidence://agent/case-triage/openai',
+              after_ref: 'rotation://openai-api-key/new-version-reference',
+              diff_summary: 'Rotate without reading or storing the value.',
+              no_op: false,
+              read_only_projection: true
+            },
+            tradeoffs: [
+              {
+                dimension: 'credential_exposure',
+                direction: 'improves',
+                description: 'Rotation invalidates the previous provider key.',
+                severity: 'high'
+              }
+            ],
+            rollback_plan: {
+              strategy: 'restore_previous_secret_version',
+              steps: ['Restore the previous secret reference if workload refresh regresses.'],
+              evidence_ref: 'evidence://agent/case-triage/openai'
+            },
+            verification_plan: {
+              strategy: 'rotation_re_evaluate',
+              steps: ['Re-run secret-permission equivalence.'],
+              success_signals: ['secret_permission_equivalence:no-equivalent-stale-access'],
+              failure_signals: ['secret_permission_equivalence:stale-reference-observed'],
+              evidence_ref: 'evidence://agent/case-triage/openai'
+            },
+            readiness_gates: [
+              { name: 'no_secret_values', status: 'passed', rationale: 'Metadata refs only.' },
+              { name: 'owner_handoff', status: 'passed', rationale: 'Owner assigned.' }
+            ],
+            ready_for_apply: true,
+            read_only_projection: true,
+            source_signals: ['secret_permission_equivalence'],
+            evidence: [
+              {
+                source: 'secret_permission_equivalence',
+                evidence_ref: 'evidence://agent/case-triage/openai',
+                label: 'Agent provider-key metadata',
+                confidence: 0.9,
+                observed_at: '2026-06-24T15:00:00Z',
+                relationship: 'agent_uses_permission_bearing_secret'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_secret_values_no_payloads',
+            impacted_nodes: ['aws:agent:case-triage', 'aws:resource:secrets-manager-secret:openai/api-key'],
+            impacted_path: [],
+            next_action: 'Assign owner handoff, execute rotation, then link verification evidence.',
+            created_at: '2026-06-24T15:00:00Z',
+            updated_at: '2026-06-24T15:00:00Z'
+          }
+        ],
+        summary: {
+          total_plans: 1,
+          filtered_plans: 1,
+          rotation_type_counts: { provider_key: 1 },
+          provider_counts: { openai: 1 },
+          severity_counts: { high: 1 },
+          status_counts: { action_required: 1 },
+          owner_assigned_count: 1,
+          ownerless_count: 0,
+          ready_for_apply_count: 1,
+          target_secret_count: 1,
+          target_key_count: 0,
+          dependent_workload_count: 1,
+          relationship_count: 2,
+          highest_score: 88,
+          average_confidence_pct: 90
+        },
+        relationships: [],
+        caveats: ['Plans never read, expose, log, rotate, or persist secret values.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -4096,6 +4227,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS permission boundary and SCP plans' })).toBeInTheDocument();
     expect(screen.getByText(/Permission boundary: deny s3:DeleteObject across 3 identities/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Permission boundary/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS secret/key rotation plans' })).toBeInTheDocument();
+    expect(screen.getByText(/Provider key rotation: openai\/api-key/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/ai-platform · Pending approver/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();
@@ -4134,6 +4268,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getSecretPermissionEquivalence).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getSecretKeyRotation).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -65,6 +65,8 @@ import {
   type AWSTrustPolicyHardeningResult,
   type AWSPermissionBoundarySCPPlan,
   type AWSPermissionBoundarySCPResult,
+  type AWSSecretKeyRotationPlan,
+  type AWSSecretKeyRotationResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11039,6 +11041,116 @@ function AWSPermissionBoundarySCPContent({
   );
 }
 
+function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
+  if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
+    return 'not-available';
+  }
+  if (!plan.ready_for_apply || plan.severity === 'high') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsSecretKeyRotationTargetLabel(plan: AWSSecretKeyRotationPlan): string {
+  const secretCount = plan.target_secrets?.length ?? 0;
+  const keyCount = plan.target_keys?.length ?? 0;
+  const workloadCount = plan.dependent_workloads?.length ?? 0;
+  return `${secretCount} secrets · ${keyCount} keys · ${workloadCount} workloads`;
+}
+
+function awsSecretKeyRotationOrderLabel(plan: AWSSecretKeyRotationPlan): string {
+  const phases = plan.rotation_order.map((step) => formatTokenLabel(step.phase));
+  if (phases.length === 0) {
+    return 'manual review';
+  }
+  return phases.slice(0, 4).join(' → ') + (phases.length > 4 ? ` +${phases.length - 4}` : '');
+}
+
+function awsSecretKeyRotationReadinessLabel(plan: AWSSecretKeyRotationPlan): string {
+  if (plan.ready_for_apply) {
+    return `ready · ${plan.owner_handoff.owner}`;
+  }
+  return `gate · ${formatTokenLabel(plan.owner_handoff.approval_state)}`;
+}
+
+function AWSSecretKeyRotationContent({
+  plans,
+  loading,
+  error,
+  onRetry
+}: {
+  plans: AWSSecretKeyRotationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = plans?.plans ?? [];
+  const summaryLine = plans
+    ? `${plans.summary.total_plans} total · ${plans.summary.ready_for_apply_count} ready · ${plans.summary.owner_assigned_count} owned · ${plans.summary.dependent_workload_count} workloads`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS secret and key rotation plans">
+      <h3>AWS secret/key rotation planner</h3>
+      <p className="idt-app-kicker">
+        Read-only provider-key, Secrets Manager, and KMS-related rotation workflows composed from metadata-only
+        evidence. Owner handoff, dependent workload order, rollback, verification, and readiness gates are projected
+        without reading or rotating secret values. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS secret/key rotation plans"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing secret/key rotation plans"
+          body="Identrail is composing secret-permission, Secrets Manager, KMS, and remediation case evidence into ranked rotation workflows."
+        />
+      ) : null}
+      {!error && !loading && plans && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={plans.status === 'blocked' ? 'Permission required' : 'No rotation plans'}
+          title={plans.status === 'blocked' ? 'Rotation plans need read-only secret and key metadata' : 'No secret/key rotation plans projected'}
+          body={plans.failure_reasons[0] ?? 'No upstream secret or KMS evidence produced a rotation plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && plans && plans.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {plans.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS secret/key rotation plans"
+          rows={rows}
+          getRowKey={(row) => row.plan_id}
+          columns={[
+            { key: 'plan', header: 'Plan', render: (row) => <strong>{row.title}</strong> },
+            { key: 'type', header: 'Type', render: (row) => formatTokenLabel(row.rotation_type) },
+            { key: 'owner', header: 'Owner handoff', render: (row) => `${row.owner_handoff.owner} · ${formatTokenLabel(row.owner_handoff.approval_state)}` },
+            { key: 'targets', header: 'Targets', render: (row) => awsSecretKeyRotationTargetLabel(row) },
+            { key: 'order', header: 'Order', render: (row) => awsSecretKeyRotationOrderLabel(row) },
+            { key: 'readiness', header: 'Readiness', render: (row) => awsSecretKeyRotationReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsSecretKeyRotationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12319,14 +12431,14 @@ function AWSRemediationContent({
       id: 'secret-rotation',
       title: 'Secret rotation planner',
       category: 'Secret rotation',
-      evidence: 'Secret metadata',
+      evidence: 'Secret/key metadata',
       owner: 'Application',
-      blastRadius: 'Secret metadata pending',
+      blastRadius: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
       nextAction: 'Plan rotation',
-      status: 'not active',
-      stage: 'not-available',
-      filters: { change: 'secret-rotation', approval: 'owner-required', stage: 'not-active', search: '' },
-      searchText: inventorySearchText(['secret rotation', 'planner', 'metadata'])
+      status: 'active',
+      stage: 'wired',
+      filters: { change: 'secret-rotation', approval: 'owner-required', stage: 'active', search: '' },
+      searchText: inventorySearchText(['secret rotation', 'key rotation', 'planner', 'metadata'])
     },
     {
       id: 'iac-pr-plan',
@@ -12498,6 +12610,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [permissionBoundarySCPLoading, setPermissionBoundarySCPLoading] = useState(false);
   const [permissionBoundarySCPError, setPermissionBoundarySCPError] = useState('');
   const permissionBoundarySCPRequestRef = useRef(0);
+  const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
+  const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
+  const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
+  const secretKeyRotationRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -12974,6 +13090,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       permissionBoundarySCPRequestRef.current += 1;
     };
   }, [loadPermissionBoundarySCP]);
+
+  const loadSecretKeyRotation = useCallback(async () => {
+    const requestID = ++secretKeyRotationRequestRef.current;
+    setSecretKeyRotation(null);
+    setSecretKeyRotationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSecretKeyRotationLoading(false);
+      return;
+    }
+    setSecretKeyRotationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSecretKeyRotationPlans(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== secretKeyRotationRequestRef.current) {
+        return;
+      }
+      setSecretKeyRotation(response.plans);
+    } catch (error) {
+      if (requestID !== secretKeyRotationRequestRef.current) {
+        return;
+      }
+      setSecretKeyRotationError(formatAPIError(error, 'Unable to load AWS secret/key rotation plans.'));
+    } finally {
+      if (requestID === secretKeyRotationRequestRef.current) {
+        setSecretKeyRotationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadSecretKeyRotation();
+    return () => {
+      secretKeyRotationRequestRef.current += 1;
+    };
+  }, [loadSecretKeyRotation]);
 
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
@@ -13477,6 +13641,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={permissionBoundarySCPLoading}
             error={permissionBoundarySCPError}
             onRetry={loadPermissionBoundarySCP}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSSecretKeyRotationContent
+            plans={secretKeyRotation}
+            loading={secretKeyRotationLoading}
+            error={secretKeyRotationError}
+            onRetry={loadSecretKeyRotation}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- Implement a read-only AWS secret/key rotation planner for issue #1533.
- Compose rotation workflows from secret-permission equivalence, Secrets Manager metadata, KMS reachability, and remediation case evidence.
- Add route/authz/OpenAPI/docs, web client types, runtime UI panel, and regression tests.

## Safety
- Plans only include metadata refs, owner handoff, workload order, rollback, verification, readiness gates, and evidence links.
- The planner never reads, rotates, logs, exposes, or persists secret values or provider key material.

## Validation
- `go test ./internal/api`
- `go test ./...`
- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `npm run build`

Closes #1533

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS secret/key rotation planner that builds ranked workflows from metadata and exposes them via a new API and UI. Implements #1533 to help owners rotate provider keys, Secrets Manager secrets, and KMS-related paths without touching secret values.

- **New Features**
  - New endpoint: GET `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation` with filters: `connector_id`, `fixture_state`, `account_id`, `region`, `rotation_type`, `provider`, `owner`, `severity`, `status`, `ready_for_apply`, `search`.
  - Planner composes plans from secret-permission equivalence, Secrets Manager metadata, KMS decrypt reachability, and remediation cases; plans include owner handoff, dependent workload order, rollback, verification, and readiness gates; read-only by design. OpenAPI, authz policy, and router updated; web client `apiClient.getAWSProjectSecretKeyRotationPlans(...)` with types and tests; UI panel “AWS secret/key rotation planner”; docs added.

- **Bug Fixes**
  - Classify AWS-native Secrets Manager rotations as `secrets_manager_secret` to avoid mixing them into provider-key plans.
  - Preserve KMS key ID rotation targets by indexing both `KMSKeyARN` and `KMSKeyID` so KMS-related plans capture key-id-only references.

<sup>Written for commit 47abf190fd7902cbf59a539017848b1c2b9b4f9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

