### PR TITLE
Add first-class email deploy secret

### DIFF
--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -164,6 +164,12 @@ jobs:
       API_REPO_SCAN_HISTORY_LIMIT_MAX: ${{ vars.API_REPO_SCAN_HISTORY_LIMIT_MAX || '' }}
       API_REPO_SCAN_MAX_FINDINGS_MAX: ${{ vars.API_REPO_SCAN_MAX_FINDINGS_MAX || '' }}
       API_REPO_SCAN_QUEUE_MAX_PENDING: ${{ vars.API_REPO_SCAN_QUEUE_MAX_PENDING || '' }}
+      API_EMAIL_PROVIDER: ${{ vars.API_EMAIL_PROVIDER || '' }}
+      API_EMAIL_FROM_ADDRESS: ${{ vars.API_EMAIL_FROM_ADDRESS || '' }}
+      API_EMAIL_REPLY_TO_ADDRESS: ${{ vars.API_EMAIL_REPLY_TO_ADDRESS || '' }}
+      API_EMAIL_APP_BASE_URL: ${{ vars.API_EMAIL_APP_BASE_URL || '' }}
+      API_EMAIL_TIMEOUT: ${{ vars.API_EMAIL_TIMEOUT || '' }}
+      API_EMAIL_API_KEY_SECRET_ARN: ${{ secrets.API_EMAIL_API_KEY_SECRET_ARN || '' }}
       API_ALLOWED_CIDR_BLOCKS_JSON: ${{ vars.API_ALLOWED_CIDR_BLOCKS_JSON || '["0.0.0.0/0"]' }}
       API_CORS_ALLOWED_ORIGINS_JSON: ${{ vars.API_CORS_ALLOWED_ORIGINS_JSON || '["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' }}
       API_TRUSTED_PROXY_CIDR_BLOCKS_JSON: ${{ vars.API_TRUSTED_PROXY_CIDR_BLOCKS_JSON || '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' }}
@@ -221,7 +227,8 @@ jobs:
             "${API_GITHUB_APP_PRIVATE_KEY_SECRET_ARN}" \
             "${API_GITHUB_APP_WEBHOOK_SECRET_ARN}" \
             "${API_GITHUB_APP_OAUTH_CLIENT_SECRET_ARN}" \
-            "${API_CONNECTOR_SECRET_KEYS_SECRET_ARN}"; do
+            "${API_CONNECTOR_SECRET_KEYS_SECRET_ARN}" \
+            "${API_EMAIL_API_KEY_SECRET_ARN}"; do
             if [ -n "${secret_arn}" ]; then
               echo "::add-mask::${secret_arn}"
             fi

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -252,7 +252,8 @@ Optional repository secret:
 - `API_EMAIL_API_KEY_SECRET_ARN`: Secrets Manager ARN containing the Resend API
   key for `IDENTRAIL_EMAIL_API_KEY`. Prefer this first-class secret over
   editing `API_EXTRA_SECRETS_JSON`, because GitHub hides existing secret values
-  on update pages.
+  on update pages. This secret can be created before email is enabled; email is
+  enabled by setting `API_EMAIL_PROVIDER=resend`.
 - `API_EXTRA_SECRETS_JSON`: JSON object mapping additional runtime secret
   environment variable names to Secrets Manager ARNs for future provider
   secrets. Prefer the first-class WorkOS and transactional email settings above

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -253,7 +253,9 @@ Optional repository secret:
   key for `IDENTRAIL_EMAIL_API_KEY`. Prefer this first-class secret over
   editing `API_EXTRA_SECRETS_JSON`, because GitHub hides existing secret values
   on update pages. This secret can be created before email is enabled; email is
