### PR TITLE
Fix permission boundary and SCP planner review follow-ups (#1532)

### DIFF
--- a/internal/api/aws_permission_boundary_scp.go
+++ b/internal/api/aws_permission_boundary_scp.go
@@ -520,6 +520,9 @@ func awsSCPPlansFromCrossAccountTrust(trust AWSCrossAccountTrustResult, orgs AWS
 }
 
 func awsSCPCandidate(finding AWSCrossAccountTrustFinding) bool {
+	if finding.FindingType == "runtime_cross_account_assumption" && !finding.TrustedWithinOrganization && strings.TrimSpace(finding.ExternalPrincipalOUPath) == "" {
+		return false
+	}
 	if finding.PublicPrincipal {
 		return true
 	}

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -426,6 +426,16 @@ func TestAWSSCPTargetScopeForResourcePolicyFindings(t *testing.T) {
 	}
 }
 
+func TestAWSCPCandidateSkipsUnscopedRuntimeAssumption(t *testing.T) {
+	if awsSCPCandidate(AWSCrossAccountTrustFinding{
+		FindingType:               "runtime_cross_account_assumption",
+		TrustedWithinOrganization: false,
+		ExternalPrincipalOUPath:   "",
+	}) {
+		t.Fatalf("runtime assumption from out-of-org principal should not be projected without an OU scope")
+	}
+}
+
 func TestAWSPermissionBoundarySCPMostCommonKeyIsDeterministic(t *testing.T) {
 	severity := awsPermissionBoundarySCPMostCommonKeyWithPriority(map[string]int{"high": 1, "critical": 1}, "medium", awsPermissionBoundarySCPSeverityPriority)
 	if severity != "critical" {

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -268,22 +268,22 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 		{
 			name:     "cross-account resource access using service token s3",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using normalized s3 token",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token kms",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
-			expected: "kms:PutKeyPolicy",
+			expected: []string{"kms:PutKeyPolicy"},
 		},
 		{
 			name:     "cross-account resource access using service token secretsmanager",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
-			expected: "secretsmanager:PutResourcePolicy",
+			expected: []string{"secretsmanager:PutResourcePolicy"},
 		},
 		{
 			name:     "fallback action",
@@ -314,7 +314,12 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 		{
 			name:     "access analyzer external access",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
-			expected: "s3:PutBucketPolicy",
+			expected: []string{"s3:PutBucketPolicy"},
+		},
+		{
+			name:     "unsupported resource type",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "sqs_queue"},
+			expected: nil,
 		},
 	}
 	for _, tc := range tests {

--- a/internal/api/aws_permission_boundary_scp_test.go
+++ b/internal/api/aws_permission_boundary_scp_test.go
@@ -266,6 +266,26 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			expected: []string{"secretsmanager:PutResourcePolicy"},
 		},
 		{
+			name:     "cross-account resource access using service token s3",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using normalized s3 token",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "s3-bucket"},
+			expected: "s3:PutBucketPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token kms",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "kms"},
+			expected: "kms:PutKeyPolicy",
+		},
+		{
+			name:     "cross-account resource access using service token secretsmanager",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "secretsmanager"},
+			expected: "secretsmanager:PutResourcePolicy",
+		},
+		{
 			name:     "fallback action",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "other_cross_account_grant", ResourceType: "s3_bucket"},
 			expected: []string{"*"},
@@ -290,6 +310,11 @@ func TestAWSSCPDeniedActionsForResourcePolicyFindings(t *testing.T) {
 			name:     "unsupported resource type",
 			finding:  AWSCrossAccountTrustFinding{FindingType: "cross_account_resource_access", ResourceType: "sqs_queue"},
 			expected: nil,
+		},
+		{
+			name:     "access analyzer external access",
+			finding:  AWSCrossAccountTrustFinding{FindingType: "access_analyzer_external_access", ResourceType: "s3"},
+			expected: "s3:PutBucketPolicy",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Three small follow-ups to the AWS permission boundary / SCP planner from [#1675](https://github.com/identrail/identrail/pull/1675) (Wave 7.04, issue [#1532](https://github.com/identrail/identrail/issues/1532)). All read-only, metadata-only, no API or contract changes.

- Skip SCP projection for `runtime_cross_account_assumption` findings whose external principal is out-of-org and has no resolved OU path. Without an OU scope there's nothing safe to attach the SCP to, so the plan would be non-actionable noise.
- Cover the remaining resource-policy denied-action mappings in tests (`s3`, `s3-bucket`, `kms`, `secretsmanager` service tokens, plus `access_analyzer_external_access` and the unsupported-type fallback) so the resource-policy branch of `awsSCPDeniedActions` doesn't regress silently.
- Add a focused test for the new `awsSCPCandidate` skip-path.

## Why

Review of [#1675](https://github.com/identrail/identrail/pull/1675) flagged two edge cases that produced unscoped or unresolved plans (no attachable target), and the resource-policy mapping table only had partial coverage. These commits tighten the projection rules without changing the planner's external contract.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (no API, schema, or persisted-record changes)
- [x] Risk level assessed (read-only; only narrows what gets projected)

## Validation

```bash
go test ./internal/api -run 'AWSCPCandidate|AWSSCP|AWSPermissionBoundary'   # ok
go vet ./internal/api                                                       # clean
make fmt-check                                                              # clean
```

## Checklist

- [x] Tests added for the new skip rule and the missing resource-policy mapping cases
- [ ] Docs updated — not needed; planner contract and operator-visible fields are unchanged
- [ ] `CHANGELOG.md` updated — not needed; no operator-visible behavior change beyond suppressing non-actionable plans
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Refs [#1532](https://github.com/identrail/identrail/issues/1532). Follow-up to [#1675](https://github.com/identrail/identrail/pull/1675).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the AWS permission boundary/SCP planner to avoid unscoped plans and strengthened test coverage for resource-policy cases. Reduces noise; no API changes. Refs #1532.

- **Bug Fixes**
  - Skip SCP projection for `runtime_cross_account_assumption` from out-of-org principals with no OU path.
  - Add tests for resource-policy denied-action mappings: `s3`, `s3-bucket`, `kms`, `secretsmanager`, `access_analyzer_external_access`, and unsupported-type fallback.
  - Add a focused test to enforce the new skip path.

<sup>Written for commit 3cba7f89a45813c9af5ba4728e32d2b3e1972fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

