### PR TITLE
AWS Platform Wave 7.07: IaC remediation PR and verification plan generator

### DIFF
--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -520,6 +520,9 @@ func awsSCPPlansFromCrossAccountTrust(trust AWSCrossAccountTrustResult, orgs AWS
 }
 
 func awsSCPCandidate(finding AWSCrossAccountTrustFinding) bool {
+	if finding.FindingType == "runtime_cross_account_assumption" && !finding.TrustedWithinOrganization && strings.TrimSpace(finding.ExternalPrincipalOUPath) == "" {
+		return false
+	}
 	if finding.PublicPrincipal {
 		return true
 	}

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -426,6 +426,16 @@ func TestAWSSCPTargetScopeForResourcePolicyFindings(t *testing.T) {
 	}
 }
 
+func TestAWSCPCandidateSkipsUnscopedRuntimeAssumption(t *testing.T) {
+	if awsSCPCandidate(AWSCrossAccountTrustFinding{
+		FindingType:               "runtime_cross_account_assumption",
+		TrustedWithinOrganization: false,
+		ExternalPrincipalOUPath:   "",
+	}) {
+		t.Fatalf("runtime assumption from out-of-org principal should not be projected without an OU scope")
+	}
+}
+
 func TestAWSPermissionBoundarySCPMostCommonKeyIsDeterministic(t *testing.T) {
 	severity := awsPermissionBoundarySCPMostCommonKeyWithPriority(map[string]int{"high": 1, "critical": 1}, "medium", awsPermissionBoundarySCPSeverityPriority)
 	if severity != "critical" {

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -268,22 +268,22 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 		{
 			name:     "cross-account resource access using service token s3",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using normalized s3 token",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token kms",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
-			expected: "kms:PutKeyPolicy",
+			expected: []string{"kms:PutKeyPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token secretsmanager",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
-			expected: "secretsmanager:PutResourcePolicy",
+			expected: []string{"secretsmanager:PutResourcePolicy"},
 		},
 		{
 			name:     "fallback action",
@@ -314,7 +314,12 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 		{
 			name:     "access analyzer external access",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
+		},
+		{
+			name:     "unsupported resource type",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "sqs_queue"},
+			expected: nil,
 		},
 	}
 	for _, tc := range tests {

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -266,6 +266,26 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			expected: []string{"secretsmanager:PutResourcePolicy"},
 		},
 		{
+			name:     "cross-account resource access using service token s3",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using normalized s3 token",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token kms",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
+			expected: "kms:PutKeyPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token secretsmanager",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
+			expected: "secretsmanager:PutResourcePolicy",
+		},
+		{
 			name:     "fallback action",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "other_cross_account_grant", ResourceType: "s3_bucket"},
 			expected: []string{"*"},
@@ -290,6 +310,11 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			name:     "unsupported resource type",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "sqs_queue"},
 			expected: nil,
+		},
+		{
+			name:     "access analyzer external access",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Add IAM least-privilege diff, trust policy hardening, and permission-boundary/SCP planning APIs and runtime surfaces.
- Expose planning artifacts via API clients, OpenAPI documentation, and product runtime loading.
- Include planner-facing test coverage and docs updates for read-only behavior, tradeoffs, rollback, and verification metadata.

Closes #1535

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only planner that generates AWS permission boundary and SCP recommendations, plus a new API and UI to view them. Implements #1532 with better scoping for STS assumptions and cleaner deny-action mapping, without mutating AWS.

- **New Features**
  - Deterministic planner emits `permission_boundary` and `scp` plans from least-privilege, cross-account trust, and org topology signals. Boundaries require 2+ identities sharing the same removal; public-principal SCPs are high breakage and non-executable.
  - New GET endpoint: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-scp with filters (connector, account, region, service, kind, target_scope, severity, status, breakage_level, ready_for_apply, search). OpenAPI and authz wired.
  - Plan payloads include target scope/IDs, statement snippets, prevented behavior, breakage projection, rollback/verification, confidence, and `ready_for_apply`.
  - Web app panel (“AWS permission boundary / SCP planner”), client types, and `getAWSProjectPermissionBoundarySCPPlans`; docs and changelog. Engine is read-only.

- **Bug Fixes**
  - Skip unscoped `runtime_cross_account_assumption` SCP candidates when the principal is outside the org and no OU path is set.
  - Normalize deny action mapping for resource policy findings and Access Analyzer external access: `s3`/`s3-bucket`→`s3:PutBucketPolicy`, `kms`→`kms:PutKeyPolicy`, `secretsmanager`→`secretsmanager:PutResourcePolicy`; ignore unsupported types.

<sup>Written for commit 3cba7f89a45813c9af5ba4728e32d2b3e1972fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

