### PR TITLE
Implement AWS permission boundary executor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
 - AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
 - AWS low-risk live remediation: `aws-low-risk-live-remediation.md`
+- AWS approved permission boundary executor: `aws-permission-boundary-executor.md`
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`

--- a/docs/aws-permission-boundary-executor.md
+++ b/docs/aws-permission-boundary-executor.md
@@ -1,0 +1,51 @@
+# AWS approved permission boundary executor
+
+Issue #1540 adds a metadata-only projection of approved AWS permission
+boundary execution records. Each entry joins the dry-run executor (#1537)
+with the permission boundary planner (#1532) for cases whose `source_type` is
+`aws_permission_boundary_scp`, whose planner kind is `permission_boundary`,
+and whose dry-run diff kind is `permission_boundary_diff`.
+
+The endpoint is read-only. It never calls IAM or Organizations write APIs and
+never reads, exposes, logs, or persists rendered policy documents, secret
+values, customer payloads, prompts, completions, browser pages,
+code-interpreter output, database rows, or object contents.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-executor`
+
+Response shape: `{ "permission_boundary_executor": AWSPermissionBoundaryExecutorResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`dry_run_id`, `case_id`, `plan_id`, `operation`, `state`, `severity`, and
+`search`.
+
+## Entry Shape
+
+Each entry includes stable source IDs, target identity/account/OU scope,
+the projected IAM `PutRolePermissionsBoundary` or `PutUserPermissionsBoundary`
+call, idempotency key, statement snippets, breakage projection,
+preconditions, policy-simulator refs, rollback and verification plans,
+audit trail, relationships, and `ready_for_live_apply`.
+
+`ready_for_live_apply` is true only when every safety precondition passes,
+the upstream dry-run is `would_succeed` and `ready_for_apply`, the planner is
+ready, breakage is `low`, scope is captured, and no kill switch is engaged.
+
+## States
+
+- `projected`: ready for the wave-8 apply runtime when its feature flag opens.
+- `precondition_failed`: upstream evidence exists but is not ready, such as
+  non-low breakage or a planner/dry-run readiness gate.
+- `blocked`: a safety gate failed, the tenant kill switch is engaged, the
+  operation is unsupported, or the dry-run is blocked.
+
+SCP plans are intentionally excluded; org-level SCP execution belongs to the
+dedicated SCP executor issue.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS approved permission boundary executor**
+panel with execution title, IAM operation, target counts, precondition counts,
+simulation outcome, readiness, and severity/state pill.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -14213,6 +14213,9 @@ components:
         title: { type: string }
         summary: { type: string }
         account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
         region: { type: string }
         identity_node_id: { type: string }
         identity_arn: { type: string }
@@ -16321,6 +16324,9 @@ components:
         title: { type: string }
         summary: { type: string }
         account_id: { type: string }
+        account_ids:
+          type: array
+          items: { type: string }
         region: { type: string }
         idempotency_key: { type: string }
         dry_run_ref: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -14120,7 +14120,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [iam_policy_diff, iam_trust_diff, role_scope_diff, secret_rotation, kms_grant_diff, ai_agent_scope_change, owner_assignment, manual_review]
+          enum: [iam_policy_diff, iam_trust_diff, role_scope_diff, secret_rotation, kms_grant_diff, permission_boundary_diff, ai_agent_scope_change, owner_assignment, manual_review]
         before_ref: { type: string }
         after_ref: { type: string }
         diff_summary: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -15219,7 +15219,7 @@ components:
         audit_trail:
           type: array
           items:
-            $ref: "#/components/schemas/AWSRemediationAuditEntry"
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
         kill_switch_engaged: { type: boolean }
         ready_for_live_apply: { type: boolean }
         read_only_projection: { type: boolean }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -14262,7 +14262,7 @@ components:
         audit_trail:
           type: array
           items:
-            $ref: "#/components/schemas/AWSRemediationAuditEntry"
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
         created_at:
           type: string
           format: date-time

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5125,7 +5125,7 @@ paths:
           name: source_type
           schema:
             type: string
-            enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius]
+            enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius, aws_permission_boundary_scp]
         - in: query
           name: lifecycle
           schema:
@@ -14191,7 +14191,7 @@ components:
         calculation_version: { type: string }
         source_type:
           type: string
-          enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius]
+          enum: [ai_agent_risk, least_privilege, secret_permission_equivalence, blast_radius, aws_permission_boundary_scp]
         source_finding_id: { type: string }
         lifecycle:
           type: string

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -594,6 +594,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-executor
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5443,6 +5448,90 @@ paths:
                     $ref: "#/components/schemas/AWSPermissionBoundarySCPResult"
         "400":
           description: Invalid AWS permission boundary and SCP request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-executor:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS approved permission boundary executor projections
+      operationId: getAWSProjectPermissionBoundaryExecutor
+      description: Joins approved remediation dry-run entries with permission-boundary planner metadata to project controlled IAM PutRolePermissionsBoundary / PutUserPermissionsBoundary execution records. Each record carries idempotency, dry-run/apply/verify metadata, target identities/accounts, preconditions, policy-simulator refs, rollback and verification plans, immutable audit entries, and graph relationships. This endpoint is metadata-only and never calls IAM or Organizations write APIs.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: dry_run_id
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: plan_id
+          schema: { type: string }
+        - in: query
+          name: operation
+          schema:
+            type: string
+            enum: [PutRolePermissionsBoundary, PutUserPermissionsBoundary]
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [projected, precondition_failed, blocked]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across execution IDs, plan IDs, target identities, intended API call, preconditions, simulator metadata, verification, audit, and evidence refs.
+      responses:
+        "200":
+          description: AWS permission boundary executor contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  permission_boundary_executor:
+                    $ref: "#/components/schemas/AWSPermissionBoundaryExecutorResult"
+        "400":
+          description: Invalid AWS permission boundary executor request
           content:
             application/json:
               schema:
@@ -15006,6 +15095,216 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPermissionBoundarySCPRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPermissionBoundaryExecutorPrecondition:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSPermissionBoundaryExecutorSimulation:
+      type: object
+      properties:
+        simulation_ref: { type: string }
+        outcome: { type: string }
+        before_ref: { type: string }
+        after_ref: { type: string }
+        denied_action_count: { type: integer }
+        target_identity_count: { type: integer }
+        signals:
+          type: array
+          items: { type: string }
+    AWSPermissionBoundaryExecutorVerification:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        status: { type: string }
+        description: { type: string }
+    AWSPermissionBoundaryExecutorRelationship:
+      type: object
+      properties:
+        execution_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSPermissionBoundaryExecutorEntry:
+      type: object
+      properties:
+        execution_id: { type: string }
+        calculation_version: { type: string }
+        dry_run_id: { type: string }
+        approval_id: { type: string }
+        case_id: { type: string }
+        plan_id: { type: string }
+        source_artifact_id: { type: string }
+        state:
+          type: string
+          enum: [projected, precondition_failed, blocked]
+        severity: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        operation:
+          type: string
+          enum: [PutRolePermissionsBoundary, PutUserPermissionsBoundary]
+        idempotency_key: { type: string }
+        target_identity_node_ids:
+          type: array
+          items: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        target_ou_paths:
+          type: array
+          items: { type: string }
+        prevented_behavior: { type: string }
+        statement_snippets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundarySCPStatementSnippet"
+        breakage_projection:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPBreakageProjection"
+        intended_api_call:
+          $ref: "#/components/schemas/AWSRemediationDryRunIntendedAPICall"
+        preconditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundaryExecutorPrecondition"
+        boundary_simulation:
+          $ref: "#/components/schemas/AWSPermissionBoundaryExecutorSimulation"
+        verifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundaryExecutorVerification"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPVerificationPlan"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationAuditEntry"
+        kill_switch_engaged: { type: boolean }
+        ready_for_live_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPermissionBoundaryExecutorSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        operation_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        ready_for_live_apply_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_precondition_count: { type: integer }
+        target_identity_count: { type: integer }
+        verification_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSPermissionBoundaryExecutorResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSPermissionBoundaryExecutorSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundaryExecutorEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundaryExecutorRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -762,6 +762,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iam-policy-diffs", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -331,7 +331,22 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 	plan.TargetIdentityNodeIDs = supportedTargets
 	targetsByOperation := awsPermissionBoundaryExecutorTargetsByOperation(supportedTargets)
 	if len(targetsByOperation) <= 1 {
-		return []AWSPermissionBoundaryExecutorEntry{awsPermissionBoundaryExecutorEntryFromDryRun(entry, plan, now)}
+		scopedPlan := plan
+		operation := awsPermissionBoundaryExecutorIntendedCall(entry).Operation
+		scopedTargets := supportedTargets
+		for op, targets := range targetsByOperation {
+			operation = op
+			scopedTargets = targets
+			break
+		}
+		scopedPlan.TargetIdentityNodeIDs = scopedTargets
+		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
+		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
+		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
+		scopedEntry := entry
+		scopedEntry.AccountID = scopedPlan.AccountID
+		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
+		return []AWSPermissionBoundaryExecutorEntry{out}
 	}
 	entries := make([]AWSPermissionBoundaryExecutorEntry, 0, len(targetsByOperation))
 	operations := make([]string, 0, len(targetsByOperation))

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -299,7 +299,7 @@ func awsPermissionBoundaryExecutorEntries(dryRunEntries []AWSRemediationDryRunEn
 		if !ok {
 			continue
 		}
-		entries = append(entries, awsPermissionBoundaryExecutorEntryFromDryRun(entry, plan, now))
+		entries = append(entries, awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)...)
 	}
 	return entries
 }
@@ -323,8 +323,42 @@ func awsPermissionBoundaryExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
 	}
 }
 
+func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSPermissionBoundaryExecutorEntry {
+	targetsByOperation := awsPermissionBoundaryExecutorTargetsByOperation(plan.TargetIdentityNodeIDs)
+	if len(targetsByOperation) <= 1 {
+		return []AWSPermissionBoundaryExecutorEntry{awsPermissionBoundaryExecutorEntryFromDryRun(entry, plan, now)}
+	}
+	entries := make([]AWSPermissionBoundaryExecutorEntry, 0, len(targetsByOperation))
+	operations := make([]string, 0, len(targetsByOperation))
+	for operation := range targetsByOperation {
+		operations = append(operations, operation)
+	}
+	sort.Strings(operations)
+	for _, operation := range operations {
+		scopedPlan := plan
+		scopedPlan.TargetIdentityNodeIDs = targetsByOperation[operation]
+		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
+		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(entry, scopedPlan.TargetIdentityNodeIDs, operation), now)
+		out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation)
+		entries = append(entries, out)
+	}
+	return entries
+}
+
+func awsPermissionBoundaryExecutorTargetsByOperation(targets []string) map[string][]string {
+	out := map[string][]string{}
+	for _, target := range emptyStrings(dedupeStrings(targets)) {
+		operation := awsRemediationDryRunPutBoundaryOperation(target)
+		out[operation] = append(out[operation], target)
+	}
+	return out
+}
+
 func awsPermissionBoundaryExecutorEntryFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) AWSPermissionBoundaryExecutorEntry {
-	call := awsPermissionBoundaryExecutorIntendedCall(entry)
+	return awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry, plan, awsPermissionBoundaryExecutorIntendedCall(entry), now)
+}
+
+func awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, call AWSRemediationDryRunIntendedAPICall, now time.Time) AWSPermissionBoundaryExecutorEntry {
 	preconditions := awsPermissionBoundaryExecutorPreconditions(entry, plan, call)
 	simulation := awsPermissionBoundaryExecutorSimulation(entry, plan)
 	verifications := awsPermissionBoundaryExecutorVerifications(entry, plan)
@@ -389,6 +423,19 @@ func awsPermissionBoundaryExecutorIntendedCall(entry AWSRemediationDryRunEntry) 
 		Idempotent:       true,
 		RequiresApproval: true,
 	}
+}
+
+func awsPermissionBoundaryExecutorIntendedCallForTargets(entry AWSRemediationDryRunEntry, targets []string, operation string) AWSRemediationDryRunIntendedAPICall {
+	call := awsPermissionBoundaryExecutorIntendedCall(entry)
+	call.Service = firstNonEmptyAWSValue(call.Service, "iam")
+	call.Operation = operation
+	call.TargetResource = firstNonEmptyAWSValue(firstString(emptyStrings(targets)), call.TargetResource, firstString(entry.ImpactedNodes))
+	if len(call.ParameterRefs) == 0 {
+		call.ParameterRefs = []string{entry.IdempotencyKey, "boundary_ref://" + entry.CaseID + "/after"}
+	}
+	call.Idempotent = true
+	call.RequiresApproval = true
+	return call
 }
 
 func awsPermissionBoundaryExecutorPreconditions(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, call AWSRemediationDryRunIntendedAPICall) []AWSPermissionBoundaryExecutorPrecondition {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -1,0 +1,781 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsPermissionBoundaryExecutorCurrentIssue = 1540
+	awsPermissionBoundaryExecutorVersion      = "aws-permission-boundary-executor-v1"
+
+	awsPermissionBoundaryExecutorStateProjected          = "projected"
+	awsPermissionBoundaryExecutorStatePreconditionFailed = "precondition_failed"
+	awsPermissionBoundaryExecutorStateBlocked            = "blocked"
+)
+
+// AWSPermissionBoundaryExecutorRequest scopes the deterministic permission
+// boundary executor projection to one AWS connector plus optional drill-down
+// filters.
+type AWSPermissionBoundaryExecutorRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	DryRunID     string `json:"dry_run_id,omitempty"`
+	CaseID       string `json:"case_id,omitempty"`
+	PlanID       string `json:"plan_id,omitempty"`
+	Operation    string `json:"operation,omitempty"`
+	State        string `json:"state,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSPermissionBoundaryExecutorEvidence = AWSPermissionBoundarySCPEvidence
+type AWSPermissionBoundaryExecutorPathStep = AWSPermissionBoundarySCPPathStep
+type AWSPermissionBoundaryExecutorDiagnostic = AWSPermissionBoundarySCPDiagnostic
+type AWSPermissionBoundaryExecutorCoverageGap = AWSPermissionBoundarySCPCoverageGap
+type AWSPermissionBoundaryExecutorAuditEntry = AWSRemediationApprovalAuditEntry
+
+// AWSPermissionBoundaryExecutorPrecondition is one safety check that must pass
+// before the executor marks a record ready_for_live_apply.
+type AWSPermissionBoundaryExecutorPrecondition struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSPermissionBoundaryExecutorSimulation records the metadata-only simulator
+// result used to decide whether a boundary is safe to apply.
+type AWSPermissionBoundaryExecutorSimulation struct {
+	SimulationRef       string   `json:"simulation_ref"`
+	Outcome             string   `json:"outcome"`
+	BeforeRef           string   `json:"before_ref"`
+	AfterRef            string   `json:"after_ref"`
+	DeniedActionCount   int      `json:"denied_action_count"`
+	TargetIdentityCount int      `json:"target_identity_count"`
+	Signals             []string `json:"signals,omitempty"`
+}
+
+// AWSPermissionBoundaryExecutorVerification describes one post-apply check a
+// downstream live executor must record before the execution can be considered
+// succeeded.
+type AWSPermissionBoundaryExecutorVerification struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+// AWSPermissionBoundaryExecutorRelationship surfaces executor->graph edges.
+type AWSPermissionBoundaryExecutorRelationship struct {
+	ExecutionID string `json:"execution_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSPermissionBoundaryExecutorEntry is the persisted-record-shaped contract
+// for an approved permission boundary execution projection. It carries
+// metadata refs only and never inlines rendered IAM policy documents, secret
+// values, or workload payloads.
+type AWSPermissionBoundaryExecutorEntry struct {
+	ExecutionID           string                                      `json:"execution_id"`
+	CalculationVersion    string                                      `json:"calculation_version"`
+	DryRunID              string                                      `json:"dry_run_id"`
+	ApprovalID            string                                      `json:"approval_id"`
+	CaseID                string                                      `json:"case_id"`
+	PlanID                string                                      `json:"plan_id"`
+	SourceArtifactID      string                                      `json:"source_artifact_id"`
+	State                 string                                      `json:"state"`
+	Severity              string                                      `json:"severity"`
+	Score                 int                                         `json:"score"`
+	Confidence            float64                                     `json:"confidence"`
+	Title                 string                                      `json:"title"`
+	Summary               string                                      `json:"summary"`
+	AccountID             string                                      `json:"account_id"`
+	Region                string                                      `json:"region"`
+	Operation             string                                      `json:"operation"`
+	IdempotencyKey        string                                      `json:"idempotency_key"`
+	TargetIdentityNodeIDs []string                                    `json:"target_identity_node_ids,omitempty"`
+	TargetAccountIDs      []string                                    `json:"target_account_ids,omitempty"`
+	TargetOUPaths         []string                                    `json:"target_ou_paths,omitempty"`
+	PreventedBehavior     string                                      `json:"prevented_behavior"`
+	StatementSnippets     []AWSPermissionBoundarySCPStatementSnippet  `json:"statement_snippets"`
+	BreakageProjection    AWSPermissionBoundarySCPBreakageProjection  `json:"breakage_projection"`
+	IntendedAPICall       AWSRemediationDryRunIntendedAPICall         `json:"intended_api_call"`
+	Preconditions         []AWSPermissionBoundaryExecutorPrecondition `json:"preconditions"`
+	BoundarySimulation    AWSPermissionBoundaryExecutorSimulation     `json:"boundary_simulation"`
+	Verifications         []AWSPermissionBoundaryExecutorVerification `json:"verifications"`
+	RollbackPlan          AWSPermissionBoundarySCPRollbackPlan        `json:"rollback_plan"`
+	VerificationPlan      AWSPermissionBoundarySCPVerificationPlan    `json:"verification_plan"`
+	AuditTrail            []AWSPermissionBoundaryExecutorAuditEntry   `json:"audit_trail"`
+	KillSwitchEngaged     bool                                        `json:"kill_switch_engaged"`
+	ReadyForLiveApply     bool                                        `json:"ready_for_live_apply"`
+	ReadOnlyProjection    bool                                        `json:"read_only_projection"`
+	SourceSignals         []string                                    `json:"source_signals"`
+	Evidence              []AWSPermissionBoundaryExecutorEvidence     `json:"evidence"`
+	EvidenceBoundary      string                                      `json:"evidence_boundary"`
+	ImpactedNodes         []string                                    `json:"impacted_nodes"`
+	ImpactedPath          []AWSPermissionBoundaryExecutorPathStep     `json:"impacted_path"`
+	NextAction            string                                      `json:"next_action"`
+	ProjectedAt           time.Time                                   `json:"projected_at"`
+	CreatedAt             time.Time                                   `json:"created_at"`
+	UpdatedAt             time.Time                                   `json:"updated_at"`
+}
+
+// AWSPermissionBoundaryExecutorSummary aggregates the unfiltered/filtered set.
+type AWSPermissionBoundaryExecutorSummary struct {
+	TotalEntries            int            `json:"total_entries"`
+	FilteredEntries         int            `json:"filtered_entries"`
+	StateCounts             map[string]int `json:"state_counts"`
+	OperationCounts         map[string]int `json:"operation_counts"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	ReadyForLiveApplyCount  int            `json:"ready_for_live_apply_count"`
+	KillSwitchEngagedCount  int            `json:"kill_switch_engaged_count"`
+	FailedPreconditionCount int            `json:"failed_precondition_count"`
+	TargetIdentityCount     int            `json:"target_identity_count"`
+	VerificationCount       int            `json:"verification_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+}
+
+// AWSPermissionBoundaryExecutorResult is the deterministic endpoint envelope.
+type AWSPermissionBoundaryExecutorResult struct {
+	TenantID           string                                      `json:"tenant_id"`
+	WorkspaceID        string                                      `json:"workspace_id"`
+	ProjectID          string                                      `json:"project_id"`
+	ConnectorID        string                                      `json:"connector_id,omitempty"`
+	AccountID          string                                      `json:"account_id,omitempty"`
+	Region             string                                      `json:"region,omitempty"`
+	ParentIssueNumber  int                                         `json:"parent_issue_number"`
+	ParentIssueRef     string                                      `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                         `json:"current_issue_number"`
+	CurrentIssueRef    string                                      `json:"current_issue_ref"`
+	Version            string                                      `json:"version"`
+	Status             string                                      `json:"status"`
+	FixtureState       string                                      `json:"fixture_state,omitempty"`
+	Confidence         float64                                     `json:"confidence"`
+	CalculationVersion string                                      `json:"calculation_version"`
+	AppliedFilters     map[string]string                           `json:"applied_filters"`
+	Summary            AWSPermissionBoundaryExecutorSummary        `json:"summary"`
+	Entries            []AWSPermissionBoundaryExecutorEntry        `json:"entries"`
+	Relationships      []AWSPermissionBoundaryExecutorRelationship `json:"relationships"`
+	Caveats            []string                                    `json:"caveats"`
+	FailureReasons     []string                                    `json:"failure_reasons"`
+	RemediationHints   []string                                    `json:"remediation_hints"`
+	EvidenceLinks      []string                                    `json:"evidence_links"`
+	CoverageGaps       []AWSPermissionBoundaryExecutorCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSPermissionBoundaryExecutorDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                   `json:"generated_at"`
+	UpdatedAt          time.Time                                   `json:"updated_at"`
+}
+
+// GetAWSPermissionBoundaryExecutor projects approved permission boundary
+// executions by joining remediation dry-run entries (#1537) with permission
+// boundary planner metadata (#1532). This layer is metadata-only: it records
+// the controlled intent, preconditions, idempotency key, rollback metadata,
+// and verification plan without calling live AWS write APIs.
+func (s *Service) GetAWSPermissionBoundaryExecutor(ctx context.Context, workspaceID string, projectID string, request AWSPermissionBoundaryExecutorRequest) (AWSPermissionBoundaryExecutorResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSPermissionBoundaryExecutorResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSPermissionBoundaryExecutorResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSPermissionBoundaryExecutorFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSPermissionBoundaryExecutorResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	dryRun, err := s.GetAWSRemediationDryRun(ctx, workspaceID, projectID, AWSRemediationDryRunRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSPermissionBoundaryExecutorResult{}, fmt.Errorf("permission boundary executor dry-run: %w", err)
+	}
+	plans, err := s.GetAWSPermissionBoundarySCPPlans(ctx, workspaceID, projectID, AWSPermissionBoundarySCPRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState, Kind: awsPermissionBoundaryKind})
+	if err != nil {
+		return AWSPermissionBoundaryExecutorResult{}, fmt.Errorf("permission boundary executor plans: %w", err)
+	}
+
+	planByID := map[string]AWSPermissionBoundarySCPPlan{}
+	for _, plan := range plans.Plans {
+		if strings.EqualFold(plan.Kind, awsPermissionBoundaryKind) {
+			planByID[plan.PlanID] = plan
+		}
+	}
+
+	entries := awsPermissionBoundaryExecutorEntries(dryRun.Entries, planByID, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].ExecutionID < entries[j].ExecutionID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSPermissionBoundaryExecutorEntries(entries, request)
+	relationships := awsPermissionBoundaryExecutorRelationships(filtered)
+	diagnostics := awsPermissionBoundaryExecutorDiagnostics(dryRun.Diagnostics, plans.Diagnostics)
+	coverageGaps := awsPermissionBoundaryExecutorCoverageGaps(dryRun.CoverageGaps, plans.CoverageGaps)
+	status, confidence := summarizeAWSPermissionBoundaryExecutorStatus(dryRun.Status, plans.Status, filtered, diagnostics)
+
+	return AWSPermissionBoundaryExecutorResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPermissionBoundaryExecutorCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPermissionBoundaryExecutorCurrentIssue),
+		Version:            awsPermissionBoundaryExecutorVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPermissionBoundaryExecutorVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSPermissionBoundaryExecutorEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsPermissionBoundaryExecutorCaveats(),
+		FailureReasons:     dedupeStrings(append(append([]string{}, dryRun.FailureReasons...), plans.FailureReasons...)),
+		RemediationHints:   awsPermissionBoundaryExecutorRemediationHints(append(dryRun.RemediationHints, plans.RemediationHints...)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPermissionBoundaryExecutorCurrentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			awsIssueURL(awsPermissionBoundarySCPCurrentIssue),
+			"/docs/aws-permission-boundary-executor",
+			"/docs/aws-remediation-dry-run-executor",
+			"/docs/aws-permission-boundary-scp-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSPermissionBoundaryExecutorFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsPermissionBoundaryExecutorEntries(dryRunEntries []AWSRemediationDryRunEntry, planByID map[string]AWSPermissionBoundarySCPPlan, now time.Time) []AWSPermissionBoundaryExecutorEntry {
+	entries := []AWSPermissionBoundaryExecutorEntry{}
+	for _, entry := range dryRunEntries {
+		if !awsPermissionBoundaryExecutorAdmits(entry) {
+			continue
+		}
+		plan, ok := planByID[entry.SourceArtifactID]
+		if !ok {
+			continue
+		}
+		entries = append(entries, awsPermissionBoundaryExecutorEntryFromDryRun(entry, plan, now))
+	}
+	return entries
+}
+
+func awsPermissionBoundaryExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
+	if !strings.EqualFold(entry.SourceType, "aws_permission_boundary_scp") {
+		return false
+	}
+	if entry.DiffIntent.NoOp {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(entry.DiffIntent.Kind), "permission_boundary_diff") {
+		return false
+	}
+	call := awsPermissionBoundaryExecutorIntendedCall(entry)
+	switch call.Operation {
+	case "PutRolePermissionsBoundary", "PutUserPermissionsBoundary":
+		return true
+	default:
+		return false
+	}
+}
+
+func awsPermissionBoundaryExecutorEntryFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) AWSPermissionBoundaryExecutorEntry {
+	call := awsPermissionBoundaryExecutorIntendedCall(entry)
+	preconditions := awsPermissionBoundaryExecutorPreconditions(entry, plan, call)
+	simulation := awsPermissionBoundaryExecutorSimulation(entry, plan)
+	verifications := awsPermissionBoundaryExecutorVerifications(entry, plan)
+	state := awsPermissionBoundaryExecutorState(entry, preconditions)
+	executionID := "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID)
+	out := AWSPermissionBoundaryExecutorEntry{
+		ExecutionID:           executionID,
+		CalculationVersion:    awsPermissionBoundaryExecutorVersion,
+		DryRunID:              entry.DryRunID,
+		ApprovalID:            entry.ApprovalID,
+		CaseID:                entry.CaseID,
+		PlanID:                plan.PlanID,
+		SourceArtifactID:      entry.SourceArtifactID,
+		State:                 state,
+		Severity:              firstNonEmptyAWSValue(entry.Severity, plan.Severity),
+		Score:                 entry.Score,
+		Confidence:            entry.Confidence,
+		Title:                 fmt.Sprintf("Permission boundary execution: %s", firstNonEmptyAWSValue(plan.Title, entry.Title)),
+		Summary:               fmt.Sprintf("Approved permission boundary execution record for plan %s (dry-run %s); Identrail records the projected IAM boundary intent and never calls AWS write APIs at this layer.", plan.PlanID, entry.DryRunID),
+		AccountID:             firstNonEmptyAWSValue(entry.AccountID, plan.AccountID),
+		Region:                firstNonEmptyAWSValue(entry.Region, plan.Region),
+		Operation:             call.Operation,
+		IdempotencyKey:        entry.IdempotencyKey,
+		TargetIdentityNodeIDs: emptyStrings(dedupeStrings(plan.TargetIdentityNodeIDs)),
+		TargetAccountIDs:      emptyStrings(dedupeStrings(plan.TargetAccountIDs)),
+		TargetOUPaths:         emptyStrings(dedupeStrings(plan.TargetOUPaths)),
+		PreventedBehavior:     plan.PreventedBehavior,
+		StatementSnippets:     plan.StatementSnippets,
+		BreakageProjection:    plan.BreakageProjection,
+		IntendedAPICall:       call,
+		Preconditions:         preconditions,
+		BoundarySimulation:    simulation,
+		Verifications:         verifications,
+		RollbackPlan:          plan.RollbackPlan,
+		VerificationPlan:      plan.VerificationPlan,
+		AuditTrail:            awsPermissionBoundaryExecutorAuditTrail(entry, state, plan, now),
+		KillSwitchEngaged:     entry.KillSwitchEngaged,
+		ReadOnlyProjection:    true,
+		SourceSignals:         dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary_executor", "remediation_dry_run"}, entry.SourceSignals...)),
+		Evidence:              plan.Evidence,
+		EvidenceBoundary:      awsPermissionBoundaryExecutorEvidenceBoundary(),
+		ImpactedNodes:         dedupeStrings(append(append([]string{}, plan.TargetIdentityNodeIDs...), append(entry.ImpactedNodes, plan.ImpactedNodes...)...)),
+		ImpactedPath:          plan.ImpactedPath,
+		NextAction:            awsPermissionBoundaryExecutorNextAction(state, call.Operation),
+		ProjectedAt:           now,
+		CreatedAt:             firstNonZeroAWSPermissionBoundaryExecutorTime(entry.CreatedAt, plan.CreatedAt, now),
+		UpdatedAt:             now,
+	}
+	out.ReadyForLiveApply = state == awsPermissionBoundaryExecutorStateProjected && entry.ReadyForApply && !entry.KillSwitchEngaged
+	return out
+}
+
+func awsPermissionBoundaryExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRemediationDryRunIntendedAPICall {
+	if len(entry.IntendedAPICalls) > 0 {
+		return entry.IntendedAPICalls[0]
+	}
+	return AWSRemediationDryRunIntendedAPICall{
+		Service:          "iam",
+		Operation:        "PutRolePermissionsBoundary",
+		TargetResource:   firstString(entry.ImpactedNodes),
+		ParameterRefs:    []string{entry.IdempotencyKey, "boundary_ref://" + entry.CaseID + "/after"},
+		Idempotent:       true,
+		RequiresApproval: true,
+	}
+}
+
+func awsPermissionBoundaryExecutorPreconditions(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, call AWSRemediationDryRunIntendedAPICall) []AWSPermissionBoundaryExecutorPrecondition {
+	identityCount := len(emptyStrings(plan.TargetIdentityNodeIDs))
+	preconditions := []AWSPermissionBoundaryExecutorPrecondition{
+		{Name: "dry_run_would_succeed", Status: awsPermissionBoundaryExecutorGateStatus(entry.Outcome == awsRemediationDryRunOutcomeWouldSucceed), Rationale: "Upstream dry-run must project would_succeed before any live apply."},
+		{Name: "ready_for_apply", Status: awsPermissionBoundaryExecutorGateStatus(entry.ReadyForApply), Rationale: "Upstream dry-run must declare ready_for_apply=true before any live apply."},
+		{Name: "kill_switch_off", Status: awsPermissionBoundaryExecutorGateStatus(!entry.KillSwitchEngaged), Rationale: "Tenant-scoped remediation kill switch must be off."},
+		{Name: "idempotency_key_present", Status: awsPermissionBoundaryExecutorGateStatus(strings.TrimSpace(entry.IdempotencyKey) != ""), Rationale: "Deterministic idempotency key must be present so retries do not double-apply."},
+		{Name: "permission_boundary_plan", Status: awsPermissionBoundaryExecutorGateStatus(strings.EqualFold(plan.Kind, awsPermissionBoundaryKind)), Rationale: "Only permission boundary plans are executable here; SCP execution belongs to its own issue."},
+		{Name: "plan_ready_for_apply", Status: awsPermissionBoundaryExecutorGateStatus(plan.ReadyForApply), Rationale: "Upstream permission boundary plan must declare ready_for_apply=true."},
+		{Name: "target_identities_present", Status: awsPermissionBoundaryExecutorGateStatus(identityCount > 0), Rationale: "At least one captured IAM identity target must be present."},
+		{Name: "canary_scope_captured", Status: awsPermissionBoundaryExecutorGateStatus(identityCount > 0 && len(plan.TargetAccountIDs) > 0), Rationale: "The plan must carry captured identity and account scope so apply can run as a bounded canary."},
+		{Name: "breakage_level_low", Status: awsPermissionBoundaryExecutorGateStatus(strings.EqualFold(plan.BreakageProjection.Level, "low")), Rationale: "Permission boundary breakage projection must be low before live apply."},
+		{Name: "operation_supported", Status: awsPermissionBoundaryExecutorGateStatus(call.Operation == "PutRolePermissionsBoundary" || call.Operation == "PutUserPermissionsBoundary"), Rationale: "Executor only supports IAM role/user permission boundary operations."},
+	}
+	if len(entry.FailedPrereqs) > 0 {
+		preconditions = append(preconditions, AWSPermissionBoundaryExecutorPrecondition{
+			Name:      "upstream_prerequisites",
+			Status:    "blocked",
+			Rationale: fmt.Sprintf("Upstream dry-run still has %d failed prerequisite(s); resolve them before retrying.", len(entry.FailedPrereqs)),
+		})
+	}
+	return preconditions
+}
+
+func awsPermissionBoundaryExecutorGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsPermissionBoundaryExecutorSimulation(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) AWSPermissionBoundaryExecutorSimulation {
+	beforeRef := firstNonEmptyAWSValue(entry.DiffIntent.BeforeRef, "permission_boundary_before://"+plan.PlanID)
+	afterRef := firstNonEmptyAWSValue(entry.DiffIntent.AfterRef, "permission_boundary_after://"+plan.PlanID)
+	outcome := "would_limit_actions"
+	if !strings.EqualFold(plan.BreakageProjection.Level, "low") {
+		outcome = "regression_risk"
+	}
+	if !plan.ReadyForApply {
+		outcome = "pending_planner_evidence"
+	}
+	return AWSPermissionBoundaryExecutorSimulation{
+		SimulationRef:       fmt.Sprintf("iam:policy_simulate://%s/permission-boundary", plan.PlanID),
+		Outcome:             outcome,
+		BeforeRef:           beforeRef,
+		AfterRef:            afterRef,
+		DeniedActionCount:   len(awsRemediationPermissionBoundaryDeniedActions(plan)),
+		TargetIdentityCount: len(emptyStrings(plan.TargetIdentityNodeIDs)),
+		Signals:             dedupeStrings(append([]string{"permission_boundary"}, plan.BreakageProjection.Signals...)),
+	}
+}
+
+func awsPermissionBoundaryExecutorVerifications(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) []AWSPermissionBoundaryExecutorVerification {
+	out := []AWSPermissionBoundaryExecutorVerification{
+		{Source: "cloudtrail", Signal: "expected_api_call_observed", Status: "pending", Description: "After live execution, confirm the IAM permission boundary operation appears in CloudTrail for the target account and region."},
+		{Source: "iam:policy_simulate", Signal: "boundary_denies_projected_actions", Status: "pending", Description: "Re-run IAM policy simulation for each captured identity and confirm the boundary denies the projected unused action set without blocking observed actions."},
+		{Source: "least_privilege", Signal: "recommendation_resolved", Status: "pending", Description: "Re-run least-privilege analysis and confirm the source recommendations no longer require permission expansion."},
+	}
+	for _, check := range entry.VerificationChecks {
+		if check.Source == "" {
+			continue
+		}
+		out = append(out, AWSPermissionBoundaryExecutorVerification{Source: check.Source, Signal: check.Signal, Status: "pending", Description: check.Description})
+	}
+	for _, signal := range plan.VerificationPlan.SuccessSignals {
+		out = append(out, AWSPermissionBoundaryExecutorVerification{Source: "planner", Signal: signal, Status: "pending", Description: "Confirm the planner success signal after live execution."})
+	}
+	return out
+}
+
+func awsPermissionBoundaryExecutorState(entry AWSRemediationDryRunEntry, preconditions []AWSPermissionBoundaryExecutorPrecondition) string {
+	if entry.KillSwitchEngaged {
+		return awsPermissionBoundaryExecutorStateBlocked
+	}
+	if entry.Outcome == awsRemediationDryRunOutcomeBlocked || entry.Outcome == awsRemediationDryRunOutcomeKillSwitched {
+		return awsPermissionBoundaryExecutorStateBlocked
+	}
+	hasBlockedPrecondition := false
+	for _, precondition := range preconditions {
+		if precondition.Status != "blocked" {
+			continue
+		}
+		hasBlockedPrecondition = true
+		if awsPermissionBoundaryExecutorPreconditionIsSafety(precondition.Name) {
+			return awsPermissionBoundaryExecutorStateBlocked
+		}
+	}
+	if hasBlockedPrecondition {
+		return awsPermissionBoundaryExecutorStatePreconditionFailed
+	}
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || !entry.ReadyForApply {
+		return awsPermissionBoundaryExecutorStatePreconditionFailed
+	}
+	return awsPermissionBoundaryExecutorStateProjected
+}
+
+func awsPermissionBoundaryExecutorPreconditionIsSafety(name string) bool {
+	switch name {
+	case "kill_switch_off", "idempotency_key_present", "permission_boundary_plan", "target_identities_present", "operation_supported":
+		return true
+	}
+	return false
+}
+
+func awsPermissionBoundaryExecutorNextAction(state, operation string) string {
+	switch state {
+	case awsPermissionBoundaryExecutorStateProjected:
+		return fmt.Sprintf("Permission boundary operation=%s is ready for the wave-8 apply runtime once its feature flag opens.", operation)
+	case awsPermissionBoundaryExecutorStatePreconditionFailed:
+		return "One or more preconditions failed; advance the upstream dry-run or permission boundary plan before retrying."
+	case awsPermissionBoundaryExecutorStateBlocked:
+		return "A safety precondition or the tenant kill switch is blocking this entry; satisfy the failing check before retrying."
+	}
+	return "Inspect this entry for the projected next action."
+}
+
+func awsPermissionBoundaryExecutorAuditTrail(entry AWSRemediationDryRunEntry, state string, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSPermissionBoundaryExecutorAuditEntry {
+	trail := []AWSPermissionBoundaryExecutorAuditEntry{}
+	trail = append(trail, entry.AuditTrail...)
+	trail = append(trail, AWSPermissionBoundaryExecutorAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("permission-boundary-projected", entry.DryRunID, plan.PlanID),
+		Actor:      "identrail-permission-boundary-executor",
+		EventType:  "permission_boundary_execution_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Plan=%s state=%s target_identities=%d; Identrail did not call any AWS write API at this layer.", plan.PlanID, state, len(emptyStrings(plan.TargetIdentityNodeIDs))),
+	})
+	return trail
+}
+
+func awsPermissionBoundaryExecutorRelationships(entries []AWSPermissionBoundaryExecutorEntry) []AWSPermissionBoundaryExecutorRelationship {
+	relationships := []AWSPermissionBoundaryExecutorRelationship{}
+	for _, entry := range entries {
+		evidenceRef := awsPermissionBoundaryExecutorFirstEvidenceRef(entry.Evidence)
+		for _, target := range entry.TargetIdentityNodeIDs {
+			if strings.TrimSpace(target) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSPermissionBoundaryExecutorRelationship{
+				ExecutionID: entry.ExecutionID,
+				Type:        "permission_boundary_targets_identity",
+				FromNodeID:  entry.ExecutionID,
+				ToNodeID:    target,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func awsPermissionBoundaryExecutorFirstEvidenceRef(evidence []AWSPermissionBoundaryExecutorEvidence) string {
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}
+
+func summarizeAWSPermissionBoundaryExecutorEntries(all, filtered []AWSPermissionBoundaryExecutorEntry, relationships []AWSPermissionBoundaryExecutorRelationship) AWSPermissionBoundaryExecutorSummary {
+	summary := AWSPermissionBoundaryExecutorSummary{
+		TotalEntries:    len(all),
+		FilteredEntries: len(filtered),
+		StateCounts:     map[string]int{},
+		OperationCounts: map[string]int{},
+		SeverityCounts:  map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.StateCounts[entry.State]++
+		if strings.TrimSpace(entry.Operation) != "" {
+			summary.OperationCounts[entry.Operation]++
+		}
+		if strings.TrimSpace(entry.Severity) != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.ReadyForLiveApply {
+			summary.ReadyForLiveApplyCount++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		for _, precondition := range entry.Preconditions {
+			if precondition.Status == "blocked" {
+				summary.FailedPreconditionCount++
+			}
+		}
+		summary.TargetIdentityCount += len(entry.TargetIdentityNodeIDs)
+		summary.VerificationCount += len(entry.Verifications)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSPermissionBoundaryExecutorEntries(entries []AWSPermissionBoundaryExecutorEntry, request AWSPermissionBoundaryExecutorRequest) ([]AWSPermissionBoundaryExecutorEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"dry_run_id": strings.TrimSpace(request.DryRunID),
+		"case_id":    strings.TrimSpace(request.CaseID),
+		"plan_id":    strings.TrimSpace(request.PlanID),
+		"operation":  normalizeAWSRuntimeEventFilterToken(request.Operation),
+		"state":      normalizeAWSRuntimeEventFilterToken(request.State),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":     strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSPermissionBoundaryExecutorEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+			continue
+		}
+		if filters["dry_run_id"] != "" && !strings.EqualFold(filters["dry_run_id"], entry.DryRunID) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["plan_id"] != "" && !strings.EqualFold(filters["plan_id"], entry.PlanID) {
+			continue
+		}
+		if filters["operation"] != "" && filters["operation"] != normalizeAWSRuntimeEventFilterToken(entry.Operation) {
+			continue
+		}
+		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsPermissionBoundaryExecutorSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsPermissionBoundaryExecutorSearchMatch(entry AWSPermissionBoundaryExecutorEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.ExecutionID, entry.DryRunID, entry.ApprovalID, entry.CaseID, entry.PlanID,
+		entry.SourceArtifactID, entry.State, entry.Severity, entry.Title, entry.Summary,
+		entry.Operation, entry.IdempotencyKey, entry.PreventedBehavior, entry.NextAction,
+		entry.IntendedAPICall.Service, entry.IntendedAPICall.Operation, entry.IntendedAPICall.TargetResource,
+		entry.BoundarySimulation.SimulationRef, entry.BoundarySimulation.Outcome, entry.BoundarySimulation.BeforeRef, entry.BoundarySimulation.AfterRef,
+		entry.BreakageProjection.Level, entry.BreakageProjection.Rationale,
+	}
+	values = append(values, entry.TargetIdentityNodeIDs...)
+	values = append(values, entry.TargetAccountIDs...)
+	values = append(values, entry.TargetOUPaths...)
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.IntendedAPICall.ParameterRefs...)
+	values = append(values, entry.BoundarySimulation.Signals...)
+	for _, snippet := range entry.StatementSnippets {
+		values = append(values, snippet.StatementSID, snippet.Effect, snippet.ChangeKind, snippet.BeforeRef, snippet.AfterRef, snippet.Rationale)
+		values = append(values, snippet.DeniedActions...)
+		values = append(values, snippet.AllowedActions...)
+		values = append(values, snippet.ResourceScope...)
+		values = append(values, snippet.ConditionKeys...)
+	}
+	for _, precondition := range entry.Preconditions {
+		values = append(values, precondition.Name, precondition.Status, precondition.Rationale)
+	}
+	for _, verification := range entry.Verifications {
+		values = append(values, verification.Source, verification.Signal, verification.Status, verification.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSPermissionBoundaryExecutorStatus(dryRunStatus, planStatus string, filtered []AWSPermissionBoundaryExecutorEntry, diagnostics []AWSPermissionBoundaryExecutorDiagnostic) (string, float64) {
+	if dryRunStatus == awsPlatformDependencyStatusBlocked || planStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if dryRunStatus == awsPlatformDependencyStatusDegraded || planStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsPermissionBoundaryExecutorCaveats() []string {
+	return []string{
+		"Permission boundary executor entries are read-only projections; Identrail never calls IAM/Organizations write APIs at this layer.",
+		"Every precondition (approval dry-run readiness, planner readiness, bounded canary scope, low breakage, idempotency key) must pass before ready_for_live_apply becomes true.",
+		"SCP plans are intentionally excluded from this executor; org-level SCP execution belongs to the dedicated SCP executor issue.",
+	}
+}
+
+func awsPermissionBoundaryExecutorRemediationHints(source []string) []string {
+	hints := []string{
+		"Resolve any failed precondition before retrying; the dry-run and permission-boundary planner upstreams own those gates.",
+		"Use the idempotency key recorded here as the deterministic id when the wave-8 apply runtime executes the IAM permission boundary call.",
+		"If the simulation outcome is `regression_risk`, reduce scope or refresh least-privilege evidence before live apply.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsPermissionBoundaryExecutorDiagnostics(dryRun []AWSRemediationApprovalDiagnostic, planner []AWSPermissionBoundarySCPDiagnostic) []AWSPermissionBoundaryExecutorDiagnostic {
+	out := make([]AWSPermissionBoundaryExecutorDiagnostic, 0, len(dryRun)+len(planner))
+	for _, diagnostic := range dryRun {
+		out = append(out, AWSPermissionBoundaryExecutorDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: diagnostic.Remediation,
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	for _, diagnostic := range planner {
+		out = append(out, AWSPermissionBoundaryExecutorDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsPermissionBoundaryExecutorCoverageGaps(dryRun []AWSRemediationApprovalCoverageGap, planner []AWSPermissionBoundarySCPCoverageGap) []AWSPermissionBoundaryExecutorCoverageGap {
+	gaps := []AWSPermissionBoundaryExecutorCoverageGap{{
+		Capability:  "aws_scp_live_apply",
+		Status:      "out_of_scope",
+		Reason:      "Issue #1540 executes permission boundary projections only; SCP guardrail execution is handled by its own wave-8 issue.",
+		Remediation: "Wire the controlled SCP executor in the matching issue after Organizations-side safety gates are in place.",
+	}}
+	for _, gap := range dryRun {
+		gaps = append(gaps, AWSPermissionBoundaryExecutorCoverageGap{
+			Capability:  gap.Capability,
+			Status:      gap.Status,
+			Reason:      gap.Reason,
+			Remediation: gap.Remediation,
+		})
+	}
+	for _, gap := range planner {
+		gaps = append(gaps, AWSPermissionBoundaryExecutorCoverageGap(gap))
+	}
+	return gaps
+}
+
+func awsPermissionBoundaryExecutorEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSPermissionBoundaryExecutorTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -614,7 +614,7 @@ func filterAWSPermissionBoundaryExecutorEntries(entries []AWSPermissionBoundaryE
 	}
 	filtered := make([]AWSPermissionBoundaryExecutorEntry, 0, len(entries))
 	for _, entry := range entries {
-		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+		if filters["account_id"] != "" && !awsPermissionBoundaryExecutorAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
@@ -644,6 +644,22 @@ func filterAWSPermissionBoundaryExecutorEntries(entries []AWSPermissionBoundaryE
 		filtered = append(filtered, entry)
 	}
 	return filtered, applied
+}
+
+func awsPermissionBoundaryExecutorAccountMatch(entry AWSPermissionBoundaryExecutorEntry, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.AccountID) == accountID {
+		return true
+	}
+	for _, targetAccountID := range entry.TargetAccountIDs {
+		if strings.TrimSpace(targetAccountID) == accountID {
+			return true
+		}
+	}
+	return false
 }
 
 func awsPermissionBoundaryExecutorSearchMatch(entry AWSPermissionBoundaryExecutorEntry, needle string) bool {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -377,18 +377,18 @@ func awsPermissionBoundaryExecutorTargetsByOperation(targets []string) map[strin
 	return out
 }
 
-// awsPermissionBoundaryExecutorSupportedTargets drops IAM group targets because
-// permission boundaries can only be attached to IAM users or roles
-// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).
-// Group identities reaching this layer would otherwise be silently bucketed into
-// PutRolePermissionsBoundary by the dry-run helper's default branch.
+// awsPermissionBoundaryExecutorSupportedTargets keeps only explicitly
+// classified IAM users and roles because permission boundaries cannot be
+// attached to IAM groups or non-IAM resources.
 func awsPermissionBoundaryExecutorSupportedTargets(targets []string) []string {
 	out := []string{}
 	for _, target := range emptyStrings(dedupeStrings(targets)) {
-		if awsRemediationDryRunIAMPrincipalKind(target) == "group" {
+		switch awsRemediationDryRunClassifiedIAMPrincipalKind(target) {
+		case "role", "user":
+			out = append(out, target)
+		default:
 			continue
 		}
-		out = append(out, target)
 	}
 	return out
 }

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -344,6 +344,7 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
 		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
 		scopedEntry := entry
+		scopedEntry.IdempotencyKey = awsPermissionBoundaryExecutorScopedIdempotencyKey(entry, operation, scopedPlan.TargetIdentityNodeIDs)
 		scopedEntry.AccountID = scopedPlan.AccountID
 		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
 		return []AWSPermissionBoundaryExecutorEntry{out}
@@ -361,12 +362,25 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
 		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
 		scopedEntry := entry
+		scopedEntry.IdempotencyKey = awsPermissionBoundaryExecutorScopedIdempotencyKey(entry, operation, scopedPlan.TargetIdentityNodeIDs)
 		scopedEntry.AccountID = scopedPlan.AccountID
 		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
 		out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation)
 		entries = append(entries, out)
 	}
 	return entries
+}
+
+func awsPermissionBoundaryExecutorScopedIdempotencyKey(entry AWSRemediationDryRunEntry, operation string, targets []string) string {
+	base := strings.TrimSpace(entry.IdempotencyKey)
+	if base == "" {
+		return ""
+	}
+	scopedTargets := strings.TrimSpace(strings.Join(emptyStrings(dedupeStrings(targets)), "|"))
+	if scopedTargets == "" {
+		return stableAWSBlastRadiusToken(base, operation)
+	}
+	return stableAWSBlastRadiusToken(base, operation, scopedTargets)
 }
 
 func awsPermissionBoundaryExecutorTargetsByOperation(targets []string) map[string][]string {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -338,8 +338,11 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 		scopedPlan := plan
 		scopedPlan.TargetIdentityNodeIDs = targetsByOperation[operation]
 		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorAccountsForTargets(scopedPlan.TargetIdentityNodeIDs)
+		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
 		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
-		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(entry, scopedPlan.TargetIdentityNodeIDs, operation), now)
+		scopedEntry := entry
+		scopedEntry.AccountID = scopedPlan.AccountID
+		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
 		out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation)
 		entries = append(entries, out)
 	}

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -330,43 +330,28 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 	}
 	plan.TargetIdentityNodeIDs = supportedTargets
 	targetsByOperation := awsPermissionBoundaryExecutorTargetsByOperation(supportedTargets)
-	if len(targetsByOperation) <= 1 {
-		scopedPlan := plan
-		operation := awsPermissionBoundaryExecutorIntendedCall(entry).Operation
-		scopedTargets := supportedTargets
-		for op, targets := range targetsByOperation {
-			operation = op
-			scopedTargets = targets
-			break
-		}
-		scopedPlan.TargetIdentityNodeIDs = scopedTargets
-		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
-		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
-		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
-		scopedEntry := entry
-		scopedEntry.IdempotencyKey = awsPermissionBoundaryExecutorScopedIdempotencyKey(entry, operation, scopedPlan.TargetIdentityNodeIDs)
-		scopedEntry.AccountID = scopedPlan.AccountID
-		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
-		return []AWSPermissionBoundaryExecutorEntry{out}
-	}
-	entries := make([]AWSPermissionBoundaryExecutorEntry, 0, len(targetsByOperation))
+	entries := make([]AWSPermissionBoundaryExecutorEntry, 0, len(supportedTargets))
 	operations := make([]string, 0, len(targetsByOperation))
 	for operation := range targetsByOperation {
 		operations = append(operations, operation)
 	}
 	sort.Strings(operations)
 	for _, operation := range operations {
-		scopedPlan := plan
-		scopedPlan.TargetIdentityNodeIDs = targetsByOperation[operation]
-		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
-		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
-		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
-		scopedEntry := entry
-		scopedEntry.IdempotencyKey = awsPermissionBoundaryExecutorScopedIdempotencyKey(entry, operation, scopedPlan.TargetIdentityNodeIDs)
-		scopedEntry.AccountID = scopedPlan.AccountID
-		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
-		out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation)
-		entries = append(entries, out)
+		for _, target := range targetsByOperation[operation] {
+			scopedPlan := plan
+			scopedPlan.TargetIdentityNodeIDs = []string{target}
+			scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
+			scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
+			scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
+			scopedEntry := entry
+			scopedEntry.IdempotencyKey = awsPermissionBoundaryExecutorScopedIdempotencyKey(entry, operation, scopedPlan.TargetIdentityNodeIDs)
+			scopedEntry.AccountID = scopedPlan.AccountID
+			out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(scopedEntry, scopedPlan.TargetIdentityNodeIDs, operation), now)
+			if len(supportedTargets) > 1 {
+				out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation, target)
+			}
+			entries = append(entries, out)
+		}
 	}
 	return entries
 }

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -337,7 +337,7 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 	for _, operation := range operations {
 		scopedPlan := plan
 		scopedPlan.TargetIdentityNodeIDs = targetsByOperation[operation]
-		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorAccountsForTargets(scopedPlan.TargetIdentityNodeIDs)
+		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
 		scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
 		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
 		scopedEntry := entry
@@ -424,6 +424,14 @@ func awsPermissionBoundaryExecutorAccountsForTargets(targets []string) []string 
 		}
 	}
 	return emptyStrings(dedupeStrings(accounts))
+}
+
+func awsPermissionBoundaryExecutorScopedAccountsForTargets(targets []string, fallback []string) []string {
+	derived := awsPermissionBoundaryExecutorAccountsForTargets(targets)
+	if len(derived) > 0 {
+		return derived
+	}
+	return emptyStrings(dedupeStrings(fallback))
 }
 
 func awsPermissionBoundaryExecutorAccountFromTarget(target string) string {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -498,7 +498,11 @@ func awsPermissionBoundaryExecutorAccountFromTarget(target string) string {
 
 func awsPermissionBoundaryExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRemediationDryRunIntendedAPICall {
 	if len(entry.IntendedAPICalls) > 0 {
-		return entry.IntendedAPICalls[0]
+		call := entry.IntendedAPICalls[0]
+		if len(call.ParameterRefs) > 0 {
+			call.ParameterRefs = append([]string{}, call.ParameterRefs...)
+		}
+		return call
 	}
 	return AWSRemediationDryRunIntendedAPICall{
 		Service:          "iam",
@@ -517,6 +521,11 @@ func awsPermissionBoundaryExecutorIntendedCallForTargets(entry AWSRemediationDry
 	call.TargetResource = firstNonEmptyAWSValue(firstString(emptyStrings(targets)), call.TargetResource, firstString(entry.ImpactedNodes))
 	if len(call.ParameterRefs) == 0 {
 		call.ParameterRefs = []string{entry.IdempotencyKey, "boundary_ref://" + entry.CaseID + "/after"}
+	} else {
+		call.ParameterRefs[0] = entry.IdempotencyKey
+		if len(call.ParameterRefs) == 1 {
+			call.ParameterRefs = append(call.ParameterRefs, "boundary_ref://"+entry.CaseID+"/after")
+		}
 	}
 	call.Idempotent = true
 	call.RequiresApproval = true

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -324,6 +324,7 @@ func awsPermissionBoundaryExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
 }
 
 func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSPermissionBoundaryExecutorEntry {
+	originalTargets := emptyStrings(plan.TargetIdentityNodeIDs)
 	supportedTargets := awsPermissionBoundaryExecutorSupportedTargets(plan.TargetIdentityNodeIDs)
 	if len(supportedTargets) == 0 {
 		return nil
@@ -336,11 +337,20 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 		operations = append(operations, operation)
 	}
 	sort.Strings(operations)
+	// The plan's account list was captured before unsupported targets were
+	// filtered out and before this split into per-target entries, so it can
+	// only be trusted as a fallback when the plan always described exactly
+	// one target; otherwise it may carry accounts that belong to a dropped
+	// target or a sibling target instead of the one this entry projects.
+	accountFallback := plan.TargetAccountIDs
+	if len(originalTargets) != 1 {
+		accountFallback = nil
+	}
 	for _, operation := range operations {
 		for _, target := range targetsByOperation[operation] {
 			scopedPlan := plan
 			scopedPlan.TargetIdentityNodeIDs = []string{target}
-			scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, plan.TargetAccountIDs)
+			scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets(scopedPlan.TargetIdentityNodeIDs, accountFallback)
 			scopedPlan.AccountID = firstString(scopedPlan.TargetAccountIDs)
 			scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
 			scopedEntry := entry

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -617,7 +617,7 @@ func filterAWSPermissionBoundaryExecutorEntries(entries []AWSPermissionBoundaryE
 		if filters["account_id"] != "" && !awsPermissionBoundaryExecutorAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+		if filters["region"] != "" && !awsPermissionBoundaryExecutorRegionMatch(entry, filters["region"]) {
 			continue
 		}
 		if filters["dry_run_id"] != "" && !strings.EqualFold(filters["dry_run_id"], entry.DryRunID) {
@@ -644,6 +644,17 @@ func filterAWSPermissionBoundaryExecutorEntries(entries []AWSPermissionBoundaryE
 		filtered = append(filtered, entry)
 	}
 	return filtered, applied
+}
+
+func awsPermissionBoundaryExecutorRegionMatch(entry AWSPermissionBoundaryExecutorEntry, region string) bool {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.Region) == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Region), region)
 }
 
 func awsPermissionBoundaryExecutorAccountMatch(entry AWSPermissionBoundaryExecutorEntry, accountID string) bool {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -337,6 +337,7 @@ func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEn
 	for _, operation := range operations {
 		scopedPlan := plan
 		scopedPlan.TargetIdentityNodeIDs = targetsByOperation[operation]
+		scopedPlan.TargetAccountIDs = awsPermissionBoundaryExecutorAccountsForTargets(scopedPlan.TargetIdentityNodeIDs)
 		scopedPlan.ImpactedNodes = emptyStrings(dedupeStrings(append(append([]string{}, scopedPlan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)))
 		out := awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry, scopedPlan, awsPermissionBoundaryExecutorIntendedCallForTargets(entry, scopedPlan.TargetIdentityNodeIDs, operation), now)
 		out.ExecutionID = "aws-permission-boundary-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, operation)
@@ -409,6 +410,29 @@ func awsPermissionBoundaryExecutorEntryFromDryRunWithCall(entry AWSRemediationDr
 	}
 	out.ReadyForLiveApply = state == awsPermissionBoundaryExecutorStateProjected && entry.ReadyForApply && !entry.KillSwitchEngaged
 	return out
+}
+
+func awsPermissionBoundaryExecutorAccountsForTargets(targets []string) []string {
+	accounts := []string{}
+	for _, target := range emptyStrings(dedupeStrings(targets)) {
+		accountID := awsPermissionBoundaryExecutorAccountFromTarget(target)
+		if accountID != "" {
+			accounts = append(accounts, accountID)
+		}
+	}
+	return emptyStrings(dedupeStrings(accounts))
+}
+
+func awsPermissionBoundaryExecutorAccountFromTarget(target string) string {
+	trimmed := strings.TrimSpace(target)
+	if idx := strings.Index(trimmed, "arn:"); idx >= 0 {
+		trimmed = trimmed[idx:]
+	}
+	parts := strings.Split(trimmed, ":")
+	if len(parts) >= 5 && strings.EqualFold(parts[2], "iam") {
+		return strings.TrimSpace(parts[4])
+	}
+	return ""
 }
 
 func awsPermissionBoundaryExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRemediationDryRunIntendedAPICall {

--- a/internal/api/aws_permission_boundary_executor.go
+++ b/internal/api/aws_permission_boundary_executor.go
@@ -324,7 +324,12 @@ func awsPermissionBoundaryExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
 }
 
 func awsPermissionBoundaryExecutorEntriesFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSPermissionBoundaryExecutorEntry {
-	targetsByOperation := awsPermissionBoundaryExecutorTargetsByOperation(plan.TargetIdentityNodeIDs)
+	supportedTargets := awsPermissionBoundaryExecutorSupportedTargets(plan.TargetIdentityNodeIDs)
+	if len(supportedTargets) == 0 {
+		return nil
+	}
+	plan.TargetIdentityNodeIDs = supportedTargets
+	targetsByOperation := awsPermissionBoundaryExecutorTargetsByOperation(supportedTargets)
 	if len(targetsByOperation) <= 1 {
 		return []AWSPermissionBoundaryExecutorEntry{awsPermissionBoundaryExecutorEntryFromDryRun(entry, plan, now)}
 	}
@@ -354,6 +359,22 @@ func awsPermissionBoundaryExecutorTargetsByOperation(targets []string) map[strin
 	for _, target := range emptyStrings(dedupeStrings(targets)) {
 		operation := awsRemediationDryRunPutBoundaryOperation(target)
 		out[operation] = append(out[operation], target)
+	}
+	return out
+}
+
+// awsPermissionBoundaryExecutorSupportedTargets drops IAM group targets because
+// permission boundaries can only be attached to IAM users or roles
+// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).
+// Group identities reaching this layer would otherwise be silently bucketed into
+// PutRolePermissionsBoundary by the dry-run helper's default branch.
+func awsPermissionBoundaryExecutorSupportedTargets(targets []string) []string {
+	out := []string{}
+	for _, target := range emptyStrings(dedupeStrings(targets)) {
+		if awsRemediationDryRunIAMPrincipalKind(target) == "group" {
+			continue
+		}
+		out = append(out, target)
 	}
 	return out
 }

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -370,7 +370,7 @@ func TestAWSPermissionBoundaryExecutorSplitsSameKindTargetsIntoCalls(t *testing.
 	}
 }
 
-func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTargets(t *testing.T) {
+func TestAWSPermissionBoundaryExecutorSplitAvoidsUnsafeAccountFallbackForNonARNTargets(t *testing.T) {
 	now := time.Date(2026, 6, 30, 11, 45, 0, 0, time.UTC)
 	plan := AWSPermissionBoundarySCPPlan{
 		PlanID:                "plan-mixed-non-arn",
@@ -400,21 +400,23 @@ func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTarg
 		}},
 	}
 
+	// Neither target's node ID carries an ARN-encoded account, and the plan
+	// originally described two targets, so no split entry can prove which of
+	// the planner's two accounts it belongs to. Each entry must leave its
+	// account scope empty rather than inheriting the full planner list,
+	// which would let one target masquerade under the other's account.
 	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
 	if len(entries) != 2 {
 		t.Fatalf("expected mixed non-ARN role/user plan to split into two executor entries: %+v", entries)
 	}
 	for _, out := range entries {
-		if len(out.TargetAccountIDs) != 2 {
-			t.Fatalf("non-ARN split entry must preserve planner target accounts: %+v", out)
-		}
-		if out.AccountID == "" {
-			t.Fatalf("non-ARN split entry must retain a primary account from the planner: %+v", out)
+		if len(out.TargetAccountIDs) != 0 || out.AccountID != "" {
+			t.Fatalf("non-ARN split entry with an unresolved account must not inherit the planner's full account list: %+v", out)
 		}
 	}
 	filtered, _ := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "222222222222"})
-	if len(filtered) != 2 {
-		t.Fatalf("planner account drill-down should retain both non-ARN split entries: %+v", filtered)
+	if len(filtered) != 0 {
+		t.Fatalf("account drill-down must not match split entries with no proven account scope: %+v", filtered)
 	}
 }
 
@@ -471,6 +473,59 @@ func TestAWSPermissionBoundaryExecutorScopesSingleOperationAfterGroupFilter(t *t
 	}
 	if out.AccountID != "222222222222" {
 		t.Fatalf("expected primary account to be retained user account, got %q", out.AccountID)
+	}
+}
+
+func TestAWSPermissionBoundaryExecutorAvoidsUnsafeAccountFallbackForUnresolvedSplitTarget(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 20, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-multi-target-non-arn-user",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-a", "aws:identity:user/app-user"},
+		TargetAccountIDs:      []string{"111111111111", "222222222222"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-multi-target-non-arn-user",
+		CaseID:           "case-multi-target-non-arn-user",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-multi-target-non-arn-user",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{
+			{
+				Service:          "iam",
+				Operation:        "PutRolePermissionsBoundary",
+				TargetResource:   "aws:identity:arn:aws:iam::111111111111:role/app-a",
+				ParameterRefs:    []string{"idk", "boundary_ref://case-multi-target-non-arn-user/after"},
+				Idempotent:       true,
+				RequiresApproval: true,
+			},
+			{
+				Service:          "iam",
+				Operation:        "PutUserPermissionsBoundary",
+				TargetResource:   "aws:identity:user/app-user",
+				ParameterRefs:    []string{"idk", "boundary_ref://case-multi-target-non-arn-user/after"},
+				Idempotent:       true,
+				RequiresApproval: true,
+			},
+		},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 2 {
+		t.Fatalf("expected one executor entry per split target, got %+v", entries)
+	}
+	for _, out := range entries {
+		if len(out.TargetIdentityNodeIDs) != 1 || out.TargetIdentityNodeIDs[0] != "aws:identity:user/app-user" {
+			continue
+		}
+		if len(out.TargetAccountIDs) != 0 || out.AccountID != "" {
+			t.Fatalf("non-ARN split target with no derivable account must not inherit the plan's full account list: %+v", out)
+		}
 	}
 }
 

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -220,8 +220,8 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 		PlanID:                "plan-mixed-principals",
 		Kind:                  awsPermissionBoundaryKind,
 		ReadyForApply:         true,
-		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/app-role", "aws:identity:arn:aws:iam::123456789012:user/app-user"},
-		TargetAccountIDs:      []string{"123456789012"},
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-role", "aws:identity:arn:aws:iam::222222222222:user/app-user"},
+		TargetAccountIDs:      []string{"111111111111", "222222222222"},
 		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
 	}
 	entry := AWSRemediationDryRunEntry{
@@ -236,7 +236,7 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
 			Service:          "iam",
 			Operation:        "PutRolePermissionsBoundary",
-			TargetResource:   "aws:identity:arn:aws:iam::123456789012:role/app-role",
+			TargetResource:   "aws:identity:arn:aws:iam::111111111111:role/app-role",
 			ParameterRefs:    []string{"idk", "boundary_ref://case-mixed/after"},
 			Idempotent:       true,
 			RequiresApproval: true,
@@ -258,6 +258,9 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	if len(roleEntry.TargetIdentityNodeIDs) != 1 || !strings.Contains(roleEntry.TargetIdentityNodeIDs[0], ":role/") {
 		t.Fatalf("role entry retained non-role targets: %+v", roleEntry.TargetIdentityNodeIDs)
 	}
+	if len(roleEntry.TargetAccountIDs) != 1 || roleEntry.TargetAccountIDs[0] != "111111111111" {
+		t.Fatalf("role entry retained wrong target accounts: %+v", roleEntry.TargetAccountIDs)
+	}
 	userEntry, ok := byOperation["PutUserPermissionsBoundary"]
 	if !ok {
 		t.Fatalf("missing user boundary entry: %+v", entries)
@@ -265,8 +268,15 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	if len(userEntry.TargetIdentityNodeIDs) != 1 || !strings.Contains(userEntry.TargetIdentityNodeIDs[0], ":user/") {
 		t.Fatalf("user entry retained non-user targets: %+v", userEntry.TargetIdentityNodeIDs)
 	}
+	if len(userEntry.TargetAccountIDs) != 1 || userEntry.TargetAccountIDs[0] != "222222222222" {
+		t.Fatalf("user entry retained wrong target accounts: %+v", userEntry.TargetAccountIDs)
+	}
 	if userEntry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" || !strings.Contains(userEntry.IntendedAPICall.TargetResource, ":user/") {
 		t.Fatalf("user entry has wrong intended call: %+v", userEntry.IntendedAPICall)
+	}
+	filtered, _ := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "111111111111"})
+	if len(filtered) != 1 || filtered[0].Operation != "PutRolePermissionsBoundary" {
+		t.Fatalf("account filter leaked cross-account split entries: %+v", filtered)
 	}
 	if roleEntry.ExecutionID == userEntry.ExecutionID {
 		t.Fatalf("split entries must have distinct execution IDs: role=%q user=%q", roleEntry.ExecutionID, userEntry.ExecutionID)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -214,6 +214,65 @@ func TestAWSPermissionBoundaryExecutorStateHonorsPreconditions(t *testing.T) {
 	}
 }
 
+func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
+	now := time.Date(2026, 6, 30, 11, 30, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-mixed-principals",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/app-role", "aws:identity:arn:aws:iam::123456789012:user/app-user"},
+		TargetAccountIDs:      []string{"123456789012"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-mixed",
+		CaseID:           "case-mixed",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-mixed-principals",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:arn:aws:iam::123456789012:role/app-role",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-mixed/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 2 {
+		t.Fatalf("expected mixed role/user plan to split into two executor entries: %+v", entries)
+	}
+	byOperation := map[string]AWSPermissionBoundaryExecutorEntry{}
+	for _, out := range entries {
+		byOperation[out.Operation] = out
+	}
+	roleEntry, ok := byOperation["PutRolePermissionsBoundary"]
+	if !ok {
+		t.Fatalf("missing role boundary entry: %+v", entries)
+	}
+	if len(roleEntry.TargetIdentityNodeIDs) != 1 || !strings.Contains(roleEntry.TargetIdentityNodeIDs[0], ":role/") {
+		t.Fatalf("role entry retained non-role targets: %+v", roleEntry.TargetIdentityNodeIDs)
+	}
+	userEntry, ok := byOperation["PutUserPermissionsBoundary"]
+	if !ok {
+		t.Fatalf("missing user boundary entry: %+v", entries)
+	}
+	if len(userEntry.TargetIdentityNodeIDs) != 1 || !strings.Contains(userEntry.TargetIdentityNodeIDs[0], ":user/") {
+		t.Fatalf("user entry retained non-user targets: %+v", userEntry.TargetIdentityNodeIDs)
+	}
+	if userEntry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" || !strings.Contains(userEntry.IntendedAPICall.TargetResource, ":user/") {
+		t.Fatalf("user entry has wrong intended call: %+v", userEntry.IntendedAPICall)
+	}
+	if roleEntry.ExecutionID == userEntry.ExecutionID {
+		t.Fatalf("split entries must have distinct execution IDs: role=%q user=%q", roleEntry.ExecutionID, userEntry.ExecutionID)
+	}
+}
+
 func TestGetAWSPermissionBoundaryExecutorFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	svc, ws := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor-states", now)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -229,6 +229,7 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 		CaseID:           "case-mixed",
 		SourceType:       "aws_permission_boundary_scp",
 		SourceArtifactID: "plan-mixed-principals",
+		AccountID:        "111111111111",
 		IdempotencyKey:   "idk",
 		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
 		ReadyForApply:    true,
@@ -261,6 +262,9 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	if len(roleEntry.TargetAccountIDs) != 1 || roleEntry.TargetAccountIDs[0] != "111111111111" {
 		t.Fatalf("role entry retained wrong target accounts: %+v", roleEntry.TargetAccountIDs)
 	}
+	if roleEntry.AccountID != "111111111111" {
+		t.Fatalf("role entry retained wrong primary account: %q", roleEntry.AccountID)
+	}
 	userEntry, ok := byOperation["PutUserPermissionsBoundary"]
 	if !ok {
 		t.Fatalf("missing user boundary entry: %+v", entries)
@@ -270,6 +274,9 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	}
 	if len(userEntry.TargetAccountIDs) != 1 || userEntry.TargetAccountIDs[0] != "222222222222" {
 		t.Fatalf("user entry retained wrong target accounts: %+v", userEntry.TargetAccountIDs)
+	}
+	if userEntry.AccountID != "222222222222" {
+		t.Fatalf("user entry retained wrong primary account: %q", userEntry.AccountID)
 	}
 	if userEntry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" || !strings.Contains(userEntry.IntendedAPICall.TargetResource, ":user/") {
 		t.Fatalf("user entry has wrong intended call: %+v", userEntry.IntendedAPICall)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -338,6 +338,86 @@ func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTarg
 	}
 }
 
+func TestAWSPermissionBoundaryExecutorFiltersGroupTargets(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 15, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-mixed-with-group",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-role", "aws:identity:arn:aws:iam::111111111111:group/app-group"},
+		TargetAccountIDs:      []string{"111111111111"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-mixed-group",
+		CaseID:           "case-mixed-group",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-mixed-with-group",
+		AccountID:        "111111111111",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:arn:aws:iam::111111111111:role/app-role",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-mixed-group/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 1 {
+		t.Fatalf("group targets should be filtered, leaving a single role entry: %+v", entries)
+	}
+	out := entries[0]
+	if out.Operation != "PutRolePermissionsBoundary" {
+		t.Fatalf("expected role-only executor operation: %q", out.Operation)
+	}
+	for _, target := range out.TargetIdentityNodeIDs {
+		if strings.Contains(target, ":group/") {
+			t.Fatalf("group target leaked into executor entry: %q", target)
+		}
+	}
+}
+
+func TestAWSPermissionBoundaryExecutorRejectsGroupOnlyPlan(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 30, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-group-only",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:group/app-group"},
+		TargetAccountIDs:      []string{"111111111111"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-group-only",
+		CaseID:           "case-group-only",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-group-only",
+		AccountID:        "111111111111",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:arn:aws:iam::111111111111:group/app-group",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-group-only/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	if entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now); len(entries) != 0 {
+		t.Fatalf("group-only boundary plan must not produce executor entries: %+v", entries)
+	}
+}
+
 func TestGetAWSPermissionBoundaryExecutorFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	svc, ws := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor-states", now)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -338,6 +338,59 @@ func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTarg
 	}
 }
 
