### PR TITLE
Implement access key quarantine planner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
 - AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
 - AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
+- AWS access key disable and quarantine planner: `aws-access-key-quarantine-planner.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-access-key-quarantine-planner.md
+++ b/docs/aws-access-key-quarantine-planner.md
@@ -1,0 +1,88 @@
+# AWS access key disable and quarantine planner
+
+Issue #1534 adds a metadata-only planner for stale, risky, or unused IAM
+access keys. It converts dormant-access findings, IAM last-used evidence, and
+runtime signals into owner-notified disable/quarantine plans with grace periods,
+rollback, verification, and readiness gates.
+
+The planner is read-only. It never calls AWS IAM write APIs, never disables an
+access key, and never reads, exposes, logs, or persists secret access key
+values, rendered policies, prompts, completions, browser pages,
+code-interpreter output, database rows, object contents, customer payloads, or
+workload payloads.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/access-key-quarantine`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `identity` | access key ID, IAM principal, node ID, or target label match |
+| `quarantine_state` | `disable_candidate`, `quarantine_candidate`, `grace_period_required`, or `needs_review` |
+| `owner` | owner notification target |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | `ready_for_quarantine`, `pending_owner`, or `review` |
+| `ready_for_apply` | `true` / `false` |
+| `search` | free-text search across plan, target, owner, order, rollback, verification, evidence, and readiness fields |
+
+Response shape: `{ "plans": AWSAccessKeyQuarantineResult }` with
+tenant/workspace/project metadata, summary counts, ranked plans,
+relationships, caveats, failure reasons, remediation hints, evidence links,
+coverage gaps, diagnostics, and generated timestamps.
+
+## Plan shape
+
+Each `AWSAccessKeyQuarantinePlan` includes:
+
+- stable `plan_id`, calculation version, issue refs, score, confidence, status,
+  and severity
+- `quarantine_state`, target access key metadata refs, affected principal refs,
+  last-used timestamp, dormant days, and grace-period days
+- `owner_notice` with assigned owner, notification state, required actors, and
+  instructions
+- ordered `notify`, `grace_period`, `dry_run`, `apply`, and `verify` steps
+- before/after intent, tradeoffs, rollback plan, verification plan, readiness
+  gates, impacted graph nodes, and evidence refs
+- `ready_for_apply`, which is only a planning signal for a future approved
+  executor or human operator
+
+`ready_for_apply` is true only when the owner is assigned, evidence confidence
+is high enough, the dormant access state is explicit, and all readiness gates
+pass. Plans with unknown evidence, low confidence, missing owner notice, or
+permission-denied upstream data remain review-only or blocked.
+
+## Failure handling
+
+- **Ready**: upstream dormant-access evidence is available and qualifying access
+  key findings can be planned.
+- **Degraded**: partial or degraded upstream evidence is visible with explicit
+  diagnostics; composed plans remain available when safe.
+- **Blocked**: permission-denied upstream evidence emits zero plans plus failure
+  reasons, remediation hints, diagnostics, and coverage gaps.
+
+Unsupported, empty, partial, degraded, and permission-denied states remain
+visible. The planner does not convert absence of evidence into proof that a key
+is safe to disable.
+
+## App surface
+
+The AWS Runtime page renders an **AWS access key quarantine plans** panel with
+plan state, owner notice, target key/principal, quarantine order, readiness,
+severity/status, and verification strategy. Loading, empty, degraded, blocked,
+and error states are explicit.
+
+## Validation
+
+1. Confirm blockers #1524 and #1529 are closed.
+2. Run dormant-access evidence with `fixture_state=success`.
+3. Call the planner endpoint with `fixture_state=success` and verify at least
+   one access-key plan includes owner notice, grace period, rollback, and
+   verification.
+4. Filter by `identity`, `quarantine_state`, `owner`, `ready_for_apply`, and
+   `search=quarantine_re_evaluate`.
+5. Run `fixture_state=empty`, `degraded`, `partial_failure`, and
+   `permission_denied` and confirm the status, diagnostics, and failure reasons
+   stay explicit.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -599,6 +599,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/access-key-quarantine
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5496,6 +5501,89 @@ paths:
                     $ref: "#/components/schemas/AWSSecretKeyRotationResult"
         "400":
           description: Invalid AWS secret/key rotation request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/access-key-quarantine:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS access key disable and quarantine plans
+      operationId: getAWSProjectAccessKeyQuarantinePlans
+      description: Generates ranked, read-only IAM access key disable and quarantine workflows from dormant access findings, last-used evidence, and runtime signals. Each plan carries owner notification, grace period, ordered quarantine steps, before/after intent, tradeoffs, rollback, verification, readiness gates, and evidence refs. The endpoint never disables AWS access keys and never reads, exposes, logs, or persists secret access key values, customer payloads, rendered policies, prompts, completions, browser pages, code-interpreter output, database rows, or object contents.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+        - in: query
+          name: quarantine_state
+          schema:
+            type: string
+            enum: [disable_candidate, quarantine_candidate, grace_period_required, needs_review]
+        - in: query
+          name: owner
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [ready_for_quarantine, pending_owner, review]
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS access key disable and quarantine plan contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    $ref: "#/components/schemas/AWSAccessKeyQuarantineResult"
+        "400":
+          description: Invalid AWS access key quarantine request
           content:
             application/json:
               schema:
@@ -14692,6 +14780,225 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSecretKeyRotationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAccessKeyQuarantineOwnerNotice:
+      type: object
+      properties:
+        owner: { type: string }
+        assigned: { type: boolean }
+        notification: { type: string }
+        grace_period: { type: string }
+        required_actors:
+          type: array
+          items: { type: string }
+        instructions:
+          type: array
+          items: { type: string }
+    AWSAccessKeyQuarantineTarget:
+      type: object
+      properties:
+        ref_type: { type: string }
+        access_key_id: { type: string }
+        node_id: { type: string }
+        principal: { type: string }
+        label: { type: string }
+        metadata_ref: { type: string }
+    AWSAccessKeyQuarantineStep:
+      type: object
+      properties:
+        order: { type: integer }
+        phase: { type: string }
+        action: { type: string }
+        actor: { type: string }
+        evidence_ref: { type: string }
+        blocks_on:
+          type: array
+          items: { type: string }
+    AWSAccessKeyQuarantineGate:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSAccessKeyQuarantineRelationship:
+      type: object
+      properties:
+        plan_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAccessKeyQuarantinePlan:
+      type: object
+      properties:
+        plan_id: { type: string }
+        calculation_version: { type: string }
+        quarantine_state:
+          type: string
+          enum: [disable_candidate, quarantine_candidate, grace_period_required, needs_review]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status:
+          type: string
+          enum: [ready_for_quarantine, pending_owner, review]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        owner_notice:
+          $ref: "#/components/schemas/AWSAccessKeyQuarantineOwnerNotice"
+        source_finding_ids:
+          type: array
+          items: { type: string }
+        target_access_keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantineTarget"
+        affected_principals:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantineTarget"
+        last_used_at:
+          type: string
+          format: date-time
+        dormant_days: { type: integer }
+        grace_period_days: { type: integer }
+        quarantine_order:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantineStep"
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        readiness_gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantineGate"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAccessKeyQuarantineSummary:
+      type: object
+      properties:
+        total_plans: { type: integer }
+        filtered_plans: { type: integer }
+        quarantine_state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        owner_assigned_count: { type: integer }
+        ownerless_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        access_key_count: { type: integer }
+        affected_principal_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSAccessKeyQuarantineResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSAccessKeyQuarantineSummary"
+        plans:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantinePlan"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAccessKeyQuarantineRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -763,6 +763,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_access_key_quarantine.go
+++ b/internal/api/aws_access_key_quarantine.go
@@ -264,17 +264,7 @@ func awsAccessKeyQuarantinePlansFromDormant(findings []AWSUnusedDormantAccessFin
 }
 
 func awsAccessKeyQuarantineFindingQualifies(finding AWSUnusedDormantAccessFinding) bool {
-	haystack := strings.ToLower(strings.Join(append([]string{finding.FindingType, finding.DormancyState, finding.PolicyScope, finding.DisplayName, finding.IdentityNodeID, finding.PrincipalARN, finding.ResourceARN}, finding.CandidateActions...), " "))
-	if strings.Contains(haystack, "access-key") || strings.Contains(haystack, "access key") || strings.Contains(haystack, "accesskey") || strings.Contains(haystack, "akia") {
-		return true
-	}
-	for _, evidence := range finding.Evidence {
-		ref := strings.ToLower(strings.Join([]string{evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship}, " "))
-		if strings.Contains(ref, "access-key") || strings.Contains(ref, "access key") || strings.Contains(ref, "accesskey") || strings.Contains(ref, "akia") {
-			return true
-		}
-	}
-	return false
+	return awsAccessKeyQuarantineAccessKeyID(finding) != ""
 }
 
 func awsAccessKeyQuarantinePlanFromFinding(finding AWSUnusedDormantAccessFinding, now time.Time) AWSAccessKeyQuarantinePlan {
@@ -414,12 +404,12 @@ func awsAccessKeyQuarantineAccessKeyID(finding AWSUnusedDormantAccessFinding) st
 		}) {
 			token = strings.TrimSpace(token)
 			normalized := strings.ToUpper(token)
-			if strings.HasPrefix(normalized, "AKIA") || strings.HasPrefix(normalized, "ASIA") {
+			if strings.HasPrefix(normalized, "AKIA") {
 				return normalized
 			}
 		}
 	}
