### PR TITLE
Implement AWS remediation dry-run executor (#1537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS remediation dry-run executor** (#1537). Adds a read-only,
+  metadata-only dry-run projection that turns approved remediation cases
+  (#1536) into deterministic dry-run records. Each entry carries source
+  approval/case IDs, idempotency key, dry-run reference, intended AWS API
+  calls (IAM `PutRolePolicy`/`UpdateAssumeRolePolicy`/`UpdateAccessKey`,
+  Secrets Manager `RotateSecret`, KMS `PutKeyPolicy`, bedrock-agent
+  `UpdateAgent`, etc. — chosen deterministically by source type),
+  affected resources, satisfied/failed prerequisites (approval state,
+  kill switch, ready-for-execution, every RBAC gate, every feature flag
+  including the `live_aws_mutation` gate that must stay off here),
+  verification checks (CloudTrail, IAM policy simulator, Access Analyzer,
+  IAM last-used), rollback plan, verification plan, tradeoffs, and a
+  composed audit trail with a `dry_run_simulated` row. The deterministic
+  outcome (`would_succeed` / `would_fail` / `requires_review` / `blocked`
+  / `kill_switch_engaged`) drives `ready_for_apply`, which is true only
+  when the upstream approval is `ready_for_execution` and no prerequisite
+  is blocked. Identrail never calls IAM/STS/Secrets Manager/KMS/
+  Organizations write APIs at this layer; controlled live apply is
+  reserved for wave-8 apply executors. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run`
+  with filters for connector, account, region, approval ID, case ID,
+  source type, outcome, risk tier, severity, and free-text search.
+  OpenAPI schemas and authz wiring follow the neighboring wave 7/8
+  endpoints. The AWS Runtime app surface now shows an **AWS remediation
+  dry-run executor** panel with dry-run title, source type, intended
+  calls, satisfied/failed prerequisites, outcome label, and
+  severity/outcome pill, with explicit loading, empty, degraded,
+  blocked, and error states.
 - Add **AWS remediation approval workflow and RBAC gates** (#1536). Adds a
   read-only, metadata-only approval-queue projection that turns remediation
   cases (#1529) into RBAC-gated approval entries. Each entry records a

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS access key disable and quarantine planner: `aws-access-key-quarantine-planner.md`
 - AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
 - AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
+- AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-remediation-dry-run-executor.md
+++ b/docs/aws-remediation-dry-run-executor.md
@@ -1,0 +1,108 @@
+# AWS remediation dry-run executor
+
+Issue #1537 adds a metadata-only dry-run projection for approved AWS
+remediation cases. It turns each approval-queue entry into an explicit dry-run
+record with the intended AWS API calls, affected resources, satisfied/failed
+prerequisites, verification checks, rollback plan, idempotency key, audit
+trail, and a deterministic outcome so operators can see exactly what would
+happen before any controlled live apply runs.
+
+The endpoint is read-only. It never calls IAM, STS, Secrets Manager, KMS, or
+Organizations write APIs, never opens external PRs, and never reads, exposes,
+logs, or persists rendered policies, secret values, customer payloads,
+prompts, completions, browser pages, code-interpreter output, database rows,
+or object contents. Live apply is reserved for the wave 8 executors
+(#1538–#1542) and intentionally out of scope here.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-dry-run`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` for deterministic demos and tests |
+| `account_id`, `region` | account and region filters |
+| `approval_id` | source approval entry filter |
+| `case_id` | source remediation case filter |
+| `source_type` | `least_privilege`, `trust_policy_hardening`, `aws_iac_remediation`, `aws_permission_boundary_scp`, `aws_secret_key_rotation`, `aws_access_key_quarantine`, `secret_permission_equivalence`, `ai_agent_risk`, `blast_radius`, … |
+| `outcome` | `would_succeed`, `would_fail`, `requires_review`, `blocked`, or `kill_switch_engaged` |
+| `risk_tier` | `critical`, `high`, `medium`, or `low` |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `search` | free-text search across dry-run, intended-call, prerequisite, verification, evidence, and audit fields |
+
+Response shape: `{ "dry_run": AWSRemediationDryRunResult }` with
+tenant/workspace/project metadata, summary counts, ranked entries,
+relationships, caveats, failure reasons, remediation hints, evidence links,
+coverage gaps, diagnostics, and generated timestamps.
+
+## Entry shape
+
+Each `AWSRemediationDryRunEntry` includes:
+
+- stable `dry_run_id`, calculation version, source `approval_id`/`case_id`,
+  source artifact ID, issue refs, score, confidence, severity, and risk tier
+- the deterministic `outcome` (`would_succeed` / `would_fail` /
+  `requires_review` / `blocked` / `kill_switch_engaged`) plus a matching
+  next-action hint
+- `intended_api_calls` (service + operation + target + idempotency-key/refs)
+  derived from the source type — for example IAM `PutRolePolicy` for
+  least-privilege diffs, IAM `UpdateAssumeRolePolicy` for trust hardening,
+  Secrets Manager `RotateSecret` for secret rotation, IAM `UpdateAccessKey`
+  for quarantine, and `bedrock-agent:UpdateAgent` for AI-agent risk
+- `affected_resources` with change kind and before/after metadata refs
+- `satisfied_prerequisites` and `failed_prerequisites` covering approval
+  state, kill switch, ready-for-execution, every RBAC gate, and every
+  feature flag (including the `live_aws_mutation` gate that must remain off
+  at this layer)
+- `verification_checks` (CloudTrail, IAM policy simulator, Access Analyzer,
+  IAM last-used) tuned by source type
+- rollback plan, verification plan, tradeoffs from the source approval, and
+  an audit trail that copies the source approval entries plus a
+  `dry_run_simulated` row with the projected outcome
+- deterministic `idempotency_key` and `dry_run_ref` so later wave apply
+  executors can re-use the same keys without re-deriving them
+- `ready_for_apply` is true only when the outcome is `would_succeed`, the
+  upstream approval is `ready_for_execution`, and no kill switch is engaged
+
+## Failure handling
+
+- **Ready**: upstream approval evidence is available and at least one dry-run
+  entry can be composed.
+- **Degraded**: partial or degraded upstream evidence is visible with explicit
+  diagnostics; composed entries stay visible when safe.
+- **Blocked**: permission-denied upstream evidence emits zero entries plus
+  failure reasons, remediation hints, diagnostics, and coverage gaps.
+
+Unsupported, empty, partial, degraded, and permission-denied states stay
+explicit. The endpoint does not convert absence of upstream evidence into
+deterministic dry-run output.
+
+## App surface
+
+The AWS Runtime page renders an **AWS remediation dry-run executor** panel
+with dry-run title, source type, intended calls, satisfied/failed
+prerequisites, outcome, and severity/outcome pill. Loading, empty, degraded,
+blocked, and error states are explicit.
+
+## Validation
+
+1. Confirm blocker #1536 is closed.
+2. Run the upstream approval queue with `fixture_state=success`.
+3. Call the dry-run endpoint with `fixture_state=success` and verify at least
+   one entry includes intended API calls, satisfied/failed prerequisites,
+   verification checks, rollback plan, idempotency key, and `dry_run_ref`.
+4. Filter by `outcome=would_succeed`, `source_type=trust_policy_hardening`,
+   and `risk_tier=high`.
+5. Run `fixture_state=empty`, `degraded`, `partial_failure`, and
+   `permission_denied` and confirm the status, diagnostics, and failure
+   reasons stay explicit.
+
+## What is intentionally out of scope
+
+- Live IAM/STS/Secrets Manager/KMS/Organizations write APIs (wave 8 executors
+  #1538–#1542 own controlled apply).
+- Persisting dry-run mutations server-side; the endpoint projects
+  deterministically from the upstream approval queue and is safe to re-query.
+- Rendering policy bodies, IaC bodies, secret values, or workload payloads.
+- Opening, pushing, or merging operator source-control PRs.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -614,6 +614,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-dry-run
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5773,6 +5778,87 @@ paths:
                     $ref: "#/components/schemas/AWSRemediationApprovalResult"
         "400":
           description: Invalid AWS remediation approval queue request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-dry-run:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS remediation dry-run executor output
+      operationId: getAWSProjectRemediationDryRun
+      description: Projects a deterministic, read-only dry-run for approved AWS remediation cases. Each entry carries source approval/case IDs, idempotency key, intended AWS API calls (service, operation, target, parameter refs), affected resources, satisfied/failed prerequisites, verification checks, rollback plan, and audit metadata. The endpoint never calls IAM/STS/Secrets Manager/KMS/Organizations write APIs and never reads, exposes, logs, or persists rendered policies, secret values, customer payloads, prompts, completions, browser pages, code-interpreter output, database rows, or object contents. Live apply belongs to wave 8 executors.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: approval_id
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: source_type
+          schema: { type: string }
+        - in: query
+          name: outcome
+          schema:
+            type: string
+            enum: [would_succeed, would_fail, requires_review, blocked, kill_switch_engaged]
+        - in: query
+          name: risk_tier
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS remediation dry-run executor contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dry_run:
+                    $ref: "#/components/schemas/AWSRemediationDryRunResult"
+        "400":
+          description: Invalid AWS remediation dry-run request
           content:
             application/json:
               schema:
@@ -15671,6 +15757,230 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSRemediationApprovalRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationDryRunIntendedAPICall:
+      type: object
+      properties:
+        service: { type: string }
+        operation: { type: string }
+        target_resource: { type: string }
+        parameter_refs:
+          type: array
+          items: { type: string }
+        idempotent: { type: boolean }
+        requires_approval: { type: boolean }
+    AWSRemediationDryRunAffectedResource:
+      type: object
+      properties:
+        node_id: { type: string }
+        resource_arn: { type: string }
+        resource_type: { type: string }
+        change_kind: { type: string }
+        before_ref: { type: string }
+        after_ref: { type: string }
+    AWSRemediationDryRunPrerequisite:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSRemediationDryRunVerificationCheck:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        description: { type: string }
+    AWSRemediationDryRunRelationship:
+      type: object
+      properties:
+        dry_run_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSRemediationDryRunEntry:
+      type: object
+      properties:
+        dry_run_id: { type: string }
+        calculation_version: { type: string }
+        approval_id: { type: string }
+        case_id: { type: string }
+        source_artifact_id: { type: string }
+        source_type: { type: string }
+        outcome:
+          type: string
+          enum: [would_succeed, would_fail, requires_review, blocked, kill_switch_engaged]
+        risk_tier:
+          type: string
+          enum: [critical, high, medium, low]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        idempotency_key: { type: string }
+        dry_run_ref: { type: string }
+        diff_intent:
+          $ref: "#/components/schemas/AWSRemediationDiffIntent"
+        intended_api_calls:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunIntendedAPICall"
+        affected_resources:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunAffectedResource"
+        satisfied_prerequisites:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunPrerequisite"
+        failed_prerequisites:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunPrerequisite"
+        verification_checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunVerificationCheck"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        kill_switch_engaged: { type: boolean }
+        ready_for_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCasePathStep"
+        next_action: { type: string }
+        simulated_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationDryRunSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        outcome_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        risk_tier_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        api_call_count: { type: integer }
+        affected_resource_count: { type: integer }
+        failed_prerequisite_count: { type: integer }
+        verification_check_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSRemediationDryRunResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSRemediationDryRunSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationDryRunRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -766,6 +766,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -360,16 +360,32 @@ func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) 
 // node IDs for an approval so each routing branch can pick the target that
 // matches the AWS API being projected. Identity-mutating calls (PutRolePolicy,
 // UpdateAccessKey, …) want the principal node, while resource-mutating calls
-// (RotateSecret, PutKeyPolicy) want the secret or KMS key node.
+// (RotateSecret, PutKeyPolicy) want the secret or KMS key node. `byNodeType`
+// is populated from the impacted-path so KMS-grant diffs whose
+// `ResourceNodeIDs` lead with the protected secret can still pick the actual
+// KMS key node.
 type awsRemediationDryRunTargetSet struct {
-	identity string
-	resource string
+	identity   string
+	resource   string
+	byNodeType map[string]string
 }
 
 func awsRemediationDryRunTargets(approval AWSRemediationApprovalEntry) awsRemediationDryRunTargetSet {
 	identity := firstNonEmptyAWSValue(awsRemediationDryRunFirstNode(approval.Scope.IdentityNodeIDs), awsRemediationDryRunFirstNode(approval.Scope.ResourceNodeIDs), awsRemediationDryRunFirstNode(approval.ImpactedNodes), approval.CaseID)
 	resource := firstNonEmptyAWSValue(awsRemediationDryRunFirstNode(approval.Scope.ResourceNodeIDs), awsRemediationDryRunFirstNode(approval.Scope.IdentityNodeIDs), awsRemediationDryRunFirstNode(approval.ImpactedNodes), approval.CaseID)
-	return awsRemediationDryRunTargetSet{identity: identity, resource: resource}
+	byNodeType := map[string]string{}
+	for _, step := range approval.ImpactedPath {
+		nodeType := strings.ToLower(strings.TrimSpace(step.NodeType))
+		nodeID := strings.TrimSpace(step.NodeID)
+		if nodeType == "" || nodeID == "" {
+			continue
+		}
+		if _, ok := byNodeType[nodeType]; ok {
+			continue
+		}
+		byNodeType[nodeType] = nodeID
+	}
+	return awsRemediationDryRunTargetSet{identity: identity, resource: resource, byNodeType: byNodeType}
 }
 
 func awsRemediationDryRunFirstNode(nodes []string) string {
@@ -379,6 +395,19 @@ func awsRemediationDryRunFirstNode(nodes []string) string {
 		}
 	}
 	return ""
+}
+
+// resourceOfType returns the impacted-path node whose type matches one of the
+// given hints, falling back to the generic resource target when no typed
+// match exists. This lets KMS-grant diffs target the KMS key node when the
+// approval scope's first `ResourceNodeIDs` entry is the protected secret.
+func (t awsRemediationDryRunTargetSet) resourceOfType(types ...string) string {
+	for _, nodeType := range types {
+		if node, ok := t.byNodeType[strings.ToLower(strings.TrimSpace(nodeType))]; ok && node != "" {
+			return node
+		}
+	}
+	return t.resource
 }
 
 // awsRemediationDryRunNoOpCall is the deterministic "no live AWS write is
@@ -428,7 +457,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "kms",
 			Operation:        "PutKeyPolicy",
-			TargetResource:   targets.resource,
+			TargetResource:   targets.resourceOfType("kms_key", "kms"),
 			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -437,7 +466,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   targets.resource,
+			TargetResource:   targets.resourceOfType("permission_bearing_secret", "secret", "secretsmanager_secret"),
 			ParameterRefs:    []string{idempotencyKey, "secret_ref://" + caseID + "/rotate"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -497,7 +526,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   targets.resource,
+			TargetResource:   targets.resourceOfType("permission_bearing_secret", "secret", "secretsmanager_secret"),
 			ParameterRefs:    []string{idempotencyKey},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -515,7 +544,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "kms",
 			Operation:        "PutKeyPolicy",
-			TargetResource:   targets.resource,
+			TargetResource:   targets.resourceOfType("kms_key", "kms"),
 			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -653,6 +653,13 @@ func awsRemediationDryRunFeatureFlagMustBeDisabled(name string) bool {
 }
 
 func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunVerificationCheck {
+	if approval.DiffIntent.NoOp {
+		return []AWSRemediationDryRunVerificationCheck{{
+			Source:      "manual_review",
+			Signal:      "noop",
+			Description: "No live AWS API call is planned for this dry-run; the source case is a manual review or owner-assignment with no deterministic diff to verify.",
+		}}
+	}
 	checks := []AWSRemediationDryRunVerificationCheck{
 		{Source: "cloudtrail", Signal: "expected_api_call_observed", Description: "After live execution, confirm the intended API call appears in CloudTrail for the target account and region."},
 		{Source: "iam:policy_simulate", Signal: "no_regression", Description: "Re-run the IAM policy simulator after live execution to confirm no regression on kept actions."},

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -466,7 +466,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   targets.resourceOfType("permission_bearing_secret", "secret", "secretsmanager_secret"),
+			TargetResource:   targets.resourceOfType("provider_key_reference", "permission_bearing_secret", "secret", "secretsmanager_secret"),
 			ParameterRefs:    []string{idempotencyKey, "secret_ref://" + caseID + "/rotate"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -526,7 +526,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   targets.resourceOfType("permission_bearing_secret", "secret", "secretsmanager_secret"),
+			TargetResource:   targets.resourceOfType("provider_key_reference", "permission_bearing_secret", "secret", "secretsmanager_secret"),
 			ParameterRefs:    []string{idempotencyKey},
 			Idempotent:       true,
 			RequiresApproval: true,

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -342,88 +342,168 @@ func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry,
 }
 
 func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunIntendedAPICall {
-	switch strings.ToLower(strings.TrimSpace(approval.SourceType)) {
-	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "iam",
-			Operation:        "PutRolePolicy",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "policy_document_ref://" + approval.CaseID + "/after"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "trust_policy_hardening":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "iam",
-			Operation:        "UpdateAssumeRolePolicy",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "trust_policy_ref://" + approval.CaseID + "/after"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "aws_permission_boundary_scp":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "iam",
-			Operation:        "PutRolePermissionsBoundary",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "boundary_ref://" + approval.CaseID + "/after"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "aws_secret_key_rotation":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "secretsmanager",
-			Operation:        "RotateSecret",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "aws_access_key_quarantine":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "iam",
-			Operation:        "UpdateAccessKey",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "status://inactive"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "secret_permission_equivalence":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "kms",
-			Operation:        "PutKeyPolicy",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "key_policy_ref://" + approval.CaseID + "/after"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "ai_agent_risk":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "bedrock-agent",
-			Operation:        "UpdateAgent",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey, "scope_ref://" + approval.CaseID + "/after"},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
-	case "blast_radius":
-		return []AWSRemediationDryRunIntendedAPICall{{
-			Service:          "iam",
-			Operation:        "DetachRolePolicy",
-			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
-			ParameterRefs:    []string{approval.IdempotencyKey},
-			Idempotent:       true,
-			RequiresApproval: true,
-		}}
+	target := awsRemediationDryRunPrimaryTarget(approval)
+	caseID := approval.CaseID
+	if call, ok := awsRemediationDryRunCallForDiffKind(approval.DiffIntent, target, approval.IdempotencyKey, caseID); ok {
+		return []AWSRemediationDryRunIntendedAPICall{call}
+	}
+	if call, ok := awsRemediationDryRunCallForSourceType(approval.SourceType, target, approval.IdempotencyKey, caseID); ok {
+		return []AWSRemediationDryRunIntendedAPICall{call}
 	}
 	return []AWSRemediationDryRunIntendedAPICall{{
 		Service:          "manual_review",
 		Operation:        "noop",
-		TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+		TargetResource:   target,
 		ParameterRefs:    []string{approval.IdempotencyKey},
 		Idempotent:       true,
 		RequiresApproval: true,
 	}}
+}
+
+// awsRemediationDryRunCallForDiffKind routes to an AWS API call based on the
+// case's projected diff intent. Source-type-only routing can mis-pick the API
+// for sources whose diff intent varies — for example a
+// `secret_permission_equivalence` case with `Kind=secret_rotation` is a
+// Secrets Manager rotation, not a KMS key-policy change.
+func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
+	if diff.NoOp {
+		return AWSRemediationDryRunIntendedAPICall{}, false
+	}
+	switch strings.ToLower(strings.TrimSpace(diff.Kind)) {
+	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "PutRolePolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "iam_trust_diff", "iac_trust_policy_pr":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "UpdateAssumeRolePolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "trust_policy_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "kms_grant_diff":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "kms",
+			Operation:        "PutKeyPolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "secret_rotation":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "secretsmanager",
+			Operation:        "RotateSecret",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "secret_ref://" + caseID + "/rotate"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "access_key_quarantine":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "UpdateAccessKey",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "status://inactive"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "ai_agent_scope_change":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "bedrock-agent",
+			Operation:        "UpdateAgent",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "scope_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	}
+	return AWSRemediationDryRunIntendedAPICall{}, false
+}
+
+func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
+	switch strings.ToLower(strings.TrimSpace(sourceType)) {
+	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "PutRolePolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "trust_policy_hardening":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "UpdateAssumeRolePolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "trust_policy_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "aws_permission_boundary_scp":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "boundary_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "aws_secret_key_rotation":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "secretsmanager",
+			Operation:        "RotateSecret",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "aws_access_key_quarantine":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "UpdateAccessKey",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "status://inactive"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "secret_permission_equivalence":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "kms",
+			Operation:        "PutKeyPolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "ai_agent_risk":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "bedrock-agent",
+			Operation:        "UpdateAgent",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey, "scope_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	case "blast_radius":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        "DetachRolePolicy",
+			TargetResource:   target,
+			ParameterRefs:    []string{idempotencyKey},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
+	}
+	return AWSRemediationDryRunIntendedAPICall{}, false
 }
 
 func awsRemediationDryRunPrimaryTarget(approval AWSRemediationApprovalEntry) string {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -438,7 +438,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets 
 	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr":
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
-			Operation:        "PutRolePolicy",
+			Operation:        awsRemediationDryRunPutPolicyOperation(targets.identity),
 			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
 			Idempotent:       true,
@@ -498,7 +498,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff":
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
-			Operation:        "PutRolePolicy",
+			Operation:        awsRemediationDryRunPutPolicyOperation(targets.identity),
 			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
 			Idempotent:       true,
@@ -516,7 +516,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 	case "aws_permission_boundary_scp":
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
-			Operation:        "PutRolePermissionsBoundary",
+			Operation:        awsRemediationDryRunPutBoundaryOperation(targets.identity),
 			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "boundary_ref://" + caseID + "/after"},
 			Idempotent:       true,
@@ -561,7 +561,7 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 	case "blast_radius":
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
-			Operation:        "DetachRolePolicy",
+			Operation:        awsRemediationDryRunDetachPolicyOperation(targets.identity),
 			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey},
 			Idempotent:       true,
@@ -569,6 +569,54 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 		}, true
 	}
 	return AWSRemediationDryRunIntendedAPICall{}, false
+}
+
+// awsRemediationDryRunIAMPrincipalKind classifies the target IAM principal as
+// role/user/group from its node ID or ARN so the dry-run can route IAM
+// inline-policy and permissions-boundary operations correctly. Returns
+// "role" when the principal type cannot be determined, which matches the
+// most common AWS machine-identity remediation target.
+func awsRemediationDryRunIAMPrincipalKind(target string) string {
+	normalized := strings.ToLower(strings.TrimSpace(target))
+	switch {
+	case normalized == "":
+		return "role"
+	case strings.Contains(normalized, ":user/"), strings.Contains(normalized, ":identity:user/"):
+		return "user"
+	case strings.Contains(normalized, ":group/"), strings.Contains(normalized, ":identity:group/"):
+		return "group"
+	default:
+		return "role"
+	}
+}
+
+func awsRemediationDryRunPutPolicyOperation(target string) string {
+	switch awsRemediationDryRunIAMPrincipalKind(target) {
+	case "user":
+		return "PutUserPolicy"
+	case "group":
+		return "PutGroupPolicy"
+	default:
+		return "PutRolePolicy"
+	}
+}
+
+func awsRemediationDryRunPutBoundaryOperation(target string) string {
+	if awsRemediationDryRunIAMPrincipalKind(target) == "user" {
+		return "PutUserPermissionsBoundary"
+	}
+	return "PutRolePermissionsBoundary"
+}
+
+func awsRemediationDryRunDetachPolicyOperation(target string) string {
+	switch awsRemediationDryRunIAMPrincipalKind(target) {
+	case "user":
+		return "DetachUserPolicy"
+	case "group":
+		return "DetachGroupPolicy"
+	default:
+		return "DetachRolePolicy"
+	}
 }
 
 func awsRemediationDryRunAffectedResources(approval AWSRemediationApprovalEntry, intended []AWSRemediationDryRunIntendedAPICall) []AWSRemediationDryRunAffectedResource {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -1,0 +1,792 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsRemediationDryRunCurrentIssue = 1537
+	awsRemediationDryRunVersion      = "aws-remediation-dry-run-executor-v1"
+
+	awsRemediationDryRunOutcomeWouldSucceed   = "would_succeed"
+	awsRemediationDryRunOutcomeWouldFail      = "would_fail"
+	awsRemediationDryRunOutcomeRequiresReview = "requires_review"
+	awsRemediationDryRunOutcomeBlocked        = "blocked"
+	awsRemediationDryRunOutcomeKillSwitched   = "kill_switch_engaged"
+)
+
+// AWSRemediationDryRunRequest scopes the deterministic dry-run executor to
+// one AWS connector plus optional operator drill-down filters.
+type AWSRemediationDryRunRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	ApprovalID   string `json:"approval_id,omitempty"`
+	CaseID       string `json:"case_id,omitempty"`
+	SourceType   string `json:"source_type,omitempty"`
+	Outcome      string `json:"outcome,omitempty"`
+	RiskTier     string `json:"risk_tier,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+// AWSRemediationDryRunIntendedAPICall describes one AWS API call the executor
+// would make when run live. The executor never invokes the API; this is a
+// metadata-only projection.
+type AWSRemediationDryRunIntendedAPICall struct {
+	Service          string   `json:"service"`
+	Operation        string   `json:"operation"`
+	TargetResource   string   `json:"target_resource,omitempty"`
+	ParameterRefs    []string `json:"parameter_refs,omitempty"`
+	Idempotent       bool     `json:"idempotent"`
+	RequiresApproval bool     `json:"requires_approval"`
+}
+
+// AWSRemediationDryRunAffectedResource records one resource that would change
+// when the executor runs live. Carries metadata refs only.
+type AWSRemediationDryRunAffectedResource struct {
+	NodeID       string `json:"node_id"`
+	ResourceARN  string `json:"resource_arn,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
+	ChangeKind   string `json:"change_kind"`
+	BeforeRef    string `json:"before_ref,omitempty"`
+	AfterRef     string `json:"after_ref,omitempty"`
+}
+
+// AWSRemediationDryRunPrerequisite is one safety prerequisite the executor
+// checks deterministically before declaring `would_succeed`.
+type AWSRemediationDryRunPrerequisite struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSRemediationDryRunVerificationCheck is one verification step the executor
+// would run after live execution to confirm the change took effect.
+type AWSRemediationDryRunVerificationCheck struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Description string `json:"description"`
+}
+
+// AWSRemediationDryRunRelationship surfaces dry-run → graph node edges.
+type AWSRemediationDryRunRelationship struct {
+	DryRunID    string `json:"dry_run_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSRemediationDryRunEntry is the persisted-record-shaped contract emitted
+// by the dry-run executor. It is metadata-only: it carries no rendered policy
+// bodies, no secret material, and no workload payloads.
+type AWSRemediationDryRunEntry struct {
+	DryRunID           string                                  `json:"dry_run_id"`
+	CalculationVersion string                                  `json:"calculation_version"`
+	ApprovalID         string                                  `json:"approval_id"`
+	CaseID             string                                  `json:"case_id"`
+	SourceArtifactID   string                                  `json:"source_artifact_id"`
+	SourceType         string                                  `json:"source_type"`
+	Outcome            string                                  `json:"outcome"`
+	RiskTier           string                                  `json:"risk_tier"`
+	Severity           string                                  `json:"severity"`
+	Score              int                                     `json:"score"`
+	Confidence         float64                                 `json:"confidence"`
+	Title              string                                  `json:"title"`
+	Summary            string                                  `json:"summary"`
+	AccountID          string                                  `json:"account_id"`
+	Region             string                                  `json:"region"`
+	IdempotencyKey     string                                  `json:"idempotency_key"`
+	DryRunRef          string                                  `json:"dry_run_ref"`
+	DiffIntent         AWSRemediationDiffIntent                `json:"diff_intent"`
+	IntendedAPICalls   []AWSRemediationDryRunIntendedAPICall   `json:"intended_api_calls"`
+	AffectedResources  []AWSRemediationDryRunAffectedResource  `json:"affected_resources"`
+	SatisfiedPrereqs   []AWSRemediationDryRunPrerequisite      `json:"satisfied_prerequisites"`
+	FailedPrereqs      []AWSRemediationDryRunPrerequisite      `json:"failed_prerequisites"`
+	VerificationChecks []AWSRemediationDryRunVerificationCheck `json:"verification_checks"`
+	RollbackPlan       AWSRemediationRollbackPlan              `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan          `json:"verification_plan"`
+	Tradeoffs          []AWSRemediationTradeoff                `json:"tradeoffs"`
+	AuditTrail         []AWSRemediationApprovalAuditEntry      `json:"audit_trail"`
+	KillSwitchEngaged  bool                                    `json:"kill_switch_engaged"`
+	ReadyForApply      bool                                    `json:"ready_for_apply"`
+	ReadOnlyProjection bool                                    `json:"read_only_projection"`
+	SourceSignals      []string                                `json:"source_signals"`
+	Evidence           []AWSRemediationApprovalEvidence        `json:"evidence"`
+	EvidenceBoundary   string                                  `json:"evidence_boundary"`
+	ImpactedNodes      []string                                `json:"impacted_nodes"`
+	ImpactedPath       []AWSRemediationApprovalPathStep        `json:"impacted_path"`
+	NextAction         string                                  `json:"next_action"`
+	SimulatedAt        time.Time                               `json:"simulated_at"`
+	CreatedAt          time.Time                               `json:"created_at"`
+	UpdatedAt          time.Time                               `json:"updated_at"`
+}
+
+// AWSRemediationDryRunSummary aggregates the unfiltered and filtered set.
+type AWSRemediationDryRunSummary struct {
+	TotalEntries           int            `json:"total_entries"`
+	FilteredEntries        int            `json:"filtered_entries"`
+	OutcomeCounts          map[string]int `json:"outcome_counts"`
+	SourceTypeCounts       map[string]int `json:"source_type_counts"`
+	RiskTierCounts         map[string]int `json:"risk_tier_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	APICallCount           int            `json:"api_call_count"`
+	AffectedResourceCount  int            `json:"affected_resource_count"`
+	FailedPrereqCount      int            `json:"failed_prerequisite_count"`
+	VerificationCount      int            `json:"verification_check_count"`
+	ReadyForApplyCount     int            `json:"ready_for_apply_count"`
+	KillSwitchEngagedCount int            `json:"kill_switch_engaged_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+// AWSRemediationDryRunResult is the deterministic envelope returned by the
+// dry-run executor.
+type AWSRemediationDryRunResult struct {
+	TenantID           string                              `json:"tenant_id"`
+	WorkspaceID        string                              `json:"workspace_id"`
+	ProjectID          string                              `json:"project_id"`
+	ConnectorID        string                              `json:"connector_id,omitempty"`
+	AccountID          string                              `json:"account_id,omitempty"`
+	Region             string                              `json:"region,omitempty"`
+	ParentIssueNumber  int                                 `json:"parent_issue_number"`
+	ParentIssueRef     string                              `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                 `json:"current_issue_number"`
+	CurrentIssueRef    string                              `json:"current_issue_ref"`
+	Version            string                              `json:"version"`
+	Status             string                              `json:"status"`
+	FixtureState       string                              `json:"fixture_state,omitempty"`
+	Confidence         float64                             `json:"confidence"`
+	CalculationVersion string                              `json:"calculation_version"`
+	AppliedFilters     map[string]string                   `json:"applied_filters"`
+	Summary            AWSRemediationDryRunSummary         `json:"summary"`
+	Entries            []AWSRemediationDryRunEntry         `json:"entries"`
+	Relationships      []AWSRemediationDryRunRelationship  `json:"relationships"`
+	Caveats            []string                            `json:"caveats"`
+	FailureReasons     []string                            `json:"failure_reasons"`
+	RemediationHints   []string                            `json:"remediation_hints"`
+	EvidenceLinks      []string                            `json:"evidence_links"`
+	CoverageGaps       []AWSRemediationApprovalCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSRemediationApprovalDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                           `json:"generated_at"`
+	UpdatedAt          time.Time                           `json:"updated_at"`
+}
+
+// GetAWSRemediationDryRun projects a deterministic, read-only dry-run for
+// approved remediation cases. It enforces the same approval/RBAC/feature-flag/
+// kill-switch gates as the approval queue and emits a metadata-only simulation
+// of the live AWS execution: intended API calls, affected resources, satisfied
+// and failed prerequisites, and verification checks. It never calls IAM/STS/
+// Organizations write APIs, never reads, exposes, logs, or persists rendered
+// policies, secret values, customer payloads, prompts, completions, browser
+// pages, code-interpreter output, database rows, or object contents.
+func (s *Service) GetAWSRemediationDryRun(ctx context.Context, workspaceID string, projectID string, request AWSRemediationDryRunRequest) (AWSRemediationDryRunResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRemediationDryRunResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRemediationDryRunResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSRemediationDryRunFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRemediationDryRunResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	queue, err := s.GetAWSRemediationApprovalQueue(ctx, workspaceID, projectID, AWSRemediationApprovalRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSRemediationDryRunResult{}, fmt.Errorf("remediation dry-run approval queue: %w", err)
+	}
+
+	entries := awsRemediationDryRunEntries(queue.Entries, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].DryRunID < entries[j].DryRunID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSRemediationDryRunEntries(entries, request)
+	relationships := awsRemediationDryRunRelationships(filtered)
+	diagnostics := awsRemediationDryRunDiagnostics(queue.Diagnostics)
+	coverageGaps := awsRemediationDryRunCoverageGaps(queue.CoverageGaps)
+	status, confidence := summarizeAWSRemediationDryRunStatus(queue.Status, filtered, diagnostics)
+
+	return AWSRemediationDryRunResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationDryRunCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationDryRunCurrentIssue),
+		Version:            awsRemediationDryRunVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationDryRunVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSRemediationDryRunEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsRemediationDryRunCaveats(),
+		FailureReasons:     dedupeStrings(queue.FailureReasons),
+		RemediationHints:   awsRemediationDryRunRemediationHints(queue.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			awsIssueURL(awsRemediationApprovalCurrentIssue),
+			"/docs/aws-remediation-dry-run-executor",
+			"/docs/aws-remediation-approval-rbac",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSRemediationDryRunFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsRemediationDryRunEntries(approvals []AWSRemediationApprovalEntry, now time.Time) []AWSRemediationDryRunEntry {
+	entries := make([]AWSRemediationDryRunEntry, 0, len(approvals))
+	for _, approval := range approvals {
+		entries = append(entries, awsRemediationDryRunEntryFromApproval(approval, now))
+	}
+	return entries
+}
+
+func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry, now time.Time) AWSRemediationDryRunEntry {
+	intended := awsRemediationDryRunIntendedAPICalls(approval)
+	resources := awsRemediationDryRunAffectedResources(approval, intended)
+	satisfied, failed := awsRemediationDryRunPrerequisites(approval)
+	checks := awsRemediationDryRunVerificationChecks(approval)
+	outcome := awsRemediationDryRunOutcome(approval, failed)
+	dryRunID := "aws-remediation-dry-run:" + stableAWSBlastRadiusToken("dry-run", approval.ApprovalID, outcome)
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:           dryRunID,
+		CalculationVersion: awsRemediationDryRunVersion,
+		ApprovalID:         approval.ApprovalID,
+		CaseID:             approval.CaseID,
+		SourceArtifactID:   approval.SourceArtifactID,
+		SourceType:         approval.SourceType,
+		Outcome:            outcome,
+		RiskTier:           approval.RiskTier,
+		Severity:           approval.Severity,
+		Score:              approval.Score,
+		Confidence:         approval.Confidence,
+		Title:              fmt.Sprintf("Dry-run: %s", approval.Title),
+		Summary:            fmt.Sprintf("Read-only simulation of remediation case %s. Identrail never calls AWS write APIs; later wave executors apply the change after approval.", approval.CaseID),
+		AccountID:          approval.AccountID,
+		Region:             approval.Region,
+		IdempotencyKey:     approval.IdempotencyKey,
+		DryRunRef:          firstNonEmptyAWSValue(approval.DryRunRef, fmt.Sprintf("dry-run://%s/%s/simulated", approval.SourceType, approval.CaseID)),
+		DiffIntent:         approval.DiffIntent,
+		IntendedAPICalls:   intended,
+		AffectedResources:  resources,
+		SatisfiedPrereqs:   satisfied,
+		FailedPrereqs:      failed,
+		VerificationChecks: checks,
+		RollbackPlan:       approval.RollbackPlan,
+		VerificationPlan:   approval.VerificationPlan,
+		Tradeoffs:          approval.Tradeoffs,
+		AuditTrail:         awsRemediationDryRunAuditTrail(approval, outcome, now),
+		KillSwitchEngaged:  approval.KillSwitchEngaged,
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings(append([]string{"remediation_approval"}, approval.SourceSignals...)),
+		Evidence:           approval.Evidence,
+		EvidenceBoundary:   awsRemediationDryRunEvidenceBoundary(),
+		ImpactedNodes:      approval.ImpactedNodes,
+		ImpactedPath:       approval.ImpactedPath,
+		NextAction:         awsRemediationDryRunNextAction(outcome),
+		SimulatedAt:        now,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	entry.ReadyForApply = outcome == awsRemediationDryRunOutcomeWouldSucceed && approval.ReadyForExecution && !approval.KillSwitchEngaged
+	return entry
+}
+
+func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunIntendedAPICall {
+	switch strings.ToLower(strings.TrimSpace(approval.SourceType)) {
+	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePolicy",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "policy_document_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "trust_policy_hardening":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "UpdateAssumeRolePolicy",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "trust_policy_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "aws_permission_boundary_scp":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "boundary_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "aws_secret_key_rotation":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "secretsmanager",
+			Operation:        "RotateSecret",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "aws_access_key_quarantine":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "UpdateAccessKey",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "status://inactive"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "secret_permission_equivalence":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "kms",
+			Operation:        "PutKeyPolicy",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "key_policy_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "ai_agent_risk":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "bedrock-agent",
+			Operation:        "UpdateAgent",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey, "scope_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	case "blast_radius":
+		return []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "DetachRolePolicy",
+			TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+			ParameterRefs:    []string{approval.IdempotencyKey},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}}
+	}
+	return []AWSRemediationDryRunIntendedAPICall{{
+		Service:          "manual_review",
+		Operation:        "noop",
+		TargetResource:   awsRemediationDryRunPrimaryTarget(approval),
+		ParameterRefs:    []string{approval.IdempotencyKey},
+		Idempotent:       true,
+		RequiresApproval: true,
+	}}
+}
+
+func awsRemediationDryRunPrimaryTarget(approval AWSRemediationApprovalEntry) string {
+	if len(approval.Scope.IdentityNodeIDs) > 0 {
+		return approval.Scope.IdentityNodeIDs[0]
+	}
+	if len(approval.Scope.ResourceNodeIDs) > 0 {
+		return approval.Scope.ResourceNodeIDs[0]
+	}
+	if len(approval.ImpactedNodes) > 0 {
+		return approval.ImpactedNodes[0]
+	}
+	return approval.CaseID
+}
+
+func awsRemediationDryRunAffectedResources(approval AWSRemediationApprovalEntry, intended []AWSRemediationDryRunIntendedAPICall) []AWSRemediationDryRunAffectedResource {
+	resources := []AWSRemediationDryRunAffectedResource{}
+	seen := map[string]struct{}{}
+	add := func(nodeID, kind string) {
+		nodeID = strings.TrimSpace(nodeID)
+		if nodeID == "" {
+			return
+		}
+		if _, ok := seen[nodeID]; ok {
+			return
+		}
+		seen[nodeID] = struct{}{}
+		resources = append(resources, AWSRemediationDryRunAffectedResource{
+			NodeID:     nodeID,
+			ChangeKind: kind,
+			BeforeRef:  firstNonEmptyAWSValue(approval.DiffIntent.BeforeRef, approval.CaseID),
+			AfterRef:   firstNonEmptyAWSValue(approval.DiffIntent.AfterRef, fmt.Sprintf("after://%s", approval.CaseID)),
+		})
+	}
+	for _, call := range intended {
+		add(call.TargetResource, "api_target")
+	}
+	for _, node := range approval.Scope.IdentityNodeIDs {
+		add(node, "identity")
+	}
+	for _, node := range approval.Scope.ResourceNodeIDs {
+		add(node, "resource")
+	}
+	for _, node := range approval.ImpactedNodes {
+		add(node, "impacted")
+	}
+	return resources
+}
+
+func awsRemediationDryRunPrerequisites(approval AWSRemediationApprovalEntry) ([]AWSRemediationDryRunPrerequisite, []AWSRemediationDryRunPrerequisite) {
+	satisfied := []AWSRemediationDryRunPrerequisite{}
+	failed := []AWSRemediationDryRunPrerequisite{}
+	add := func(name, status, rationale string) {
+		entry := AWSRemediationDryRunPrerequisite{Name: name, Status: status, Rationale: rationale}
+		if status == "passed" {
+			satisfied = append(satisfied, entry)
+			return
+		}
+		failed = append(failed, entry)
+	}
+	add("approval_state_approved", awsRemediationDryRunGateStatus(approval.State == awsRemediationApprovalStateApproved), "Approval queue entry must be in state=approved before live execution.")
+	add("kill_switch_off", awsRemediationDryRunGateStatus(!approval.KillSwitchEngaged), "Tenant-scoped remediation kill switch must be off.")
+	add("ready_for_execution", awsRemediationDryRunGateStatus(approval.ReadyForExecution), "Approval entry must declare ready_for_execution=true.")
+	for _, gate := range approval.RBACGates {
+		add("rbac:"+gate.Name, awsRemediationDryRunGateStatus(gate.Status == "passed"), gate.Rationale)
+	}
+	for _, flag := range approval.FeatureFlags {
+		if flag.Name == "live_aws_mutation" {
+			add("feature_flag:"+flag.Name, awsRemediationDryRunGateStatus(!flag.Enabled), flag.Rationale)
+			continue
+		}
+		add("feature_flag:"+flag.Name, awsRemediationDryRunGateStatus(flag.Enabled), flag.Rationale)
+	}
+	return satisfied, failed
+}
+
+func awsRemediationDryRunGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunVerificationCheck {
+	checks := []AWSRemediationDryRunVerificationCheck{
+		{Source: "cloudtrail", Signal: "expected_api_call_observed", Description: "After live execution, confirm the intended API call appears in CloudTrail for the target account and region."},
+		{Source: "iam:policy_simulate", Signal: "no_regression", Description: "Re-run the IAM policy simulator after live execution to confirm no regression on kept actions."},
+	}
+	if strings.EqualFold(approval.SourceType, "trust_policy_hardening") || strings.EqualFold(approval.SourceType, "blast_radius") {
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer after live execution to confirm no new external-trust findings."})
+	}
+	if strings.EqualFold(approval.SourceType, "aws_access_key_quarantine") {
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "iam:last_used", Signal: "no_runtime_after_disable", Description: "Re-check IAM last-used/runtime evidence after disable to confirm no further key activity."})
+	}
+	return checks
+}
+
+func awsRemediationDryRunOutcome(approval AWSRemediationApprovalEntry, failed []AWSRemediationDryRunPrerequisite) string {
+	if approval.KillSwitchEngaged {
+		return awsRemediationDryRunOutcomeKillSwitched
+	}
+	if approval.State == awsRemediationApprovalStateBlocked {
+		return awsRemediationDryRunOutcomeBlocked
+	}
+	if approval.State != awsRemediationApprovalStateApproved {
+		return awsRemediationDryRunOutcomeRequiresReview
+	}
+	if len(failed) > 0 {
+		return awsRemediationDryRunOutcomeWouldFail
+	}
+	if !approval.ReadyForExecution {
+		return awsRemediationDryRunOutcomeRequiresReview
+	}
+	return awsRemediationDryRunOutcomeWouldSucceed
+}
+
+func awsRemediationDryRunNextAction(outcome string) string {
+	switch outcome {
+	case awsRemediationDryRunOutcomeWouldSucceed:
+		return "Dry-run satisfied; later wave executors may schedule a controlled live apply when their feature flag opens."
+	case awsRemediationDryRunOutcomeWouldFail:
+		return "Resolve the failed prerequisites listed on this entry before retrying the dry-run."
+	case awsRemediationDryRunOutcomeRequiresReview:
+		return "Approval queue entry is not yet approved or ready for execution; advance the approval workflow first."
+	case awsRemediationDryRunOutcomeBlocked:
+		return "Approval queue entry is blocked by an RBAC gate; satisfy the failing gate before retrying."
+	case awsRemediationDryRunOutcomeKillSwitched:
+		return "Tenant remediation kill switch is engaged; disable it before retrying."
+	}
+	return "Inspect the dry-run entry for the projected next action."
+}
+
+func awsRemediationDryRunAuditTrail(approval AWSRemediationApprovalEntry, outcome string, now time.Time) []AWSRemediationApprovalAuditEntry {
+	trail := []AWSRemediationApprovalAuditEntry{}
+	trail = append(trail, approval.AuditTrail...)
+	trail = append(trail, AWSRemediationApprovalAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("dry-run-projected", approval.ApprovalID, outcome),
+		Actor:      "identrail-dry-run-executor",
+		EventType:  "dry_run_simulated",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Dry-run projected outcome=%s for approval %s.", outcome, approval.ApprovalID),
+	})
+	return trail
+}
+
+func awsRemediationDryRunRelationships(entries []AWSRemediationDryRunEntry) []AWSRemediationDryRunRelationship {
+	relationships := []AWSRemediationDryRunRelationship{}
+	for _, entry := range entries {
+		evidenceRef := firstAWSRemediationCaseEvidenceRef(entry.Evidence)
+		for _, resource := range entry.AffectedResources {
+			if strings.TrimSpace(resource.NodeID) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSRemediationDryRunRelationship{
+				DryRunID:    entry.DryRunID,
+				Type:        "dry_run_targets_node",
+				FromNodeID:  entry.DryRunID,
+				ToNodeID:    resource.NodeID,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSRemediationDryRunEntries(all, filtered []AWSRemediationDryRunEntry, relationships []AWSRemediationDryRunRelationship) AWSRemediationDryRunSummary {
+	summary := AWSRemediationDryRunSummary{
+		TotalEntries:     len(all),
+		FilteredEntries:  len(filtered),
+		OutcomeCounts:    map[string]int{},
+		SourceTypeCounts: map[string]int{},
+		RiskTierCounts:   map[string]int{},
+		SeverityCounts:   map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.OutcomeCounts[entry.Outcome]++
+		if strings.TrimSpace(entry.SourceType) != "" {
+			summary.SourceTypeCounts[entry.SourceType]++
+		}
+		if strings.TrimSpace(entry.RiskTier) != "" {
+			summary.RiskTierCounts[entry.RiskTier]++
+		}
+		if strings.TrimSpace(entry.Severity) != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		summary.APICallCount += len(entry.IntendedAPICalls)
+		summary.AffectedResourceCount += len(entry.AffectedResources)
+		summary.FailedPrereqCount += len(entry.FailedPrereqs)
+		summary.VerificationCount += len(entry.VerificationChecks)
+		if entry.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSRemediationDryRunEntries(entries []AWSRemediationDryRunEntry, request AWSRemediationDryRunRequest) ([]AWSRemediationDryRunEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":  strings.TrimSpace(request.AccountID),
+		"region":      strings.TrimSpace(request.Region),
+		"approval_id": strings.TrimSpace(request.ApprovalID),
+		"case_id":     strings.TrimSpace(request.CaseID),
+		"source_type": normalizeAWSRuntimeEventFilterToken(request.SourceType),
+		"outcome":     normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"risk_tier":   normalizeAWSRuntimeEventFilterToken(request.RiskTier),
+		"severity":    normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":      strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSRemediationDryRunEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+			continue
+		}
+		if filters["approval_id"] != "" && !strings.EqualFold(filters["approval_id"], entry.ApprovalID) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["source_type"] != "" && filters["source_type"] != normalizeAWSRuntimeEventFilterToken(entry.SourceType) {
+			continue
+		}
+		if filters["outcome"] != "" && filters["outcome"] != normalizeAWSRuntimeEventFilterToken(entry.Outcome) {
+			continue
+		}
+		if filters["risk_tier"] != "" && filters["risk_tier"] != normalizeAWSRuntimeEventFilterToken(entry.RiskTier) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsRemediationDryRunSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsRemediationDryRunSearchMatch(entry AWSRemediationDryRunEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.DryRunID, entry.ApprovalID, entry.CaseID, entry.SourceArtifactID, entry.SourceType,
+		entry.Outcome, entry.RiskTier, entry.Severity, entry.Title, entry.Summary,
+		entry.IdempotencyKey, entry.DryRunRef, entry.NextAction,
+		entry.DiffIntent.Kind, entry.DiffIntent.DiffSummary,
+		entry.RollbackPlan.Strategy, entry.VerificationPlan.Strategy,
+	}
+	values = append(values, entry.SourceSignals...)
+	for _, call := range entry.IntendedAPICalls {
+		values = append(values, call.Service, call.Operation, call.TargetResource)
+		values = append(values, call.ParameterRefs...)
+	}
+	for _, resource := range entry.AffectedResources {
+		values = append(values, resource.NodeID, resource.ResourceARN, resource.ResourceType, resource.ChangeKind)
+	}
+	for _, prereq := range entry.SatisfiedPrereqs {
+		values = append(values, prereq.Name, prereq.Status, prereq.Rationale)
+	}
+	for _, prereq := range entry.FailedPrereqs {
+		values = append(values, prereq.Name, prereq.Status, prereq.Rationale)
+	}
+	for _, check := range entry.VerificationChecks {
+		values = append(values, check.Source, check.Signal, check.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSRemediationDryRunStatus(sourceStatus string, filtered []AWSRemediationDryRunEntry, diagnostics []AWSRemediationApprovalDiagnostic) (string, float64) {
+	if sourceStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sourceStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsRemediationDryRunCaveats() []string {
+	return []string{
+		"Dry-run entries are read-only projections; Identrail never calls IAM, STS, Secrets Manager, KMS, or Organizations write APIs at this layer.",
+		"Failed prerequisites, RBAC gates, feature flags, and the tenant kill switch are enforced server-side before any entry can declare ready_for_apply.",
+		"ready_for_apply is only a planning signal — controlled live execution belongs to wave 8 executors and their own feature flags.",
+	}
+}
+
+func awsRemediationDryRunRemediationHints(source []string) []string {
+	hints := []string{
+		"Resolve any failed prerequisites on the dry-run entry before scheduling a live apply.",
+		"Re-run the dry-run after lifecycle, approval, or feature-flag changes; the executor is safe to re-query.",
+		"Use the idempotency key from the dry-run entry when wiring later wave apply/verify executors so retries do not double-apply.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsRemediationDryRunDiagnostics(source []AWSRemediationApprovalDiagnostic) []AWSRemediationApprovalDiagnostic {
+	out := make([]AWSRemediationApprovalDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSRemediationApprovalDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsRemediationDryRunCoverageGaps(source []AWSRemediationApprovalCoverageGap) []AWSRemediationApprovalCoverageGap {
+	gaps := []AWSRemediationApprovalCoverageGap{{
+		Capability:  "aws_remediation_live_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1537 emits dry-run projections only; live IAM/STS/Secrets/KMS/Organizations write APIs are reserved for the wave 8 apply executors (#1538 and later).",
+		Remediation: "Wire the controlled live-apply executors in the matching wave 8 issues once their safety gates are in place.",
+	}}
+	for _, gap := range source {
+		gaps = append(gaps, AWSRemediationApprovalCoverageGap(gap))
+	}
+	return gaps
+}
+
+func awsRemediationDryRunEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -491,7 +491,7 @@ func awsRemediationDryRunPrerequisites(approval AWSRemediationApprovalEntry) ([]
 		add("rbac:"+gate.Name, awsRemediationDryRunGateStatus(gate.Status == "passed"), gate.Rationale)
 	}
 	for _, flag := range approval.FeatureFlags {
-		if flag.Name == "live_aws_mutation" {
+		if awsRemediationDryRunFeatureFlagMustBeDisabled(flag.Name) {
 			add("feature_flag:"+flag.Name, awsRemediationDryRunGateStatus(!flag.Enabled), flag.Rationale)
 			continue
 		}
@@ -505,6 +505,19 @@ func awsRemediationDryRunGateStatus(ok bool) string {
 		return "passed"
 	}
 	return "blocked"
+}
+
+// awsRemediationDryRunFeatureFlagMustBeDisabled lists the safety flags whose
+// disabled state is the healthy default at the dry-run layer. The tenant
+// remediation kill switch and the live-AWS-mutation gate are both expected to
+// stay off until later wave executors open them; treating them as "passed
+// when enabled" would incorrectly mark healthy approvals as blocked.
+func awsRemediationDryRunFeatureFlagMustBeDisabled(name string) bool {
+	switch name {
+	case "live_aws_mutation", "remediation_kill_switch":
+		return true
+	}
+	return false
 }
 
 func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunVerificationCheck {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -343,6 +343,9 @@ func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry,
 
 func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunIntendedAPICall {
 	target := awsRemediationDryRunPrimaryTarget(approval)
+	if approval.DiffIntent.NoOp {
+		return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(target, approval.IdempotencyKey)}
+	}
 	caseID := approval.CaseID
 	if call, ok := awsRemediationDryRunCallForDiffKind(approval.DiffIntent, target, approval.IdempotencyKey, caseID); ok {
 		return []AWSRemediationDryRunIntendedAPICall{call}
@@ -350,14 +353,22 @@ func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) 
 	if call, ok := awsRemediationDryRunCallForSourceType(approval.SourceType, target, approval.IdempotencyKey, caseID); ok {
 		return []AWSRemediationDryRunIntendedAPICall{call}
 	}
-	return []AWSRemediationDryRunIntendedAPICall{{
+	return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(target, approval.IdempotencyKey)}
+}
+
+// awsRemediationDryRunNoOpCall is the deterministic "no live AWS write is
+// planned" projection. NoOp diff intents (manual_review, owner_assignment)
+// must surface this directly so the dry-run never advertises a write the
+// case engine declined to project.
+func awsRemediationDryRunNoOpCall(target, idempotencyKey string) AWSRemediationDryRunIntendedAPICall {
+	return AWSRemediationDryRunIntendedAPICall{
 		Service:          "manual_review",
 		Operation:        "noop",
 		TargetResource:   target,
-		ParameterRefs:    []string{approval.IdempotencyKey},
+		ParameterRefs:    []string{idempotencyKey},
 		Idempotent:       true,
 		RequiresApproval: true,
-	}}
+	}
 }
 
 // awsRemediationDryRunCallForDiffKind routes to an AWS API call based on the

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -727,7 +727,17 @@ func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry
 	}
 	checks := []AWSRemediationDryRunVerificationCheck{
 		{Source: "cloudtrail", Signal: "expected_api_call_observed", Description: "After live execution, confirm the intended API call appears in CloudTrail for the target account and region."},
-		{Source: "iam:policy_simulate", Signal: "no_regression", Description: "Re-run the IAM policy simulator after live execution to confirm no regression on kept actions."},
+	}
+	if awsRemediationDryRunWantsIAMSimulator(approval) {
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "iam:policy_simulate", Signal: "no_regression", Description: "Re-run the IAM policy simulator after live execution to confirm no regression on kept actions."})
+	}
+	switch strings.ToLower(strings.TrimSpace(approval.DiffIntent.Kind)) {
+	case "secret_rotation":
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "secretsmanager", Signal: "rotation_success", Description: "Confirm the projected secret rotation completed and downstream readers picked up the new credential reference."})
+	case "kms_grant_diff":
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "kms", Signal: "grant_policy_applied", Description: "Confirm the projected KMS key-policy change applied and the broad decrypt/admin reachability is gone."})
+	case "ai_agent_scope_change":
+		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "bedrock-agent", Signal: "agent_scope_applied", Description: "Confirm the agent scope change applied and the narrowed tool/capability surface is reflected in runtime evidence."})
 	}
 	if strings.EqualFold(approval.SourceType, "trust_policy_hardening") || strings.EqualFold(approval.SourceType, "blast_radius") {
 		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer after live execution to confirm no new external-trust findings."})
@@ -736,6 +746,31 @@ func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry
 		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "iam:last_used", Signal: "no_runtime_after_disable", Description: "Re-check IAM last-used/runtime evidence after disable to confirm no further key activity."})
 	}
 	return checks
+}
+
+// awsRemediationDryRunWantsIAMSimulator returns true when the projected change
+// affects an IAM identity/trust policy or boundary, so the IAM policy simulator
+// has something to simulate. Non-IAM mutations (secret rotation, KMS grant
+// policy, agent scope change) should not advertise an IAM simulator check.
+func awsRemediationDryRunWantsIAMSimulator(approval AWSRemediationApprovalEntry) bool {
+	switch strings.ToLower(strings.TrimSpace(approval.DiffIntent.Kind)) {
+	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr",
+		"iam_trust_diff", "iac_trust_policy_pr",
+		"permission_boundary_diff", "access_key_quarantine":
+		return true
+	case "":
+		// Fall through to the source-type gate when the case engine omitted
+		// the diff kind.
+	default:
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(approval.SourceType)) {
+	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff",
+		"trust_policy_hardening", "aws_permission_boundary_scp",
+		"aws_access_key_quarantine", "blast_radius":
+		return true
+	}
+	return false
 }
 
 func awsRemediationDryRunOutcome(approval AWSRemediationApprovalEntry, failed []AWSRemediationDryRunPrerequisite) string {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -342,18 +342,43 @@ func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry,
 }
 
 func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunIntendedAPICall {
-	target := awsRemediationDryRunPrimaryTarget(approval)
+	targets := awsRemediationDryRunTargets(approval)
 	if approval.DiffIntent.NoOp {
-		return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(target, approval.IdempotencyKey)}
+		return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(targets.identity, approval.IdempotencyKey)}
 	}
 	caseID := approval.CaseID
