### PR TITLE
Fix KMS secret rotation follow-up cases

### DIFF
--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -303,6 +303,7 @@ func awsSecretKeyRotationPlans(sources awsSecretKeyRotationSources, now time.Tim
 	plans := []AWSSecretKeyRotationPlan{}
 	secretsByARN, secretsByNode, secretsByKMS := awsSecretPermissionSecretIndexes(sources.secrets)
 	kmsByARN := awsSecretKeyRotationKMSIndex(sources.kms)
+	secretsByKMS = awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kmsByARN)
 	caseByFinding := awsSecretKeyRotationCaseIndex(sources.cases)
 	for _, finding := range sources.equivalence.Findings {
 		if p, ok := awsSecretKeyRotationPlanFromEquivalence(finding, secretsByARN, secretsByNode, kmsByARN, caseByFinding, now); ok {
@@ -453,7 +454,8 @@ func awsSecretKeyRotationPlanFromMetadata(secret AWSSecretsManagerMetadataRecord
 		UpdatedAt:        now,
 	}
 	kmsRef := awsSecretKeyRotationKMSRef(secret)
-	if kmsRef != "" && len(secretsByKMS[kmsRef]) > 1 {
+	canonicalKMSRef := awsSecretKeyRotationCanonicalKMSRef(kmsRef, kmsByARN)
+	if canonicalKMSRef != "" && (len(secretsByKMS[canonicalKMSRef]) > 1 || len(secretsByKMS[kmsRef]) > 1) {
 		plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "shared_kms_key", Status: "review", Rationale: "Multiple secrets use the same KMS key; stage rotation and verification per dependent secret."})
 	}
 	return finalizeAWSSecretKeyRotationPlan(plan)
@@ -484,8 +486,8 @@ func finalizeAWSSecretKeyRotationPlan(plan AWSSecretKeyRotationPlan) AWSSecretKe
 
 func awsSecretKeyRotationType(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) string {
 	normalized := normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType)
-	secretRef := strings.ToLower(strings.Join([]string{finding.SecretNodeID, finding.SecretARN, finding.SecretLabel, secret.KMSKeyARN, strings.Join(finding.SourceSignals, " ")}, " "))
-	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") {
+	secretRef := strings.ToLower(strings.Join([]string{finding.SecretNodeID, finding.SecretARN, finding.SecretLabel, secret.KMSKeyARN, secret.KMSKeyID, strings.Join(finding.SourceSignals, " ")}, " "))
+	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") || strings.TrimSpace(secret.KMSKeyARN) != "" || strings.TrimSpace(secret.KMSKeyID) != "" {
 		return "kms_related"
 	}
 	if awsSecretKeyRotationIsProviderKeyFinding(normalized, finding.Provider) {
@@ -702,6 +704,34 @@ func awsSecretKeyRotationKMSIndex(kms AWSKMSDecryptReachabilityInventoryResult) 
 
 func awsSecretKeyRotationKMSRef(secret AWSSecretsManagerMetadataRecord) string {
 	return strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(secret.KMSKeyARN, secret.KMSKeyID)))