-  enabled by setting `API_EMAIL_PROVIDER=resend`.
+  enabled by setting `API_EMAIL_PROVIDER=resend`. If email provider/from settings
+  already live in `API_EXTRA_ENVIRONMENT_JSON`, this secret still supplies
+  `IDENTRAIL_EMAIL_API_KEY` without editing `API_EXTRA_SECRETS_JSON`.
 - `API_EXTRA_SECRETS_JSON`: JSON object mapping additional runtime secret
   environment variable names to Secrets Manager ARNs for future provider
   secrets. Prefer the first-class WorkOS and transactional email settings above

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -215,6 +215,18 @@ Optional repository variables:
 - `API_REPO_SCAN_HISTORY_LIMIT_MAX`
 - `API_REPO_SCAN_MAX_FINDINGS_MAX`
 - `API_REPO_SCAN_QUEUE_MAX_PENDING`
+- `API_EMAIL_PROVIDER`: set to `resend` to enable backend transactional email
+  for hosted API signup flows.
+- `API_EMAIL_FROM_ADDRESS`: verified sender used by transactional email, such
+  as `Identrail <hello@send.identrail.com>`. Required when
+  `API_EMAIL_PROVIDER=resend`.
+- `API_EMAIL_REPLY_TO_ADDRESS`: optional reply-to address, such as
+  `support@identrail.com`.
+- `API_EMAIL_APP_BASE_URL`: optional web-app origin used for email CTA links
+  when it differs from `IDENTRAIL_PUBLIC_BASE_URL`, such as
+  `https://app.identrail.com`.
+- `API_EMAIL_TIMEOUT`: optional Resend request timeout. The runtime default is
+  `3s`.
 - `API_WORKER_ENABLED`: defaults to `true`; set to `false` to deploy only the
   hosted API and leave queued scans pending
 - `API_WORKER_CONTAINER_IMAGE`: optional immutable worker image; blank derives
@@ -237,9 +249,14 @@ repository scan requests, and the worker processes those queued scans.
 
 Optional repository secret:
 
+- `API_EMAIL_API_KEY_SECRET_ARN`: Secrets Manager ARN containing the Resend API
+  key for `IDENTRAIL_EMAIL_API_KEY`. Prefer this first-class secret over
+  editing `API_EXTRA_SECRETS_JSON`, because GitHub hides existing secret values
+  on update pages.
 - `API_EXTRA_SECRETS_JSON`: JSON object mapping additional runtime secret
   environment variable names to Secrets Manager ARNs for future provider
-  secrets. Prefer the first-class WorkOS settings above for hosted auth.
+  secrets. Prefer the first-class WorkOS and transactional email settings above
+  for hosted auth and email.
 
 Do not put database URLs, API keys, cookie secrets, or OAuth credentials directly
 in tfvars files, docs, GitHub variables, or Terraform state. Use Secrets Manager

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -240,18 +240,6 @@ email_api_key_secret="$(trim "${API_EMAIL_API_KEY_SECRET_ARN:-}")"
 email_environment="{}"
 email_secrets="{}"
 if [ -n "${email_provider}" ] || [ -n "${email_from_address}" ] || [ -n "${email_reply_to_address}" ] || [ -n "${email_app_base_url}" ] || [ -n "${email_timeout}" ]; then