+func TestAWSPermissionBoundaryExecutorScopesSingleOperationAfterGroupFilter(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 45, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-group-filtered-into-user",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:identity:arn:aws:iam::222222222222:user/app-user"},
+		TargetAccountIDs:      []string{"111111111111", "222222222222"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+		ImpactedNodes:         []string{"aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:identity:arn:aws:iam::222222222222:user/app-user"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-group-filtered-into-user",
+		CaseID:           "case-group-filtered-into-user",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-group-filtered-into-user",
+		AccountID:        "111111111111",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:arn:aws:iam::111111111111:group/app-group",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-group-filtered-into-user/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 1 {
+		t.Fatalf("group filter to single user should produce one executor entry: %+v", entries)
+	}
+	out := entries[0]
+	if out.Operation != "PutUserPermissionsBoundary" {
+		t.Fatalf("expected scoped single-operation entry to target user permissions boundary, got %q", out.Operation)
+	}
+	if out.IntendedAPICall.Operation != "PutUserPermissionsBoundary" {
+		t.Fatalf("expected intended call to recompute for user-only split, got %+v", out.IntendedAPICall)
+	}
+	if len(out.TargetIdentityNodeIDs) != 1 || !strings.HasSuffix(out.TargetIdentityNodeIDs[0], ":user/app-user") {
+		t.Fatalf("expected filtered target identities to keep only the user identity: %+v", out.TargetIdentityNodeIDs)
+	}
+	if len(out.TargetAccountIDs) != 1 || out.TargetAccountIDs[0] != "222222222222" {
+		t.Fatalf("expected account scope to be narrowed to retained user account: %+v", out.TargetAccountIDs)
+	}
+	if out.AccountID != "222222222222" {
+		t.Fatalf("expected primary account to be retained user account, got %q", out.AccountID)
+	}
+}
+
 func TestAWSPermissionBoundaryExecutorFiltersGroupTargets(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 15, 0, 0, time.UTC)
 	plan := AWSPermissionBoundarySCPPlan{

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -474,13 +474,13 @@ func TestAWSPermissionBoundaryExecutorScopesSingleOperationAfterGroupFilter(t *t
 	}
 }
 