-	return firstNonEmptyAWSValue(finding.ResourceNodeID, finding.ResourceARN, finding.DisplayName)
+	return ""
 }
 
 func awsAccessKeyQuarantinePrincipalTarget(finding AWSUnusedDormantAccessFinding, evidenceRef string) AWSAccessKeyQuarantineTarget {

--- a/internal/api/aws_access_key_quarantine.go
+++ b/internal/api/aws_access_key_quarantine.go
@@ -1,0 +1,717 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsAccessKeyQuarantineCurrentIssue = 1534
+	awsAccessKeyQuarantineVersion      = "aws-access-key-quarantine-planner-v1"
+)
+
+// AWSAccessKeyQuarantineRequest scopes read-only access-key quarantine planning
+// to one AWS connector plus optional operator drill-down filters.
+type AWSAccessKeyQuarantineRequest struct {
+	ConnectorID     string `json:"connector_id,omitempty"`
+	FixtureState    string `json:"fixture_state,omitempty"`
+	AccountID       string `json:"account_id,omitempty"`
+	Region          string `json:"region,omitempty"`
+	Identity        string `json:"identity,omitempty"`
+	QuarantineState string `json:"quarantine_state,omitempty"`
+	Owner           string `json:"owner,omitempty"`
+	Severity        string `json:"severity,omitempty"`
+	Status          string `json:"status,omitempty"`
+	ReadyForApply   string `json:"ready_for_apply,omitempty"`
+	Search          string `json:"search,omitempty"`
+}
+
+type AWSAccessKeyQuarantineEvidence = AWSLeastPrivilegeEvidence
+type AWSAccessKeyQuarantinePathStep = AWSLeastPrivilegePathStep
+type AWSAccessKeyQuarantineDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSAccessKeyQuarantineCoverageGap = AWSLeastPrivilegeCoverageGap
+
+type AWSAccessKeyQuarantineOwnerNotice struct {
+	Owner          string   `json:"owner"`
+	Assigned       bool     `json:"assigned"`
+	Notification   string   `json:"notification"`
+	GracePeriod    string   `json:"grace_period"`
+	RequiredActors []string `json:"required_actors,omitempty"`
+	Instructions   []string `json:"instructions,omitempty"`
+}
+
+type AWSAccessKeyQuarantineTarget struct {
+	RefType     string `json:"ref_type"`
+	AccessKeyID string `json:"access_key_id,omitempty"`
+	NodeID      string `json:"node_id,omitempty"`
+	Principal   string `json:"principal,omitempty"`
+	Label       string `json:"label"`
+	MetadataRef string `json:"metadata_ref,omitempty"`
+}
+
+type AWSAccessKeyQuarantineStep struct {
+	Order       int      `json:"order"`
+	Phase       string   `json:"phase"`
+	Action      string   `json:"action"`
+	Actor       string   `json:"actor,omitempty"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+	BlocksOn    []string `json:"blocks_on,omitempty"`
+}
+
+type AWSAccessKeyQuarantineGate struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+type AWSAccessKeyQuarantinePlan struct {
+	PlanID             string                            `json:"plan_id"`
+	CalculationVersion string                            `json:"calculation_version"`
+	QuarantineState    string                            `json:"quarantine_state"`
+	Severity           string                            `json:"severity"`
+	Status             string                            `json:"status"`
+	Score              int                               `json:"score"`
+	Confidence         float64                           `json:"confidence"`
+	Title              string                            `json:"title"`
+	Summary            string                            `json:"summary"`
+	AccountID          string                            `json:"account_id"`
+	Region             string                            `json:"region"`
+	OwnerNotice        AWSAccessKeyQuarantineOwnerNotice `json:"owner_notice"`
+	SourceFindingIDs   []string                          `json:"source_finding_ids"`
+	TargetAccessKeys   []AWSAccessKeyQuarantineTarget    `json:"target_access_keys"`
+	AffectedPrincipals []AWSAccessKeyQuarantineTarget    `json:"affected_principals,omitempty"`
+	LastUsedAt         time.Time                         `json:"last_used_at,omitzero"`
+	DormantDays        int                               `json:"dormant_days"`
+	GracePeriodDays    int                               `json:"grace_period_days"`
+	QuarantineOrder    []AWSAccessKeyQuarantineStep      `json:"quarantine_order"`
+	DiffIntent         AWSRemediationDiffIntent          `json:"diff_intent"`
+	Tradeoffs          []AWSRemediationTradeoff          `json:"tradeoffs"`
+	RollbackPlan       AWSRemediationRollbackPlan        `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan    `json:"verification_plan"`
+	ReadinessGates     []AWSAccessKeyQuarantineGate      `json:"readiness_gates"`
+	ReadyForApply      bool                              `json:"ready_for_apply"`
+	ReadOnlyProjection bool                              `json:"read_only_projection"`
+	SourceSignals      []string                          `json:"source_signals"`
+	Evidence           []AWSAccessKeyQuarantineEvidence  `json:"evidence"`
+	EvidenceBoundary   string                            `json:"evidence_boundary"`
+	ImpactedNodes      []string                          `json:"impacted_nodes"`
+	ImpactedPath       []AWSAccessKeyQuarantinePathStep  `json:"impacted_path"`
+	NextAction         string                            `json:"next_action"`
+	CreatedAt          time.Time                         `json:"created_at"`
+	UpdatedAt          time.Time                         `json:"updated_at"`
+}
+
+type AWSAccessKeyQuarantineRelationship struct {
+	PlanID      string `json:"plan_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+type AWSAccessKeyQuarantineSummary struct {
+	TotalPlans             int            `json:"total_plans"`
+	FilteredPlans          int            `json:"filtered_plans"`
+	QuarantineStateCounts  map[string]int `json:"quarantine_state_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	StatusCounts           map[string]int `json:"status_counts"`
+	OwnerAssignedCount     int            `json:"owner_assigned_count"`
+	OwnerlessCount         int            `json:"ownerless_count"`
+	ReadyForApplyCount     int            `json:"ready_for_apply_count"`
+	AccessKeyCount         int            `json:"access_key_count"`
+	AffectedPrincipalCount int            `json:"affected_principal_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+type AWSAccessKeyQuarantineResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	CalculationVersion string                               `json:"calculation_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Summary            AWSAccessKeyQuarantineSummary        `json:"summary"`
+	Plans              []AWSAccessKeyQuarantinePlan         `json:"plans"`
+	Relationships      []AWSAccessKeyQuarantineRelationship `json:"relationships"`
+	Caveats            []string                             `json:"caveats"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSAccessKeyQuarantineCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSAccessKeyQuarantineDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// GetAWSAccessKeyQuarantinePlans composes ranked, read-only disable/quarantine
+// workflows for stale or risky access-key evidence. It never disables keys and
+// never reads, returns, logs, or persists secret access-key material.
+func (s *Service) GetAWSAccessKeyQuarantinePlans(ctx context.Context, workspaceID string, projectID string, request AWSAccessKeyQuarantineRequest) (AWSAccessKeyQuarantineResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAccessKeyQuarantineResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAccessKeyQuarantineResult{}, err
+	}
+	fixtureState := normalizeAWSAccessKeyQuarantineFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAccessKeyQuarantineResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	dormant, err := s.GetAWSUnusedDormantAccessFindings(ctx, workspaceID, projectID, AWSUnusedDormantAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+	})
+	if err != nil {
+		return AWSAccessKeyQuarantineResult{}, fmt.Errorf("access key quarantine dormant access: %w", err)
+	}
+	plans := awsAccessKeyQuarantinePlansFromDormant(dormant.Findings, dormant.GeneratedAt)
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Score == plans[j].Score {
+			return plans[i].PlanID < plans[j].PlanID
+		}
+		return plans[i].Score > plans[j].Score
+	})
+	filtered, applied := filterAWSAccessKeyQuarantinePlans(plans, request)
+	relationships := awsAccessKeyQuarantineRelationships(filtered)
+	status, confidence := summarizeAWSAccessKeyQuarantineStatus(dormant.Status, filtered, dormant.Diagnostics)
+
+	return AWSAccessKeyQuarantineResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAccessKeyQuarantineCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAccessKeyQuarantineCurrentIssue),
+		Version:            awsAccessKeyQuarantineVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsAccessKeyQuarantineVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSAccessKeyQuarantinePlans(plans, filtered, relationships),
+		Plans:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsAccessKeyQuarantineCaveats(dormant.Caveats),
+		FailureReasons:     dormant.FailureReasons,
+		RemediationHints:   awsAccessKeyQuarantineRemediationHints(dormant.RemediationHints),
+		EvidenceLinks: dedupeStrings(append(dormant.EvidenceLinks,
+			awsIssueURL(awsAccessKeyQuarantineCurrentIssue),
+			"/docs/aws-access-key-quarantine-planner",
+		)),
+		CoverageGaps: awsAccessKeyQuarantineCoverageGaps(dormant.CoverageGaps),
+		Diagnostics:  awsAccessKeyQuarantineDiagnostics(dormant.Diagnostics),
+		GeneratedAt:  dormant.GeneratedAt,
+		UpdatedAt:    dormant.UpdatedAt,
+	}, nil
+}
+
+func normalizeAWSAccessKeyQuarantineFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsAccessKeyQuarantinePlansFromDormant(findings []AWSUnusedDormantAccessFinding, now time.Time) []AWSAccessKeyQuarantinePlan {
+	plans := []AWSAccessKeyQuarantinePlan{}
+	for _, finding := range findings {
+		if !awsAccessKeyQuarantineFindingQualifies(finding) {
+			continue
+		}
+		plans = append(plans, awsAccessKeyQuarantinePlanFromFinding(finding, now))
+	}
+	return plans
+}
+
+func awsAccessKeyQuarantineFindingQualifies(finding AWSUnusedDormantAccessFinding) bool {
+	haystack := strings.ToLower(strings.Join(append([]string{finding.FindingType, finding.DormancyState, finding.PolicyScope, finding.DisplayName, finding.IdentityNodeID, finding.PrincipalARN, finding.ResourceARN}, finding.CandidateActions...), " "))
+	if strings.Contains(haystack, "access-key") || strings.Contains(haystack, "access key") || strings.Contains(haystack, "accesskey") || strings.Contains(haystack, "akia") {
+		return true
+	}
+	for _, evidence := range finding.Evidence {
+		ref := strings.ToLower(strings.Join([]string{evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship}, " "))
+		if strings.Contains(ref, "access-key") || strings.Contains(ref, "access key") || strings.Contains(ref, "accesskey") || strings.Contains(ref, "akia") {
+			return true
+		}
+	}
+	return false
+}
+
+func awsAccessKeyQuarantinePlanFromFinding(finding AWSUnusedDormantAccessFinding, now time.Time) AWSAccessKeyQuarantinePlan {
+	evidenceRef := firstLeastPrivilegeEvidenceRef(finding.Evidence)
+	owner := awsAccessKeyQuarantineOwner(finding)
+	ownerAssigned := owner != "unassigned"
+	state := awsAccessKeyQuarantineState(finding)
+	graceDays := awsAccessKeyQuarantineGracePeriodDays(finding)
+	accessKeyID := awsAccessKeyQuarantineAccessKeyID(finding)
+	targetNodeID := finding.ResourceNodeID
+	if targetNodeID == "" && accessKeyID != "" {
+		targetNodeID = "aws:iam-access-key:" + accessKeyID
+	}
+	target := AWSAccessKeyQuarantineTarget{
+		RefType:     "iam_access_key",
+		AccessKeyID: accessKeyID,
+		NodeID:      targetNodeID,
+		Principal:   finding.PrincipalARN,
+		Label:       firstNonEmptyAWSValue(accessKeyID, "access key reference"),
+		MetadataRef: evidenceRef,
+	}
+	plan := AWSAccessKeyQuarantinePlan{
+		PlanID:             "aws-access-key-quarantine:" + stableAWSBlastRadiusToken(finding.FindingID, accessKeyID, state),
+		CalculationVersion: awsAccessKeyQuarantineVersion,
+		QuarantineState:    state,
+		Severity:           finding.Severity,
+		Status:             awsAccessKeyQuarantineStatusFromFinding(finding),
+		Score:              finding.Score,
+		Confidence:         finding.Confidence,
+		Title:              fmt.Sprintf("Access key quarantine: %s", firstNonEmptyAWSValue(accessKeyID, finding.DisplayName, finding.IdentityNodeID)),
+		Summary:            fmt.Sprintf("%s Plan a read-only disable/quarantine workflow with owner notice, grace period, rollback, and verification before any live IAM change.", finding.Rationale),
+		AccountID:          finding.AccountID,
+		Region:             finding.Region,
+		OwnerNotice:        awsAccessKeyQuarantineOwnerNotice(owner, ownerAssigned, graceDays, state),
+		SourceFindingIDs:   []string{finding.FindingID, finding.RemediationCase.CaseID},
+		TargetAccessKeys:   []AWSAccessKeyQuarantineTarget{target},
+		AffectedPrincipals: []AWSAccessKeyQuarantineTarget{awsAccessKeyQuarantinePrincipalTarget(finding, evidenceRef)},
+		LastUsedAt:         finding.LastUsedAt,
+		DormantDays:        finding.DormantDays,
+		GracePeriodDays:    graceDays,
+		QuarantineOrder:    awsAccessKeyQuarantineOrder(owner, evidenceRef, graceDays),
+		DiffIntent: AWSRemediationDiffIntent{
+			Kind:               "access_key_quarantine",
+			BeforeRef:          evidenceRef,
+			AfterRef:           "quarantine://" + finding.FindingID + "/disable-after-grace",
+			DiffSummary:        "Plan DisableAccessKey after owner notice and grace-period verification; no live key disable is performed by this endpoint.",
+			ReadOnlyProjection: true,
+		},
+		Tradeoffs:          awsAccessKeyQuarantineTradeoffs(finding),
+		RollbackPlan:       awsAccessKeyQuarantineRollback(evidenceRef),
+		VerificationPlan:   awsAccessKeyQuarantineVerification(evidenceRef),
+		ReadinessGates:     awsAccessKeyQuarantineReadinessGates(finding, ownerAssigned),
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings(append([]string{"unused_dormant_access"}, finding.EvidenceSources()...)),
+		Evidence:           finding.Evidence,
+		EvidenceBoundary:   awsAccessKeyQuarantineEvidenceBoundary(),
+		ImpactedNodes:      emptyStrings(dedupeStrings(append([]string{target.NodeID, finding.IdentityNodeID, finding.PrincipalARN}, finding.ImpactedNodes...))),
+		ImpactedPath:       finding.ImpactedPath,
+		NextAction:         "Notify the owner, wait through the grace window, verify no runtime use, then execute DisableAccessKey outside Identrail with linked evidence.",
+		CreatedAt:          firstNonZeroAWSAccessKeyQuarantineTime(finding.CreatedAt, now),
+		UpdatedAt:          firstNonZeroAWSAccessKeyQuarantineTime(finding.UpdatedAt, now),
+	}
+	plan.ReadyForApply = ownerAssigned && plan.Confidence >= 0.75 && plan.Status == "ready_for_quarantine" && finding.DormancyState != "unknown"
+	for _, gate := range plan.ReadinessGates {
+		if gate.Status == "blocked" {
+			plan.ReadyForApply = false
+		}
+	}
+	return plan
+}
+
+func (finding AWSUnusedDormantAccessFinding) EvidenceSources() []string {
+	out := []string{}
+	for _, evidence := range finding.Evidence {
+		out = append(out, evidence.Source)
+	}
+	return out
+}
+
+func awsAccessKeyQuarantineOwner(finding AWSUnusedDormantAccessFinding) string {
+	for _, step := range finding.ImpactedPath {
+		if strings.Contains(strings.ToLower(step.Label), "owner:") {
+			return strings.TrimSpace(strings.TrimPrefix(step.Label, "owner:"))
+		}
+	}
+	if strings.TrimSpace(finding.OwnerContext) != "" && !strings.Contains(finding.OwnerContext, "review") {
+		return finding.OwnerContext
+	}
+	return "unassigned"
+}
+
+func awsAccessKeyQuarantineState(finding AWSUnusedDormantAccessFinding) string {
+	switch finding.DormancyState {
+	case "never_used":
+		return "disable_candidate"
+	case "stale":
+		return "quarantine_candidate"
+	case "no_runtime_evidence":
+		return "grace_period_required"
+	default:
+		return "needs_review"
+	}
+}
+
+func awsAccessKeyQuarantineStatusFromFinding(finding AWSUnusedDormantAccessFinding) string {
+	if finding.Status == "cleanup_candidate" && finding.Confidence >= 0.75 {
+		return "ready_for_quarantine"
+	}
+	if finding.DormancyState == "unknown" || finding.Confidence < 0.7 {
+		return "review"
+	}
+	return "pending_owner"
+}
+
+func awsAccessKeyQuarantineGracePeriodDays(finding AWSUnusedDormantAccessFinding) int {
+	switch finding.DormancyState {
+	case "never_used":
+		return 3
+	case "stale":
+		return 7
+	case "no_runtime_evidence":
+		return 14
+	default:
+		return 0
+	}
+}
+
+func awsAccessKeyQuarantineAccessKeyID(finding AWSUnusedDormantAccessFinding) string {
+	candidates := []string{finding.ResourceNodeID, finding.ResourceARN, finding.DisplayName, finding.PolicyScope}
+	candidates = append(candidates, finding.CandidateActions...)
+	for _, evidence := range finding.Evidence {
+		candidates = append(candidates, evidence.Label, evidence.EvidenceRef)
+	}
+	for _, candidate := range candidates {
+		for _, token := range strings.FieldsFunc(candidate, func(r rune) bool {
+			return r == '/' || r == ':' || r == '|' || r == ' ' || r == ',' || r == ';'
+		}) {
+			token = strings.TrimSpace(token)
+			normalized := strings.ToUpper(token)
+			if strings.HasPrefix(normalized, "AKIA") || strings.HasPrefix(normalized, "ASIA") {
+				return normalized
+			}
+		}
+	}
+	return firstNonEmptyAWSValue(finding.ResourceNodeID, finding.ResourceARN, finding.DisplayName)
+}
+
+func awsAccessKeyQuarantinePrincipalTarget(finding AWSUnusedDormantAccessFinding, evidenceRef string) AWSAccessKeyQuarantineTarget {
+	return AWSAccessKeyQuarantineTarget{
+		RefType:     "iam_principal",
+		NodeID:      finding.IdentityNodeID,
+		Principal:   finding.PrincipalARN,
+		Label:       firstNonEmptyAWSValue(finding.DisplayName, shortAWSARN(finding.PrincipalARN), finding.IdentityNodeID, "principal"),
+		MetadataRef: evidenceRef,
+	}
+}
+
+func awsAccessKeyQuarantineOwnerNotice(owner string, assigned bool, graceDays int, state string) AWSAccessKeyQuarantineOwnerNotice {
+	return AWSAccessKeyQuarantineOwnerNotice{
+		Owner:        owner,
+		Assigned:     assigned,
+		Notification: "owner_notification_required",
+		GracePeriod:  fmt.Sprintf("P%dD", graceDays),
+		RequiredActors: []string{
+			"identity-owner",
+			"security-reviewer",
+			"platform-operator",
+		},
+		Instructions: []string{
+			fmt.Sprintf("Notify %s and record acknowledgement before quarantine.", firstNonEmptyAWSValue(owner, "the owner")),
+			fmt.Sprintf("Keep the key active for the %s window unless emergency severity is approved.", formatAWSBlastRadiusLabel(state)),
+		},
+	}
+}
+
+func awsAccessKeyQuarantineOrder(owner string, evidenceRef string, graceDays int) []AWSAccessKeyQuarantineStep {
+	actor := firstNonEmptyAWSValue(owner, "identity-owner")
+	return []AWSAccessKeyQuarantineStep{
+		{Order: 1, Phase: "notify", Action: "Notify the owner and capture acknowledgement for the access-key quarantine plan.", Actor: actor, EvidenceRef: evidenceRef},
+		{Order: 2, Phase: "grace_period", Action: fmt.Sprintf("Wait %d day(s) while monitoring runtime use and breakage signals.", graceDays), Actor: "security-reviewer", EvidenceRef: evidenceRef, BlocksOn: []string{"notify"}},
+		{Order: 3, Phase: "dry_run", Action: "Confirm dependent workloads can run without the key using metadata-only evidence and owner attestation.", Actor: "platform-operator", EvidenceRef: evidenceRef, BlocksOn: []string{"grace_period"}},
+		{Order: 4, Phase: "apply", Action: "Disable the access key in IAM outside Identrail after approval; this planner does not mutate AWS.", Actor: "platform-operator", EvidenceRef: evidenceRef, BlocksOn: []string{"dry_run"}},
+		{Order: 5, Phase: "verify", Action: "Verify no AccessDenied or fallback use appears after disable; link CloudTrail and IAM last-used evidence.", Actor: "security-reviewer", EvidenceRef: evidenceRef, BlocksOn: []string{"apply"}},
+	}
+}
+
+func awsAccessKeyQuarantineTradeoffs(finding AWSUnusedDormantAccessFinding) []AWSRemediationTradeoff {
+	return []AWSRemediationTradeoff{
+		{Dimension: "credential_exposure", Direction: "improves", Description: "Disabling the key removes a long-lived credential path after the grace window.", Severity: finding.Severity},
+		{Dimension: "breakage_risk", Direction: "worsens", Description: "Any workload still using the key can fail after disable; owner notice and dry-run evidence reduce that risk.", Severity: "medium"},
+		{Dimension: "auditability", Direction: "improves", Description: "The plan preserves evidence refs, owner acknowledgement, rollback, and verification steps before live mutation.", Severity: "low"},
+	}
+}
+
+func awsAccessKeyQuarantineRollback(evidenceRef string) AWSRemediationRollbackPlan {
+	return AWSRemediationRollbackPlan{
+		Strategy:    "reactivate_access_key_or_swap_credential",
+		Steps:       []string{"Re-enable the disabled access key only if emergency owner approval is recorded.", "Prefer issuing a new scoped credential and updating dependent workloads instead of leaving the old key active.", "Re-run runtime and IAM last-used evidence checks after rollback."},
+		EvidenceRef: evidenceRef,
+	}
+}
+
+func awsAccessKeyQuarantineVerification(evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "quarantine_re_evaluate",
+		Steps:          []string{"Confirm the key has no last-used or runtime activity during the grace period.", "After disable, check CloudTrail and workload telemetry for AccessDenied or fallback credential use.", "Attach owner acknowledgement, dry-run, apply, and verify evidence to the remediation case."},
+		SuccessSignals: []string{"iam:last-used-none-after-disable", "cloudtrail:no-access-key-use", "owner:acknowledged-quarantine"},
+		FailureSignals: []string{"cloudtrail:access-key-use-observed", "workload:credential-breakage", "owner:business-exception"},
+		EvidenceRef:    evidenceRef,
+	}
+}
+
+func awsAccessKeyQuarantineReadinessGates(finding AWSUnusedDormantAccessFinding, ownerAssigned bool) []AWSAccessKeyQuarantineGate {
+	gates := []AWSAccessKeyQuarantineGate{
+		{Name: "read_only_projection", Status: "passed", Rationale: "Plan contains metadata refs and never disables access keys directly."},
+		{Name: "owner_notice", Status: awsAccessKeyQuarantineGateStatus(ownerAssigned), Rationale: "Owner notification and acknowledgement are required before quarantine."},
+		{Name: "runtime_evidence", Status: awsAccessKeyQuarantineGateStatus(finding.DormancyState != "unknown"), Rationale: "Last-used or runtime evidence must be explicit before disable planning."},
+	}
+	if finding.Confidence < 0.7 {
+		gates = append(gates, AWSAccessKeyQuarantineGate{Name: "confidence", Status: "blocked", Rationale: "Low-confidence evidence cannot become a ready quarantine plan."})
+	}
+	return gates
+}
+
+func awsAccessKeyQuarantineGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func filterAWSAccessKeyQuarantinePlans(plans []AWSAccessKeyQuarantinePlan, request AWSAccessKeyQuarantineRequest) ([]AWSAccessKeyQuarantinePlan, map[string]string) {
+	filters := map[string]string{
+		"account_id":       strings.TrimSpace(request.AccountID),
+		"region":           strings.TrimSpace(request.Region),
+		"identity":         strings.TrimSpace(request.Identity),
+		"quarantine_state": normalizeAWSRuntimeEventFilterToken(request.QuarantineState),
+		"owner":            normalizeAWSRuntimeEventFilterToken(request.Owner),
+		"severity":         normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":           normalizeAWSRuntimeEventFilterToken(request.Status),
+		"ready_for_apply":  strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":           strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSAccessKeyQuarantinePlan, 0, len(plans))
+	for _, plan := range plans {
+		if filters["account_id"] != "" && filters["account_id"] != plan.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], plan.Region) {
+			continue
+		}
+		if filters["quarantine_state"] != "" && filters["quarantine_state"] != normalizeAWSRuntimeEventFilterToken(plan.QuarantineState) {
+			continue
+		}
+		if filters["owner"] != "" && filters["owner"] != normalizeAWSRuntimeEventFilterToken(plan.OwnerNotice.Owner) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(plan.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(plan.Status) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != plan.ReadyForApply {
+				continue
+			}
+		}
+		if filters["identity"] != "" && !awsRuntimeEventMatchesAny(filters["identity"], awsAccessKeyQuarantineIdentityValues(plan)...) {
+			continue
+		}
+		if filters["search"] != "" && !awsAccessKeyQuarantineSearchMatch(plan, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, plan)
+	}
+	return filtered, applied
+}
+
+func awsAccessKeyQuarantineIdentityValues(plan AWSAccessKeyQuarantinePlan) []string {
+	out := []string{}
+	for _, target := range append(plan.TargetAccessKeys, plan.AffectedPrincipals...) {
+		out = append(out, target.NodeID, target.Principal, target.Label, target.AccessKeyID)
+	}
+	out = append(out, plan.ImpactedNodes...)
+	for _, step := range plan.ImpactedPath {
+		out = append(out, step.NodeID, step.Label)
+	}
+	return dedupeStrings(out)
+}
+
+func awsAccessKeyQuarantineSearchMatch(plan AWSAccessKeyQuarantinePlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	haystack := []string{
+		plan.PlanID, plan.QuarantineState, plan.Status, plan.Title, plan.Summary, plan.OwnerNotice.Owner,
+		plan.DiffIntent.DiffSummary, plan.RollbackPlan.Strategy, plan.VerificationPlan.Strategy, plan.NextAction,
+	}
+	haystack = append(haystack, plan.SourceFindingIDs...)
+	haystack = append(haystack, plan.SourceSignals...)
+	haystack = append(haystack, plan.RollbackPlan.Steps...)
+	haystack = append(haystack, plan.VerificationPlan.Steps...)
+	haystack = append(haystack, plan.VerificationPlan.SuccessSignals...)
+	haystack = append(haystack, plan.VerificationPlan.FailureSignals...)
+	for _, target := range append(plan.TargetAccessKeys, plan.AffectedPrincipals...) {
+		haystack = append(haystack, target.RefType, target.AccessKeyID, target.NodeID, target.Principal, target.Label, target.MetadataRef)
+	}
+	for _, tradeoff := range plan.Tradeoffs {
+		haystack = append(haystack, tradeoff.Dimension, tradeoff.Direction, tradeoff.Description, tradeoff.Severity)
+	}
+	for _, gate := range plan.ReadinessGates {
+		haystack = append(haystack, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, step := range plan.QuarantineOrder {
+		haystack = append(haystack, step.Phase, step.Action, step.Actor)
+	}
+	for _, evidence := range plan.Evidence {
+		haystack = append(haystack, evidence.Source, evidence.EvidenceRef, evidence.Label, evidence.Relationship)
+	}
+	return strings.Contains(strings.ToLower(strings.Join(haystack, " ")), needle)
+}
+
+func awsAccessKeyQuarantineRelationships(plans []AWSAccessKeyQuarantinePlan) []AWSAccessKeyQuarantineRelationship {
+	out := []AWSAccessKeyQuarantineRelationship{}
+	for _, plan := range plans {
+		evidenceRef := firstLeastPrivilegeEvidenceRef(plan.Evidence)
+		for _, target := range plan.TargetAccessKeys {
+			to := firstNonEmptyAWSValue(target.NodeID, target.AccessKeyID, target.Label)
+			if to != "" {
+				out = append(out, AWSAccessKeyQuarantineRelationship{PlanID: plan.PlanID, Type: "quarantine_targets_access_key", FromNodeID: plan.PlanID, ToNodeID: to, EvidenceRef: evidenceRef})
+			}
+		}
+		for _, principal := range plan.AffectedPrincipals {
+			to := firstNonEmptyAWSValue(principal.NodeID, principal.Principal, principal.Label)
+			if to != "" {
+				out = append(out, AWSAccessKeyQuarantineRelationship{PlanID: plan.PlanID, Type: "quarantine_notifies_principal_owner", FromNodeID: plan.PlanID, ToNodeID: to, EvidenceRef: evidenceRef})
+			}
+		}
+	}
+	return out
+}
+
+func summarizeAWSAccessKeyQuarantinePlans(all, filtered []AWSAccessKeyQuarantinePlan, relationships []AWSAccessKeyQuarantineRelationship) AWSAccessKeyQuarantineSummary {
+	summary := AWSAccessKeyQuarantineSummary{
+		TotalPlans:            len(all),
+		FilteredPlans:         len(filtered),
+		QuarantineStateCounts: map[string]int{},
+		SeverityCounts:        map[string]int{},
+		StatusCounts:          map[string]int{},
+		RelationshipCount:     len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, plan := range filtered {
+		summary.QuarantineStateCounts[plan.QuarantineState]++
+		summary.SeverityCounts[plan.Severity]++
+		summary.StatusCounts[plan.Status]++
+		if plan.OwnerNotice.Assigned {
+			summary.OwnerAssignedCount++
+		} else {
+			summary.OwnerlessCount++
+		}
+		if plan.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		summary.AccessKeyCount += len(plan.TargetAccessKeys)
+		summary.AffectedPrincipalCount += len(plan.AffectedPrincipals)
+		if plan.Score > summary.HighestScore {
+			summary.HighestScore = plan.Score
+		}
+		confidenceTotal += plan.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func summarizeAWSAccessKeyQuarantineStatus(sourceStatus string, filtered []AWSAccessKeyQuarantinePlan, diagnostics []AWSUnusedDormantAccessDiagnostic) (string, float64) {
+	if sourceStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0
+	}
+	if len(filtered) == 0 || sourceStatus == awsPlatformDependencyStatusDegraded || len(diagnostics) > 0 {
+		return awsPlatformDependencyStatusDegraded, 0.64
+	}
+	return awsPlatformDependencyStatusReady, 0.82
+}
+
+func awsAccessKeyQuarantineCaveats(source []string) []string {
+	return dedupeStrings(append(source, "This planner never disables IAM access keys; it emits owner-notice, grace-period, rollback, and verification metadata only."))
+}
+
+func awsAccessKeyQuarantineRemediationHints(source []string) []string {
+	return emptyStrings(dedupeStrings(append(source, "Use these plans to coordinate owner-approved DisableAccessKey execution outside Identrail, then link dry-run/apply/verify evidence to the remediation case.")))
+}
+
+func awsAccessKeyQuarantineCoverageGaps(source []AWSUnusedDormantAccessCoverageGap) []AWSAccessKeyQuarantineCoverageGap {
+	out := []AWSAccessKeyQuarantineCoverageGap{{
+		Capability:  "access_key_quarantine_execution",
+		Status:      "planned",
+		Reason:      "This issue emits non-mutating quarantine plans only; live DisableAccessKey execution is intentionally out of scope.",
+		Remediation: "Use approved remediation/governance executors in a later wave to perform live IAM mutation.",
+	}}
+	for _, gap := range source {
+		out = append(out, AWSAccessKeyQuarantineCoverageGap(gap))
+	}
+	return out
+}
+
+func awsAccessKeyQuarantineDiagnostics(source []AWSUnusedDormantAccessDiagnostic) []AWSAccessKeyQuarantineDiagnostic {
+	out := make([]AWSAccessKeyQuarantineDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSAccessKeyQuarantineDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsAccessKeyQuarantineEvidenceBoundary() string {
+	return "metadata-only: access key IDs, IAM last-used/runtime refs, owner labels, and remediation case refs; no secret access key material, customer payloads, rendered policies, prompts, completions, database rows, or object contents."
+}
+
+func firstNonZeroAWSAccessKeyQuarantineTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_access_key_quarantine_test.go
+++ b/internal/api/aws_access_key_quarantine_test.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAccessKeyQuarantineService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestAWSAccessKeyQuarantinePlanFromFindingBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 25, 9, 30, 0, 0, time.UTC)
+	accessKeyID := "AKIA" + "ORDERS123456"
+	finding := AWSUnusedDormantAccessFinding{
+		FindingID:      "aws-unused-dormant-access:orders-key",
+		DormancyState:  "stale",
+		Severity:       "high",
+		Status:         "cleanup_candidate",
+		Score:          82,
+		Confidence:     0.86,
+		AccountID:      "123456789012",
+		Region:         "us-east-1",
+		IdentityNodeID: "aws:identity:user/orders-ci",
+		PrincipalARN:   "arn:aws:iam::123456789012:user/orders-ci",
+		ResourceNodeID: "aws:iam-access-key:" + accessKeyID,
+		DisplayName:    accessKeyID,
+		OwnerContext:   "orders-platform",
+		Rationale:      "IAM last-used reports stale access key activity.",
+		LastUsedAt:     now.Add(-100 * 24 * time.Hour),
+		DormantDays:    100,
+		CandidateActions: []string{
+			"iam:DisableAccessKey",
+		},
+		ImpactedNodes: []string{"aws:iam-access-key:" + accessKeyID, "aws:identity:user/orders-ci"},
+		Evidence: []AWSUnusedDormantAccessEvidence{{
+			Source:       "iam_last_used",
+			EvidenceRef:  "runtime-evidence://access-key/" + accessKeyID,
+			Label:        accessKeyID,
+			Confidence:   0.86,
+			ObservedAt:   now.Add(-100 * 24 * time.Hour),
+			Relationship: "stale_access_key",
+		}},
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now,
+	}
+
+	plan := awsAccessKeyQuarantinePlanFromFinding(finding, now)
+	if plan.PlanID == "" || plan.CalculationVersion != awsAccessKeyQuarantineVersion {
+		t.Fatalf("plan missing stable metadata: %+v", plan)
+	}
+	if plan.QuarantineState != "quarantine_candidate" || plan.Status != "ready_for_quarantine" || !plan.ReadyForApply {
+		t.Fatalf("expected ready quarantine candidate: %+v", plan)
+	}
+	if plan.OwnerNotice.Owner != "orders-platform" || !plan.OwnerNotice.Assigned || plan.GracePeriodDays != 7 {
+		t.Fatalf("expected owner notice and grace period: %+v", plan.OwnerNotice)
+	}
+	if len(plan.TargetAccessKeys) != 1 || plan.TargetAccessKeys[0].AccessKeyID != accessKeyID {
+		t.Fatalf("expected access key target: %+v", plan.TargetAccessKeys)
+	}
+	if !plan.ReadOnlyProjection || !plan.DiffIntent.ReadOnlyProjection || plan.DiffIntent.Kind != "access_key_quarantine" {
+		t.Fatalf("plan must remain read-only with quarantine diff intent: %+v", plan.DiffIntent)
+	}
+	if len(plan.QuarantineOrder) != 5 || plan.RollbackPlan.Strategy == "" || plan.VerificationPlan.Strategy == "" {
+		t.Fatalf("plan missing order, rollback, or verification: %+v", plan)
+	}
+	serialized, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"secret_key\"", "\"access_key_secret\"", "\"private_key\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("plan serialized forbidden sensitive payload marker %q: %s", forbidden, lower)
+		}
+	}
+}
+
+func TestGetAWSAccessKeyQuarantinePlansBuildsAndFilters(t *testing.T) {
+	now := time.Date(2026, 6, 25, 9, 35, 0, 0, time.UTC)
+	svc, ws := newAccessKeyQuarantineService(t, "project-access-key-quarantine", now)
+
+	result, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine", AWSAccessKeyQuarantineRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get access key quarantine plans: %v", err)
+	}
+	if result.CurrentIssueRef != "#1534" || result.Version != awsAccessKeyQuarantineVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Plans) == 0 {
+		t.Fatalf("expected success fixture to produce access key quarantine plans: %+v", result)
+	}
+	if result.Summary.TotalPlans != len(result.Plans) || len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected summary/caveats/gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Plans); i++ {
+		if result.Plans[i-1].Score < result.Plans[i].Score {
+			t.Fatalf("plans are not ranked by descending score: %+v", result.Plans)
+		}
+	}
+
+	filtered, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine", AWSAccessKeyQuarantineRequest{
+		ConnectorID:     "aws-prod",
+		FixtureState:    "success",
+		QuarantineState: "quarantine_candidate",
+		Search:          "quarantine_re_evaluate",
+	})
+	if err != nil {
+		t.Fatalf("filtered access key quarantine plans: %v", err)
+	}
+	if filtered.AppliedFilters["quarantine_state"] != "quarantine-candidate" || filtered.AppliedFilters["search"] != "quarantine_re_evaluate" {
+		t.Fatalf("expected applied filters, got %+v", filtered.AppliedFilters)
+	}
+	for _, plan := range filtered.Plans {
+		if plan.QuarantineState != "quarantine_candidate" || !awsAccessKeyQuarantineSearchMatch(plan, "quarantine_re_evaluate") {
+			t.Fatalf("filter leaked plan: %+v", plan)
+		}
+	}
+
+	accessKeyID := "AKIA" + "ORDERS123456"
+	keyFiltered, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine", AWSAccessKeyQuarantineRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     accessKeyID,
+	})
+	if err != nil {
+		t.Fatalf("access key identity filter: %v", err)
+	}
+	if len(keyFiltered.Plans) == 0 {
+		t.Fatalf("expected identity access key filter to match target key plans: %+v", keyFiltered)
+	}
+	for _, plan := range keyFiltered.Plans {
+		if !awsRuntimeEventMatchesAny(accessKeyID, awsAccessKeyQuarantineIdentityValues(plan)...) {
+			t.Fatalf("access key identity filter leaked non-matching plan: %+v", plan)
+		}
+	}
+}
+
+func TestFilterAWSAccessKeyQuarantinePlansNormalizesReadyForApplyAliases(t *testing.T) {
+	plans := []AWSAccessKeyQuarantinePlan{
+		{
+			PlanID:          "ready",
+			AccountID:       "123456789012",
+			Region:          "us-east-1",
+			QuarantineState: "quarantine_candidate",
+			OwnerNotice:     AWSAccessKeyQuarantineOwnerNotice{Owner: "orders-platform"},
+			ReadyForApply:   true,
+		},
+		{
+			PlanID:          "not-ready",
+			AccountID:       "123456789012",
+			Region:          "us-east-1",
+			QuarantineState: "needs_review",
+			OwnerNotice:     AWSAccessKeyQuarantineOwnerNotice{Owner: "security-review"},
+			ReadyForApply:   false,
+		},
+	}
+
+	ready, readyApplied := filterAWSAccessKeyQuarantinePlans(plans, AWSAccessKeyQuarantineRequest{ReadyForApply: "yes"})
+	if readyApplied["ready_for_apply"] != "yes" || len(ready) != 1 || ready[0].PlanID != "ready" {
+		t.Fatalf("expected ready_for_apply=yes to match ready plans, got applied=%+v plans=%+v", readyApplied, ready)
+	}
+
+	notReady, notReadyApplied := filterAWSAccessKeyQuarantinePlans(plans, AWSAccessKeyQuarantineRequest{ReadyForApply: "no"})
+	if notReadyApplied["ready_for_apply"] != "no" || len(notReady) != 1 || notReady[0].PlanID != "not-ready" {
+		t.Fatalf("expected ready_for_apply=no to match non-ready plans, got applied=%+v plans=%+v", notReadyApplied, notReady)
+	}
+}
+
+func TestAWSAccessKeyQuarantineAccessKeyIDCanonicalizesCasing(t *testing.T) {
+	accessKeyID := "AKIA" + "ORDERS123456"
+	lowerAccessKeyID := strings.ToLower(accessKeyID)
+	finding := AWSUnusedDormantAccessFinding{
+		PolicyScope: lowerAccessKeyID + ":*",
+		Evidence: []AWSUnusedDormantAccessEvidence{{
+			EvidenceRef: "runtime-evidence://access-key/" + lowerAccessKeyID,
+			Label:       lowerAccessKeyID,
+		}},
+	}
+
+	if got := awsAccessKeyQuarantineAccessKeyID(finding); got != accessKeyID {
+		t.Fatalf("expected canonical uppercase access key id, got %q", got)
+	}
+}
+
+func TestGetAWSAccessKeyQuarantinePlansFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 25, 9, 40, 0, 0, time.UTC)
+	svc, ws := newAccessKeyQuarantineService(t, "project-access-key-quarantine-states", now)
+
+	denied, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine-states", AWSAccessKeyQuarantineRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Plans) != 0 || len(denied.Diagnostics) == 0 {
+		t.Fatalf("permission denied must be explicit and suppress plans: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine-states", AWSAccessKeyQuarantineRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Summary.TotalPlans != 0 || empty.Status == "blocked" {
+		t.Fatalf("empty fixture should produce no non-blocked plans: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSAccessKeyQuarantinePlans(defaultScopeContext(), ws, "project-access-key-quarantine-states", AWSAccessKeyQuarantineRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSAccessKeyQuarantine(t *testing.T) {
+	now := time.Date(2026, 6, 25, 9, 45, 0, 0, time.UTC)
+	svc, _ := newAccessKeyQuarantineService(t, "project-access-key-quarantine-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-access-key-quarantine-route/aws/access-key-quarantine?connector_id=aws-prod&fixture_state=success&quarantine_state=quarantine_candidate", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plans AWSAccessKeyQuarantineResult `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Plans.CurrentIssueRef != "#1534" || body.Plans.AppliedFilters["quarantine_state"] != "quarantine-candidate" {
+		t.Fatalf("unexpected route payload: %+v", body.Plans)
+	}
+}