-	if call, ok := awsRemediationDryRunCallForDiffKind(approval.DiffIntent, target, approval.IdempotencyKey, caseID); ok {
+	if call, ok := awsRemediationDryRunCallForDiffKind(approval.DiffIntent, targets, approval.IdempotencyKey, caseID); ok {
 		return []AWSRemediationDryRunIntendedAPICall{call}
 	}
-	if call, ok := awsRemediationDryRunCallForSourceType(approval.SourceType, target, approval.IdempotencyKey, caseID); ok {
+	if call, ok := awsRemediationDryRunCallForSourceType(approval.SourceType, targets, approval.IdempotencyKey, caseID); ok {
 		return []AWSRemediationDryRunIntendedAPICall{call}
 	}
-	return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(target, approval.IdempotencyKey)}
+	return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(targets.identity, approval.IdempotencyKey)}
+}
+
+// awsRemediationDryRunTargetSet pairs the identity-first and resource-first
+// node IDs for an approval so each routing branch can pick the target that
+// matches the AWS API being projected. Identity-mutating calls (PutRolePolicy,
+// UpdateAccessKey, …) want the principal node, while resource-mutating calls
+// (RotateSecret, PutKeyPolicy) want the secret or KMS key node.
+type awsRemediationDryRunTargetSet struct {
+	identity string
+	resource string
+}
+
+func awsRemediationDryRunTargets(approval AWSRemediationApprovalEntry) awsRemediationDryRunTargetSet {
+	identity := firstNonEmptyAWSValue(awsRemediationDryRunFirstNode(approval.Scope.IdentityNodeIDs), awsRemediationDryRunFirstNode(approval.Scope.ResourceNodeIDs), awsRemediationDryRunFirstNode(approval.ImpactedNodes), approval.CaseID)
+	resource := firstNonEmptyAWSValue(awsRemediationDryRunFirstNode(approval.Scope.ResourceNodeIDs), awsRemediationDryRunFirstNode(approval.Scope.IdentityNodeIDs), awsRemediationDryRunFirstNode(approval.ImpactedNodes), approval.CaseID)
+	return awsRemediationDryRunTargetSet{identity: identity, resource: resource}
+}
+
+func awsRemediationDryRunFirstNode(nodes []string) string {
+	for _, node := range nodes {
+		if strings.TrimSpace(node) != "" {
+			return node
+		}
+	}
+	return ""
 }
 
 // awsRemediationDryRunNoOpCall is the deterministic "no live AWS write is