-func TestAWSPermissionBoundaryExecutorFiltersGroupTargets(t *testing.T) {
+func TestAWSPermissionBoundaryExecutorFiltersUnsupportedTargets(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 15, 0, 0, time.UTC)
 	plan := AWSPermissionBoundarySCPPlan{
 		PlanID:                "plan-mixed-with-group",
 		Kind:                  awsPermissionBoundaryKind,
 		ReadyForApply:         true,
-		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-role", "aws:identity:arn:aws:iam::111111111111:group/app-group"},
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-role", "aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:s3:::payments-prod"},
 		TargetAccountIDs:      []string{"111111111111"},
 		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
 	}
@@ -513,19 +513,19 @@ func TestAWSPermissionBoundaryExecutorFiltersGroupTargets(t *testing.T) {
 		t.Fatalf("expected role-only executor operation: %q", out.Operation)
 	}
 	for _, target := range out.TargetIdentityNodeIDs {
-		if strings.Contains(target, ":group/") {
-			t.Fatalf("group target leaked into executor entry: %q", target)
+		if strings.Contains(target, ":group/") || strings.HasPrefix(target, "aws:s3:::") {
+			t.Fatalf("unsupported target leaked into executor entry: %q", target)
 		}
 	}
 }
 
-func TestAWSPermissionBoundaryExecutorRejectsGroupOnlyPlan(t *testing.T) {
+func TestAWSPermissionBoundaryExecutorRejectsUnsupportedOnlyPlan(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 30, 0, 0, time.UTC)
 	plan := AWSPermissionBoundarySCPPlan{
 		PlanID:                "plan-group-only",
 		Kind:                  awsPermissionBoundaryKind,
 		ReadyForApply:         true,
-		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:group/app-group"},
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:s3:::payments-prod"},
 		TargetAccountIDs:      []string{"111111111111"},
 		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
 	}
@@ -550,7 +550,7 @@ func TestAWSPermissionBoundaryExecutorRejectsGroupOnlyPlan(t *testing.T) {
 	}
 
 	if entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now); len(entries) != 0 {
-		t.Fatalf("group-only boundary plan must not produce executor entries: %+v", entries)
+		t.Fatalf("unsupported-only boundary plan must not produce executor entries: %+v", entries)
 	}
 }
 

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -290,6 +290,54 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	}
 }
 