+}
+
+func awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS map[string][]AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) map[string][]AWSSecretsManagerMetadataRecord {
+	if len(secretsByKMS) == 0 {
+		return secretsByKMS
+	}
+	out := map[string][]AWSSecretsManagerMetadataRecord{}
+	for ref, secrets := range secretsByKMS {
+		canonical := awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
+		if canonical == "" {
+			continue
+		}
+		out[canonical] = append(out[canonical], secrets...)
+	}
+	return out
+}
+
+func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {
+	ref = strings.ToLower(strings.TrimSpace(ref))
+	if ref == "" {
+		return ""
+	}
+	record := kmsByARN[ref]
+	canonical := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.KeyARN, record.KeyID, firstString(record.Aliases), ref)))
+	if canonical == "" {
+		return ref
+	}
+	return canonical
 }
 
 func awsSecretKeyRotationKMSRecordRefs(record AWSKMSDecryptReachabilityRecord) []string {

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -486,11 +486,14 @@ func finalizeAWSSecretKeyRotationPlan(plan AWSSecretKeyRotationPlan) AWSSecretKe
 
 func awsSecretKeyRotationType(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) string {
 	normalized := normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType)
+	if strings.Contains(normalized, "kms") {
+		return "kms_related"
+	}
 	if awsSecretKeyRotationIsProviderKeyFinding(normalized, finding.Provider) {
 		return "provider_key"
 	}
 	secretRef := strings.ToLower(strings.Join([]string{finding.SecretNodeID, finding.SecretARN, finding.SecretLabel, secret.KMSKeyARN, secret.KMSKeyID, strings.Join(finding.SourceSignals, " ")}, " "))
-	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") || strings.TrimSpace(secret.KMSKeyARN) != "" || strings.TrimSpace(secret.KMSKeyID) != "" {
+	if strings.Contains(secretRef, "kms") || strings.TrimSpace(secret.KMSKeyARN) != "" || strings.TrimSpace(secret.KMSKeyID) != "" {
 		return "kms_related"
 	}
 	return "secrets_manager_secret"
@@ -758,7 +761,7 @@ func awsSecretKeyRotationCanonicalKMSRefForSecret(ref string, secret AWSSecretsM
 	if record, ok := awsSecretKeyRotationKMSRecordForRefAndScope(ref, secret.AccountID, secret.Region, kmsByARN); ok {
 		return awsSecretKeyRotationCanonicalKMSRecordRef(record, ref)
 	}
-	return awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
+	return ref
 }
 
 func awsSecretKeyRotationKMSRecordForSecret(secret AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) (AWSKMSDecryptReachabilityRecord, bool) {
@@ -770,6 +773,12 @@ func awsSecretKeyRotationKMSRecordForRefAndScope(ref string, accountID string, r
 	if scoped := awsSecretKeyRotationScopedKMSRef(accountID, region, ref); scoped != "" {
 		if record, ok := kmsByARN[scoped]; ok {
 			return record, true
+		}
+		if !awsSecretKeyRotationIsKeyARNRef(ref) {
+			if record, ok := kmsByARN[ref]; ok && record.AccountID == "" && record.Region == "" {
+				return record, true
+			}
+			return AWSKMSDecryptReachabilityRecord{}, false
 		}
 	}
 	record, ok := kmsByARN[ref]
@@ -799,6 +808,10 @@ func awsSecretKeyRotationNormalizeKMSLookupRef(ref string) string {
 		ref = ref[strings.LastIndex(ref, ":alias/")+1:]
 	}
 	return ref
+}
+
+func awsSecretKeyRotationIsKeyARNRef(ref string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(ref)), ":key/")
 }
 
 func awsSecretKeyRotationScopedKMSRef(accountID, region, ref string) string {

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -711,14 +711,31 @@ func awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS map[string][]AWSSecr
 		return secretsByKMS
 	}
 	out := map[string][]AWSSecretsManagerMetadataRecord{}
+	seen := map[string]map[string]struct{}{}
 	for ref, secrets := range secretsByKMS {
 		canonical := awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
 		if canonical == "" {
 			continue
 		}
-		out[canonical] = append(out[canonical], secrets...)
+		if seen[canonical] == nil {
+			seen[canonical] = map[string]struct{}{}
+		}
+		for _, secret := range secrets {
+			key := awsSecretKeyRotationSecretDedupeKey(secret)
+			if key != "" {
+				if _, ok := seen[canonical][key]; ok {
+					continue
+				}
+				seen[canonical][key] = struct{}{}
+			}
+			out[canonical] = append(out[canonical], secret)
+		}
 	}
 	return out