-  if [ "${email_provider}" != "resend" ]; then
-    fail "API_EMAIL_PROVIDER must be resend when transactional email is configured"
-  fi
-  if [ -z "${email_api_key_secret}" ]; then
-    fail "API_EMAIL_API_KEY_SECRET_ARN is required when API_EMAIL_PROVIDER=resend"
-  fi
-  if [ -z "${email_from_address}" ]; then
-    fail "API_EMAIL_FROM_ADDRESS is required when API_EMAIL_PROVIDER=resend"
-  fi
-  if ! [[ "${email_api_key_secret}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
-    fail "API_EMAIL_API_KEY_SECRET_ARN must be a Secrets Manager ARN in ${aws_region}"
-  fi
   email_environment="$(
     jq -nce \
       --arg provider "${email_provider}" \
@@ -259,19 +247,41 @@ if [ -n "${email_provider}" ] || [ -n "${email_from_address}" ] || [ -n "${email
       --arg reply_to_address "${email_reply_to_address}" \
       --arg app_base_url "${email_app_base_url}" \
       --arg timeout "${email_timeout}" \
-      '{
-        IDENTRAIL_EMAIL_PROVIDER: $provider,
-        IDENTRAIL_EMAIL_FROM_ADDRESS: $from_address
-      }
+      '(if $provider != "" then {IDENTRAIL_EMAIL_PROVIDER: $provider} else {} end)
+      + (if $from_address != "" then {IDENTRAIL_EMAIL_FROM_ADDRESS: $from_address} else {} end)
       + (if $reply_to_address != "" then {IDENTRAIL_EMAIL_REPLY_TO_ADDRESS: $reply_to_address} else {} end)
       + (if $app_base_url != "" then {IDENTRAIL_EMAIL_APP_BASE_URL: $app_base_url} else {} end)
       + (if $timeout != "" then {IDENTRAIL_EMAIL_TIMEOUT: $timeout} else {} end)'
   )"
-  email_secrets="$(
-    jq -nce \
-      --arg api_key_secret "${email_api_key_secret}" \
-      '{IDENTRAIL_EMAIL_API_KEY: $api_key_secret}'
-  )"
+fi
+effective_email_environment="$(
+  jq -nce \
+    --argjson extra_environment "${extra_environment}" \
+    --argjson email_environment "${email_environment}" \
+    '$extra_environment + $email_environment'
+)"
+effective_email_provider="$(jq -r '(.IDENTRAIL_EMAIL_PROVIDER // "") | ascii_downcase' <<< "${effective_email_environment}")"
+case "${effective_email_provider}" in
+  ""|resend) ;;
+  *) fail "IDENTRAIL_EMAIL_PROVIDER must be resend when transactional email is configured" ;;
+esac
+if [ "${effective_email_provider}" = "resend" ]; then
+  effective_email_from_address="$(jq -r '.IDENTRAIL_EMAIL_FROM_ADDRESS // ""' <<< "${effective_email_environment}")"
+  if [ -z "$(trim "${effective_email_from_address}")" ]; then
+    fail "API_EMAIL_FROM_ADDRESS or IDENTRAIL_EMAIL_FROM_ADDRESS in API_EXTRA_ENVIRONMENT_JSON is required when transactional email is enabled"
+  fi
+  if [ -n "${email_api_key_secret}" ]; then
+    if ! [[ "${email_api_key_secret}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
+      fail "API_EMAIL_API_KEY_SECRET_ARN must be a Secrets Manager ARN in ${aws_region}"
+    fi
+    email_secrets="$(
+      jq -nce \
+        --arg api_key_secret "${email_api_key_secret}" \
+        '{IDENTRAIL_EMAIL_API_KEY: $api_key_secret}'
+    )"
+  elif [ "$(jq -r 'has("IDENTRAIL_EMAIL_API_KEY")' <<< "${extra_secrets}")" != "true" ]; then
+    fail "API_EMAIL_API_KEY_SECRET_ARN or IDENTRAIL_EMAIL_API_KEY in API_EXTRA_SECRETS_JSON is required when transactional email is enabled"
+  fi
 fi
 
 workos_feature_enabled="$(trim "${API_FEATURE_WORKOS_LOGIN:-}")"

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -239,7 +239,7 @@ email_timeout="$(trim "${API_EMAIL_TIMEOUT:-}")"
 email_api_key_secret="$(trim "${API_EMAIL_API_KEY_SECRET_ARN:-}")"
 email_environment="{}"
 email_secrets="{}"
-if [ -n "${email_provider}" ] || [ -n "${email_from_address}" ] || [ -n "${email_reply_to_address}" ] || [ -n "${email_app_base_url}" ] || [ -n "${email_timeout}" ] || [ -n "${email_api_key_secret}" ]; then
+if [ -n "${email_provider}" ] || [ -n "${email_from_address}" ] || [ -n "${email_reply_to_address}" ] || [ -n "${email_app_base_url}" ] || [ -n "${email_timeout}" ]; then
   if [ "${email_provider}" != "resend" ]; then
     fail "API_EMAIL_PROVIDER must be resend when transactional email is configured"
   fi

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -231,6 +231,49 @@ case "${github_feature_enabled}" in
   *) fail "API_FEATURE_CONNECTOR_GITHUB_V2 must be true or false" ;;
 esac
 