--- a/internal/api/aws_access_key_quarantine_test.go
+++ b/internal/api/aws_access_key_quarantine_test.go
@@ -193,6 +193,52 @@ func TestAWSAccessKeyQuarantineAccessKeyIDCanonicalizesCasing(t *testing.T) {
 	}
 }
 
+func TestAWSAccessKeyQuarantinePlansRequireLongLivedIAMAccessKey(t *testing.T) {
+	now := time.Date(2026, 6, 25, 9, 38, 0, 0, time.UTC)
+	sessionKeyID := "ASIA" + "SESSION123456"
+	findings := []AWSUnusedDormantAccessFinding{
+		{
+			FindingID:     "aws-unused-dormant-access:sts-session-key",
+			DormancyState: "stale",
+			Status:        "cleanup_candidate",
+			Confidence:    0.9,
+			DisplayName:   sessionKeyID,
+			PolicyScope:   sessionKeyID + ":*",
+			OwnerContext:  "orders-platform",
+			Evidence: []AWSUnusedDormantAccessEvidence{{
+				Source:      "cloudtrail",
+				EvidenceRef: "runtime-evidence://session-key/" + sessionKeyID,
+				Label:       sessionKeyID,
+			}},
+		},
+		{
+			FindingID:      "aws-unused-dormant-access:shakia-user",
+			DormancyState:  "stale",
+			Status:         "cleanup_candidate",
+			Confidence:     0.9,
+			DisplayName:    "shakia-ci",
+			IdentityNodeID: "aws:identity:user/shakia-ci",
+			ResourceNodeID: "aws:identity:user/shakia-ci",
+			OwnerContext:   "orders-platform",
+			CandidateActions: []string{
+				"iam:DisableAccessKey",
+			},
+			Evidence: []AWSUnusedDormantAccessEvidence{{
+				Source:      "iam_last_used",
+				EvidenceRef: "runtime-evidence://principal/shakia-ci",
+				Label:       "shakia-ci",
+			}},
+		},
+	}
+
+	if got := awsAccessKeyQuarantineAccessKeyID(findings[0]); got != "" {
+		t.Fatalf("STS session key must not be treated as an IAM access key, got %q", got)
+	}
+	if plans := awsAccessKeyQuarantinePlansFromDormant(findings, now); len(plans) != 0 {
+		t.Fatalf("expected non-IAM-key findings to be excluded from quarantine plans: %+v", plans)
+	}
+}
+
 func TestGetAWSAccessKeyQuarantinePlansFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 25, 9, 40, 0, 0, time.UTC)
 	svc, ws := newAccessKeyQuarantineService(t, "project-access-key-quarantine-states", now)

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -523,6 +523,9 @@ func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventReco
 		if normalizeAWSRuntimeEventFilterToken(record.Status) != "stale" {
 			return AWSLeastPrivilegeRecommendation{}, false
 		}