+func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTargets(t *testing.T) {
+	now := time.Date(2026, 6, 30, 11, 45, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-mixed-non-arn",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:role/app-role", "aws:identity:user/app-user"},
+		TargetAccountIDs:      []string{"111111111111", "222222222222"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-mixed-non-arn",
+		CaseID:           "case-mixed-non-arn",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-mixed-non-arn",
+		AccountID:        "111111111111",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:role/app-role",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-mixed-non-arn/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 2 {
+		t.Fatalf("expected mixed non-ARN role/user plan to split into two executor entries: %+v", entries)
+	}
+	for _, out := range entries {
+		if len(out.TargetAccountIDs) != 2 {
+			t.Fatalf("non-ARN split entry must preserve planner target accounts: %+v", out)
+		}
+		if out.AccountID == "" {
+			t.Fatalf("non-ARN split entry must retain a primary account from the planner: %+v", out)
+		}
+	}
+	filtered, _ := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "222222222222"})
+	if len(filtered) != 2 {
+		t.Fatalf("planner account drill-down should retain both non-ARN split entries: %+v", filtered)
+	}
+}
+
 func TestGetAWSPermissionBoundaryExecutorFailureStates(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	svc, ws := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor-states", now)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -281,6 +281,9 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	if userEntry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" || !strings.Contains(userEntry.IntendedAPICall.TargetResource, ":user/") {
 		t.Fatalf("user entry has wrong intended call: %+v", userEntry.IntendedAPICall)
 	}
+	if len(userEntry.IntendedAPICall.ParameterRefs) == 0 || userEntry.IntendedAPICall.ParameterRefs[0] != userEntry.IdempotencyKey {
+		t.Fatalf("user entry intended call should refresh its idempotency parameter ref: %+v", userEntry.IntendedAPICall)
+	}
 	if roleEntry.IdempotencyKey == userEntry.IdempotencyKey {
 		t.Fatalf("split entries should have distinct idempotency keys: role=%q user=%q", roleEntry.IdempotencyKey, userEntry.IdempotencyKey)
 	}
@@ -296,6 +299,9 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	}
 	if roleEntry.ExecutionID == userEntry.ExecutionID {
 		t.Fatalf("split entries must have distinct execution IDs: role=%q user=%q", roleEntry.ExecutionID, userEntry.ExecutionID)
+	}
+	if len(roleEntry.IntendedAPICall.ParameterRefs) == 0 || roleEntry.IntendedAPICall.ParameterRefs[0] != roleEntry.IdempotencyKey {
+		t.Fatalf("role entry intended call should refresh its idempotency parameter ref: %+v", roleEntry.IntendedAPICall)
 	}
 }
 
@@ -388,6 +394,9 @@ func TestAWSPermissionBoundaryExecutorScopesSingleOperationAfterGroupFilter(t *t
 	}
 	if out.IntendedAPICall.Operation != "PutUserPermissionsBoundary" {
 		t.Fatalf("expected intended call to recompute for user-only split, got %+v", out.IntendedAPICall)
+	}
+	if len(out.IntendedAPICall.ParameterRefs) == 0 || out.IntendedAPICall.ParameterRefs[0] != out.IdempotencyKey {
+		t.Fatalf("scoped single-operation intended call should refresh idempotency parameter ref: %+v", out.IntendedAPICall)
 	}
 	if len(out.TargetIdentityNodeIDs) != 1 || !strings.HasSuffix(out.TargetIdentityNodeIDs[0], ":user/app-user") {
 		t.Fatalf("expected filtered target identities to keep only the user identity: %+v", out.TargetIdentityNodeIDs)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -281,6 +281,15 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	if userEntry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" || !strings.Contains(userEntry.IntendedAPICall.TargetResource, ":user/") {
 		t.Fatalf("user entry has wrong intended call: %+v", userEntry.IntendedAPICall)
 	}
+	if roleEntry.IdempotencyKey == userEntry.IdempotencyKey {
+		t.Fatalf("split entries should have distinct idempotency keys: role=%q user=%q", roleEntry.IdempotencyKey, userEntry.IdempotencyKey)
+	}
+	if roleEntry.IdempotencyKey != stableAWSBlastRadiusToken("idk", "PutRolePermissionsBoundary", roleEntry.TargetIdentityNodeIDs[0]) {
+		t.Fatalf("unexpected role split idempotency key: %q", roleEntry.IdempotencyKey)
+	}
+	if userEntry.IdempotencyKey != stableAWSBlastRadiusToken("idk", "PutUserPermissionsBoundary", userEntry.TargetIdentityNodeIDs[0]) {
+		t.Fatalf("unexpected user split idempotency key: %q", userEntry.IdempotencyKey)
+	}
 	filtered, _ := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "111111111111"})
 	if len(filtered) != 1 || filtered[0].Operation != "PutRolePermissionsBoundary" {
 		t.Fatalf("account filter leaked cross-account split entries: %+v", filtered)

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -305,6 +305,71 @@ func TestAWSPermissionBoundaryExecutorSplitsMixedPrincipalKinds(t *testing.T) {
 	}
 }
 
