### PR TITLE
Implement AWS remediation approval workflow and RBAC gates (#1536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS remediation approval workflow and RBAC gates** (#1536). Adds a
+  read-only, metadata-only approval-queue projection that turns remediation
+  cases (#1529) into RBAC-gated approval entries. Each entry records a
+  deterministic `approval_id`, source `case_id`, idempotency key, dry-run
+  reference, risk tier (critical/high/medium/low scaled from severity),
+  requestor (role/label/required/acknowledged), required approver roles
+  (with incident-commander added for critical/high and data-protection-reviewer
+  for AI-agent and secret-equivalence sources), explicit scope
+  (scope_type, account, region, connector, identity, resource nodes), RBAC
+  gates (tenant scope, read-only projection, requestor assignment, approver
+  quorum, confidence floor, approval-required), feature flags (always-on
+  workflow flag, tenant-scoped remediation kill switch, live-AWS-mutation
+  gate, critical-risk dual control, IaC-PR-required when the case originates
+  from the IaC PR generator), state (`requested`/`under_review`/`approved`/
+  `denied`/`expired`/`blocked`), expiry (12h critical / 24h high / 48h medium
+  / 72h default), tradeoffs, rollback plan, verification plan, audit trail
+  (`approval_requested` plus per-approver `approval_required` entries), and
+  evidence refs. `ready_for_execution` is true only when state is `approved`,
+  no kill switch is engaged, and every RBAC gate is passed. Identrail never
+  calls IAM/STS/Organizations write APIs at this layer; controlled execution
+  is reserved for wave-8 executors. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue`
+  with filters for connector, account, region, case ID, state, risk tier,
+  scope type, requestor, approver role, severity, ready-for-execution,
+  kill-switch-engaged, and free-text search. OpenAPI schemas and authz wiring
+  follow the neighboring wave 7 planners. The AWS Runtime app surface now
+  shows an **AWS remediation approval workflow and RBAC gates** panel with
+  approval title, state, risk tier, requestor, required approvers, scope,
+  gate label, and severity/state pill, with explicit loading, empty,
+  degraded, blocked, and error states.
 - Add **AWS IaC remediation PR and verification plan generator** (#1535). Adds
   a read-only, metadata-only generator that turns IAM least-privilege diffs
   (#1530) and trust-policy hardening plans (#1531) into ranked IaC remediation

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
 - AWS access key disable and quarantine planner: `aws-access-key-quarantine-planner.md`
 - AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
+- AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-remediation-approval-rbac.md
+++ b/docs/aws-remediation-approval-rbac.md
@@ -1,0 +1,107 @@
+# AWS remediation approval workflow and RBAC gates
+
+Issue #1536 adds a metadata-only approval-queue projection for AWS remediation
+cases. It turns each remediation case into an explicit approval entry with
+risk tier, requestor, required approver roles, RBAC gates, feature flags
+(including a tenant-scoped kill switch), idempotency key, scope, audit trail,
+rollback plan, verification plan, and evidence refs so operators can see what
+must happen before any live AWS mutation runs.
+
+The endpoint is read-only. It never opens, applies, or rolls back any AWS
+change, never calls IAM, STS, or Organizations write APIs, and never reads,
+exposes, logs, or persists rendered policies, secret values, customer
+payloads, prompts, completions, browser pages, code-interpreter output,
+database rows, or object contents. Live controlled execution belongs to the
+wave 8 executors (#1537–#1542) and is intentionally out of scope here.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-approval-queue`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `case_id` | source remediation case ID filter |
+| `state` | `requested`, `under_review`, `approved`, `denied`, `expired`, or `blocked` |
+| `risk_tier` | `critical`, `high`, `medium`, or `low` |
+| `scope_type` | `identity`, `resource`, `account`, `ou`, or `org_root` |
+| `requestor` | requestor label / owner match |
+| `approver_role` | required approver role match |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `ready_for_execution` | `true` / `false` / `yes` / `no` |
+| `kill_switch_engaged` | `true` / `false` / `yes` / `no` |
+| `search` | free-text search across approval, scope, gate, flag, audit, and evidence fields |
+
+Response shape: `{ "queue": AWSRemediationApprovalResult }` with
+tenant/workspace/project metadata, summary counts, ranked entries,
+relationships, caveats, failure reasons, remediation hints, evidence links,
+coverage gaps, diagnostics, and generated timestamps.
+
+## Entry shape
+
+Each `AWSRemediationApprovalEntry` includes:
+
+- stable `approval_id`, calculation version, source `case_id`, source artifact
+  ID, issue refs, score, confidence, severity, and risk tier
+- requestor (role/label/required/acknowledged) plus required approver roles
+  scaled by risk tier (critical/high require an incident-commander; AI-agent
+  and secret-equivalence sources require a data-protection-reviewer)
+- explicit `scope` (scope type plus account, region, connector, identity, and
+  resource node IDs)
+- `rbac_gates` for tenant scope, read-only projection, requestor assignment,
+  approver quorum, confidence floor, and approval-required acknowledgement
+- `feature_flags` for the always-on approval workflow, the tenant-scoped
+  remediation kill switch, the live-AWS-mutation gate (off here), critical-risk
+  dual control, and IaC remediation PR requirements when the source is the
+  IaC PR generator
+- deterministic `idempotency_key` and `dry_run_ref` placeholders so later
+  wave executors can wire dry-run, apply, and verify without re-deriving IDs
+- `state`, `expires_at` (12h critical / 24h high / 48h medium / 72h default),
+  `ready_for_execution` (only when state is `approved`, no kill switch, and no
+  gate is blocked), tradeoffs, rollback plan, verification plan, and audit
+  trail with `approval_requested` plus per-approver `approval_required` entries
+
+## Failure handling
+
+- **Ready**: upstream remediation case evidence is available and at least one
+  approval entry can be composed.
+- **Degraded**: partial or degraded upstream evidence is visible with explicit
+  diagnostics; composed entries stay visible when safe.
+- **Blocked**: permission-denied upstream evidence emits zero entries plus
+  failure reasons, remediation hints, diagnostics, and coverage gaps.
+
+Unsupported, empty, partial, degraded, and permission-denied states stay
+explicit. The endpoint does not convert absence of upstream evidence into
+deterministic approval.
+
+## App surface
+
+The AWS Runtime page renders an **AWS remediation approval workflow and RBAC
+gates** panel with approval title, state, risk tier, requestor, required
+approvers, scope, gates, and severity/state pill. Loading, empty, degraded,
+blocked, and error states are explicit.
+
+## Validation
+
+1. Confirm blocker #1535 is closed.
+2. Run upstream remediation cases with `fixture_state=success`.
+3. Call the approval queue endpoint with `fixture_state=success` and verify at
+   least one entry includes requestor, approver quorum, RBAC gates, feature
+   flags (including `remediation_kill_switch`), idempotency key, expiry, and
+   audit trail.
+4. Filter by `risk_tier=high`, `approver_role=security-reviewer`,
+   `ready_for_execution=false`, and `kill_switch_engaged=false`.
+5. Run `fixture_state=empty`, `degraded`, `partial_failure`, and
+   `permission_denied` and confirm the status, diagnostics, and failure reasons
+   stay explicit.
+
+## What is intentionally out of scope
+
+- Live IAM/STS/Organizations write APIs (waves 8.02–8.07 own controlled
+  execution).
+- Persisting approval state mutations server-side; the endpoint projects
+  deterministically from upstream cases and is safe to re-query.
+- Rendering policy bodies, IaC bodies, secret values, or workload payloads.
+- Opening, pushing, or merging operator source-control PRs.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -609,6 +609,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-approval-queue
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5672,6 +5677,102 @@ paths:
                     $ref: "#/components/schemas/AWSIaCRemediationResult"
         "400":
           description: Invalid AWS IaC remediation plans request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-approval-queue:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS remediation approval queue with RBAC gates
+      operationId: getAWSProjectRemediationApprovalQueue
+      description: Projects a deterministic, read-only AWS remediation approval queue from upstream remediation cases. Each entry carries source-case ID, idempotency key, dry-run reference, risk tier, requestor, required approver roles, scope (account/region/connector/identity/resource), RBAC gates, feature flags (including the tenant-scoped remediation kill switch), state (`requested`/`under_review`/`approved`/`denied`/`expired`/`blocked`), expiry, audit trail, rollback, verification, and evidence refs. The endpoint never opens, applies, or rolls back any AWS change and never reads, exposes, logs, or persists rendered policies, secret values, customer payloads, prompts, completions, browser pages, code-interpreter output, database rows, or object contents. Live IAM/STS/Organizations write APIs are gated to later wave 8 executors.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [requested, under_review, approved, denied, expired, blocked]
+        - in: query
+          name: risk_tier
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: scope_type
+          schema:
+            type: string
+            enum: [identity, resource, account, ou, org_root]
+        - in: query
+          name: requestor
+          schema: { type: string }
+        - in: query
+          name: approver_role
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: ready_for_execution
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: kill_switch_engaged
+          schema:
+            type: string
+            enum: ["true", "false", "yes", "no"]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS remediation approval queue contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queue:
+                    $ref: "#/components/schemas/AWSRemediationApprovalResult"
+        "400":
+          description: Invalid AWS remediation approval queue request
           content:
             application/json:
               schema:
@@ -13820,6 +13921,18 @@ components:
         updated_at:
           type: string
           format: date-time
+    AWSRemediationCaseEvidence:
+      allOf:
+        - $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+    AWSRemediationCasePathStep:
+      allOf:
+        - $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+    AWSRemediationCaseCoverageGap:
+      allOf:
+        - $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+    AWSRemediationCaseDiagnostic:
+      allOf:
+        - $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
     AWSRemediationCaseSummary:
       type: object
       properties:
@@ -15332,6 +15445,252 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationApprovalActor:
+      type: object
+      properties:
+        role: { type: string }
+        label: { type: string }
+        required: { type: boolean }
+        acknowledged: { type: boolean }
+    AWSRemediationApprovalScope:
+      type: object
+      properties:
+        scope_type:
+          type: string
+          enum: [identity, resource, account, ou, org_root]
+        account_ids:
+          type: array
+          items: { type: string }
+        regions:
+          type: array
+          items: { type: string }
+        connector_ids:
+          type: array
+          items: { type: string }
+        identity_node_ids:
+          type: array
+          items: { type: string }
+        resource_node_ids:
+          type: array
+          items: { type: string }
+    AWSRemediationApprovalRBACGate:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        required_role: { type: string }
+        rationale: { type: string }
+    AWSRemediationApprovalFeatureFlag:
+      type: object
+      properties:
+        name: { type: string }
+        enabled: { type: boolean }
+        scope: { type: string }
+        rationale: { type: string }
+    AWSRemediationApprovalRelationship:
+      type: object
+      properties:
+        approval_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSRemediationApprovalAuditEntry:
+      type: object
+      description: |
+        Audit row attached to an approval queue entry. Actor labels are operator
+        roles or owner identifiers, and event types include the approval workflow
+        transitions in addition to the remediation-case lifecycle transitions.
+      properties:
+        event_id: { type: string }
+        actor: { type: string }
+        event_type: { type: string }
+        occurred_at:
+          type: string
+          format: date-time
+        evidence_ref: { type: string }
+        notes: { type: string }
+    AWSRemediationApprovalEntry:
+      type: object
+      properties:
+        approval_id: { type: string }
+        calculation_version: { type: string }
+        case_id: { type: string }
+        source_artifact_id: { type: string }
+        source_type: { type: string }
+        state:
+          type: string
+          enum: [requested, under_review, approved, denied, expired, blocked]
+        risk_tier:
+          type: string
+          enum: [critical, high, medium, low]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        requestor:
+          $ref: "#/components/schemas/AWSRemediationApprovalActor"
+        required_approvers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalActor"
+        scope:
+          $ref: "#/components/schemas/AWSRemediationApprovalScope"
+        rbac_gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalRBACGate"
+        feature_flags:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalFeatureFlag"
+        idempotency_key: { type: string }
+        dry_run_ref: { type: string }
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        ready_for_execution: { type: boolean }
+        kill_switch_engaged: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCasePathStep"
+        next_action: { type: string }
+        requested_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationApprovalSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        risk_tier_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        scope_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        required_approver_count: { type: integer }
+        ready_for_execution_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        rbac_gate_blocked_count: { type: integer }
+        audit_entry_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSRemediationApprovalResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSRemediationApprovalSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseDiagnostic"
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -765,6 +765,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -514,7 +514,7 @@ func awsRemediationApprovalDeriveState(source AWSRemediationCase, gates []AWSRem
 	switch strings.ToLower(strings.TrimSpace(source.Lifecycle)) {
 	case "proposed", "pending":
 		return awsRemediationApprovalStateRequested
-	case "under_review", "review":
+	case "in_review", "under_review", "review":
 		return awsRemediationApprovalStateReview
 	case "approved":
 		return awsRemediationApprovalStateApproved

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -1,0 +1,871 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsRemediationApprovalCurrentIssue = 1536
+	awsRemediationApprovalVersion      = "aws-remediation-approval-rbac-v1"
+
+	awsRemediationApprovalStateRequested = "requested"
+	awsRemediationApprovalStateReview    = "under_review"
+	awsRemediationApprovalStateApproved  = "approved"
+	awsRemediationApprovalStateDenied    = "denied"
+	awsRemediationApprovalStateExpired   = "expired"
+	awsRemediationApprovalStateBlocked   = "blocked"
+
+	awsRemediationApprovalRiskCritical = "critical"
+	awsRemediationApprovalRiskHigh     = "high"
+	awsRemediationApprovalRiskMedium   = "medium"
+	awsRemediationApprovalRiskLow      = "low"
+
+	awsRemediationApprovalDefaultGraceHours = 72
+)
+
+// AWSRemediationApprovalRequest scopes the deterministic approval-queue
+// projection to one AWS connector plus optional operator drill-down filters.
+type AWSRemediationApprovalRequest struct {
+	ConnectorID       string `json:"connector_id,omitempty"`
+	FixtureState      string `json:"fixture_state,omitempty"`
+	AccountID         string `json:"account_id,omitempty"`
+	Region            string `json:"region,omitempty"`
+	CaseID            string `json:"case_id,omitempty"`
+	State             string `json:"state,omitempty"`
+	RiskTier          string `json:"risk_tier,omitempty"`
+	ScopeType         string `json:"scope_type,omitempty"`
+	Requestor         string `json:"requestor,omitempty"`
+	ApproverRole      string `json:"approver_role,omitempty"`
+	Severity          string `json:"severity,omitempty"`
+	ReadyForExecution string `json:"ready_for_execution,omitempty"`
+	KillSwitchEngaged string `json:"kill_switch_engaged,omitempty"`
+	Search            string `json:"search,omitempty"`
+}
+
+// Reuse upstream evidence and path-step shapes so the approval-queue contract
+// stays consistent with its source cases.
+type AWSRemediationApprovalEvidence = AWSRemediationCaseEvidence
+type AWSRemediationApprovalPathStep = AWSRemediationCasePathStep
+type AWSRemediationApprovalDiagnostic = AWSRemediationCaseDiagnostic
+type AWSRemediationApprovalCoverageGap = AWSRemediationCaseCoverageGap
+type AWSRemediationApprovalAuditEntry = AWSRemediationAuditEntry
+
+// AWSRemediationApprovalActor names one operator role with explicit
+// requestor/approver context. Roles are deterministic strings.
+type AWSRemediationApprovalActor struct {
+	Role         string `json:"role"`
+	Label        string `json:"label"`
+	Required     bool   `json:"required"`
+	Acknowledged bool   `json:"acknowledged"`
+}
+
+// AWSRemediationApprovalScope records the explicit blast surface the approval
+// applies to. Tenancy boundaries are preserved by carrying the connector,
+// account, and region context on every entry.
+type AWSRemediationApprovalScope struct {
+	ScopeType       string   `json:"scope_type"`
+	AccountIDs      []string `json:"account_ids,omitempty"`
+	Regions         []string `json:"regions,omitempty"`
+	ConnectorIDs    []string `json:"connector_ids,omitempty"`
+	IdentityNodeIDs []string `json:"identity_node_ids,omitempty"`
+	ResourceNodeIDs []string `json:"resource_node_ids,omitempty"`
+}
+
+// AWSRemediationApprovalRBACGate explains one role-based access check the
+// approval workflow enforces. Each gate carries a deterministic status and
+// rationale so the app can show which check blocks the workflow.
+type AWSRemediationApprovalRBACGate struct {
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	RequiredRole string `json:"required_role"`
+	Rationale    string `json:"rationale"`
+}
+
+// AWSRemediationApprovalFeatureFlag pins the deterministic feature-flag state
+// at projection time so operators can see why a queue entry is or isn't
+// executable.
+type AWSRemediationApprovalFeatureFlag struct {
+	Name      string `json:"name"`
+	Enabled   bool   `json:"enabled"`
+	Scope     string `json:"scope"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSRemediationApprovalEntry is the persisted-record-shaped contract emitted
+// by the approval workflow. It is metadata-only: it carries no rendered IAC
+// or policy bodies, no secret material, and no workload payloads. The entry
+// records *what* approval is required and *what* state it is in; live AWS
+// mutation belongs to later wave executors.
+type AWSRemediationApprovalEntry struct {
+	ApprovalID         string                              `json:"approval_id"`
+	CalculationVersion string                              `json:"calculation_version"`
+	CaseID             string                              `json:"case_id"`
+	SourceArtifactID   string                              `json:"source_artifact_id"`
+	SourceType         string                              `json:"source_type"`
+	State              string                              `json:"state"`
+	RiskTier           string                              `json:"risk_tier"`
+	Severity           string                              `json:"severity"`
+	Score              int                                 `json:"score"`
+	Confidence         float64                             `json:"confidence"`
+	Title              string                              `json:"title"`
+	Summary            string                              `json:"summary"`
+	AccountID          string                              `json:"account_id"`
+	Region             string                              `json:"region"`
+	Requestor          AWSRemediationApprovalActor         `json:"requestor"`
+	RequiredApprovers  []AWSRemediationApprovalActor       `json:"required_approvers"`
+	Scope              AWSRemediationApprovalScope         `json:"scope"`
+	RBACGates          []AWSRemediationApprovalRBACGate    `json:"rbac_gates"`
+	FeatureFlags       []AWSRemediationApprovalFeatureFlag `json:"feature_flags"`
+	IdempotencyKey     string                              `json:"idempotency_key"`
+	DryRunRef          string                              `json:"dry_run_ref,omitempty"`
+	DiffIntent         AWSRemediationDiffIntent            `json:"diff_intent"`
+	Tradeoffs          []AWSRemediationTradeoff            `json:"tradeoffs"`
+	RollbackPlan       AWSRemediationRollbackPlan          `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan      `json:"verification_plan"`
+	AuditTrail         []AWSRemediationApprovalAuditEntry  `json:"audit_trail"`
+	ReadyForExecution  bool                                `json:"ready_for_execution"`
+	KillSwitchEngaged  bool                                `json:"kill_switch_engaged"`
+	ReadOnlyProjection bool                                `json:"read_only_projection"`
+	SourceSignals      []string                            `json:"source_signals"`
+	Evidence           []AWSRemediationApprovalEvidence    `json:"evidence"`
+	EvidenceBoundary   string                              `json:"evidence_boundary"`
+	ImpactedNodes      []string                            `json:"impacted_nodes"`
+	ImpactedPath       []AWSRemediationApprovalPathStep    `json:"impacted_path"`
+	NextAction         string                              `json:"next_action"`
+	RequestedAt        time.Time                           `json:"requested_at"`
+	ExpiresAt          time.Time                           `json:"expires_at"`
+	CreatedAt          time.Time                           `json:"created_at"`
+	UpdatedAt          time.Time                           `json:"updated_at"`
+}
+
+// AWSRemediationApprovalSummary aggregates the unfiltered and filtered queue.
+type AWSRemediationApprovalSummary struct {
+	TotalEntries          int            `json:"total_entries"`
+	FilteredEntries       int            `json:"filtered_entries"`
+	StateCounts           map[string]int `json:"state_counts"`
+	RiskTierCounts        map[string]int `json:"risk_tier_counts"`
+	SeverityCounts        map[string]int `json:"severity_counts"`
+	ScopeTypeCounts       map[string]int `json:"scope_type_counts"`
+	RequiredApproverCount int            `json:"required_approver_count"`
+	ReadyForExecution     int            `json:"ready_for_execution_count"`
+	KillSwitchEngaged     int            `json:"kill_switch_engaged_count"`
+	RBACGateBlockedCount  int            `json:"rbac_gate_blocked_count"`
+	AuditEntryCount       int            `json:"audit_entry_count"`
+	RelationshipCount     int            `json:"relationship_count"`
+	HighestScore          int            `json:"highest_score"`
+	AverageConfidencePct  int            `json:"average_confidence_pct"`
+}
+
+// AWSRemediationApprovalRelationship surfaces approval→graph node edges so the
+// app can join approvals against the same impacted nodes as their source case.
+type AWSRemediationApprovalRelationship struct {
+	ApprovalID  string `json:"approval_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSRemediationApprovalResult is the deterministic envelope returned by the
+// approval-queue endpoint.
+type AWSRemediationApprovalResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	CalculationVersion string                               `json:"calculation_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Summary            AWSRemediationApprovalSummary        `json:"summary"`
+	Entries            []AWSRemediationApprovalEntry        `json:"entries"`
+	Relationships      []AWSRemediationApprovalRelationship `json:"relationships"`
+	Caveats            []string                             `json:"caveats"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSRemediationApprovalCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSRemediationApprovalDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// GetAWSRemediationApprovalQueue projects a deterministic, read-only AWS
+// remediation approval queue from upstream remediation cases. It enforces the
+// approval, RBAC, feature-flag, and scope gates server-side but never mutates
+// AWS, never calls IAM/STS/Organizations write APIs, and never reads, exposes,
+// logs, or persists rendered policies, secret values, customer payloads,
+// prompts, completions, browser pages, code-interpreter output, database rows,
+// or object contents.
+func (s *Service) GetAWSRemediationApprovalQueue(ctx context.Context, workspaceID string, projectID string, request AWSRemediationApprovalRequest) (AWSRemediationApprovalResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRemediationApprovalResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRemediationApprovalResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSRemediationApprovalFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRemediationApprovalResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSRemediationApprovalResult{}, fmt.Errorf("remediation approval cases: %w", err)
+	}
+
+	entries := awsRemediationApprovalEntries(cases.Cases, now, connectorID)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].ApprovalID < entries[j].ApprovalID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSRemediationApprovalEntries(entries, request)
+	relationships := awsRemediationApprovalRelationships(filtered)
+	diagnostics := awsRemediationApprovalDiagnostics(cases.Diagnostics)
+	coverageGaps := awsRemediationApprovalCoverageGaps(cases.CoverageGaps)
+	status, confidence := summarizeAWSRemediationApprovalStatus(cases.Status, filtered, diagnostics)
+
+	return AWSRemediationApprovalResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationApprovalCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationApprovalCurrentIssue),
+		Version:            awsRemediationApprovalVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationApprovalVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSRemediationApprovalEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsRemediationApprovalCaveats(),
+		FailureReasons:     dedupeStrings(cases.FailureReasons),
+		RemediationHints:   awsRemediationApprovalRemediationHints(cases.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationApprovalCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-remediation-approval-rbac",
+			"/docs/aws-remediation-case-model",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSRemediationApprovalFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsRemediationApprovalEntries(cases []AWSRemediationCase, now time.Time, connectorID string) []AWSRemediationApprovalEntry {
+	entries := make([]AWSRemediationApprovalEntry, 0, len(cases))
+	for _, source := range cases {
+		entries = append(entries, awsRemediationApprovalEntryFromCase(source, now, connectorID))
+	}
+	return entries
+}
+
+func awsRemediationApprovalEntryFromCase(source AWSRemediationCase, now time.Time, connectorID string) AWSRemediationApprovalEntry {
+	riskTier := awsRemediationApprovalRiskTier(source)
+	requestor := awsRemediationApprovalRequestor(source)
+	approvers := awsRemediationApprovalRequiredApprovers(source, riskTier)
+	scope := awsRemediationApprovalScope(source, connectorID)
+	gates := awsRemediationApprovalRBACGates(source, approvers)
+	flags := awsRemediationApprovalFeatureFlags(source, riskTier)
+	killSwitch := awsRemediationApprovalFeatureFlagEngaged(flags, "remediation_kill_switch")
+	state := awsRemediationApprovalDeriveState(source, gates, killSwitch)
+	idempotency := awsRemediationApprovalIdempotencyKey(source)
+	expires := awsRemediationApprovalExpiresAt(source, now, riskTier)
+	audit := awsRemediationApprovalAuditTrail(source, state, requestor, approvers, now)
+	evidenceRef := firstAWSRemediationCaseEvidenceRef(source.Evidence)
+	entry := AWSRemediationApprovalEntry{
+		ApprovalID:         "aws-remediation-approval:" + stableAWSBlastRadiusToken("approval", source.CaseID, riskTier),
+		CalculationVersion: awsRemediationApprovalVersion,
+		CaseID:             source.CaseID,
+		SourceArtifactID:   source.SourceFindingID,
+		SourceType:         source.SourceType,
+		State:              state,
+		RiskTier:           riskTier,
+		Severity:           source.Severity,
+		Score:              source.Score,
+		Confidence:         source.Confidence,
+		Title:              fmt.Sprintf("Approval: %s", source.Title),
+		Summary:            fmt.Sprintf("RBAC-gated approval workflow for remediation case %s. Identrail does not mutate AWS; later wave executors apply the change after approval.", source.CaseID),
+		AccountID:          source.AccountID,
+		Region:             source.Region,
+		Requestor:          requestor,
+		RequiredApprovers:  approvers,
+		Scope:              scope,
+		RBACGates:          gates,
+		FeatureFlags:       flags,
+		IdempotencyKey:     idempotency,
+		DryRunRef:          fmt.Sprintf("dry-run://%s/%s/proposed", source.SourceType, source.CaseID),
+		DiffIntent:         source.DiffIntent,
+		Tradeoffs:          source.Tradeoffs,
+		RollbackPlan:       source.RollbackPlan,
+		VerificationPlan:   source.VerificationPlan,
+		AuditTrail:         audit,
+		KillSwitchEngaged:  killSwitch,
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings(append([]string{"remediation_case"}, source.SourceSignals...)),
+		Evidence:           source.Evidence,
+		EvidenceBoundary:   awsRemediationApprovalEvidenceBoundary(),
+		ImpactedNodes:      source.ImpactedNodes,
+		ImpactedPath:       source.ImpactedPath,
+		NextAction:         awsRemediationApprovalNextAction(state, riskTier),
+		RequestedAt:        source.CreatedAt,
+		ExpiresAt:          expires,
+		CreatedAt:          source.CreatedAt,
+		UpdatedAt:          firstNonZeroAWSRemediationApprovalTime(source.UpdatedAt, now),
+	}
+	entry.ReadyForExecution = state == awsRemediationApprovalStateApproved && !killSwitch && awsRemediationApprovalAllGatesPassed(gates)
+	if entry.RequestedAt.IsZero() {
+		entry.RequestedAt = now
+	}
+	_ = evidenceRef
+	return entry
+}
+
+func awsRemediationApprovalRiskTier(source AWSRemediationCase) string {
+	switch strings.ToLower(strings.TrimSpace(source.Severity)) {
+	case "critical":
+		return awsRemediationApprovalRiskCritical
+	case "high":
+		return awsRemediationApprovalRiskHigh
+	case "medium":
+		return awsRemediationApprovalRiskMedium
+	default:
+		return awsRemediationApprovalRiskLow
+	}
+}
+
+func awsRemediationApprovalRequestor(source AWSRemediationCase) AWSRemediationApprovalActor {
+	if source.OwnerAssigned && strings.TrimSpace(source.Owner) != "" {
+		return AWSRemediationApprovalActor{
+			Role:         "remediation-requestor",
+			Label:        source.Owner,
+			Required:     true,
+			Acknowledged: true,
+		}
+	}
+	return AWSRemediationApprovalActor{
+		Role:         "remediation-requestor",
+		Label:        "unassigned",
+		Required:     true,
+		Acknowledged: false,
+	}
+}
+
+func awsRemediationApprovalRequiredApprovers(source AWSRemediationCase, riskTier string) []AWSRemediationApprovalActor {
+	approvers := []AWSRemediationApprovalActor{
+		{Role: "security-reviewer", Label: "security-reviewer", Required: true},
+		{Role: "platform-operator", Label: "platform-operator", Required: true},
+	}
+	if riskTier == awsRemediationApprovalRiskCritical || riskTier == awsRemediationApprovalRiskHigh {
+		approvers = append(approvers, AWSRemediationApprovalActor{Role: "incident-commander", Label: "incident-commander", Required: true})
+	}
+	if strings.EqualFold(source.SourceType, "ai_agent_risk") || strings.EqualFold(source.SourceType, "secret_permission_equivalence") {
+		approvers = append(approvers, AWSRemediationApprovalActor{Role: "data-protection-reviewer", Label: "data-protection-reviewer", Required: true})
+	}
+	return approvers
+}
+
+func awsRemediationApprovalScope(source AWSRemediationCase, connectorID string) AWSRemediationApprovalScope {
+	scopeType := "identity"
+	if len(source.ResourceNodeIDs) > 0 {
+		scopeType = "resource"
+	}
+	if strings.EqualFold(source.SourceType, "blast_radius") {
+		scopeType = "account"
+	}
+	connectors := []string{}
+	if strings.TrimSpace(connectorID) != "" {
+		connectors = append(connectors, connectorID)
+	}
+	identityNodes := []string{}
+	if strings.TrimSpace(source.IdentityNodeID) != "" {
+		identityNodes = append(identityNodes, source.IdentityNodeID)
+	}
+	return AWSRemediationApprovalScope{
+		ScopeType:       scopeType,
+		AccountIDs:      emptyStrings(dedupeStrings([]string{source.AccountID})),
+		Regions:         emptyStrings(dedupeStrings([]string{source.Region})),
+		ConnectorIDs:    connectors,
+		IdentityNodeIDs: identityNodes,
+		ResourceNodeIDs: emptyStrings(dedupeStrings(source.ResourceNodeIDs)),
+	}
+}
+
+func awsRemediationApprovalRBACGates(source AWSRemediationCase, approvers []AWSRemediationApprovalActor) []AWSRemediationApprovalRBACGate {
+	gates := []AWSRemediationApprovalRBACGate{
+		{Name: "tenant_scope", Status: "passed", RequiredRole: "tenant-member", Rationale: "Tenant, workspace, project, and connector boundaries are preserved on every approval entry."},
+		{Name: "read_only_projection", Status: "passed", RequiredRole: "remediation-viewer", Rationale: "Identrail emits approval metadata only; no AWS write API is called here."},
+		{Name: "requestor_assigned", Status: awsRemediationApprovalGateStatus(source.OwnerAssigned), RequiredRole: "remediation-requestor", Rationale: "An accountable requestor must be assigned before the approval workflow can advance."},
+		{Name: "approver_quorum", Status: awsRemediationApprovalGateStatus(len(approvers) >= 2), RequiredRole: "remediation-approver", Rationale: "At least two required approver roles must acknowledge the request before execution."},
+	}
+	if source.Confidence < 0.7 {
+		gates = append(gates, AWSRemediationApprovalRBACGate{Name: "confidence_floor", Status: "blocked", RequiredRole: "remediation-approver", Rationale: "Upstream evidence confidence is below the 0.7 threshold required to advance the approval."})
+	}
+	if !source.ApprovalRequired {
+		gates = append(gates, AWSRemediationApprovalRBACGate{Name: "approval_required", Status: "blocked", RequiredRole: "remediation-approver", Rationale: "Source case is marked no-approval-required; this queue entry is informational only."})
+	}
+	return gates
+}
+
+func awsRemediationApprovalGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsRemediationApprovalFeatureFlags(source AWSRemediationCase, riskTier string) []AWSRemediationApprovalFeatureFlag {
+	flags := []AWSRemediationApprovalFeatureFlag{
+		{Name: "aws_remediation_approval_workflow", Enabled: true, Scope: "tenant", Rationale: "Approval workflow projection is always-on; later wave executors gate live AWS mutation behind their own flags."},
+		{Name: "remediation_kill_switch", Enabled: false, Scope: "tenant", Rationale: "Tenant-scoped kill switch for AWS remediation execution; default off in this projection."},
+		{Name: "live_aws_mutation", Enabled: false, Scope: "tenant", Rationale: "Live AWS mutation is intentionally disabled at this layer; later wave executors implement controlled execution."},
+	}
+	if riskTier == awsRemediationApprovalRiskCritical {
+		flags = append(flags, AWSRemediationApprovalFeatureFlag{Name: "critical_risk_dual_control", Enabled: true, Scope: "case", Rationale: "Critical-risk approvals require dual-control acknowledgement before execution."})
+	}
+	if strings.EqualFold(source.SourceType, "aws_iac_remediation") {
+		flags = append(flags, AWSRemediationApprovalFeatureFlag{Name: "iac_remediation_pr_required", Enabled: true, Scope: "case", Rationale: "IaC remediation cases require an operator-owned source-control PR before approval can advance."})
+	}
+	return flags
+}
+
+func awsRemediationApprovalFeatureFlagEngaged(flags []AWSRemediationApprovalFeatureFlag, name string) bool {
+	for _, flag := range flags {
+		if flag.Name == name {
+			return flag.Enabled
+		}
+	}
+	return false
+}
+
+func awsRemediationApprovalDeriveState(source AWSRemediationCase, gates []AWSRemediationApprovalRBACGate, killSwitch bool) string {
+	if killSwitch {
+		return awsRemediationApprovalStateBlocked
+	}
+	for _, gate := range gates {
+		if gate.Status == "blocked" {
+			return awsRemediationApprovalStateBlocked
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(source.ApprovalState)) {
+	case "approved":
+		return awsRemediationApprovalStateApproved
+	case "denied":
+		return awsRemediationApprovalStateDenied
+	case "expired":
+		return awsRemediationApprovalStateExpired
+	case "under_review", "review":
+		return awsRemediationApprovalStateReview
+	}
+	switch strings.ToLower(strings.TrimSpace(source.Lifecycle)) {
+	case "proposed", "pending":
+		return awsRemediationApprovalStateRequested
+	case "under_review", "review":
+		return awsRemediationApprovalStateReview
+	case "approved":
+		return awsRemediationApprovalStateApproved
+	case "denied":
+		return awsRemediationApprovalStateDenied
+	case "expired":
+		return awsRemediationApprovalStateExpired
+	}
+	if !source.ApprovalRequired {
+		return awsRemediationApprovalStateBlocked
+	}
+	return awsRemediationApprovalStateRequested
+}
+
+func awsRemediationApprovalIdempotencyKey(source AWSRemediationCase) string {
+	return "aws-remediation-approval:" + stableAWSBlastRadiusToken("idempotency", source.CaseID, source.CalculationVersion)
+}
+
+func awsRemediationApprovalExpiresAt(source AWSRemediationCase, now time.Time, riskTier string) time.Time {
+	base := source.UpdatedAt
+	if base.IsZero() {
+		base = now
+	}
+	grace := time.Duration(awsRemediationApprovalDefaultGraceHours) * time.Hour
+	switch riskTier {
+	case awsRemediationApprovalRiskCritical:
+		grace = 12 * time.Hour
+	case awsRemediationApprovalRiskHigh:
+		grace = 24 * time.Hour
+	case awsRemediationApprovalRiskMedium:
+		grace = 48 * time.Hour
+	}
+	return base.Add(grace)
+}
+
+func awsRemediationApprovalAuditTrail(source AWSRemediationCase, state string, requestor AWSRemediationApprovalActor, approvers []AWSRemediationApprovalActor, now time.Time) []AWSRemediationApprovalAuditEntry {
+	occurredAt := source.CreatedAt
+	if occurredAt.IsZero() {
+		occurredAt = now
+	}
+	trail := []AWSRemediationApprovalAuditEntry{}
+	trail = append(trail, source.AuditTrail...)
+	trail = append(trail, AWSRemediationApprovalAuditEntry{
+		EventID:     stableAWSBlastRadiusToken("approval-request", source.CaseID, requestor.Label),
+		Actor:       requestor.Label,
+		EventType:   "approval_requested",
+		OccurredAt:  occurredAt,
+		EvidenceRef: firstAWSRemediationCaseEvidenceRef(source.Evidence),
+		Notes:       fmt.Sprintf("Approval workflow entry projected; state=%s.", state),
+	})
+	for _, approver := range approvers {
+		trail = append(trail, AWSRemediationApprovalAuditEntry{
+			EventID:    stableAWSBlastRadiusToken("approval-required", source.CaseID, approver.Role),
+			Actor:      approver.Label,
+			EventType:  "approval_required",
+			OccurredAt: occurredAt,
+			Notes:      fmt.Sprintf("Required approver role %s pending acknowledgement.", approver.Role),
+		})
+	}
+	return trail
+}
+
+func awsRemediationApprovalNextAction(state, riskTier string) string {
+	switch state {
+	case awsRemediationApprovalStateApproved:
+		return "Approval granted; later wave executors may run the dry-run, apply, and verify workflow when their feature flag opens."
+	case awsRemediationApprovalStateDenied:
+		return "Approval denied; revisit the source remediation case before re-requesting."
+	case awsRemediationApprovalStateExpired:
+		return "Approval window expired; re-evaluate evidence and re-request approval if the change is still required."
+	case awsRemediationApprovalStateBlocked:
+		return "Approval blocked by an RBAC gate or kill switch; satisfy the failing gate before retrying."
+	case awsRemediationApprovalStateReview:
+		return fmt.Sprintf("Approver quorum is reviewing; risk_tier=%s. Capture any additional evidence before voting.", riskTier)
+	}
+	return fmt.Sprintf("Awaiting approver acknowledgement; required quorum varies by risk_tier=%s.", riskTier)
+}
+
+func awsRemediationApprovalAllGatesPassed(gates []AWSRemediationApprovalRBACGate) bool {
+	for _, gate := range gates {
+		if gate.Status == "blocked" {
+			return false
+		}
+	}
+	return true
+}
+
+func firstNonZeroAWSRemediationApprovalTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func firstAWSRemediationCaseEvidenceRef(evidence []AWSRemediationCaseEvidence) string {
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}
+
+func filterAWSRemediationApprovalEntries(entries []AWSRemediationApprovalEntry, request AWSRemediationApprovalRequest) ([]AWSRemediationApprovalEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":          strings.TrimSpace(request.AccountID),
+		"region":              strings.TrimSpace(request.Region),
+		"case_id":             strings.TrimSpace(request.CaseID),
+		"state":               normalizeAWSRuntimeEventFilterToken(request.State),
+		"risk_tier":           normalizeAWSRuntimeEventFilterToken(request.RiskTier),
+		"scope_type":          normalizeAWSRuntimeEventFilterToken(request.ScopeType),
+		"requestor":           normalizeAWSRuntimeEventFilterToken(request.Requestor),
+		"approver_role":       normalizeAWSRuntimeEventFilterToken(request.ApproverRole),
+		"severity":            normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"ready_for_execution": strings.ToLower(strings.TrimSpace(request.ReadyForExecution)),
+		"kill_switch_engaged": strings.ToLower(strings.TrimSpace(request.KillSwitchEngaged)),
+		"search":              strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSRemediationApprovalEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		if filters["risk_tier"] != "" && filters["risk_tier"] != normalizeAWSRuntimeEventFilterToken(entry.RiskTier) {
+			continue
+		}
+		if filters["scope_type"] != "" && filters["scope_type"] != normalizeAWSRuntimeEventFilterToken(entry.Scope.ScopeType) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["requestor"] != "" && filters["requestor"] != normalizeAWSRuntimeEventFilterToken(entry.Requestor.Label) {
+			continue
+		}
+		if filters["approver_role"] != "" && !awsRemediationApprovalHasApproverRole(entry, filters["approver_role"]) {
+			continue
+		}
+		if filters["ready_for_execution"] != "" {
+			want := filters["ready_for_execution"]
+			if (want == "true" || want == "yes") != entry.ReadyForExecution {
+				continue
+			}
+		}
+		if filters["kill_switch_engaged"] != "" {
+			want := filters["kill_switch_engaged"]
+			if (want == "true" || want == "yes") != entry.KillSwitchEngaged {
+				continue
+			}
+		}
+		if filters["search"] != "" && !awsRemediationApprovalSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsRemediationApprovalHasApproverRole(entry AWSRemediationApprovalEntry, needle string) bool {
+	needle = normalizeAWSRuntimeEventFilterToken(needle)
+	if needle == "" {
+		return true
+	}
+	for _, approver := range entry.RequiredApprovers {
+		if normalizeAWSRuntimeEventFilterToken(approver.Role) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func awsRemediationApprovalSearchMatch(entry AWSRemediationApprovalEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.ApprovalID, entry.CaseID, entry.SourceArtifactID, entry.SourceType, entry.State, entry.RiskTier,
+		entry.Severity, entry.Title, entry.Summary, entry.IdempotencyKey, entry.DryRunRef, entry.NextAction,
+		entry.Requestor.Role, entry.Requestor.Label, entry.Scope.ScopeType,
+		entry.DiffIntent.Kind, entry.DiffIntent.DiffSummary,
+		entry.RollbackPlan.Strategy, entry.VerificationPlan.Strategy,
+	}
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.Scope.AccountIDs...)
+	values = append(values, entry.Scope.Regions...)
+	values = append(values, entry.Scope.ConnectorIDs...)
+	values = append(values, entry.Scope.IdentityNodeIDs...)
+	values = append(values, entry.Scope.ResourceNodeIDs...)
+	for _, approver := range entry.RequiredApprovers {
+		values = append(values, approver.Role, approver.Label)
+	}
+	for _, gate := range entry.RBACGates {
+		values = append(values, gate.Name, gate.Status, gate.RequiredRole, gate.Rationale)
+	}
+	for _, flag := range entry.FeatureFlags {
+		values = append(values, flag.Name, flag.Scope, flag.Rationale)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsRemediationApprovalRelationships(entries []AWSRemediationApprovalEntry) []AWSRemediationApprovalRelationship {
+	relationships := []AWSRemediationApprovalRelationship{}
+	for _, entry := range entries {
+		evidenceRef := firstAWSRemediationCaseEvidenceRef(entry.Evidence)
+		for _, target := range entry.ImpactedNodes {
+			if strings.TrimSpace(target) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSRemediationApprovalRelationship{
+				ApprovalID:  entry.ApprovalID,
+				Type:        "approval_targets_node",
+				FromNodeID:  entry.ApprovalID,
+				ToNodeID:    target,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSRemediationApprovalEntries(all, filtered []AWSRemediationApprovalEntry, relationships []AWSRemediationApprovalRelationship) AWSRemediationApprovalSummary {
+	summary := AWSRemediationApprovalSummary{
+		TotalEntries:    len(all),
+		FilteredEntries: len(filtered),
+		StateCounts:     map[string]int{},
+		RiskTierCounts:  map[string]int{},
+		SeverityCounts:  map[string]int{},
+		ScopeTypeCounts: map[string]int{},
+	}
+	confidenceTotal := 0.0
+	auditTotal := 0
+	gateBlockedTotal := 0
+	for _, entry := range filtered {
+		summary.StateCounts[entry.State]++
+		summary.RiskTierCounts[entry.RiskTier]++
+		summary.SeverityCounts[entry.Severity]++
+		summary.ScopeTypeCounts[entry.Scope.ScopeType]++
+		summary.RequiredApproverCount += len(entry.RequiredApprovers)
+		if entry.ReadyForExecution {
+			summary.ReadyForExecution++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngaged++
+		}
+		for _, gate := range entry.RBACGates {
+			if gate.Status == "blocked" {
+				gateBlockedTotal++
+			}
+		}
+		auditTotal += len(entry.AuditTrail)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RBACGateBlockedCount = gateBlockedTotal
+	summary.AuditEntryCount = auditTotal
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func summarizeAWSRemediationApprovalStatus(sourceStatus string, filtered []AWSRemediationApprovalEntry, diagnostics []AWSRemediationApprovalDiagnostic) (string, float64) {
+	if sourceStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sourceStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsRemediationApprovalCaveats() []string {
+	return []string{
+		"Approval workflow entries are read-only projections; Identrail never calls IAM, STS, or Organizations write APIs at this layer.",
+		"RBAC gates, feature flags, kill switch, idempotency keys, and scope checks are enforced server-side before any entry can become ready_for_execution.",
+		"ready_for_execution is only a planning signal — controlled live execution belongs to the wave 8 executors and their own feature flags.",
+	}
+}
+
+func awsRemediationApprovalRemediationHints(source []string) []string {
+	hints := []string{
+		"Approvers should attach acknowledgement evidence (e.g. ticket link, change request) to the source remediation case before voting.",
+		"If the kill switch engages, all approvals stay blocked until the tenant feature flag flips off; later wave executors honour the same gate.",
+		"Use the idempotency key as the deterministic id when wiring later wave dry-run, apply, and verify executors so retries do not double-apply.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsRemediationApprovalDiagnostics(source []AWSRemediationCaseDiagnostic) []AWSRemediationApprovalDiagnostic {
+	out := make([]AWSRemediationApprovalDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSRemediationApprovalDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsRemediationApprovalCoverageGaps(source []AWSRemediationCaseCoverageGap) []AWSRemediationApprovalCoverageGap {
+	gaps := []AWSRemediationApprovalCoverageGap{{
+		Capability:  "aws_remediation_live_execution",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1536 implements the approval workflow and RBAC gates only; live IAM/STS/Organizations write APIs are not called by this endpoint.",
+		Remediation: "Wire the dry-run, apply, and verify executors in wave 8 issues (#1537, #1538, #1539, #1540, #1541, #1542) once their safety gates are in place.",
+	}}
+	for _, gap := range source {
+		gaps = append(gaps, AWSRemediationApprovalCoverageGap(gap))
+	}
+	return gaps
+}
+
+func awsRemediationApprovalEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -502,6 +502,8 @@ func awsRemediationApprovalDeriveState(source AWSRemediationCase, gates []AWSRem
 	switch strings.ToLower(strings.TrimSpace(source.ApprovalState)) {
 	case "approved":
 		return awsRemediationApprovalStateApproved
+	case "pending_approver":
+		return awsRemediationApprovalStateReview
 	case "denied":
 		return awsRemediationApprovalStateDenied
 	case "expired":

--- a/internal/api/aws_remediation_approval_test.go
+++ b/internal/api/aws_remediation_approval_test.go
@@ -213,6 +213,33 @@ func TestAWSRemediationApprovalScopeUsesAccountForBlastRadiusSource(t *testing.T
 	}
 }
 
+func TestAWSRemediationApprovalDeriveStatePreservesInReviewLifecycle(t *testing.T) {
+	cases := []struct {
+		lifecycle string
+		want      string
+	}{
+		{lifecycle: "in_review", want: awsRemediationApprovalStateReview},
+		{lifecycle: "under_review", want: awsRemediationApprovalStateReview},
+		{lifecycle: "review", want: awsRemediationApprovalStateReview},
+		{lifecycle: "proposed", want: awsRemediationApprovalStateRequested},
+	}
+	for _, tc := range cases {
+		source := AWSRemediationCase{
+			CaseID:           "case-lifecycle-" + tc.lifecycle,
+			Lifecycle:        tc.lifecycle,
+			Owner:            "orders-platform",
+			OwnerAssigned:    true,
+			ApprovalRequired: true,
+			Confidence:       0.92,
+		}
+		gates := awsRemediationApprovalRBACGates(source, awsRemediationApprovalRequiredApprovers(source, awsRemediationApprovalRiskLow))
+		got := awsRemediationApprovalDeriveState(source, gates, false)
+		if got != tc.want {
+			t.Fatalf("lifecycle=%q: state=%q want=%q gates=%+v", tc.lifecycle, got, tc.want, gates)
+		}
+	}
+}
+
 func TestAWSRemediationApprovalIdempotencyKeyIsDeterministic(t *testing.T) {
 	source := AWSRemediationCase{CaseID: "case-determinism", CalculationVersion: "deterministic"}
 	first := awsRemediationApprovalIdempotencyKey(source)

--- a/internal/api/aws_remediation_approval_test.go
+++ b/internal/api/aws_remediation_approval_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newRemediationApprovalService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSRemediationApprovalQueueBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 26, 11, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationApprovalService(t, "project-remediation-approval", now)
+
+	result, err := svc.GetAWSRemediationApprovalQueue(defaultScopeContext(), ws, "project-remediation-approval", AWSRemediationApprovalRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation approval queue: %v", err)
+	}
+	if result.CurrentIssueRef != "#1536" || result.Version != awsRemediationApprovalVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Entries) == 0 || result.Summary.TotalEntries != len(result.Entries) {
+		t.Fatalf("expected approval entries and matching summary: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Entries); i++ {
+		if result.Entries[i-1].Score < result.Entries[i].Score {
+			t.Fatalf("entries are not ranked by descending score: %+v", result.Entries)
+		}
+	}
+	for _, entry := range result.Entries {
+		if entry.ApprovalID == "" || entry.CalculationVersion != awsRemediationApprovalVersion || entry.CaseID == "" {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.IdempotencyKey == "" {
+			t.Fatalf("entry missing idempotency key: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if len(entry.RequiredApprovers) < 2 {
+			t.Fatalf("entry must require at least two approvers: %+v", entry.RequiredApprovers)
+		}
+		if len(entry.RBACGates) == 0 || len(entry.FeatureFlags) == 0 {
+			t.Fatalf("entry missing RBAC gates or feature flags: %+v", entry)
+		}
+		sawKillSwitch := false
+		for _, flag := range entry.FeatureFlags {
+			if flag.Name == "remediation_kill_switch" {
+				sawKillSwitch = true
+			}
+		}
+		if !sawKillSwitch {
+			t.Fatalf("entry feature flags must include remediation_kill_switch: %+v", entry.FeatureFlags)
+		}
+		if entry.EvidenceBoundary != awsRemediationApprovalEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		if entry.ExpiresAt.IsZero() {
+			t.Fatalf("entry expiry must be set: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("approval queue serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestFilterAWSRemediationApprovalEntriesAppliesFilters(t *testing.T) {
+	entries := []AWSRemediationApprovalEntry{
+		{
+			ApprovalID:        "ready",
+			CaseID:            "case-a",
+			AccountID:         "123456789012",
+			Region:            "us-east-1",
+			State:             awsRemediationApprovalStateApproved,
+			RiskTier:          awsRemediationApprovalRiskLow,
+			Severity:          "low",
+			Scope:             AWSRemediationApprovalScope{ScopeType: "identity"},
+			Requestor:         AWSRemediationApprovalActor{Role: "remediation-requestor", Label: "orders-platform"},
+			RequiredApprovers: []AWSRemediationApprovalActor{{Role: "security-reviewer"}, {Role: "platform-operator"}},
+			ReadyForExecution: true,
+		},
+		{
+			ApprovalID:        "blocked",
+			CaseID:            "case-b",
+			AccountID:         "123456789012",
+			Region:            "us-east-1",
+			State:             awsRemediationApprovalStateBlocked,
+			RiskTier:          awsRemediationApprovalRiskCritical,
+			Severity:          "critical",
+			Scope:             AWSRemediationApprovalScope{ScopeType: "account"},
+			Requestor:         AWSRemediationApprovalActor{Role: "remediation-requestor", Label: "unassigned"},
+			RequiredApprovers: []AWSRemediationApprovalActor{{Role: "security-reviewer"}, {Role: "platform-operator"}, {Role: "incident-commander"}},
+			KillSwitchEngaged: true,
+		},
+	}
+
+	ready, readyApplied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{ReadyForExecution: "yes"})
+	if readyApplied["ready_for_execution"] != "yes" || len(ready) != 1 || ready[0].ApprovalID != "ready" {
+		t.Fatalf("expected ready_for_execution=yes to match ready entries, got applied=%+v entries=%+v", readyApplied, ready)
+	}
+
+	critical, criticalApplied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{RiskTier: "critical"})
+	if criticalApplied["risk_tier"] != "critical" || len(critical) != 1 || critical[0].ApprovalID != "blocked" {
+		t.Fatalf("expected risk_tier=critical to match critical entries, got applied=%+v entries=%+v", criticalApplied, critical)
+	}
+
+	kill, killApplied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{KillSwitchEngaged: "true"})
+	if killApplied["kill_switch_engaged"] != "true" || len(kill) != 1 || kill[0].ApprovalID != "blocked" {
+		t.Fatalf("expected kill_switch_engaged=true to match killed entries, got applied=%+v entries=%+v", killApplied, kill)
+	}
+
+	approver, approverApplied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{ApproverRole: "incident-commander"})
+	if approverApplied["approver_role"] != "incident-commander" || len(approver) != 1 || approver[0].ApprovalID != "blocked" {
+		t.Fatalf("expected approver_role=incident-commander to match critical entries, got applied=%+v entries=%+v", approverApplied, approver)
+	}
+}
+
+func TestAWSRemediationApprovalEntryHonorsRBACGatesAndKillSwitch(t *testing.T) {
+	source := AWSRemediationCase{
+		CaseID:             "case-rbac",
+		CalculationVersion: "test",
+		Severity:           "high",
+		Confidence:         0.92,
+		OwnerAssigned:      false,
+		Owner:              "",
+		ApprovalRequired:   true,
+		Lifecycle:          "proposed",
+		ImpactedNodes:      []string{"aws:identity:role/orders-ci"},
+	}
+	entry := awsRemediationApprovalEntryFromCase(source, time.Date(2026, 6, 26, 11, 30, 0, 0, time.UTC), "aws-prod")
+	if entry.State != awsRemediationApprovalStateBlocked {
+		t.Fatalf("expected unassigned requestor to block approval, got state=%q gates=%+v", entry.State, entry.RBACGates)
+	}
+	if entry.ReadyForExecution {
+		t.Fatalf("blocked entry must not be ready_for_execution: %+v", entry)
+	}
+	sawIncidentCommander := false
+	for _, approver := range entry.RequiredApprovers {
+		if approver.Role == "incident-commander" {
+			sawIncidentCommander = true
+		}
+	}
+	if !sawIncidentCommander {
+		t.Fatalf("high-risk entry must require incident-commander approver: %+v", entry.RequiredApprovers)
+	}
+}
+
+func TestAWSRemediationApprovalRequiresDataProtectionReviewerForSensitiveSources(t *testing.T) {
+	cases := []struct {
+		sourceType string
+		want       bool
+	}{
+		{sourceType: "ai_agent_risk", want: true},
+		{sourceType: "secret_permission_equivalence", want: true},
+		{sourceType: "least_privilege", want: false},
+		{sourceType: "aws_ai_agent_risk", want: false},
+	}
+	for _, tc := range cases {
+		approvers := awsRemediationApprovalRequiredApprovers(AWSRemediationCase{SourceType: tc.sourceType}, awsRemediationApprovalRiskMedium)
+		gotDataProtection := false
+		for _, approver := range approvers {
+			if approver.Role == "data-protection-reviewer" {
+				gotDataProtection = true
+			}
+		}
+		if gotDataProtection != tc.want {
+			t.Fatalf("source_type=%q: data-protection-reviewer required=%v, got=%v approvers=%+v", tc.sourceType, tc.want, gotDataProtection, approvers)
+		}
+	}
+}
+
+func TestAWSRemediationApprovalScopeUsesAccountForBlastRadiusSource(t *testing.T) {
+	cases := []struct {
+		sourceType      string
+		resourceNodeIDs []string
+		want            string
+	}{
+		{sourceType: "blast_radius", resourceNodeIDs: []string{"aws:identity:role/orders-ci"}, want: "account"},
+		{sourceType: "aws_blast_radius", resourceNodeIDs: []string{"aws:identity:role/orders-ci"}, want: "resource"},
+		{sourceType: "least_privilege", resourceNodeIDs: []string{"aws:identity:role/orders-ci"}, want: "resource"},
+		{sourceType: "least_privilege", resourceNodeIDs: nil, want: "identity"},
+	}
+	for _, tc := range cases {
+		scope := awsRemediationApprovalScope(AWSRemediationCase{SourceType: tc.sourceType, ResourceNodeIDs: tc.resourceNodeIDs}, "aws-prod")
+		if scope.ScopeType != tc.want {
+			t.Fatalf("source_type=%q resourceNodes=%v: scope_type=%q want=%q", tc.sourceType, tc.resourceNodeIDs, scope.ScopeType, tc.want)
+		}
+	}
+}
+
+func TestAWSRemediationApprovalIdempotencyKeyIsDeterministic(t *testing.T) {
+	source := AWSRemediationCase{CaseID: "case-determinism", CalculationVersion: "deterministic"}
+	first := awsRemediationApprovalIdempotencyKey(source)
+	second := awsRemediationApprovalIdempotencyKey(source)
+	if first == "" || first != second {
+		t.Fatalf("idempotency key must be deterministic and non-empty, got %q vs %q", first, second)
+	}
+}
+
+func TestGetAWSRemediationApprovalQueueFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationApprovalService(t, "project-remediation-approval-states", now)
+
+	denied, err := svc.GetAWSRemediationApprovalQueue(defaultScopeContext(), ws, "project-remediation-approval-states", AWSRemediationApprovalRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Entries) != 0 {
+		t.Fatalf("permission denied must be explicit and suppress entries: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSRemediationApprovalQueue(defaultScopeContext(), ws, "project-remediation-approval-states", AWSRemediationApprovalRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not produce a blocked status: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSRemediationApprovalQueue(defaultScopeContext(), ws, "project-remediation-approval-states", AWSRemediationApprovalRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSRemediationApprovalQueue(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 15, 0, 0, time.UTC)
+	svc, _ := newRemediationApprovalService(t, "project-remediation-approval-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-remediation-approval-route/aws/remediation-approval-queue?connector_id=aws-prod&fixture_state=success&risk_tier=high", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Queue AWSRemediationApprovalResult `json:"queue"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Queue.CurrentIssueRef != "#1536" || body.Queue.AppliedFilters["risk_tier"] != "high" {
+		t.Fatalf("unexpected route payload: %+v", body.Queue)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3312,6 +3312,46 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSRemediationApprovalQueue(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRemediationApprovalRequest{
+			ConnectorID:       strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:      strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:         strings.TrimSpace(c.Query("account_id")),
+			Region:            strings.TrimSpace(c.Query("region")),
+			CaseID:            strings.TrimSpace(c.Query("case_id")),
+			State:             strings.TrimSpace(c.Query("state")),
+			RiskTier:          strings.TrimSpace(c.Query("risk_tier")),
+			ScopeType:         strings.TrimSpace(c.Query("scope_type")),
+			Requestor:         strings.TrimSpace(c.Query("requestor")),
+			ApproverRole:      strings.TrimSpace(c.Query("approver_role")),
+			Severity:          strings.TrimSpace(c.Query("severity")),
+			ReadyForExecution: strings.TrimSpace(c.Query("ready_for_execution")),
+			KillSwitchEngaged: strings.TrimSpace(c.Query("kill_switch_engaged")),
+			Search:            strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws remediation approval queue request"})
+			default:
+				logger.Error("get aws remediation approval queue",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws remediation approval queue"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"queue": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1876,6 +1876,52 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS remediation approval queue with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectRemediationApprovalQueue(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        caseID: 'aws-remediation-case:orders-ci',
+        state: 'requested',
+        riskTier: 'high',
+        scopeType: 'identity',
+        requestor: 'orders-platform',
+        approverRole: 'security-reviewer',
+        severity: 'high',
+        readyForExecution: 'false',
+        killSwitchEngaged: 'false',
+        search: 'remediation_kill_switch'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/remediation-approval-queue?');
+    expect(url).toContain('connector_id=aws-prod');
+    expect(url).toContain('risk_tier=high');
+    expect(url).toContain('approver_role=security-reviewer');
+    expect(url).toContain('kill_switch_engaged=false');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3913,6 +3913,155 @@ export type AWSIaCRemediationQuery = {
   readyForApply?: string;
   search?: string;
 };
+export type AWSRemediationApprovalStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSRemediationApprovalFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSRemediationApprovalState = 'requested' | 'under_review' | 'approved' | 'denied' | 'expired' | 'blocked' | string;
+export type AWSRemediationApprovalRiskTier = 'critical' | 'high' | 'medium' | 'low' | string;
+export type AWSRemediationApprovalScopeType = 'identity' | 'resource' | 'account' | 'ou' | 'org_root' | string;
+
+export type AWSRemediationApprovalActor = {
+  role: string;
+  label: string;
+  required: boolean;
+  acknowledged: boolean;
+};
+
+export type AWSRemediationApprovalScope = {
+  scope_type: AWSRemediationApprovalScopeType;
+  account_ids?: string[];
+  regions?: string[];
+  connector_ids?: string[];
+  identity_node_ids?: string[];
+  resource_node_ids?: string[];
+};
+
+export type AWSRemediationApprovalRBACGate = {
+  name: string;
+  status: string;
+  required_role: string;
+  rationale: string;
+};
+
+export type AWSRemediationApprovalFeatureFlag = {
+  name: string;
+  enabled: boolean;
+  scope: string;
+  rationale: string;
+};
+
+export type AWSRemediationApprovalRelationship = {
+  approval_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSRemediationApprovalEntry = {
+  approval_id: string;
+  calculation_version: string;
+  case_id: string;
+  source_artifact_id: string;
+  source_type: string;
+  state: AWSRemediationApprovalState;
+  risk_tier: AWSRemediationApprovalRiskTier;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  requestor: AWSRemediationApprovalActor;
+  required_approvers: AWSRemediationApprovalActor[];
+  scope: AWSRemediationApprovalScope;
+  rbac_gates: AWSRemediationApprovalRBACGate[];
+  feature_flags: AWSRemediationApprovalFeatureFlag[];
+  idempotency_key: string;
+  dry_run_ref?: string;
+  diff_intent: AWSRemediationDiffIntent;
+  tradeoffs: AWSRemediationTradeoff[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  audit_trail: AWSRemediationAuditEntry[];
+  ready_for_execution: boolean;
+  kill_switch_engaged: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  requested_at: string;
+  expires_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationApprovalSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  state_counts: Record<string, number>;
+  risk_tier_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  scope_type_counts: Record<string, number>;
+  required_approver_count: number;
+  ready_for_execution_count: number;
+  kill_switch_engaged_count: number;
+  rbac_gate_blocked_count: number;
+  audit_entry_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSRemediationApprovalResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSRemediationApprovalStatus;
+  fixture_state?: AWSRemediationApprovalFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSRemediationApprovalSummary;
+  entries: AWSRemediationApprovalEntry[];
+  relationships: AWSRemediationApprovalRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationApprovalQuery = {
+  connectorID?: string;
+  fixtureState?: AWSRemediationApprovalFixtureState;
+  accountID?: string;
+  region?: string;
+  caseID?: string;
+  state?: string;
+  riskTier?: string;
+  scopeType?: string;
+  requestor?: string;
+  approverRole?: string;
+  severity?: string;
+  readyForExecution?: string;
+  killSwitchEngaged?: string;
+  search?: string;
+};
 
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
@@ -8188,6 +8337,32 @@ export const apiClient = {
         severity: query?.severity,
         status: query?.status,
         ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectRemediationApprovalQueue(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSRemediationApprovalQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ queue: AWSRemediationApprovalResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/remediation-approval-queue${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        case_id: query?.caseID,
+        state: query?.state,
+        risk_tier: query?.riskTier,
+        scope_type: query?.scopeType,
+        requestor: query?.requestor,
+        approver_role: query?.approverRole,
+        severity: query?.severity,
+        ready_for_execution: query?.readyForExecution,
+        kill_switch_engaged: query?.killSwitchEngaged,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -71,6 +71,8 @@ import {
   type AWSAccessKeyQuarantineResult,
   type AWSIaCRemediationPlan,
   type AWSIaCRemediationResult,
+  type AWSRemediationApprovalEntry,
+  type AWSRemediationApprovalResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11372,6 +11374,123 @@ function AWSIaCRemediationContent({
   );
 }
 
+function awsRemediationApprovalStage(entry: AWSRemediationApprovalEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.state === 'blocked' || entry.state === 'denied' || entry.state === 'expired') {
+    return 'not-available';
+  }
+  if (!entry.ready_for_execution) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsRemediationApprovalApproverLabel(entry: AWSRemediationApprovalEntry): string {
+  const roles = entry.required_approvers.map((approver) => approver.role);
+  if (roles.length === 0) {
+    return 'manual review';
+  }
+  return roles.slice(0, 3).join(' · ') + (roles.length > 3 ? ` +${roles.length - 3}` : '');
+}
+
+function awsRemediationApprovalScopeLabel(entry: AWSRemediationApprovalEntry): string {
+  const scope = entry.scope;
+  const accounts = scope.account_ids?.length ?? 0;
+  const regions = scope.regions?.length ?? 0;
+  return `${formatTokenLabel(scope.scope_type)} · ${accounts} account${accounts === 1 ? '' : 's'} / ${regions} region${regions === 1 ? '' : 's'}`;
+}
+
+function awsRemediationApprovalGateLabel(entry: AWSRemediationApprovalEntry): string {
+  if (entry.kill_switch_engaged) {
+    return 'kill switch · engaged';
+  }
+  const blocked = entry.rbac_gates.find((gate) => gate.status === 'blocked');
+  if (blocked) {
+    return `gate · ${formatTokenLabel(blocked.name)}`;
+  }
+  if (entry.ready_for_execution) {
+    return 'ready · gates passed';
+  }
+  return `awaiting · ${formatTokenLabel(entry.state)}`;
+}
+
+function AWSRemediationApprovalContent({
+  queue,
+  loading,
+  error,
+  onRetry
+}: {
+  queue: AWSRemediationApprovalResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = queue?.entries ?? [];
+  const summaryLine = queue
+    ? `${queue.summary.total_entries} total · ${queue.summary.ready_for_execution_count} ready · ${queue.summary.rbac_gate_blocked_count} gate-blocked · ${queue.summary.audit_entry_count} audit entries`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS remediation approval queue">
+      <h3>AWS remediation approval workflow and RBAC gates</h3>
+      <p className="idt-app-kicker">
+        Read-only approval queue projected from remediation cases, with risk-tier, requestor, required approver roles,
+        RBAC gates, tenant-scoped kill switch, feature flags, idempotency keys, scope, audit trail, rollback, and
+        verification metadata. Identrail does not call IAM/STS/Organizations write APIs at this layer. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS remediation approval queue"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Composing approval queue"
+          body="Identrail is projecting remediation cases into RBAC-gated approval queue entries with risk tier, scope, and audit trail."
+        />
+      ) : null}
+      {!error && !loading && queue && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={queue.status === 'blocked' ? 'Permission required' : 'No approval entries'}
+          title={queue.status === 'blocked' ? 'Approval queue needs read-only remediation case evidence' : 'No remediation approvals projected'}
+          body={queue.failure_reasons[0] ?? 'No upstream remediation case evidence produced an approval-queue entry for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && queue && queue.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {queue.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS remediation approval queue"
+          rows={rows}
+          getRowKey={(row) => row.approval_id}
+          columns={[
+            { key: 'approval', header: 'Approval', render: (row) => <strong>{row.title}</strong> },
+            { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+            { key: 'risk', header: 'Risk tier', render: (row) => formatTokenLabel(row.risk_tier) },
+            { key: 'requestor', header: 'Requestor', render: (row) => `${row.requestor.label} · ${formatTokenLabel(row.requestor.role)}` },
+            { key: 'approvers', header: 'Required approvers', render: (row) => awsRemediationApprovalApproverLabel(row) },
+            { key: 'scope', header: 'Scope', render: (row) => awsRemediationApprovalScopeLabel(row) },
+            { key: 'gates', header: 'Gates', render: (row) => awsRemediationApprovalGateLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsRemediationApprovalStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12843,6 +12962,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [iacRemediationLoading, setIacRemediationLoading] = useState(false);
   const [iacRemediationError, setIacRemediationError] = useState('');
   const iacRemediationRequestRef = useRef(0);
+  const [remediationApproval, setRemediationApproval] = useState<AWSRemediationApprovalResult | null>(null);
+  const [remediationApprovalLoading, setRemediationApprovalLoading] = useState(false);
+  const [remediationApprovalError, setRemediationApprovalError] = useState('');
+  const remediationApprovalRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -13464,6 +13587,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadIacRemediation]);
 
+  const loadRemediationApproval = useCallback(async () => {
+    const requestID = ++remediationApprovalRequestRef.current;
+    setRemediationApproval(null);
+    setRemediationApprovalError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setRemediationApprovalLoading(false);
+      return;
+    }
+    setRemediationApprovalLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRemediationApprovalQueue(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== remediationApprovalRequestRef.current) {
+        return;
+      }
+      setRemediationApproval(response.queue);
+    } catch (error) {
+      if (requestID !== remediationApprovalRequestRef.current) {
+        return;
+      }
+      setRemediationApprovalError(formatAPIError(error, 'Unable to load AWS remediation approval queue.'));
+    } finally {
+      if (requestID === remediationApprovalRequestRef.current) {
+        setRemediationApprovalLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadRemediationApproval();
+    return () => {
+      remediationApprovalRequestRef.current += 1;
+    };
+  }, [loadRemediationApproval]);
+
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
     setBlastRadius(null);
@@ -13990,6 +14161,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={iacRemediationLoading}
             error={iacRemediationError}
             onRetry={loadIacRemediation}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSRemediationApprovalContent
+            queue={remediationApproval}
+            loading={remediationApprovalLoading}
+            error={remediationApprovalError}
+            onRetry={loadRemediationApproval}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Adds a read-only AWS remediation approval-queue projection that turns
remediation cases (#1529) into RBAC-gated approval entries with risk tier,
requestor, required approver roles, RBAC gates, tenant-scoped kill switch,
feature flags, idempotency keys, scope, audit trail, rollback, verification,
and evidence refs. Identrail does not call IAM/STS/Organizations write APIs at
this layer; controlled execution belongs to the wave-8 executors (#1537–#1542).

Closes #1536. Part of #1472.

## Why

Wave 8 needs an explicit approval/RBAC framework before any live AWS
mutation can land. This PR ships the safety-gated projection plus the
deterministic idempotency key, dry-run reference, expiry, audit trail, and
feature flags later wave executors will hang their dry-run/apply/verify
behaviour off.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive endpoint, types, and UI)
- [x] Risk level assessed (read-only projection; never calls AWS write APIs; never inlines policy bodies or secrets)

## Validation

\`\`\`bash
make fmt-check
go vet ./...
go test ./internal/api/...
make api-example-contract-check
make web-route-integrity-check
npm run test:ci --prefix web
npm run build --prefix web
\`\`\`

All passed locally on this branch (fresh off origin/dev).

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] \`CHANGELOG.md\` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1536
Refs #1472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only AWS remediation approval workflow with RBAC gates that projects remediation cases into an approval queue, exposed via a new API and an AWS Runtime UI panel; also fixes approval state mapping and updates the OpenAPI contract. Closes #1536.

- **New Features**
  - `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue` with filters (connector, account, region, case, state, risk tier, scope type, requestor, approver role, severity, ready_for_execution, kill_switch_engaged, search); authorized by project `tenancy.read`.
  - Entries include `approval_id`, idempotency key, risk tier, requestor, required approver roles, explicit scope, RBAC gates, feature flags (incl. tenant kill switch), state, expiry, audit trail, relationships, and `ready_for_execution`. Projects from remediation cases with summary counts and status (`ready`/`degraded`/`blocked`); no IAM/STS/Organizations write calls. OpenAPI schemas, docs, and tests added.
  - Web: `getAWSProjectRemediationApprovalQueue` client; AWS Runtime page panel with loading/empty/degraded/blocked/error states.

- **Bug Fixes**
  - Map upstream `pending_approver` to `under_review`.
  - Preserve `in_review` lifecycle as `under_review`.
  - Correct OpenAPI schema references for the approval contract to use shared types.

<sup>Written for commit 519c6c14e2262cbc3aa62195f71f1a0b1feea8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

