### PR TITLE
Implement AWS low-risk live remediation (#1538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS low-risk live remediation** (#1538). Adds a read-only,
+  metadata-only projection of allowlisted low-risk AWS remediation actions
+  derived from the approved dry-run executor (#1537). The allowlist is
+  intentionally narrow and code-managed: `iam:TagRole` (tagging),
+  `iam:UntagRole` (stale-metadata cleanup), `iam:UpdateAccessKey` (approved
+  quarantine disable), and `iam:DetachRolePolicy` (approved orphaned-policy
+  detach). Each entry pairs a dry-run record with one allowlist rule, copies
+  the deterministic idempotency key, captures the intended mutation
+  (service/operation/target/before/after), preflight checks (allowlist
+  admission, dry-run-would-succeed, ready-for-apply, kill-switch-off,
+  idempotency-key-present, upstream prerequisites), per-source verification
+  records, rollback plan, verification plan, tradeoffs, and an audit trail
+  with a `low_risk_execution_projected` row. The state is `projected` when
+  safety preflights pass and the dry-run is ready, `skipped` when the dry-run
+  is not yet ready, and `blocked` when a safety preflight fails or the kill
+  switch is engaged. `ready_for_live_apply` is true only when state is
+  `projected`, the upstream dry-run is itself `ready_for_apply`, and no kill
+  switch is engaged. Identrail never calls IAM/STS/Secrets Manager/KMS/
+  Organizations write APIs at this layer; controlled live apply is reserved
+  for wave-8.04+ executors. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation`
+  with filters for connector, account, region, dry-run ID, case ID,
+  allowlist action, action category, state, severity, and free-text search.
+  OpenAPI schemas and authz wiring follow the neighboring wave-7/8
+  endpoints. The AWS Runtime app surface now shows an **AWS low-risk live
+  remediation** panel with execution title, allowlist rule, action and
+  category, preflight pass/blocked counts, readiness label, and
+  severity/state pill, with explicit loading, empty, degraded, blocked, and
+  error states.
 - Add **AWS remediation dry-run executor** (#1537). Adds a read-only,
   metadata-only dry-run projection that turns approved remediation cases
   (#1536) into deterministic dry-run records. Each entry carries source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 - Add **AWS low-risk live remediation** (#1538). Adds a read-only,
   metadata-only projection of allowlisted low-risk AWS remediation actions
   derived from the approved dry-run executor (#1537). The allowlist is
-  intentionally narrow and code-managed: `iam:TagRole` (tagging),
-  `iam:UntagRole` (stale-metadata cleanup), `iam:UpdateAccessKey` (approved
-  quarantine disable), and `iam:DetachRolePolicy` (approved orphaned-policy
-  detach). Each entry pairs a dry-run record with one allowlist rule, copies
+  intentionally narrow and code-managed: `iam:UpdateAccessKey` (approved
+  quarantine disable) and `iam:DetachRolePolicy` (approved orphaned-policy
+  detach). Every rule declares a `MaxBlastRadius`, and the projection
+  rejects any upstream dry-run whose `risk_tier` or `severity` exceeds the
+  rule's ceiling so high/critical entries never leak into the low-risk
+  projection. Each admitted entry pairs a dry-run record with one allowlist
+  rule, copies
   the deterministic idempotency key, captures the intended mutation
   (service/operation/target/before/after), preflight checks (allowlist
   admission, dry-run-would-succeed, ready-for-apply, kill-switch-off,

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
 - AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
 - AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
+- AWS low-risk live remediation: `aws-low-risk-live-remediation.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-low-risk-live-remediation.md
+++ b/docs/aws-low-risk-live-remediation.md
@@ -1,0 +1,117 @@
+# AWS low-risk live remediation
+
+Issue #1538 adds a metadata-only projection of allowlisted low-risk AWS
+remediations derived from the upstream dry-run executor (#1537). Each entry
+pairs a dry-run record with one code-managed allowlist rule (tagging,
+stale-metadata cleanup, approved detach/disable), captures the idempotency
+key, intended mutation, preflight checks, verification records, rollback
+plan, and audit trail so the wave-8.04+ live-apply executors can replay the
+change idempotently.
+
+The endpoint is read-only. It never calls IAM, STS, Secrets Manager, KMS, or
+Organizations write APIs, never opens external PRs, and never reads,
+exposes, logs, or persists rendered policies, secret values, customer
+payloads, prompts, completions, browser pages, code-interpreter output,
+database rows, or object contents.
+
+## Allowlist
+
+The allowlist is defined in code (`awsLowRiskRemediationAllowlist`) and any
+change is a code review under the wave-8 safety controls.
+
+| Rule | Category | Action | Match sources | Rationale |
+|---|---|---|---|---|
+| `iam_tag_role_owner` | `tagging` | `iam:TagRole` | least_privilege, aws_iac_remediation | Add/update an owner tag; tagging is reversible and does not change permissions. |
+| `iam_untag_role_stale_owner` | `stale_metadata_cleanup` | `iam:UntagRole` | least_privilege | Remove a stale owner tag flagged by the upstream finding. |
+| `iam_update_access_key_quarantine` | `approved_disable` | `iam:UpdateAccessKey` | aws_access_key_quarantine | Mark a stale access key Inactive once the quarantine planner approved disable. |
+| `iam_detach_role_policy_orphaned` | `approved_detach` | `iam:DetachRolePolicy` | least_privilege, blast_radius | Detach an orphaned role-managed policy with no observed runtime use. |
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/low-risk-live-remediation`
+
+| Query param | Purpose |
+|---|---|
+| `connector_id` | scope to one AWS connector |
+| `fixture_state` | `success` / `empty` / `degraded` / `partial_failure` / `permission_denied` |
+| `account_id`, `region` | account and region filters |
+| `dry_run_id`, `case_id` | source filters |
+| `action` | allowlist action filter (e.g. `iam:UpdateAccessKey`) |
+| `action_category` | `tagging`, `stale_metadata_cleanup`, `approved_disable`, `approved_detach` |
+| `state` | `projected`, `skipped`, or `blocked` |
+| `severity` | `critical`, `high`, `medium`, or `low` |
+| `search` | free-text search across execution, allowlist, mutation, preflight, verification, audit, and evidence fields |
+
+Response shape: `{ "low_risk_live_remediation": AWSLowRiskRemediationResult }`
+with tenant/workspace/project metadata, the allowlist, summary counts, ranked
+entries, relationships, caveats, failure reasons, remediation hints, evidence
+links, coverage gaps, diagnostics, and generated timestamps.
+
+## Entry shape
+
+Each `AWSLowRiskRemediationEntry` includes:
+
+- stable `execution_id`, calculation version, source `dry_run_id`/
+  `approval_id`/`case_id`, issue refs, score, confidence, severity, and state
+- the matched `allowlist_rule` (name, category, action, match-sources,
+  max blast radius, rationale)
+- a deterministic `mutation` record (service, operation, target resource,
+  before/after refs, parameter refs)
+- `preflights` (allowlist-admitted, dry-run-would-succeed, ready-for-apply,
+  kill-switch-off, idempotency-key-present, upstream-prereq) plus per-source
+  `verifications` carried over from the dry-run
+- rollback plan, verification plan, tradeoffs from the source dry-run, and an
+  audit trail that copies the upstream entries plus a
+  `low_risk_execution_projected` row
+- `ready_for_live_apply` is true only when state is `projected`, the upstream
+  dry-run is itself `ready_for_apply`, and no kill switch is engaged
+
+## State semantics
+
+- **projected**: allowlist matched, every safety preflight passes, upstream
+  dry-run is `would_succeed` and `ready_for_apply`. Eligible for wave-8.04+
+  live apply when the apply executor's feature flag opens.
+- **skipped**: allowlist matched, but the upstream dry-run is not yet
+  `would_succeed` or `ready_for_apply` (no safety violation — just not ready
+  yet).
+- **blocked**: kill switch engaged or a safety preflight (allowlist,
+  idempotency, kill switch, upstream prerequisites) failed.
+
+## Failure handling
+
+- **Ready**: upstream dry-run evidence is available and at least one entry
+  matches the allowlist.
+- **Degraded**: partial or degraded upstream evidence; composed entries stay
+  visible when safe.
+- **Blocked**: permission-denied upstream evidence emits zero entries plus
+  failure reasons, remediation hints, diagnostics, and coverage gaps.
+
+## App surface
+
+The AWS Runtime page renders an **AWS low-risk live remediation** panel with
+execution title, allowlist rule, action + category, preflight pass/blocked
+count, readiness, and severity/state pill. Loading, empty, degraded, blocked,
+and error states are explicit.
+
+## Validation
+
+1. Confirm blocker #1537 is closed.
+2. Run upstream dry-run with `fixture_state=success`.
+3. Call the low-risk endpoint with `fixture_state=success` and verify at
+   least one entry includes mutation, preflights, verifications, allowlist
+   rule, idempotency key, and audit trail.
+4. Filter by `state=projected`, `action_category=approved_disable`,
+   `action=iam:UpdateAccessKey`.
+5. Run `fixture_state=empty`, `degraded`, `partial_failure`, and
+   `permission_denied` and confirm the status, diagnostics, and failure
+   reasons stay explicit.
+
+## What is intentionally out of scope
+
+- Live IAM/STS/Secrets Manager/KMS/Organizations write APIs (wave-8.04+
+  executors own controlled apply).
+- Persisting execution-state mutations server-side; the endpoint projects
+  deterministically from the upstream dry-run and is safe to re-query.
+- Allowlist extensions outside the four rules above; expanding the allowlist
+  is a code change reviewed under wave-8 safety controls.
+- Rendering policy bodies, IaC bodies, secret values, or workload payloads.

--- a/docs/aws-low-risk-live-remediation.md
+++ b/docs/aws-low-risk-live-remediation.md
@@ -2,11 +2,10 @@
 
 Issue #1538 adds a metadata-only projection of allowlisted low-risk AWS
 remediations derived from the upstream dry-run executor (#1537). Each entry
-pairs a dry-run record with one code-managed allowlist rule (tagging,
-stale-metadata cleanup, approved detach/disable), captures the idempotency
-key, intended mutation, preflight checks, verification records, rollback
-plan, and audit trail so the wave-8.04+ live-apply executors can replay the
-change idempotently.
+pairs a dry-run record with one code-managed allowlist rule (approved
+detach/disable), captures the idempotency key, intended mutation, preflight
+checks, verification records, rollback plan, and audit trail so the
+wave-8.04+ live-apply executors can replay the change idempotently.
 
 The endpoint is read-only. It never calls IAM, STS, Secrets Manager, KMS, or
 Organizations write APIs, never opens external PRs, and never reads,
@@ -17,14 +16,21 @@ database rows, or object contents.
 ## Allowlist
 
 The allowlist is defined in code (`awsLowRiskRemediationAllowlist`) and any
-change is a code review under the wave-8 safety controls.
+change is a code review under the wave-8 safety controls. Every rule
+declares `MaxBlastRadius`; the projection rejects any upstream dry-run whose
+`risk_tier` or `severity` exceeds that ceiling, so high/critical entries
+never appear in the low-risk projection even if their action and source
+match.
 
-| Rule | Category | Action | Match sources | Rationale |
-|---|---|---|---|---|
-| `iam_tag_role_owner` | `tagging` | `iam:TagRole` | least_privilege, aws_iac_remediation | Add/update an owner tag; tagging is reversible and does not change permissions. |
-| `iam_untag_role_stale_owner` | `stale_metadata_cleanup` | `iam:UntagRole` | least_privilege | Remove a stale owner tag flagged by the upstream finding. |
-| `iam_update_access_key_quarantine` | `approved_disable` | `iam:UpdateAccessKey` | aws_access_key_quarantine | Mark a stale access key Inactive once the quarantine planner approved disable. |
-| `iam_detach_role_policy_orphaned` | `approved_detach` | `iam:DetachRolePolicy` | least_privilege, blast_radius | Detach an orphaned role-managed policy with no observed runtime use. |
+| Rule | Category | Action | Match sources | Max blast radius | Rationale |
+|---|---|---|---|---|---|
+| `iam_update_access_key_quarantine` | `approved_disable` | `iam:UpdateAccessKey` | aws_access_key_quarantine | low | Mark a stale access key Inactive once the quarantine planner approved disable. |
+| `iam_detach_role_policy_orphaned` | `approved_detach` | `iam:DetachRolePolicy` | least_privilege, blast_radius | low | Detach an orphaned role-managed policy with no observed runtime use. |
+
+Tagging and stale-metadata-cleanup categories are reserved in the contract
+(`action_category` enum) for future rules, but no rule is admitted until the
+dry-run executor emits the corresponding AWS action — advertising a rule
+that the dry-run can't produce would mislead operators and the UI.
 
 ## API
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -619,6 +619,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/low-risk-live-remediation
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/blast-radius
     action: tenancy.read
     resource_type: project
@@ -5859,6 +5864,87 @@ paths:
                     $ref: "#/components/schemas/AWSRemediationDryRunResult"
         "400":
           description: Invalid AWS remediation dry-run request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/low-risk-live-remediation:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS low-risk live remediation projection
+      operationId: getAWSProjectLowRiskLiveRemediation
+      description: Projects a deterministic, read-only set of allowlisted low-risk AWS remediations derived from the upstream dry-run executor. Each entry pairs a dry-run record with one code-managed allowlist rule (tagging, stale-metadata cleanup, approved detach/disable) and carries the idempotency key, intended mutation, preflight checks, verification records, rollback plan, and audit trail. The endpoint never calls IAM/STS/Secrets Manager/KMS/Organizations write APIs at this layer and never reads, exposes, logs, or persists rendered policies, secret values, customer payloads, prompts, completions, browser pages, code-interpreter output, database rows, or object contents. Controlled live apply belongs to wave-8.04+ executors.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: dry_run_id
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: action
+          schema: { type: string }
+        - in: query
+          name: action_category
+          schema:
+            type: string
+            enum: [tagging, stale_metadata_cleanup, approved_disable, approved_detach]
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [projected, skipped, blocked]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS low-risk live remediation contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  low_risk_live_remediation:
+                    $ref: "#/components/schemas/AWSLowRiskRemediationResult"
+        "400":
+          description: Invalid AWS low-risk live remediation request
           content:
             application/json:
               schema:
@@ -15981,6 +16067,228 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSRemediationDryRunRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLowRiskRemediationAllowlistRule:
+      type: object
+      properties:
+        name: { type: string }
+        category:
+          type: string
+          enum: [tagging, stale_metadata_cleanup, approved_disable, approved_detach]
+        action: { type: string }
+        match_sources:
+          type: array
+          items: { type: string }
+        max_blast_radius:
+          type: string
+          enum: [low, medium, high]
+        rationale: { type: string }
+    AWSLowRiskRemediationPreflight:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSLowRiskRemediationMutationRecord:
+      type: object
+      properties:
+        service: { type: string }
+        operation: { type: string }
+        target_resource: { type: string }
+        change_kind: { type: string }
+        before_ref: { type: string }
+        after_ref: { type: string }
+        parameter_refs:
+          type: array
+          items: { type: string }
+    AWSLowRiskRemediationVerificationRecord:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        status: { type: string }
+        description: { type: string }
+    AWSLowRiskRemediationRelationship:
+      type: object
+      properties:
+        execution_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSLowRiskRemediationEntry:
+      type: object
+      properties:
+        execution_id: { type: string }
+        calculation_version: { type: string }
+        dry_run_id: { type: string }
+        approval_id: { type: string }
+        case_id: { type: string }
+        source_artifact_id: { type: string }
+        source_type: { type: string }
+        state:
+          type: string
+          enum: [projected, skipped, blocked]
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        idempotency_key: { type: string }
+        allowlist_rule:
+          $ref: "#/components/schemas/AWSLowRiskRemediationAllowlistRule"
+        mutation:
+          $ref: "#/components/schemas/AWSLowRiskRemediationMutationRecord"
+        preflights:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLowRiskRemediationPreflight"
+        verifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLowRiskRemediationVerificationRecord"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSRemediationRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSRemediationVerificationPlan"
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        kill_switch_engaged: { type: boolean }
+        ready_for_live_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCaseEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCasePathStep"
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLowRiskRemediationSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        action_counts:
+          type: object
+          additionalProperties: { type: integer }
+        category_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        ready_for_live_apply_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_preflight_count: { type: integer }
+        mutation_count: { type: integer }
+        verification_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSLowRiskRemediationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        allowlist:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLowRiskRemediationAllowlistRule"
+        summary:
+          $ref: "#/components/schemas/AWSLowRiskRemediationSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLowRiskRemediationEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLowRiskRemediationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -767,6 +767,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-approval-queue", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_low_risk_live_remediation.go
+++ b/internal/api/aws_low_risk_live_remediation.go
@@ -193,35 +193,22 @@ type AWSLowRiskRemediationResult struct {
 
 // awsLowRiskRemediationAllowlist is the deterministic, code-managed set of
 // AWS actions admitted into the low-risk live remediation flow. The list is
-// intentionally narrow: tagging-style metadata changes, stale-metadata
-// cleanup, and approved detach/disable operations whose dry-run already
-// projected `would_succeed` with low blast radius. Any change to this list is
-// a code change reviewed under wave-8 safety controls.
+// intentionally narrow: only approved detach/disable operations whose
+// upstream dry-run already projects `would_succeed` at the `low` risk tier.
+// Tagging and stale-metadata-cleanup categories are tracked for future
+// rules but no rule is admitted until the dry-run routing emits the
+// corresponding action; advertising a rule that the dry-run never produces
+// would mislead operators. Any change to this list is a code change
+// reviewed under the wave-8 safety controls.
 func awsLowRiskRemediationAllowlist() []AWSLowRiskRemediationAllowlistRule {
 	return []AWSLowRiskRemediationAllowlistRule{
-		{
-			Name:           "iam_tag_role_owner",
-			Category:       "tagging",
-			Action:         "iam:TagRole",
-			MatchSources:   []string{"least_privilege", "aws_iac_remediation"},
-			MaxBlastRadius: "low",
-			Rationale:      "Add or update an owner tag on a role with a successful dry-run; tagging is reversible and does not change permissions.",
-		},
-		{
-			Name:           "iam_untag_role_stale_owner",
-			Category:       "stale_metadata_cleanup",
-			Action:         "iam:UntagRole",
-			MatchSources:   []string{"least_privilege"},
-			MaxBlastRadius: "low",
-			Rationale:      "Remove a stale owner tag on a role with a successful dry-run when the upstream finding flagged the metadata as out of date.",
-		},
 		{
 			Name:           "iam_update_access_key_quarantine",
 			Category:       "approved_disable",
 			Action:         "iam:UpdateAccessKey",
 			MatchSources:   []string{"aws_access_key_quarantine"},
 			MaxBlastRadius: "low",
-			Rationale:      "Mark an IAM access key Inactive when the access-key quarantine planner approved the disable and the dry-run projected would_succeed.",
+			Rationale:      "Mark an IAM access key Inactive when the access-key quarantine planner approved the disable and the dry-run projected would_succeed at the low risk tier.",
 		},
 		{
 			Name:           "iam_detach_role_policy_orphaned",
@@ -229,7 +216,7 @@ func awsLowRiskRemediationAllowlist() []AWSLowRiskRemediationAllowlistRule {
 			Action:         "iam:DetachRolePolicy",
 			MatchSources:   []string{"least_privilege", "blast_radius"},
 			MaxBlastRadius: "low",
-			Rationale:      "Detach a role-managed policy that the upstream dry-run flagged as orphaned with no observed runtime use.",
+			Rationale:      "Detach a role-managed policy that the upstream dry-run flagged as orphaned with no observed runtime use at the low risk tier.",
 		},
 	}
 }
@@ -358,6 +345,9 @@ func awsLowRiskRemediationEntries(dryRunEntries []AWSRemediationDryRunEntry, all
 		if !awsLowRiskRemediationSourceAdmitted(rule, entry.SourceType) {
 			continue
 		}
+		if !awsLowRiskRemediationRiskTierAdmitted(rule, entry) {
+			continue
+		}
 		entries = append(entries, awsLowRiskRemediationEntryFromDryRun(entry, call, rule, now))
 	}
 	return entries
@@ -373,6 +363,39 @@ func awsLowRiskRemediationSourceAdmitted(rule AWSLowRiskRemediationAllowlistRule
 		}
 	}
 	return false
+}
+
+// awsLowRiskRemediationRiskTierAdmitted blocks any dry-run entry whose
+// projected risk tier or severity exceeds the allowlist rule's
+// MaxBlastRadius. Without this check, an approved high/critical entry
+// matching by action+source could leak into the low-risk projection even
+// though the rule declares MaxBlastRadius="low".
+func awsLowRiskRemediationRiskTierAdmitted(rule AWSLowRiskRemediationAllowlistRule, entry AWSRemediationDryRunEntry) bool {
+	ceiling := awsLowRiskRemediationRiskRank(rule.MaxBlastRadius)
+	if ceiling < 0 {
+		return true
+	}
+	if rank := awsLowRiskRemediationRiskRank(entry.RiskTier); rank >= 0 && rank > ceiling {
+		return false
+	}
+	if rank := awsLowRiskRemediationRiskRank(entry.Severity); rank >= 0 && rank > ceiling {
+		return false
+	}
+	return true
+}
+
+func awsLowRiskRemediationRiskRank(value string) int {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "low":
+		return 0
+	case "medium":
+		return 1
+	case "high":
+		return 2
+	case "critical":
+		return 3
+	}
+	return -1
 }
 
 func awsLowRiskRemediationEntryFromDryRun(entry AWSRemediationDryRunEntry, call AWSRemediationDryRunIntendedAPICall, rule AWSLowRiskRemediationAllowlistRule, now time.Time) AWSLowRiskRemediationEntry {

--- a/internal/api/aws_low_risk_live_remediation.go
+++ b/internal/api/aws_low_risk_live_remediation.go
@@ -1,0 +1,768 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsLowRiskRemediationCurrentIssue = 1538
+	awsLowRiskRemediationVersion      = "aws-low-risk-live-remediation-v1"
+
+	awsLowRiskRemediationStateProjected = "projected"
+	awsLowRiskRemediationStateSkipped   = "skipped"
+	awsLowRiskRemediationStateBlocked   = "blocked"
+)
+
+// AWSLowRiskRemediationRequest scopes the deterministic low-risk live
+// remediation projection to one AWS connector plus optional operator
+// drill-down filters.
+type AWSLowRiskRemediationRequest struct {
+	ConnectorID    string `json:"connector_id,omitempty"`
+	FixtureState   string `json:"fixture_state,omitempty"`
+	AccountID      string `json:"account_id,omitempty"`
+	Region         string `json:"region,omitempty"`
+	DryRunID       string `json:"dry_run_id,omitempty"`
+	CaseID         string `json:"case_id,omitempty"`
+	Action         string `json:"action,omitempty"`
+	ActionCategory string `json:"action_category,omitempty"`
+	State          string `json:"state,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	Search         string `json:"search,omitempty"`
+}
+
+// Reuse shapes from the dry-run/approval layers so the executor record stays
+// consistent with the rest of the wave-8 stack.
+type AWSLowRiskRemediationEvidence = AWSRemediationApprovalEvidence
+type AWSLowRiskRemediationPathStep = AWSRemediationApprovalPathStep
+type AWSLowRiskRemediationDiagnostic = AWSRemediationApprovalDiagnostic
+type AWSLowRiskRemediationCoverageGap = AWSRemediationApprovalCoverageGap
+type AWSLowRiskRemediationAuditEntry = AWSRemediationApprovalAuditEntry
+
+// AWSLowRiskRemediationAllowlistRule names the deterministic rule that admits
+// a dry-run action into the low-risk live remediation set. Operators and any
+// later executor can trace every entry back to a rule by name.
+type AWSLowRiskRemediationAllowlistRule struct {
+	Name           string   `json:"name"`
+	Category       string   `json:"category"`
+	Action         string   `json:"action"`
+	MatchSources   []string `json:"match_sources,omitempty"`
+	MaxBlastRadius string   `json:"max_blast_radius,omitempty"`
+	Rationale      string   `json:"rationale"`
+}
+
+// AWSLowRiskRemediationPreflight is one safety check the executor performs
+// before declaring a record `ready_for_live_apply`. The set mirrors the
+// upstream dry-run prerequisites plus the action allowlist and idempotency
+// match.
+type AWSLowRiskRemediationPreflight struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSLowRiskRemediationMutationRecord describes what the executor would mutate
+// in AWS. Identrail does not call AWS write APIs at this layer; the record
+// captures the intent so the wave-8.04+ executors can replay it
+// idempotently.
+type AWSLowRiskRemediationMutationRecord struct {
+	Service        string   `json:"service"`
+	Operation      string   `json:"operation"`
+	TargetResource string   `json:"target_resource"`
+	ChangeKind     string   `json:"change_kind"`
+	BeforeRef      string   `json:"before_ref,omitempty"`
+	AfterRef       string   `json:"after_ref,omitempty"`
+	ParameterRefs  []string `json:"parameter_refs,omitempty"`
+}
+
+// AWSLowRiskRemediationVerificationRecord describes the deterministic
+// post-execution verification step that must succeed before the change is
+// recorded as `succeeded` by a downstream executor.
+type AWSLowRiskRemediationVerificationRecord struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+// AWSLowRiskRemediationRelationship surfaces execution→graph node edges.
+type AWSLowRiskRemediationRelationship struct {
+	ExecutionID string `json:"execution_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSLowRiskRemediationEntry is the persisted-record-shaped contract emitted
+// by the low-risk live remediation executor. It is metadata-only: it carries
+// no rendered policy bodies, no secret material, and no workload payloads.
+// Live IAM/STS/Organizations write APIs are gated to wave-8.04+ executors.
+type AWSLowRiskRemediationEntry struct {
+	ExecutionID        string                                    `json:"execution_id"`
+	CalculationVersion string                                    `json:"calculation_version"`
+	DryRunID           string                                    `json:"dry_run_id"`
+	ApprovalID         string                                    `json:"approval_id"`
+	CaseID             string                                    `json:"case_id"`
+	SourceArtifactID   string                                    `json:"source_artifact_id"`
+	SourceType         string                                    `json:"source_type"`
+	State              string                                    `json:"state"`
+	Severity           string                                    `json:"severity"`
+	Score              int                                       `json:"score"`
+	Confidence         float64                                   `json:"confidence"`
+	Title              string                                    `json:"title"`
+	Summary            string                                    `json:"summary"`
+	AccountID          string                                    `json:"account_id"`
+	Region             string                                    `json:"region"`
+	IdempotencyKey     string                                    `json:"idempotency_key"`
+	AllowlistRule      AWSLowRiskRemediationAllowlistRule        `json:"allowlist_rule"`
+	Mutation           AWSLowRiskRemediationMutationRecord       `json:"mutation"`
+	Preflights         []AWSLowRiskRemediationPreflight          `json:"preflights"`
+	Verifications      []AWSLowRiskRemediationVerificationRecord `json:"verifications"`
+	RollbackPlan       AWSRemediationRollbackPlan                `json:"rollback_plan"`
+	VerificationPlan   AWSRemediationVerificationPlan            `json:"verification_plan"`
+	Tradeoffs          []AWSRemediationTradeoff                  `json:"tradeoffs"`
+	AuditTrail         []AWSLowRiskRemediationAuditEntry         `json:"audit_trail"`
+	KillSwitchEngaged  bool                                      `json:"kill_switch_engaged"`
+	ReadyForLiveApply  bool                                      `json:"ready_for_live_apply"`
+	ReadOnlyProjection bool                                      `json:"read_only_projection"`
+	SourceSignals      []string                                  `json:"source_signals"`
+	Evidence           []AWSLowRiskRemediationEvidence           `json:"evidence"`
+	EvidenceBoundary   string                                    `json:"evidence_boundary"`
+	ImpactedNodes      []string                                  `json:"impacted_nodes"`
+	ImpactedPath       []AWSLowRiskRemediationPathStep           `json:"impacted_path"`
+	NextAction         string                                    `json:"next_action"`
+	ProjectedAt        time.Time                                 `json:"projected_at"`
+	CreatedAt          time.Time                                 `json:"created_at"`
+	UpdatedAt          time.Time                                 `json:"updated_at"`
+}
+
+// AWSLowRiskRemediationSummary aggregates the unfiltered and filtered set.
+type AWSLowRiskRemediationSummary struct {
+	TotalEntries           int            `json:"total_entries"`
+	FilteredEntries        int            `json:"filtered_entries"`
+	StateCounts            map[string]int `json:"state_counts"`
+	ActionCounts           map[string]int `json:"action_counts"`
+	CategoryCounts         map[string]int `json:"category_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	ReadyForLiveApplyCount int            `json:"ready_for_live_apply_count"`
+	KillSwitchEngagedCount int            `json:"kill_switch_engaged_count"`
+	FailedPreflightCount   int            `json:"failed_preflight_count"`
+	MutationCount          int            `json:"mutation_count"`
+	VerificationCount      int            `json:"verification_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+// AWSLowRiskRemediationResult is the deterministic envelope returned by the
+// low-risk live remediation endpoint.
+type AWSLowRiskRemediationResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	CalculationVersion string                               `json:"calculation_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Allowlist          []AWSLowRiskRemediationAllowlistRule `json:"allowlist"`
+	Summary            AWSLowRiskRemediationSummary         `json:"summary"`
+	Entries            []AWSLowRiskRemediationEntry         `json:"entries"`
+	Relationships      []AWSLowRiskRemediationRelationship  `json:"relationships"`
+	Caveats            []string                             `json:"caveats"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSLowRiskRemediationCoverageGap   `json:"coverage_gaps"`
+	Diagnostics        []AWSLowRiskRemediationDiagnostic    `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// awsLowRiskRemediationAllowlist is the deterministic, code-managed set of
+// AWS actions admitted into the low-risk live remediation flow. The list is
+// intentionally narrow: tagging-style metadata changes, stale-metadata
+// cleanup, and approved detach/disable operations whose dry-run already
+// projected `would_succeed` with low blast radius. Any change to this list is
+// a code change reviewed under wave-8 safety controls.
+func awsLowRiskRemediationAllowlist() []AWSLowRiskRemediationAllowlistRule {
+	return []AWSLowRiskRemediationAllowlistRule{
+		{
+			Name:           "iam_tag_role_owner",
+			Category:       "tagging",
+			Action:         "iam:TagRole",
+			MatchSources:   []string{"least_privilege", "aws_iac_remediation"},
+			MaxBlastRadius: "low",
+			Rationale:      "Add or update an owner tag on a role with a successful dry-run; tagging is reversible and does not change permissions.",
+		},
+		{
+			Name:           "iam_untag_role_stale_owner",
+			Category:       "stale_metadata_cleanup",
+			Action:         "iam:UntagRole",
+			MatchSources:   []string{"least_privilege"},
+			MaxBlastRadius: "low",
+			Rationale:      "Remove a stale owner tag on a role with a successful dry-run when the upstream finding flagged the metadata as out of date.",
+		},
+		{
+			Name:           "iam_update_access_key_quarantine",
+			Category:       "approved_disable",
+			Action:         "iam:UpdateAccessKey",
+			MatchSources:   []string{"aws_access_key_quarantine"},
+			MaxBlastRadius: "low",
+			Rationale:      "Mark an IAM access key Inactive when the access-key quarantine planner approved the disable and the dry-run projected would_succeed.",
+		},
+		{
+			Name:           "iam_detach_role_policy_orphaned",
+			Category:       "approved_detach",
+			Action:         "iam:DetachRolePolicy",
+			MatchSources:   []string{"least_privilege", "blast_radius"},
+			MaxBlastRadius: "low",
+			Rationale:      "Detach a role-managed policy that the upstream dry-run flagged as orphaned with no observed runtime use.",
+		},
+	}
+}
+
+// GetAWSLowRiskRemediation projects the deterministic, read-only low-risk
+// live remediation set from the upstream dry-run executor. Each entry pairs
+// a dry-run record with one allowlist rule, preserves the idempotency key,
+// captures the intended mutation/verification/rollback metadata, and never
+// calls IAM/STS/Organizations write APIs at this layer. Controlled live
+// execution belongs to the wave-8.04+ executors and their own feature flags.
+func (s *Service) GetAWSLowRiskRemediation(ctx context.Context, workspaceID string, projectID string, request AWSLowRiskRemediationRequest) (AWSLowRiskRemediationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSLowRiskRemediationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSLowRiskRemediationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSLowRiskRemediationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSLowRiskRemediationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	dryRun, err := s.GetAWSRemediationDryRun(ctx, workspaceID, projectID, AWSRemediationDryRunRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSLowRiskRemediationResult{}, fmt.Errorf("low-risk remediation dry-run: %w", err)
+	}
+
+	allowlist := awsLowRiskRemediationAllowlist()
+	allowlistByAction := map[string]AWSLowRiskRemediationAllowlistRule{}
+	for _, rule := range allowlist {
+		allowlistByAction[strings.ToLower(rule.Action)] = rule
+	}
+	entries := awsLowRiskRemediationEntries(dryRun.Entries, allowlistByAction, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].ExecutionID < entries[j].ExecutionID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSLowRiskRemediationEntries(entries, request)
+	relationships := awsLowRiskRemediationRelationships(filtered)
+	diagnostics := awsLowRiskRemediationDiagnostics(dryRun.Diagnostics)
+	coverageGaps := awsLowRiskRemediationCoverageGaps(dryRun.CoverageGaps)
+	status, confidence := summarizeAWSLowRiskRemediationStatus(dryRun.Status, filtered, diagnostics)
+
+	return AWSLowRiskRemediationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsLowRiskRemediationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsLowRiskRemediationCurrentIssue),
+		Version:            awsLowRiskRemediationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsLowRiskRemediationVersion,
+		AppliedFilters:     applied,
+		Allowlist:          allowlist,
+		Summary:            summarizeAWSLowRiskRemediationEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsLowRiskRemediationCaveats(),
+		FailureReasons:     dedupeStrings(dryRun.FailureReasons),
+		RemediationHints:   awsLowRiskRemediationRemediationHints(dryRun.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsLowRiskRemediationCurrentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			awsIssueURL(awsRemediationApprovalCurrentIssue),
+			"/docs/aws-low-risk-live-remediation",
+			"/docs/aws-remediation-dry-run-executor",
+			"/docs/aws-remediation-approval-rbac",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSLowRiskRemediationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsLowRiskRemediationEntries(dryRunEntries []AWSRemediationDryRunEntry, allowlistByAction map[string]AWSLowRiskRemediationAllowlistRule, now time.Time) []AWSLowRiskRemediationEntry {
+	entries := []AWSLowRiskRemediationEntry{}
+	for _, entry := range dryRunEntries {
+		if len(entry.IntendedAPICalls) == 0 {
+			continue
+		}
+		call := entry.IntendedAPICalls[0]
+		action := strings.ToLower(call.Service + ":" + call.Operation)
+		rule, ok := allowlistByAction[action]
+		if !ok {
+			continue
+		}
+		if !awsLowRiskRemediationSourceAdmitted(rule, entry.SourceType) {
+			continue
+		}
+		entries = append(entries, awsLowRiskRemediationEntryFromDryRun(entry, call, rule, now))
+	}
+	return entries
+}
+
+func awsLowRiskRemediationSourceAdmitted(rule AWSLowRiskRemediationAllowlistRule, sourceType string) bool {
+	if len(rule.MatchSources) == 0 {
+		return true
+	}
+	for _, match := range rule.MatchSources {
+		if strings.EqualFold(match, sourceType) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsLowRiskRemediationEntryFromDryRun(entry AWSRemediationDryRunEntry, call AWSRemediationDryRunIntendedAPICall, rule AWSLowRiskRemediationAllowlistRule, now time.Time) AWSLowRiskRemediationEntry {
+	preflights := awsLowRiskRemediationPreflights(entry, rule)
+	mutation := awsLowRiskRemediationMutation(entry, call, rule)
+	verifications := awsLowRiskRemediationVerifications(entry)
+	state := awsLowRiskRemediationState(entry, preflights)
+	executionID := "aws-low-risk-remediation:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, rule.Name)
+	out := AWSLowRiskRemediationEntry{
+		ExecutionID:        executionID,
+		CalculationVersion: awsLowRiskRemediationVersion,
+		DryRunID:           entry.DryRunID,
+		ApprovalID:         entry.ApprovalID,
+		CaseID:             entry.CaseID,
+		SourceArtifactID:   entry.SourceArtifactID,
+		SourceType:         entry.SourceType,
+		State:              state,
+		Severity:           entry.Severity,
+		Score:              entry.Score,
+		Confidence:         entry.Confidence,
+		Title:              fmt.Sprintf("Low-risk remediation: %s", entry.Title),
+		Summary:            fmt.Sprintf("Allowlisted low-risk live remediation for dry-run %s; Identrail records intent and idempotency only and never calls AWS write APIs at this layer.", entry.DryRunID),
+		AccountID:          entry.AccountID,
+		Region:             entry.Region,
+		IdempotencyKey:     entry.IdempotencyKey,
+		AllowlistRule:      rule,
+		Mutation:           mutation,
+		Preflights:         preflights,
+		Verifications:      verifications,
+		RollbackPlan:       entry.RollbackPlan,
+		VerificationPlan:   entry.VerificationPlan,
+		Tradeoffs:          entry.Tradeoffs,
+		AuditTrail:         awsLowRiskRemediationAuditTrail(entry, state, rule, now),
+		KillSwitchEngaged:  entry.KillSwitchEngaged,
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings(append([]string{"remediation_dry_run", "low_risk_allowlist"}, entry.SourceSignals...)),
+		Evidence:           entry.Evidence,
+		EvidenceBoundary:   awsLowRiskRemediationEvidenceBoundary(),
+		ImpactedNodes:      entry.ImpactedNodes,
+		ImpactedPath:       entry.ImpactedPath,
+		NextAction:         awsLowRiskRemediationNextAction(state, rule),
+		ProjectedAt:        now,
+		CreatedAt:          firstNonZeroAWSLowRiskRemediationTime(entry.CreatedAt, now),
+		UpdatedAt:          now,
+	}
+	out.ReadyForLiveApply = state == awsLowRiskRemediationStateProjected && entry.ReadyForApply && !entry.KillSwitchEngaged
+	return out
+}
+
+func awsLowRiskRemediationPreflights(entry AWSRemediationDryRunEntry, rule AWSLowRiskRemediationAllowlistRule) []AWSLowRiskRemediationPreflight {
+	preflights := []AWSLowRiskRemediationPreflight{
+		{
+			Name:      "allowlist_action_admitted",
+			Status:    "passed",
+			Rationale: fmt.Sprintf("Action %s is admitted by allowlist rule %s.", rule.Action, rule.Name),
+		},
+		{
+			Name:      "dry_run_would_succeed",
+			Status:    awsLowRiskRemediationPreflightStatus(entry.Outcome == awsRemediationDryRunOutcomeWouldSucceed),
+			Rationale: "Upstream dry-run must project would_succeed before any live apply.",
+		},
+		{
+			Name:      "ready_for_apply",
+			Status:    awsLowRiskRemediationPreflightStatus(entry.ReadyForApply),
+			Rationale: "Upstream dry-run must declare ready_for_apply=true before any live apply.",
+		},
+		{
+			Name:      "kill_switch_off",
+			Status:    awsLowRiskRemediationPreflightStatus(!entry.KillSwitchEngaged),
+			Rationale: "Tenant-scoped remediation kill switch must be off.",
+		},
+		{
+			Name:      "idempotency_key_present",
+			Status:    awsLowRiskRemediationPreflightStatus(strings.TrimSpace(entry.IdempotencyKey) != ""),
+			Rationale: "Deterministic idempotency key must be present so retries do not double-apply.",
+		},
+	}
+	if len(entry.FailedPrereqs) > 0 {
+		preflights = append(preflights, AWSLowRiskRemediationPreflight{
+			Name:      "upstream_prerequisites",
+			Status:    "blocked",
+			Rationale: fmt.Sprintf("Upstream dry-run still has %d failed prerequisite(s); resolve them before retrying.", len(entry.FailedPrereqs)),
+		})
+	}
+	return preflights
+}
+
+func awsLowRiskRemediationPreflightStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsLowRiskRemediationMutation(entry AWSRemediationDryRunEntry, call AWSRemediationDryRunIntendedAPICall, rule AWSLowRiskRemediationAllowlistRule) AWSLowRiskRemediationMutationRecord {
+	return AWSLowRiskRemediationMutationRecord{
+		Service:        call.Service,
+		Operation:      call.Operation,
+		TargetResource: call.TargetResource,
+		ChangeKind:     rule.Category,
+		BeforeRef:      firstNonEmptyAWSValue(entry.DiffIntent.BeforeRef, entry.CaseID),
+		AfterRef:       firstNonEmptyAWSValue(entry.DiffIntent.AfterRef, fmt.Sprintf("after://%s", entry.CaseID)),
+		ParameterRefs:  call.ParameterRefs,
+	}
+}
+
+func awsLowRiskRemediationVerifications(entry AWSRemediationDryRunEntry) []AWSLowRiskRemediationVerificationRecord {
+	out := make([]AWSLowRiskRemediationVerificationRecord, 0, len(entry.VerificationChecks))
+	for _, check := range entry.VerificationChecks {
+		out = append(out, AWSLowRiskRemediationVerificationRecord{
+			Source:      check.Source,
+			Signal:      check.Signal,
+			Status:      "pending",
+			Description: check.Description,
+		})
+	}
+	return out
+}
+
+func awsLowRiskRemediationState(entry AWSRemediationDryRunEntry, preflights []AWSLowRiskRemediationPreflight) string {
+	if entry.KillSwitchEngaged {
+		return awsLowRiskRemediationStateBlocked
+	}
+	for _, preflight := range preflights {
+		if preflight.Status != "blocked" {
+			continue
+		}
+		// Safety-preflight failures (kill switch, idempotency, allowlist,
+		// upstream-prereq) put the entry into `blocked`; readiness failures
+		// (dry-run outcome or ready_for_apply) put it into `skipped` so
+		// operators see the difference between "unsafe" and "not yet ready".
+		if awsLowRiskRemediationPreflightIsSafety(preflight.Name) {
+			return awsLowRiskRemediationStateBlocked
+		}
+	}
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || !entry.ReadyForApply {
+		return awsLowRiskRemediationStateSkipped
+	}
+	return awsLowRiskRemediationStateProjected
+}
+
+func awsLowRiskRemediationPreflightIsSafety(name string) bool {
+	switch name {
+	case "allowlist_action_admitted", "kill_switch_off", "idempotency_key_present", "upstream_prerequisites":
+		return true
+	}
+	return false
+}
+
+func awsLowRiskRemediationNextAction(state string, rule AWSLowRiskRemediationAllowlistRule) string {
+	switch state {
+	case awsLowRiskRemediationStateProjected:
+		return fmt.Sprintf("Allowlist rule %s admits this mutation; the wave-8.04+ live executor may apply it idempotently when its feature flag opens.", rule.Name)
+	case awsLowRiskRemediationStateSkipped:
+		return "Upstream dry-run is not ready (outcome != would_succeed or ready_for_apply=false); advance the dry-run before retrying."
+	case awsLowRiskRemediationStateBlocked:
+		return "A preflight check or the tenant kill switch is blocking this entry; satisfy the failing check before retrying."
+	}
+	return "Inspect this entry for the projected next action."
+}
+
+func awsLowRiskRemediationAuditTrail(entry AWSRemediationDryRunEntry, state string, rule AWSLowRiskRemediationAllowlistRule, now time.Time) []AWSLowRiskRemediationAuditEntry {
+	trail := []AWSLowRiskRemediationAuditEntry{}
+	trail = append(trail, entry.AuditTrail...)
+	trail = append(trail, AWSLowRiskRemediationAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("low-risk-projected", entry.DryRunID, rule.Name),
+		Actor:      "identrail-low-risk-executor",
+		EventType:  "low_risk_execution_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Allowlist rule=%s state=%s; Identrail did not call any AWS write API at this layer.", rule.Name, state),
+	})
+	return trail
+}
+
+func awsLowRiskRemediationRelationships(entries []AWSLowRiskRemediationEntry) []AWSLowRiskRemediationRelationship {
+	relationships := []AWSLowRiskRemediationRelationship{}
+	for _, entry := range entries {
+		evidenceRef := firstAWSRemediationCaseEvidenceRef(entry.Evidence)
+		target := strings.TrimSpace(entry.Mutation.TargetResource)
+		if target != "" {
+			relationships = append(relationships, AWSLowRiskRemediationRelationship{
+				ExecutionID: entry.ExecutionID,
+				Type:        "low_risk_targets_node",
+				FromNodeID:  entry.ExecutionID,
+				ToNodeID:    target,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSLowRiskRemediationEntries(all, filtered []AWSLowRiskRemediationEntry, relationships []AWSLowRiskRemediationRelationship) AWSLowRiskRemediationSummary {
+	summary := AWSLowRiskRemediationSummary{
+		TotalEntries:    len(all),
+		FilteredEntries: len(filtered),
+		StateCounts:     map[string]int{},
+		ActionCounts:    map[string]int{},
+		CategoryCounts:  map[string]int{},
+		SeverityCounts:  map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.StateCounts[entry.State]++
+		summary.ActionCounts[entry.AllowlistRule.Action]++
+		summary.CategoryCounts[entry.AllowlistRule.Category]++
+		if strings.TrimSpace(entry.Severity) != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.ReadyForLiveApply {
+			summary.ReadyForLiveApplyCount++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		for _, preflight := range entry.Preflights {
+			if preflight.Status == "blocked" {
+				summary.FailedPreflightCount++
+			}
+		}
+		summary.MutationCount++
+		summary.VerificationCount += len(entry.Verifications)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSLowRiskRemediationEntries(entries []AWSLowRiskRemediationEntry, request AWSLowRiskRemediationRequest) ([]AWSLowRiskRemediationEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"dry_run_id":      strings.TrimSpace(request.DryRunID),
+		"case_id":         strings.TrimSpace(request.CaseID),
+		"action":          strings.TrimSpace(request.Action),
+		"action_category": normalizeAWSRuntimeEventFilterToken(request.ActionCategory),
+		"state":           normalizeAWSRuntimeEventFilterToken(request.State),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSLowRiskRemediationEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+			continue
+		}
+		if filters["dry_run_id"] != "" && !strings.EqualFold(filters["dry_run_id"], entry.DryRunID) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["action"] != "" && !strings.EqualFold(filters["action"], entry.AllowlistRule.Action) {
+			continue
+		}
+		if filters["action_category"] != "" && filters["action_category"] != normalizeAWSRuntimeEventFilterToken(entry.AllowlistRule.Category) {
+			continue
+		}
+		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsLowRiskRemediationSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsLowRiskRemediationSearchMatch(entry AWSLowRiskRemediationEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.ExecutionID, entry.DryRunID, entry.ApprovalID, entry.CaseID,
+		entry.SourceArtifactID, entry.SourceType, entry.State, entry.Severity,
+		entry.Title, entry.Summary, entry.IdempotencyKey, entry.NextAction,
+		entry.AllowlistRule.Name, entry.AllowlistRule.Category, entry.AllowlistRule.Action, entry.AllowlistRule.Rationale,
+		entry.Mutation.Service, entry.Mutation.Operation, entry.Mutation.TargetResource, entry.Mutation.ChangeKind,
+		entry.RollbackPlan.Strategy, entry.VerificationPlan.Strategy,
+	}
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.Mutation.ParameterRefs...)
+	for _, preflight := range entry.Preflights {
+		values = append(values, preflight.Name, preflight.Status, preflight.Rationale)
+	}
+	for _, verification := range entry.Verifications {
+		values = append(values, verification.Source, verification.Signal, verification.Status, verification.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSLowRiskRemediationStatus(sourceStatus string, filtered []AWSLowRiskRemediationEntry, diagnostics []AWSLowRiskRemediationDiagnostic) (string, float64) {
+	if sourceStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if sourceStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsLowRiskRemediationCaveats() []string {
+	return []string{
+		"Low-risk live remediation entries are read-only projections; Identrail never calls IAM, STS, Secrets Manager, KMS, or Organizations write APIs at this layer.",
+		"Only allowlisted AWS actions are admitted (tagging, stale-metadata cleanup, approved detach/disable); any action outside the allowlist is excluded from this projection.",
+		"ready_for_live_apply is a planning signal — controlled live execution belongs to the wave-8.04+ executors and their own feature flags.",
+	}
+}
+
+func awsLowRiskRemediationRemediationHints(source []string) []string {
+	hints := []string{
+		"Resolve any failed preflight before retrying; the dry-run upstream determines outcome and ready_for_apply for these entries.",
+		"Use the idempotency key recorded here as the deterministic id when later wave executors apply the change so retries cannot double-apply.",
+		"Every allowlist rule is code-managed; any change to the allowlist is a code review under the wave-8 safety controls.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsLowRiskRemediationDiagnostics(source []AWSRemediationApprovalDiagnostic) []AWSLowRiskRemediationDiagnostic {
+	out := make([]AWSLowRiskRemediationDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSLowRiskRemediationDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsLowRiskRemediationCoverageGaps(source []AWSRemediationApprovalCoverageGap) []AWSLowRiskRemediationCoverageGap {
+	gaps := []AWSLowRiskRemediationCoverageGap{{
+		Capability:  "aws_low_risk_live_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1538 emits low-risk live remediation projections only; the live IAM write call is gated to the wave-8.04+ apply executors.",
+		Remediation: "Wire the controlled live-apply executors in the matching wave-8 issues once their safety gates are in place.",
+	}}
+	for _, gap := range source {
+		gaps = append(gaps, AWSLowRiskRemediationCoverageGap(gap))
+	}
+	return gaps
+}
+
+func awsLowRiskRemediationEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSLowRiskRemediationTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_low_risk_live_remediation_test.go
+++ b/internal/api/aws_low_risk_live_remediation_test.go
@@ -1,0 +1,285 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newLowRiskRemediationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSLowRiskRemediationBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	svc, ws := newLowRiskRemediationService(t, "project-low-risk-remediation", now)
+
+	result, err := svc.GetAWSLowRiskRemediation(defaultScopeContext(), ws, "project-low-risk-remediation", AWSLowRiskRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get low-risk remediation: %v", err)
+	}
+	if result.CurrentIssueRef != "#1538" || result.Version != awsLowRiskRemediationVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Allowlist) == 0 {
+		t.Fatalf("expected allowlist to be present in the result: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	for i := 1; i < len(result.Entries); i++ {
+		if result.Entries[i-1].Score < result.Entries[i].Score {
+			t.Fatalf("entries are not ranked by descending score: %+v", result.Entries)
+		}
+	}
+	for _, entry := range result.Entries {
+		if entry.ExecutionID == "" || entry.CalculationVersion != awsLowRiskRemediationVersion || entry.DryRunID == "" || entry.CaseID == "" {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.IdempotencyKey == "" {
+			t.Fatalf("entry missing idempotency key: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if entry.Mutation.Service == "" || entry.Mutation.Operation == "" {
+			t.Fatalf("entry missing mutation: %+v", entry)
+		}
+		if entry.AllowlistRule.Name == "" || entry.AllowlistRule.Action == "" {
+			t.Fatalf("entry missing allowlist rule: %+v", entry)
+		}
+		if len(entry.Preflights) == 0 {
+			t.Fatalf("entry missing preflights: %+v", entry)
+		}
+		if entry.EvidenceBoundary != awsLowRiskRemediationEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		if entry.State == "" {
+			t.Fatalf("entry missing state: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("low-risk remediation serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSLowRiskRemediationOnlyAdmitsAllowlistedActions(t *testing.T) {
+	now := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC)
+	allowlistByAction := map[string]AWSLowRiskRemediationAllowlistRule{}
+	for _, rule := range awsLowRiskRemediationAllowlist() {
+		allowlistByAction[strings.ToLower(rule.Action)] = rule
+	}
+
+	dryRunEntries := []AWSRemediationDryRunEntry{
+		{
+			DryRunID:       "dry-run-allowlisted",
+			ApprovalID:     "approval-allowlisted",
+			CaseID:         "case-allowlisted",
+			SourceType:     "aws_access_key_quarantine",
+			IdempotencyKey: "idk-1",
+			Outcome:        awsRemediationDryRunOutcomeWouldSucceed,
+			ReadyForApply:  true,
+			IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+				Service:        "iam",
+				Operation:      "UpdateAccessKey",
+				TargetResource: "AKIA-orders",
+				ParameterRefs:  []string{"status://inactive"},
+			}},
+		},
+		{
+			DryRunID:       "dry-run-not-allowlisted",
+			ApprovalID:     "approval-not-allowlisted",
+			CaseID:         "case-not-allowlisted",
+			SourceType:     "trust_policy_hardening",
+			IdempotencyKey: "idk-2",
+			Outcome:        awsRemediationDryRunOutcomeWouldSucceed,
+			ReadyForApply:  true,
+			IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+				Service:        "iam",
+				Operation:      "UpdateAssumeRolePolicy",
+				TargetResource: "aws:identity:role/orders-ci",
+			}},
+		},
+		{
+			DryRunID:       "dry-run-wrong-source",
+			ApprovalID:     "approval-wrong-source",
+			CaseID:         "case-wrong-source",
+			SourceType:     "blast_radius",
+			IdempotencyKey: "idk-3",
+			Outcome:        awsRemediationDryRunOutcomeWouldSucceed,
+			ReadyForApply:  true,
+			IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+				Service:        "iam",
+				Operation:      "UpdateAccessKey",
+				TargetResource: "AKIA-orders",
+			}},
+		},
+	}
+
+	entries := awsLowRiskRemediationEntries(dryRunEntries, allowlistByAction, now)
+	if len(entries) != 1 {
+		t.Fatalf("expected only the allowlisted-and-source-matched entry to admit, got %+v", entries)
+	}
+	if entries[0].DryRunID != "dry-run-allowlisted" {
+		t.Fatalf("expected dry-run-allowlisted entry, got %+v", entries[0])
+	}
+	if entries[0].AllowlistRule.Name == "" || entries[0].AllowlistRule.Action != "iam:UpdateAccessKey" {
+		t.Fatalf("admitted entry missing allowlist rule: %+v", entries[0].AllowlistRule)
+	}
+}
+
+func TestAWSLowRiskRemediationStateHonorsDryRunGates(t *testing.T) {
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	allowlistByAction := map[string]AWSLowRiskRemediationAllowlistRule{}
+	for _, rule := range awsLowRiskRemediationAllowlist() {
+		allowlistByAction[strings.ToLower(rule.Action)] = rule
+	}
+	ready := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-ready",
+		CaseID:           "case-ready",
+		SourceType:       "aws_access_key_quarantine",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "UpdateAccessKey", TargetResource: "AKIA-x"}},
+	}
+	entries := awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{ready}, allowlistByAction, now)
+	if entries[0].State != awsLowRiskRemediationStateProjected || !entries[0].ReadyForLiveApply {
+		t.Fatalf("ready dry-run must project ready-for-live-apply, got %+v", entries[0])
+	}
+
+	skipped := ready
+	skipped.Outcome = awsRemediationDryRunOutcomeRequiresReview
+	skipped.ReadyForApply = false
+	skipped.DryRunID = "dr-skipped"
+	skipped.CaseID = "case-skipped"
+	entries = awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{skipped}, allowlistByAction, now)
+	if entries[0].State != awsLowRiskRemediationStateSkipped || entries[0].ReadyForLiveApply {
+		t.Fatalf("not-ready dry-run must surface skipped state, got %+v", entries[0])
+	}
+
+	blocked := ready
+	blocked.DryRunID = "dr-blocked"
+	blocked.CaseID = "case-blocked"
+	blocked.KillSwitchEngaged = true
+	entries = awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{blocked}, allowlistByAction, now)
+	if entries[0].State != awsLowRiskRemediationStateBlocked || entries[0].ReadyForLiveApply {
+		t.Fatalf("kill switch must block low-risk entry, got %+v", entries[0])
+	}
+}
+
+func TestFilterAWSLowRiskRemediationEntriesAppliesFilters(t *testing.T) {
+	entries := []AWSLowRiskRemediationEntry{
+		{
+			ExecutionID:   "exec-tag",
+			DryRunID:      "dr-1",
+			CaseID:        "case-1",
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			State:         awsLowRiskRemediationStateProjected,
+			Severity:      "low",
+			AllowlistRule: AWSLowRiskRemediationAllowlistRule{Name: "iam_tag_role_owner", Category: "tagging", Action: "iam:TagRole"},
+			Mutation:      AWSLowRiskRemediationMutationRecord{Service: "iam", Operation: "TagRole"},
+		},
+		{
+			ExecutionID:   "exec-detach",
+			DryRunID:      "dr-2",
+			CaseID:        "case-2",
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			State:         awsLowRiskRemediationStateBlocked,
+			Severity:      "high",
+			AllowlistRule: AWSLowRiskRemediationAllowlistRule{Name: "iam_detach_role_policy_orphaned", Category: "approved_detach", Action: "iam:DetachRolePolicy"},
+			Mutation:      AWSLowRiskRemediationMutationRecord{Service: "iam", Operation: "DetachRolePolicy"},
+		},
+	}
+
+	projected, applied := filterAWSLowRiskRemediationEntries(entries, AWSLowRiskRemediationRequest{State: awsLowRiskRemediationStateProjected})
+	if applied["state"] != awsLowRiskRemediationStateProjected || len(projected) != 1 || projected[0].ExecutionID != "exec-tag" {
+		t.Fatalf("expected state=projected filter: applied=%+v entries=%+v", applied, projected)
+	}
+
+	detach, applied := filterAWSLowRiskRemediationEntries(entries, AWSLowRiskRemediationRequest{ActionCategory: "approved_detach"})
+	if applied["action_category"] != "approved-detach" || len(detach) != 1 || detach[0].ExecutionID != "exec-detach" {
+		t.Fatalf("expected action_category filter: applied=%+v entries=%+v", applied, detach)
+	}
+
+	action, applied := filterAWSLowRiskRemediationEntries(entries, AWSLowRiskRemediationRequest{Action: "iam:TagRole"})
+	if applied["action"] != "iam:TagRole" || len(action) != 1 || action[0].ExecutionID != "exec-tag" {
+		t.Fatalf("expected action filter: applied=%+v entries=%+v", applied, action)
+	}
+}
+
+func TestGetAWSLowRiskRemediationFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC)
+	svc, ws := newLowRiskRemediationService(t, "project-low-risk-remediation-states", now)
+
+	denied, err := svc.GetAWSLowRiskRemediation(defaultScopeContext(), ws, "project-low-risk-remediation-states", AWSLowRiskRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Entries) != 0 {
+		t.Fatalf("permission denied must be explicit and suppress entries: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSLowRiskRemediation(defaultScopeContext(), ws, "project-low-risk-remediation-states", AWSLowRiskRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+	})
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if empty.Status == "blocked" {
+		t.Fatalf("empty fixture should not produce a blocked status: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSLowRiskRemediation(defaultScopeContext(), ws, "project-low-risk-remediation-states", AWSLowRiskRemediationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSLowRiskRemediation(t *testing.T) {
+	now := time.Date(2026, 6, 28, 14, 0, 0, 0, time.UTC)
+	svc, _ := newLowRiskRemediationService(t, "project-low-risk-remediation-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-low-risk-remediation-route/aws/low-risk-live-remediation?connector_id=aws-prod&fixture_state=success&state=projected", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		LowRisk AWSLowRiskRemediationResult `json:"low_risk_live_remediation"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.LowRisk.CurrentIssueRef != "#1538" || body.LowRisk.AppliedFilters["state"] != "projected" {
+		t.Fatalf("unexpected route payload: %+v", body.LowRisk)
+	}
+}

--- a/internal/api/aws_low_risk_live_remediation_test.go
+++ b/internal/api/aws_low_risk_live_remediation_test.go
@@ -148,6 +148,72 @@ func TestAWSLowRiskRemediationOnlyAdmitsAllowlistedActions(t *testing.T) {
 	}
 }
 
+func TestAWSLowRiskRemediationEnforcesMaxBlastRadiusByRiskTier(t *testing.T) {
+	now := time.Date(2026, 6, 28, 11, 30, 0, 0, time.UTC)
+	allowlistByAction := map[string]AWSLowRiskRemediationAllowlistRule{}
+	for _, rule := range awsLowRiskRemediationAllowlist() {
+		allowlistByAction[strings.ToLower(rule.Action)] = rule
+	}
+
+	base := AWSRemediationDryRunEntry{
+		CaseID:           "case-tier",
+		SourceType:       "aws_access_key_quarantine",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "UpdateAccessKey", TargetResource: "AKIA-1"}},
+	}
+
+	low := base
+	low.DryRunID = "dr-low"
+	low.RiskTier = "low"
+	low.Severity = "low"
+	if got := awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{low}, allowlistByAction, now); len(got) != 1 {
+		t.Fatalf("low risk_tier entry must be admitted, got %+v", got)
+	}
+
+	high := base
+	high.DryRunID = "dr-high"
+	high.RiskTier = "high"
+	high.Severity = "high"
+	if got := awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{high}, allowlistByAction, now); len(got) != 0 {
+		t.Fatalf("high risk_tier entry must be excluded from the low-risk projection, got %+v", got)
+	}
+
+	criticalBySeverity := base
+	criticalBySeverity.DryRunID = "dr-critical-severity"
+	criticalBySeverity.RiskTier = "low"
+	criticalBySeverity.Severity = "critical"
+	if got := awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{criticalBySeverity}, allowlistByAction, now); len(got) != 0 {
+		t.Fatalf("critical severity must be excluded even if risk_tier is reported low, got %+v", got)
+	}
+
+	mediumLow := base
+	mediumLow.DryRunID = "dr-medium"
+	mediumLow.RiskTier = "medium"
+	mediumLow.Severity = "low"
+	if got := awsLowRiskRemediationEntries([]AWSRemediationDryRunEntry{mediumLow}, allowlistByAction, now); len(got) != 0 {
+		t.Fatalf("medium risk_tier exceeds MaxBlastRadius=low and must be excluded, got %+v", got)
+	}
+}
+
+func TestAWSLowRiskRemediationAllowlistOnlyAdvertisesReachableActions(t *testing.T) {
+	// Every allowlist rule must map to an AWS action the dry-run executor can
+	// actually emit today. Advertising rules that the dry-run never produces
+	// would mislead operators and the UI.
+	reachable := map[string]struct{}{
+		"iam:updateaccesskey":   {},
+		"iam:detachrolepolicy":  {},
+		"iam:detachuserpolicy":  {},
+		"iam:detachgrouppolicy": {},
+	}
+	for _, rule := range awsLowRiskRemediationAllowlist() {
+		if _, ok := reachable[strings.ToLower(rule.Action)]; !ok {
+			t.Fatalf("allowlist rule %s advertises unreachable action %s; wire the dry-run executor before advertising it", rule.Name, rule.Action)
+		}
+	}
+}
+
 func TestAWSLowRiskRemediationStateHonorsDryRunGates(t *testing.T) {
 	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
 	allowlistByAction := map[string]AWSLowRiskRemediationAllowlistRule{}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3389,6 +3389,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"dry_run": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSLowRiskRemediation(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSLowRiskRemediationRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			DryRunID:       strings.TrimSpace(c.Query("dry_run_id")),
+			CaseID:         strings.TrimSpace(c.Query("case_id")),
+			Action:         strings.TrimSpace(c.Query("action")),
+			ActionCategory: strings.TrimSpace(c.Query("action_category")),
+			State:          strings.TrimSpace(c.Query("state")),
+			Severity:       strings.TrimSpace(c.Query("severity")),
+			Search:         strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws low-risk live remediation request"})
+			default:
+				logger.Error("get aws low-risk live remediation",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws low-risk live remediation"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"low_risk_live_remediation": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1964,6 +1964,48 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS low-risk live remediation with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ low_risk_live_remediation: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectLowRiskLiveRemediation(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        dryRunID: 'aws-remediation-dry-run:orders-ci',
+        caseID: 'aws-remediation-case:orders-ci',
+        action: 'iam:UpdateAccessKey',
+        actionCategory: 'approved_disable',
+        state: 'projected',
+        severity: 'low',
+        search: 'allowlist'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/low-risk-live-remediation?');
+    expect(url).toContain('action_category=approved_disable');
+    expect(url).toContain('state=projected');
+    expect(url).toContain('action=iam%3AUpdateAccessKey');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Secrets Manager metadata inventory with scoped headers and fixture state', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4209,6 +4209,152 @@ export type AWSRemediationDryRunQuery = {
   search?: string;
 };
 
+export type AWSLowRiskRemediationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSLowRiskRemediationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSLowRiskRemediationState = 'projected' | 'skipped' | 'blocked' | string;
+export type AWSLowRiskRemediationActionCategory = 'tagging' | 'stale_metadata_cleanup' | 'approved_disable' | 'approved_detach' | string;
+
+export type AWSLowRiskRemediationAllowlistRule = {
+  name: string;
+  category: AWSLowRiskRemediationActionCategory;
+  action: string;
+  match_sources?: string[];
+  max_blast_radius?: string;
+  rationale: string;
+};
+
+export type AWSLowRiskRemediationPreflight = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSLowRiskRemediationMutationRecord = {
+  service: string;
+  operation: string;
+  target_resource: string;
+  change_kind: string;
+  before_ref?: string;
+  after_ref?: string;
+  parameter_refs?: string[];
+};
+
+export type AWSLowRiskRemediationVerificationRecord = {
+  source: string;
+  signal: string;
+  status: string;
+  description: string;
+};
+
+export type AWSLowRiskRemediationRelationship = {
+  execution_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSLowRiskRemediationEntry = {
+  execution_id: string;
+  calculation_version: string;
+  dry_run_id: string;
+  approval_id: string;
+  case_id: string;
+  source_artifact_id: string;
+  source_type: string;
+  state: AWSLowRiskRemediationState;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  idempotency_key: string;
+  allowlist_rule: AWSLowRiskRemediationAllowlistRule;
+  mutation: AWSLowRiskRemediationMutationRecord;
+  preflights: AWSLowRiskRemediationPreflight[];
+  verifications: AWSLowRiskRemediationVerificationRecord[];
+  rollback_plan: AWSRemediationRollbackPlan;
+  verification_plan: AWSRemediationVerificationPlan;
+  tradeoffs: AWSRemediationTradeoff[];
+  audit_trail: AWSRemediationAuditEntry[];
+  kill_switch_engaged: boolean;
+  ready_for_live_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSLowRiskRemediationSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  state_counts: Record<string, number>;
+  action_counts: Record<string, number>;
+  category_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  ready_for_live_apply_count: number;
+  kill_switch_engaged_count: number;
+  failed_preflight_count: number;
+  mutation_count: number;
+  verification_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSLowRiskRemediationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSLowRiskRemediationStatus;
+  fixture_state?: AWSLowRiskRemediationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  allowlist: AWSLowRiskRemediationAllowlistRule[];
+  summary: AWSLowRiskRemediationSummary;
+  entries: AWSLowRiskRemediationEntry[];
+  relationships: AWSLowRiskRemediationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSLowRiskRemediationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSLowRiskRemediationFixtureState;
+  accountID?: string;
+  region?: string;
+  dryRunID?: string;
+  caseID?: string;
+  action?: string;
+  actionCategory?: string;
+  state?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSBlastRadiusStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSBlastRadiusFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSBlastRadiusSeverity = 'critical' | 'high' | 'medium' | 'low' | string;
@@ -8531,6 +8677,29 @@ export const apiClient = {
         source_type: query?.sourceType,
         outcome: query?.outcome,
         risk_tier: query?.riskTier,
+        severity: query?.severity,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectLowRiskLiveRemediation(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSLowRiskRemediationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ low_risk_live_remediation: AWSLowRiskRemediationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/low-risk-live-remediation${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        dry_run_id: query?.dryRunID,
+        case_id: query?.caseID,
+        action: query?.action,
+        action_category: query?.actionCategory,
+        state: query?.state,
         severity: query?.severity,
         search: query?.search
       })}`,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -75,6 +75,8 @@ import {
   type AWSRemediationApprovalResult,
   type AWSRemediationDryRunEntry,
   type AWSRemediationDryRunResult,
+  type AWSLowRiskRemediationEntry,
+  type AWSLowRiskRemediationResult,
   type AWSBlastRadiusFinding,
   type AWSBlastRadiusResult,
   type AWSLeastPrivilegeRecommendation,
@@ -11601,6 +11603,111 @@ function AWSRemediationDryRunContent({
   );
 }
 
+function awsLowRiskRemediationStage(entry: AWSLowRiskRemediationEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.state === 'blocked') {
+    return 'not-available';
+  }
+  if (entry.state !== 'projected' || !entry.ready_for_live_apply) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsLowRiskRemediationActionLabel(entry: AWSLowRiskRemediationEntry): string {
+  const rule = entry.allowlist_rule;
+  return `${rule.action} · ${formatTokenLabel(rule.category)}`;
+}
+
+function awsLowRiskRemediationPreflightLabel(entry: AWSLowRiskRemediationEntry): string {
+  const passed = entry.preflights.filter((preflight) => preflight.status === 'passed').length;
+  const blocked = entry.preflights.length - passed;
+  return `${passed} passed · ${blocked} blocked`;
+}
+
+function awsLowRiskRemediationReadinessLabel(entry: AWSLowRiskRemediationEntry): string {
+  if (entry.ready_for_live_apply) {
+    return `ready · ${entry.verifications.length} verifications`;
+  }
+  return formatTokenLabel(entry.state);
+}
+
+function AWSLowRiskRemediationContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSLowRiskRemediationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = result?.entries ?? [];
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.allowlist.length} allowlist rules · ${result.summary.failed_preflight_count} blocked preflights`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS low-risk live remediation">
+      <h3>AWS low-risk live remediation</h3>
+      <p className="idt-app-kicker">
+        Read-only projection of allowlisted low-risk remediations (tagging, stale-metadata cleanup, approved
+        detach/disable) derived from the approved dry-run executor. Each entry records the allowlist rule, idempotency
+        key, intended mutation, preflight checks, verification records, and audit trail. Identrail never calls IAM/STS/
+        Secrets Manager/KMS/Organizations write APIs at this layer. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS low-risk live remediation"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Projecting low-risk remediation"
+          body="Identrail is matching approved dry-run entries against the code-managed allowlist of low-risk AWS actions."
+        />
+      ) : null}
+      {!error && !loading && result && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={result.status === 'blocked' ? 'Permission required' : 'No low-risk entries'}
+          title={result.status === 'blocked' ? 'Low-risk projection needs approved dry-run evidence' : 'No low-risk entries projected'}
+          body={result.failure_reasons[0] ?? 'No upstream dry-run entry matched an allowlist rule for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && result && result.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {result.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS low-risk live remediation entries"
+          rows={rows}
+          getRowKey={(row) => row.execution_id}
+          columns={[
+            { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
+            { key: 'rule', header: 'Allowlist rule', render: (row) => formatTokenLabel(row.allowlist_rule.name) },
+            { key: 'action', header: 'Action', render: (row) => awsLowRiskRemediationActionLabel(row) },
+            { key: 'preflights', header: 'Preflights', render: (row) => awsLowRiskRemediationPreflightLabel(row) },
+            { key: 'state', header: 'State', render: (row) => awsLowRiskRemediationReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsLowRiskRemediationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsBlastRadiusSeverityStage(severity: string): AWSCapabilityStage {
   switch (severity) {
     case 'critical':
@@ -13080,6 +13187,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [remediationDryRunLoading, setRemediationDryRunLoading] = useState(false);
   const [remediationDryRunError, setRemediationDryRunError] = useState('');
   const remediationDryRunRequestRef = useRef(0);
+  const [lowRiskRemediation, setLowRiskRemediation] = useState<AWSLowRiskRemediationResult | null>(null);
+  const [lowRiskRemediationLoading, setLowRiskRemediationLoading] = useState(false);
+  const [lowRiskRemediationError, setLowRiskRemediationError] = useState('');
+  const lowRiskRemediationRequestRef = useRef(0);
   const [blastRadius, setBlastRadius] = useState<AWSBlastRadiusResult | null>(null);
   const [blastRadiusLoading, setBlastRadiusLoading] = useState(false);
   const [blastRadiusError, setBlastRadiusError] = useState('');
@@ -13797,6 +13908,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     };
   }, [loadRemediationDryRun]);
 
+  const loadLowRiskRemediation = useCallback(async () => {
+    const requestID = ++lowRiskRemediationRequestRef.current;
+    setLowRiskRemediation(null);
+    setLowRiskRemediationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setLowRiskRemediationLoading(false);
+      return;
+    }
+    setLowRiskRemediationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectLowRiskLiveRemediation(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== lowRiskRemediationRequestRef.current) {
+        return;
+      }
+      setLowRiskRemediation(response.low_risk_live_remediation);
+    } catch (error) {
+      if (requestID !== lowRiskRemediationRequestRef.current) {
+        return;
+      }
+      setLowRiskRemediationError(formatAPIError(error, 'Unable to load AWS low-risk live remediation.'));
+    } finally {
+      if (requestID === lowRiskRemediationRequestRef.current) {
+        setLowRiskRemediationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadLowRiskRemediation();
+    return () => {
+      lowRiskRemediationRequestRef.current += 1;
+    };
+  }, [loadLowRiskRemediation]);
+
   const loadBlastRadius = useCallback(async () => {
     const requestID = ++blastRadiusRequestRef.current;
     setBlastRadius(null);
@@ -14339,6 +14498,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={remediationDryRunLoading}
             error={remediationDryRunError}
             onRetry={loadRemediationDryRun}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSLowRiskRemediationContent
+            result={lowRiskRemediation}
+            loading={lowRiskRemediationLoading}
+            error={lowRiskRemediationError}
+            onRetry={loadLowRiskRemediation}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary

Adds a read-only, metadata-only projection of allowlisted low-risk AWS
remediation actions derived from the approved dry-run executor (#1537). The
allowlist is intentionally narrow and code-managed: `iam:TagRole`,
`iam:UntagRole`, `iam:UpdateAccessKey` (approved quarantine disable), and
`iam:DetachRolePolicy` (approved orphaned-policy detach). Each entry records
the allowlist rule, idempotency key, intended mutation, preflight checks
(allowlist admitted, dry-run-would-succeed, ready-for-apply, kill-switch-off,
idempotency key present, upstream prereqs), per-source verification records,
rollback plan, and audit trail. State semantics: `projected` (safety
preflights passed + dry-run ready), `skipped` (dry-run not ready), `blocked`
(safety preflight failed or kill switch engaged). `ready_for_live_apply` is
true only when state is `projected` and the upstream dry-run is itself
`ready_for_apply`.

Closes #1538. Part of #1472.

## Why

Wave 8 needs a narrow, well-defined surface for the first wave of actual live
AWS remediations. This PR ships the metadata projection plus the
deterministic allowlist + idempotency the wave-8.04+ apply executors will use
to replay changes safely.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive endpoint, types, and UI)
- [x] Risk level assessed (read-only projection; never calls AWS write APIs; never inlines policy bodies or secrets)

## Validation

\`\`\`bash
make fmt-check
go vet ./...
go test ./internal/api/...
make api-example-contract-check
make web-route-integrity-check
npm run test:ci --prefix web
npm run build --prefix web
\`\`\`

All passed locally on this branch (fresh off origin/dev).

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] \`CHANGELOG.md\` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1538
Refs #1472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only, metadata‑only projection of allowlisted low‑risk AWS live remediations from the approved dry‑run executor. Enforces a low‑risk tier ceiling and ships a new API, OpenAPI types, and a UI panel; closes #1538 and prepares wave‑8 apply executors without calling AWS write APIs.

- **New Features**
  - Added `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation` with filters for connector, account, region, dry‑run ID, case ID, `action`, `action_category`, `state`, `severity`, and `search`.
  - Code‑managed allowlist (narrow by design): `iam:UpdateAccessKey` (approved disable) and `iam:DetachRolePolicy` (approved detach). Each rule declares a `MaxBlastRadius=low`; the projection rejects any dry‑run with `risk_tier`/`severity` above that ceiling.
  - States: `projected`, `skipped`, `blocked`. `ready_for_live_apply` only when state is `projected`, upstream dry‑run is `ready_for_apply`, and no kill switch is engaged.
  - OpenAPI v1 updated with route and response/entry schemas; authz wired for project `tenancy.read`.
  - New docs: `aws-low-risk-live-remediation.md`; `CHANGELOG.md` updated.
  - Web: added client method `getAWSProjectLowRiskLiveRemediation`, TS types and tests, and an AWS Runtime panel showing rule, action/category, preflight pass/blocked, readiness, and severity/state with loading/empty/degraded/blocked/error states.

<sup>Written for commit 767043a91369b44fad4b61b167e647fa820d3f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