+}
+
+func awsSecretKeyRotationSecretDedupeKey(secret AWSSecretsManagerMetadataRecord) string {
+	return strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(secret.SecretARN, secret.FromNodeID, secret.SecretName, secret.EvidenceRef)))
 }
 
 func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -486,12 +486,12 @@ func finalizeAWSSecretKeyRotationPlan(plan AWSSecretKeyRotationPlan) AWSSecretKe
 
 func awsSecretKeyRotationType(finding AWSSecretPermissionEquivalenceFinding, secret AWSSecretsManagerMetadataRecord) string {
 	normalized := normalizeAWSRuntimeEventFilterToken(finding.EquivalenceType)
+	if awsSecretKeyRotationIsProviderKeyFinding(normalized, finding.Provider) {
+		return "provider_key"
+	}
 	secretRef := strings.ToLower(strings.Join([]string{finding.SecretNodeID, finding.SecretARN, finding.SecretLabel, secret.KMSKeyARN, secret.KMSKeyID, strings.Join(finding.SourceSignals, " ")}, " "))
 	if strings.Contains(normalized, "kms") || strings.Contains(secretRef, "kms") || strings.TrimSpace(secret.KMSKeyARN) != "" || strings.TrimSpace(secret.KMSKeyID) != "" {
 		return "kms_related"
-	}
-	if awsSecretKeyRotationIsProviderKeyFinding(normalized, finding.Provider) {
-		return "provider_key"
 	}
 	return "secrets_manager_secret"
 }