+email_provider="$(trim "${API_EMAIL_PROVIDER:-}")"
+email_from_address="$(trim "${API_EMAIL_FROM_ADDRESS:-}")"
+email_reply_to_address="$(trim "${API_EMAIL_REPLY_TO_ADDRESS:-}")"
+email_app_base_url="$(trim "${API_EMAIL_APP_BASE_URL:-}")"
+email_timeout="$(trim "${API_EMAIL_TIMEOUT:-}")"
+email_api_key_secret="$(trim "${API_EMAIL_API_KEY_SECRET_ARN:-}")"
+email_environment="{}"
+email_secrets="{}"
+if [ -n "${email_provider}" ] || [ -n "${email_from_address}" ] || [ -n "${email_reply_to_address}" ] || [ -n "${email_app_base_url}" ] || [ -n "${email_timeout}" ] || [ -n "${email_api_key_secret}" ]; then
+  if [ "${email_provider}" != "resend" ]; then
+    fail "API_EMAIL_PROVIDER must be resend when transactional email is configured"
+  fi
+  if [ -z "${email_api_key_secret}" ]; then
+    fail "API_EMAIL_API_KEY_SECRET_ARN is required when API_EMAIL_PROVIDER=resend"
+  fi
+  if [ -z "${email_from_address}" ]; then
+    fail "API_EMAIL_FROM_ADDRESS is required when API_EMAIL_PROVIDER=resend"
+  fi
+  if ! [[ "${email_api_key_secret}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
+    fail "API_EMAIL_API_KEY_SECRET_ARN must be a Secrets Manager ARN in ${aws_region}"
+  fi
+  email_environment="$(
+    jq -nce \
+      --arg provider "${email_provider}" \
+      --arg from_address "${email_from_address}" \
+      --arg reply_to_address "${email_reply_to_address}" \
+      --arg app_base_url "${email_app_base_url}" \
+      --arg timeout "${email_timeout}" \
+      '{
+        IDENTRAIL_EMAIL_PROVIDER: $provider,
+        IDENTRAIL_EMAIL_FROM_ADDRESS: $from_address
+      }
+      + (if $reply_to_address != "" then {IDENTRAIL_EMAIL_REPLY_TO_ADDRESS: $reply_to_address} else {} end)
+      + (if $app_base_url != "" then {IDENTRAIL_EMAIL_APP_BASE_URL: $app_base_url} else {} end)
+      + (if $timeout != "" then {IDENTRAIL_EMAIL_TIMEOUT: $timeout} else {} end)'
+  )"
+  email_secrets="$(
+    jq -nce \
+      --arg api_key_secret "${email_api_key_secret}" \
+      '{IDENTRAIL_EMAIL_API_KEY: $api_key_secret}'
+  )"
+fi
+
 workos_feature_enabled="$(trim "${API_FEATURE_WORKOS_LOGIN:-}")"
 workos_client_id="$(trim "${API_WORKOS_CLIENT_ID:-}")"
 workos_environment_id="$(trim "${API_WORKOS_ENVIRONMENT_ID:-}")"
@@ -476,6 +519,8 @@ jq -n \
   --argjson extra_environment "${extra_environment}" \
   --argjson extra_secrets "${extra_secrets}" \
   --argjson repo_scan_environment "${repo_scan_environment}" \