@@ -376,7 +401,7 @@ func awsRemediationDryRunNoOpCall(target, idempotencyKey string) AWSRemediationD
 // for sources whose diff intent varies — for example a
 // `secret_permission_equivalence` case with `Kind=secret_rotation` is a
 // Secrets Manager rotation, not a KMS key-policy change.
-func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
+func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets awsRemediationDryRunTargetSet, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
 	if diff.NoOp {
 		return AWSRemediationDryRunIntendedAPICall{}, false
 	}
@@ -385,7 +410,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "PutRolePolicy",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -394,7 +419,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "UpdateAssumeRolePolicy",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "trust_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -403,7 +428,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "kms",
 			Operation:        "PutKeyPolicy",
-			TargetResource:   target,
+			TargetResource:   targets.resource,
 			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -412,7 +437,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   target,
+			TargetResource:   targets.resource,
 			ParameterRefs:    []string{idempotencyKey, "secret_ref://" + caseID + "/rotate"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -421,7 +446,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "UpdateAccessKey",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "status://inactive"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -430,7 +455,7 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "bedrock-agent",
 			Operation:        "UpdateAgent",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "scope_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -439,13 +464,13 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, target, 
 	return AWSRemediationDryRunIntendedAPICall{}, false
 }
 
-func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
+func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemediationDryRunTargetSet, idempotencyKey, caseID string) (AWSRemediationDryRunIntendedAPICall, bool) {
 	switch strings.ToLower(strings.TrimSpace(sourceType)) {
 	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff":
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "PutRolePolicy",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "policy_document_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -454,7 +479,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "UpdateAssumeRolePolicy",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "trust_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -463,7 +488,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "PutRolePermissionsBoundary",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "boundary_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -472,7 +497,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "secretsmanager",
 			Operation:        "RotateSecret",
-			TargetResource:   target,
+			TargetResource:   targets.resource,
 			ParameterRefs:    []string{idempotencyKey},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -481,7 +506,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "UpdateAccessKey",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "status://inactive"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -490,7 +515,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "kms",
 			Operation:        "PutKeyPolicy",
-			TargetResource:   target,
+			TargetResource:   targets.resource,
 			ParameterRefs:    []string{idempotencyKey, "key_policy_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -499,7 +524,7 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "bedrock-agent",
 			Operation:        "UpdateAgent",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey, "scope_ref://" + caseID + "/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -508,26 +533,13 @@ func awsRemediationDryRunCallForSourceType(sourceType, target, idempotencyKey, c
 		return AWSRemediationDryRunIntendedAPICall{
 			Service:          "iam",
 			Operation:        "DetachRolePolicy",
-			TargetResource:   target,
+			TargetResource:   targets.identity,
 			ParameterRefs:    []string{idempotencyKey},
 			Idempotent:       true,
 			RequiresApproval: true,
 		}, true
 	}
 	return AWSRemediationDryRunIntendedAPICall{}, false
-}
-
-func awsRemediationDryRunPrimaryTarget(approval AWSRemediationApprovalEntry) string {
-	if len(approval.Scope.IdentityNodeIDs) > 0 {
-		return approval.Scope.IdentityNodeIDs[0]
-	}
-	if len(approval.Scope.ResourceNodeIDs) > 0 {
-		return approval.Scope.ResourceNodeIDs[0]
-	}
-	if len(approval.ImpactedNodes) > 0 {
-		return approval.ImpactedNodes[0]
-	}
-	return approval.CaseID
 }
 
 func awsRemediationDryRunAffectedResources(approval AWSRemediationApprovalEntry, intended []AWSRemediationDryRunIntendedAPICall) []AWSRemediationDryRunAffectedResource {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -750,13 +750,14 @@ func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry
 
 // awsRemediationDryRunWantsIAMSimulator returns true when the projected change
 // affects an IAM identity/trust policy or boundary, so the IAM policy simulator
-// has something to simulate. Non-IAM mutations (secret rotation, KMS grant
-// policy, agent scope change) should not advertise an IAM simulator check.
+// has something to simulate. Non-policy mutations (secret rotation, KMS grant
+// policy, agent scope change, access key quarantine) should not advertise an
+// IAM simulator check.
 func awsRemediationDryRunWantsIAMSimulator(approval AWSRemediationApprovalEntry) bool {
 	switch strings.ToLower(strings.TrimSpace(approval.DiffIntent.Kind)) {
 	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr",
 		"iam_trust_diff", "iac_trust_policy_pr",
-		"permission_boundary_diff", "access_key_quarantine":
+		"permission_boundary_diff":
 		return true
 	case "":
 		// Fall through to the source-type gate when the case engine omitted
@@ -766,8 +767,7 @@ func awsRemediationDryRunWantsIAMSimulator(approval AWSRemediationApprovalEntry)
 	}
 	switch strings.ToLower(strings.TrimSpace(approval.SourceType)) {
 	case "least_privilege", "aws_iac_remediation", "aws_iam_policy_diff",
-		"trust_policy_hardening", "aws_permission_boundary_scp",
-		"aws_access_key_quarantine", "blast_radius":
+		"trust_policy_hardening", "aws_permission_boundary_scp", "blast_radius":
 		return true
 	}
 	return false

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -638,6 +638,23 @@ func awsRemediationDryRunAffectedResources(approval AWSRemediationApprovalEntry,
 			AfterRef:   firstNonEmptyAWSValue(approval.DiffIntent.AfterRef, fmt.Sprintf("after://%s", approval.CaseID)),
 		})
 	}
+	// No-op diff intents (manual_review, owner_assignment) project the
+	// `manual_review:noop` call and have no AWS write to apply. Mark the
+	// scope/impacted nodes as `context` instead of `would_change` so
+	// operators and later automation never treat manual-review entries as
+	// executable mutations.
+	if approval.DiffIntent.NoOp {
+		for _, node := range approval.Scope.IdentityNodeIDs {
+			add(node, "context")
+		}
+		for _, node := range approval.Scope.ResourceNodeIDs {
+			add(node, "context")
+		}
+		for _, node := range approval.ImpactedNodes {
+			add(node, "context")
+		}
+		return resources
+	}
 	for _, call := range intended {
 		add(call.TargetResource, "api_target")
 	}

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -499,6 +499,35 @@ func TestAWSRemediationDryRunIAMOperationFollowsPrincipalKind(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunSecretRotationPicksProviderKeyNode(t *testing.T) {
+	// AI-agent external_credential_exposure cases emit a secret_rotation diff
+	// where `ResourceNodeIDs` only carries an empty sensitive resource — the
+	// credential reference itself lives in the impacted path as a
+	// `provider_key_reference` node. The dry-run must pick that node so the
+	// RotateSecret target is the credential to rotate, not the agent identity.
+	approval := AWSRemediationApprovalEntry{
+		SourceType:     "ai_agent_risk",
+		CaseID:         "case-provider-key",
+		IdempotencyKey: "idk",
+		Scope: AWSRemediationApprovalScope{
+			IdentityNodeIDs: []string{"aws:identity:role/orders-agent"},
+			ResourceNodeIDs: []string{},
+		},
+		ImpactedPath: []AWSRemediationApprovalPathStep{
+			{NodeID: "aws:identity:role/orders-agent", NodeType: "identity", Label: "orders-agent"},
+			{NodeID: "aws:provider-key:openai://orders-agent", NodeType: "provider_key_reference", Label: "openai key"},
+		},
+		DiffIntent: AWSRemediationDiffIntent{Kind: "secret_rotation"},
+	}
+	calls := awsRemediationDryRunIntendedAPICalls(approval)
+	if len(calls) == 0 || calls[0].Service != "secretsmanager" || calls[0].Operation != "RotateSecret" {
+		t.Fatalf("provider_key_reference cases must still route to secretsmanager:RotateSecret, got %+v", calls)
+	}
+	if calls[0].TargetResource != "aws:provider-key:openai://orders-agent" {
+		t.Fatalf("secret_rotation must target the provider_key_reference node, got %q", calls[0].TargetResource)
+	}
+}
+
 func TestAWSRemediationDryRunAffectedResourcesAreContextOnlyForNoOpDiffs(t *testing.T) {
 	approval := AWSRemediationApprovalEntry{
 		SourceType:     "least_privilege",

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -425,6 +425,80 @@ func TestAWSRemediationDryRunVerificationSuppressesLiveChecksForNoOpDiffs(t *tes
 	}
 }
 
+func TestAWSRemediationDryRunIAMOperationFollowsPrincipalKind(t *testing.T) {
+	cases := []struct {
+		name       string
+		approval   AWSRemediationApprovalEntry
+		wantOp     string
+		wantTarget string
+	}{
+		{
+			name: "role principal keeps PutRolePolicy",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "least_privilege",
+				CaseID:         "case-role-lp",
+				IdempotencyKey: "idk",
+				Scope:          AWSRemediationApprovalScope{IdentityNodeIDs: []string{"aws:identity:role/orders-ci"}},
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantOp:     "PutRolePolicy",
+			wantTarget: "aws:identity:role/orders-ci",
+		},
+		{
+			name: "user principal switches to PutUserPolicy",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "least_privilege",
+				CaseID:         "case-user-lp",
+				IdempotencyKey: "idk",
+				Scope:          AWSRemediationApprovalScope{IdentityNodeIDs: []string{"arn:aws:iam::123456789012:user/shakia-ci"}},
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantOp:     "PutUserPolicy",
+			wantTarget: "arn:aws:iam::123456789012:user/shakia-ci",
+		},
+		{
+			name: "group principal switches to PutGroupPolicy",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "least_privilege",
+				CaseID:         "case-group-lp",
+				IdempotencyKey: "idk",
+				Scope:          AWSRemediationApprovalScope{IdentityNodeIDs: []string{"arn:aws:iam::123456789012:group/platform-engineers"}},
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantOp:     "PutGroupPolicy",
+			wantTarget: "arn:aws:iam::123456789012:group/platform-engineers",
+		},
+		{
+			name: "user permission boundary switches to PutUserPermissionsBoundary",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "aws_permission_boundary_scp",
+				CaseID:         "case-user-boundary",
+				IdempotencyKey: "idk",
+				Scope:          AWSRemediationApprovalScope{IdentityNodeIDs: []string{"aws:identity:user/shakia-ci"}},
+			},
+			wantOp:     "PutUserPermissionsBoundary",
+			wantTarget: "aws:identity:user/shakia-ci",
+		},
+		{
+			name: "blast_radius user principal switches to DetachUserPolicy",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "blast_radius",
+				CaseID:         "case-blast-user",
+				IdempotencyKey: "idk",
+				Scope:          AWSRemediationApprovalScope{IdentityNodeIDs: []string{"arn:aws:iam::123456789012:user/shakia-ci"}},
+			},
+			wantOp:     "DetachUserPolicy",
+			wantTarget: "arn:aws:iam::123456789012:user/shakia-ci",
+		},
+	}
+	for _, tc := range cases {
+		calls := awsRemediationDryRunIntendedAPICalls(tc.approval)
+		if len(calls) == 0 || calls[0].Operation != tc.wantOp || calls[0].TargetResource != tc.wantTarget {
+			t.Fatalf("%s: want op=%s target=%s, got %+v", tc.name, tc.wantOp, tc.wantTarget, calls)
+		}
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -499,6 +499,47 @@ func TestAWSRemediationDryRunIAMOperationFollowsPrincipalKind(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunAffectedResourcesAreContextOnlyForNoOpDiffs(t *testing.T) {
+	approval := AWSRemediationApprovalEntry{
+		SourceType:     "least_privilege",
+		CaseID:         "case-noop-affected",
+		IdempotencyKey: "idk",
+		Scope: AWSRemediationApprovalScope{
+			IdentityNodeIDs: []string{"aws:identity:role/orders-ci"},
+			ResourceNodeIDs: []string{"aws:s3:bucket/orders"},
+		},
+		ImpactedNodes: []string{"aws:identity:role/orders-ci", "aws:s3:bucket/orders", "aws:s3:bucket/exports"},
+		DiffIntent:    AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true},
+	}
+	intended := awsRemediationDryRunIntendedAPICalls(approval)
+	resources := awsRemediationDryRunAffectedResources(approval, intended)
+	if len(resources) == 0 {
+		t.Fatalf("expected scope/impacted nodes to surface as context entries, got none")
+	}
+	for _, resource := range resources {
+		if resource.ChangeKind != "context" {
+			t.Fatalf("no-op diff intent must mark every affected resource as context, got %+v", resource)
+		}
+		if resource.NodeID == intended[0].TargetResource && resource.NodeID == "manual_review" {
+			t.Fatalf("no-op diff intent must not record the noop call target as an api_target, got %+v", resource)
+		}
+	}
+	// And the executable path should still record api_target / identity / resource / impacted kinds.
+	live := approval
+	live.DiffIntent = AWSRemediationDiffIntent{Kind: "iam_policy_diff"}
+	liveCalls := awsRemediationDryRunIntendedAPICalls(live)
+	liveResources := awsRemediationDryRunAffectedResources(live, liveCalls)
+	sawAPITarget := false
+	for _, resource := range liveResources {
+		if resource.ChangeKind == "api_target" {
+			sawAPITarget = true
+		}
+	}
+	if !sawAPITarget {
+		t.Fatalf("executable dry-run must still record an api_target affected resource, got %+v", liveResources)
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newRemediationDryRunService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSRemediationDryRunBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run", now)
+
+	result, err := svc.GetAWSRemediationDryRun(defaultScopeContext(), ws, "project-remediation-dry-run", AWSRemediationDryRunRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation dry-run: %v", err)
+	}
+	if result.CurrentIssueRef != "#1537" || result.Version != awsRemediationDryRunVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Entries) == 0 || result.Summary.TotalEntries != len(result.Entries) {
+		t.Fatalf("expected dry-run entries and matching summary: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Entries); i++ {
+		if result.Entries[i-1].Score < result.Entries[i].Score {
+			t.Fatalf("entries are not ranked by descending score: %+v", result.Entries)
+		}
+	}
+	for _, entry := range result.Entries {
+		if entry.DryRunID == "" || entry.CalculationVersion != awsRemediationDryRunVersion || entry.ApprovalID == "" || entry.CaseID == "" {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.IdempotencyKey == "" || entry.DryRunRef == "" {
+			t.Fatalf("entry missing idempotency key or dry_run_ref: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if len(entry.IntendedAPICalls) == 0 {
+			t.Fatalf("entry missing intended API calls: %+v", entry)
+		}
+		for _, call := range entry.IntendedAPICalls {
+			if call.Service == "" || call.Operation == "" {
+				t.Fatalf("intended API call missing service/operation: %+v", call)
+			}
+		}
+		if len(entry.SatisfiedPrereqs)+len(entry.FailedPrereqs) == 0 {
+			t.Fatalf("entry missing prerequisites: %+v", entry)
+		}
+		if len(entry.VerificationChecks) == 0 {
+			t.Fatalf("entry missing verification checks: %+v", entry)
+		}
+		if entry.EvidenceBoundary != awsRemediationDryRunEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		if entry.Outcome == "" {
+			t.Fatalf("entry missing outcome: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("dry-run serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestFilterAWSRemediationDryRunEntriesAppliesFilters(t *testing.T) {
+	entries := []AWSRemediationDryRunEntry{
+		{
+			DryRunID:   "ready",
+			ApprovalID: "approval-a",
+			CaseID:     "case-a",
+			AccountID:  "123456789012",
+			Region:     "us-east-1",
+			SourceType: "least_privilege",
+			Outcome:    awsRemediationDryRunOutcomeWouldSucceed,
+			RiskTier:   awsRemediationApprovalRiskLow,
+			Severity:   "low",
+		},
+		{
+			DryRunID:   "kill",
+			ApprovalID: "approval-b",
+			CaseID:     "case-b",
+			AccountID:  "123456789012",
+			Region:     "us-east-1",
+			SourceType: "trust_policy_hardening",
+			Outcome:    awsRemediationDryRunOutcomeKillSwitched,
+			RiskTier:   awsRemediationApprovalRiskCritical,
+			Severity:   "critical",
+		},
+	}
+
+	succeed, succeedApplied := filterAWSRemediationDryRunEntries(entries, AWSRemediationDryRunRequest{Outcome: awsRemediationDryRunOutcomeWouldSucceed})
+	if succeedApplied["outcome"] != "would-succeed" || len(succeed) != 1 || succeed[0].DryRunID != "ready" {
+		t.Fatalf("expected outcome=would_succeed filter: applied=%+v entries=%+v", succeedApplied, succeed)
+	}
+
+	trust, trustApplied := filterAWSRemediationDryRunEntries(entries, AWSRemediationDryRunRequest{SourceType: "trust_policy_hardening"})
+	if trustApplied["source_type"] != "trust-policy-hardening" || len(trust) != 1 || trust[0].DryRunID != "kill" {
+		t.Fatalf("expected source_type filter: applied=%+v entries=%+v", trustApplied, trust)
+	}
+}
+
+func TestAWSRemediationDryRunOutcomeHonorsApprovalGates(t *testing.T) {
+	now := time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC)
+
+	approved := AWSRemediationApprovalEntry{
+		ApprovalID:        "approval-approved",
+		CaseID:            "case-approved",
+		State:             awsRemediationApprovalStateApproved,
+		ReadyForExecution: true,
+		FeatureFlags:      []AWSRemediationApprovalFeatureFlag{{Name: "live_aws_mutation", Enabled: false, Rationale: "off"}},
+		RBACGates:         []AWSRemediationApprovalRBACGate{{Name: "approver_quorum", Status: "passed"}},
+		Scope:             AWSRemediationApprovalScope{IdentityNodeIDs: []string{"aws:identity:role/orders-ci"}},
+	}
+	if got := awsRemediationDryRunEntryFromApproval(approved, now).Outcome; got != awsRemediationDryRunOutcomeWouldSucceed {
+		t.Fatalf("approved+ready entry must project would_succeed, got %q", got)
+	}
+
+	blocked := approved
+	blocked.State = awsRemediationApprovalStateBlocked
+	if got := awsRemediationDryRunEntryFromApproval(blocked, now).Outcome; got != awsRemediationDryRunOutcomeBlocked {
+		t.Fatalf("blocked approval must project blocked outcome, got %q", got)
+	}
+
+	killSwitch := approved
+	killSwitch.KillSwitchEngaged = true
+	if got := awsRemediationDryRunEntryFromApproval(killSwitch, now).Outcome; got != awsRemediationDryRunOutcomeKillSwitched {
+		t.Fatalf("kill switch must override outcome, got %q", got)
+	}
+
+	pending := approved
+	pending.State = awsRemediationApprovalStateRequested
+	if got := awsRemediationDryRunEntryFromApproval(pending, now).Outcome; got != awsRemediationDryRunOutcomeRequiresReview {
+		t.Fatalf("pending approval must project requires_review, got %q", got)
+	}
+
+	failedGate := approved
+	failedGate.RBACGates = []AWSRemediationApprovalRBACGate{{Name: "approver_quorum", Status: "blocked"}}
+	entry := awsRemediationDryRunEntryFromApproval(failedGate, now)
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldFail {
+		t.Fatalf("failed prerequisite must project would_fail, got %q", entry.Outcome)
+	}
+	if len(entry.FailedPrereqs) == 0 {
+		t.Fatalf("failed prereqs must be populated when gate is blocked: %+v", entry.FailedPrereqs)
+	}
+	if entry.ReadyForApply {
+		t.Fatalf("would_fail entry must not be ready_for_apply: %+v", entry)
+	}
+}
+
+func TestAWSRemediationDryRunIntendedAPICallVariesBySourceType(t *testing.T) {
+	cases := []struct {
+		sourceType string
+		service    string
+		operation  string
+	}{
+		{"least_privilege", "iam", "PutRolePolicy"},
+		{"trust_policy_hardening", "iam", "UpdateAssumeRolePolicy"},
+		{"aws_permission_boundary_scp", "iam", "PutRolePermissionsBoundary"},
+		{"aws_secret_key_rotation", "secretsmanager", "RotateSecret"},
+		{"aws_access_key_quarantine", "iam", "UpdateAccessKey"},
+		{"secret_permission_equivalence", "kms", "PutKeyPolicy"},
+		{"ai_agent_risk", "bedrock-agent", "UpdateAgent"},
+		{"blast_radius", "iam", "DetachRolePolicy"},
+	}
+	for _, tc := range cases {
+		calls := awsRemediationDryRunIntendedAPICalls(AWSRemediationApprovalEntry{SourceType: tc.sourceType, CaseID: "case", IdempotencyKey: "idk"})
+		if len(calls) == 0 || calls[0].Service != tc.service || calls[0].Operation != tc.operation {
+			t.Fatalf("source_type=%q: expected %s.%s, got %+v", tc.sourceType, tc.service, tc.operation, calls)
+		}
+	}
+}
+
+func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)
+
+	denied, err := svc.GetAWSRemediationDryRun(defaultScopeContext(), ws, "project-remediation-dry-run-states", AWSRemediationDryRunRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Entries) != 0 {
+		t.Fatalf("permission denied must be explicit and suppress entries: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSRemediationDryRun(defaultScopeContext(), ws, "project-remediation-dry-run-states", AWSRemediationDryRunRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not produce a blocked status: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSRemediationDryRun(defaultScopeContext(), ws, "project-remediation-dry-run-states", AWSRemediationDryRunRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSRemediationDryRun(t *testing.T) {
+	now := time.Date(2026, 6, 27, 13, 0, 0, 0, time.UTC)
+	svc, _ := newRemediationDryRunService(t, "project-remediation-dry-run-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-remediation-dry-run-route/aws/remediation-dry-run?connector_id=aws-prod&fixture_state=success&outcome=would_succeed", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		DryRun AWSRemediationDryRunResult `json:"dry_run"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.DryRun.CurrentIssueRef != "#1537" || body.DryRun.AppliedFilters["outcome"] != "would-succeed" {
+		t.Fatalf("unexpected route payload: %+v", body.DryRun)
+	}
+}

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -499,6 +499,79 @@ func TestAWSRemediationDryRunIAMOperationFollowsPrincipalKind(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *testing.T) {
+	cases := []struct {
+		name          string
+		approval      AWSRemediationApprovalEntry
+		wantSimulator bool
+		wantSignal    string
+	}{
+		{
+			name: "iam_policy_diff includes simulator",
+			approval: AWSRemediationApprovalEntry{
+				SourceType: "least_privilege",
+				DiffIntent: AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantSimulator: true,
+		},
+		{
+			name: "iam_trust_diff includes simulator",
+			approval: AWSRemediationApprovalEntry{
+				SourceType: "trust_policy_hardening",
+				DiffIntent: AWSRemediationDiffIntent{Kind: "iam_trust_diff"},
+			},
+			wantSimulator: true,
+		},
+		{
+			name:          "secret_rotation skips simulator and adds rotation_success",
+			approval:      AWSRemediationApprovalEntry{SourceType: "secret_permission_equivalence", DiffIntent: AWSRemediationDiffIntent{Kind: "secret_rotation"}},
+			wantSimulator: false,
+			wantSignal:    "rotation_success",
+		},
+		{
+			name:          "kms_grant_diff skips simulator and adds grant_policy_applied",
+			approval:      AWSRemediationApprovalEntry{SourceType: "secret_permission_equivalence", DiffIntent: AWSRemediationDiffIntent{Kind: "kms_grant_diff"}},
+			wantSimulator: false,
+			wantSignal:    "grant_policy_applied",
+		},
+		{
+			name:          "ai_agent_scope_change skips simulator and adds agent_scope_applied",
+			approval:      AWSRemediationApprovalEntry{SourceType: "ai_agent_risk", DiffIntent: AWSRemediationDiffIntent{Kind: "ai_agent_scope_change"}},
+			wantSimulator: false,
+			wantSignal:    "agent_scope_applied",
+		},
+		{
+			name:          "empty diff kind falls back to source-type gate (least_privilege)",
+			approval:      AWSRemediationApprovalEntry{SourceType: "least_privilege"},
+			wantSimulator: true,
+		},
+		{
+			name:          "empty diff kind for unrelated source skips simulator",
+			approval:      AWSRemediationApprovalEntry{SourceType: "aws_secret_key_rotation"},
+			wantSimulator: false,
+		},
+	}
+	for _, tc := range cases {
+		checks := awsRemediationDryRunVerificationChecks(tc.approval)
+		sawSimulator := false
+		sawSignal := tc.wantSignal == ""
+		for _, check := range checks {
+			if check.Source == "iam:policy_simulate" {
+				sawSimulator = true
+			}
+			if tc.wantSignal != "" && check.Signal == tc.wantSignal {
+				sawSignal = true
+			}
+		}
+		if sawSimulator != tc.wantSimulator {
+			t.Fatalf("%s: simulator presence=%v want=%v checks=%+v", tc.name, sawSimulator, tc.wantSimulator, checks)
+		}
+		if !sawSignal {
+			t.Fatalf("%s: missing expected signal %q in checks=%+v", tc.name, tc.wantSignal, checks)
+		}
+	}
+}
+
 func TestAWSRemediationDryRunSecretRotationPicksProviderKeyNode(t *testing.T) {
 	// AI-agent external_credential_exposure cases emit a secret_rotation diff
 	// where `ResourceNodeIDs` only carries an empty sensitive resource — the

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -276,18 +276,19 @@ func TestAWSRemediationDryRunIntendedAPICallPrefersDiffIntentKind(t *testing.T) 
 		}
 	}
 
-	// No-op diff intents (manual_review, owner_assignment) must not consume the
-	// diff-kind branch; the source-type fallback (or manual_review default)
-	// keeps the routing honest.
-	noop := AWSRemediationApprovalEntry{
-		SourceType:     "least_privilege",
-		CaseID:         "case-noop",
-		IdempotencyKey: "idk",
-		DiffIntent:     AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true},
+	// No-op diff intents (manual_review, owner_assignment) must surface as the
+	// `manual_review:noop` call regardless of source type so the dry-run never
+	// advertises a live AWS write the case engine declined to project.
+	noopCases := []AWSRemediationApprovalEntry{
+		{SourceType: "least_privilege", CaseID: "case-lp-noop", IdempotencyKey: "idk", DiffIntent: AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true}},
+		{SourceType: "ai_agent_risk", CaseID: "case-agent-noop", IdempotencyKey: "idk", DiffIntent: AWSRemediationDiffIntent{Kind: "owner_assignment", NoOp: true}},
+		{SourceType: "blast_radius", CaseID: "case-blast-noop", IdempotencyKey: "idk", DiffIntent: AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true}},
 	}
-	calls := awsRemediationDryRunIntendedAPICalls(noop)
-	if len(calls) == 0 || calls[0].Service != "iam" || calls[0].Operation != "PutRolePolicy" {
-		t.Fatalf("no-op diff intent must fall through to source-type routing for least_privilege, got %+v", calls)
+	for _, noop := range noopCases {
+		calls := awsRemediationDryRunIntendedAPICalls(noop)
+		if len(calls) != 1 || calls[0].Service != "manual_review" || calls[0].Operation != "noop" {
+			t.Fatalf("no-op diff intent (source=%s) must surface manual_review:noop, got %+v", noop.SourceType, calls)
+		}
 	}
 }
 

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -248,6 +248,49 @@ func TestAWSRemediationDryRunIntendedAPICallVariesBySourceType(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunIntendedAPICallPrefersDiffIntentKind(t *testing.T) {
+	cases := []struct {
+		name       string
+		sourceType string
+		diffKind   string
+		service    string
+		operation  string
+	}{
+		{name: "equivalence with secret_rotation diff", sourceType: "secret_permission_equivalence", diffKind: "secret_rotation", service: "secretsmanager", operation: "RotateSecret"},
+		{name: "equivalence with iam_policy_diff", sourceType: "secret_permission_equivalence", diffKind: "iam_policy_diff", service: "iam", operation: "PutRolePolicy"},
+		{name: "equivalence with kms grant diff", sourceType: "secret_permission_equivalence", diffKind: "kms_grant_diff", service: "kms", operation: "PutKeyPolicy"},
+		{name: "blast radius with trust diff", sourceType: "blast_radius", diffKind: "iam_trust_diff", service: "iam", operation: "UpdateAssumeRolePolicy"},
+		{name: "blast radius with ai agent scope", sourceType: "blast_radius", diffKind: "ai_agent_scope_change", service: "bedrock-agent", operation: "UpdateAgent"},
+		{name: "iac trust pr", sourceType: "aws_iac_remediation", diffKind: "iac_trust_policy_pr", service: "iam", operation: "UpdateAssumeRolePolicy"},
+	}
+	for _, tc := range cases {
+		approval := AWSRemediationApprovalEntry{
+			SourceType:     tc.sourceType,
+			CaseID:         "case-" + tc.name,
+			IdempotencyKey: "idk",
+			DiffIntent:     AWSRemediationDiffIntent{Kind: tc.diffKind},
+		}
+		calls := awsRemediationDryRunIntendedAPICalls(approval)
+		if len(calls) == 0 || calls[0].Service != tc.service || calls[0].Operation != tc.operation {
+			t.Fatalf("%s: expected %s.%s, got %+v", tc.name, tc.service, tc.operation, calls)
+		}
+	}
+
+	// No-op diff intents (manual_review, owner_assignment) must not consume the
+	// diff-kind branch; the source-type fallback (or manual_review default)
+	// keeps the routing honest.
+	noop := AWSRemediationApprovalEntry{
+		SourceType:     "least_privilege",
+		CaseID:         "case-noop",
+		IdempotencyKey: "idk",
+		DiffIntent:     AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true},
+	}
+	calls := awsRemediationDryRunIntendedAPICalls(noop)
+	if len(calls) == 0 || calls[0].Service != "iam" || calls[0].Operation != "PutRolePolicy" {
+		t.Fatalf("no-op diff intent must fall through to source-type routing for least_privilege, got %+v", calls)
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -173,6 +173,58 @@ func TestAWSRemediationDryRunOutcomeHonorsApprovalGates(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunPrerequisitesTreatSafetyFlagsAsPassedWhenDisabled(t *testing.T) {
+	approval := AWSRemediationApprovalEntry{
+		ApprovalID:        "approval-safety-flags",
+		CaseID:            "case-safety-flags",
+		State:             awsRemediationApprovalStateApproved,
+		ReadyForExecution: true,
+		RBACGates:         []AWSRemediationApprovalRBACGate{{Name: "approver_quorum", Status: "passed"}},
+		FeatureFlags: []AWSRemediationApprovalFeatureFlag{
+			{Name: "aws_remediation_approval_workflow", Enabled: true, Rationale: "always on"},
+			{Name: "remediation_kill_switch", Enabled: false, Rationale: "default off"},
+			{Name: "live_aws_mutation", Enabled: false, Rationale: "default off"},
+		},
+	}
+	satisfied, failed := awsRemediationDryRunPrerequisites(approval)
+	if len(failed) != 0 {
+		t.Fatalf("disabled kill switch / live_aws_mutation must not be a failed prereq: failed=%+v", failed)
+	}
+	for _, name := range []string{"feature_flag:remediation_kill_switch", "feature_flag:live_aws_mutation"} {
+		found := false
+		for _, prereq := range satisfied {
+			if prereq.Name == name && prereq.Status == "passed" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s to be marked passed when disabled: satisfied=%+v", name, satisfied)
+		}
+	}
+	entry := awsRemediationDryRunEntryFromApproval(approval, time.Date(2026, 6, 27, 14, 0, 0, 0, time.UTC))
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || !entry.ReadyForApply {
+		t.Fatalf("healthy approval with disabled safety flags must reach would_succeed/ready_for_apply, got outcome=%q ready=%v failed=%+v", entry.Outcome, entry.ReadyForApply, entry.FailedPrereqs)
+	}
+
+	// And the opposite: kill switch engaged must block.
+	approvalKill := approval
+	approvalKill.KillSwitchEngaged = true
+	approvalKill.FeatureFlags = []AWSRemediationApprovalFeatureFlag{
+		{Name: "remediation_kill_switch", Enabled: true, Rationale: "engaged"},
+		{Name: "live_aws_mutation", Enabled: false, Rationale: "default off"},
+	}
+	_, failedKill := awsRemediationDryRunPrerequisites(approvalKill)
+	sawKill := false
+	for _, prereq := range failedKill {
+		if prereq.Name == "feature_flag:remediation_kill_switch" {
+			sawKill = true
+		}
+	}
+	if !sawKill {
+		t.Fatalf("expected engaged kill switch to register as a failed prereq: failed=%+v", failedKill)
+	}
+}
+
 func TestAWSRemediationDryRunIntendedAPICallVariesBySourceType(t *testing.T) {
 	cases := []struct {
 		sourceType string

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -541,6 +541,12 @@ func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *tes
 			wantSignal:    "agent_scope_applied",
 		},
 		{
+			name:          "access_key_quarantine skips simulator and keeps last-used verification",
+			approval:      AWSRemediationApprovalEntry{SourceType: "aws_access_key_quarantine", DiffIntent: AWSRemediationDiffIntent{Kind: "access_key_quarantine"}},
+			wantSimulator: false,
+			wantSignal:    "no_runtime_after_disable",
+		},
+		{
 			name:          "empty diff kind falls back to source-type gate (least_privilege)",
 			approval:      AWSRemediationApprovalEntry{SourceType: "least_privilege"},
 			wantSimulator: true,

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -400,6 +400,31 @@ func TestAWSRemediationDryRunKMSGrantDiffTargetsKMSKeyFromImpactedPath(t *testin
 	}
 }
 
+func TestAWSRemediationDryRunVerificationSuppressesLiveChecksForNoOpDiffs(t *testing.T) {
+	noop := AWSRemediationApprovalEntry{
+		SourceType: "least_privilege",
+		DiffIntent: AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true},
+	}
+	checks := awsRemediationDryRunVerificationChecks(noop)
+	if len(checks) != 1 || checks[0].Source != "manual_review" || checks[0].Signal != "noop" {
+		t.Fatalf("no-op diff intent must surface a manual_review:noop verification check, got %+v", checks)
+	}
+
+	live := AWSRemediationApprovalEntry{
+		SourceType: "trust_policy_hardening",
+		DiffIntent: AWSRemediationDiffIntent{Kind: "iam_trust_diff"},
+	}
+	checks = awsRemediationDryRunVerificationChecks(live)
+	if len(checks) < 2 {
+		t.Fatalf("non-noop entries must keep live verification checks, got %+v", checks)
+	}
+	for _, check := range checks {
+		if check.Source == "manual_review" && check.Signal == "noop" {
+			t.Fatalf("non-noop entries must not include manual_review:noop, got %+v", checks)
+		}
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -292,6 +292,71 @@ func TestAWSRemediationDryRunIntendedAPICallPrefersDiffIntentKind(t *testing.T) 
 	}
 }
 
+func TestAWSRemediationDryRunIntendedAPICallTargetsResourceForResourceMutations(t *testing.T) {
+	scope := AWSRemediationApprovalScope{
+		IdentityNodeIDs: []string{"aws:identity:role/orders-ci"},
+		ResourceNodeIDs: []string{"aws:secret:arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-token"},
+	}
+	cases := []struct {
+		name       string
+		approval   AWSRemediationApprovalEntry
+		wantTarget string
+	}{
+		{
+			name: "secret_rotation diff targets the secret",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "secret_permission_equivalence",
+				CaseID:         "case-secret-rotation",
+				IdempotencyKey: "idk",
+				Scope:          scope,
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "secret_rotation"},
+			},
+			wantTarget: scope.ResourceNodeIDs[0],
+		},
+		{
+			name: "kms grant diff targets the KMS resource",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "secret_permission_equivalence",
+				CaseID:         "case-kms",
+				IdempotencyKey: "idk",
+				Scope: AWSRemediationApprovalScope{
+					IdentityNodeIDs: []string{"aws:identity:role/orders-ci"},
+					ResourceNodeIDs: []string{"aws:kms:key/abcd"},
+				},
+				DiffIntent: AWSRemediationDiffIntent{Kind: "kms_grant_diff"},
+			},
+			wantTarget: "aws:kms:key/abcd",
+		},
+		{
+			name: "iam policy diff targets the role identity",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "secret_permission_equivalence",
+				CaseID:         "case-iam",
+				IdempotencyKey: "idk",
+				Scope:          scope,
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantTarget: scope.IdentityNodeIDs[0],
+		},
+		{
+			name: "aws_secret_key_rotation source-type fallback targets the secret",
+			approval: AWSRemediationApprovalEntry{
+				SourceType:     "aws_secret_key_rotation",
+				CaseID:         "case-rotation-source",
+				IdempotencyKey: "idk",
+				Scope:          scope,
+			},
+			wantTarget: scope.ResourceNodeIDs[0],
+		},
+	}
+	for _, tc := range cases {
+		calls := awsRemediationDryRunIntendedAPICalls(tc.approval)
+		if len(calls) == 0 || calls[0].TargetResource != tc.wantTarget {
+			t.Fatalf("%s: target_resource=%q want=%q calls=%+v", tc.name, calls[0].TargetResource, tc.wantTarget, calls)
+		}
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -357,6 +357,49 @@ func TestAWSRemediationDryRunIntendedAPICallTargetsResourceForResourceMutations(
 	}
 }
 
+func TestAWSRemediationDryRunKMSGrantDiffTargetsKMSKeyFromImpactedPath(t *testing.T) {
+	// KMS-backed secret_permission_equivalence cases lead ResourceNodeIDs with
+	// the protected secret and only carry the KMS key in the impacted path.
+	// The dry-run must pick the KMS key as the PutKeyPolicy target.
+	approval := AWSRemediationApprovalEntry{
+		SourceType:     "secret_permission_equivalence",
+		CaseID:         "case-kms-impacted",
+		IdempotencyKey: "idk",
+		Scope: AWSRemediationApprovalScope{
+			IdentityNodeIDs: []string{"aws:identity:role/orders-ci"},
+			ResourceNodeIDs: []string{"aws:secret:orders-token"},
+		},
+		ImpactedPath: []AWSRemediationApprovalPathStep{
+			{NodeID: "aws:identity:role/orders-ci", NodeType: "identity", Label: "orders-ci"},
+			{NodeID: "aws:kms:key/orders-cmk", NodeType: "kms_key", Label: "orders-cmk"},
+			{NodeID: "aws:secret:orders-token", NodeType: "permission_bearing_secret", Label: "orders-token"},
+		},
+		DiffIntent: AWSRemediationDiffIntent{Kind: "kms_grant_diff"},
+	}
+	calls := awsRemediationDryRunIntendedAPICalls(approval)
+	if len(calls) == 0 || calls[0].Service != "kms" || calls[0].Operation != "PutKeyPolicy" || calls[0].TargetResource != "aws:kms:key/orders-cmk" {
+		t.Fatalf("kms_grant_diff must target the KMS key node from impacted_path, got %+v", calls)
+	}
+
+	// secret_rotation must still prefer the permission_bearing_secret node.
+	approval.DiffIntent.Kind = "secret_rotation"
+	approval.Scope.ResourceNodeIDs = []string{"aws:kms:key/orders-cmk"}
+	calls = awsRemediationDryRunIntendedAPICalls(approval)
+	if len(calls) == 0 || calls[0].Service != "secretsmanager" || calls[0].Operation != "RotateSecret" || calls[0].TargetResource != "aws:secret:orders-token" {
+		t.Fatalf("secret_rotation must target the permission_bearing_secret node from impacted_path, got %+v", calls)
+	}
+
+	// When the impacted path is missing typed nodes, the generic resource
+	// target still wins so the dry-run is never empty.
+	approval.ImpactedPath = nil
+	approval.Scope.ResourceNodeIDs = []string{"aws:secret:fallback"}
+	approval.DiffIntent.Kind = "secret_rotation"
+	calls = awsRemediationDryRunIntendedAPICalls(approval)
+	if len(calls) == 0 || calls[0].TargetResource != "aws:secret:fallback" {
+		t.Fatalf("missing impacted_path types must fall back to the generic resource target, got %+v", calls)
+	}
+}
+
 func TestGetAWSRemediationDryRunFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	svc, ws := newRemediationDryRunService(t, "project-remediation-dry-run-states", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3352,6 +3352,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"queue": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSRemediationDryRun(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRemediationDryRunRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			ApprovalID:   strings.TrimSpace(c.Query("approval_id")),
+			CaseID:       strings.TrimSpace(c.Query("case_id")),
+			SourceType:   strings.TrimSpace(c.Query("source_type")),
+			Outcome:      strings.TrimSpace(c.Query("outcome")),
+			RiskTier:     strings.TrimSpace(c.Query("risk_tier")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws remediation dry-run request"})
+			default:
+				logger.Error("get aws remediation dry-run",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws remediation dry-run"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"dry_run": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1922,6 +1922,48 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS remediation dry-run with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ dry_run: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectRemediationDryRun(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        approvalID: 'aws-remediation-approval:orders-ci',
+        caseID: 'aws-remediation-case:orders-ci',
+        sourceType: 'least_privilege',
+        outcome: 'would_succeed',
+        riskTier: 'medium',
+        severity: 'medium',
+        search: 'PutRolePolicy'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/remediation-dry-run?');
+    expect(url).toContain('source_type=least_privilege');
+    expect(url).toContain('outcome=would_succeed');
+    expect(url).toContain('risk_tier=medium');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4063,6 +4063,152 @@ export type AWSRemediationApprovalQuery = {
   search?: string;
 };
 
+export type AWSRemediationDryRunStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSRemediationDryRunFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSRemediationDryRunOutcome = 'would_succeed' | 'would_fail' | 'requires_review' | 'blocked' | 'kill_switch_engaged' | string;
+
+export type AWSRemediationDryRunIntendedAPICall = {
+  service: string;
+  operation: string;
+  target_resource?: string;
+  parameter_refs?: string[];
+  idempotent: boolean;
+  requires_approval: boolean;
+};
+
+export type AWSRemediationDryRunAffectedResource = {
+  node_id: string;
+  resource_arn?: string;
+  resource_type?: string;
+  change_kind: string;
+  before_ref?: string;
+  after_ref?: string;
+};
+
+export type AWSRemediationDryRunPrerequisite = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSRemediationDryRunVerificationCheck = {
+  source: string;
+  signal: string;
+  description: string;
+};
+
+export type AWSRemediationDryRunRelationship = {
+  dry_run_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSRemediationDryRunEntry = {
+  dry_run_id: string;
+  calculation_version: string;
+  approval_id: string;
+  case_id: string;
+  source_artifact_id: string;
+  source_type: string;
+  outcome: AWSRemediationDryRunOutcome;
+  risk_tier: string;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  idempotency_key: string;
+  dry_run_ref: string;
+  diff_intent: AWSRemediationDiffIntent;
+  intended_api_calls: AWSRemediationDryRunIntendedAPICall[];
+  affected_resources: AWSRemediationDryRunAffectedResource[];
+  satisfied_prerequisites: AWSRemediationDryRunPrerequisite[];
+  failed_prerequisites: AWSRemediationDryRunPrerequisite[];
+  verification_checks: AWSRemediationDryRunVerificationCheck[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  tradeoffs: AWSRemediationTradeoff[];
+  audit_trail: AWSRemediationAuditEntry[];
+  kill_switch_engaged: boolean;
+  ready_for_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  simulated_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationDryRunSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  outcome_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  risk_tier_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  api_call_count: number;
+  affected_resource_count: number;
+  failed_prerequisite_count: number;
+  verification_check_count: number;
+  ready_for_apply_count: number;
+  kill_switch_engaged_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSRemediationDryRunResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSRemediationDryRunStatus;
+  fixture_state?: AWSRemediationDryRunFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSRemediationDryRunSummary;
+  entries: AWSRemediationDryRunEntry[];
+  relationships: AWSRemediationDryRunRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSRemediationDryRunQuery = {
+  connectorID?: string;
+  fixtureState?: AWSRemediationDryRunFixtureState;
+  accountID?: string;
+  region?: string;
+  approvalID?: string;
+  caseID?: string;
+  sourceType?: string;
+  outcome?: string;
+  riskTier?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -8363,6 +8509,29 @@ export const apiClient = {
         severity: query?.severity,
         ready_for_execution: query?.readyForExecution,
         kill_switch_engaged: query?.killSwitchEngaged,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectRemediationDryRun(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSRemediationDryRunQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ dry_run: AWSRemediationDryRunResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/remediation-dry-run${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        approval_id: query?.approvalID,
+        case_id: query?.caseID,
+        source_type: query?.sourceType,
+        outcome: query?.outcome,
+        risk_tier: query?.riskTier,
+        severity: query?.severity,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -73,6 +73,8 @@ import {
   type AWSIaCRemediationResult,
   type AWSRemediationApprovalEntry,
   type AWSRemediationApprovalResult,
+  type AWSRemediationDryRunEntry,
+  type AWSRemediationDryRunResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11491,6 +11493,114 @@ function AWSRemediationApprovalContent({
   );
 }
 
+function awsRemediationDryRunStage(entry: AWSRemediationDryRunEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.outcome === 'blocked' || entry.outcome === 'kill_switch_engaged') {
+    return 'not-available';
+  }
+  if (entry.outcome !== 'would_succeed') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsRemediationDryRunAPICallLabel(entry: AWSRemediationDryRunEntry): string {
+  if (entry.intended_api_calls.length === 0) {
+    return 'manual review';
+  }
+  const labels = entry.intended_api_calls.map((call) => `${call.service}:${call.operation}`);
+  return labels.slice(0, 2).join(' · ') + (labels.length > 2 ? ` +${labels.length - 2}` : '');
+}
+
+function awsRemediationDryRunPrereqLabel(entry: AWSRemediationDryRunEntry): string {
+  const failed = entry.failed_prerequisites.length;
+  const satisfied = entry.satisfied_prerequisites.length;
+  return `${satisfied} passed · ${failed} blocked`;
+}
+
+function awsRemediationDryRunOutcomeLabel(entry: AWSRemediationDryRunEntry): string {
+  if (entry.ready_for_apply) {
+    return `ready · ${entry.verification_checks.length} checks`;
+  }
+  return formatTokenLabel(entry.outcome);
+}
+
+function AWSRemediationDryRunContent({
+  dryRun,
+  loading,
+  error,
+  onRetry
+}: {
+  dryRun: AWSRemediationDryRunResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = dryRun?.entries ?? [];
+  const summaryLine = dryRun
+    ? `${dryRun.summary.total_entries} total · ${dryRun.summary.ready_for_apply_count} ready · ${dryRun.summary.api_call_count} intended API calls · ${dryRun.summary.failed_prerequisite_count} blocked prereqs`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS remediation dry-run executor">
+      <h3>AWS remediation dry-run executor</h3>
+      <p className="idt-app-kicker">
+        Read-only dry-run projection from approved remediation cases. Each entry carries the intended AWS API calls,
+        affected resources, satisfied/failed prerequisites, and cloud verification checks — Identrail never calls AWS
+        write APIs at this layer. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS remediation dry-run"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Simulating dry-run"
+          body="Identrail is simulating the approved remediation cases against the AWS API surface to project intended calls and verification checks."
+        />
+      ) : null}
+      {!error && !loading && dryRun && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={dryRun.status === 'blocked' ? 'Permission required' : 'No dry-run entries'}
+          title={dryRun.status === 'blocked' ? 'Dry-run needs approved remediation evidence' : 'No dry-run entries projected'}
+          body={dryRun.failure_reasons[0] ?? 'No upstream approval queue evidence produced a dry-run entry for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && dryRun && dryRun.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {dryRun.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS remediation dry-run entries"
+          rows={rows}
+          getRowKey={(row) => row.dry_run_id}
+          columns={[
+            { key: 'dry_run', header: 'Dry-run', render: (row) => <strong>{row.title}</strong> },
+            { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+            { key: 'api_calls', header: 'Intended calls', render: (row) => awsRemediationDryRunAPICallLabel(row) },
+            { key: 'prereqs', header: 'Prerequisites', render: (row) => awsRemediationDryRunPrereqLabel(row) },
+            { key: 'outcome', header: 'Outcome', render: (row) => awsRemediationDryRunOutcomeLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsRemediationDryRunStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.outcome)}`} />
+              )
+            },
+            { key: 'verification', header: 'Verification', render: (row) => `${row.verification_checks.length} check${row.verification_checks.length === 1 ? '' : 's'}` }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -12966,6 +13076,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [remediationApprovalLoading, setRemediationApprovalLoading] = useState(false);
   const [remediationApprovalError, setRemediationApprovalError] = useState('');
   const remediationApprovalRequestRef = useRef(0);
+  const [remediationDryRun, setRemediationDryRun] = useState<AWSRemediationDryRunResult | null>(null);
+  const [remediationDryRunLoading, setRemediationDryRunLoading] = useState(false);
+  const [remediationDryRunError, setRemediationDryRunError] = useState('');
+  const remediationDryRunRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -13635,6 +13749,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadRemediationApproval]);
 
+  const loadRemediationDryRun = useCallback(async () => {
+    const requestID = ++remediationDryRunRequestRef.current;
+    setRemediationDryRun(null);
+    setRemediationDryRunError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setRemediationDryRunLoading(false);
+      return;
+    }
+    setRemediationDryRunLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRemediationDryRun(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== remediationDryRunRequestRef.current) {
+        return;
+      }
+      setRemediationDryRun(response.dry_run);
+    } catch (error) {
+      if (requestID !== remediationDryRunRequestRef.current) {
+        return;
+      }
+      setRemediationDryRunError(formatAPIError(error, 'Unable to load AWS remediation dry-run.'));
+    } finally {
+      if (requestID === remediationDryRunRequestRef.current) {
+        setRemediationDryRunLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadRemediationDryRun();
+    return () => {
+      remediationDryRunRequestRef.current += 1;
+    };
+  }, [loadRemediationDryRun]);
+
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
     setBlastRadius(null);
@@ -14169,6 +14331,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={remediationApprovalLoading}
             error={remediationApprovalError}
             onRetry={loadRemediationApproval}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSRemediationDryRunContent
+            dryRun={remediationDryRun}
+            loading={remediationDryRunLoading}
+            error={remediationDryRunError}
+            onRetry={loadRemediationDryRun}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Adds a read-only AWS remediation dry-run executor that turns approved
remediation cases (from the #1536 approval queue) into deterministic dry-run
records. Each entry projects the intended AWS API calls (IAM
`PutRolePolicy`/`UpdateAssumeRolePolicy`/`UpdateAccessKey`, Secrets Manager
`RotateSecret`, KMS `PutKeyPolicy`, bedrock-agent `UpdateAgent`, etc. — chosen
deterministically by source type), affected resources, satisfied/failed
prerequisites (approval state, kill switch, ready-for-execution, every RBAC
gate, every feature flag including the `live_aws_mutation` gate that must
stay off), verification checks (CloudTrail / IAM policy simulator / Access
Analyzer / IAM last-used), rollback plan, idempotency key, audit trail, and a
deterministic outcome (`would_succeed` / `would_fail` / `requires_review` /
`blocked` / `kill_switch_engaged`).

Closes #1537. Part of #1472.

## Why

Wave 8 needs a dry-run gate between approval and live apply so operators can
see exactly what would happen — which AWS API calls, which resources, which
prerequisites still block — before any wave-8 apply executor mutates AWS.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive endpoint, types, and UI)
- [x] Risk level assessed (read-only projection; never calls IAM/STS/Secrets Manager/KMS/Organizations write APIs; never inlines policy bodies or secrets)

## Validation

\`\`\`bash
make fmt-check
go vet ./...
go test ./internal/api/...
make api-example-contract-check
make web-route-integrity-check
npm run test:ci --prefix web
npm run build --prefix web
\`\`\`

All passed locally on this branch (fresh off origin/dev).

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] \`CHANGELOG.md\` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1537
Refs #1472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS remediation dry-run executor that projects approved remediation cases into deterministic dry-run records and exposes them via a new API and UI panel. This lets operators preview intended AWS calls, resource impact, prerequisites, and outcomes before any live changes (implements #1537).

- New Features
  - API: `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run` with filters (connector, fixture_state, account, region, approval ID, case ID, source type, outcome, risk tier, severity, search). OpenAPI + authz wired; metadata-only; never calls AWS write APIs.
  - Deterministic output: routes by diff intent and IAM principal kind; adds `target_resource` for mutating calls; resolves KMS grant targets; no-op intents expose `manual_review:noop`. Includes affected resources, prerequisite and verification checks, audit trail, outcomes, and `ready_for_apply` when safe.
  - Web: new client method and AWS Runtime panel listing intended calls, prerequisites, outcomes, and severity/outcome pills with loading/empty/degraded/blocked/error states.
  - Docs & tests: added `aws-remediation-dry-run-executor.md`, OpenAPI updates, and server/web tests for contract, filters, routing, no-op calls, failure states, and target mapping.

- Bug Fixes
  - Treat disabled safety flags as satisfied: `remediation_kill_switch` and `live_aws_mutation`; kill switch engagement surfaces a failed prereq and `kill_switch_engaged` outcome.
  - Suppress live verification checks for no-op dry-runs.
  - Gate IAM policy simulator checks to IAM policy and trust diffs only.
  - Mark no-op affected resources as `context`.
  - Include `provider_key_reference` in Secrets Manager rotation target lookup.
  - Fix access key dry-run verification.

<sup>Written for commit 7d49a9f5bb1e0f6bdc99b4fffaa288cca4e54183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