@@ -742,6 +742,9 @@ func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSD
 	ref = strings.ToLower(strings.TrimSpace(ref))
 	if ref == "" {
 		return ""
+	}
+	if strings.Contains(ref, ":alias/") {
+		ref = ref[strings.LastIndex(ref, ":alias/")+1:]
 	}
 	record := kmsByARN[ref]
 	canonical := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.KeyARN, record.KeyID, firstString(record.Aliases), ref)))

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -533,7 +533,7 @@ func awsSecretKeyRotationTargetsForKMS(secret AWSSecretsManagerMetadataRecord, k
 	if kmsRef == "" {
 		return nil
 	}
-	record := kmsByARN[kmsRef]
+	record, _ := awsSecretKeyRotationKMSRecordForSecret(secret, kmsByARN)
 	arn := firstNonEmptyAWSValue(secret.KMSKeyARN, record.KeyARN)
 	return []AWSSecretKeyRotationTargetRef{{
 		RefType:     "kms_key",
@@ -755,12 +755,25 @@ func awsSecretKeyRotationCanonicalKMSRefForSecret(ref string, secret AWSSecretsM
 	if ref == "" {
 		return ""
 	}
-	if scoped := awsSecretKeyRotationScopedKMSRef(secret.AccountID, secret.Region, ref); scoped != "" {
-		if record, ok := kmsByARN[scoped]; ok {
-			return awsSecretKeyRotationCanonicalKMSRecordRef(record, ref)
-		}
+	if record, ok := awsSecretKeyRotationKMSRecordForRefAndScope(ref, secret.AccountID, secret.Region, kmsByARN); ok {
+		return awsSecretKeyRotationCanonicalKMSRecordRef(record, ref)
 	}
 	return awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
+}
+
+func awsSecretKeyRotationKMSRecordForSecret(secret AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) (AWSKMSDecryptReachabilityRecord, bool) {
+	return awsSecretKeyRotationKMSRecordForRefAndScope(awsSecretKeyRotationKMSRef(secret), secret.AccountID, secret.Region, kmsByARN)
+}
+
+func awsSecretKeyRotationKMSRecordForRefAndScope(ref string, accountID string, region string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) (AWSKMSDecryptReachabilityRecord, bool) {
+	ref = awsSecretKeyRotationNormalizeKMSLookupRef(ref)
+	if scoped := awsSecretKeyRotationScopedKMSRef(accountID, region, ref); scoped != "" {
+		if record, ok := kmsByARN[scoped]; ok {
+			return record, true
+		}
+	}
+	record, ok := kmsByARN[ref]
+	return record, ok
 }
 
 func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {

--- a/internal/api/aws_secret_key_rotation.go
+++ b/internal/api/aws_secret_key_rotation.go
@@ -454,7 +454,7 @@ func awsSecretKeyRotationPlanFromMetadata(secret AWSSecretsManagerMetadataRecord
 		UpdatedAt:        now,
 	}
 	kmsRef := awsSecretKeyRotationKMSRef(secret)
-	canonicalKMSRef := awsSecretKeyRotationCanonicalKMSRef(kmsRef, kmsByARN)
+	canonicalKMSRef := awsSecretKeyRotationCanonicalKMSRefForSecret(kmsRef, secret, kmsByARN)
 	if canonicalKMSRef != "" && (len(secretsByKMS[canonicalKMSRef]) > 1 || len(secretsByKMS[kmsRef]) > 1) {
 		plan.ReadinessGates = append(plan.ReadinessGates, AWSSecretKeyRotationReadinessGate{Name: "shared_kms_key", Status: "review", Rationale: "Multiple secrets use the same KMS key; stage rotation and verification per dependent secret."})
 	}
@@ -694,8 +694,20 @@ func awsSecretKeyRotationScoreForSecret(secret AWSSecretsManagerMetadataRecord) 
 
 func awsSecretKeyRotationKMSIndex(kms AWSKMSDecryptReachabilityInventoryResult) map[string]AWSKMSDecryptReachabilityRecord {
 	out := map[string]AWSKMSDecryptReachabilityRecord{}
+	ambiguous := map[string]struct{}{}
 	for _, record := range kms.Records {
 		for _, ref := range awsSecretKeyRotationKMSRecordRefs(record) {
+			if scoped := awsSecretKeyRotationScopedKMSRef(record.AccountID, record.Region, ref); scoped != "" {
+				out[scoped] = record
+			}
+			if existing, ok := out[ref]; ok && (existing.KeyARN != record.KeyARN || existing.AccountID != record.AccountID || existing.Region != record.Region) {
+				ambiguous[ref] = struct{}{}
+				delete(out, ref)
+				continue
+			}
+			if _, ok := ambiguous[ref]; ok {
+				continue
+			}
 			out[ref] = record
 		}
 	}
@@ -713,14 +725,14 @@ func awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS map[string][]AWSSecr
 	out := map[string][]AWSSecretsManagerMetadataRecord{}
 	seen := map[string]map[string]struct{}{}
 	for ref, secrets := range secretsByKMS {
-		canonical := awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
-		if canonical == "" {
-			continue
-		}
-		if seen[canonical] == nil {
-			seen[canonical] = map[string]struct{}{}
-		}
 		for _, secret := range secrets {
+			canonical := awsSecretKeyRotationCanonicalKMSRefForSecret(ref, secret, kmsByARN)
+			if canonical == "" {
+				continue
+			}
+			if seen[canonical] == nil {
+				seen[canonical] = map[string]struct{}{}
+			}
 			key := awsSecretKeyRotationSecretDedupeKey(secret)
 			if key != "" {
 				if _, ok := seen[canonical][key]; ok {
@@ -738,20 +750,52 @@ func awsSecretKeyRotationSecretDedupeKey(secret AWSSecretsManagerMetadataRecord)
 	return strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(secret.SecretARN, secret.FromNodeID, secret.SecretName, secret.EvidenceRef)))
 }
 
-func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {
-	ref = strings.ToLower(strings.TrimSpace(ref))
+func awsSecretKeyRotationCanonicalKMSRefForSecret(ref string, secret AWSSecretsManagerMetadataRecord, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {
+	ref = awsSecretKeyRotationNormalizeKMSLookupRef(ref)
 	if ref == "" {
 		return ""
 	}
+	if scoped := awsSecretKeyRotationScopedKMSRef(secret.AccountID, secret.Region, ref); scoped != "" {
+		if record, ok := kmsByARN[scoped]; ok {
+			return awsSecretKeyRotationCanonicalKMSRecordRef(record, ref)
+		}
+	}
+	return awsSecretKeyRotationCanonicalKMSRef(ref, kmsByARN)
+}
+
+func awsSecretKeyRotationCanonicalKMSRef(ref string, kmsByARN map[string]AWSKMSDecryptReachabilityRecord) string {
+	ref = awsSecretKeyRotationNormalizeKMSLookupRef(ref)
+	if ref == "" {
+		return ""
+	}
+	record := kmsByARN[ref]
+	return awsSecretKeyRotationCanonicalKMSRecordRef(record, ref)
+}
+
+func awsSecretKeyRotationCanonicalKMSRecordRef(record AWSKMSDecryptReachabilityRecord, fallback string) string {
+	canonical := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.KeyARN, record.KeyID, firstString(record.Aliases), fallback)))
+	if canonical == "" {
+		return fallback
+	}
+	return canonical
+}
+
+func awsSecretKeyRotationNormalizeKMSLookupRef(ref string) string {
+	ref = strings.ToLower(strings.TrimSpace(ref))
 	if strings.Contains(ref, ":alias/") {
 		ref = ref[strings.LastIndex(ref, ":alias/")+1:]
 	}
-	record := kmsByARN[ref]
-	canonical := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(record.KeyARN, record.KeyID, firstString(record.Aliases), ref)))
-	if canonical == "" {
-		return ref
+	return ref
+}
+
+func awsSecretKeyRotationScopedKMSRef(accountID, region, ref string) string {
+	accountID = strings.ToLower(strings.TrimSpace(accountID))
+	region = strings.ToLower(strings.TrimSpace(region))
+	ref = awsSecretKeyRotationNormalizeKMSLookupRef(ref)
+	if accountID == "" || region == "" || ref == "" {
+		return ""
 	}
-	return canonical
+	return accountID + "|" + region + "|" + ref
 }
 
 func awsSecretKeyRotationKMSRecordRefs(record AWSKMSDecryptReachabilityRecord) []string {

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -300,8 +300,8 @@ func TestAWSSecretKeyRotationPlanFromMetadataScopesBareKMSAliases(t *testing.T) 
 		otherAccountSecret,
 	}})
 	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{
-		{AccountID: "111111111111", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:111111111111:key/primary", Aliases: []string{"alias/aws/secretsmanager"}},
-		{AccountID: "222222222222", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:222222222222:key/primary", Aliases: []string{"alias/aws/secretsmanager"}},
+		{AccountID: "111111111111", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:111111111111:key/primary", Aliases: []string{"alias/aws/secretsmanager"}, FromNodeID: "aws:resource:kms-key:111111111111/primary", EvidenceRef: "evidence://kms/111111111111"},
+		{AccountID: "222222222222", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:222222222222:key/primary", Aliases: []string{"alias/aws/secretsmanager"}, FromNodeID: "aws:resource:kms-key:222222222222/primary", EvidenceRef: "evidence://kms/222222222222"},
 	}})
 
 	canonicalSecretsByKMS := awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kms)
@@ -312,6 +312,9 @@ func TestAWSSecretKeyRotationPlanFromMetadataScopesBareKMSAliases(t *testing.T) 
 		t.Fatalf("expected account-scoped alias bucket for second account, got %d: %+v", got, canonicalSecretsByKMS)
 	}
 	plan := awsSecretKeyRotationPlanFromMetadata(secret, canonicalSecretsByKMS, kms, now)
+	if len(plan.TargetKeys) != 1 || plan.TargetKeys[0].NodeID != "aws:resource:kms-key:111111111111/primary" || plan.TargetKeys[0].ARN != "arn:aws:kms:us-east-1:111111111111:key/primary" || plan.TargetKeys[0].MetadataRef != "evidence://kms/111111111111" {
+		t.Fatalf("expected scoped KMS target metadata for first account: %+v", plan.TargetKeys)
+	}
 	if awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
 		t.Fatalf("same bare alias in another account must not get shared KMS gate: %+v", plan.ReadinessGates)
 	}

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -320,6 +320,50 @@ func TestAWSSecretKeyRotationPlanFromMetadataScopesBareKMSAliases(t *testing.T) 
 	}
 }
 