+  --argjson email_environment "${email_environment}" \
+  --argjson email_secrets "${email_secrets}" \
   --argjson workos_environment "${workos_environment}" \
   --argjson workos_secrets "${workos_secrets}" \
   --argjson github_environment "${github_environment}" \
@@ -511,12 +556,12 @@ jq -n \
     worker_desired_count: $worker_desired_count,
     worker_task_cpu: $worker_task_cpu,
     worker_task_memory: $worker_task_memory,
-    api_environment_variables: ($extra_environment + $repo_scan_environment + $workos_environment + $github_environment + {
+    api_environment_variables: ($extra_environment + $repo_scan_environment + $email_environment + $workos_environment + $github_environment + {
       IDENTRAIL_FEATURE_NEW_AUTH: "true",
       IDENTRAIL_FEATURE_ONBOARDING_WIZARD: $onboarding_feature_enabled,
       IDENTRAIL_PUBLIC_BASE_URL: "https://api.identrail.com"
     }),
-    api_secrets: ($extra_secrets + $workos_secrets + $github_secrets + {
+    api_secrets: ($extra_secrets + $email_secrets + $workos_secrets + $github_secrets + {
       IDENTRAIL_DATABASE_URL: $api_database_secret,
       IDENTRAIL_SESSION_KEY: $api_session_secret
     }),


### PR DESCRIPTION
## Summary
- add first-class AWS API deploy inputs for transactional email env config
- wire `API_EMAIL_API_KEY_SECRET_ARN` to `IDENTRAIL_EMAIL_API_KEY` without touching `API_EXTRA_SECRETS_JSON`
- document the safer setup path for hosted API email

## Why
GitHub hides existing secret values on update pages, so operators cannot safely append the Resend ARN to `API_EXTRA_SECRETS_JSON` without risking the existing WorkOS/login secret JSON.

## Validation
- [x] `bash -n scripts/prepare_aws_api_deploy.sh`
- [x] `git diff --check`
- [x] workflow YAML parsed successfully
- [x] `scripts/prepare_aws_api_deploy.sh` with `API_EMAIL_*` sample inputs
- [x] missing `API_EMAIL_API_KEY_SECRET_ARN` guardrail check

## AI Assistance Disclosure
- AI-assisted: No
- Tools used:
- Areas where used:
- Human verification performed:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class transactional email config and a dedicated deploy secret for the AWS manual deploy. Now merges with any existing `API_EXTRA_*` email settings so you can stage the secret safely and adopt gradually.

- **New Features**
  - Adds email inputs: `API_EMAIL_PROVIDER`, `API_EMAIL_FROM_ADDRESS`, `API_EMAIL_REPLY_TO_ADDRESS`, `API_EMAIL_APP_BASE_URL`, `API_EMAIL_TIMEOUT`, `API_EMAIL_API_KEY_SECRET_ARN`.
  - Validates email setup in `scripts/prepare_aws_api_deploy.sh` (requires `resend`, checks required fields and region-scoped ARN, merges with any `API_EXTRA_ENVIRONMENT_JSON`/`API_EXTRA_SECRETS_JSON` values, injects env/secrets, and masks the secret in the deploy workflow).
  - Updates `docs/aws-api-hosting.md` to document the safer, first-class email setup.

- **Migration**
  - Set `API_EMAIL_PROVIDER=resend` and `API_EMAIL_FROM_ADDRESS`.
  - Store the Resend API key in Secrets Manager and set `API_EMAIL_API_KEY_SECRET_ARN`.
  - Optionally set `API_EMAIL_REPLY_TO_ADDRESS`, `API_EMAIL_APP_BASE_URL`, and `API_EMAIL_TIMEOUT`.
  - You can create `API_EMAIL_API_KEY_SECRET_ARN` ahead of time; email is enabled only when `API_EMAIL_PROVIDER=resend` is set.

<sup>Written for commit d557ae27196d79251328c69ac51b702d428c8481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