+		if normalizeAWSRuntimeEventFilterToken(record.TargetResourceType) == "iam-access-key" || normalizeAWSRuntimeEventFilterToken(record.SignalScope) == "access-key" {
+			return AWSLeastPrivilegeRecommendation{}, false
+		}
 		service := normalizeAWSRuntimeEventFilterToken(firstNonEmptyAWSValue(record.TargetResourceName, serviceFromAWSAction(record.Action), record.EventSource))
 		action := awsLeastPrivilegeServiceAction(service)
 		evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, fmt.Sprintf("runtime-evidence://%s", record.EventID))

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -214,6 +214,35 @@ func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalDowngradesLowConfidence
 	}
 }
 
+func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalSkipsAccessKeyLastUsed(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 26, 0, 0, time.UTC)
+	accessKeyID := "AKIA" + "ORDERS123456"
+	record := AWSRuntimeEventRecord{
+		EventID:             "evt-iam-last-used-access-key",
+		AccountID:           "111111111111",
+		Region:              "us-east-1",
+		EventType:           "iam-last-used",
+		EventSource:         "iam.amazonaws.com",
+		EventName:           "AccessKeyLastUsed",
+		Action:              "iam:AccessKeyLastUsed",
+		ActorPrincipalARN:   "arn:aws:iam::111111111111:user/orders-ci",
+		ActorIdentityNodeID: "aws:identity:user/orders-ci",
+		TargetResourceName:  accessKeyID,
+		TargetResourceType:  "iam_access_key",
+		ResourceNodeID:      "aws:iam-access-key:" + accessKeyID,
+		SignalCategory:      "iam-last-used",
+		EvidenceRef:         "runtime-evidence://access-key/" + accessKeyID,
+		Confidence:          0.86,
+		ObservedAt:          now.Add(-120 * 24 * time.Hour),
+		Status:              "stale",
+		SignalScope:         "access-key",
+	}
+
+	if recommendation, ok := awsLeastPrivilegeRecommendationFromRuntimeSignal(record, now); ok {
+		t.Fatalf("access-key last-used signals must stay out of service-action diffs: %+v", recommendation)
+	}
+}
+
 func TestGetAWSLeastPrivilegePermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 20, 8, 30, 0, 0, time.UTC)
 	svc, ws := newLeastPrivilegeService(t, "project-least-privilege-states", now)

--- a/internal/api/aws_runtime_cloudtrail_test.go
+++ b/internal/api/aws_runtime_cloudtrail_test.go
@@ -422,6 +422,65 @@ func TestGetAWSRuntimeEventsFactoryErrorAttachesDiagnosticAndFallsBackToFixture(
 	}
 }
 
+func TestGetAWSRuntimeEventsAppendsSignalsWhenCloudTrailFactoryFailsAndFixturesSuppressed(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 6, 14, 20, 5, 0, 0, time.UTC)
+	seedDefaultProject(t, store, ctx, "project-runtime-factory-error-signals")
+	seedAWSConnectorForScanTest(t, store, ctx, "project-runtime-factory-error-signals", "aws-prod", domain.ConnectorStatusActive, "healthy", now)
+	grantRuntimeEvidenceCapability(t, store, ctx, "project-runtime-factory-error-signals", "aws-prod")
+
+	accessKeyID := "AKIA" + "ORDERS123456"
+	signals := &fakeRuntimeSignalIngester{result: AWSRuntimeSignalIngestResult{
+		Status: "ready",
+		Records: []AWSRuntimeEventRecord{{
+			EventID:             "iam-access-key-last-used:" + strings.ToLower(accessKeyID),
+			AccountID:           "123456789012",
+			Region:              "us-east-1",
+			EventType:           "iam-last-used",
+			EventSource:         "iam.amazonaws.com",
+			EventName:           "AccessKeyLastUsed",
+			Action:              "iam:AccessKeyLastUsed",
+			ActorPrincipalARN:   "arn:aws:iam::123456789012:user/orders-ci",
+			ActorIdentityNodeID: "aws:identity:user/orders-ci",
+			TargetResourceARN:   "aws:iam-access-key:" + accessKeyID,
+			TargetResourceType:  "iam_access_key",
+			TargetResourceName:  accessKeyID,
+			ResourceNodeID:      "aws:iam-access-key:" + accessKeyID,
+			SignalCategory:      "iam-last-used",
+			SignalScope:         "access-key",
+			EvidenceRef:         "runtime-evidence://access-key/" + accessKeyID,
+			Confidence:          0.86,
+			ObservedAt:          now.Add(-100 * 24 * time.Hour),
+			CollectedAt:         now,
+			Status:              "stale",
+		}},
+	}}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.AWSCloudTrailLookupEventsFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSCloudTrailRuntimeEventIngester, error) {
+		return nil, errors.New("lookup events unavailable")
+	}
+	svc.AWSRuntimeSignalFactory = func(_ context.Context, _ AWSConnectionStatus) (AWSRuntimeSignalIngester, error) {
+		return signals, nil
+	}
+
+	result, err := svc.GetAWSRuntimeEvents(ctx, "default", "project-runtime-factory-error-signals", AWSRuntimeEventRequest{
+		ConnectorID:            "aws-prod",
+		EventType:              "iam-last-used",
+		SuppressFixtureRecords: true,
+	})
+	if err != nil {
+		t.Fatalf("get runtime events: %v", err)
+	}
+	if len(result.Records) != 1 || result.Records[0].EventID != "iam-access-key-last-used:"+strings.ToLower(accessKeyID) {
+		t.Fatalf("expected live IAM access-key signal without fixture records, got %+v", result.Records)
+	}
+	if len(signals.calls) != 1 {
+		t.Fatalf("expected IAM signal ingester to run after CloudTrail factory failure, got %d calls", len(signals.calls))
+	}
+}
+
 func TestRuntimeEventRecordFromNormalizedUsesCanonicalAgentNodeID(t *testing.T) {
 	// The runtime evidence graph must key agent nodes on the same
 	// shape (aws:agent:<account>:<region>:<type>/<id>) the

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -275,7 +275,7 @@ func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, p
 			result.FailureReasons = dedupeStrings(append(result.FailureReasons, "CloudTrail LookupEvents ingester is not available for this connector"))
 			result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Confirm the CloudTrail role grants metadata-only cloudtrail:LookupEvents and retry."))
 		}
-		return result, nil
+		return s.appendAWSRuntimeSignals(ctx, scope, project, connection, result, request, now)
 	}
 	// Capability-gated fallback: when a factory is wired and the
 	// connector is otherwise live but the connector's effective
@@ -321,7 +321,11 @@ func (s *Service) GetAWSRuntimeEvents(ctx context.Context, workspaceID string, p
 		result.RemediationHints = dedupeStrings(append(result.RemediationHints, "Grant the runtime_evidence connector capability and confirm the AWS role policy allows cloudtrail:LookupEvents."))
 		return result, nil
 	}
-	return buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, now)
+	result, err := buildAWSRuntimeEvents(scope, project, connection, hasConnection, request, now)
+	if err != nil {
+		return result, err
+	}
+	return s.appendAWSRuntimeSignals(ctx, scope, project, connection, result, request, now)
 }
 
 // awsConnectorHasRuntimeEvidence reports whether the connector's

--- a/internal/api/aws_runtime_events.go
+++ b/internal/api/aws_runtime_events.go
@@ -833,6 +833,8 @@ func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState
 	role := fmt.Sprintf("arn:aws:iam::%s:role/identrail-runtime-reader", accountID)
 	lambdaRole := fmt.Sprintf("arn:aws:iam::%s:role/lambda-invoice-agent", accountID)
 	agentRole := fmt.Sprintf("arn:aws:iam::%s:role/agentcore-case-triage-runtime", accountID)