+func TestAWSSecretKeyRotationPlanFromMetadataAvoidsCrossScopeAliasFallback(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 11, 55, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "111111111111",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:111111111111:secret:billing/api-key",
+		SecretName:    "billing/api-key",
+		KMSKeyID:      "alias/aws/secretsmanager",
+		OwningService: "billing",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/billing",
+		FromNodeID:    "aws:resource:secrets-manager-secret:billing/api-key",
+		Confidence:    0.81,
+		Tags:          map[string]string{"owner": "billing-platform"},
+	}
+	otherAccountSecret := AWSSecretsManagerMetadataRecord{
+		AccountID:  "222222222222",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:222222222222:secret:billing/webhook",
+		SecretName: "billing/webhook",
+		KMSKeyID:   "alias/aws/secretsmanager",
+	}
+	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{
+		secret,
+		otherAccountSecret,
+	}})
+	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{
+		{AccountID: "222222222222", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:222222222222:key/primary", Aliases: []string{"alias/aws/secretsmanager"}, FromNodeID: "aws:resource:kms-key:222222222222/primary", EvidenceRef: "evidence://kms/222222222222"},
+	}})
+
+	canonicalSecretsByKMS := awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kms)
+	if got := len(canonicalSecretsByKMS["alias/aws/secretsmanager"]); got != 1 {
+		t.Fatalf("expected unresolved first-account alias bucket to stay local, got %d: %+v", got, canonicalSecretsByKMS)
+	}
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, canonicalSecretsByKMS, kms, now)
+	if len(plan.TargetKeys) != 1 || plan.TargetKeys[0].NodeID == "aws:resource:kms-key:222222222222/primary" || plan.TargetKeys[0].MetadataRef == "evidence://kms/222222222222" {
+		t.Fatalf("first-account secret must not borrow second-account KMS target: %+v", plan.TargetKeys)
+	}
+	if awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("missing scoped KMS record must not use another account for shared gate: %+v", plan.ReadinessGates)
+	}
+}
+
 func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
 	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
 	secret := AWSSecretsManagerMetadataRecord{
@@ -396,6 +440,10 @@ func TestAWSSecretKeyRotationTypeKeepsAWSNativeSecretFindings(t *testing.T) {
 	external.Provider = credentialProviderOpenAI
 	if got := awsSecretKeyRotationType(external, AWSSecretsManagerMetadataRecord{}); got != "provider_key" {
 		t.Fatalf("external provider finding should remain provider_key, got %q", got)
+	}
+	external.EquivalenceType = "kms_decrypt_secret_equivalence"
+	if got := awsSecretKeyRotationType(external, AWSSecretsManagerMetadataRecord{}); got != "kms_related" {
+		t.Fatalf("external provider KMS finding should remain kms_related, got %q", got)
 	}
 	external.EquivalenceType = "workload_provider_key_equivalence"
 	providerKeySecret := secret

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -222,7 +222,7 @@ func TestAWSSecretKeyRotationPlanFromMetadataCanonicalizesSharedKMSRefs(t *testi
 	}
 	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{
 		secret,
-		{SecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/webhook", KMSKeyID: "alias/billing-secrets"},
+		{SecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/webhook", KMSKeyARN: "arn:aws:kms:us-east-1:123456789012:alias/billing-secrets"},
 	}})
 	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{{
 		KeyARN:     keyARN,
@@ -348,6 +348,12 @@ func TestAWSSecretKeyRotationTypeKeepsAWSNativeSecretFindings(t *testing.T) {
 	external.Provider = credentialProviderOpenAI
 	if got := awsSecretKeyRotationType(external, AWSSecretsManagerMetadataRecord{}); got != "provider_key" {
 		t.Fatalf("external provider finding should remain provider_key, got %q", got)
+	}
+	external.EquivalenceType = "workload_provider_key_equivalence"
+	providerKeySecret := secret
+	providerKeySecret.KMSKeyID = "alias/orders-secrets"
+	if got := awsSecretKeyRotationType(external, providerKeySecret); got != "provider_key" {
+		t.Fatalf("external provider finding with KMS metadata should remain provider_key, got %q", got)
 	}
 
 	aliasBackedSecret := secret

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -237,6 +237,41 @@ func TestAWSSecretKeyRotationPlanFromMetadataCanonicalizesSharedKMSRefs(t *testi
 	}
 }
 
+func TestAWSSecretKeyRotationPlanFromMetadataDoesNotDuplicateCanonicalKMSRefs(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 11, 45, 0, time.UTC)
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/billing"
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "123456789012",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/api-key",
+		SecretName:    "billing/api-key",
+		KMSKeyARN:     keyARN,
+		KMSKeyID:      "alias/billing-secrets",
+		OwningService: "billing",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/billing",
+		FromNodeID:    "aws:resource:secrets-manager-secret:billing/api-key",
+		Confidence:    0.81,
+		Tags:          map[string]string{"owner": "billing-platform"},
+	}
+	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{secret}})
+	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{{
+		KeyARN:  keyARN,
+		KeyID:   "billing",
+		Aliases: []string{"alias/billing-secrets"},
+	}}})
+
+	canonicalSecretsByKMS := awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kms)
+	if got := len(canonicalSecretsByKMS[strings.ToLower(keyARN)]); got != 1 {
+		t.Fatalf("expected canonical KMS bucket to dedupe same secret, got %d: %+v", got, canonicalSecretsByKMS)
+	}
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, canonicalSecretsByKMS, kms, now)
+	if awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("single secret with arn and alias refs must not get shared KMS gate: %+v", plan.ReadinessGates)
+	}
+}
+
 func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
 	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
 	secret := AWSSecretsManagerMetadataRecord{

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -272,6 +272,51 @@ func TestAWSSecretKeyRotationPlanFromMetadataDoesNotDuplicateCanonicalKMSRefs(t 
 	}
 }
 
