### PR TITLE
Implement AWS IaC remediation PR plan generator (#1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS IaC remediation PR and verification plan generator** (#1535). Adds
+  a read-only, metadata-only generator that turns IAM least-privilege diffs
+  (#1530) and trust-policy hardening plans (#1531) into ranked IaC remediation
+  PR plans for Terraform, CloudFormation, CDK, and policy-as-code. Each plan
+  carries `change_kind` (`iam_policy_diff` / `trust_policy_hardening`),
+  `iac_target` (`terraform` / `cloudformation` / `cdk` / `policy_as_code`),
+  file change intent (with deterministic per-target paths and IaC resource
+  type), local validation hints, cloud verification checks, PR notes (title,
+  summary, labels, evidence refs, reviewers), tradeoffs, rollback plan,
+  verification plan, readiness gates (read-only projection, upstream readiness,
+  and a public-principal review gate for trust hardening), and a deterministic
+  `ready_for_apply` flag. Identrail never opens, pushes, or merges a PR, never
+  calls AWS IAM write APIs, and never inlines rendered IaC bodies, policy
+  bodies, secret values, or workload payloads. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans`
+  with filters for connector, account, region, identity, IaC target, change
+  kind, severity, status, ready-for-apply, and free-text search. OpenAPI
+  schemas and authz wiring follow the neighboring Wave 7 planners. The AWS
+  Runtime app surface now shows an **AWS IaC remediation PR generator** panel
+  with plan title, change kind, IaC target, validation tools, readiness gate,
+  severity/status pill, and cloud verification count, with explicit loading,
+  empty, degraded, blocked, and error states.
 - Add **AWS permission boundary and SCP recommendation planner** (#1532).
   Adds a read-only, metadata-only engine that turns upstream least-privilege
   (#1522), cross-account-trust (#1526), and AWS Organizations topology

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
 - AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
 - AWS access key disable and quarantine planner: `aws-access-key-quarantine-planner.md`
+- AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-iac-remediation-planner.md
+++ b/docs/aws-iac-remediation-planner.md
@@ -1,0 +1,104 @@
+# AWS IaC remediation PR and verification plan generator
+
+Issue #1535 adds a metadata-only generator that turns IAM least-privilege diffs
+(issue #1530) and trust-policy hardening plans (issue #1531) into ranked,
+read-only IaC remediation PR plans. Each plan ships file change intent, local
+validation hints, cloud verification checks, PR notes, rollback, verification,
+and readiness gates so operators can land the change through their own
+source-control system instead of guessing how to translate Identrail evidence
+into Terraform, CloudFormation, CDK, or policy-as-code edits.
+
+The generator is read-only. It never opens, pushes, or merges a PR, never calls
+AWS IAM write APIs, and never reads, exposes, logs, or persists rendered IaC
+bodies, rendered policy bodies, secret values, prompts, completions, browser
+pages, code-interpreter output, database rows, object contents, customer
+payloads, or workload payloads.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iac-remediation-plans`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `identity` | identity node ID, identity ARN, identity name, resource node ID, or resource ARN match |
+| `iac_target` | `terraform`, `cloudformation`, `cdk`, or `policy_as_code` |
+| `change_kind` | `iam_policy_diff` or `trust_policy_hardening` |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `status` | upstream-derived plan status |
+| `ready_for_apply` | `true` / `false` |
+| `search` | free-text search across plan, file change, validation, verification, PR notes, rollback, and evidence fields |
+
+Response shape: `{ "plans": AWSIaCRemediationResult }` with
+tenant/workspace/project metadata, summary counts, ranked plans,
+relationships, caveats, failure reasons, remediation hints, evidence links,
+coverage gaps, diagnostics, and generated timestamps.
+
+## Plan shape
+
+Each `AWSIaCRemediationPlan` includes:
+
+- stable `plan_id`, calculation version, source artifact ID, issue refs, score,
+  confidence, status, and severity
+- `change_kind` (`iam_policy_diff` or `trust_policy_hardening`) plus `iac_target`
+  (`terraform`, `cloudformation`, `cdk`, or `policy_as_code`)
+- `file_changes` with path, change intent, IaC resource type, and before/after
+  metadata refs
+- `validation_hints` describing the local commands the operator should run
+  before the PR (e.g. `terraform plan`, `cfn-lint`, `cdk diff`, `conftest test`)
+- `cloud_verification` describing the cloud signals to watch after merge (e.g.
+  IAM policy simulator, CloudTrail, IAM last-used, Access Analyzer)
+- `pr_notes` skeleton (title, summary, labels, evidence refs, reviewers) so the
+  operator can paste a consistent PR body in their source-control system
+- `diff_intent`, tradeoffs, rollback plan, verification plan, readiness gates,
+  impacted graph nodes, and evidence refs
+- `ready_for_apply`, which is only a planning signal — Identrail never opens the
+  PR, never applies the IaC change, and never calls IAM write APIs
+
+`ready_for_apply` is true only when the upstream IAM diff or trust hardening
+plan is itself ready for apply and the IaC readiness gates pass (read-only
+projection, upstream readiness, and — for trust hardening — a public-principal
+review gate). Plans driven by low-confidence, manual-review, or
+public-principal upstream evidence stay blocked.
+
+## Failure handling
+
+- **Ready**: upstream IAM diff and trust hardening are available and at least
+  one IaC PR plan can be composed.
+- **Degraded**: one or both upstream sources are partial, degraded, or
+  diagnostic-bearing; composed plans stay visible when safe.
+- **Blocked**: upstream permission-denied evidence emits zero plans plus
+  failure reasons, remediation hints, diagnostics, and coverage gaps.
+
+Unsupported, empty, partial, degraded, and permission-denied states stay
+explicit. The generator does not convert absence of upstream evidence into a
+deterministic IaC PR.
+
+## App surface
+
+The AWS Runtime page renders an **AWS IaC remediation PR generator** panel with
+plan title, change kind, IaC target and file count, validation tools, readiness
+gate, severity/status pill, and cloud verification count. Loading, empty,
+degraded, blocked, and error states are explicit.
+
+## Validation
+
+1. Confirm blockers #1530 and #1531 are closed.
+2. Run IAM policy diff and trust hardening upstreams with `fixture_state=success`.
+3. Call the IaC remediation endpoint with `fixture_state=success` and verify
+   at least one IaC PR plan includes file changes, validation hints, cloud
+   verification, PR notes, rollback, and verification.
+4. Filter by `iac_target=terraform`, `change_kind=iam_policy_diff`,
+   `ready_for_apply=true`, and `search=terraform validate`.
+5. Run `fixture_state=empty`, `degraded`, `partial_failure`, and
+   `permission_denied` and confirm the status, diagnostics, and failure reasons
+   stay explicit.
+
+## What is intentionally out of scope
+
+- Opening, pushing, or merging PRs in the operator's source-control system.
+- Live AWS IAM, trust policy, or organization SCP mutation.
+- Rendering full IaC bodies, policy bodies, or workload payloads.
+- Wave-8 approval, dry-run, apply, and verify executors.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -604,6 +604,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iac-remediation-plans
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5584,6 +5589,89 @@ paths:
                     $ref: "#/components/schemas/AWSAccessKeyQuarantineResult"
         "400":
           description: Invalid AWS access key quarantine request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iac-remediation-plans:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS IaC remediation PR and verification plans
+      operationId: getAWSProjectIaCRemediationPlans
+      description: Generates ranked, read-only IaC remediation PR plans from IAM policy least-privilege diffs and trust-policy hardening plans. Each plan carries IaC target (Terraform, CloudFormation, CDK, or policy-as-code), file change intent, local validation hints, cloud verification checks, PR notes, tradeoffs, rollback, verification, readiness gates, and evidence refs. The endpoint never opens or pushes a PR, never mutates AWS, and never reads, exposes, logs, or persists rendered IaC bodies, rendered policy bodies, secret values, customer payloads, prompts, completions, browser pages, code-interpreter output, database rows, or object contents.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: identity
+          schema: { type: string }
+        - in: query
+          name: iac_target
+          schema:
+            type: string
+            enum: [terraform, cloudformation, cdk, policy_as_code]
+        - in: query
+          name: change_kind
+          schema:
+            type: string
+            enum: [iam_policy_diff, trust_policy_hardening]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: status
+          schema: { type: string }
+        - in: query
+          name: ready_for_apply
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS IaC remediation PR plan contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    $ref: "#/components/schemas/AWSIaCRemediationResult"
+        "400":
+          description: Invalid AWS IaC remediation plans request
           content:
             application/json:
               schema:
@@ -14999,6 +15087,231 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAccessKeyQuarantineRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSIaCFileChange:
+      type: object
+      properties:
+        path: { type: string }
+        change_intent: { type: string }
+        resource_type: { type: string }
+        before_ref: { type: string }
+        after_ref: { type: string }
+        rationale: { type: string }
+    AWSIaCValidationHint:
+      type: object
+      properties:
+        tool: { type: string }
+        command: { type: string }
+        description: { type: string }
+    AWSIaCCloudVerificationCheck:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        description: { type: string }
+    AWSIaCPRNotes:
+      type: object
+      properties:
+        title: { type: string }
+        summary: { type: string }
+        labels:
+          type: array
+          items: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        reviewers:
+          type: array
+          items: { type: string }
+    AWSIaCReadinessGate:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSIaCRemediationRelationship:
+      type: object
+      properties:
+        plan_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSIaCRemediationPlan:
+      type: object
+      properties:
+        plan_id: { type: string }
+        calculation_version: { type: string }
+        change_kind:
+          type: string
+          enum: [iam_policy_diff, trust_policy_hardening]
+        iac_target:
+          type: string
+          enum: [terraform, cloudformation, cdk, policy_as_code]
+        source_artifact_id: { type: string }
+        source_case_id: { type: string }
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        status: { type: string }
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        identity_node_id: { type: string }
+        identity_arn: { type: string }
+        identity_name: { type: string }
+        resource_node_id: { type: string }
+        resource_arn: { type: string }
+        file_changes:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCFileChange"
+        validation_hints:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCValidationHint"
+        cloud_verification:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCCloudVerificationCheck"
+        pr_notes:
+          $ref: "#/components/schemas/AWSIaCPRNotes"
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        readiness_gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCReadinessGate"
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSIaCRemediationSummary:
+      type: object
+      properties:
+        total_plans: { type: integer }
+        filtered_plans: { type: integer }
+        change_kind_counts:
+          type: object
+          additionalProperties: { type: integer }
+        iac_target_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        ready_for_apply_count: { type: integer }
+        manual_review_count: { type: integer }
+        file_change_count: { type: integer }
+        validation_hint_count: { type: integer }
+        verification_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSIaCRemediationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSIaCRemediationSummary"
+        plans:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCRemediationPlan"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSIaCRemediationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -764,6 +764,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_iac_remediation_plans.go
+++ b/internal/api/aws_iac_remediation_plans.go
@@ -339,7 +339,7 @@ func awsIaCRemediationPlanFromIAMDiff(diff AWSIAMPolicyDiff, now time.Time) (AWS
 	resourceSlug := awsIaCResourceSlug(firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, diff.DiffID))
 	evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(diff.Evidence))
 	files := awsIaCFileChangesForIAMDiff(diff, target, resourceSlug, evidenceRef)
-	validation := awsIaCValidationHintsForTarget(target)
+	validation := awsIaCValidationHintsForTarget(target, files)
 	verification := awsIaCCloudVerificationForIAMDiff(diff)
 	gates := awsIaCReadinessGatesForIAMDiff(diff)
 	pr := awsIaCPRNotesForIAMDiff(diff)
@@ -400,7 +400,7 @@ func awsIaCRemediationPlanFromTrustHardening(hardening AWSTrustPolicyHardeningPl
 	resourceSlug := awsIaCResourceSlug(firstNonEmptyAWSValue(hardening.ResourceLabel, hardening.ResourceNodeID, hardening.PlanID))
 	evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(hardening.Evidence))
 	files := awsIaCFileChangesForTrustHardening(hardening, target, resourceSlug, evidenceRef)
-	validation := awsIaCValidationHintsForTarget(target)
+	validation := awsIaCValidationHintsForTarget(target, files)
 	verification := awsIaCCloudVerificationForTrustHardening(hardening)
 	gates := awsIaCReadinessGatesForTrustHardening(hardening)
 	pr := awsIaCPRNotesForTrustHardening(hardening)
@@ -628,13 +628,23 @@ func awsIaCResourceTypeForTrustPolicy(target string) string {
 	}
 }
 