+	ciUser := fmt.Sprintf("arn:aws:iam::%s:user/orders-ci", accountID)
+	accessKeyID := "AKIA" + "ORDERS123456"
 	session := func(id string, principal string, started time.Time) AWSRuntimeEventSession {
 		sourceIdentity := "identrail-fixture"
 		lineageStatus := "resolved"
@@ -869,6 +871,7 @@ func awsRuntimeEventFixtureRecords(accountID string, region string, fixtureState
 		awsRuntimeEventFixtureRecord(accountID, region, "evt-s3-access", "api-call", "s3.amazonaws.com", "GetObject", "s3:GetObject", lambdaRole, fmt.Sprintf("arn:aws:s3:::billing-artifacts-%s/reports/redacted", accountID), "s3_object_metadata", "application", "cloudtrail", base.Add(14*time.Minute), session("sess-invoice-agent", lambdaRole, base.Add(6*time.Minute))),
 		awsRuntimeEventFixtureRecord(accountID, region, "evt-agent-tool", "agent-tool", "bedrock-agentcore.amazonaws.com", "InvokeTool", "bedrock-agentcore:InvokeTool", agentRole, fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:agent-runtime-endpoint/runtime-case-triage/blue", region, accountID), "agent_tool_target", "security", "agent-runtime", base.Add(19*time.Minute), session("sess-agentcore-runtime", agentRole, base.Add(18*time.Minute))),
 		awsRuntimeSignalFixtureRecord(accountID, region, "evt-iam-last-used-lambda", "iam-last-used", "iam.amazonaws.com", "ServiceLastAccessed", "lambda:LastAuthenticated", lambdaRole, "aws-service://lambda", "aws_service", "Lambda", "iam-last-used", checkedAt.Add(-120*24*time.Hour), base.Add(34*time.Minute), "stale", 0.78, "service", ""),
+		awsRuntimeSignalFixtureRecord(accountID, region, "evt-iam-last-used-access-key", "iam-last-used", "iam.amazonaws.com", "AccessKeyLastUsed", "iam:AccessKeyLastUsed", ciUser, "aws:iam-access-key:"+accessKeyID, "iam_access_key", accessKeyID, "iam-last-used", checkedAt.Add(-100*24*time.Hour), base.Add(35*time.Minute), "stale", 0.86, "role", ""),
 		awsRuntimeSignalFixtureRecord(accountID, region, "evt-access-analyzer-open-secret", "access-analyzer", "access-analyzer.amazonaws.com", "Finding", "secretsmanager:GetSecretValue", "access-analyzer:external-principal", fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:prod/ai/openai-key", region, accountID), "AWS::SecretsManager::Secret", "prod/ai/openai-key", "access-analyzer", base.Add(24*time.Minute), base.Add(33*time.Minute), "observed", 0.9, "account", fmt.Sprintf("arn:aws:access-analyzer:%s:%s:analyzer/identrail-fixture", region, accountID)),
 	}
 	records[4].AgentID = "runtime-case-triage"

--- a/internal/api/aws_runtime_events_test.go
+++ b/internal/api/aws_runtime_events_test.go
@@ -29,13 +29,13 @@ func TestGetAWSRuntimeEventsBuildsMetadataOnlyContract(t *testing.T) {
 	if result.CurrentIssueRef != "#1517" || result.Version != awsRuntimeEventsVersion || result.Status != "ready" {
 		t.Fatalf("unexpected runtime event contract metadata: %+v", result)
 	}
-	if result.Summary.TotalEvents != 7 || result.Summary.FilteredEvents != 7 || result.Summary.RelationshipCount != len(result.Relationships) {
+	if result.Summary.TotalEvents != 8 || result.Summary.FilteredEvents != 8 || result.Summary.RelationshipCount != len(result.Relationships) {
 		t.Fatalf("unexpected runtime event summary: %+v relationships=%d", result.Summary, len(result.Relationships))
 	}
-	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 || result.Summary.IAMLastUsedSignalCount != 1 || result.Summary.AccessAnalyzerCount != 1 {
+	if result.Summary.SecretReadCount != 1 || result.Summary.KMSDecryptCount != 1 || result.Summary.AgentEventCount != 1 || result.Summary.STSSessionCount == 0 || result.Summary.IAMLastUsedSignalCount != 2 || result.Summary.AccessAnalyzerCount != 1 {
 		t.Fatalf("expected runtime event type counts, got %+v", result.Summary)
 	}
-	if result.Summary.DormantAccessCount != 1 {
+	if result.Summary.DormantAccessCount != 2 {
 		t.Fatalf("expected dormant access count from stale IAM last-used signal, got %+v", result.Summary)
 	}
 	if result.Summary.LineageResolvedCount == 0 || result.Summary.MissingSourceIDCount == 0 {
@@ -77,6 +77,7 @@ func TestGetAWSRuntimeEventsFiltersIAMAccessSignals(t *testing.T) {
 		wantSignal    string
 		wantAnalyzer  bool
 		wantEventType string
+		wantFiltered  int
 	}{
 		{
 			name:          "iam last-used",
@@ -84,6 +85,7 @@ func TestGetAWSRuntimeEventsFiltersIAMAccessSignals(t *testing.T) {
 			evidence:      "iam-last-used",
 			wantSignal:    "iam-last-used",
 			wantEventType: "iam-last-used",
+			wantFiltered:  2,
 		},
 		{
 			name:          "access analyzer",
@@ -92,6 +94,7 @@ func TestGetAWSRuntimeEventsFiltersIAMAccessSignals(t *testing.T) {
 			wantSignal:    "access-analyzer",
 			wantAnalyzer:  true,
 			wantEventType: "access-analyzer",
+			wantFiltered:  1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,18 +106,19 @@ func TestGetAWSRuntimeEventsFiltersIAMAccessSignals(t *testing.T) {
 			if err != nil {
 				t.Fatalf("get filtered signal runtime events: %v", err)
 			}
-			if result.Summary.TotalEvents != 7 || result.Summary.FilteredEvents != 1 || len(result.Records) != 1 {
+			if result.Summary.TotalEvents != 8 || result.Summary.FilteredEvents != tc.wantFiltered || len(result.Records) != tc.wantFiltered {
 				t.Fatalf("expected one filtered signal with retained total count, got summary=%+v records=%+v", result.Summary, result.Records)
 			}
-			record := result.Records[0]
-			if record.EventType != tc.wantEventType || record.SignalCategory != tc.wantSignal || record.EvidenceCategory != tc.evidence {
-				t.Fatalf("expected filtered signal metadata, got %+v", record)
-			}
-			if record.SignalStaleAt.IsZero() || record.SignalScope == "" {
-				t.Fatalf("expected signal stale timestamp and scope, got %+v", record)
-			}
-			if tc.wantAnalyzer && record.AnalyzerARN == "" {
-				t.Fatalf("expected analyzer ARN, got %+v", record)
+			for _, record := range result.Records {
+				if record.EventType != tc.wantEventType || record.SignalCategory != tc.wantSignal || record.EvidenceCategory != tc.evidence {
+					t.Fatalf("expected filtered signal metadata, got %+v", record)
+				}
+				if record.SignalStaleAt.IsZero() || record.SignalScope == "" {
+					t.Fatalf("expected signal stale timestamp and scope, got %+v", record)
+				}
+				if tc.wantAnalyzer && record.AnalyzerARN == "" {
+					t.Fatalf("expected analyzer ARN, got %+v", record)
+				}
 			}
 		})
 	}

--- a/internal/api/aws_unused_dormant_access.go
+++ b/internal/api/aws_unused_dormant_access.go
@@ -150,11 +150,12 @@ func (s *Service) GetAWSUnusedDormantAccessFindings(ctx context.Context, workspa
 
 	findings := awsUnusedDormantFindingsFromRecommendations(leastPrivilege.Recommendations, leastPrivilege.GeneratedAt)
 	accessKeySignals, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
-		ConnectorID:  request.ConnectorID,
-		FixtureState: request.FixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		EventType:    "iam-last-used",
+		ConnectorID:            request.ConnectorID,
+		FixtureState:           request.FixtureState,
+		AccountID:              request.AccountID,
+		Region:                 request.Region,
+		EventType:              "iam-last-used",
+		SuppressFixtureRecords: awsUnusedDormantSuppressAccessKeyFixtures(request, leastPrivilege),
 	})
 	if err != nil {
 		return AWSUnusedDormantAccessResult{}, err
@@ -213,6 +214,10 @@ func awsUnusedDormantFindingsFromRecommendations(recommendations []AWSLeastPrivi
 		findings = append(findings, awsUnusedDormantFindingFromRecommendation(recommendation, now))
 	}
 	return findings
+}
+
+func awsUnusedDormantSuppressAccessKeyFixtures(request AWSUnusedDormantAccessRequest, leastPrivilege AWSLeastPrivilegeResult) bool {
+	return strings.TrimSpace(request.FixtureState) == "" && strings.TrimSpace(leastPrivilege.FixtureState) == ""
 }
 
 func awsUnusedDormantFindingsFromAccessKeySignals(records []AWSRuntimeEventRecord, now time.Time) []AWSUnusedDormantAccessFinding {

--- a/internal/api/aws_unused_dormant_access.go
+++ b/internal/api/aws_unused_dormant_access.go
@@ -149,6 +149,17 @@ func (s *Service) GetAWSUnusedDormantAccessFindings(ctx context.Context, workspa
 	}
 
 	findings := awsUnusedDormantFindingsFromRecommendations(leastPrivilege.Recommendations, leastPrivilege.GeneratedAt)
+	accessKeySignals, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:  request.ConnectorID,
+		FixtureState: request.FixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		EventType:    "iam-last-used",
+	})
+	if err != nil {
+		return AWSUnusedDormantAccessResult{}, err
+	}
+	findings = append(findings, awsUnusedDormantFindingsFromAccessKeySignals(accessKeySignals.Records, accessKeySignals.GeneratedAt)...)
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Score == findings[j].Score {
 			return findings[i].FindingID < findings[j].FindingID
@@ -202,6 +213,104 @@ func awsUnusedDormantFindingsFromRecommendations(recommendations []AWSLeastPrivi
 		findings = append(findings, awsUnusedDormantFindingFromRecommendation(recommendation, now))
 	}
 	return findings
+}
+
+func awsUnusedDormantFindingsFromAccessKeySignals(records []AWSRuntimeEventRecord, now time.Time) []AWSUnusedDormantAccessFinding {
+	findings := []AWSUnusedDormantAccessFinding{}
+	for _, record := range records {
+		if normalizeAWSRuntimeEventFilterToken(record.SignalCategory) != "iam-last-used" || normalizeAWSRuntimeEventFilterToken(record.TargetResourceType) != "iam-access-key" {
+			continue
+		}
+		if normalizeAWSRuntimeEventFilterToken(record.Status) != "stale" && normalizeAWSRuntimeEventFilterToken(record.Status) != "never-used" {
+			continue
+		}
+		accessKeyID := awsAccessKeyIDFromRuntimeRecord(record)
+		if accessKeyID == "" {
+			continue
+		}
+		observedAt := record.ObservedAt
+		dormantDays := 0
+		if !observedAt.IsZero() {
+			dormantDays = int(now.Sub(observedAt).Hours() / 24)
+			if dormantDays < 0 {
+				dormantDays = 0
+			}
+		}
+		state := "stale"
+		if normalizeAWSRuntimeEventFilterToken(record.Status) == "never-used" {
+			state = "never_used"
+		}
+		evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, "runtime-evidence://access-key/"+accessKeyID)
+		findings = append(findings, AWSUnusedDormantAccessFinding{
+			FindingID:          "aws-unused-dormant-access:" + stableAWSBlastRadiusToken(record.EventID, accessKeyID, state),
+			CalculationVersion: awsUnusedDormantAccessVersion,
+			FindingType:        "dormant_access",
+			DormancyState:      state,
+			Severity:           "high",
+			Status:             "cleanup_candidate",
+			Score:              82,
+			Confidence:         record.Confidence,
+			AccountID:          record.AccountID,
+			Region:             record.Region,
+			Service:            "iam",
+			IdentityNodeID:     record.ActorIdentityNodeID,
+			PrincipalARN:       record.ActorPrincipalARN,
+			ResourceNodeID:     firstNonEmptyAWSValue(record.ResourceNodeID, "aws:iam-access-key:"+accessKeyID),
+			ResourceARN:        record.TargetResourceARN,
+			DisplayName:        accessKeyID,
+			OwnerContext:       "identity-owner-review",
+			PolicyScope:        accessKeyID + ":*",
+			Rationale:          "IAM access-key last-used metadata reports stale key activity and needs owner confirmation before quarantine.",
+			LastUsedAt:         observedAt,
+			DormantDays:        dormantDays,
+			ScanWindowDays:     awsUnusedDormantScanWindowDays(state, dormantDays),
+			CandidateActions:   []string{"iam:DisableAccessKey"},
+			ObservedActions:    []string{record.Action},
+			GrantedActions:     []string{"iam:DisableAccessKey"},
+			ImpactedNodes:      dedupeStrings([]string{firstNonEmptyAWSValue(record.ResourceNodeID, "aws:iam-access-key:"+accessKeyID), record.ActorIdentityNodeID, record.ActorPrincipalARN}),
+			ImpactedPath: []AWSUnusedDormantAccessPathStep{
+				awsLeastPrivilegePathStep(record.ActorIdentityNodeID, "identity", firstNonEmptyAWSValue(shortAWSARN(record.ActorPrincipalARN), record.ActorIdentityNodeID), record.AccountID, record.Region),
+				awsLeastPrivilegePathStep(firstNonEmptyAWSValue(record.ResourceNodeID, "aws:iam-access-key:"+accessKeyID), "iam_access_key", accessKeyID, record.AccountID, record.Region),
+			},
+			Evidence: []AWSUnusedDormantAccessEvidence{{
+				Source:       "iam_last_used",
+				EvidenceRef:  evidenceRef,
+				Label:        accessKeyID,
+				Confidence:   record.Confidence,
+				ObservedAt:   observedAt,
+				Relationship: "stale_access_key",
+			}},
+			NextAction: "Ask the key owner to confirm whether stale access is still required before planning quarantine.",
+			RemediationCase: AWSUnusedDormantAccessRemediationCasePreview{
+				CaseID:             "aws-unused-dormant-preview:" + stableAWSBlastRadiusToken(record.EventID, accessKeyID, state),
+				Title:              "Stale access-key quarantine review",
+				RecommendedAction:  "Create a read-only case to coordinate owner-approved access-key quarantine.",
+				ApprovalRequired:   true,
+				BlockingEvidence:   []string{evidenceRef},
+				ImpactedNodeCount:  2,
+				EstimatedRiskDrop:  68,
+				BreakagePrediction: "low",
+				ReadOnlyProjection: true,
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+	}
+	return findings
+}
+
+func awsAccessKeyIDFromRuntimeRecord(record AWSRuntimeEventRecord) string {
+	for _, candidate := range []string{record.TargetResourceName, record.ResourceNodeID, record.TargetResourceARN, record.EvidenceRef} {
+		for _, token := range strings.FieldsFunc(candidate, func(r rune) bool {
+			return r == '/' || r == ':' || r == '|' || r == ' ' || r == ',' || r == ';'
+		}) {
+			normalized := strings.ToUpper(strings.TrimSpace(token))
+			if strings.HasPrefix(normalized, "AKIA") {
+				return normalized
+			}
+		}
+	}
+	return ""
 }
 
 func awsUnusedDormantRecommendationQualifies(recommendation AWSLeastPrivilegeRecommendation) bool {

--- a/internal/api/aws_unused_dormant_access_test.go
+++ b/internal/api/aws_unused_dormant_access_test.go
@@ -132,6 +132,29 @@ func TestAWSUnusedDormantAccessQualificationSkipsActiveReviewSignals(t *testing.
 	}
 }
 
+func TestAWSUnusedDormantAccessSuppressesAccessKeyFixturesOnlyForLiveLookups(t *testing.T) {
+	live := awsUnusedDormantSuppressAccessKeyFixtures(AWSUnusedDormantAccessRequest{}, AWSLeastPrivilegeResult{})
+	if !live {
+		t.Fatal("expected live dormant access lookups to suppress fallback runtime fixtures")
+	}
+
+	explicitFixture := awsUnusedDormantSuppressAccessKeyFixtures(
+		AWSUnusedDormantAccessRequest{FixtureState: "success"},
+		AWSLeastPrivilegeResult{FixtureState: "success"},
+	)
+	if explicitFixture {
+		t.Fatal("explicit fixture_state requests must keep deterministic fixture access-key evidence")
+	}
+
+	sourceFixture := awsUnusedDormantSuppressAccessKeyFixtures(
+		AWSUnusedDormantAccessRequest{},
+		AWSLeastPrivilegeResult{FixtureState: "permission_denied"},
+	)
+	if sourceFixture {
+		t.Fatal("non-live least-privilege source states must not force runtime fixture suppression")
+	}
+}
+
 func TestGetAWSUnusedDormantAccessPermissionDeniedAndEmptyStatesAreExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 20, 9, 20, 0, 0, time.UTC)
 	svc, ws := newLeastPrivilegeService(t, "project-unused-dormant-states", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3238,6 +3238,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAccessKeyQuarantinePlans(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAccessKeyQuarantineRequest{
+			ConnectorID:     strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:    strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:       strings.TrimSpace(c.Query("account_id")),
+			Region:          strings.TrimSpace(c.Query("region")),
+			Identity:        strings.TrimSpace(c.Query("identity")),
+			QuarantineState: strings.TrimSpace(c.Query("quarantine_state")),
+			Owner:           strings.TrimSpace(c.Query("owner")),
+			Severity:        strings.TrimSpace(c.Query("severity")),
+			Status:          strings.TrimSpace(c.Query("status")),
+			ReadyForApply:   strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:          strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws access key quarantine request"})
+			default:
+				logger.Error("get aws access key quarantine",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws access key quarantine plans"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plans": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -23,6 +23,9 @@ const (
 
 type IAMAPI interface {
 	ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	ListUsers(context.Context, *iam.ListUsersInput, ...func(*iam.Options)) (*iam.ListUsersOutput, error)
+	ListAccessKeys(context.Context, *iam.ListAccessKeysInput, ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	GetAccessKeyLastUsed(context.Context, *iam.GetAccessKeyLastUsedInput, ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error)
 	GenerateServiceLastAccessedDetails(context.Context, *iam.GenerateServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GenerateServiceLastAccessedDetailsOutput, error)
 	GetServiceLastAccessedDetails(context.Context, *iam.GetServiceLastAccessedDetailsInput, ...func(*iam.Options)) (*iam.GetServiceLastAccessedDetailsOutput, error)
 }
@@ -37,6 +40,8 @@ type IngestRequest struct {
 	AccountID          string
 	Region             string
 	MaxRoles           int32
+	MaxUsers           int32
+	MaxAccessKeys      int32
 	MaxServicesPerRole int32
 	MaxAnalyzers       int32
 	MaxFindings        int32
@@ -133,6 +138,12 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 	if request.MaxRoles <= 0 {
 		request.MaxRoles = 8
 	}
+	if request.MaxUsers <= 0 {
+		request.MaxUsers = 8
+	}
+	if request.MaxAccessKeys <= 0 {
+		request.MaxAccessKeys = 16
+	}
 	if request.MaxServicesPerRole <= 0 {
 		request.MaxServicesPerRole = 8
 	}
@@ -226,12 +237,16 @@ func (i *Ingester) Ingest(ctx context.Context, request IngestRequest) (IngestRes
 	if len(result.Signals) == 0 && allSignalCollectorsPermissionDenied(result.CoverageGaps) {
 		result.Status = "blocked"
 		result.FailureReasons = []string{"IAM last-used and Access Analyzer permissions are unavailable"}
-		result.RemediationHints = []string{"Grant metadata-only iam:ListRoles, iam:GenerateServiceLastAccessedDetails, iam:GetServiceLastAccessedDetails, access-analyzer:ListAnalyzers, and access-analyzer:ListFindings."}
+		result.RemediationHints = []string{"Grant metadata-only iam:ListRoles, iam:ListUsers, iam:ListAccessKeys, iam:GetAccessKeyLastUsed, iam:GenerateServiceLastAccessedDetails, iam:GetServiceLastAccessedDetails, access-analyzer:ListAnalyzers, and access-analyzer:ListFindings."}
 	}
 	return result, nil
 }
 
 func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap, error) {
+	signals := []Signal{}
+	diagnostics := []Diagnostic{}
+	gaps := []CoverageGap{}
+
 	out, err := i.IAM.ListRoles(ctx, &iam.ListRolesInput{MaxItems: awsv2.Int32(request.MaxRoles)})
 	if err != nil {
 		if isContextCancellation(err) {
@@ -244,9 +259,6 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			Remediation: "Grant iam:ListRoles plus service last-accessed read APIs.",
 		}}, nil
 	}
-	signals := []Signal{}
-	diagnostics := []Diagnostic{}
-	gaps := []CoverageGap{}
 	for idx, role := range out.Roles {
 		if int32(idx) >= request.MaxRoles {
 			break
@@ -411,6 +423,136 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 			Status:      "history_truncated",
 			Reason:      "IAM role listing exceeded the bounded per-run role budget.",
 			Remediation: "Rerun with a larger IAM last-used role budget or shard by path prefix.",
+		})
+	}
+	keySignals, keyDiagnostics, keyGaps, keyErr := i.collectIAMAccessKeyLastUsed(ctx, request)
+	if keyErr != nil {
+		return nil, nil, nil, keyErr
+	}
+	signals = append(signals, keySignals...)
+	diagnostics = append(diagnostics, keyDiagnostics...)
+	gaps = append(gaps, keyGaps...)
+	return signals, diagnostics, gaps, nil
+}
+
+func (i *Ingester) collectIAMAccessKeyLastUsed(ctx context.Context, request IngestRequest) ([]Signal, []Diagnostic, []CoverageGap, error) {
+	users, err := i.IAM.ListUsers(ctx, &iam.ListUsersInput{MaxItems: awsv2.Int32(request.MaxUsers)})
+	if err != nil {
+		if isContextCancellation(err) {
+			return nil, nil, nil, err
+		}
+		return nil, []Diagnostic{permissionAwareDiagnostic("iam:access-keys", "iam_access_key_last_used_permission_denied", "iam_access_key_last_used_failed", fmt.Sprintf("IAM user listing failed for access-key last-used collection: %v", err), "Grant metadata-only iam:ListUsers, iam:ListAccessKeys, and iam:GetAccessKeyLastUsed.", err)}, []CoverageGap{{
+			Capability:  "iam_access_key_last_used",
+			Status:      permissionAwareStatus(err),
+			Reason:      "IAM users could not be listed for access-key last-used collection.",
+			Remediation: "Grant iam:ListUsers plus access-key metadata read APIs.",
+		}}, nil
+	}
+
+	signals := []Signal{}
+	diagnostics := []Diagnostic{}
+	gaps := []CoverageGap{}
+	totalKeys := int32(0)
+	for userIdx, user := range users.Users {
+		if int32(userIdx) >= request.MaxUsers || totalKeys >= request.MaxAccessKeys {
+			break
+		}
+		userName := awsv2.ToString(user.UserName)
+		userARN := awsv2.ToString(user.Arn)
+		if userName == "" {
+			continue
+		}
+		keys, listErr := i.IAM.ListAccessKeys(ctx, &iam.ListAccessKeysInput{
+			UserName: awsv2.String(userName),
+			MaxItems: awsv2.Int32(request.MaxAccessKeys - totalKeys),
+		})
+		if listErr != nil {
+			if isContextCancellation(listErr) {
+				return nil, nil, nil, listErr
+			}
+			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:user:"+userName, "iam_access_key_last_used_permission_denied", "iam_access_key_list_failed", fmt.Sprintf("IAM access keys could not be listed for %s: %v", userName, listErr), "Grant iam:ListAccessKeys for metadata-only access-key evidence.", listErr))
+			gaps = append(gaps, CoverageGap{
+				Capability:  "iam_access_key_last_used",
+				Status:      permissionAwareStatus(listErr),
+				Reason:      fmt.Sprintf("Access keys could not be listed for IAM user %s.", userName),
+				Remediation: "Grant iam:ListAccessKeys and retry collection.",
+			})
+			continue
+		}
+		for _, key := range keys.AccessKeyMetadata {
+			if totalKeys >= request.MaxAccessKeys {
+				break
+			}
+			keyID := awsv2.ToString(key.AccessKeyId)
+			if keyID == "" || key.Status == iamtypes.StatusTypeInactive {
+				continue
+			}
+			lastUsed, getErr := i.IAM.GetAccessKeyLastUsed(ctx, &iam.GetAccessKeyLastUsedInput{AccessKeyId: awsv2.String(keyID)})
+			if getErr != nil {
+				if isContextCancellation(getErr) {
+					return nil, nil, nil, getErr
+				}
+				diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:access-key:"+keyID, "iam_access_key_last_used_permission_denied", "iam_access_key_last_used_lookup_failed", fmt.Sprintf("IAM access-key last-used metadata could not be read for %s: %v", keyID, getErr), "Grant iam:GetAccessKeyLastUsed for metadata-only access-key evidence.", getErr))
+				continue
+			}
+			totalKeys++
+			keyUser := firstNonEmpty(awsv2.ToString(lastUsed.UserName), awsv2.ToString(key.UserName), userName)
+			if userARN == "" {
+				userARN = fmt.Sprintf("arn:aws:iam::%s:user/%s", request.AccountID, keyUser)
+			}
+			observedAt := request.CollectedAt
+			region := request.Region
+			status := "never_used"
+			confidence := 0.74
+			action := "iam:AccessKeyNeverUsed"
+			eventName := "AccessKeyNeverUsed"
+			if lastUsed.AccessKeyLastUsed != nil && lastUsed.AccessKeyLastUsed.LastUsedDate != nil {
+				observedAt = lastUsed.AccessKeyLastUsed.LastUsedDate.UTC()
+				region = firstNonEmpty(awsv2.ToString(lastUsed.AccessKeyLastUsed.Region), request.Region)
+				status = iamLastUsedStatus(observedAt, request.CollectedAt)
+				confidence = 0.86
+				action = "iam:AccessKeyLastUsed"
+				eventName = "AccessKeyLastUsed"
+			} else if key.CreateDate != nil {
+				observedAt = key.CreateDate.UTC()
+				status = iamNeverUsedStatus(key.CreateDate, request.CollectedAt)
+			}
+			signals = append(signals, Signal{
+				EventID:            "iam-access-key-last-used:" + sanitizeToken(keyID),
+				AccountID:          request.AccountID,
+				Region:             region,
+				Category:           "iam-last-used",
+				Scope:              "access-key",
+				EventSource:        "iam.amazonaws.com",
+				EventName:          eventName,
+				Action:             action,
+				ActorPrincipalARN:  userARN,
+				ActorPrincipalType: "iam_user",
+				TargetResourceARN:  "aws:iam-access-key:" + keyID,
+				TargetResourceType: "iam_access_key",
+				TargetResourceName: keyID,
+				Status:             status,
+				Confidence:         confidence,
+				ObservedAt:         observedAt,
+				CollectedAt:        request.CollectedAt,
+				StaleAt:            request.CollectedAt,
+			})
+		}
+		if keys.IsTruncated {
+			gaps = append(gaps, CoverageGap{
+				Capability:  "iam_access_key_last_used",
+				Status:      "history_truncated",
+				Reason:      fmt.Sprintf("Access key listing for IAM user %s exceeded the bounded per-run key budget.", userName),
+				Remediation: "Rerun with a larger access-key budget or shard by IAM path prefix.",
+			})
+		}
+	}
+	if users.IsTruncated || totalKeys >= request.MaxAccessKeys {
+		gaps = append(gaps, CoverageGap{
+			Capability:  "iam_access_key_last_used",
+			Status:      "history_truncated",
+			Reason:      "IAM user or access-key listing exceeded the bounded per-run budget.",
+			Remediation: "Rerun with larger IAM user/access-key budgets or shard by IAM path prefix.",
 		})
 	}
 	return signals, diagnostics, gaps, nil

--- a/internal/runtime/awssignals/signals.go
+++ b/internal/runtime/awssignals/signals.go
@@ -252,178 +252,180 @@ func (i *Ingester) collectIAMLastUsed(ctx context.Context, request IngestRequest
 		if isContextCancellation(err) {
 			return nil, nil, nil, err
 		}
-		return nil, []Diagnostic{permissionAwareDiagnostic("iam", "iam_last_used_permission_denied", "iam_last_used_failed", fmt.Sprintf("IAM role listing failed: %v", err), "Grant metadata-only iam:ListRoles and retry.", err)}, []CoverageGap{{
+		diagnostics = append(diagnostics, permissionAwareDiagnostic("iam", "iam_last_used_permission_denied", "iam_last_used_failed", fmt.Sprintf("IAM role listing failed: %v", err), "Grant metadata-only iam:ListRoles and retry.", err))
+		gaps = append(gaps, CoverageGap{
 			Capability:  "iam_last_used",
 			Status:      permissionAwareStatus(err),
 			Reason:      "IAM roles could not be listed for last-used collection.",
 			Remediation: "Grant iam:ListRoles plus service last-accessed read APIs.",
-		}}, nil
-	}
-	for idx, role := range out.Roles {
-		if int32(idx) >= request.MaxRoles {
-			break
-		}
-		roleARN := awsv2.ToString(role.Arn)
-		roleName := awsv2.ToString(role.RoleName)
-		if roleARN == "" {
-			continue
-		}
-		if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
-			region := firstNonEmpty(awsv2.ToString(role.RoleLastUsed.Region), request.Region)
-			lastUsed := role.RoleLastUsed.LastUsedDate.UTC()
-			signals = append(signals, Signal{
-				EventID:            "iam-role-last-used:" + sanitizeToken(roleARN),
-				AccountID:          request.AccountID,
-				Region:             region,
-				Category:           "iam-last-used",
-				Scope:              "role",
-				EventSource:        "iam.amazonaws.com",
-				EventName:          "RoleLastUsed",
-				Action:             "iam:RoleLastUsed",
-				ActorPrincipalARN:  roleARN,
-				ActorPrincipalType: "iam_role",
-				TargetResourceARN:  roleARN,
-				TargetResourceType: "iam_role",
-				TargetResourceName: roleName,
-				Status:             iamLastUsedStatus(lastUsed, request.CollectedAt),
-				Confidence:         0.82,
-				ObservedAt:         lastUsed,
-				CollectedAt:        request.CollectedAt,
-				StaleAt:            request.CollectedAt,
-			})
-		} else {
-			status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
-			confidence := 0.52
-			observedAt := request.CollectedAt
-			if role.CreateDate != nil {
-				observedAt = role.CreateDate.UTC()
-			}
-			if status == "stale" {
-				confidence = 0.68
-			}
-			signals = append(signals, Signal{
-				EventID:            "iam-role-never-used:" + sanitizeToken(roleARN),
-				AccountID:          request.AccountID,
-				Region:             request.Region,
-				Category:           "iam-last-used",
-				Scope:              "role",
-				EventSource:        "iam.amazonaws.com",
-				EventName:          "RoleNeverUsed",
-				Action:             "iam:RoleNeverUsed",
-				ActorPrincipalARN:  roleARN,
-				ActorPrincipalType: "iam_role",
-				TargetResourceARN:  roleARN,
-				TargetResourceType: "iam_role",
-				TargetResourceName: roleName,
-				Status:             status,
-				Confidence:         confidence,
-				ObservedAt:         observedAt,
-				CollectedAt:        request.CollectedAt,
-				StaleAt:            request.CollectedAt,
-			})
-		}
-		job, genErr := i.IAM.GenerateServiceLastAccessedDetails(ctx, &iam.GenerateServiceLastAccessedDetailsInput{
-			Arn:         awsv2.String(roleARN),
-			Granularity: iamtypes.AccessAdvisorUsageGranularityTypeServiceLevel,
 		})
-		if genErr != nil {
-			if isContextCancellation(genErr) {
-				return nil, nil, nil, genErr
-			}
-			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
-			continue
-		}
-		details, truncated, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
-		if getErr != nil {
-			if isContextCancellation(getErr) {
-				return nil, nil, nil, getErr
-			}
-			diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
-			continue
-		}
-		if details.JobStatus != iamtypes.JobStatusTypeCompleted {
-			diagnostics = append(diagnostics, Diagnostic{
-				SourceID:    "iam:" + roleName,
-				Code:        "iam_last_used_report_pending",
-				Message:     fmt.Sprintf("IAM service last-used report for %s is %s.", roleName, details.JobStatus),
-				Remediation: "Retry collection after IAM finishes the report; existing role-last-used evidence remains visible.",
-				Retryable:   true,
-			})
-			gaps = append(gaps, CoverageGap{
-				Capability:  "iam_last_used",
-				Status:      "partial_failure",
-				Reason:      fmt.Sprintf("Service last-used report for %s was not complete.", roleName),
-				Remediation: "Retry collection after IAM report completion.",
-			})
-			continue
-		}
-		staleAt := request.CollectedAt
-		if details.JobCompletionDate != nil {
-			staleAt = details.JobCompletionDate.UTC()
-		}
-		if truncated {
-			gaps = append(gaps, CoverageGap{
-				Capability:  "iam_last_used",
-				Status:      "history_truncated",
-				Reason:      fmt.Sprintf("Service last-used report for %s exceeded the bounded per-role service budget.", roleName),
-				Remediation: "Rerun with a larger IAM last-used service budget or add paginated report reuse.",
-			})
-		}
-		for svcIdx, service := range details.ServicesLastAccessed {
-			if int32(svcIdx) >= request.MaxServicesPerRole {
+	} else {
+		for idx, role := range out.Roles {
+			if int32(idx) >= request.MaxRoles {
 				break
 			}
-			serviceNamespace := awsv2.ToString(service.ServiceNamespace)
-			serviceName := firstNonEmpty(awsv2.ToString(service.ServiceName), serviceNamespace)
-			actor := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedEntity), roleARN)
-			region := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedRegion), request.Region)
-			lastAuthenticated := request.CollectedAt
-			status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
-			confidence := 0.52
-			if service.LastAuthenticated != nil {
-				lastAuthenticated = service.LastAuthenticated.UTC()
-				status = iamLastUsedStatus(lastAuthenticated, request.CollectedAt)
-				confidence = 0.86
-				if status == "stale" {
-					confidence = 0.78
-				}
+			roleARN := awsv2.ToString(role.Arn)
+			roleName := awsv2.ToString(role.RoleName)
+			if roleARN == "" {
+				continue
+			}
+			if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
+				region := firstNonEmpty(awsv2.ToString(role.RoleLastUsed.Region), request.Region)
+				lastUsed := role.RoleLastUsed.LastUsedDate.UTC()
+				signals = append(signals, Signal{
+					EventID:            "iam-role-last-used:" + sanitizeToken(roleARN),
+					AccountID:          request.AccountID,
+					Region:             region,
+					Category:           "iam-last-used",
+					Scope:              "role",
+					EventSource:        "iam.amazonaws.com",
+					EventName:          "RoleLastUsed",
+					Action:             "iam:RoleLastUsed",
+					ActorPrincipalARN:  roleARN,
+					ActorPrincipalType: "iam_role",
+					TargetResourceARN:  roleARN,
+					TargetResourceType: "iam_role",
+					TargetResourceName: roleName,
+					Status:             iamLastUsedStatus(lastUsed, request.CollectedAt),
+					Confidence:         0.82,
+					ObservedAt:         lastUsed,
+					CollectedAt:        request.CollectedAt,
+					StaleAt:            request.CollectedAt,
+				})
 			} else {
+				status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
+				confidence := 0.52
+				observedAt := request.CollectedAt
 				if role.CreateDate != nil {
-					lastAuthenticated = role.CreateDate.UTC()
+					observedAt = role.CreateDate.UTC()
 				}
 				if status == "stale" {
 					confidence = 0.68
 				}
+				signals = append(signals, Signal{
+					EventID:            "iam-role-never-used:" + sanitizeToken(roleARN),
+					AccountID:          request.AccountID,
+					Region:             request.Region,
+					Category:           "iam-last-used",
+					Scope:              "role",
+					EventSource:        "iam.amazonaws.com",
+					EventName:          "RoleNeverUsed",
+					Action:             "iam:RoleNeverUsed",
+					ActorPrincipalARN:  roleARN,
+					ActorPrincipalType: "iam_role",
+					TargetResourceARN:  roleARN,
+					TargetResourceType: "iam_role",
+					TargetResourceName: roleName,
+					Status:             status,
+					Confidence:         confidence,
+					ObservedAt:         observedAt,
+					CollectedAt:        request.CollectedAt,
+					StaleAt:            request.CollectedAt,
+				})
 			}
-			signals = append(signals, Signal{
-				EventID:            "iam-service-last-used:" + sanitizeToken(roleARN) + ":" + sanitizeToken(serviceNamespace),
-				AccountID:          request.AccountID,
-				Region:             region,
-				Category:           "iam-last-used",
-				Scope:              "service",
-				EventSource:        "iam.amazonaws.com",
-				EventName:          serviceLastAccessedEventName(service.LastAuthenticated != nil),
-				Action:             serviceLastAccessedAction(serviceNamespace, service.LastAuthenticated != nil),
-				ActorPrincipalARN:  actor,
-				ActorPrincipalType: principalTypeFromARN(actor),
-				TargetResourceARN:  "aws-service://" + serviceNamespace,
-				TargetResourceType: "aws_service",
-				TargetResourceName: serviceName,
-				Status:             status,
-				Confidence:         confidence,
-				ObservedAt:         lastAuthenticated,
-				CollectedAt:        request.CollectedAt,
-				StaleAt:            staleAt,
+			job, genErr := i.IAM.GenerateServiceLastAccessedDetails(ctx, &iam.GenerateServiceLastAccessedDetailsInput{
+				Arn:         awsv2.String(roleARN),
+				Granularity: iamtypes.AccessAdvisorUsageGranularityTypeServiceLevel,
+			})
+			if genErr != nil {
+				if isContextCancellation(genErr) {
+					return nil, nil, nil, genErr
+				}
+				diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_generation_failed", fmt.Sprintf("IAM service last-used report could not be generated for %s: %v", roleName, genErr), "Grant iam:GenerateServiceLastAccessedDetails and retry.", genErr))
+				continue
+			}
+			details, truncated, getErr := i.getServiceLastAccessedDetails(ctx, job.JobId, request)
+			if getErr != nil {
+				if isContextCancellation(getErr) {
+					return nil, nil, nil, getErr
+				}
+				diagnostics = append(diagnostics, permissionAwareDiagnostic("iam:"+roleName, "iam_last_used_permission_denied", "iam_last_used_report_failed", fmt.Sprintf("IAM service last-used report could not be read for %s: %v", roleName, getErr), "Grant iam:GetServiceLastAccessedDetails and retry.", getErr))
+				continue
+			}
+			if details.JobStatus != iamtypes.JobStatusTypeCompleted {
+				diagnostics = append(diagnostics, Diagnostic{
+					SourceID:    "iam:" + roleName,
+					Code:        "iam_last_used_report_pending",
+					Message:     fmt.Sprintf("IAM service last-used report for %s is %s.", roleName, details.JobStatus),
+					Remediation: "Retry collection after IAM finishes the report; existing role-last-used evidence remains visible.",
+					Retryable:   true,
+				})
+				gaps = append(gaps, CoverageGap{
+					Capability:  "iam_last_used",
+					Status:      "partial_failure",
+					Reason:      fmt.Sprintf("Service last-used report for %s was not complete.", roleName),
+					Remediation: "Retry collection after IAM report completion.",
+				})
+				continue
+			}
+			staleAt := request.CollectedAt
+			if details.JobCompletionDate != nil {
+				staleAt = details.JobCompletionDate.UTC()
+			}
+			if truncated {
+				gaps = append(gaps, CoverageGap{
+					Capability:  "iam_last_used",
+					Status:      "history_truncated",
+					Reason:      fmt.Sprintf("Service last-used report for %s exceeded the bounded per-role service budget.", roleName),
+					Remediation: "Rerun with a larger IAM last-used service budget or add paginated report reuse.",
+				})
+			}
+			for svcIdx, service := range details.ServicesLastAccessed {
+				if int32(svcIdx) >= request.MaxServicesPerRole {
+					break
+				}
+				serviceNamespace := awsv2.ToString(service.ServiceNamespace)
+				serviceName := firstNonEmpty(awsv2.ToString(service.ServiceName), serviceNamespace)
+				actor := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedEntity), roleARN)
+				region := firstNonEmpty(awsv2.ToString(service.LastAuthenticatedRegion), request.Region)
+				lastAuthenticated := request.CollectedAt
+				status := iamNeverUsedStatus(role.CreateDate, request.CollectedAt)
+				confidence := 0.52
+				if service.LastAuthenticated != nil {
+					lastAuthenticated = service.LastAuthenticated.UTC()
+					status = iamLastUsedStatus(lastAuthenticated, request.CollectedAt)
+					confidence = 0.86
+					if status == "stale" {
+						confidence = 0.78
+					}
+				} else {
+					if role.CreateDate != nil {
+						lastAuthenticated = role.CreateDate.UTC()
+					}
+					if status == "stale" {
+						confidence = 0.68
+					}
+				}
+				signals = append(signals, Signal{
+					EventID:            "iam-service-last-used:" + sanitizeToken(roleARN) + ":" + sanitizeToken(serviceNamespace),
+					AccountID:          request.AccountID,
+					Region:             region,
+					Category:           "iam-last-used",
+					Scope:              "service",
+					EventSource:        "iam.amazonaws.com",
+					EventName:          serviceLastAccessedEventName(service.LastAuthenticated != nil),
+					Action:             serviceLastAccessedAction(serviceNamespace, service.LastAuthenticated != nil),
+					ActorPrincipalARN:  actor,
+					ActorPrincipalType: principalTypeFromARN(actor),
+					TargetResourceARN:  "aws-service://" + serviceNamespace,
+					TargetResourceType: "aws_service",
+					TargetResourceName: serviceName,
+					Status:             status,
+					Confidence:         confidence,
+					ObservedAt:         lastAuthenticated,
+					CollectedAt:        request.CollectedAt,
+					StaleAt:            staleAt,
+				})
+			}
+		}
+		if out.IsTruncated {
+			gaps = append(gaps, CoverageGap{
+				Capability:  "iam_last_used",
+				Status:      "history_truncated",
+				Reason:      "IAM role listing exceeded the bounded per-run role budget.",
+				Remediation: "Rerun with a larger IAM last-used role budget or shard by path prefix.",
 			})
 		}
-	}
-	if out.IsTruncated {
-		gaps = append(gaps, CoverageGap{
-			Capability:  "iam_last_used",
-			Status:      "history_truncated",
-			Reason:      "IAM role listing exceeded the bounded per-run role budget.",
-			Remediation: "Rerun with a larger IAM last-used role budget or shard by path prefix.",
-		})
 	}
 	keySignals, keyDiagnostics, keyGaps, keyErr := i.collectIAMAccessKeyLastUsed(ctx, request)
 	if keyErr != nil {

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -16,12 +16,17 @@ import (
 
 type fakeIAMAPI struct {
 	listRolesErr     error
+	listUsersErr     error
+	listAccessKeyErr error
+	getAccessKeyErr  error
 	getStatus        iamtypes.JobStatusType
 	truncated        bool
 	emptyRoles       bool
+	emptyUsers       bool
 	neverUsedRole    bool
 	neverUsedService bool
 	roleCreationDate *time.Time
+	keyLastUsedDate  *time.Time
 }
 
 func (f fakeIAMAPI) ListRoles(context.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
@@ -71,6 +76,52 @@ func (f fakeIAMAPI) GetServiceLastAccessedDetails(context.Context, *iam.GetServi
 		JobCompletionDate:    &completedAt,
 		IsTruncated:          f.truncated,
 		ServicesLastAccessed: []iamtypes.ServiceLastAccessed{service},
+	}, nil
+}
+
+func (f fakeIAMAPI) ListUsers(context.Context, *iam.ListUsersInput, ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
+	if f.listUsersErr != nil {
+		return nil, f.listUsersErr
+	}
+	if f.emptyUsers {
+		return &iam.ListUsersOutput{}, nil
+	}
+	return &iam.ListUsersOutput{Users: []iamtypes.User{{
+		Arn:      awsv2.String("arn:aws:iam::123456789012:user/orders-ci"),
+		UserName: awsv2.String("orders-ci"),
+	}}}, nil
+}
+
+func (f fakeIAMAPI) ListAccessKeys(context.Context, *iam.ListAccessKeysInput, ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	if f.listAccessKeyErr != nil {
+		return nil, f.listAccessKeyErr
+	}
+	createdAt := time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC)
+	accessKeyID := "AKIA" + "ORDERS123456"
+	return &iam.ListAccessKeysOutput{AccessKeyMetadata: []iamtypes.AccessKeyMetadata{{
+		AccessKeyId: awsv2.String(accessKeyID),
+		CreateDate:  &createdAt,
+		Status:      iamtypes.StatusTypeActive,
+		UserName:    awsv2.String("orders-ci"),
+	}}}, nil
+}
+
+func (f fakeIAMAPI) GetAccessKeyLastUsed(context.Context, *iam.GetAccessKeyLastUsedInput, ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error) {
+	if f.getAccessKeyErr != nil {
+		return nil, f.getAccessKeyErr
+	}
+	lastUsed := f.keyLastUsedDate
+	if lastUsed == nil {
+		defaultLastUsed := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+		lastUsed = &defaultLastUsed
+	}
+	return &iam.GetAccessKeyLastUsedOutput{
+		UserName: awsv2.String("orders-ci"),
+		AccessKeyLastUsed: &iamtypes.AccessKeyLastUsed{
+			LastUsedDate: lastUsed,
+			Region:       awsv2.String("us-east-1"),
+			ServiceName:  awsv2.String("Amazon S3"),
+		},
 	}, nil
 }
 
@@ -177,7 +228,7 @@ func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
 	if result.Status != "ready" || len(result.Diagnostics) != 0 || len(result.CoverageGaps) != 0 {
 		t.Fatalf("expected ready metadata-only signal result, got %+v", result)
 	}
-	var roleLastUsed, serviceLastUsed, analyzerFinding *Signal
+	var roleLastUsed, serviceLastUsed, accessKeyLastUsed, analyzerFinding *Signal
 	for idx := range result.Signals {
 		signal := &result.Signals[idx]
 		switch {
@@ -185,18 +236,23 @@ func TestIngesterCollectsIAMLastUsedAndAccessAnalyzerSignals(t *testing.T) {
 			roleLastUsed = signal
 		case signal.EventID == "iam-service-last-used:arn-aws-iam-123456789012-role-payments-worker:s3":
 			serviceLastUsed = signal
+		case signal.EventID == "iam-access-key-last-used:"+"akia"+"orders123456":
+			accessKeyLastUsed = signal
 		case strings.HasPrefix(signal.EventID, "access-analyzer:"):
 			analyzerFinding = signal
 		}
 	}
-	if roleLastUsed == nil || serviceLastUsed == nil || analyzerFinding == nil {
-		t.Fatalf("expected role, service, and analyzer signals, got %+v", result.Signals)
+	if roleLastUsed == nil || serviceLastUsed == nil || accessKeyLastUsed == nil || analyzerFinding == nil {
+		t.Fatalf("expected role, service, access-key, and analyzer signals, got %+v", result.Signals)
 	}
 	if roleLastUsed.Category != "iam-last-used" || roleLastUsed.Scope != "role" || !roleLastUsed.StaleAt.Equal(collectedAt) {
 		t.Fatalf("unexpected role last-used signal: %+v", roleLastUsed)
 	}
 	if serviceLastUsed.TargetResourceARN != "aws-service://s3" || serviceLastUsed.Scope != "service" || serviceLastUsed.StaleAt.IsZero() {
 		t.Fatalf("unexpected service last-used signal: %+v", serviceLastUsed)
+	}
+	if accessKeyLastUsed.Scope != "access-key" || accessKeyLastUsed.TargetResourceType != "iam_access_key" || accessKeyLastUsed.TargetResourceName != "AKIA"+"ORDERS123456" {
+		t.Fatalf("unexpected access-key last-used signal: %+v", accessKeyLastUsed)
 	}
 	if analyzerFinding.Category != "access-analyzer" || analyzerFinding.Scope != "account" || analyzerFinding.AnalyzerARN == "" || analyzerFinding.StaleAt.IsZero() || analyzerFinding.Confidence < 0.89 {
 		t.Fatalf("unexpected Access Analyzer signal: %+v", analyzerFinding)
@@ -228,7 +284,7 @@ func TestIngesterSkipsCrossAccountAccessAnalyzerFindings(t *testing.T) {
 			Resource:             awsv2.String("arn:aws:secretsmanager:us-east-1:999999999999:secret:prod/other"),
 		},
 	}
-	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{
+	result, err := New(fakeIAMAPI{emptyRoles: true, emptyUsers: true}, fakeAccessAnalyzerAPI{
 		analyzerType: accessanalyzertypes.TypeOrganization,
 		findings:     findings,
 	}).Ingest(context.Background(), IngestRequest{
@@ -252,7 +308,7 @@ func TestIngesterSkipsCrossAccountAccessAnalyzerFindings(t *testing.T) {
 
 func TestIngesterUsesFindingsV2ForInternalAccessAnalyzers(t *testing.T) {
 	collectedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
-	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{
+	result, err := New(fakeIAMAPI{emptyRoles: true, emptyUsers: true}, fakeAccessAnalyzerAPI{
 		analyzerType:    accessanalyzertypes.TypeAccountInternalAccess,
 		listFindingsErr: errors.New("legacy ListFindings should not be called"),
 	}).Ingest(context.Background(), IngestRequest{
@@ -481,7 +537,7 @@ func TestIngesterBlocksWhenIAMAndAnalyzerFindingsAreDenied(t *testing.T) {
 }
 
 func TestIngesterDoesNotBlockWhenOnlyOneCollectorIsDenied(t *testing.T) {
-	result, err := New(fakeIAMAPI{emptyRoles: true}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+	result, err := New(fakeIAMAPI{emptyRoles: true, emptyUsers: true}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",
 		Region:      "us-east-1",
 		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),

--- a/internal/runtime/awssignals/signals_test.go
+++ b/internal/runtime/awssignals/signals_test.go
@@ -498,7 +498,7 @@ func TestIngesterPropagatesContextCancellation(t *testing.T) {
 }
 
 func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
-	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized"), listUsersErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listAnalyzersErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",
 		Region:      "us-east-1",
 		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
@@ -509,7 +509,7 @@ func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 	if result.Status != "blocked" || len(result.Signals) != 0 {
 		t.Fatalf("expected blocked result without partial signal leakage, got %+v", result)
 	}
-	if len(result.Diagnostics) != 2 || len(result.CoverageGaps) != 2 {
+	if len(result.Diagnostics) != 3 || len(result.CoverageGaps) != 3 {
 		t.Fatalf("expected IAM and Access Analyzer diagnostics/gaps, got %+v", result)
 	}
 	for _, diagnostic := range result.Diagnostics {
@@ -519,8 +519,28 @@ func TestIngesterReportsPermissionDeniedCoverage(t *testing.T) {
 	}
 }
 
+func TestIngesterCollectsAccessKeysWhenRoleListingDenied(t *testing.T) {
+	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{emptyAnalyzers: true}).Ingest(context.Background(), IngestRequest{
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ingest role-denied signals: %v", err)
+	}
+	if result.Status != "degraded" || len(result.Signals) == 0 {
+		t.Fatalf("expected degraded result with access-key signals, got %+v", result)
+	}
+	for _, signal := range result.Signals {
+		if signal.Scope == "access-key" && signal.TargetResourceType == "iam_access_key" {
+			return
+		}
+	}
+	t.Fatalf("expected access-key signal despite role listing denial, got %+v", result.Signals)
+}
+
 func TestIngesterBlocksWhenIAMAndAnalyzerFindingsAreDenied(t *testing.T) {
-	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listFindingsErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
+	result, err := New(fakeIAMAPI{listRolesErr: errors.New("AccessDenied: not authorized"), listUsersErr: errors.New("AccessDenied: not authorized")}, fakeAccessAnalyzerAPI{listFindingsErr: errors.New("AccessDeniedException")}).Ingest(context.Background(), IngestRequest{
 		AccountID:   "123456789012",
 		Region:      "us-east-1",
 		CollectedAt: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1794,6 +1794,47 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS access key quarantine plans with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plans: { status: 'ready', plans: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectAccessKeyQuarantinePlans(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'orders-ci',
+        quarantineState: 'quarantine_candidate',
+        owner: 'orders-platform',
+        severity: 'high',
+        status: 'ready_for_quarantine',
+        readyForApply: 'true',
+        search: 'quarantine_re_evaluate'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/access-key-quarantine?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=orders-ci&quarantine_state=quarantine_candidate&owner=orders-platform&severity=high&status=ready_for_quarantine&ready_for_apply=true&search=quarantine_re_evaluate'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3621,6 +3621,148 @@ export type AWSSecretKeyRotationQuery = {
   search?: string;
 };
 
+export type AWSAccessKeyQuarantineStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAccessKeyQuarantineFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSAccessKeyQuarantineState = 'disable_candidate' | 'quarantine_candidate' | 'grace_period_required' | 'needs_review' | string;
+
+export type AWSAccessKeyQuarantineOwnerNotice = {
+  owner: string;
+  assigned: boolean;
+  notification: string;
+  grace_period: string;
+  required_actors?: string[];
+  instructions?: string[];
+};
+
+export type AWSAccessKeyQuarantineTarget = {
+  ref_type: string;
+  access_key_id?: string;
+  node_id?: string;
+  principal?: string;
+  label: string;
+  metadata_ref?: string;
+};
+
+export type AWSAccessKeyQuarantineStep = {
+  order: number;
+  phase: string;
+  action: string;
+  actor?: string;
+  evidence_ref?: string;
+  blocks_on?: string[];
+};
+
+export type AWSAccessKeyQuarantineGate = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSAccessKeyQuarantinePlan = {
+  plan_id: string;
+  calculation_version: string;
+  quarantine_state: AWSAccessKeyQuarantineState;
+  severity: string;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  owner_notice: AWSAccessKeyQuarantineOwnerNotice;
+  source_finding_ids: string[];
+  target_access_keys: AWSAccessKeyQuarantineTarget[];
+  affected_principals?: AWSAccessKeyQuarantineTarget[];
+  last_used_at?: string;
+  dormant_days: number;
+  grace_period_days: number;
+  quarantine_order: AWSAccessKeyQuarantineStep[];
+  diff_intent: AWSRemediationDiffIntent;
+  tradeoffs: AWSRemediationTradeoff[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  readiness_gates: AWSAccessKeyQuarantineGate[];
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSAccessKeyQuarantineRelationship = {
+  plan_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSAccessKeyQuarantineSummary = {
+  total_plans: number;
+  filtered_plans: number;
+  quarantine_state_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  owner_assigned_count: number;
+  ownerless_count: number;
+  ready_for_apply_count: number;
+  access_key_count: number;
+  affected_principal_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSAccessKeyQuarantineResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAccessKeyQuarantineStatus;
+  fixture_state?: AWSAccessKeyQuarantineFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSAccessKeyQuarantineSummary;
+  plans: AWSAccessKeyQuarantinePlan[];
+  relationships: AWSAccessKeyQuarantineRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSAccessKeyQuarantineQuery = {
+  connectorID?: string;
+  fixtureState?: AWSAccessKeyQuarantineFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  quarantineState?: string;
+  owner?: string;
+  severity?: string;
+  status?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -7845,6 +7987,29 @@ export const apiClient = {
         region: query?.region,
         rotation_type: query?.rotationType,
         provider: query?.provider,
+        owner: query?.owner,
+        severity: query?.severity,
+        status: query?.status,
+        ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAccessKeyQuarantinePlans(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSAccessKeyQuarantineQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plans: AWSAccessKeyQuarantineResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/access-key-quarantine${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        quarantine_state: query?.quarantineState,
         owner: query?.owner,
         severity: query?.severity,
         status: query?.status,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3904,6 +3904,139 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const accessKeyID = 'AKIA' + 'ORDERS123456';
+    const getAccessKeyQuarantine = vi.spyOn(api.apiClient, 'getAWSProjectAccessKeyQuarantinePlans').mockResolvedValue({
+      plans: {
+        status: 'ready',
+        plans: [
+          {
+            plan_id: 'aws-access-key-quarantine:orders-ci',
+            calculation_version: 'aws-access-key-quarantine-planner-v1',
+            quarantine_state: 'quarantine_candidate',
+            severity: 'high',
+            status: 'ready_for_quarantine',
+            score: 82,
+            confidence: 0.86,
+            title: `Access key quarantine: ${accessKeyID}`,
+            summary: 'Plan a stale access key quarantine workflow.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            owner_notice: {
+              owner: 'orders-platform',
+              assigned: true,
+              notification: 'owner_notification_required',
+              grace_period: 'P7D',
+              required_actors: ['identity-owner', 'security-reviewer'],
+              instructions: ['Notify owner before quarantine.']
+            },
+            source_finding_ids: ['aws-unused-dormant-access:orders-key'],
+            target_access_keys: [
+              {
+                ref_type: 'iam_access_key',
+                access_key_id: accessKeyID,
+                node_id: `aws:iam-access-key:${accessKeyID}`,
+                principal: 'arn:aws:iam::123456789012:user/orders-ci',
+                label: accessKeyID,
+                metadata_ref: `runtime-evidence://access-key/${accessKeyID}`
+              }
+            ],
+            affected_principals: [
+              {
+                ref_type: 'iam_principal',
+                node_id: 'aws:identity:user/orders-ci',
+                principal: 'arn:aws:iam::123456789012:user/orders-ci',
+                label: 'orders-ci',
+                metadata_ref: `runtime-evidence://access-key/${accessKeyID}`
+              }
+            ],
+            last_used_at: '2026-03-17T09:35:00Z',
+            dormant_days: 100,
+            grace_period_days: 7,
+            quarantine_order: [
+              { order: 1, phase: 'notify', action: 'Notify owner.', actor: 'orders-platform' },
+              { order: 2, phase: 'grace_period', action: 'Monitor runtime use.', actor: 'security-reviewer' },
+              { order: 3, phase: 'dry_run', action: 'Confirm workload replacement.', actor: 'platform-operator' },
+              { order: 4, phase: 'apply', action: 'Disable outside Identrail.', actor: 'platform-operator' },
+              { order: 5, phase: 'verify', action: 'Verify no key use.', actor: 'security-reviewer' }
+            ],
+            diff_intent: {
+              kind: 'access_key_quarantine',
+              before_ref: `runtime-evidence://access-key/${accessKeyID}`,
+              after_ref: 'quarantine://orders-key/disable-after-grace',
+              diff_summary: 'Plan DisableAccessKey after owner notice and grace-period verification.',
+              no_op: false,
+              read_only_projection: true
+            },
+            tradeoffs: [
+              {
+                dimension: 'credential_exposure',
+                direction: 'improves',
+                description: 'Disabling key removes long-lived credential path.',
+                severity: 'high'
+              }
+            ],
+            rollback_plan: {
+              strategy: 'reactivate_access_key_or_swap_credential',
+              steps: ['Re-enable only with emergency owner approval.'],
+              evidence_ref: `runtime-evidence://access-key/${accessKeyID}`
+            },
+            verification_plan: {
+              strategy: 'quarantine_re_evaluate',
+              steps: ['Check CloudTrail and IAM last-used evidence.'],
+              success_signals: ['cloudtrail:no-access-key-use'],
+              failure_signals: ['cloudtrail:access-key-use-observed'],
+              evidence_ref: `runtime-evidence://access-key/${accessKeyID}`
+            },
+            readiness_gates: [
+              { name: 'read_only_projection', status: 'passed', rationale: 'Metadata refs only.' },
+              { name: 'owner_notice', status: 'passed', rationale: 'Owner assigned.' },
+              { name: 'runtime_evidence', status: 'passed', rationale: 'Last-used evidence exists.' }
+            ],
+            ready_for_apply: true,
+            read_only_projection: true,
+            source_signals: ['unused_dormant_access', 'iam_last_used'],
+            evidence: [
+              {
+                source: 'iam_last_used',
+                evidence_ref: `runtime-evidence://access-key/${accessKeyID}`,
+                label: accessKeyID,
+                confidence: 0.86,
+                observed_at: '2026-03-17T09:35:00Z',
+                relationship: 'stale_access_key'
+              }
+            ],
+            evidence_boundary: 'metadata_only_no_secret_values_no_payloads',
+            impacted_nodes: [`aws:iam-access-key:${accessKeyID}`, 'aws:identity:user/orders-ci'],
+            impacted_path: [],
+            next_action: 'Notify the owner and wait through the grace window.',
+            created_at: '2026-06-25T09:35:00Z',
+            updated_at: '2026-06-25T09:35:00Z'
+          }
+        ],
+        summary: {
+          total_plans: 1,
+          filtered_plans: 1,
+          quarantine_state_counts: { quarantine_candidate: 1 },
+          severity_counts: { high: 1 },
+          status_counts: { ready_for_quarantine: 1 },
+          owner_assigned_count: 1,
+          ownerless_count: 0,
+          ready_for_apply_count: 1,
+          access_key_count: 1,
+          affected_principal_count: 1,
+          relationship_count: 2,
+          highest_score: 82,
+          average_confidence_pct: 86
+        },
+        relationships: [],
+        caveats: ['Plans never disable IAM access keys directly.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     vi.spyOn(api.apiClient, 'getAWSProjectBlastRadius').mockResolvedValue({
       intelligence: {
         status: 'degraded',
@@ -4230,6 +4363,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS secret/key rotation plans' })).toBeInTheDocument();
     expect(screen.getByText(/Provider key rotation: openai\/api-key/i)).toBeInTheDocument();
     expect(screen.getAllByText(/ai-platform · Pending approver/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS access key quarantine plans' })).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`Access key quarantine: ${accessKeyID}`, 'i'))).toBeInTheDocument();
+    expect(screen.getAllByText(/orders-platform · Owner notification required/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS least privilege recommendations' })).toBeInTheDocument();
     expect(screen.getByText(/Remove secretsmanager:GetSecretValue/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS unused and dormant access findings' })).toBeInTheDocument();
@@ -4274,6 +4410,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getSecretKeyRotation).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getAccessKeyQuarantine).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -67,6 +67,8 @@ import {
   type AWSPermissionBoundarySCPResult,
   type AWSSecretKeyRotationPlan,
   type AWSSecretKeyRotationResult,
+  type AWSAccessKeyQuarantinePlan,
+  type AWSAccessKeyQuarantineResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11151,6 +11153,115 @@ function AWSSecretKeyRotationContent({
   );
 }
 
+function awsAccessKeyQuarantineStage(plan: AWSAccessKeyQuarantinePlan): AWSCapabilityStage {
+  if (!plan.owner_notice.assigned || plan.status === 'review') {
+    return 'not-available';
+  }
+  if (!plan.ready_for_apply || plan.severity === 'high') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsAccessKeyQuarantineTargetLabel(plan: AWSAccessKeyQuarantinePlan): string {
+  const keyLabel = plan.target_access_keys.map((target) => target.access_key_id || target.label).filter(Boolean).join(', ');
+  const principalCount = plan.affected_principals?.length ?? 0;
+  return `${keyLabel || 'Access key'} · ${principalCount} principal${principalCount === 1 ? '' : 's'}`;
+}
+
+function awsAccessKeyQuarantineOrderLabel(plan: AWSAccessKeyQuarantinePlan): string {
+  const phases = plan.quarantine_order.map((step) => formatTokenLabel(step.phase));
+  if (phases.length === 0) {
+    return 'manual review';
+  }
+  return phases.slice(0, 4).join(' → ') + (phases.length > 4 ? ` +${phases.length - 4}` : '');
+}
+
+function awsAccessKeyQuarantineReadinessLabel(plan: AWSAccessKeyQuarantinePlan): string {
+  if (plan.ready_for_apply) {
+    return `ready · ${plan.grace_period_days}d grace`;
+  }
+  const blockedGate = plan.readiness_gates.find((gate) => gate.status === 'blocked');
+  return `gate · ${formatTokenLabel(blockedGate?.name ?? plan.status)}`;
+}
+
+function AWSAccessKeyQuarantineContent({
+  plans,
+  loading,
+  error,
+  onRetry
+}: {
+  plans: AWSAccessKeyQuarantineResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = plans?.plans ?? [];
+  const summaryLine = plans
+    ? `${plans.summary.total_plans} total · ${plans.summary.ready_for_apply_count} ready · ${plans.summary.access_key_count} keys · ${plans.summary.owner_assigned_count} owned`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS access key quarantine plans">
+      <h3>AWS access key quarantine planner</h3>
+      <p className="idt-app-kicker">
+        Read-only disable/quarantine workflows for stale or risky IAM access keys with owner notice, grace period,
+        rollback, verification, and explicit readiness gates. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS access key quarantine plans"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing access key quarantine plans"
+          body="Identrail is joining dormant access, IAM last-used evidence, owner context, and remediation-case metadata into ranked quarantine workflows."
+        />
+      ) : null}
+      {!error && !loading && plans && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={plans.status === 'blocked' ? 'Permission required' : 'No quarantine plans'}
+          title={plans.status === 'blocked' ? 'Quarantine plans need read-only access-key evidence' : 'No access key quarantine plans projected'}
+          body={plans.failure_reasons[0] ?? 'No upstream dormant access evidence produced an access-key quarantine plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && plans && plans.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {plans.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS access key quarantine plans"
+          rows={rows}
+          getRowKey={(row) => row.plan_id}
+          columns={[
+            { key: 'plan', header: 'Plan', render: (row) => <strong>{row.title}</strong> },
+            { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.quarantine_state) },
+            { key: 'owner', header: 'Owner notice', render: (row) => `${row.owner_notice.owner} · ${formatTokenLabel(row.owner_notice.notification)}` },
+            { key: 'target', header: 'Target', render: (row) => awsAccessKeyQuarantineTargetLabel(row) },
+            { key: 'order', header: 'Order', render: (row) => awsAccessKeyQuarantineOrderLabel(row) },
+            { key: 'readiness', header: 'Readiness', render: (row) => awsAccessKeyQuarantineReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsAccessKeyQuarantineStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => formatTokenLabel(row.verification_plan.strategy) }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12614,6 +12725,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
   const secretKeyRotationRequestRef = useRef(0);
+  const [accessKeyQuarantine, setAccessKeyQuarantine] = useState<AWSAccessKeyQuarantineResult | null>(null);
+  const [accessKeyQuarantineLoading, setAccessKeyQuarantineLoading] = useState(false);
+  const [accessKeyQuarantineError, setAccessKeyQuarantineError] = useState('');
+  const accessKeyQuarantineRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -13139,6 +13254,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadSecretKeyRotation]);
 
+  const loadAccessKeyQuarantine = useCallback(async () => {
+    const requestID = ++accessKeyQuarantineRequestRef.current;
+    setAccessKeyQuarantine(null);
+    setAccessKeyQuarantineError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAccessKeyQuarantineLoading(false);
+      return;
+    }
+    setAccessKeyQuarantineLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAccessKeyQuarantinePlans(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== accessKeyQuarantineRequestRef.current) {
+        return;
+      }
+      setAccessKeyQuarantine(response.plans);
+    } catch (error) {
+      if (requestID !== accessKeyQuarantineRequestRef.current) {
+        return;
+      }
+      setAccessKeyQuarantineError(formatAPIError(error, 'Unable to load AWS access key quarantine plans.'));
+    } finally {
+      if (requestID === accessKeyQuarantineRequestRef.current) {
+        setAccessKeyQuarantineLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadAccessKeyQuarantine();
+    return () => {
+      accessKeyQuarantineRequestRef.current += 1;
+    };
+  }, [loadAccessKeyQuarantine]);
+
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
     setBlastRadius(null);
@@ -13649,6 +13812,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={secretKeyRotationLoading}
             error={secretKeyRotationError}
             onRetry={loadSecretKeyRotation}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSAccessKeyQuarantineContent
+            plans={accessKeyQuarantine}
+            loading={accessKeyQuarantineLoading}
+            error={accessKeyQuarantineError}
+            onRetry={loadAccessKeyQuarantine}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- Add read-only AWS access key disable/quarantine planner API and runtime UI panel.
- Surface owner notice, grace period, ordered quarantine steps, rollback, verification, readiness gates, OpenAPI docs, and client types.
- Add fixture evidence plus backend/frontend regression tests, including key-aware identity filtering and safe fake-key casing.

## Validation
- go test ./internal/api
- npm test -- --run src/productShell.test.tsx src/api/client.test.ts

Closes #1534