+func TestAWSSecretKeyRotationPlanFromMetadataScopesBareKMSAliases(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 11, 50, 0, time.UTC)
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "111111111111",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:111111111111:secret:billing/api-key",
+		SecretName:    "billing/api-key",
+		KMSKeyID:      "alias/aws/secretsmanager",
+		OwningService: "billing",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/billing",
+		FromNodeID:    "aws:resource:secrets-manager-secret:billing/api-key",
+		Confidence:    0.81,
+		Tags:          map[string]string{"owner": "billing-platform"},
+	}
+	otherAccountSecret := AWSSecretsManagerMetadataRecord{
+		AccountID:  "222222222222",
+		Region:     "us-east-1",
+		SecretARN:  "arn:aws:secretsmanager:us-east-1:222222222222:secret:billing/webhook",
+		SecretName: "billing/webhook",
+		KMSKeyID:   "alias/aws/secretsmanager",
+	}
+	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{
+		secret,
+		otherAccountSecret,
+	}})
+	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{
+		{AccountID: "111111111111", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:111111111111:key/primary", Aliases: []string{"alias/aws/secretsmanager"}},
+		{AccountID: "222222222222", Region: "us-east-1", KeyARN: "arn:aws:kms:us-east-1:222222222222:key/primary", Aliases: []string{"alias/aws/secretsmanager"}},
+	}})
+
+	canonicalSecretsByKMS := awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kms)
+	if got := len(canonicalSecretsByKMS["arn:aws:kms:us-east-1:111111111111:key/primary"]); got != 1 {
+		t.Fatalf("expected account-scoped alias bucket for first account, got %d: %+v", got, canonicalSecretsByKMS)
+	}
+	if got := len(canonicalSecretsByKMS["arn:aws:kms:us-east-1:222222222222:key/primary"]); got != 1 {
+		t.Fatalf("expected account-scoped alias bucket for second account, got %d: %+v", got, canonicalSecretsByKMS)
+	}
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, canonicalSecretsByKMS, kms, now)
+	if awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("same bare alias in another account must not get shared KMS gate: %+v", plan.ReadinessGates)
+	}
+}
+
 func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
 	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
 	secret := AWSSecretsManagerMetadataRecord{

--- a/internal/api/aws_secret_key_rotation_test.go
+++ b/internal/api/aws_secret_key_rotation_test.go
@@ -203,6 +203,40 @@ func TestAWSSecretKeyRotationPlanFromMetadataPreservesKMSKeyID(t *testing.T) {
 	}
 }
 