-func awsIaCValidationHintsForTarget(target string) []AWSIaCValidationHint {
+func awsIaCValidationHintsForTarget(target string, fileChanges []AWSIaCFileChange) []AWSIaCValidationHint {
 	switch target {
 	case awsIaCTargetCloudFormation:
-		return []AWSIaCValidationHint{
-			{Tool: "cfn-lint", Command: "cfn-lint cloudformation/identrail/**/*.yaml", Description: "Lint the CloudFormation template before opening the PR."},
-			{Tool: "aws cloudformation validate-template", Command: "aws cloudformation validate-template --template-body file://template.yaml", Description: "Validate the template against the CloudFormation schema."},
+		cloudTemplateCommands := []AWSIaCValidationHint{}
+		for _, file := range fileChanges {
+			if !strings.HasSuffix(file.Path, ".yaml") {
+				continue
+			}
+			cloudTemplateCommands = append(cloudTemplateCommands, AWSIaCValidationHint{
+				Tool:        "aws cloudformation validate-template",
+				Command:     fmt.Sprintf("aws cloudformation validate-template --template-body file://%s", file.Path),
+				Description: "Validate each generated CloudFormation template before opening the PR.",
+			})
 		}
+		return append([]AWSIaCValidationHint{
+			{Tool: "cfn-lint", Command: "cfn-lint cloudformation/identrail/**/*.yaml", Description: "Lint the generated CloudFormation templates before opening the PR."},
+		}, cloudTemplateCommands...)
 	case awsIaCTargetCDK:
 		return []AWSIaCValidationHint{
 			{Tool: "cdk synth", Command: "cdk synth --strict", Description: "Synthesize the CDK app and fail on warnings before opening the PR."},

--- a/internal/api/aws_iac_remediation_plans.go
+++ b/internal/api/aws_iac_remediation_plans.go
@@ -1,0 +1,1034 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsIaCRemediationCurrentIssue = 1535
+	awsIaCRemediationVersion      = "aws-iac-remediation-plan-generator-v1"
+
+	awsIaCTargetTerraform      = "terraform"
+	awsIaCTargetCloudFormation = "cloudformation"
+	awsIaCTargetCDK            = "cdk"
+	awsIaCTargetPolicyAsCode   = "policy_as_code"
+
+	awsIaCChangeKindIAMPolicyDiff       = "iam_policy_diff"
+	awsIaCChangeKindTrustPolicyHardened = "trust_policy_hardening"
+)
+
+// AWSIaCRemediationRequest scopes the deterministic IaC remediation PR
+// generator to one AWS connector plus optional operator drill-down filters.
+type AWSIaCRemediationRequest struct {
+	ConnectorID   string `json:"connector_id,omitempty"`
+	FixtureState  string `json:"fixture_state,omitempty"`
+	AccountID     string `json:"account_id,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Identity      string `json:"identity,omitempty"`
+	IaCTarget     string `json:"iac_target,omitempty"`
+	ChangeKind    string `json:"change_kind,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	ReadyForApply string `json:"ready_for_apply,omitempty"`
+	Search        string `json:"search,omitempty"`
+}
+
+// Reuse upstream evidence shapes so the generator stays consistent with its
+// IAM-diff and trust-hardening sources.
+type AWSIaCRemediationEvidence = AWSLeastPrivilegeEvidence
+type AWSIaCRemediationPathStep = AWSLeastPrivilegePathStep
+type AWSIaCRemediationDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSIaCRemediationCoverageGap = AWSLeastPrivilegeCoverageGap
+
+// AWSIaCFileChange describes one file the generated PR would touch. Bodies are
+// intentionally not inlined; the generator emits change intent and references
+// to upstream before/after metadata only.
+type AWSIaCFileChange struct {
+	Path         string `json:"path"`
+	ChangeIntent string `json:"change_intent"`
+	ResourceType string `json:"resource_type,omitempty"`
+	BeforeRef    string `json:"before_ref,omitempty"`
+	AfterRef     string `json:"after_ref,omitempty"`
+	Rationale    string `json:"rationale"`
+}
+
+// AWSIaCValidationHint records a local validation step the operator should run
+// before opening the PR. Commands are operator-runnable but the generator does
+// not execute them.
+type AWSIaCValidationHint struct {
+	Tool        string `json:"tool"`
+	Command     string `json:"command"`
+	Description string `json:"description"`
+}
+
+// AWSIaCCloudVerificationCheck records a cloud-side verification step after
+// the PR ships. Each entry is metadata-only and refers to evidence sources.
+type AWSIaCCloudVerificationCheck struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Description string `json:"description"`
+}
+
+// AWSIaCPRNotes is the deterministic PR-body skeleton the generator emits.
+// The generator never opens a PR externally; this is metadata only.
+type AWSIaCPRNotes struct {
+	Title        string   `json:"title"`
+	Summary      string   `json:"summary"`
+	Labels       []string `json:"labels,omitempty"`
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+	Reviewers    []string `json:"reviewers,omitempty"`
+}
+
+// AWSIaCReadinessGate explains one prerequisite the operator must satisfy
+// before the IaC PR can ship.
+type AWSIaCReadinessGate struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSIaCRemediationRelationship surfaces plan→graph node edges so the app and
+// downstream graph consumers can show why a plan touches a node.
+type AWSIaCRemediationRelationship struct {
+	PlanID      string `json:"plan_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSIaCRemediationPlan is the persisted-record-shaped contract emitted by the
+// IaC remediation PR generator. It carries change intent, file paths,
+// validation hints, cloud verification, PR notes, rollback, and verification
+// metadata only. Rendered IaC bodies, secret values, and customer payloads are
+// never inlined.
+type AWSIaCRemediationPlan struct {
+	PlanID             string                         `json:"plan_id"`
+	CalculationVersion string                         `json:"calculation_version"`
+	ChangeKind         string                         `json:"change_kind"`
+	IaCTarget          string                         `json:"iac_target"`
+	SourceArtifactID   string                         `json:"source_artifact_id"`
+	SourceCaseID       string                         `json:"source_case_id,omitempty"`
+	Severity           string                         `json:"severity"`
+	Status             string                         `json:"status"`
+	Score              int                            `json:"score"`
+	Confidence         float64                        `json:"confidence"`
+	Title              string                         `json:"title"`
+	Summary            string                         `json:"summary"`
+	AccountID          string                         `json:"account_id"`
+	Region             string                         `json:"region"`
+	Service            string                         `json:"service,omitempty"`
+	IdentityNodeID     string                         `json:"identity_node_id,omitempty"`
+	IdentityARN        string                         `json:"identity_arn,omitempty"`
+	IdentityName       string                         `json:"identity_name,omitempty"`
+	ResourceNodeID     string                         `json:"resource_node_id,omitempty"`
+	ResourceARN        string                         `json:"resource_arn,omitempty"`
+	FileChanges        []AWSIaCFileChange             `json:"file_changes"`
+	ValidationHints    []AWSIaCValidationHint         `json:"validation_hints"`
+	CloudVerification  []AWSIaCCloudVerificationCheck `json:"cloud_verification"`
+	PRNotes            AWSIaCPRNotes                  `json:"pr_notes"`
+	DiffIntent         AWSRemediationDiffIntent       `json:"diff_intent"`
+	Tradeoffs          []AWSRemediationTradeoff       `json:"tradeoffs"`
+	RollbackPlan       AWSRemediationRollbackPlan     `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan `json:"verification_plan"`
+	ReadinessGates     []AWSIaCReadinessGate          `json:"readiness_gates"`
+	ReadyForApply      bool                           `json:"ready_for_apply"`
+	ReadOnlyProjection bool                           `json:"read_only_projection"`
+	SourceSignals      []string                       `json:"source_signals"`
+	Evidence           []AWSIaCRemediationEvidence    `json:"evidence"`
+	EvidenceBoundary   string                         `json:"evidence_boundary"`
+	ImpactedNodes      []string                       `json:"impacted_nodes"`
+	ImpactedPath       []AWSIaCRemediationPathStep    `json:"impacted_path"`
+	NextAction         string                         `json:"next_action"`
+	CreatedAt          time.Time                      `json:"created_at"`
+	UpdatedAt          time.Time                      `json:"updated_at"`
+}
+
+// AWSIaCRemediationSummary aggregates the unfiltered and filtered plan set.
+type AWSIaCRemediationSummary struct {
+	TotalPlans           int            `json:"total_plans"`
+	FilteredPlans        int            `json:"filtered_plans"`
+	ChangeKindCounts     map[string]int `json:"change_kind_counts"`
+	IaCTargetCounts      map[string]int `json:"iac_target_counts"`
+	SeverityCounts       map[string]int `json:"severity_counts"`
+	StatusCounts         map[string]int `json:"status_counts"`
+	ReadyForApplyCount   int            `json:"ready_for_apply_count"`
+	ManualReviewCount    int            `json:"manual_review_count"`
+	FileChangeCount      int            `json:"file_change_count"`
+	ValidationHintCount  int            `json:"validation_hint_count"`
+	VerificationCount    int            `json:"verification_count"`
+	RelationshipCount    int            `json:"relationship_count"`
+	HighestScore         int            `json:"highest_score"`
+	AverageConfidencePct int            `json:"average_confidence_pct"`
+}
+
+// AWSIaCRemediationResult is the deterministic generator envelope.
+type AWSIaCRemediationResult struct {
+	TenantID           string                          `json:"tenant_id"`
+	WorkspaceID        string                          `json:"workspace_id"`
+	ProjectID          string                          `json:"project_id"`
+	ConnectorID        string                          `json:"connector_id,omitempty"`
+	AccountID          string                          `json:"account_id,omitempty"`
+	Region             string                          `json:"region,omitempty"`
+	ParentIssueNumber  int                             `json:"parent_issue_number"`
+	ParentIssueRef     string                          `json:"parent_issue_ref"`
+	CurrentIssueNumber int                             `json:"current_issue_number"`
+	CurrentIssueRef    string                          `json:"current_issue_ref"`
+	Version            string                          `json:"version"`
+	Status             string                          `json:"status"`
+	FixtureState       string                          `json:"fixture_state,omitempty"`
+	Confidence         float64                         `json:"confidence"`
+	CalculationVersion string                          `json:"calculation_version"`
+	AppliedFilters     map[string]string               `json:"applied_filters"`
+	Summary            AWSIaCRemediationSummary        `json:"summary"`
+	Plans              []AWSIaCRemediationPlan         `json:"plans"`
+	Relationships      []AWSIaCRemediationRelationship `json:"relationships"`
+	Caveats            []string                        `json:"caveats"`
+	FailureReasons     []string                        `json:"failure_reasons"`
+	RemediationHints   []string                        `json:"remediation_hints"`
+	EvidenceLinks      []string                        `json:"evidence_links"`
+	CoverageGaps       []AWSIaCRemediationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSIaCRemediationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                       `json:"generated_at"`
+	UpdatedAt          time.Time                       `json:"updated_at"`
+}
+
+type awsIaCRemediationSources struct {
+	iamPolicyDiffs       AWSIAMPolicyDiffResult
+	trustPolicyHardening AWSTrustPolicyHardeningResult
+}
+
+// GetAWSIaCRemediationPlans composes ranked IaC remediation PR and
+// verification plans from upstream IAM policy diffs and trust policy hardening
+// plans. The generator is read-only: it never opens a real PR, never mutates
+// AWS, never reads or returns rendered IaC bodies, secret values, or workload
+// payloads, and treats unknown or denied evidence as explicit states instead
+// of deterministic truth.
+func (s *Service) GetAWSIaCRemediationPlans(ctx context.Context, workspaceID string, projectID string, request AWSIaCRemediationRequest) (AWSIaCRemediationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSIaCRemediationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSIaCRemediationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSIaCRemediationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSIaCRemediationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, err := s.awsIaCRemediationSources(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSIaCRemediationResult{}, err
+	}
+	plans := awsIaCRemediationPlans(sources, now)
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Score == plans[j].Score {
+			return plans[i].PlanID < plans[j].PlanID
+		}
+		return plans[i].Score > plans[j].Score
+	})
+	filtered, applied := filterAWSIaCRemediationPlans(plans, request)
+	relationships := awsIaCRemediationRelationships(filtered)
+	diagnostics := awsIaCRemediationDiagnostics(sources)
+	coverageGaps := awsIaCRemediationCoverageGaps(sources)
+	status, confidence := summarizeAWSIaCRemediationStatus(sources, filtered, diagnostics)
+
+	return AWSIaCRemediationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsIaCRemediationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsIaCRemediationCurrentIssue),
+		Version:            awsIaCRemediationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsIaCRemediationVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSIaCRemediationPlans(plans, filtered, relationships),
+		Plans:              filtered,
+		Relationships:      relationships,
+		Caveats:            awsIaCRemediationCaveats(),
+		FailureReasons:     awsIaCRemediationFailureReasons(sources),
+		RemediationHints:   awsIaCRemediationRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsIaCRemediationCurrentIssue),
+			awsIssueURL(awsIAMPolicyDiffCurrentIssue),
+			awsIssueURL(awsTrustPolicyHardeningCurrentIssue),
+			"/docs/aws-iac-remediation-planner",
+			"/docs/aws-iam-policy-least-privilege-diff",
+			"/docs/aws-trust-policy-hardening-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSIaCRemediationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func (s *Service) awsIaCRemediationSources(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) (awsIaCRemediationSources, error) {
+	diffs, err := s.GetAWSIAMPolicyDiffs(ctx, workspaceID, projectID, AWSIAMPolicyDiffRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsIaCRemediationSources{}, fmt.Errorf("iac remediation iam policy diffs: %w", err)
+	}
+	trust, err := s.GetAWSTrustPolicyHardeningPlans(ctx, workspaceID, projectID, AWSTrustPolicyHardeningRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsIaCRemediationSources{}, fmt.Errorf("iac remediation trust policy hardening: %w", err)
+	}
+	return awsIaCRemediationSources{iamPolicyDiffs: diffs, trustPolicyHardening: trust}, nil
+}
+
+func awsIaCRemediationPlans(sources awsIaCRemediationSources, now time.Time) []AWSIaCRemediationPlan {
+	plans := []AWSIaCRemediationPlan{}
+	for _, diff := range sources.iamPolicyDiffs.Diffs {
+		if plan, ok := awsIaCRemediationPlanFromIAMDiff(diff, now); ok {
+			plans = append(plans, plan)
+		}
+	}
+	for _, hardening := range sources.trustPolicyHardening.Plans {
+		if plan, ok := awsIaCRemediationPlanFromTrustHardening(hardening, now); ok {
+			plans = append(plans, plan)
+		}
+	}
+	return plans
+}
+
+func awsIaCRemediationPlanFromIAMDiff(diff AWSIAMPolicyDiff, now time.Time) (AWSIaCRemediationPlan, bool) {
+	if diff.DiffID == "" {
+		return AWSIaCRemediationPlan{}, false
+	}
+	target := awsIaCTargetForService(diff.Service, diff.ResourceARN)
+	resourceSlug := awsIaCResourceSlug(firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, diff.DiffID))
+	evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(diff.Evidence))
+	files := awsIaCFileChangesForIAMDiff(diff, target, resourceSlug, evidenceRef)
+	validation := awsIaCValidationHintsForTarget(target)
+	verification := awsIaCCloudVerificationForIAMDiff(diff)
+	gates := awsIaCReadinessGatesForIAMDiff(diff)
+	pr := awsIaCPRNotesForIAMDiff(diff)
+	plan := AWSIaCRemediationPlan{
+		PlanID:             "aws-iac-remediation:" + stableAWSBlastRadiusToken(awsIaCChangeKindIAMPolicyDiff, target, diff.DiffID),
+		CalculationVersion: awsIaCRemediationVersion,
+		ChangeKind:         awsIaCChangeKindIAMPolicyDiff,
+		IaCTarget:          target,
+		SourceArtifactID:   diff.DiffID,
+		Severity:           diff.Severity,
+		Status:             diff.Status,
+		Score:              diff.Score,
+		Confidence:         diff.Confidence,
+		Title:              fmt.Sprintf("IaC PR (%s): scope %s least-privilege", awsIaCTargetLabel(target), firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, "IAM identity")),
+		Summary:            diff.Summary,
+		AccountID:          diff.AccountID,
+		Region:             diff.Region,
+		Service:            diff.Service,
+		IdentityNodeID:     diff.IdentityNodeID,
+		IdentityARN:        diff.IdentityARN,
+		IdentityName:       diff.IdentityName,
+		ResourceNodeID:     diff.ResourceNodeID,
+		ResourceARN:        diff.ResourceARN,
+		FileChanges:        files,
+		ValidationHints:    validation,
+		CloudVerification:  verification,
+		PRNotes:            pr,
+		DiffIntent: AWSRemediationDiffIntent{
+			Kind:               "iac_iam_policy_pr",
+			BeforeRef:          firstNonEmptyAWSValue(evidenceRef, diff.DiffID),
+			AfterRef:           fmt.Sprintf("iac://%s/%s/after", target, diff.DiffID),
+			DiffSummary:        fmt.Sprintf("Apply the projected IAM least-privilege diff via %s; no AWS write API is called by Identrail.", awsIaCTargetLabel(target)),
+			ReadOnlyProjection: true,
+		},
+		Tradeoffs:          awsIaCTradeoffsForIAMDiff(diff),
+		RollbackPlan:       awsIaCRollbackForIAMDiff(diff, evidenceRef),
+		VerificationPlan:   awsIaCVerificationPlanForIAMDiff(diff, evidenceRef),
+		ReadinessGates:     gates,
+		ReadyForApply:      awsIaCReadyForApply(gates, diff.ReadyForApply),
+		ReadOnlyProjection: true,
+		SourceSignals:      []string{"iam_policy_diff"},
+		Evidence:           diff.Evidence,
+		EvidenceBoundary:   awsIaCRemediationEvidenceBoundary(),
+		ImpactedNodes:      diff.ImpactedNodes,
+		ImpactedPath:       diff.ImpactedPath,
+		NextAction:         "Open the generated IaC PR in the operator's source-control system; Identrail does not push or create PRs.",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return plan, true
+}
+
+func awsIaCRemediationPlanFromTrustHardening(hardening AWSTrustPolicyHardeningPlan, now time.Time) (AWSIaCRemediationPlan, bool) {
+	if hardening.PlanID == "" {
+		return AWSIaCRemediationPlan{}, false
+	}
+	target := awsIaCTargetForService(hardening.Service, hardening.ResourceARN)
+	resourceSlug := awsIaCResourceSlug(firstNonEmptyAWSValue(hardening.ResourceLabel, hardening.ResourceNodeID, hardening.PlanID))
+	evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(hardening.Evidence))
+	files := awsIaCFileChangesForTrustHardening(hardening, target, resourceSlug, evidenceRef)
+	validation := awsIaCValidationHintsForTarget(target)
+	verification := awsIaCCloudVerificationForTrustHardening(hardening)
+	gates := awsIaCReadinessGatesForTrustHardening(hardening)
+	pr := awsIaCPRNotesForTrustHardening(hardening)
+	plan := AWSIaCRemediationPlan{
+		PlanID:             "aws-iac-remediation:" + stableAWSBlastRadiusToken(awsIaCChangeKindTrustPolicyHardened, target, hardening.PlanID),
+		CalculationVersion: awsIaCRemediationVersion,
+		ChangeKind:         awsIaCChangeKindTrustPolicyHardened,
+		IaCTarget:          target,
+		SourceArtifactID:   hardening.PlanID,
+		Severity:           hardening.Severity,
+		Status:             hardening.Status,
+		Score:              hardening.Score,
+		Confidence:         hardening.Confidence,
+		Title:              fmt.Sprintf("IaC PR (%s): harden trust policy for %s", awsIaCTargetLabel(target), firstNonEmptyAWSValue(hardening.ResourceLabel, hardening.ResourceNodeID, "trusting resource")),
+		Summary:            hardening.Summary,
+		AccountID:          hardening.AccountID,
+		Region:             hardening.Region,
+		Service:            hardening.Service,
+		ResourceNodeID:     hardening.ResourceNodeID,
+		ResourceARN:        hardening.ResourceARN,
+		IdentityName:       hardening.ResourceLabel,
+		FileChanges:        files,
+		ValidationHints:    validation,
+		CloudVerification:  verification,
+		PRNotes:            pr,
+		DiffIntent: AWSRemediationDiffIntent{
+			Kind:               "iac_trust_policy_pr",
+			BeforeRef:          firstNonEmptyAWSValue(evidenceRef, hardening.PlanID),
+			AfterRef:           fmt.Sprintf("iac://%s/%s/after", target, hardening.PlanID),
+			DiffSummary:        fmt.Sprintf("Apply trust-policy hardening (%s) via %s; no AWS write API is called by Identrail.", formatAWSBlastRadiusLabel(hardening.HardeningDirection), awsIaCTargetLabel(target)),
+			ReadOnlyProjection: true,
+		},
+		Tradeoffs:          awsIaCTradeoffsForTrustHardening(hardening),
+		RollbackPlan:       awsIaCRollbackForTrustHardening(hardening, evidenceRef),
+		VerificationPlan:   awsIaCVerificationPlanForTrustHardening(hardening, evidenceRef),
+		ReadinessGates:     gates,
+		ReadyForApply:      awsIaCReadyForApply(gates, hardening.ReadyForApply),
+		ReadOnlyProjection: true,
+		SourceSignals:      []string{"trust_policy_hardening"},
+		Evidence:           hardening.Evidence,
+		EvidenceBoundary:   awsIaCRemediationEvidenceBoundary(),
+		ImpactedNodes:      hardening.ImpactedNodes,
+		ImpactedPath:       hardening.ImpactedPath,
+		NextAction:         "Open the generated IaC PR in the operator's source-control system; Identrail does not push or create PRs.",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return plan, true
+}
+
+func awsIaCTargetForService(service string, resourceARN string) string {
+	lower := strings.ToLower(strings.TrimSpace(resourceARN))
+	if strings.Contains(lower, ":cloudformation:") || strings.Contains(lower, ":stack/") {
+		return awsIaCTargetCloudFormation
+	}
+	switch strings.ToLower(strings.TrimSpace(service)) {
+	case "organizations", "scp", "config":
+		return awsIaCTargetPolicyAsCode
+	case "cdk":
+		return awsIaCTargetCDK
+	}
+	return awsIaCTargetTerraform
+}
+
+func awsIaCTargetLabel(target string) string {
+	switch target {
+	case awsIaCTargetTerraform:
+		return "Terraform"
+	case awsIaCTargetCloudFormation:
+		return "CloudFormation"
+	case awsIaCTargetCDK:
+		return "CDK"
+	case awsIaCTargetPolicyAsCode:
+		return "policy-as-code"
+	default:
+		return strings.TrimSpace(target)
+	}
+}
+
+func awsIaCResourceSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "identrail-remediation"
+	}
+	cleaned := strings.Builder{}
+	prevDash := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			cleaned.WriteRune(r)
+			prevDash = false
+		case r == '-' || r == '_':
+			cleaned.WriteRune('-')
+			prevDash = r == '-'
+		default:
+			if !prevDash {
+				cleaned.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	slug := strings.Trim(cleaned.String(), "-")
+	if slug == "" {
+		return "identrail-remediation"
+	}
+	if len(slug) > 60 {
+		slug = slug[:60]
+		slug = strings.Trim(slug, "-")
+	}
+	return slug
+}
+
+func awsIaCFileChangesForIAMDiff(diff AWSIAMPolicyDiff, target, slug, evidenceRef string) []AWSIaCFileChange {
+	dir := awsIaCDirectoryForTarget(target)
+	file := dir + "/" + slug + awsIaCFileExtensionForTarget(target, awsIaCChangeKindIAMPolicyDiff)
+	resourceType := awsIaCResourceTypeForIAMPolicy(target)
+	changeIntent := "scope_least_privilege"
+	rationale := fmt.Sprintf("Remove %d unused action(s) and keep %d observed action(s) on %s.", len(diff.RemovedActions), len(diff.KeptActions), firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, "the identity"))
+	if diff.Decision == "review" {
+		changeIntent = "manual_review"
+		rationale = "Least-privilege decision is not yet conclusive; PR placeholder reserves the path and links the manual-review evidence."
+	}
+	files := []AWSIaCFileChange{{
+		Path:         file,
+		ChangeIntent: changeIntent,
+		ResourceType: resourceType,
+		BeforeRef:    firstNonEmptyAWSValue(evidenceRef, diff.DiffID),
+		AfterRef:     fmt.Sprintf("iac://%s/%s/policy-after", target, diff.DiffID),
+		Rationale:    rationale,
+	}}
+	files = append(files, AWSIaCFileChange{
+		Path:         dir + "/" + slug + "/README.md",
+		ChangeIntent: "documentation",
+		BeforeRef:    diff.DiffID,
+		AfterRef:     fmt.Sprintf("iac://%s/%s/readme-after", target, diff.DiffID),
+		Rationale:    "Operator-readable summary of the projected least-privilege diff, validation, and verification steps.",
+	})
+	return files
+}
+
+func awsIaCFileChangesForTrustHardening(hardening AWSTrustPolicyHardeningPlan, target, slug, evidenceRef string) []AWSIaCFileChange {
+	dir := awsIaCDirectoryForTarget(target)
+	file := dir + "/" + slug + awsIaCFileExtensionForTarget(target, awsIaCChangeKindTrustPolicyHardened)
+	resourceType := awsIaCResourceTypeForTrustPolicy(target)
+	rationale := fmt.Sprintf("Harden trust policy direction=%s with %d condition recommendation(s) for %s.", firstNonEmptyAWSValue(hardening.HardeningDirection, "manual_review"), len(hardening.ConditionRecommendations), firstNonEmptyAWSValue(hardening.ResourceLabel, hardening.ResourceNodeID, "the trusting resource"))
+	files := []AWSIaCFileChange{{
+		Path:         file,
+		ChangeIntent: "harden_trust_policy",
+		ResourceType: resourceType,
+		BeforeRef:    firstNonEmptyAWSValue(evidenceRef, hardening.PlanID),
+		AfterRef:     fmt.Sprintf("iac://%s/%s/trust-after", target, hardening.PlanID),
+		Rationale:    rationale,
+	}}
+	files = append(files, AWSIaCFileChange{
+		Path:         dir + "/" + slug + "/README.md",
+		ChangeIntent: "documentation",
+		BeforeRef:    hardening.PlanID,
+		AfterRef:     fmt.Sprintf("iac://%s/%s/readme-after", target, hardening.PlanID),
+		Rationale:    "Operator-readable summary of the trust-hardening change, validation, and cloud verification steps.",
+	})
+	return files
+}
+
+func awsIaCDirectoryForTarget(target string) string {
+	switch target {
+	case awsIaCTargetCloudFormation:
+		return "cloudformation/identrail"
+	case awsIaCTargetCDK:
+		return "cdk/identrail"
+	case awsIaCTargetPolicyAsCode:
+		return "policies/identrail"
+	default:
+		return "terraform/identrail"
+	}
+}
+
+func awsIaCFileExtensionForTarget(target, changeKind string) string {
+	switch target {
+	case awsIaCTargetCloudFormation:
+		if changeKind == awsIaCChangeKindTrustPolicyHardened {
+			return "/trust_policy.yaml"
+		}
+		return "/iam_policy.yaml"
+	case awsIaCTargetCDK:
+		if changeKind == awsIaCChangeKindTrustPolicyHardened {
+			return "/trust_policy.ts"
+		}
+		return "/iam_policy.ts"
+	case awsIaCTargetPolicyAsCode:
+		if changeKind == awsIaCChangeKindTrustPolicyHardened {
+			return "/trust_policy.rego"
+		}
+		return "/policy.rego"
+	default:
+		if changeKind == awsIaCChangeKindTrustPolicyHardened {
+			return "/trust_policy.tf"
+		}
+		return "/iam_policy.tf"
+	}
+}
+
+func awsIaCResourceTypeForIAMPolicy(target string) string {
+	switch target {
+	case awsIaCTargetCloudFormation:
+		return "AWS::IAM::ManagedPolicy"
+	case awsIaCTargetCDK:
+		return "iam.ManagedPolicy"
+	case awsIaCTargetPolicyAsCode:
+		return "rego.iam.policy"
+	default:
+		return "aws_iam_policy"
+	}
+}
+
+func awsIaCResourceTypeForTrustPolicy(target string) string {
+	switch target {
+	case awsIaCTargetCloudFormation:
+		return "AWS::IAM::Role.AssumeRolePolicyDocument"
+	case awsIaCTargetCDK:
+		return "iam.Role.assumeRolePolicy"
+	case awsIaCTargetPolicyAsCode:
+		return "rego.iam.trust_policy"
+	default:
+		return "aws_iam_role.assume_role_policy"
+	}
+}
+
+func awsIaCValidationHintsForTarget(target string) []AWSIaCValidationHint {
+	switch target {
+	case awsIaCTargetCloudFormation:
+		return []AWSIaCValidationHint{
+			{Tool: "cfn-lint", Command: "cfn-lint cloudformation/identrail/**/*.yaml", Description: "Lint the CloudFormation template before opening the PR."},
+			{Tool: "aws cloudformation validate-template", Command: "aws cloudformation validate-template --template-body file://template.yaml", Description: "Validate the template against the CloudFormation schema."},
+		}
+	case awsIaCTargetCDK:
+		return []AWSIaCValidationHint{
+			{Tool: "cdk synth", Command: "cdk synth --strict", Description: "Synthesize the CDK app and fail on warnings before opening the PR."},
+			{Tool: "cdk diff", Command: "cdk diff", Description: "Confirm the projected resource diff matches the IaC plan."},
+		}
+	case awsIaCTargetPolicyAsCode:
+		return []AWSIaCValidationHint{
+			{Tool: "opa fmt", Command: "opa fmt -d policies/identrail", Description: "Format and lint the Rego policy bundle."},
+			{Tool: "conftest test", Command: "conftest test policies/identrail", Description: "Run the policy-as-code unit tests for the new guardrail."},
+		}
+	default:
+		return []AWSIaCValidationHint{
+			{Tool: "terraform validate", Command: "terraform -chdir=terraform/identrail validate", Description: "Run terraform validate before opening the PR."},
+			{Tool: "terraform plan", Command: "terraform -chdir=terraform/identrail plan -out plan.tfplan", Description: "Confirm the projected resource changes match the IaC plan."},
+		}
+	}
+}
+
+func awsIaCCloudVerificationForIAMDiff(diff AWSIAMPolicyDiff) []AWSIaCCloudVerificationCheck {
+	checks := []AWSIaCCloudVerificationCheck{
+		{Source: "iam:policy_simulate", Signal: "no_regression_on_kept_actions", Description: "Use the IAM policy simulator to confirm kept actions still evaluate as Allow after merge."},
+		{Source: "cloudtrail", Signal: "no_access_denied_observed", Description: "Watch CloudTrail for AccessDenied events on observed callers in the first 24 hours after merge."},
+	}
+	if len(diff.ObservedActions) > 0 {
+		checks = append(checks, AWSIaCCloudVerificationCheck{Source: "iam:last_used", Signal: "observed_actions_still_callable", Description: "Re-check IAM Access Analyzer / last-used signals for the observed action set."})
+	}
+	return checks
+}
+
+func awsIaCCloudVerificationForTrustHardening(hardening AWSTrustPolicyHardeningPlan) []AWSIaCCloudVerificationCheck {
+	checks := []AWSIaCCloudVerificationCheck{
+		{Source: "cloudtrail:AssumeRole", Signal: "expected_principals_only", Description: "Verify CloudTrail AssumeRole events only originate from the hardened principal set."},
+		{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer to confirm no new external-trust findings appear after merge."},
+	}
+	if len(hardening.ConditionRecommendations) > 0 {
+		checks = append(checks, AWSIaCCloudVerificationCheck{Source: "iam:policy_simulate", Signal: "conditions_enforced", Description: "Simulate the new trust policy conditions against representative caller contexts."})
+	}
+	return checks
+}
+
+func awsIaCReadinessGatesForIAMDiff(diff AWSIAMPolicyDiff) []AWSIaCReadinessGate {
+	gates := []AWSIaCReadinessGate{{Name: "read_only_projection", Status: "passed", Rationale: "Generator emits change intent and metadata refs only; no PR is opened by Identrail."}}
+	if diff.Decision == "review" {
+		gates = append(gates, AWSIaCReadinessGate{Name: "upstream_decision", Status: "blocked", Rationale: "Upstream IAM diff is in manual review; the PR placeholder cannot be applied yet."})
+		return gates
+	}
+	if !diff.ReadyForApply {
+		gates = append(gates, AWSIaCReadinessGate{Name: "upstream_ready_for_apply", Status: "blocked", Rationale: "Upstream IAM diff is not yet ready for apply (breakage or confidence gate not met)."})
+	} else {
+		gates = append(gates, AWSIaCReadinessGate{Name: "upstream_ready_for_apply", Status: "passed", Rationale: "Upstream IAM diff is ready for apply at low projected breakage."})
+	}
+	if diff.Confidence < 0.75 {
+		gates = append(gates, AWSIaCReadinessGate{Name: "confidence", Status: "blocked", Rationale: "Upstream confidence is below the 0.75 threshold required for an applyable IaC PR."})
+	}
+	return gates
+}
+
+func awsIaCReadinessGatesForTrustHardening(hardening AWSTrustPolicyHardeningPlan) []AWSIaCReadinessGate {
+	gates := []AWSIaCReadinessGate{{Name: "read_only_projection", Status: "passed", Rationale: "Generator emits change intent and metadata refs only; no PR is opened by Identrail."}}
+	if !hardening.ReadyForApply {
+		gates = append(gates, AWSIaCReadinessGate{Name: "upstream_ready_for_apply", Status: "blocked", Rationale: "Upstream trust-hardening plan is not yet ready for apply."})
+	} else {
+		gates = append(gates, AWSIaCReadinessGate{Name: "upstream_ready_for_apply", Status: "passed", Rationale: "Upstream trust-hardening plan is ready for apply."})
+	}
+	if hardening.PublicPrincipal {
+		gates = append(gates, AWSIaCReadinessGate{Name: "public_principal_review", Status: "blocked", Rationale: "Trust policy currently permits a public principal; an additional reviewer is required before the PR can ship."})
+	}
+	return gates
+}
+
+func awsIaCReadyForApply(gates []AWSIaCReadinessGate, upstreamReady bool) bool {
+	if !upstreamReady {
+		return false
+	}
+	for _, gate := range gates {
+		if gate.Status == "blocked" {
+			return false
+		}
+	}
+	return true
+}
+
+func awsIaCPRNotesForIAMDiff(diff AWSIAMPolicyDiff) AWSIaCPRNotes {
+	return AWSIaCPRNotes{
+		Title:        fmt.Sprintf("identrail: scope %s least-privilege (diff %s)", firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, "IAM identity"), diff.DiffID),
+		Summary:      fmt.Sprintf("Applies the projected least-privilege diff from Identrail IAM analysis. Decision=%s, breakage=%s, confidence=%.2f. Review the validation steps before merge.", diff.Decision, diff.BreakageProjection.Level, diff.Confidence),
+		Labels:       dedupeStrings([]string{"identrail", "iam-least-privilege", diff.Decision}),
+		EvidenceRefs: awsIAMPolicyDiffEvidenceRefs(diff.Evidence),
+		Reviewers:    []string{"identity-owner", "security-reviewer"},
+	}
+}
+
+func awsIaCPRNotesForTrustHardening(hardening AWSTrustPolicyHardeningPlan) AWSIaCPRNotes {
+	return AWSIaCPRNotes{
+		Title:        fmt.Sprintf("identrail: harden trust policy %s (plan %s)", firstNonEmptyAWSValue(hardening.ResourceLabel, hardening.ResourceNodeID, "AWS role"), hardening.PlanID),
+		Summary:      fmt.Sprintf("Applies the projected trust-policy hardening from Identrail cross-account-trust analysis. Direction=%s, breakage=%s, confidence=%.2f. Review the validation steps before merge.", hardening.HardeningDirection, hardening.BreakageProjection.Level, hardening.Confidence),
+		Labels:       dedupeStrings([]string{"identrail", "trust-policy-hardening", hardening.HardeningDirection}),
+		EvidenceRefs: awsIAMPolicyDiffEvidenceRefs(hardening.Evidence),
+		Reviewers:    []string{"resource-owner", "security-reviewer"},
+	}
+}
+
+func awsIaCTradeoffsForIAMDiff(diff AWSIAMPolicyDiff) []AWSRemediationTradeoff {
+	return []AWSRemediationTradeoff{
+		{Dimension: "least_privilege", Direction: "improves", Description: fmt.Sprintf("Removes %d unused IAM action(s) from %s.", len(diff.RemovedActions), firstNonEmptyAWSValue(diff.IdentityName, diff.IdentityNodeID, "the identity")), Severity: diff.Severity},
+		{Dimension: "breakage_risk", Direction: "worsens", Description: fmt.Sprintf("Projected breakage level after merge is %s; rely on the validation and verification plans before rollout.", diff.BreakageProjection.Level), Severity: "medium"},
+		{Dimension: "review_velocity", Direction: "improves", Description: "IaC PR keeps the change reviewable, auditable, and reversible via source control.", Severity: "low"},
+	}
+}
+
+func awsIaCTradeoffsForTrustHardening(hardening AWSTrustPolicyHardeningPlan) []AWSRemediationTradeoff {
+	return []AWSRemediationTradeoff{
+		{Dimension: "trust_surface", Direction: "improves", Description: fmt.Sprintf("Hardens trust direction=%s with %d condition recommendation(s).", hardening.HardeningDirection, len(hardening.ConditionRecommendations)), Severity: hardening.Severity},
+		{Dimension: "breakage_risk", Direction: "worsens", Description: fmt.Sprintf("Projected breakage level after merge is %s; pair with cloud verification before rollout.", hardening.BreakageProjection.Level), Severity: "medium"},
+		{Dimension: "auditability", Direction: "improves", Description: "IaC PR records the trust-policy change history in source control alongside Identrail evidence refs.", Severity: "low"},
+	}
+}
+
+func awsIaCRollbackForIAMDiff(diff AWSIAMPolicyDiff, evidenceRef string) AWSRemediationRollbackPlan {
+	return AWSRemediationRollbackPlan{
+		Strategy:    "revert_iac_pr",
+		Steps:       []string{"Revert the merged IaC PR to restore the prior IAM policy state.", "Re-run terraform/cdk/cloudformation apply to reconcile drift.", "Re-evaluate Identrail least-privilege after rollback to confirm decision flipped back."},
+		EvidenceRef: firstNonEmptyAWSValue(evidenceRef, diff.DiffID),
+	}
+}
+
+func awsIaCRollbackForTrustHardening(hardening AWSTrustPolicyHardeningPlan, evidenceRef string) AWSRemediationRollbackPlan {
+	return AWSRemediationRollbackPlan{
+		Strategy:    "revert_iac_pr",
+		Steps:       []string{"Revert the merged IaC PR to restore the prior trust policy.", "Re-run terraform/cdk/cloudformation apply to reconcile drift.", "Re-run Access Analyzer to confirm the previous trust surface is restored."},
+		EvidenceRef: firstNonEmptyAWSValue(evidenceRef, hardening.PlanID),
+	}
+}
+
+func awsIaCVerificationPlanForIAMDiff(diff AWSIAMPolicyDiff, evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "iac_pr_verification",
+		Steps:          []string{"Run the validation hints locally before opening the PR.", "After merge, monitor CloudTrail and IAM last-used signals during the verification window.", "Re-run Identrail least-privilege analysis and confirm the decision flips to keep."},
+		SuccessSignals: []string{"policy_simulate:no-regression", "least_privilege:decision-keep", "cloudtrail:no-access-denied"},
+		FailureSignals: []string{"policy_simulate:denied-observed-action", "cloudtrail:access-denied-spike"},
+		EvidenceRef:    firstNonEmptyAWSValue(evidenceRef, diff.DiffID),
+	}
+}
+
+func awsIaCVerificationPlanForTrustHardening(hardening AWSTrustPolicyHardeningPlan, evidenceRef string) AWSRemediationVerificationPlan {
+	return AWSRemediationVerificationPlan{
+		Strategy:       "iac_pr_verification",
+		Steps:          []string{"Run the validation hints locally before opening the PR.", "After merge, watch CloudTrail AssumeRole telemetry for the expected principal set.", "Re-run Access Analyzer to confirm no new external findings."},
+		SuccessSignals: []string{"cloudtrail:expected-principals", "access_analyzer:no-external-findings", "policy_simulate:conditions-enforced"},
+		FailureSignals: []string{"cloudtrail:unexpected-principal", "access_analyzer:new-external-finding"},
+		EvidenceRef:    firstNonEmptyAWSValue(evidenceRef, hardening.PlanID),
+	}
+}
+
+func awsIaCRemediationRelationships(plans []AWSIaCRemediationPlan) []AWSIaCRemediationRelationship {
+	relationships := []AWSIaCRemediationRelationship{}
+	for _, plan := range plans {
+		evidenceRef := firstString(awsIAMPolicyDiffEvidenceRefs(plan.Evidence))
+		from := firstNonEmptyAWSValue(plan.IdentityNodeID, plan.ResourceNodeID, plan.PlanID)
+		for _, target := range plan.ImpactedNodes {
+			if target == "" || target == from {
+				continue
+			}
+			relationships = append(relationships, AWSIaCRemediationRelationship{
+				PlanID:      plan.PlanID,
+				Type:        "iac_remediation_target",
+				FromNodeID:  from,
+				ToNodeID:    target,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSIaCRemediationPlans(all, filtered []AWSIaCRemediationPlan, relationships []AWSIaCRemediationRelationship) AWSIaCRemediationSummary {
+	summary := AWSIaCRemediationSummary{
+		TotalPlans:        len(all),
+		FilteredPlans:     len(filtered),
+		ChangeKindCounts:  map[string]int{},
+		IaCTargetCounts:   map[string]int{},
+		SeverityCounts:    map[string]int{},
+		StatusCounts:      map[string]int{},
+		RelationshipCount: len(relationships),
+	}
+	confidenceTotal := 0.0
+	for _, plan := range filtered {
+		summary.ChangeKindCounts[plan.ChangeKind]++
+		summary.IaCTargetCounts[plan.IaCTarget]++
+		summary.SeverityCounts[plan.Severity]++
+		summary.StatusCounts[plan.Status]++
+		if plan.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		if plan.Status == "review" || plan.Status == "manual_review" {
+			summary.ManualReviewCount++
+		}
+		summary.FileChangeCount += len(plan.FileChanges)
+		summary.ValidationHintCount += len(plan.ValidationHints)
+		summary.VerificationCount += len(plan.CloudVerification)
+		if plan.Score > summary.HighestScore {
+			summary.HighestScore = plan.Score
+		}
+		confidenceTotal += plan.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSIaCRemediationPlans(plans []AWSIaCRemediationPlan, request AWSIaCRemediationRequest) ([]AWSIaCRemediationPlan, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"identity":        strings.TrimSpace(request.Identity),
+		"iac_target":      normalizeAWSRuntimeEventFilterToken(request.IaCTarget),
+		"change_kind":     normalizeAWSRuntimeEventFilterToken(request.ChangeKind),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":          normalizeAWSRuntimeEventFilterToken(request.Status),
+		"ready_for_apply": strings.ToLower(strings.TrimSpace(request.ReadyForApply)),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSIaCRemediationPlan, 0, len(plans))
+	for _, plan := range plans {
+		if filters["account_id"] != "" && filters["account_id"] != plan.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], plan.Region) {
+			continue
+		}
+		if filters["iac_target"] != "" && filters["iac_target"] != normalizeAWSRuntimeEventFilterToken(plan.IaCTarget) {
+			continue
+		}
+		if filters["change_kind"] != "" && filters["change_kind"] != normalizeAWSRuntimeEventFilterToken(plan.ChangeKind) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(plan.Severity) {
+			continue
+		}
+		if filters["status"] != "" && filters["status"] != normalizeAWSRuntimeEventFilterToken(plan.Status) {
+			continue
+		}
+		if filters["ready_for_apply"] != "" {
+			want := filters["ready_for_apply"]
+			if (want == "true" || want == "yes") != plan.ReadyForApply {
+				continue
+			}
+		}
+		if filters["identity"] != "" && !awsIaCRemediationIdentityMatch(plan, filters["identity"]) {
+			continue
+		}
+		if filters["search"] != "" && !awsIaCRemediationSearchMatch(plan, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, plan)
+	}
+	return filtered, applied
+}
+
+func awsIaCRemediationIdentityMatch(plan AWSIaCRemediationPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	hay := strings.ToLower(strings.Join([]string{plan.IdentityNodeID, plan.IdentityARN, plan.IdentityName, plan.ResourceNodeID, plan.ResourceARN}, " "))
+	return strings.Contains(hay, needle)
+}
+
+func awsIaCRemediationSearchMatch(plan AWSIaCRemediationPlan, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		plan.PlanID, plan.Title, plan.Summary, plan.SourceArtifactID, plan.ChangeKind, plan.IaCTarget,
+		plan.Severity, plan.Status, plan.Service, plan.IdentityNodeID, plan.IdentityARN, plan.IdentityName,
+		plan.ResourceNodeID, plan.ResourceARN, plan.NextAction, plan.PRNotes.Title, plan.PRNotes.Summary,
+		plan.DiffIntent.DiffSummary, plan.RollbackPlan.Strategy, plan.VerificationPlan.Strategy,
+	}
+	values = append(values, plan.SourceSignals...)
+	values = append(values, plan.PRNotes.Labels...)
+	values = append(values, plan.PRNotes.EvidenceRefs...)
+	values = append(values, plan.PRNotes.Reviewers...)
+	values = append(values, plan.RollbackPlan.Steps...)
+	values = append(values, plan.VerificationPlan.Steps...)
+	values = append(values, plan.VerificationPlan.SuccessSignals...)
+	values = append(values, plan.VerificationPlan.FailureSignals...)
+	for _, file := range plan.FileChanges {
+		values = append(values, file.Path, file.ChangeIntent, file.ResourceType, file.Rationale)
+	}
+	for _, hint := range plan.ValidationHints {
+		values = append(values, hint.Tool, hint.Command, hint.Description)
+	}
+	for _, check := range plan.CloudVerification {
+		values = append(values, check.Source, check.Signal, check.Description)
+	}
+	for _, gate := range plan.ReadinessGates {
+		values = append(values, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, tradeoff := range plan.Tradeoffs {
+		values = append(values, tradeoff.Dimension, tradeoff.Direction, tradeoff.Description, tradeoff.Severity)
+	}
+	for _, evidence := range plan.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSIaCRemediationStatus(sources awsIaCRemediationSources, filtered []AWSIaCRemediationPlan, diagnostics []AWSIaCRemediationDiagnostic) (string, float64) {
+	if sources.iamPolicyDiffs.Status == awsPlatformDependencyStatusBlocked && sources.trustPolicyHardening.Status == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	if sources.iamPolicyDiffs.Status == awsPlatformDependencyStatusBlocked || sources.trustPolicyHardening.Status == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusDegraded, 0.6
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sources.iamPolicyDiffs.Status == awsPlatformDependencyStatusDegraded || sources.trustPolicyHardening.Status == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsIaCRemediationCaveats() []string {
+	return []string{
+		"IaC remediation plans are read-only PR projections; Identrail never opens, pushes, or merges a PR on the operator's behalf.",
+		"File-change rationale and validation hints carry metadata refs only — never rendered IaC bodies, IAM policy bodies, secret values, or workload payloads.",
+		"ready_for_apply is derived deterministically from upstream IAM-diff/trust-hardening readiness plus a public-principal review gate; approval, execute, and verify transitions belong to future wave issues.",
+	}
+}
+
+func awsIaCRemediationFailureReasons(sources awsIaCRemediationSources) []string {
+	return dedupeStrings(append(append([]string{}, sources.iamPolicyDiffs.FailureReasons...), sources.trustPolicyHardening.FailureReasons...))
+}
+
+func awsIaCRemediationRemediationHints(sources awsIaCRemediationSources) []string {
+	hints := []string{
+		"Open each generated PR in your source-control system manually; Identrail does not push commits or open PRs.",
+		"Run the validation hints locally and link the run output in the PR body alongside Identrail evidence refs.",
+		"After merge, follow the cloud verification checks; revert the PR if a failure signal appears in the first verification window.",
+	}
+	hints = append(hints, sources.iamPolicyDiffs.RemediationHints...)
+	hints = append(hints, sources.trustPolicyHardening.RemediationHints...)
+	return dedupeStrings(hints)
+}
+
+func awsIaCRemediationDiagnostics(sources awsIaCRemediationSources) []AWSIaCRemediationDiagnostic {
+	out := []AWSIaCRemediationDiagnostic{}
+	for _, d := range sources.iamPolicyDiffs.Diagnostics {
+		out = append(out, AWSIaCRemediationDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range sources.trustPolicyHardening.Diagnostics {
+		out = append(out, AWSIaCRemediationDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	return out
+}
+
+func awsIaCRemediationCoverageGaps(sources awsIaCRemediationSources) []AWSIaCRemediationCoverageGap {
+	out := []AWSIaCRemediationCoverageGap{{
+		Capability:  "iac_pr_publish",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1535 emits IaC PR plans only; opening, pushing, or merging the PR happens in the operator's source-control system, not in Identrail.",
+		Remediation: "Use the operator's source-control workflow to land the generated PR; later waves wire approval and execution gates around live AWS apply.",
+	}}
+	for _, g := range sources.iamPolicyDiffs.CoverageGaps {
+		out = append(out, AWSIaCRemediationCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	for _, g := range sources.trustPolicyHardening.CoverageGaps {
+		out = append(out, AWSIaCRemediationCoverageGap{Capability: g.Capability, Status: g.Status, Reason: g.Reason, Remediation: g.Remediation})
+	}
+	return out
+}
+
+func awsIaCRemediationEvidenceBoundary() string {
+	return "metadata_only_no_rendered_iac_bodies_no_rendered_policy_bodies_no_secret_values_no_workload_payloads"
+}

--- a/internal/api/aws_iac_remediation_plans_test.go
+++ b/internal/api/aws_iac_remediation_plans_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newIaCRemediationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSIaCRemediationPlansBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	svc, ws := newIaCRemediationService(t, "project-iac-remediation", now)
+
+	result, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get iac remediation plans: %v", err)
+	}
+	if result.CurrentIssueRef != "#1535" || result.Version != awsIaCRemediationVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Plans) == 0 || result.Summary.TotalPlans != len(result.Plans) {
+		t.Fatalf("expected iac remediation plans and matching summary: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Plans); i++ {
+		if result.Plans[i-1].Score < result.Plans[i].Score {
+			t.Fatalf("plans are not ranked by descending score: %+v", result.Plans)
+		}
+	}
+	sawIAM := false
+	sawTrust := false
+	for _, plan := range result.Plans {
+		if plan.PlanID == "" || plan.CalculationVersion != awsIaCRemediationVersion || plan.SourceArtifactID == "" {
+			t.Fatalf("plan missing stable metadata: %+v", plan)
+		}
+		if !plan.ReadOnlyProjection {
+			t.Fatalf("plan must be a read-only projection: %+v", plan)
+		}
+		if plan.IaCTarget == "" || plan.ChangeKind == "" {
+			t.Fatalf("plan missing IaC target or change kind: %+v", plan)
+		}
+		if len(plan.FileChanges) == 0 || len(plan.ValidationHints) == 0 || len(plan.CloudVerification) == 0 {
+			t.Fatalf("plan missing file changes, validation, or verification: %+v", plan)
+		}
+		if plan.RollbackPlan.Strategy == "" || plan.VerificationPlan.Strategy == "" {
+			t.Fatalf("plan missing rollback or verification plan: %+v", plan)
+		}
+		if plan.PRNotes.Title == "" || plan.PRNotes.Summary == "" {
+			t.Fatalf("plan missing PR notes: %+v", plan.PRNotes)
+		}
+		if plan.EvidenceBoundary != awsIaCRemediationEvidenceBoundary() {
+			t.Fatalf("plan crossed evidence boundary: %+v", plan)
+		}
+		if plan.ChangeKind == awsIaCChangeKindIAMPolicyDiff {
+			sawIAM = true
+		}
+		if plan.ChangeKind == awsIaCChangeKindTrustPolicyHardened {
+			sawTrust = true
+		}
+	}
+	if !sawIAM && !sawTrust {
+		t.Fatalf("expected at least one IAM-diff or trust-hardening plan in the contract output")
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("plan serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestGetAWSIaCRemediationPlansAppliesFilters(t *testing.T) {
+	now := time.Date(2026, 6, 26, 10, 15, 0, 0, time.UTC)
+	svc, ws := newIaCRemediationService(t, "project-iac-remediation-filters", now)
+
+	iamOnly, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation-filters", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		ChangeKind:   awsIaCChangeKindIAMPolicyDiff,
+	})
+	if err != nil {
+		t.Fatalf("change_kind filter: %v", err)
+	}
+	if iamOnly.AppliedFilters["change_kind"] != strings.ReplaceAll(awsIaCChangeKindIAMPolicyDiff, "_", "-") {
+		t.Fatalf("expected applied change_kind filter, got %+v", iamOnly.AppliedFilters)
+	}
+	for _, plan := range iamOnly.Plans {
+		if plan.ChangeKind != awsIaCChangeKindIAMPolicyDiff {
+			t.Fatalf("change_kind filter leaked %s plan: %+v", plan.ChangeKind, plan)
+		}
+	}
+
+	terraformOnly, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation-filters", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		IaCTarget:    awsIaCTargetTerraform,
+		Search:       "terraform validate",
+	})
+	if err != nil {
+		t.Fatalf("iac_target filter: %v", err)
+	}
+	if terraformOnly.AppliedFilters["iac_target"] != awsIaCTargetTerraform {
+		t.Fatalf("expected applied iac_target filter, got %+v", terraformOnly.AppliedFilters)
+	}
+	for _, plan := range terraformOnly.Plans {
+		if plan.IaCTarget != awsIaCTargetTerraform {
+			t.Fatalf("iac_target filter leaked %s plan: %+v", plan.IaCTarget, plan)
+		}
+	}
+}
+
+func TestFilterAWSIaCRemediationPlansNormalizesReadyForApplyAliases(t *testing.T) {
+	plans := []AWSIaCRemediationPlan{
+		{
+			PlanID:        "ready",
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			ChangeKind:    awsIaCChangeKindIAMPolicyDiff,
+			IaCTarget:     awsIaCTargetTerraform,
+			ReadyForApply: true,
+		},
+		{
+			PlanID:        "not-ready",
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			ChangeKind:    awsIaCChangeKindTrustPolicyHardened,
+			IaCTarget:     awsIaCTargetTerraform,
+			ReadyForApply: false,
+		},
+	}
+
+	ready, readyApplied := filterAWSIaCRemediationPlans(plans, AWSIaCRemediationRequest{ReadyForApply: "yes"})
+	if readyApplied["ready_for_apply"] != "yes" || len(ready) != 1 || ready[0].PlanID != "ready" {
+		t.Fatalf("expected ready_for_apply=yes to match ready plans, got applied=%+v plans=%+v", readyApplied, ready)
+	}
+
+	notReady, notReadyApplied := filterAWSIaCRemediationPlans(plans, AWSIaCRemediationRequest{ReadyForApply: "no"})
+	if notReadyApplied["ready_for_apply"] != "no" || len(notReady) != 1 || notReady[0].PlanID != "not-ready" {
+		t.Fatalf("expected ready_for_apply=no to match non-ready plans, got applied=%+v plans=%+v", notReadyApplied, notReady)
+	}
+}
+
+func TestAWSIaCRemediationFileChangesUseTargetSpecificPaths(t *testing.T) {
+	diff := AWSIAMPolicyDiff{
+		DiffID:       "aws-iam-policy-diff:test",
+		Service:      "lambda",
+		ResourceARN:  "arn:aws:lambda:us-east-1:123456789012:function/orders",
+		Decision:     "remove",
+		IdentityName: "orders-ci",
+		KeptActions:  []string{"s3:GetObject"},
+	}
+
+	for _, target := range []string{awsIaCTargetTerraform, awsIaCTargetCloudFormation, awsIaCTargetCDK, awsIaCTargetPolicyAsCode} {
+		files := awsIaCFileChangesForIAMDiff(diff, target, "orders-ci", "evidence://orders-ci")
+		if len(files) < 2 {
+			t.Fatalf("%s: expected at least two file changes, got %+v", target, files)
+		}
+		root := awsIaCDirectoryForTarget(target)
+		if !strings.HasPrefix(files[0].Path, root+"/") || !strings.HasPrefix(files[1].Path, root+"/") {
+			t.Fatalf("%s: file path missing target directory: %+v", target, files)
+		}
+		if files[0].BeforeRef == "" || files[0].AfterRef == "" {
+			t.Fatalf("%s: file change missing before/after refs: %+v", target, files[0])
+		}
+	}
+}
+
+func TestAWSIaCReadyForApplyHonorsUpstreamGates(t *testing.T) {
+	hardening := AWSTrustPolicyHardeningPlan{
+		PlanID:             "aws-trust-policy-hardening:1",
+		HardeningDirection: "narrow_principal",
+		PublicPrincipal:    true,
+		ReadyForApply:      true,
+	}
+	plan, ok := awsIaCRemediationPlanFromTrustHardening(hardening, time.Now().UTC())
+	if !ok {
+		t.Fatalf("expected plan from trust hardening")
+	}
+	if plan.ReadyForApply {
+		t.Fatalf("expected public-principal gate to block ready_for_apply: %+v", plan.ReadinessGates)
+	}
+	if blocked := false; func() bool {
+		for _, gate := range plan.ReadinessGates {
+			if gate.Name == "public_principal_review" && gate.Status == "blocked" {
+				blocked = true
+			}
+		}
+		return blocked
+	}() != true {
+		t.Fatalf("expected public_principal_review gate to be present and blocked: %+v", plan.ReadinessGates)
+	}
+}
+
+func TestGetAWSIaCRemediationPlansFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 26, 10, 30, 0, 0, time.UTC)
+	svc, ws := newIaCRemediationService(t, "project-iac-remediation-states", now)
+
+	denied, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation-states", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Plans) != 0 {
+		t.Fatalf("permission denied must be explicit and suppress plans: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation-states", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not produce a blocked status: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSIaCRemediationPlans(defaultScopeContext(), ws, "project-iac-remediation-states", AWSIaCRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSIaCRemediationPlans(t *testing.T) {
+	now := time.Date(2026, 6, 26, 10, 45, 0, 0, time.UTC)
+	svc, _ := newIaCRemediationService(t, "project-iac-remediation-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-iac-remediation-route/aws/iac-remediation-plans?connector_id=aws-prod&fixture_state=success&iac_target=terraform", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Plans AWSIaCRemediationResult `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Plans.CurrentIssueRef != "#1535" || body.Plans.AppliedFilters["iac_target"] != "terraform" {
+		t.Fatalf("unexpected route payload: %+v", body.Plans)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3275,6 +3275,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSIaCRemediationPlans(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSIaCRemediationRequest{
+			ConnectorID:   strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:  strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:     strings.TrimSpace(c.Query("account_id")),
+			Region:        strings.TrimSpace(c.Query("region")),
+			Identity:      strings.TrimSpace(c.Query("identity")),
+			IaCTarget:     strings.TrimSpace(c.Query("iac_target")),
+			ChangeKind:    strings.TrimSpace(c.Query("change_kind")),
+			Severity:      strings.TrimSpace(c.Query("severity")),
+			Status:        strings.TrimSpace(c.Query("status")),
+			ReadyForApply: strings.TrimSpace(c.Query("ready_for_apply")),
+			Search:        strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws iac remediation plans request"})
+			default:
+				logger.Error("get aws iac remediation plans",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws iac remediation plans"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"plans": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1835,6 +1835,47 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS IaC remediation PR plans with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plans: { status: 'ready', plans: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectIaCRemediationPlans(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        identity: 'orders-ci',
+        iacTarget: 'terraform',
+        changeKind: 'iam_policy_diff',
+        severity: 'high',
+        status: 'ready_for_apply',
+        readyForApply: 'true',
+        search: 'terraform validate'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/iac-remediation-plans?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=orders-ci&iac_target=terraform&change_kind=iam_policy_diff&severity=high&status=ready_for_apply&ready_for_apply=true&search=terraform+validate'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3763,6 +3763,157 @@ export type AWSAccessKeyQuarantineQuery = {
   search?: string;
 };
 
+export type AWSIaCRemediationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSIaCRemediationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSIaCRemediationTarget = 'terraform' | 'cloudformation' | 'cdk' | 'policy_as_code' | string;
+export type AWSIaCRemediationChangeKind = 'iam_policy_diff' | 'trust_policy_hardening' | string;
+
+export type AWSIaCFileChange = {
+  path: string;
+  change_intent: string;
+  resource_type?: string;
+  before_ref?: string;
+  after_ref?: string;
+  rationale: string;
+};
+
+export type AWSIaCValidationHint = {
+  tool: string;
+  command: string;
+  description: string;
+};
+
+export type AWSIaCCloudVerificationCheck = {
+  source: string;
+  signal: string;
+  description: string;
+};
+
+export type AWSIaCPRNotes = {
+  title: string;
+  summary: string;
+  labels?: string[];
+  evidence_refs?: string[];
+  reviewers?: string[];
+};
+
+export type AWSIaCReadinessGate = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSIaCRemediationRelationship = {
+  plan_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSIaCRemediationPlan = {
+  plan_id: string;
+  calculation_version: string;
+  change_kind: AWSIaCRemediationChangeKind;
+  iac_target: AWSIaCRemediationTarget;
+  source_artifact_id: string;
+  source_case_id?: string;
+  severity: string;
+  status: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  service?: string;
+  identity_node_id?: string;
+  identity_arn?: string;
+  identity_name?: string;
+  resource_node_id?: string;
+  resource_arn?: string;
+  file_changes: AWSIaCFileChange[];
+  validation_hints: AWSIaCValidationHint[];
+  cloud_verification: AWSIaCCloudVerificationCheck[];
+  pr_notes: AWSIaCPRNotes;
+  diff_intent: AWSRemediationDiffIntent;
+  tradeoffs: AWSRemediationTradeoff[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  readiness_gates: AWSIaCReadinessGate[];
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSIaCRemediationSummary = {
+  total_plans: number;
+  filtered_plans: number;
+  change_kind_counts: Record<string, number>;
+  iac_target_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  ready_for_apply_count: number;
+  manual_review_count: number;
+  file_change_count: number;
+  validation_hint_count: number;
+  verification_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSIaCRemediationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSIaCRemediationStatus;
+  fixture_state?: AWSIaCRemediationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSIaCRemediationSummary;
+  plans: AWSIaCRemediationPlan[];
+  relationships: AWSIaCRemediationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSIaCRemediationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSIaCRemediationFixtureState;
+  accountID?: string;
+  region?: string;
+  identity?: string;
+  iacTarget?: string;
+  changeKind?: string;
+  severity?: string;
+  status?: string;
+  readyForApply?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -8011,6 +8162,29 @@ export const apiClient = {
         identity: query?.identity,
         quarantine_state: query?.quarantineState,
         owner: query?.owner,
+        severity: query?.severity,
+        status: query?.status,
+        ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectIaCRemediationPlans(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSIaCRemediationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ plans: AWSIaCRemediationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/iac-remediation-plans${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        identity: query?.identity,
+        iac_target: query?.iacTarget,
+        change_kind: query?.changeKind,
         severity: query?.severity,
         status: query?.status,
         ready_for_apply: query?.readyForApply,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -69,6 +69,8 @@ import {
   type AWSSecretKeyRotationResult,
   type AWSAccessKeyQuarantinePlan,
   type AWSAccessKeyQuarantineResult,
+  type AWSIaCRemediationPlan,
+  type AWSIaCRemediationResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11262,6 +11264,114 @@ function AWSAccessKeyQuarantineContent({
   );
 }
 
+function awsIaCRemediationStage(plan: AWSIaCRemediationPlan): AWSCapabilityStage {
+  if (plan.status === 'review' || plan.status === 'manual_review') {
+    return 'not-available';
+  }
+  if (!plan.ready_for_apply) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsIaCRemediationTargetLabel(plan: AWSIaCRemediationPlan): string {
+  const fileCount = plan.file_changes.length;
+  return `${formatTokenLabel(plan.iac_target)} · ${fileCount} file${fileCount === 1 ? '' : 's'}`;
+}
+
+function awsIaCRemediationValidationLabel(plan: AWSIaCRemediationPlan): string {
+  const tools = plan.validation_hints.map((hint) => hint.tool);
+  if (tools.length === 0) {
+    return 'manual review';
+  }
+  return tools.slice(0, 3).join(' · ') + (tools.length > 3 ? ` +${tools.length - 3}` : '');
+}
+
+function awsIaCRemediationReadinessLabel(plan: AWSIaCRemediationPlan): string {
+  if (plan.ready_for_apply) {
+    return `ready · ${plan.cloud_verification.length} cloud checks`;
+  }
+  const blockedGate = plan.readiness_gates.find((gate) => gate.status === 'blocked');
+  return `gate · ${formatTokenLabel(blockedGate?.name ?? plan.status)}`;
+}
+
+function AWSIaCRemediationContent({
+  plans,
+  loading,
+  error,
+  onRetry
+}: {
+  plans: AWSIaCRemediationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = plans?.plans ?? [];
+  const summaryLine = plans
+    ? `${plans.summary.total_plans} total · ${plans.summary.ready_for_apply_count} ready · ${plans.summary.file_change_count} files · ${plans.summary.verification_count} cloud checks`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS IaC remediation PR plans">
+      <h3>AWS IaC remediation PR generator</h3>
+      <p className="idt-app-kicker">
+        Read-only IaC remediation PR plans composed from IAM least-privilege diffs and trust-policy hardening, with file
+        change intent, local validation hints, cloud verification, rollback, and readiness gates. Identrail never opens
+        or pushes the PR for you. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS IaC remediation plans"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing IaC remediation PR plans"
+          body="Identrail is joining IAM least-privilege diffs and trust-policy hardening into ranked IaC PR plans with validation and cloud verification."
+        />
+      ) : null}
+      {!error && !loading && plans && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={plans.status === 'blocked' ? 'Permission required' : 'No IaC PR plans'}
+          title={plans.status === 'blocked' ? 'IaC PR plans need read-only IAM and trust evidence' : 'No IaC remediation PR plans projected'}
+          body={plans.failure_reasons[0] ?? 'No upstream IAM diff or trust-hardening evidence produced an IaC PR plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && plans && plans.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {plans.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS IaC remediation PR plans"
+          rows={rows}
+          getRowKey={(row) => row.plan_id}
+          columns={[
+            { key: 'plan', header: 'Plan', render: (row) => <strong>{row.title}</strong> },
+            { key: 'change', header: 'Change', render: (row) => formatTokenLabel(row.change_kind) },
+            { key: 'target', header: 'Target', render: (row) => awsIaCRemediationTargetLabel(row) },
+            { key: 'validation', header: 'Validation', render: (row) => awsIaCRemediationValidationLabel(row) },
+            { key: 'readiness', header: 'Readiness', render: (row) => awsIaCRemediationReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsIaCRemediationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}`} />
+              )
+            },
+            { key: 'verification', header: 'Cloud verification', render: (row) => `${row.cloud_verification.length} check${row.cloud_verification.length === 1 ? '' : 's'}` }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12729,6 +12839,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [accessKeyQuarantineLoading, setAccessKeyQuarantineLoading] = useState(false);
   const [accessKeyQuarantineError, setAccessKeyQuarantineError] = useState('');
   const accessKeyQuarantineRequestRef = useRef(0);
+  const [iacRemediation, setIacRemediation] = useState<AWSIaCRemediationResult | null>(null);
+  const [iacRemediationLoading, setIacRemediationLoading] = useState(false);
+  const [iacRemediationError, setIacRemediationError] = useState('');
+  const iacRemediationRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -13302,6 +13416,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadAccessKeyQuarantine]);
 
+  const loadIacRemediation = useCallback(async () => {
+    const requestID = ++iacRemediationRequestRef.current;
+    setIacRemediation(null);
+    setIacRemediationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setIacRemediationLoading(false);
+      return;
+    }
+    setIacRemediationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectIaCRemediationPlans(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== iacRemediationRequestRef.current) {
+        return;
+      }
+      setIacRemediation(response.plans);
+    } catch (error) {
+      if (requestID !== iacRemediationRequestRef.current) {
+        return;
+      }
+      setIacRemediationError(formatAPIError(error, 'Unable to load AWS IaC remediation plans.'));
+    } finally {
+      if (requestID === iacRemediationRequestRef.current) {
+        setIacRemediationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadIacRemediation();
+    return () => {
+      iacRemediationRequestRef.current += 1;
+    };
+  }, [loadIacRemediation]);
+
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
     setBlastRadius(null);
@@ -13820,6 +13982,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={accessKeyQuarantineLoading}
             error={accessKeyQuarantineError}
             onRetry={loadAccessKeyQuarantine}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSIaCRemediationContent
+            plans={iacRemediation}
+            loading={iacRemediationLoading}
+            error={iacRemediationError}
+            onRetry={loadIacRemediation}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Adds a metadata-only AWS IaC remediation PR and verification plan generator
that turns IAM least-privilege diffs (#1530) and trust-policy hardening plans
(#1531) into ranked Terraform, CloudFormation, CDK, and policy-as-code PR
plans. Each plan carries file change intent, local validation hints, cloud
verification, PR notes, rollback, verification, and readiness gates so
operators can land the change through their own source-control system.

Closes #1535. Part of #1472.

## Why

Wave 7 remediation planning needs explainable IaC fix paths so operators stop
hand-translating IAM/trust-policy evidence into Terraform or CloudFormation
edits. This issue is the focused PR-sized step that wires those plans into the
AWS Runtime app surface without opening any external PR or calling any AWS
write API.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive endpoint, types, and UI)
- [x] Risk level assessed (read-only generator; never opens PRs, never mutates AWS, never inlines IaC/policy bodies or secrets)

## Validation

```bash
make fmt-check
go vet ./...
go test ./internal/api/...
make api-example-contract-check
make web-route-integrity-check
npm run test:ci --prefix web
npm run build --prefix web
```

All passed locally on this branch.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1535
Refs #1472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only generator that turns IAM least‑privilege diffs and trust‑policy hardening plans into ranked Terraform/CloudFormation/CDK/policy‑as‑code PR and verification plans. Closes #1535 (part of #1472).

- **New Features**
  - Generate ranked, deterministic PR plans for `terraform`, `cloudformation`, `cdk`, and `policy_as_code` from IAM least‑privilege diffs (#1530) and trust‑policy hardening plans (#1531).
  - Each plan includes file change intent (paths/resource types), validation hints, cloud verification checks, PR notes, tradeoffs, rollback, verification, readiness gates, and a `ready_for_apply` flag. Read‑only: no PRs opened; no AWS write APIs.

- **API + Web**
  - Added `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/iac-remediation-plans` with filters (`connector_id`, `iac_target`, `change_kind`, `account_id`/`region`/`identity`, `severity`/`status`, `ready_for_apply`, `search`, and `fixture_state`); updated route auth and OpenAPI.
  - New docs page `aws-iac-remediation-planner.md`. Fixed CloudFormation validation hint path in generated plans. Added TS models, `getAWSProjectIaCRemediationPlans`, product shell UI, and API/client tests.

<sup>Written for commit dd4744fe0bb70296a818fa86002d55f6b3699b54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