+func TestAWSPermissionBoundaryExecutorSplitsSameKindTargetsIntoCalls(t *testing.T) {
+	now := time.Date(2026, 7, 1, 7, 30, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-same-kind-principals",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-a", "aws:identity:arn:aws:iam::111111111111:role/app-b"},
+		TargetAccountIDs:      []string{"111111111111"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-same-kind",
+		CaseID:           "case-same-kind",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-same-kind-principals",
+		AccountID:        "111111111111",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{
+			Service:          "iam",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetResource:   "aws:identity:arn:aws:iam::111111111111:role/app-a",
+			ParameterRefs:    []string{"idk", "boundary_ref://case-same-kind/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}},
+	}
+
+	entries := awsPermissionBoundaryExecutorEntriesFromDryRun(entry, plan, now)
+	if len(entries) != 2 {
+		t.Fatalf("expected same-kind role plan to split into one entry per intended call: %+v", entries)
+	}
+	seenExecutions := map[string]bool{}
+	seenKeys := map[string]bool{}
+	seenTargets := map[string]bool{}
+	for _, out := range entries {
+		if len(out.TargetIdentityNodeIDs) != 1 {
+			t.Fatalf("entry should retain exactly one target identity: %+v", out.TargetIdentityNodeIDs)
+		}
+		target := out.TargetIdentityNodeIDs[0]
+		if out.IntendedAPICall.Operation != "PutRolePermissionsBoundary" || out.IntendedAPICall.TargetResource != target {
+			t.Fatalf("intended call must target the retained identity: target=%q call=%+v", target, out.IntendedAPICall)
+		}
+		if len(out.IntendedAPICall.ParameterRefs) == 0 || out.IntendedAPICall.ParameterRefs[0] != out.IdempotencyKey {
+			t.Fatalf("intended call should refresh its idempotency parameter ref: %+v", out.IntendedAPICall)
+		}
+		if seenExecutions[out.ExecutionID] {
+			t.Fatalf("same-kind split entries must have distinct execution IDs: %+v", entries)
+		}
+		if seenKeys[out.IdempotencyKey] {
+			t.Fatalf("same-kind split entries must have distinct idempotency keys: %+v", entries)
+		}
+		seenExecutions[out.ExecutionID] = true
+		seenKeys[out.IdempotencyKey] = true
+		seenTargets[target] = true
+	}
+	for _, target := range plan.TargetIdentityNodeIDs {
+		if !seenTargets[target] {
+			t.Fatalf("missing executor entry for target %q in %+v", target, entries)
+		}
+	}
+}
+
 func TestAWSPermissionBoundaryExecutorSplitPreservesPlannerAccountsForNonARNTargets(t *testing.T) {
 	now := time.Date(2026, 6, 30, 11, 45, 0, 0, time.UTC)
 	plan := AWSPermissionBoundarySCPPlan{

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -237,6 +237,48 @@ func TestGetAWSPermissionBoundaryExecutorFailureStates(t *testing.T) {
 	}
 }
 
+func TestFilterAWSPermissionBoundaryExecutorEntriesMatchesTargetAccounts(t *testing.T) {
+	entries := []AWSPermissionBoundaryExecutorEntry{
+		{
+			ExecutionID:      "exec-cross-account",
+			DryRunID:         "dr-1",
+			CaseID:           "case-1",
+			PlanID:           "plan-cross-account",
+			AccountID:        "",
+			Region:           "us-east-1",
+			State:            awsPermissionBoundaryExecutorStateBlocked,
+			Severity:         "high",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetAccountIDs: []string{"111111111111", "222222222222"},
+		},
+		{
+			ExecutionID:      "exec-other-account",
+			DryRunID:         "dr-2",
+			CaseID:           "case-2",
+			PlanID:           "plan-other-account",
+			AccountID:        "333333333333",
+			Region:           "us-east-1",
+			State:            awsPermissionBoundaryExecutorStateProjected,
+			Severity:         "medium",
+			Operation:        "PutRolePermissionsBoundary",
+			TargetAccountIDs: []string{"333333333333"},
+		},
+	}
+
+	filtered, applied := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "111111111111"})
+	if applied["account_id"] != "111111111111" {
+		t.Fatalf("expected applied account filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-cross-account" {
+		t.Fatalf("expected target account match to retain cross-account entry: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{AccountID: "444444444444"})
+	if len(filtered) != 0 {
+		t.Fatalf("unexpected entries for unmatched target account: %+v", filtered)
+	}
+}
+
 func TestAWSPermissionBoundaryExecutorAggregatesDryRunDiagnostics(t *testing.T) {
 	diagnostics := awsPermissionBoundaryExecutorDiagnostics(
 		[]AWSRemediationApprovalDiagnostic{{

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -1,0 +1,318 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newPermissionBoundaryExecutorService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSPermissionBoundaryExecutorBuildsContract(t *testing.T) {
+	now := time.Date(2026, 6, 30, 10, 0, 0, 0, time.UTC)
+	svc, ws := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor", now)
+
+	result, err := svc.GetAWSPermissionBoundaryExecutor(defaultScopeContext(), ws, "project-permission-boundary-executor", AWSPermissionBoundaryExecutorRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get permission boundary executor: %v", err)
+	}
+	if result.CurrentIssueRef != "#1540" || result.Version != awsPermissionBoundaryExecutorVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Entries) == 0 {
+		t.Fatalf("expected permission-boundary dry-run entries to join to planner records: summary=%+v", result.Summary)
+	}
+	if len(result.Caveats) == 0 || len(result.CoverageGaps) == 0 {
+		t.Fatalf("expected caveats and coverage gaps: %+v", result)
+	}
+	blockedEntries := 0
+	for i := 1; i < len(result.Entries); i++ {
+		if result.Entries[i-1].Score < result.Entries[i].Score {
+			t.Fatalf("entries are not ranked by descending score: %+v", result.Entries)
+		}
+	}
+	for _, entry := range result.Entries {
+		if entry.ExecutionID == "" || entry.CalculationVersion != awsPermissionBoundaryExecutorVersion {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.DryRunID == "" || entry.PlanID == "" || entry.CaseID == "" {
+			t.Fatalf("entry missing source IDs: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if entry.IntendedAPICall.Service != "iam" {
+			t.Fatalf("entry must project IAM calls: %+v", entry.IntendedAPICall)
+		}
+		if entry.IntendedAPICall.Operation != "PutRolePermissionsBoundary" && entry.IntendedAPICall.Operation != "PutUserPermissionsBoundary" {
+			t.Fatalf("entry must project permission boundary operations: %+v", entry.IntendedAPICall)
+		}
+		if len(entry.TargetIdentityNodeIDs) == 0 || len(entry.Preconditions) == 0 {
+			t.Fatalf("entry missing target identities or preconditions: %+v", entry)
+		}
+		if entry.BoundarySimulation.SimulationRef == "" || entry.BoundarySimulation.TargetIdentityCount == 0 {
+			t.Fatalf("entry missing boundary simulation: %+v", entry.BoundarySimulation)
+		}
+		if entry.EvidenceBoundary != awsPermissionBoundaryExecutorEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		if entry.State == awsPermissionBoundaryExecutorStateBlocked {
+			blockedEntries++
+		}
+	}
+	if blockedEntries == 0 {
+		t.Fatalf("success fixture must surface blocked unsafe boundary entries: %+v", result.Entries)
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("permission boundary executor serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSPermissionBoundaryExecutorAdmitsOnlyBoundaryDryRuns(t *testing.T) {
+	cases := []struct {
+		name      string
+		entry     AWSRemediationDryRunEntry
+		wantAdmit bool
+	}{
+		{
+			name: "permission boundary dry-run is admitted",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePermissionsBoundary"}},
+			},
+			wantAdmit: true,
+		},
+		{
+			name: "user boundary dry-run is admitted",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutUserPermissionsBoundary"}},
+			},
+			wantAdmit: true,
+		},
+		{
+			name: "scp diff is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "scp_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "organizations", Operation: "AttachPolicy"}},
+			},
+			wantAdmit: false,
+		},
+		{
+			name: "trust-policy source is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "trust_policy_hardening",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePermissionsBoundary"}},
+			},
+			wantAdmit: false,
+		},
+		{
+			name: "noop boundary diff is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff", NoOp: true},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePermissionsBoundary"}},
+			},
+			wantAdmit: false,
+		},
+		{
+			name: "unsupported operation is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePolicy"}},
+			},
+			wantAdmit: false,
+		},
+	}
+	for _, tc := range cases {
+		got := awsPermissionBoundaryExecutorAdmits(tc.entry)
+		if got != tc.wantAdmit {
+			t.Fatalf("%s: admits=%v want=%v", tc.name, got, tc.wantAdmit)
+		}
+	}
+}
+
+func TestAWSPermissionBoundaryExecutorStateHonorsPreconditions(t *testing.T) {
+	now := time.Date(2026, 6, 30, 11, 0, 0, 0, time.UTC)
+	readyPlan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "plan-ready",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/app-a", "aws:identity:arn:aws:iam::123456789012:role/app-b"},
+		TargetAccountIDs:      []string{"123456789012"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-ready",
+		CaseID:           "case-ready",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "plan-ready",
+		IdempotencyKey:   "idk",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePermissionsBoundary"}},
+	}
+	out := awsPermissionBoundaryExecutorEntryFromDryRun(entry, readyPlan, now)
+	if out.State != awsPermissionBoundaryExecutorStateProjected || !out.ReadyForLiveApply {
+		t.Fatalf("ready entry must reach projected/ready_for_live_apply, got %+v", out)
+	}
+
+	noTargets := readyPlan
+	noTargets.TargetIdentityNodeIDs = nil
+	out = awsPermissionBoundaryExecutorEntryFromDryRun(entry, noTargets, now)
+	if out.State != awsPermissionBoundaryExecutorStateBlocked {
+		t.Fatalf("missing targets must block live apply, got state=%q", out.State)
+	}
+
+	planNotReady := readyPlan
+	planNotReady.ReadyForApply = false
+	out = awsPermissionBoundaryExecutorEntryFromDryRun(entry, planNotReady, now)
+	if out.State != awsPermissionBoundaryExecutorStatePreconditionFailed {
+		t.Fatalf("planner not ready must surface precondition_failed, got state=%q", out.State)
+	}
+
+	highBreakage := readyPlan
+	highBreakage.BreakageProjection.Level = "high"
+	out = awsPermissionBoundaryExecutorEntryFromDryRun(entry, highBreakage, now)
+	if out.State != awsPermissionBoundaryExecutorStatePreconditionFailed {
+		t.Fatalf("high breakage must surface precondition_failed, got state=%q", out.State)
+	}
+
+	killSwitch := entry
+	killSwitch.KillSwitchEngaged = true
+	out = awsPermissionBoundaryExecutorEntryFromDryRun(killSwitch, readyPlan, now)
+	if out.State != awsPermissionBoundaryExecutorStateBlocked || out.ReadyForLiveApply {
+		t.Fatalf("kill switch must block, got %+v", out)
+	}
+}
+
+func TestGetAWSPermissionBoundaryExecutorFailureStates(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	svc, ws := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor-states", now)
+
+	denied, err := svc.GetAWSPermissionBoundaryExecutor(defaultScopeContext(), ws, "project-permission-boundary-executor-states", AWSPermissionBoundaryExecutorRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("permission denied: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Entries) != 0 {
+		t.Fatalf("permission denied must be explicit and suppress entries: %+v", denied)
+	}
+
+	if _, err := svc.GetAWSPermissionBoundaryExecutor(defaultScopeContext(), ws, "project-permission-boundary-executor-states", AWSPermissionBoundaryExecutorRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestAWSPermissionBoundaryExecutorAggregatesDryRunDiagnostics(t *testing.T) {
+	diagnostics := awsPermissionBoundaryExecutorDiagnostics(
+		[]AWSRemediationApprovalDiagnostic{{
+			Collector:   "aws_remediation_dry_run",
+			SourceID:    "dry-run-source",
+			Code:        "dry_run_partial_failure",
+			Message:     "Dry-run source was partially unavailable.",
+			Remediation: "Retry the dry-run source.",
+			Retryable:   true,
+		}},
+		[]AWSPermissionBoundarySCPDiagnostic{{
+			Collector:   "aws_permission_boundary_scp",
+			SourceID:    "planner-source",
+			Code:        "planner_degraded",
+			Message:     "Planner source was degraded.",
+			Remediation: "Retry the planner source.",
+			Retryable:   true,
+		}},
+	)
+	if len(diagnostics) != 2 || diagnostics[0].Collector != "aws_remediation_dry_run" || diagnostics[1].Collector != "aws_permission_boundary_scp" {
+		t.Fatalf("executor diagnostics must preserve dry-run and planner sources: %+v", diagnostics)
+	}
+
+	gaps := awsPermissionBoundaryExecutorCoverageGaps(
+		[]AWSRemediationApprovalCoverageGap{{
+			Capability:  "dry_run_approval_queue",
+			Status:      "partial_failure",
+			Reason:      "Approval queue source was partially unavailable.",
+			Remediation: "Retry approval queue collection.",
+		}},
+		[]AWSPermissionBoundarySCPCoverageGap{{
+			Capability:  "permission_boundary_runtime_evidence",
+			Status:      "degraded",
+			Reason:      "Runtime evidence was delayed.",
+			Remediation: "Retry runtime evidence collection.",
+		}},
+	)
+	foundDryRunGap := false
+	foundPlannerGap := false
+	for _, gap := range gaps {
+		switch gap.Capability {
+		case "dry_run_approval_queue":
+			foundDryRunGap = true
+		case "permission_boundary_runtime_evidence":
+			foundPlannerGap = true
+		}
+	}
+	if !foundDryRunGap || !foundPlannerGap {
+		t.Fatalf("executor coverage gaps must preserve dry-run and planner sources: %+v", gaps)
+	}
+}
+
+func TestRouterAWSPermissionBoundaryExecutor(t *testing.T) {
+	now := time.Date(2026, 6, 30, 13, 0, 0, 0, time.UTC)
+	svc, _ := newPermissionBoundaryExecutorService(t, "project-permission-boundary-executor-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-permission-boundary-executor-route/aws/permission-boundary-executor?connector_id=aws-prod&fixture_state=success&state=blocked", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Executor AWSPermissionBoundaryExecutorResult `json:"permission_boundary_executor"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Executor.CurrentIssueRef != "#1540" || body.Executor.AppliedFilters["state"] != "blocked" {
+		t.Fatalf("unexpected route payload: %+v", body.Executor)
+	}
+	if len(body.Executor.Entries) == 0 {
+		t.Fatalf("blocked success fixture route must return unsafe executor entries: %+v", body.Executor)
+	}
+	for _, entry := range body.Executor.Entries {
+		if entry.State != awsPermissionBoundaryExecutorStateBlocked || entry.ReadyForLiveApply {
+			t.Fatalf("blocked route returned executable entry: %+v", entry)
+		}
+	}
+}

--- a/internal/api/aws_permission_boundary_executor_test.go
+++ b/internal/api/aws_permission_boundary_executor_test.go
@@ -279,6 +279,31 @@ func TestFilterAWSPermissionBoundaryExecutorEntriesMatchesTargetAccounts(t *test
 	}
 }
 
+func TestFilterAWSPermissionBoundaryExecutorEntriesKeepsMultiRegionEntries(t *testing.T) {
+	entries := []AWSPermissionBoundaryExecutorEntry{
+		{
+			ExecutionID: "exec-multi-region",
+			Region:      "",
+			State:       awsPermissionBoundaryExecutorStateBlocked,
+			Operation:   "PutRolePermissionsBoundary",
+		},
+		{
+			ExecutionID: "exec-west",
+			Region:      "us-west-2",
+			State:       awsPermissionBoundaryExecutorStateProjected,
+			Operation:   "PutRolePermissionsBoundary",
+		},
+	}
+
+	filtered, applied := filterAWSPermissionBoundaryExecutorEntries(entries, AWSPermissionBoundaryExecutorRequest{Region: "us-east-1"})
+	if applied["region"] != "us-east-1" {
+		t.Fatalf("expected applied region filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-multi-region" {
+		t.Fatalf("expected empty-region executor entry to survive region drill-down: %+v", filtered)
+	}
+}
+
 func TestAWSPermissionBoundaryExecutorAggregatesDryRunDiagnostics(t *testing.T) {
 	diagnostics := awsPermissionBoundaryExecutorDiagnostics(
 		[]AWSRemediationApprovalDiagnostic{{

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -433,13 +433,19 @@ func awsRemediationApprovalScope(source AWSRemediationCase, connectorID string) 
 	if strings.TrimSpace(source.IdentityNodeID) != "" {
 		identityNodes = append(identityNodes, source.IdentityNodeID)
 	}
+	resourceNodes := emptyStrings(dedupeStrings(source.ResourceNodeIDs))
+	if strings.EqualFold(source.SourceType, "aws_permission_boundary_scp") {
+		scopeType = "identity"
+		identityNodes = append(identityNodes, source.ResourceNodeIDs...)
+		resourceNodes = nil
+	}
 	return AWSRemediationApprovalScope{
 		ScopeType:       scopeType,
 		AccountIDs:      emptyStrings(dedupeStrings([]string{source.AccountID})),
 		Regions:         emptyStrings(dedupeStrings([]string{source.Region})),
 		ConnectorIDs:    connectors,
-		IdentityNodeIDs: identityNodes,
-		ResourceNodeIDs: emptyStrings(dedupeStrings(source.ResourceNodeIDs)),
+		IdentityNodeIDs: emptyStrings(dedupeStrings(identityNodes)),
+		ResourceNodeIDs: resourceNodes,
 	}
 }
 

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -338,7 +338,7 @@ func awsRemediationApprovalEntryFromCase(source AWSRemediationCase, now time.Tim
 		Confidence:         source.Confidence,
 		Title:              fmt.Sprintf("Approval: %s", source.Title),
 		Summary:            fmt.Sprintf("RBAC-gated approval workflow for remediation case %s. Identrail does not mutate AWS; later wave executors apply the change after approval.", source.CaseID),
-		AccountID:          source.AccountID,
+		AccountID:          firstNonEmptyAWSValue(source.AccountID, firstString(source.TargetAccountIDs)),
 		Region:             source.Region,
 		Requestor:          requestor,
 		RequiredApprovers:  approvers,
@@ -441,7 +441,7 @@ func awsRemediationApprovalScope(source AWSRemediationCase, connectorID string) 
 	}
 	return AWSRemediationApprovalScope{
 		ScopeType:       scopeType,
-		AccountIDs:      emptyStrings(dedupeStrings([]string{source.AccountID})),
+		AccountIDs:      emptyStrings(dedupeStrings(append([]string{source.AccountID}, source.TargetAccountIDs...))),
 		Regions:         emptyStrings(dedupeStrings([]string{source.Region})),
 		ConnectorIDs:    connectors,
 		IdentityNodeIDs: emptyStrings(dedupeStrings(identityNodes)),
@@ -652,7 +652,7 @@ func filterAWSRemediationApprovalEntries(entries []AWSRemediationApprovalEntry, 
 	}
 	filtered := make([]AWSRemediationApprovalEntry, 0, len(entries))
 	for _, entry := range entries {
-		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+		if filters["account_id"] != "" && !awsRemediationApprovalAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
@@ -697,6 +697,22 @@ func filterAWSRemediationApprovalEntries(entries []AWSRemediationApprovalEntry, 
 		filtered = append(filtered, entry)
 	}
 	return filtered, applied
+}
+
+func awsRemediationApprovalAccountMatch(entry AWSRemediationApprovalEntry, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.AccountID) == accountID {
+		return true
+	}
+	for _, scopeAccountID := range entry.Scope.AccountIDs {
+		if strings.TrimSpace(scopeAccountID) == accountID {
+			return true
+		}
+	}
+	return false
 }
 
 func awsRemediationApprovalHasApproverRole(entry AWSRemediationApprovalEntry, needle string) bool {

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -655,7 +655,7 @@ func filterAWSRemediationApprovalEntries(entries []AWSRemediationApprovalEntry, 
 		if filters["account_id"] != "" && !awsRemediationApprovalAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+		if filters["region"] != "" && !awsRemediationApprovalRegionMatch(entry, filters["region"]) {
 			continue
 		}
 		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
@@ -713,6 +713,17 @@ func awsRemediationApprovalAccountMatch(entry AWSRemediationApprovalEntry, accou
 		}
 	}
 	return false
+}
+
+func awsRemediationApprovalRegionMatch(entry AWSRemediationApprovalEntry, region string) bool {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.Region) == "" && strings.EqualFold(entry.SourceType, "aws_permission_boundary_scp") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Region), region)
 }
 
 func awsRemediationApprovalHasApproverRole(entry AWSRemediationApprovalEntry, needle string) bool {

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -436,7 +436,7 @@ func awsRemediationApprovalScope(source AWSRemediationCase, connectorID string) 
 	resourceNodes := emptyStrings(dedupeStrings(source.ResourceNodeIDs))
 	if strings.EqualFold(source.SourceType, "aws_permission_boundary_scp") {
 		scopeType = "identity"
-		identityNodes = append(identityNodes, source.ResourceNodeIDs...)
+		identityNodes = awsPermissionBoundaryExecutorSupportedTargets(append(identityNodes, source.ResourceNodeIDs...))
 		resourceNodes = nil
 	}
 	return AWSRemediationApprovalScope{

--- a/internal/api/aws_remediation_approval_test.go
+++ b/internal/api/aws_remediation_approval_test.go
@@ -140,6 +140,29 @@ func TestFilterAWSRemediationApprovalEntriesAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationApprovalEntriesMatchesScopeAccounts(t *testing.T) {
+	entries := []AWSRemediationApprovalEntry{
+		{
+			ApprovalID: "boundary-cross-account",
+			AccountID:  "",
+			Scope:      AWSRemediationApprovalScope{ScopeType: "identity", AccountIDs: []string{"111111111111", "222222222222"}},
+		},
+		{
+			ApprovalID: "boundary-other-account",
+			AccountID:  "333333333333",
+			Scope:      AWSRemediationApprovalScope{ScopeType: "identity", AccountIDs: []string{"333333333333"}},
+		},
+	}
+
+	filtered, applied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{AccountID: "222222222222"})
+	if applied["account_id"] != "222222222222" {
+		t.Fatalf("expected applied account filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].ApprovalID != "boundary-cross-account" {
+		t.Fatalf("expected scope account match to retain approval entry: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationApprovalEntryHonorsRBACGatesAndKillSwitch(t *testing.T) {
 	source := AWSRemediationCase{
 		CaseID:             "case-rbac",

--- a/internal/api/aws_remediation_approval_test.go
+++ b/internal/api/aws_remediation_approval_test.go
@@ -259,6 +259,33 @@ func TestAWSRemediationApprovalScopeUsesAccountForBlastRadiusSource(t *testing.T
 	}
 }
 
+func TestAWSRemediationApprovalScopeFiltersPermissionBoundaryTargets(t *testing.T) {
+	scope := awsRemediationApprovalScope(AWSRemediationCase{
+		SourceType:     "aws_permission_boundary_scp",
+		IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:role/app-role",
+		ResourceNodeIDs: []string{
+			"aws:s3:::payments-prod",
+			"aws:identity:arn:aws:iam::111111111111:group/app-group",
+			"aws:identity:arn:aws:iam::222222222222:user/app-user",
+		},
+	}, "aws-prod")
+	if scope.ScopeType != "identity" || len(scope.ResourceNodeIDs) != 0 {
+		t.Fatalf("permission boundary scope should stay identity-only, got %+v", scope)
+	}
+	want := map[string]bool{
+		"aws:identity:arn:aws:iam::111111111111:role/app-role": true,
+		"aws:identity:arn:aws:iam::222222222222:user/app-user": true,
+	}
+	if len(scope.IdentityNodeIDs) != len(want) {
+		t.Fatalf("expected only explicit IAM role/user targets, got %+v", scope.IdentityNodeIDs)
+	}
+	for _, target := range scope.IdentityNodeIDs {
+		if !want[target] {
+			t.Fatalf("unsupported permission boundary target leaked into approval scope: %q in %+v", target, scope.IdentityNodeIDs)
+		}
+	}
+}
+
 func TestAWSRemediationApprovalDeriveStatePreservesInReviewLifecycle(t *testing.T) {
 	cases := []struct {
 		lifecycle string

--- a/internal/api/aws_remediation_approval_test.go
+++ b/internal/api/aws_remediation_approval_test.go
@@ -163,6 +163,29 @@ func TestFilterAWSRemediationApprovalEntriesMatchesScopeAccounts(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationApprovalEntriesKeepsMultiRegionBoundaryEntries(t *testing.T) {
+	entries := []AWSRemediationApprovalEntry{
+		{
+			ApprovalID: "approval-multi-region-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "",
+		},
+		{
+			ApprovalID: "approval-west-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "us-west-2",
+		},
+	}
+
+	filtered, applied := filterAWSRemediationApprovalEntries(entries, AWSRemediationApprovalRequest{Region: "us-east-1"})
+	if applied["region"] != "us-east-1" {
+		t.Fatalf("expected applied region filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].ApprovalID != "approval-multi-region-boundary" {
+		t.Fatalf("expected empty-region boundary approval to survive region drill-down: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationApprovalEntryHonorsRBACGatesAndKillSwitch(t *testing.T) {
 	source := AWSRemediationCase{
 		CaseID:             "case-rbac",

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -686,10 +686,12 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 	supportedTargets := awsPermissionBoundaryExecutorSupportedTargets(plan.TargetIdentityNodeIDs)
 	filteredImpactedNodes := []string{}
 	for _, node := range emptyStrings(plan.ImpactedNodes) {
-		if awsRemediationDryRunIAMPrincipalKind(node) == "group" {
+		switch awsRemediationDryRunClassifiedIAMPrincipalKind(node) {
+		case "role", "user":
+			filteredImpactedNodes = append(filteredImpactedNodes, node)
+		default:
 			continue
 		}
-		filteredImpactedNodes = append(filteredImpactedNodes, node)
 	}
 	identityNodeID := firstString(emptyStrings(supportedTargets))
 	if identityNodeID == "" {

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -198,6 +198,7 @@ type awsRemediationCaseSources struct {
 	equivalence AWSSecretPermissionEquivalenceResult
 	blast       AWSBlastRadiusResult
 	trust       AWSTrustPolicyHardeningResult
+	boundary    AWSPermissionBoundarySCPResult
 }
 
 // GetAWSRemediationCases composes ranked, explainable remediation cases from
@@ -276,12 +277,14 @@ func (s *Service) GetAWSRemediationCases(ctx context.Context, workspaceID string
 			awsIssueURL(awsSecretPermissionEquivalenceCurrentIssue),
 			awsIssueURL(awsBlastRadiusCurrentIssue),
 			awsIssueURL(awsTrustPolicyHardeningCurrentIssue),
+			awsIssueURL(awsPermissionBoundarySCPCurrentIssue),
 			"/docs/aws-remediation-case-model",
 			"/docs/aws-ai-agent-risk-engine",
 			"/docs/aws-least-privilege",
 			"/docs/aws-secret-permission-equivalence-engine",
 			"/docs/aws-blast-radius-engine",
 			"/docs/aws-trust-policy-hardening-planner",
+			"/docs/aws-permission-boundary-scp-planner",
 			awsBaselineProjectEvidenceURL(scope, project),
 		}),
 		CoverageGaps: coverageGaps,
@@ -328,7 +331,11 @@ func (s *Service) awsRemediationCaseSourceSignals(ctx context.Context, workspace
 	if err != nil {
 		return awsRemediationCaseSources{}, fmt.Errorf("remediation case trust policy hardening: %w", err)
 	}
-	return awsRemediationCaseSources{risk: risk, least: least, equivalence: equivalence, blast: blast, trust: trust}, nil
+	boundary, err := s.GetAWSPermissionBoundarySCPPlans(ctx, workspaceID, projectID, AWSPermissionBoundarySCPRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return awsRemediationCaseSources{}, fmt.Errorf("remediation case permission boundary scp: %w", err)
+	}
+	return awsRemediationCaseSources{risk: risk, least: least, equivalence: equivalence, blast: blast, trust: trust, boundary: boundary}, nil
 }
 
 func awsRemediationCases(sources awsRemediationCaseSources, now time.Time) []AWSRemediationCase {
@@ -355,6 +362,11 @@ func awsRemediationCases(sources awsRemediationCaseSources, now time.Time) []AWS
 	}
 	for _, plan := range sources.trust.Plans {
 		if c, ok := awsRemediationCaseFromTrustPolicyHardening(plan, now); ok {
+			cases = append(cases, c)
+		}
+	}
+	for _, plan := range sources.boundary.Plans {
+		if c, ok := awsRemediationCaseFromPermissionBoundary(plan, now); ok {
 			cases = append(cases, c)
 		}
 	}
@@ -666,6 +678,69 @@ func awsRemediationTrustPolicyHardeningIsIAMRole(plan AWSTrustPolicyHardeningPla
 	return strings.Contains(resourceNodeID, ":role/")
 }
 
+func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan, now time.Time) (AWSRemediationCase, bool) {
+	if plan.PlanID == "" || !strings.EqualFold(plan.Kind, awsPermissionBoundaryKind) {
+		return AWSRemediationCase{}, false
+	}
+	identityNodeID := firstString(emptyStrings(plan.TargetIdentityNodeIDs))
+	if identityNodeID == "" {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("permission-boundary", plan.PlanID)
+	evidenceRef := firstString(awsRemediationEvidenceRefs(plan.Evidence))
+	deniedActions := awsRemediationPermissionBoundaryDeniedActions(plan)
+	diff := AWSRemediationDiffIntent{
+		Kind:               "permission_boundary_diff",
+		BeforeRef:          evidenceRef,
+		AfterRef:           "permission-boundary://" + plan.PlanID + "/intended-boundary",
+		DiffSummary:        fmt.Sprintf("Apply permission boundary plan %s to %d captured identity target(s); deny %s before live execution.", plan.PlanID, len(emptyStrings(plan.TargetIdentityNodeIDs)), firstNonEmptyAWSValue(strings.Join(deniedActions, ", "), "the projected unused action set")),
+		ReadOnlyProjection: true,
+	}
+	owner, ownerAssigned := "iam-platform", true
+	approvalRequired := awsRemediationApprovalRequired(plan.Severity, diff.Kind)
+	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, plan.Status)
+	if plan.ReadyForApply && normalizeAWSRuntimeEventFilterToken(plan.Status) == "action-required" {
+		approvalState = "approved"
+	}
+	lifecycle := awsRemediationLifecycle(plan.Status, plan.Confidence, ownerAssigned, approvalState, diff)
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "aws_permission_boundary_scp",
+		SourceFindingID:    plan.PlanID,
+		Lifecycle:          lifecycle,
+		Severity:           plan.Severity,
+		Status:             plan.Status,
+		Score:              plan.Score,
+		Confidence:         plan.Confidence,
+		Title:              fmt.Sprintf("Permission boundary executor for %s", firstNonEmptyAWSValue(plan.Service, identityNodeID)),
+		Summary:            plan.Summary,
+		AccountID:          plan.AccountID,
+		Region:             plan.Region,
+		IdentityNodeID:     identityNodeID,
+		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
+		IdentityType:       "iam_role",
+		ResourceNodeIDs:    awsRemediationResourceNodes(plan.TargetIdentityNodeIDs, plan.ImpactedNodes),
+		Owner:              owner,
+		OwnerAssigned:      ownerAssigned,
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForPermissionBoundary(plan),
+		RollbackPlan:       awsRemediationRollbackFromPermissionBoundary(plan, evidenceRef),
+		VerificationPlan:   awsRemediationVerificationFromPermissionBoundary(plan, evidenceRef),
+		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary"}, plan.SourceSignals...)),
+		Evidence:           plan.Evidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      dedupeStrings(append(append([]string{}, plan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)),
+		ImpactedPath:       plan.ImpactedPath,
+		NextActions:        awsRemediationNextActionList(plan.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
 func finalizeAWSRemediationCase(c AWSRemediationCase, now time.Time) AWSRemediationCase {
 	c.SourceSignals = dedupeStrings(c.SourceSignals)
 	c.ImpactedNodes = emptyStrings(dedupeStrings(c.ImpactedNodes))
@@ -802,7 +877,7 @@ func awsRemediationApprovalRequired(severity, diffKind string) bool {
 		return true
 	}
 	switch diffKind {
-	case "secret_rotation", "iam_trust_diff", "kms_grant_diff":
+	case "secret_rotation", "iam_trust_diff", "kms_grant_diff", "permission_boundary_diff":
 		return true
 	}
 	return false
@@ -962,6 +1037,18 @@ func awsRemediationTradeoffsForTrustPolicyHardening(plan AWSTrustPolicyHardening
 	return out
 }
 
+func awsRemediationTradeoffsForPermissionBoundary(plan AWSPermissionBoundarySCPPlan) []AWSRemediationTradeoff {
+	out := []AWSRemediationTradeoff{
+		{Dimension: "downstream_blast_radius", Direction: "improves", Description: fmt.Sprintf("Applying the permission boundary prevents re-introduction of unused privileges across %d captured identity target(s).", len(emptyStrings(plan.TargetIdentityNodeIDs))), Severity: plan.Severity},
+	}
+	if strings.EqualFold(plan.BreakageProjection.Level, "low") {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "neutral", Description: plan.BreakageProjection.Rationale, Severity: "low"})
+	} else {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "worsens", Description: plan.BreakageProjection.Rationale, Severity: firstNonEmptyAWSValue(plan.BreakageProjection.Level, "medium")})
+	}
+	return out
+}
+
 func awsRemediationRollbackForDiff(diff AWSRemediationDiffIntent, evidenceRef string) AWSRemediationRollbackPlan {
 	switch diff.Kind {
 	case "iam_policy_diff", "role_scope_diff":
@@ -972,6 +1059,8 @@ func awsRemediationRollbackForDiff(diff AWSRemediationDiffIntent, evidenceRef st
 		return AWSRemediationRollbackPlan{Strategy: "re_create_secret_reference", Steps: []string{"Reissue the prior credential or restore the previous reference if the workload regressed.", "Capture rotation evidence in the case audit trail."}, EvidenceRef: evidenceRef}
 	case "kms_grant_diff":
 		return AWSRemediationRollbackPlan{Strategy: "restore_grant", Steps: []string{"Restore the previous KMS grant or key policy statement.", "Re-run KMS-decrypt reachability to confirm the rollback."}, EvidenceRef: evidenceRef}
+	case "permission_boundary_diff":
+		return AWSRemediationRollbackPlan{Strategy: "detach_permission_boundary", Steps: []string{"Detach the projected permission boundary from the captured identity targets.", "Re-run least-privilege and IAM policy simulation to confirm the rollback."}, EvidenceRef: evidenceRef}
 	case "ai_agent_scope_change":
 		return AWSRemediationRollbackPlan{Strategy: "re_enable_tool", Steps: []string{"Re-enable the removed tool or capability scope on the AI agent definition.", "Re-run runtime/tool-call correlation."}, EvidenceRef: evidenceRef}
 	case "owner_assignment":
@@ -1091,6 +1180,46 @@ func awsRemediationVerificationFromTrustPolicyHardening(plan AWSTrustPolicyHarde
 		FailureSignals: verification.FailureSignals,
 		EvidenceRef:    firstNonEmptyAWSValue(verification.EvidenceRef, evidenceRef),
 	}
+}
+
+func awsRemediationRollbackFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan, evidenceRef string) AWSRemediationRollbackPlan {
+	rollback := plan.RollbackPlan
+	if len(rollback.Steps) == 0 {
+		return awsRemediationRollbackForDiff(AWSRemediationDiffIntent{Kind: "permission_boundary_diff"}, evidenceRef)
+	}
+	return AWSRemediationRollbackPlan{
+		Strategy:    firstNonEmptyAWSValue(rollback.Strategy, "detach_permission_boundary"),
+		Steps:       rollback.Steps,
+		EvidenceRef: firstNonEmptyAWSValue(rollback.EvidenceRef, evidenceRef),
+	}
+}
+
+func awsRemediationVerificationFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan, evidenceRef string) AWSRemediationVerificationPlan {
+	verification := plan.VerificationPlan
+	if len(verification.Steps) == 0 {
+		return AWSRemediationVerificationPlan{
+			Strategy:       "permission_boundary_re_evaluate",
+			Steps:          []string{"Re-run IAM policy simulation for the boundary-bound identities.", "Re-run least-privilege and confirm the removed action set does not reappear."},
+			SuccessSignals: []string{"permission_boundary:denies-unused-actions", "least_privilege:decision-keep"},
+			FailureSignals: []string{"permission_boundary:observed-action-denied", "least_privilege:decision-remove"},
+			EvidenceRef:    evidenceRef,
+		}
+	}
+	return AWSRemediationVerificationPlan{
+		Strategy:       firstNonEmptyAWSValue(verification.Strategy, "permission_boundary_re_evaluate"),
+		Steps:          verification.Steps,
+		SuccessSignals: verification.SuccessSignals,
+		FailureSignals: verification.FailureSignals,
+		EvidenceRef:    firstNonEmptyAWSValue(verification.EvidenceRef, evidenceRef),
+	}
+}
+
+func awsRemediationPermissionBoundaryDeniedActions(plan AWSPermissionBoundarySCPPlan) []string {
+	out := []string{}
+	for _, snippet := range plan.StatementSnippets {
+		out = append(out, snippet.DeniedActions...)
+	}
+	return emptyStrings(dedupeStrings(out))
 }
 
 func awsRemediationResourceNodes(values ...interface{}) []string {
@@ -1298,7 +1427,7 @@ func awsRemediationCaseSearchMatch(c AWSRemediationCase, needle string) bool {
 }
 
 func summarizeAWSRemediationCaseStatus(sources awsRemediationCaseSources, filtered []AWSRemediationCase, diagnostics []AWSRemediationCaseDiagnostic) (string, float64) {
-	statuses := []string{sources.risk.Status, sources.least.Status, sources.equivalence.Status, sources.blast.Status, sources.trust.Status}
+	statuses := []string{sources.risk.Status, sources.least.Status, sources.equivalence.Status, sources.blast.Status, sources.trust.Status, sources.boundary.Status}
 	for _, status := range statuses {
 		if status == awsPlatformDependencyStatusBlocked {
 			return awsPlatformDependencyStatusBlocked, 0.35
@@ -1328,6 +1457,7 @@ func awsRemediationCaseFailureReasons(sources awsRemediationCaseSources) []strin
 		sources.equivalence.FailureReasons,
 		sources.blast.FailureReasons,
 		sources.trust.FailureReasons,
+		sources.boundary.FailureReasons,
 	} {
 		out = append(out, messages...)
 	}
@@ -1345,6 +1475,7 @@ func awsRemediationCaseRemediationHints(sources awsRemediationCaseSources) []str
 		sources.equivalence.RemediationHints,
 		sources.blast.RemediationHints,
 		sources.trust.RemediationHints,
+		sources.boundary.RemediationHints,
 	} {
 		out = append(out, messages...)
 	}
@@ -1382,6 +1513,9 @@ func awsRemediationCaseDiagnostics(sources awsRemediationCaseSources) []AWSRemed
 	for _, d := range sources.trust.Diagnostics {
 		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
 	}
+	for _, d := range sources.boundary.Diagnostics {
+		appendDiag(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+	}
 	return out
 }
 
@@ -1408,6 +1542,9 @@ func awsRemediationCaseCoverageGaps(sources awsRemediationCaseSources) []AWSReme
 		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
 	}
 	for _, g := range sources.trust.CoverageGaps {
+		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
+	}
+	for _, g := range sources.boundary.CoverageGaps {
 		appendGap(g.Capability, g.Status, g.Reason, g.Remediation)
 	}
 	return out

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -733,23 +733,29 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
 		IdentityType:       awsRemediationPermissionBoundaryIdentityType(identityNodeID),
-		ResourceNodeIDs:    awsRemediationResourceNodes(supportedTargets, filteredImpactedNodes),
-		Owner:              owner,
-		OwnerAssigned:      ownerAssigned,
-		ApprovalRequired:   approvalRequired,
-		ApprovalState:      approvalState,
-		DiffIntent:         diff,
-		Tradeoffs:          awsRemediationTradeoffsForPermissionBoundary(plan),
-		RollbackPlan:       awsRemediationRollbackFromPermissionBoundary(plan, evidenceRef),
-		VerificationPlan:   awsRemediationVerificationFromPermissionBoundary(plan, evidenceRef),
-		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary"}, plan.SourceSignals...)),
-		Evidence:           plan.Evidence,
-		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
-		ImpactedNodes:      dedupeStrings(append(append([]string{}, supportedTargets...), filteredImpactedNodes...)),
-		ImpactedPath:       plan.ImpactedPath,
-		NextActions:        awsRemediationNextActionList(plan.NextAction, diff),
-		CreatedAt:          now,
-		UpdatedAt:          now,
+		// ResourceNodeIDs is the vehicle awsRemediationApprovalScope uses to
+		// pull extra targets into Scope.IdentityNodeIDs for this source
+		// type, so it must stay limited to the plan's retained boundary
+		// targets. filteredImpactedNodes may include other IAM roles/users
+		// that are merely context (e.g. an sts:AssumeRole target) and must
+		// not be promoted into apply scope; they stay in ImpactedNodes only.
+		ResourceNodeIDs:  awsRemediationResourceNodes(supportedTargets),
+		Owner:            owner,
+		OwnerAssigned:    ownerAssigned,
+		ApprovalRequired: approvalRequired,
+		ApprovalState:    approvalState,
+		DiffIntent:       diff,
+		Tradeoffs:        awsRemediationTradeoffsForPermissionBoundary(plan),
+		RollbackPlan:     awsRemediationRollbackFromPermissionBoundary(plan, evidenceRef),
+		VerificationPlan: awsRemediationVerificationFromPermissionBoundary(plan, evidenceRef),
+		SourceSignals:    dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary"}, plan.SourceSignals...)),
+		Evidence:         plan.Evidence,
+		EvidenceBoundary: awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:    dedupeStrings(append(append([]string{}, supportedTargets...), filteredImpactedNodes...)),
+		ImpactedPath:     plan.ImpactedPath,
+		NextActions:      awsRemediationNextActionList(plan.NextAction, diff),
+		CreatedAt:        now,
+		UpdatedAt:        now,
 	}
 	return finalizeAWSRemediationCase(c, now), true
 }

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -683,7 +683,8 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 	if plan.PlanID == "" || !strings.EqualFold(plan.Kind, awsPermissionBoundaryKind) {
 		return AWSRemediationCase{}, false
 	}
-	identityNodeID := firstString(emptyStrings(plan.TargetIdentityNodeIDs))
+	supportedTargets := awsPermissionBoundaryExecutorSupportedTargets(plan.TargetIdentityNodeIDs)
+	identityNodeID := firstString(emptyStrings(supportedTargets))
 	if identityNodeID == "" {
 		return AWSRemediationCase{}, false
 	}
@@ -722,7 +723,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
 		IdentityType:       "iam_role",
-		ResourceNodeIDs:    awsRemediationResourceNodes(plan.TargetIdentityNodeIDs, plan.ImpactedNodes),
+		ResourceNodeIDs:    awsRemediationResourceNodes(supportedTargets, plan.ImpactedNodes),
 		Owner:              owner,
 		OwnerAssigned:      ownerAssigned,
 		ApprovalRequired:   approvalRequired,
@@ -734,7 +735,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary"}, plan.SourceSignals...)),
 		Evidence:           plan.Evidence,
 		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
-		ImpactedNodes:      dedupeStrings(append(append([]string{}, plan.TargetIdentityNodeIDs...), plan.ImpactedNodes...)),
+		ImpactedNodes:      dedupeStrings(append(append([]string{}, supportedTargets...), plan.ImpactedNodes...)),
 		ImpactedPath:       plan.ImpactedPath,
 		NextActions:        awsRemediationNextActionList(plan.NextAction, diff),
 		CreatedAt:          now,

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -684,6 +684,13 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		return AWSRemediationCase{}, false
 	}
 	supportedTargets := awsPermissionBoundaryExecutorSupportedTargets(plan.TargetIdentityNodeIDs)
+	filteredImpactedNodes := []string{}
+	for _, node := range emptyStrings(plan.ImpactedNodes) {
+		if awsRemediationDryRunIAMPrincipalKind(node) == "group" {
+			continue
+		}
+		filteredImpactedNodes = append(filteredImpactedNodes, node)
+	}
 	identityNodeID := firstString(emptyStrings(supportedTargets))
 	if identityNodeID == "" {
 		return AWSRemediationCase{}, false
@@ -723,7 +730,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
 		IdentityType:       "iam_role",
-		ResourceNodeIDs:    awsRemediationResourceNodes(supportedTargets, plan.ImpactedNodes),
+		ResourceNodeIDs:    awsRemediationResourceNodes(supportedTargets, filteredImpactedNodes),
 		Owner:              owner,
 		OwnerAssigned:      ownerAssigned,
 		ApprovalRequired:   approvalRequired,
@@ -735,7 +742,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "permission_boundary"}, plan.SourceSignals...)),
 		Evidence:           plan.Evidence,
 		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
-		ImpactedNodes:      dedupeStrings(append(append([]string{}, supportedTargets...), plan.ImpactedNodes...)),
+		ImpactedNodes:      dedupeStrings(append(append([]string{}, supportedTargets...), filteredImpactedNodes...)),
 		ImpactedPath:       plan.ImpactedPath,
 		NextActions:        awsRemediationNextActionList(plan.NextAction, diff),
 		CreatedAt:          now,

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -695,6 +695,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 	if identityNodeID == "" {
 		return AWSRemediationCase{}, false
 	}
+	scopedTargetAccountIDs := awsPermissionBoundaryExecutorScopedAccountsForTargets(supportedTargets, plan.TargetAccountIDs)
 	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("permission-boundary", plan.PlanID)
 	evidenceRef := firstString(awsRemediationEvidenceRefs(plan.Evidence))
 	deniedActions := awsRemediationPermissionBoundaryDeniedActions(plan)
@@ -724,8 +725,8 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		Confidence:         plan.Confidence,
 		Title:              fmt.Sprintf("Permission boundary executor for %s", firstNonEmptyAWSValue(plan.Service, identityNodeID)),
 		Summary:            plan.Summary,
-		AccountID:          firstNonEmptyAWSValue(plan.AccountID, firstString(plan.TargetAccountIDs)),
-		TargetAccountIDs:   emptyStrings(dedupeStrings(plan.TargetAccountIDs)),
+		AccountID:          firstString(scopedTargetAccountIDs),
+		TargetAccountIDs:   scopedTargetAccountIDs,
 		Region:             plan.Region,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -114,6 +114,7 @@ type AWSRemediationCase struct {
 	Title              string                         `json:"title"`
 	Summary            string                         `json:"summary"`
 	AccountID          string                         `json:"account_id"`
+	TargetAccountIDs   []string                       `json:"target_account_ids,omitempty"`
 	Region             string                         `json:"region"`
 	IdentityNodeID     string                         `json:"identity_node_id,omitempty"`
 	IdentityARN        string                         `json:"identity_arn,omitempty"`
@@ -715,7 +716,8 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		Confidence:         plan.Confidence,
 		Title:              fmt.Sprintf("Permission boundary executor for %s", firstNonEmptyAWSValue(plan.Service, identityNodeID)),
 		Summary:            plan.Summary,
-		AccountID:          plan.AccountID,
+		AccountID:          firstNonEmptyAWSValue(plan.AccountID, firstString(plan.TargetAccountIDs)),
+		TargetAccountIDs:   emptyStrings(dedupeStrings(plan.TargetAccountIDs)),
 		Region:             plan.Region,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
@@ -803,6 +805,7 @@ func mergeAWSRemediationCase(existing, incoming AWSRemediationCase) AWSRemediati
 	merged.Evidence = append(append([]AWSRemediationCaseEvidence{}, merged.Evidence...), incoming.Evidence...)
 	merged.ImpactedNodes = emptyStrings(dedupeStrings(append(merged.ImpactedNodes, incoming.ImpactedNodes...)))
 	merged.ResourceNodeIDs = emptyStrings(dedupeStrings(append(merged.ResourceNodeIDs, incoming.ResourceNodeIDs...)))
+	merged.TargetAccountIDs = emptyStrings(dedupeStrings(append(merged.TargetAccountIDs, incoming.TargetAccountIDs...)))
 	merged.NextActions = dedupeStrings(append(merged.NextActions, incoming.NextActions...))
 	merged.Tradeoffs = append(merged.Tradeoffs, incoming.Tradeoffs...)
 	merged.AuditTrail = append(merged.AuditTrail, incoming.AuditTrail...)
@@ -1352,7 +1355,7 @@ func filterAWSRemediationCases(cases []AWSRemediationCase, request AWSRemediatio
 	}
 	filtered := make([]AWSRemediationCase, 0, len(cases))
 	for _, c := range cases {
-		if filters["account_id"] != "" && filters["account_id"] != c.AccountID {
+		if filters["account_id"] != "" && !awsRemediationCaseAccountMatch(c, filters["account_id"]) {
 			continue
 		}
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], c.Region) {
@@ -1390,6 +1393,22 @@ func filterAWSRemediationCases(cases []AWSRemediationCase, request AWSRemediatio
 	return filtered, applied
 }
 
+func awsRemediationCaseAccountMatch(c AWSRemediationCase, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.TrimSpace(c.AccountID) == accountID {
+		return true
+	}
+	for _, targetAccountID := range c.TargetAccountIDs {
+		if strings.TrimSpace(targetAccountID) == accountID {
+			return true
+		}
+	}
+	return false
+}
+
 func awsRemediationCaseIdentityMatch(c AWSRemediationCase, needle string) bool {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
@@ -1405,6 +1424,7 @@ func awsRemediationCaseSearchMatch(c AWSRemediationCase, needle string) bool {
 		return true
 	}
 	values := []string{c.CaseID, c.Title, c.Summary, c.SourceFindingID, c.SourceType, c.Lifecycle, c.Severity, c.Status, c.ApprovalState, c.IdentityNodeID, c.IdentityARN, c.IdentityName, c.Provider, c.Owner, c.DiffIntent.Kind, c.DiffIntent.DiffSummary, c.DiffIntent.BeforeRef, c.DiffIntent.AfterRef, c.RollbackPlan.Strategy, c.VerificationPlan.Strategy}
+	values = append(values, c.TargetAccountIDs...)
 	values = append(values, c.ResourceNodeIDs...)
 	values = append(values, c.SourceSignals...)
 	values = append(values, c.ImpactedNodes...)

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -758,21 +758,6 @@ func awsRemediationPermissionBoundaryScopedAccounts(plan AWSPermissionBoundarySC
 		return derived
 	}
 	originalTargets := emptyStrings(plan.TargetIdentityNodeIDs)
-	targetAccounts := emptyStrings(plan.TargetAccountIDs)
-	supported := map[string]bool{}
-	for _, target := range emptyStrings(dedupeStrings(supportedTargets)) {
-		supported[strings.TrimSpace(target)] = true
-	}
-	scoped := []string{}
-	for i, target := range originalTargets {
-		if !supported[strings.TrimSpace(target)] || i >= len(targetAccounts) {
-			continue
-		}
-		scoped = append(scoped, targetAccounts[i])
-	}
-	if len(scoped) > 0 {
-		return emptyStrings(dedupeStrings(scoped))
-	}
 	if len(emptyStrings(supportedTargets)) == len(originalTargets) {
 		return emptyStrings(dedupeStrings(plan.TargetAccountIDs))
 	}

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -1358,7 +1358,7 @@ func filterAWSRemediationCases(cases []AWSRemediationCase, request AWSRemediatio
 		if filters["account_id"] != "" && !awsRemediationCaseAccountMatch(c, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && !strings.EqualFold(filters["region"], c.Region) {
+		if filters["region"] != "" && !awsRemediationCaseRegionMatch(c, filters["region"]) {
 			continue
 		}
 		if filters["source_type"] != "" && filters["source_type"] != normalizeAWSRuntimeEventFilterToken(c.SourceType) {
@@ -1409,12 +1409,27 @@ func awsRemediationCaseAccountMatch(c AWSRemediationCase, accountID string) bool
 	return false
 }
 
+func awsRemediationCaseRegionMatch(c AWSRemediationCase, region string) bool {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return true
+	}
+	if strings.TrimSpace(c.Region) == "" && strings.EqualFold(c.SourceType, "aws_permission_boundary_scp") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(c.Region), region)
+}
+
 func awsRemediationCaseIdentityMatch(c AWSRemediationCase, needle string) bool {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
 		return true
 	}
-	hay := strings.ToLower(strings.Join([]string{c.IdentityNodeID, c.IdentityARN, c.IdentityName, c.IdentityType, c.Owner}, " "))
+	values := []string{c.IdentityNodeID, c.IdentityARN, c.IdentityName, c.IdentityType, c.Owner}
+	if strings.EqualFold(c.SourceType, "aws_permission_boundary_scp") {
+		values = append(values, c.ResourceNodeIDs...)
+	}
+	hay := strings.ToLower(strings.Join(values, " "))
 	return strings.Contains(hay, needle)
 }
 

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -695,7 +695,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 	if identityNodeID == "" {
 		return AWSRemediationCase{}, false
 	}
-	scopedTargetAccountIDs := awsPermissionBoundaryExecutorScopedAccountsForTargets(supportedTargets, plan.TargetAccountIDs)
+	scopedTargetAccountIDs := awsRemediationPermissionBoundaryScopedAccounts(plan, supportedTargets)
 	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("permission-boundary", plan.PlanID)
 	evidenceRef := firstString(awsRemediationEvidenceRefs(plan.Evidence))
 	deniedActions := awsRemediationPermissionBoundaryDeniedActions(plan)
@@ -730,7 +730,7 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		Region:             plan.Region,
 		IdentityNodeID:     identityNodeID,
 		IdentityName:       firstNonEmptyAWSValue(shortAWSARN(identityNodeID), identityNodeID),
-		IdentityType:       "iam_role",
+		IdentityType:       awsRemediationPermissionBoundaryIdentityType(identityNodeID),
 		ResourceNodeIDs:    awsRemediationResourceNodes(supportedTargets, filteredImpactedNodes),
 		Owner:              owner,
 		OwnerAssigned:      ownerAssigned,
@@ -750,6 +750,40 @@ func awsRemediationCaseFromPermissionBoundary(plan AWSPermissionBoundarySCPPlan,
 		UpdatedAt:          now,
 	}
 	return finalizeAWSRemediationCase(c, now), true
+}
+
+func awsRemediationPermissionBoundaryScopedAccounts(plan AWSPermissionBoundarySCPPlan, supportedTargets []string) []string {
+	derived := awsPermissionBoundaryExecutorAccountsForTargets(supportedTargets)
+	if len(derived) > 0 {
+		return derived
+	}
+	originalTargets := emptyStrings(plan.TargetIdentityNodeIDs)
+	targetAccounts := emptyStrings(plan.TargetAccountIDs)
+	supported := map[string]bool{}
+	for _, target := range emptyStrings(dedupeStrings(supportedTargets)) {
+		supported[strings.TrimSpace(target)] = true
+	}
+	scoped := []string{}
+	for i, target := range originalTargets {
+		if !supported[strings.TrimSpace(target)] || i >= len(targetAccounts) {
+			continue
+		}
+		scoped = append(scoped, targetAccounts[i])
+	}
+	if len(scoped) > 0 {
+		return emptyStrings(dedupeStrings(scoped))
+	}
+	if len(emptyStrings(supportedTargets)) == len(originalTargets) {
+		return emptyStrings(dedupeStrings(plan.TargetAccountIDs))
+	}
+	return nil
+}
+
+func awsRemediationPermissionBoundaryIdentityType(target string) string {
+	if awsRemediationDryRunIAMPrincipalKind(target) == "user" {
+		return "iam_user"
+	}
+	return "iam_role"
 }
 
 func finalizeAWSRemediationCase(c AWSRemediationCase, now time.Time) AWSRemediationCase {

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -330,11 +330,24 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	if nonARNCase.IdentityType != "iam_user" {
 		t.Fatalf("expected non-ARN retained user target to drive case identity type, got %q", nonARNCase.IdentityType)
 	}
-	if nonARNCase.AccountID != "222222222222" {
-		t.Fatalf("expected non-ARN case account to use retained target account, got %q", nonARNCase.AccountID)
+	if nonARNCase.AccountID != "" {
+		t.Fatalf("expected non-ARN filtered case account to avoid unsafe de-duped account fallback, got %q", nonARNCase.AccountID)
 	}
-	if len(nonARNCase.TargetAccountIDs) != 1 || nonARNCase.TargetAccountIDs[0] != "222222222222" {
-		t.Fatalf("expected non-ARN target accounts to exclude unsupported target accounts: %+v", nonARNCase.TargetAccountIDs)
+	if len(nonARNCase.TargetAccountIDs) != 0 {
+		t.Fatalf("expected non-ARN filtered target accounts to avoid unsafe de-duped account fallback: %+v", nonARNCase.TargetAccountIDs)
+	}
+
+	nonARNRepeatedAccountPlan := plan
+	nonARNRepeatedAccountPlan.PlanID = "permission-boundary-non-arn-repeated-account"
+	nonARNRepeatedAccountPlan.TargetIdentityNodeIDs = []string{"aws:identity:role/app-a", "aws:identity:role/app-b", "aws:identity:group/app-group"}
+	nonARNRepeatedAccountPlan.ImpactedNodes = []string{"aws:identity:role/app-a", "aws:identity:role/app-b", "aws:identity:group/app-group"}
+	nonARNRepeatedAccountPlan.TargetAccountIDs = []string{"111111111111", "222222222222"}
+	nonARNRepeatedAccountCase, ok := awsRemediationCaseFromPermissionBoundary(nonARNRepeatedAccountPlan, now)
+	if !ok {
+		t.Fatalf("expected permission boundary case from non-ARN repeated-account plan")
+	}
+	if nonARNRepeatedAccountCase.AccountID != "" || len(nonARNRepeatedAccountCase.TargetAccountIDs) != 0 {
+		t.Fatalf("expected non-ARN filtered case to avoid assigning de-duped group account scope: %+v", nonARNRepeatedAccountCase)
 	}
 
 	groupOnlyPlan := plan

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -39,6 +39,9 @@ func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
 	if result.Summary.SourceTypeCounts["trust_policy_hardening"] == 0 {
 		t.Fatalf("expected IAM role trust-policy hardening cases for downstream dry-run/executor joins: %+v", result.Summary.SourceTypeCounts)
 	}
+	if result.Summary.SourceTypeCounts["aws_permission_boundary_scp"] == 0 {
+		t.Fatalf("expected permission-boundary cases for downstream dry-run/executor joins: %+v", result.Summary.SourceTypeCounts)
+	}
 	if result.Summary.RelationshipCount != len(result.Relationships) || len(result.Relationships) == 0 {
 		t.Fatalf("expected relationships and matching count: summary=%+v relationships=%+v", result.Summary, result.Relationships)
 	}
@@ -71,6 +74,9 @@ func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
 		}
 		if c.SourceType == "trust_policy_hardening" && (c.IdentityType != "iam_role" || c.DiffIntent.Kind != "iam_trust_diff") {
 			t.Fatalf("trust-policy hardening case must stay scoped to IAM role trust diffs: %+v", c)
+		}
+		if c.SourceType == "aws_permission_boundary_scp" && (c.IdentityType != "iam_role" || c.DiffIntent.Kind != "permission_boundary_diff") {
+			t.Fatalf("permission-boundary case must stay scoped to IAM role boundary diffs: %+v", c)
 		}
 		if len(c.AuditTrail) == 0 || c.AuditTrail[0].EventType != "proposed" {
 			t.Fatalf("case missing proposed audit entry: %+v", c.AuditTrail)

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -309,6 +309,12 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	if len(boundaryCase.ImpactedNodes) != 1 || boundaryCase.ImpactedNodes[0] != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
 		t.Fatalf("expected impacted nodes to exclude unsupported target kinds: %+v", boundaryCase.ImpactedNodes)
 	}
+	if boundaryCase.AccountID != "222222222222" {
+		t.Fatalf("expected case account to use retained target account, got %q", boundaryCase.AccountID)
+	}
+	if len(boundaryCase.TargetAccountIDs) != 1 || boundaryCase.TargetAccountIDs[0] != "222222222222" {
+		t.Fatalf("expected target accounts to exclude unsupported target accounts: %+v", boundaryCase.TargetAccountIDs)
+	}
 
 	groupOnlyPlan := plan
 	groupOnlyPlan.PlanID = "permission-boundary-group-only"

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -232,6 +232,54 @@ func TestFilterAWSRemediationCasesMatchesBoundaryTargetAccounts(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationCasesKeepsMultiRegionBoundaryCases(t *testing.T) {
+	cases := []AWSRemediationCase{
+		{
+			CaseID:     "case-multi-region-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "",
+		},
+		{
+			CaseID:     "case-west-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "us-west-2",
+		},
+	}
+
+	filtered, applied := filterAWSRemediationCases(cases, AWSRemediationCaseRequest{Region: "us-east-1"})
+	if applied["region"] != "us-east-1" {
+		t.Fatalf("expected applied region filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].CaseID != "case-multi-region-boundary" {
+		t.Fatalf("expected empty-region boundary case to survive region drill-down: %+v", filtered)
+	}
+}
+
+func TestFilterAWSRemediationCasesMatchesBoundaryTargetIdentity(t *testing.T) {
+	cases := []AWSRemediationCase{
+		{
+			CaseID:          "case-cross-identity-boundary",
+			SourceType:      "aws_permission_boundary_scp",
+			IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/app-a",
+			ResourceNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-a", "aws:identity:arn:aws:iam::111111111111:role/app-b"},
+		},
+		{
+			CaseID:          "case-other-boundary",
+			SourceType:      "aws_permission_boundary_scp",
+			IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/app-c",
+			ResourceNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-c"},
+		},
+	}
+
+	filtered, applied := filterAWSRemediationCases(cases, AWSRemediationCaseRequest{Identity: "role/app-b"})
+	if applied["identity"] != "role/app-b" {
+		t.Fatalf("expected applied identity filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].CaseID != "case-cross-identity-boundary" {
+		t.Fatalf("expected boundary target identity match to retain case: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 10, 0, 0, time.UTC)
 	ownerless := AWSAIAgentRiskFinding{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -306,6 +306,9 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	if len(boundaryCase.ResourceNodeIDs) != 1 || boundaryCase.ResourceNodeIDs[0] != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
 		t.Fatalf("expected resource nodes to exclude unsupported target kinds: %+v", boundaryCase.ResourceNodeIDs)
 	}
+	if len(boundaryCase.ImpactedNodes) != 1 || boundaryCase.ImpactedNodes[0] != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
+		t.Fatalf("expected impacted nodes to exclude unsupported target kinds: %+v", boundaryCase.ImpactedNodes)
+	}
 
 	groupOnlyPlan := plan
 	groupOnlyPlan.PlanID = "permission-boundary-group-only"

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -205,6 +205,33 @@ func TestGetAWSRemediationCasesAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationCasesMatchesBoundaryTargetAccounts(t *testing.T) {
+	cases := []AWSRemediationCase{
+		{
+			CaseID:           "case-cross-account-boundary",
+			SourceType:       "aws_permission_boundary_scp",
+			AccountID:        "",
+			TargetAccountIDs: []string{"111111111111", "222222222222"},
+			Region:           "us-east-1",
+		},
+		{
+			CaseID:           "case-other-boundary",
+			SourceType:       "aws_permission_boundary_scp",
+			AccountID:        "333333333333",
+			TargetAccountIDs: []string{"333333333333"},
+			Region:           "us-east-1",
+		},
+	}
+
+	filtered, applied := filterAWSRemediationCases(cases, AWSRemediationCaseRequest{AccountID: "222222222222"})
+	if applied["account_id"] != "222222222222" {
+		t.Fatalf("expected applied account filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].CaseID != "case-cross-account-boundary" {
+		t.Fatalf("expected target account match to retain boundary case: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 10, 0, 0, time.UTC)
 	ownerless := AWSAIAgentRiskFinding{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -75,8 +75,8 @@ func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
 		if c.SourceType == "trust_policy_hardening" && (c.IdentityType != "iam_role" || c.DiffIntent.Kind != "iam_trust_diff") {
 			t.Fatalf("trust-policy hardening case must stay scoped to IAM role trust diffs: %+v", c)
 		}
-		if c.SourceType == "aws_permission_boundary_scp" && (c.IdentityType != "iam_role" || c.DiffIntent.Kind != "permission_boundary_diff") {
-			t.Fatalf("permission-boundary case must stay scoped to IAM role boundary diffs: %+v", c)
+		if c.SourceType == "aws_permission_boundary_scp" && ((c.IdentityType != "iam_role" && c.IdentityType != "iam_user") || c.DiffIntent.Kind != "permission_boundary_diff") {
+			t.Fatalf("permission-boundary case must stay scoped to IAM identity boundary diffs: %+v", c)
 		}
 		if len(c.AuditTrail) == 0 || c.AuditTrail[0].EventType != "proposed" {
 			t.Fatalf("case missing proposed audit entry: %+v", c.AuditTrail)
@@ -303,6 +303,9 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	if boundaryCase.IdentityNodeID != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
 		t.Fatalf("expected first supported target node to drive case identity: %+v", boundaryCase)
 	}
+	if boundaryCase.IdentityType != "iam_user" {
+		t.Fatalf("expected retained user target to drive case identity type, got %q", boundaryCase.IdentityType)
+	}
 	if len(boundaryCase.ResourceNodeIDs) != 1 || boundaryCase.ResourceNodeIDs[0] != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
 		t.Fatalf("expected resource nodes to exclude unsupported target kinds: %+v", boundaryCase.ResourceNodeIDs)
 	}
@@ -314,6 +317,24 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	}
 	if len(boundaryCase.TargetAccountIDs) != 1 || boundaryCase.TargetAccountIDs[0] != "222222222222" {
 		t.Fatalf("expected target accounts to exclude unsupported target accounts: %+v", boundaryCase.TargetAccountIDs)
+	}
+
+	nonARNPlan := plan
+	nonARNPlan.PlanID = "permission-boundary-non-arn-unsupported-targets"
+	nonARNPlan.TargetIdentityNodeIDs = []string{"aws:identity:group/app-group", "aws:identity:user/app-user"}
+	nonARNPlan.ImpactedNodes = []string{"aws:identity:group/app-group", "aws:identity:user/app-user"}
+	nonARNCase, ok := awsRemediationCaseFromPermissionBoundary(nonARNPlan, now)
+	if !ok {
+		t.Fatalf("expected permission boundary case from non-ARN role/user plan")
+	}
+	if nonARNCase.IdentityType != "iam_user" {
+		t.Fatalf("expected non-ARN retained user target to drive case identity type, got %q", nonARNCase.IdentityType)
+	}
+	if nonARNCase.AccountID != "222222222222" {
+		t.Fatalf("expected non-ARN case account to use retained target account, got %q", nonARNCase.AccountID)
+	}
+	if len(nonARNCase.TargetAccountIDs) != 1 || nonARNCase.TargetAccountIDs[0] != "222222222222" {
+		t.Fatalf("expected non-ARN target accounts to exclude unsupported target accounts: %+v", nonARNCase.TargetAccountIDs)
 	}
 
 	groupOnlyPlan := plan

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -287,10 +287,12 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 		Kind:   awsPermissionBoundaryKind,
 		TargetIdentityNodeIDs: []string{
 			"aws:identity:arn:aws:iam::111111111111:group/app-group",
+			"aws:s3:::payments-prod",
 			"aws:identity:arn:aws:iam::222222222222:user/app-user",
 		},
 		ImpactedNodes: []string{
 			"aws:identity:arn:aws:iam::111111111111:group/app-group",
+			"aws:s3:::payments-prod",
 			"aws:identity:arn:aws:iam::222222222222:user/app-user",
 		},
 		TargetAccountIDs: []string{"111111111111", "222222222222"},
@@ -321,8 +323,8 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 
 	nonARNPlan := plan
 	nonARNPlan.PlanID = "permission-boundary-non-arn-unsupported-targets"
-	nonARNPlan.TargetIdentityNodeIDs = []string{"aws:identity:group/app-group", "aws:identity:user/app-user"}
-	nonARNPlan.ImpactedNodes = []string{"aws:identity:group/app-group", "aws:identity:user/app-user"}
+	nonARNPlan.TargetIdentityNodeIDs = []string{"aws:identity:group/app-group", "aws:s3:::payments-prod", "aws:identity:user/app-user"}
+	nonARNPlan.ImpactedNodes = []string{"aws:identity:group/app-group", "aws:s3:::payments-prod", "aws:identity:user/app-user"}
 	nonARNCase, ok := awsRemediationCaseFromPermissionBoundary(nonARNPlan, now)
 	if !ok {
 		t.Fatalf("expected permission boundary case from non-ARN role/user plan")
@@ -352,9 +354,9 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 
 	groupOnlyPlan := plan
 	groupOnlyPlan.PlanID = "permission-boundary-group-only"
-	groupOnlyPlan.TargetIdentityNodeIDs = []string{"aws:identity:arn:aws:iam::111111111111:group/app-group"}
+	groupOnlyPlan.TargetIdentityNodeIDs = []string{"aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:s3:::payments-prod"}
 	if _, ok = awsRemediationCaseFromPermissionBoundary(groupOnlyPlan, now); ok {
-		t.Fatalf("expected group-only boundary plan to be filtered before case projection")
+		t.Fatalf("expected unsupported-only boundary plan to be filtered before case projection")
 	}
 }
 

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -280,6 +280,41 @@ func TestFilterAWSRemediationCasesMatchesBoundaryTargetIdentity(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID: "permission-boundary-unsupported-targets",
+		Kind:   awsPermissionBoundaryKind,
+		TargetIdentityNodeIDs: []string{
+			"aws:identity:arn:aws:iam::111111111111:group/app-group",
+			"aws:identity:arn:aws:iam::222222222222:user/app-user",
+		},
+		ImpactedNodes: []string{
+			"aws:identity:arn:aws:iam::111111111111:group/app-group",
+			"aws:identity:arn:aws:iam::222222222222:user/app-user",
+		},
+		TargetAccountIDs: []string{"111111111111", "222222222222"},
+	}
+
+	boundaryCase, ok := awsRemediationCaseFromPermissionBoundary(plan, now)
+	if !ok {
+		t.Fatalf("expected permission boundary case from role/user plan")
+	}
+	if boundaryCase.IdentityNodeID != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
+		t.Fatalf("expected first supported target node to drive case identity: %+v", boundaryCase)
+	}
+	if len(boundaryCase.ResourceNodeIDs) != 1 || boundaryCase.ResourceNodeIDs[0] != "aws:identity:arn:aws:iam::222222222222:user/app-user" {
+		t.Fatalf("expected resource nodes to exclude unsupported target kinds: %+v", boundaryCase.ResourceNodeIDs)
+	}
+
+	groupOnlyPlan := plan
+	groupOnlyPlan.PlanID = "permission-boundary-group-only"
+	groupOnlyPlan.TargetIdentityNodeIDs = []string{"aws:identity:arn:aws:iam::111111111111:group/app-group"}
+	if _, ok = awsRemediationCaseFromPermissionBoundary(groupOnlyPlan, now); ok {
+		t.Fatalf("expected group-only boundary plan to be filtered before case projection")
+	}
+}
+
 func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 10, 0, 0, time.UTC)
 	ownerless := AWSAIAgentRiskFinding{

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -360,6 +360,46 @@ func TestAWSRemediationCaseFromPermissionBoundaryFiltersUnsupportedTargets(t *te
 	}
 }
 
+func TestAWSRemediationCaseFromPermissionBoundaryKeepsContextOnlyImpactedRolesOutOfApplyScope(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 5, 0, 0, time.UTC)
+	plan := AWSPermissionBoundarySCPPlan{
+		PlanID:                "permission-boundary-context-only-impacted-role",
+		Kind:                  awsPermissionBoundaryKind,
+		ReadyForApply:         true,
+		TargetIdentityNodeIDs: []string{"aws:identity:arn:aws:iam::111111111111:role/app-role"},
+		TargetAccountIDs:      []string{"111111111111"},
+		BreakageProjection:    AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+		ImpactedNodes: []string{
+			"aws:identity:arn:aws:iam::111111111111:role/app-role",
+			"aws:identity:arn:aws:iam::111111111111:role/assumed-by-app-role",
+		},
+	}
+
+	boundaryCase, ok := awsRemediationCaseFromPermissionBoundary(plan, now)
+	if !ok {
+		t.Fatalf("expected permission boundary case from single-target plan")
+	}
+	if len(boundaryCase.ResourceNodeIDs) != 1 || boundaryCase.ResourceNodeIDs[0] != "aws:identity:arn:aws:iam::111111111111:role/app-role" {
+		t.Fatalf("context-only impacted role must not be promoted into apply scope via ResourceNodeIDs: %+v", boundaryCase.ResourceNodeIDs)
+	}
+	foundContextRole := false
+	for _, node := range boundaryCase.ImpactedNodes {
+		if node == "aws:identity:arn:aws:iam::111111111111:role/assumed-by-app-role" {
+			foundContextRole = true
+		}
+	}
+	if !foundContextRole {
+		t.Fatalf("context-only impacted role should still be retained as context in ImpactedNodes: %+v", boundaryCase.ImpactedNodes)
+	}
+
+	scope := awsRemediationApprovalScope(boundaryCase, "aws-prod")
+	for _, node := range scope.IdentityNodeIDs {
+		if node == "aws:identity:arn:aws:iam::111111111111:role/assumed-by-app-role" {
+			t.Fatalf("context-only impacted role must not be promoted into approval identity scope: %+v", scope.IdentityNodeIDs)
+		}
+	}
+}
+
 func TestAWSRemediationCaseDerivesLifecycleAndApproval(t *testing.T) {
 	now := time.Date(2026, 6, 23, 10, 10, 0, 0, time.UTC)
 	ownerless := AWSAIAgentRiskFinding{

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -348,6 +348,11 @@ func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) 
 	if approval.DiffIntent.NoOp {
 		return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(targets.identity, approval.IdempotencyKey)}
 	}
+	if awsRemediationDryRunIsPermissionBoundaryApproval(approval) {
+		if calls := awsRemediationDryRunPermissionBoundaryCalls(approval); len(calls) > 0 {
+			return calls
+		}
+	}
 	caseID := approval.CaseID
 	if call, ok := awsRemediationDryRunCallForDiffKind(approval.DiffIntent, targets, approval.IdempotencyKey, caseID); ok {
 		return []AWSRemediationDryRunIntendedAPICall{call}
@@ -356,6 +361,38 @@ func awsRemediationDryRunIntendedAPICalls(approval AWSRemediationApprovalEntry) 
 		return []AWSRemediationDryRunIntendedAPICall{call}
 	}
 	return []AWSRemediationDryRunIntendedAPICall{awsRemediationDryRunNoOpCall(targets.identity, approval.IdempotencyKey)}
+}
+
+func awsRemediationDryRunIsPermissionBoundaryApproval(approval AWSRemediationApprovalEntry) bool {
+	return strings.EqualFold(approval.SourceType, "aws_permission_boundary_scp") || strings.EqualFold(strings.TrimSpace(approval.DiffIntent.Kind), "permission_boundary_diff")
+}
+
+func awsRemediationDryRunPermissionBoundaryCalls(approval AWSRemediationApprovalEntry) []AWSRemediationDryRunIntendedAPICall {
+	targets := awsPermissionBoundaryExecutorSupportedTargets(approval.Scope.IdentityNodeIDs)
+	calls := make([]AWSRemediationDryRunIntendedAPICall, 0, len(targets))
+	for _, target := range targets {
+		operation := awsRemediationDryRunPutBoundaryOperation(target)
+		calls = append(calls, AWSRemediationDryRunIntendedAPICall{
+			Service:          "iam",
+			Operation:        operation,
+			TargetResource:   target,
+			ParameterRefs:    []string{awsRemediationDryRunScopedIdempotencyKey(approval.IdempotencyKey, operation, target), "boundary_ref://" + approval.CaseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		})
+	}
+	return calls
+}
+
+func awsRemediationDryRunScopedIdempotencyKey(base, operation, target string) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return ""
+	}
+	if strings.TrimSpace(target) == "" {
+		return stableAWSBlastRadiusToken(base, operation)
+	}
+	return stableAWSBlastRadiusToken(base, operation, target)
 }
 
 // awsRemediationDryRunTargetSet pairs the identity-first and resource-first

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -912,7 +912,7 @@ func filterAWSRemediationDryRunEntries(entries []AWSRemediationDryRunEntry, requ
 		if filters["account_id"] != "" && !awsRemediationDryRunAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+		if filters["region"] != "" && !awsRemediationDryRunRegionMatch(entry, filters["region"]) {
 			continue
 		}
 		if filters["approval_id"] != "" && !strings.EqualFold(filters["approval_id"], entry.ApprovalID) {
@@ -955,6 +955,17 @@ func awsRemediationDryRunAccountMatch(entry AWSRemediationDryRunEntry, accountID
 		}
 	}
 	return false
+}
+
+func awsRemediationDryRunRegionMatch(entry AWSRemediationDryRunEntry, region string) bool {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.Region) == "" && strings.EqualFold(entry.SourceType, "aws_permission_boundary_scp") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Region), region)
 }
 
 func awsRemediationDryRunSearchMatch(entry AWSRemediationDryRunEntry, needle string) bool {

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -612,20 +612,29 @@ func awsRemediationDryRunCallForSourceType(sourceType string, targets awsRemedia
 
 // awsRemediationDryRunIAMPrincipalKind classifies the target IAM principal as
 // role/user/group from its node ID or ARN so the dry-run can route IAM
-// inline-policy and permissions-boundary operations correctly. Returns
-// "role" when the principal type cannot be determined, which matches the
-// most common AWS machine-identity remediation target.
+// inline-policy operations correctly. Returns "role" when the principal type
+// cannot be determined, which matches the most common AWS machine-identity
+// remediation target.
 func awsRemediationDryRunIAMPrincipalKind(target string) string {
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(target); kind != "" {
+		return kind
+	}
+	return "role"
+}
+
+func awsRemediationDryRunClassifiedIAMPrincipalKind(target string) string {
 	normalized := strings.ToLower(strings.TrimSpace(target))
 	switch {
 	case normalized == "":
-		return "role"
+		return ""
 	case strings.Contains(normalized, ":user/"), strings.Contains(normalized, ":identity:user/"):
 		return "user"
 	case strings.Contains(normalized, ":group/"), strings.Contains(normalized, ":identity:group/"):
 		return "group"
-	default:
+	case strings.Contains(normalized, ":role/"), strings.Contains(normalized, ":identity:role/"):
 		return "role"
+	default:
+		return ""
 	}
 }
 

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -101,6 +101,7 @@ type AWSRemediationDryRunEntry struct {
 	Title              string                                  `json:"title"`
 	Summary            string                                  `json:"summary"`
 	AccountID          string                                  `json:"account_id"`
+	AccountIDs         []string                                `json:"account_ids,omitempty"`
 	Region             string                                  `json:"region"`
 	IdempotencyKey     string                                  `json:"idempotency_key"`
 	DryRunRef          string                                  `json:"dry_run_ref"`
@@ -311,7 +312,8 @@ func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry,
 		Confidence:         approval.Confidence,
 		Title:              fmt.Sprintf("Dry-run: %s", approval.Title),
 		Summary:            fmt.Sprintf("Read-only simulation of remediation case %s. Identrail never calls AWS write APIs; later wave executors apply the change after approval.", approval.CaseID),
-		AccountID:          approval.AccountID,
+		AccountID:          firstNonEmptyAWSValue(approval.AccountID, firstString(approval.Scope.AccountIDs)),
+		AccountIDs:         emptyStrings(dedupeStrings(approval.Scope.AccountIDs)),
 		Region:             approval.Region,
 		IdempotencyKey:     approval.IdempotencyKey,
 		DryRunRef:          firstNonEmptyAWSValue(approval.DryRunRef, fmt.Sprintf("dry-run://%s/%s/simulated", approval.SourceType, approval.CaseID)),
@@ -907,7 +909,7 @@ func filterAWSRemediationDryRunEntries(entries []AWSRemediationDryRunEntry, requ
 	}
 	filtered := make([]AWSRemediationDryRunEntry, 0, len(entries))
 	for _, entry := range entries {
-		if filters["account_id"] != "" && filters["account_id"] != entry.AccountID {
+		if filters["account_id"] != "" && !awsRemediationDryRunAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
@@ -939,6 +941,22 @@ func filterAWSRemediationDryRunEntries(entries []AWSRemediationDryRunEntry, requ
 	return filtered, applied
 }
 
+func awsRemediationDryRunAccountMatch(entry AWSRemediationDryRunEntry, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.AccountID) == accountID {
+		return true
+	}
+	for _, scopedAccountID := range entry.AccountIDs {
+		if strings.TrimSpace(scopedAccountID) == accountID {
+			return true
+		}
+	}
+	return false
+}
+
 func awsRemediationDryRunSearchMatch(entry AWSRemediationDryRunEntry, needle string) bool {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
@@ -951,6 +969,7 @@ func awsRemediationDryRunSearchMatch(entry AWSRemediationDryRunEntry, needle str
 		entry.DiffIntent.Kind, entry.DiffIntent.DiffSummary,
 		entry.RollbackPlan.Strategy, entry.VerificationPlan.Strategy,
 	}
+	values = append(values, entry.AccountIDs...)
 	values = append(values, entry.SourceSignals...)
 	for _, call := range entry.IntendedAPICalls {
 		values = append(values, call.Service, call.Operation, call.TargetResource)

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -148,6 +148,29 @@ func TestFilterAWSRemediationDryRunEntriesMatchesScopedAccounts(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationDryRunEntriesKeepsMultiRegionBoundaryEntries(t *testing.T) {
+	entries := []AWSRemediationDryRunEntry{
+		{
+			DryRunID:   "dry-run-multi-region-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "",
+		},
+		{
+			DryRunID:   "dry-run-west-boundary",
+			SourceType: "aws_permission_boundary_scp",
+			Region:     "us-west-2",
+		},
+	}
+
+	filtered, applied := filterAWSRemediationDryRunEntries(entries, AWSRemediationDryRunRequest{Region: "us-east-1"})
+	if applied["region"] != "us-east-1" {
+		t.Fatalf("expected applied region filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].DryRunID != "dry-run-multi-region-boundary" {
+		t.Fatalf("expected empty-region boundary dry-run to survive region drill-down: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationDryRunOutcomeHonorsApprovalGates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC)
 

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -545,6 +545,69 @@ func TestAWSRemediationDryRunIAMOperationFollowsPrincipalKind(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget(t *testing.T) {
+	approval := AWSRemediationApprovalEntry{
+		SourceType:     "aws_permission_boundary_scp",
+		CaseID:         "case-boundary-multi-target",
+		IdempotencyKey: "idk",
+		Scope: AWSRemediationApprovalScope{
+			IdentityNodeIDs: []string{
+				"aws:identity:arn:aws:iam::111111111111:role/app-a",
+				"aws:identity:arn:aws:iam::111111111111:role/app-b",
+				"aws:identity:arn:aws:iam::111111111111:user/app-user",
+			},
+		},
+		DiffIntent: AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+	}
+
+	calls := awsRemediationDryRunIntendedAPICalls(approval)
+	if len(calls) != 3 {
+		t.Fatalf("expected one permission-boundary dry-run call per retained target, got %+v", calls)
+	}
+	seenTargets := map[string]bool{}
+	seenIdempotencyRefs := map[string]bool{}
+	for _, call := range calls {
+		if call.Service != "iam" || !call.Idempotent || !call.RequiresApproval {
+			t.Fatalf("permission-boundary dry-run call has wrong metadata: %+v", call)
+		}
+		if call.Operation != "PutRolePermissionsBoundary" && call.Operation != "PutUserPermissionsBoundary" {
+			t.Fatalf("permission-boundary dry-run call has wrong operation: %+v", call)
+		}
+		if strings.Contains(call.TargetResource, ":user/") && call.Operation != "PutUserPermissionsBoundary" {
+			t.Fatalf("user target must use PutUserPermissionsBoundary: %+v", call)
+		}
+		if strings.Contains(call.TargetResource, ":role/") && call.Operation != "PutRolePermissionsBoundary" {
+			t.Fatalf("role target must use PutRolePermissionsBoundary: %+v", call)
+		}
+		if len(call.ParameterRefs) == 0 || strings.TrimSpace(call.ParameterRefs[0]) == "" {
+			t.Fatalf("permission-boundary dry-run call should have a scoped idempotency ref: %+v", call)
+		}
+		if seenIdempotencyRefs[call.ParameterRefs[0]] {
+			t.Fatalf("permission-boundary dry-run calls should not share idempotency refs: %+v", calls)
+		}
+		seenTargets[call.TargetResource] = true
+		seenIdempotencyRefs[call.ParameterRefs[0]] = true
+	}
+	for _, target := range approval.Scope.IdentityNodeIDs {
+		if !seenTargets[target] {
+			t.Fatalf("missing permission-boundary dry-run call for target %q in %+v", target, calls)
+		}
+	}
+
+	resources := awsRemediationDryRunAffectedResources(approval, calls)
+	apiTargets := map[string]bool{}
+	for _, resource := range resources {
+		if resource.ChangeKind == "api_target" {
+			apiTargets[resource.NodeID] = true
+		}
+	}
+	for _, target := range approval.Scope.IdentityNodeIDs {
+		if !apiTargets[target] {
+			t.Fatalf("missing api_target affected resource for target %q in %+v", target, resources)
+		}
+	}
+}
+
 func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -553,11 +553,19 @@ func TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget(t *testing.T) 
 		Scope: AWSRemediationApprovalScope{
 			IdentityNodeIDs: []string{
 				"aws:identity:arn:aws:iam::111111111111:role/app-a",
+				"aws:s3:::payments-prod",
+				"aws:identity:arn:aws:iam::111111111111:group/app-group",
 				"aws:identity:arn:aws:iam::111111111111:role/app-b",
 				"aws:identity:arn:aws:iam::111111111111:user/app-user",
+				"aws:bedrock-agent:us-east-1:111111111111:agent/app-agent",
 			},
 		},
 		DiffIntent: AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+	}
+	wantTargets := []string{
+		"aws:identity:arn:aws:iam::111111111111:role/app-a",
+		"aws:identity:arn:aws:iam::111111111111:role/app-b",
+		"aws:identity:arn:aws:iam::111111111111:user/app-user",
 	}
 
 	calls := awsRemediationDryRunIntendedAPICalls(approval)
@@ -588,9 +596,14 @@ func TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget(t *testing.T) 
 		seenTargets[call.TargetResource] = true
 		seenIdempotencyRefs[call.ParameterRefs[0]] = true
 	}
-	for _, target := range approval.Scope.IdentityNodeIDs {
+	for _, target := range wantTargets {
 		if !seenTargets[target] {
 			t.Fatalf("missing permission-boundary dry-run call for target %q in %+v", target, calls)
+		}
+	}
+	for _, unsupported := range []string{"aws:s3:::payments-prod", "aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:bedrock-agent:us-east-1:111111111111:agent/app-agent"} {
+		if seenTargets[unsupported] {
+			t.Fatalf("unsupported permission-boundary target should not produce a dry-run call: %q in %+v", unsupported, calls)
 		}
 	}
 
@@ -601,9 +614,14 @@ func TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget(t *testing.T) 
 			apiTargets[resource.NodeID] = true
 		}
 	}
-	for _, target := range approval.Scope.IdentityNodeIDs {
+	for _, target := range wantTargets {
 		if !apiTargets[target] {
 			t.Fatalf("missing api_target affected resource for target %q in %+v", target, resources)
+		}
+	}
+	for _, unsupported := range []string{"aws:s3:::payments-prod", "aws:identity:arn:aws:iam::111111111111:group/app-group", "aws:bedrock-agent:us-east-1:111111111111:agent/app-agent"} {
+		if apiTargets[unsupported] {
+			t.Fatalf("unsupported permission-boundary target should not be reported as an api_target: %q in %+v", unsupported, resources)
 		}
 	}
 }

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -125,6 +125,29 @@ func TestFilterAWSRemediationDryRunEntriesAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestFilterAWSRemediationDryRunEntriesMatchesScopedAccounts(t *testing.T) {
+	entries := []AWSRemediationDryRunEntry{
+		{
+			DryRunID:   "boundary-cross-account",
+			AccountID:  "",
+			AccountIDs: []string{"111111111111", "222222222222"},
+		},
+		{
+			DryRunID:   "boundary-other-account",
+			AccountID:  "333333333333",
+			AccountIDs: []string{"333333333333"},
+		},
+	}
+
+	filtered, applied := filterAWSRemediationDryRunEntries(entries, AWSRemediationDryRunRequest{AccountID: "111111111111"})
+	if applied["account_id"] != "111111111111" {
+		t.Fatalf("expected applied account filter, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].DryRunID != "boundary-cross-account" {
+		t.Fatalf("expected scoped account match to retain dry-run entry: %+v", filtered)
+	}
+}
+
 func TestAWSRemediationDryRunOutcomeHonorsApprovalGates(t *testing.T) {
 	now := time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3201,6 +3201,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"plans": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-executor", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPermissionBoundaryExecutor(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPermissionBoundaryExecutorRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			DryRunID:     strings.TrimSpace(c.Query("dry_run_id")),
+			CaseID:       strings.TrimSpace(c.Query("case_id")),
+			PlanID:       strings.TrimSpace(c.Query("plan_id")),
+			Operation:    strings.TrimSpace(c.Query("operation")),
+			State:        strings.TrimSpace(c.Query("state")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws permission boundary executor request"})
+			default:
+				logger.Error("get aws permission boundary executor",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws permission boundary executor"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"permission_boundary_executor": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1747,6 +1747,48 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS permission boundary executor with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ permission_boundary_executor: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectPermissionBoundaryExecutor(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        dryRunID: 'aws-remediation-dry-run:boundary-1',
+        caseID: 'aws-remediation-case:boundary-1',
+        planID: 'aws-permission-boundary-scp:boundary-1',
+        operation: 'PutRolePermissionsBoundary',
+        state: 'blocked',
+        severity: 'high',
+        search: 'permission boundary'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/permission-boundary-executor?');
+    expect(url).toContain('operation=PutRolePermissionsBoundary');
+    expect(url).toContain('plan_id=aws-permission-boundary-scp%3Aboundary-1');
+    expect(url).toContain('state=blocked');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS secret/key rotation plans with scoped headers and filters', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3470,6 +3470,146 @@ export type AWSPermissionBoundarySCPQuery = {
   search?: string;
 };
 
+export type AWSPermissionBoundaryExecutorStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSPermissionBoundaryExecutorFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSPermissionBoundaryExecutorState = 'projected' | 'precondition_failed' | 'blocked' | string;
+
+export type AWSPermissionBoundaryExecutorPrecondition = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSPermissionBoundaryExecutorSimulation = {
+  simulation_ref: string;
+  outcome: string;
+  before_ref: string;
+  after_ref: string;
+  denied_action_count: number;
+  target_identity_count: number;
+  signals?: string[];
+};
+
+export type AWSPermissionBoundaryExecutorVerification = {
+  source: string;
+  signal: string;
+  status: string;
+  description: string;
+};
+
+export type AWSPermissionBoundaryExecutorRelationship = {
+  execution_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSPermissionBoundaryExecutorEntry = {
+  execution_id: string;
+  calculation_version: string;
+  dry_run_id: string;
+  approval_id: string;
+  case_id: string;
+  plan_id: string;
+  source_artifact_id: string;
+  state: AWSPermissionBoundaryExecutorState;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  operation: string;
+  idempotency_key: string;
+  target_identity_node_ids?: string[];
+  target_account_ids?: string[];
+  target_ou_paths?: string[];
+  prevented_behavior: string;
+  statement_snippets: AWSPermissionBoundarySCPStatementSnippet[];
+  breakage_projection: AWSPermissionBoundarySCPBreakageProjection;
+  intended_api_call: AWSRemediationDryRunIntendedAPICall;
+  preconditions: AWSPermissionBoundaryExecutorPrecondition[];
+  boundary_simulation: AWSPermissionBoundaryExecutorSimulation;
+  verifications: AWSPermissionBoundaryExecutorVerification[];
+  rollback_plan: AWSPermissionBoundarySCPRollbackPlan;
+  verification_plan: AWSPermissionBoundarySCPVerificationPlan;
+  audit_trail: AWSRemediationAuditEntry[];
+  kill_switch_engaged: boolean;
+  ready_for_live_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSPermissionBoundaryExecutorSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  state_counts: Record<string, number>;
+  operation_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  ready_for_live_apply_count: number;
+  kill_switch_engaged_count: number;
+  failed_precondition_count: number;
+  target_identity_count: number;
+  verification_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSPermissionBoundaryExecutorResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSPermissionBoundaryExecutorStatus;
+  fixture_state?: AWSPermissionBoundaryExecutorFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSPermissionBoundaryExecutorSummary;
+  entries: AWSPermissionBoundaryExecutorEntry[];
+  relationships: AWSPermissionBoundaryExecutorRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSPermissionBoundaryExecutorQuery = {
+  connectorID?: string;
+  fixtureState?: AWSPermissionBoundaryExecutorFixtureState;
+  accountID?: string;
+  region?: string;
+  dryRunID?: string;
+  caseID?: string;
+  planID?: string;
+  operation?: string;
+  state?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -8703,6 +8843,29 @@ export const apiClient = {
         status: query?.status,
         breakage_level: query?.breakageLevel,
         ready_for_apply: query?.readyForApply,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectPermissionBoundaryExecutor(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSPermissionBoundaryExecutorQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ permission_boundary_executor: AWSPermissionBoundaryExecutorResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/permission-boundary-executor${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        dry_run_id: query?.dryRunID,
+        case_id: query?.caseID,
+        plan_id: query?.planID,
+        operation: query?.operation,
+        state: query?.state,
+        severity: query?.severity,
         search: query?.search
       })}`,
       auth

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2893,6 +2893,7 @@ export type AWSRemediationCase = {
   title: string;
   summary: string;
   account_id: string;
+  target_account_ids?: string[];
   region: string;
   identity_node_id?: string;
   identity_arn?: string;
@@ -4260,6 +4261,7 @@ export type AWSRemediationDryRunEntry = {
   title: string;
   summary: string;
   account_id: string;
+  account_ids?: string[];
   region: string;
   idempotency_key: string;
   dry_run_ref: string;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3773,6 +3773,137 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getPermissionBoundaryExecutor = vi.spyOn(api.apiClient, 'getAWSProjectPermissionBoundaryExecutor').mockResolvedValue({
+      permission_boundary_executor: {
+        status: 'ready',
+        entries: [
+          {
+            execution_id: 'aws-permission-boundary-executor:s3-delete-object',
+            calculation_version: 'aws-permission-boundary-executor-v1',
+            dry_run_id: 'aws-remediation-dry-run:s3-delete-object',
+            approval_id: 'aws-remediation-approval:s3-delete-object',
+            case_id: 'aws-remediation-case:s3-delete-object',
+            plan_id: 'aws-permission-boundary-scp:s3-delete-object',
+            source_artifact_id: 'aws-permission-boundary-scp:s3-delete-object',
+            state: 'projected',
+            severity: 'high',
+            score: 74,
+            confidence: 0.86,
+            title: 'Permission boundary execution: deny s3:DeleteObject',
+            summary: 'Approved permission boundary execution record for the repeated S3 delete action.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            operation: 'PutRolePermissionsBoundary',
+            idempotency_key: 'idempotency://s3-delete-object',
+            target_identity_node_ids: [
+              'aws:identity:arn:aws:iam::111111111111:role/loader-a',
+              'aws:identity:arn:aws:iam::222222222222:role/loader-b',
+              'aws:identity:arn:aws:iam::111111111111:role/loader-c'
+            ],
+            target_account_ids: ['111111111111', '222222222222'],
+            target_ou_paths: ['/root/security'],
+            prevented_behavior: 'Re-grant or future use of s3:DeleteObject by any boundary-bound identity.',
+            statement_snippets: [
+              {
+                statement_sid: 'permission-boundary-projection',
+                effect: 'Deny',
+                change_kind: 'deny_repeated_action',
+                before_ref: 'evidence://least/loader',
+                after_ref: 'permission-boundary://repeated-action/s3%3Adeleteobject',
+                denied_actions: ['s3:DeleteObject'],
+                allowed_actions: [],
+                resource_scope: ['*'],
+                rationale: '3 identities across 2 account(s) all have least-privilege removal for s3:DeleteObject.'
+              }
+            ],
+            breakage_projection: {
+              level: 'low',
+              rationale: 'All affected identities already have a least-privilege remove decision.',
+              affected_identities: 3,
+              affected_accounts: 2,
+              affected_ous: 1,
+              signals: ['affected_identities:3', 'affected_accounts:2', 'affected_ous:1']
+            },
+            intended_api_call: {
+              service: 'iam',
+              operation: 'PutRolePermissionsBoundary',
+              target_resource: 'aws:identity:arn:aws:iam::111111111111:role/loader-a',
+              parameter_refs: ['idempotency://s3-delete-object', 'boundary_ref://aws-remediation-case:s3-delete-object/after'],
+              idempotent: true,
+              requires_approval: true
+            },
+            preconditions: [
+              { name: 'dry_run_would_succeed', status: 'passed', rationale: 'Dry-run passed.' },
+              { name: 'breakage_level_low', status: 'passed', rationale: 'Breakage projection is low.' }
+            ],
+            boundary_simulation: {
+              simulation_ref: 'iam:policy_simulate://aws-permission-boundary-scp:s3-delete-object/permission-boundary',
+              outcome: 'would_limit_actions',
+              before_ref: 'evidence://least/loader',
+              after_ref: 'permission-boundary://aws-permission-boundary-scp:s3-delete-object/intended-boundary',
+              denied_action_count: 1,
+              target_identity_count: 3,
+              signals: ['permission_boundary', 'affected_identities:3']
+            },
+            verifications: [
+              {
+                source: 'iam:policy_simulate',
+                signal: 'boundary_denies_projected_actions',
+                status: 'pending',
+                description: 'Re-run IAM policy simulation for each captured identity.'
+              }
+            ],
+            rollback_plan: {
+              strategy: 'detach_permission_boundary',
+              steps: ['Detach the projected permission boundary from each captured identity.'],
+              evidence_ref: 'evidence://least/loader'
+            },
+            verification_plan: {
+              strategy: 'policy_simulate',
+              steps: ['Use IAM policy simulator to confirm the boundary denies the action.'],
+              success_signals: ['policy_simulate:no-regression'],
+              failure_signals: ['policy_simulate:denied-observed-action'],
+              evidence_ref: 'evidence://least/loader'
+            },
+            audit_trail: [],
+            kill_switch_engaged: false,
+            ready_for_live_apply: true,
+            read_only_projection: true,
+            source_signals: ['aws_permission_boundary_scp', 'remediation_dry_run'],
+            evidence: [],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            impacted_nodes: ['aws:identity:arn:aws:iam::111111111111:role/loader-a'],
+            impacted_path: [],
+            next_action: 'Permission boundary operation=PutRolePermissionsBoundary is ready for the wave-8 apply runtime once its feature flag opens.',
+            projected_at: '2026-06-30T10:00:00Z',
+            created_at: '2026-06-30T10:00:00Z',
+            updated_at: '2026-06-30T10:00:00Z'
+          }
+        ],
+        summary: {
+          total_entries: 1,
+          filtered_entries: 1,
+          state_counts: { projected: 1 },
+          operation_counts: { PutRolePermissionsBoundary: 1 },
+          severity_counts: { high: 1 },
+          ready_for_live_apply_count: 1,
+          kill_switch_engaged_count: 0,
+          failed_precondition_count: 0,
+          target_identity_count: 3,
+          verification_count: 1,
+          relationship_count: 3,
+          highest_score: 74,
+          average_confidence_pct: 86
+        },
+        relationships: [],
+        caveats: ['Permission boundary executor entries are read-only projections.'],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
     const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
@@ -4360,6 +4491,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS permission boundary and SCP plans' })).toBeInTheDocument();
     expect(screen.getByText(/Permission boundary: deny s3:DeleteObject across 3 identities/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Permission boundary/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS permission boundary executor entries' })).toBeInTheDocument();
+    expect(screen.getByText(/Permission boundary execution: deny s3:DeleteObject/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/PutRolePermissionsBoundary/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS secret/key rotation plans' })).toBeInTheDocument();
     expect(screen.getByText(/Provider key rotation: openai\/api-key/i)).toBeInTheDocument();
     expect(screen.getAllByText(/ai-platform · Pending approver/i).length).toBeGreaterThan(0);
@@ -4416,6 +4550,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getAccessKeyQuarantine).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getPermissionBoundaryExecutor).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -77,6 +77,8 @@ import {
   type AWSRemediationDryRunResult,
   type AWSLowRiskRemediationEntry,
   type AWSLowRiskRemediationResult,
+  type AWSPermissionBoundaryExecutorEntry,
+  type AWSPermissionBoundaryExecutorResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11053,6 +11055,113 @@ function AWSPermissionBoundarySCPContent({
   );
 }
 
+function awsPermissionBoundaryExecutorStage(entry: AWSPermissionBoundaryExecutorEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.state === 'blocked') {
+    return 'not-available';
+  }
+  if (entry.state !== 'projected' || !entry.ready_for_live_apply) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsPermissionBoundaryExecutorTargetLabel(entry: AWSPermissionBoundaryExecutorEntry): string {
+  const identities = entry.target_identity_node_ids?.length ?? 0;
+  const accounts = entry.target_account_ids?.length ?? 0;
+  return `${identities} identities · ${accounts} accounts`;
+}
+
+function awsPermissionBoundaryExecutorPreconditionLabel(entry: AWSPermissionBoundaryExecutorEntry): string {
+  const passed = entry.preconditions.filter((precondition) => precondition.status === 'passed').length;
+  const blocked = entry.preconditions.length - passed;
+  return `${passed} passed · ${blocked} blocked`;
+}
+
+function awsPermissionBoundaryExecutorReadinessLabel(entry: AWSPermissionBoundaryExecutorEntry): string {
+  if (entry.ready_for_live_apply) {
+    return `ready · ${entry.verifications.length} verifications`;
+  }
+  return formatTokenLabel(entry.state);
+}
+
+function AWSPermissionBoundaryExecutorContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSPermissionBoundaryExecutorResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = result?.entries ?? [];
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.summary.failed_precondition_count} blocked preconditions · ${result.summary.target_identity_count} identities`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS approved permission boundary executor">
+      <h3>AWS approved permission boundary executor</h3>
+      <p className="idt-app-kicker">
+        Read-only projection that joins dry-run readiness with permission-boundary planner metadata. Each entry records
+        the idempotency key, intended IAM permission-boundary call, target identity scope, simulator metadata,
+        preconditions, rollback plan, verification records, and audit trail. Identrail never calls IAM write APIs at this
+        layer. {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS permission boundary executor"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Projecting permission boundary execution"
+          body="Identrail is joining dry-run readiness with permission boundary planner metadata to project execution records."
+        />
+      ) : null}
+      {!error && !loading && result && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={result.status === 'blocked' ? 'Permission required' : 'No permission boundary executor entries'}
+          title={result.status === 'blocked' ? 'Permission boundary executor needs approved dry-run and planner evidence' : 'No permission boundary executor entries projected'}
+          body={result.failure_reasons[0] ?? 'No upstream dry-run entry joined a permission boundary plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && result && result.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {result.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS permission boundary executor entries"
+          rows={rows}
+          getRowKey={(row) => row.execution_id}
+          columns={[
+            { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
+            { key: 'operation', header: 'Operation', render: (row) => row.operation },
+            { key: 'target', header: 'Target', render: (row) => awsPermissionBoundaryExecutorTargetLabel(row) },
+            { key: 'preconditions', header: 'Preconditions', render: (row) => awsPermissionBoundaryExecutorPreconditionLabel(row) },
+            { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
+            { key: 'state', header: 'State', render: (row) => awsPermissionBoundaryExecutorReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsPermissionBoundaryExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13269,6 +13378,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [permissionBoundarySCPLoading, setPermissionBoundarySCPLoading] = useState(false);
   const [permissionBoundarySCPError, setPermissionBoundarySCPError] = useState('');
   const permissionBoundarySCPRequestRef = useRef(0);
+  const [permissionBoundaryExecutor, setPermissionBoundaryExecutor] = useState<AWSPermissionBoundaryExecutorResult | null>(null);
+  const [permissionBoundaryExecutorLoading, setPermissionBoundaryExecutorLoading] = useState(false);
+  const [permissionBoundaryExecutorError, setPermissionBoundaryExecutorError] = useState('');
+  const permissionBoundaryExecutorRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -13773,6 +13886,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       permissionBoundarySCPRequestRef.current += 1;
     };
   }, [loadPermissionBoundarySCP]);
+
+  const loadPermissionBoundaryExecutor = useCallback(async () => {
+    const requestID = ++permissionBoundaryExecutorRequestRef.current;
+    setPermissionBoundaryExecutor(null);
+    setPermissionBoundaryExecutorError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setPermissionBoundaryExecutorLoading(false);
+      return;
+    }
+    setPermissionBoundaryExecutorLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectPermissionBoundaryExecutor(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== permissionBoundaryExecutorRequestRef.current) {
+        return;
+      }
+      setPermissionBoundaryExecutor(response.permission_boundary_executor);
+    } catch (error) {
+      if (requestID !== permissionBoundaryExecutorRequestRef.current) {
+        return;
+      }
+      setPermissionBoundaryExecutorError(formatAPIError(error, 'Unable to load AWS permission boundary executor.'));
+    } finally {
+      if (requestID === permissionBoundaryExecutorRequestRef.current) {
+        setPermissionBoundaryExecutorLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadPermissionBoundaryExecutor();
+    return () => {
+      permissionBoundaryExecutorRequestRef.current += 1;
+    };
+  }, [loadPermissionBoundaryExecutor]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -14612,6 +14773,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={permissionBoundarySCPLoading}
             error={permissionBoundarySCPError}
             onRetry={loadPermissionBoundarySCP}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSPermissionBoundaryExecutorContent
+            result={permissionBoundaryExecutor}
+            loading={permissionBoundaryExecutorLoading}
+            error={permissionBoundaryExecutorError}
+            onRetry={loadPermissionBoundaryExecutor}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- implement the AWS approved permission boundary executor endpoint for issue #1540
- feed permission-boundary planner output into remediation cases, approvals, dry-run, route auth, OpenAPI, docs, and the AWS runtime UI
- keep SCP execution out of scope and blocked/unsafe boundary entries explicit

## Validation
- go test ./internal/api
- npm test -- --run src/api/client.test.ts src/productShell.test.tsx
- npx tsc -b
- git diff --check

Closes #1540

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only AWS permission boundary executor that projects approved boundary changes by joining planner, dry‑run, and approvals, with per‑principal ops, per‑target calls, scoped target accounts, and a wired UI (implements #1540). SCP writes are out of scope; blocked/unsafe states are explicit; unsupported targets are rejected; no account fallback for split targets; context‑only impacted roles are excluded from apply scope.

- **New Features**
  - API: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/permission-boundary-executor` with filters (`connector_id`, `fixture_state`, `account_id`, `region`, `dry_run_id`, `case_id`, `plan_id`, `operation`, `state`, `severity`, `search`).
  - Execution model: split operations per principal; split calls per target; dry‑run emits per‑target calls; targets scoped across accounts.
  - Safety: no IAM/Organizations writes; no policy/secret rendering; rejects unsupported targets (e.g., IAM groups); states include `projected`, `precondition_failed`, `blocked`.
  - Integration: joins dry‑run, approvals, cases, planner; cases/approvals/dry‑run expose target accounts; UI shows readiness and target counts; docs added; OpenAPI adds executor route and publishes source type `aws_permission_boundary_scp` and diff kind `permission_boundary_diff`; route auth added; client `getAWSProjectPermissionBoundaryExecutor` with types.

- **Bug Fixes**
  - Account scoping and filtering: match scoped target accounts across split operations, approvals, cases, dry‑run, and executor; remove executor account fallback for split targets.
  - Filters/schema: boundary scope filters for identity/resource nodes; principal‑specific `operation` filtering; OpenAPI executor audit schema fixed.
  - Metadata alignment: boundary case target metadata aligns so planner targets, target accounts, and executor/UI counts match; multi‑region boundary entries retained.
  - Apply scope: exclude context‑only impacted roles from boundary apply scope.

<sup>Written for commit aaa3de49b82cb0ae8eef811e8a5c14f0ce1096df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