+func TestAWSSecretKeyRotationPlanFromMetadataCanonicalizesSharedKMSRefs(t *testing.T) {
+	now := time.Date(2026, 6, 24, 15, 11, 30, 0, time.UTC)
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/billing"
+	secret := AWSSecretsManagerMetadataRecord{
+		AccountID:     "123456789012",
+		Region:        "us-east-1",
+		Service:       "secretsmanager",
+		SecretARN:     "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/api-key",
+		SecretName:    "billing/api-key",
+		KMSKeyARN:     keyARN,
+		OwningService: "billing",
+		SecretStatus:  "active",
+		EvidenceRef:   "evidence://secret/billing",
+		FromNodeID:    "aws:resource:secrets-manager-secret:billing/api-key",
+		Confidence:    0.81,
+		Tags:          map[string]string{"owner": "billing-platform"},
+	}
+	_, _, secretsByKMS := awsSecretPermissionSecretIndexes(AWSSecretsManagerMetadataInventoryResult{Records: []AWSSecretsManagerMetadataRecord{
+		secret,
+		{SecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:billing/webhook", KMSKeyID: "alias/billing-secrets"},
+	}})
+	kms := awsSecretKeyRotationKMSIndex(AWSKMSDecryptReachabilityInventoryResult{Records: []AWSKMSDecryptReachabilityRecord{{
+		KeyARN:     keyARN,
+		KeyID:      "billing",
+		Aliases:    []string{"alias/billing-secrets"},
+		FromNodeID: "aws:resource:kms-key:billing",
+	}}})
+
+	plan := awsSecretKeyRotationPlanFromMetadata(secret, awsSecretKeyRotationCanonicalSecretsByKMS(secretsByKMS, kms), kms, now)
+	if !awsSecretKeyRotationSearchMatch(plan, "shared_kms_key") {
+		t.Fatalf("expected shared KMS readiness gate for canonical arn/alias refs: %+v", plan.ReadinessGates)
+	}
+}
+
 func TestAWSSecretKeyRotationPlanFromMetadataDoesNotAssignFallbackOwner(t *testing.T) {
 	now := time.Date(2026, 6, 24, 15, 12, 0, 0, time.UTC)
 	secret := AWSSecretsManagerMetadataRecord{
@@ -279,6 +313,12 @@ func TestAWSSecretKeyRotationTypeKeepsAWSNativeSecretFindings(t *testing.T) {
 	external.Provider = credentialProviderOpenAI
 	if got := awsSecretKeyRotationType(external, AWSSecretsManagerMetadataRecord{}); got != "provider_key" {
 		t.Fatalf("external provider finding should remain provider_key, got %q", got)
+	}
+
+	aliasBackedSecret := secret
+	aliasBackedSecret.KMSKeyID = "alias/orders-secrets"
+	if got := awsSecretKeyRotationType(finding, aliasBackedSecret); got != "kms_related" {
+		t.Fatalf("AWS-native secret finding with KMSKeyID should be kms_related, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Refs #1533

Follow-up to #1676 addressing the remaining review comments on the secret/key rotation planner.\n\nChanges:\n- Classify equivalence-backed secret rotation plans as `kms_related` when the matched Secrets Manager metadata only has `KMSKeyID` or an alias and no resolved `KMSKeyARN`.\n- Canonicalize KMS refs through the KMS reachability index before checking whether multiple secrets share the same key, so ARN/alias/key-id forms are grouped together.\n- Add regression coverage for alias-only KMS classification and shared-key readiness gates across mixed KMS ref forms.\n\nValidation:\n- `go test ./internal/api -run "TestAWSSecretKeyRotationPlanFromMetadata(PreservesKMSKeyID|CanonicalizesSharedKMSRefs)|TestAWSSecretKeyRotationTypeKeepsAWSNativeSecretFindings"`\n- `go test ./internal/api -run "TestAWSSecretKeyRotation|TestGetAWSSecretKeyRotation|TestRouterAWSSecretKeyRotation"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes KMS secret rotation edge cases by canonicalizing, scoping, and deduplicating KMS references. Avoids cross‑account alias leaks, picks the right key per account/region, and keeps KMS vs provider‑key classification accurate.

- **Bug Fixes**
  - Canonicalize KMS refs via the reachability index. Scope alias lookups and target key resolution by account/region, avoid cross‑scope fallback when a bare alias can’t be resolved, and drop ambiguous unscoped refs.
  - Preserve types: keep `provider_key` findings as `provider_key` even with KMS metadata; classify alias‑only or `KMSKeyID`‑only secrets and external‑provider KMS equivalence findings as `kms_related`.
  - Deduplicate canonical KMS buckets and per‑secret entries so ARN/alias/key‑id forms aren’t double‑counted, and only add the shared‑key gate when multiple distinct secrets share the same canonical key.

<sup>Written for commit 64319dacfb368dacd54c4728554c7dcc434cd8d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

