### PR TITLE
Block ambiguous boundary dry-runs

### DIFF
--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -439,7 +439,7 @@ func awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval AWSR
 	if !hasNonArnTarget {
 		return true
 	}
-	return len(scopedAccounts) == 1
+	return len(scopedAccounts) == 1 && len(targets) == 1
 }
 
 // awsRemediationDryRunTargetSet pairs the identity-first and resource-first
@@ -790,7 +790,7 @@ func awsRemediationDryRunPrerequisites(approval AWSRemediationApprovalEntry) ([]
 		add("feature_flag:"+flag.Name, awsRemediationDryRunGateStatus(flag.Enabled), flag.Rationale)
 	}
 	if awsRemediationDryRunIsPermissionBoundaryApproval(approval) {
-		add("permission_boundary_target_account_scope", awsRemediationDryRunGateStatus(awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval)), "Every permission-boundary dry-run target must carry an account in its ARN or be scoped by exactly one approval account.")
+		add("permission_boundary_target_account_scope", awsRemediationDryRunGateStatus(awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval)), "Every permission-boundary dry-run target must carry an account in its ARN, or if the target is non-ARN it must use exactly one approval account and be the only supported target.")
 	}
 	return satisfied, failed
 }

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -395,6 +395,22 @@ func awsRemediationDryRunScopedIdempotencyKey(base, operation, target string) st
 	return stableAWSBlastRadiusToken(base, operation, target)
 }
 
+func awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval AWSRemediationApprovalEntry) bool {
+	for _, target := range awsPermissionBoundaryExecutorSupportedTargets(approval.Scope.IdentityNodeIDs) {
+		if !awsRemediationDryRunPermissionBoundaryTargetHasAccountScope(approval, target) {
+			return false
+		}
+	}
+	return true
+}
+
+func awsRemediationDryRunPermissionBoundaryTargetHasAccountScope(approval AWSRemediationApprovalEntry, target string) bool {
+	if awsPermissionBoundaryExecutorAccountFromTarget(target) != "" {
+		return true
+	}
+	return len(emptyStrings(dedupeStrings(approval.Scope.AccountIDs))) == 1
+}
+
 // awsRemediationDryRunTargetSet pairs the identity-first and resource-first
 // node IDs for an approval so each routing branch can pick the target that
 // matches the AWS API being projected. Identity-mutating calls (PutRolePolicy,
@@ -741,6 +757,9 @@ func awsRemediationDryRunPrerequisites(approval AWSRemediationApprovalEntry) ([]
 			continue
 		}
 		add("feature_flag:"+flag.Name, awsRemediationDryRunGateStatus(flag.Enabled), flag.Rationale)
+	}
+	if awsRemediationDryRunIsPermissionBoundaryApproval(approval) {
+		add("permission_boundary_target_account_scope", awsRemediationDryRunGateStatus(awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval)), "Every permission-boundary dry-run target must carry an account in its ARN or be scoped by exactly one approval account.")
 	}
 	return satisfied, failed
 }

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -293,10 +293,13 @@ func awsRemediationDryRunEntries(approvals []AWSRemediationApprovalEntry, now ti
 
 func awsRemediationDryRunEntryFromApproval(approval AWSRemediationApprovalEntry, now time.Time) AWSRemediationDryRunEntry {
 	intended := awsRemediationDryRunIntendedAPICalls(approval)
-	resources := awsRemediationDryRunAffectedResources(approval, intended)
 	satisfied, failed := awsRemediationDryRunPrerequisites(approval)
 	checks := awsRemediationDryRunVerificationChecks(approval)
 	outcome := awsRemediationDryRunOutcome(approval, failed)
+	if awsRemediationDryRunShouldRestrictPermissionBoundaryCallsToReviewedTarget(approval, failed) {
+		intended = awsRemediationDryRunPermissionBoundaryReviewedTargetCalls(intended)
+	}
+	resources := awsRemediationDryRunAffectedResources(approval, intended)
 	dryRunID := "aws-remediation-dry-run:" + stableAWSBlastRadiusToken("dry-run", approval.ApprovalID, outcome)
 	entry := AWSRemediationDryRunEntry{
 		DryRunID:           dryRunID,
@@ -384,6 +387,28 @@ func awsRemediationDryRunPermissionBoundaryCalls(approval AWSRemediationApproval
 	return calls
 }
 
+func awsRemediationDryRunShouldRestrictPermissionBoundaryCallsToReviewedTarget(approval AWSRemediationApprovalEntry, failed []AWSRemediationDryRunPrerequisite) bool {
+	if !awsRemediationDryRunIsPermissionBoundaryApproval(approval) {
+		return false
+	}
+	for _, prereq := range failed {
+		if prereq.Name == "permission_boundary_target_account_scope" && strings.EqualFold(prereq.Status, "blocked") {
+			return true
+		}
+	}
+	return false
+}
+
+func awsRemediationDryRunPermissionBoundaryReviewedTargetCalls(calls []AWSRemediationDryRunIntendedAPICall) []AWSRemediationDryRunIntendedAPICall {
+	if len(calls) == 0 {
+		return calls
+	}
+	// Preserve deterministic reviewed-target intent: if scope validation blocked
+	// the case, show the first supported target that was already projected,
+	// mirroring the same single target used by the approval review UX for fixup.
+	return calls[:1]
+}
+
 func awsRemediationDryRunScopedIdempotencyKey(base, operation, target string) string {
 	base = strings.TrimSpace(base)
 	if base == "" {
@@ -396,19 +421,25 @@ func awsRemediationDryRunScopedIdempotencyKey(base, operation, target string) st
 }
 
 func awsRemediationDryRunPermissionBoundaryTargetsHaveAccountScope(approval AWSRemediationApprovalEntry) bool {
-	for _, target := range awsPermissionBoundaryExecutorSupportedTargets(approval.Scope.IdentityNodeIDs) {
-		if !awsRemediationDryRunPermissionBoundaryTargetHasAccountScope(approval, target) {
-			return false
-		}
-	}
-	return true
-}
+	targets := awsPermissionBoundaryExecutorSupportedTargets(approval.Scope.IdentityNodeIDs)
+	scopedAccounts := emptyStrings(dedupeStrings(approval.Scope.AccountIDs))
 
-func awsRemediationDryRunPermissionBoundaryTargetHasAccountScope(approval AWSRemediationApprovalEntry, target string) bool {
-	if awsPermissionBoundaryExecutorAccountFromTarget(target) != "" {
+	hasNonArnTarget := false
+	hasArnTarget := false
+	for _, target := range targets {
+		if awsPermissionBoundaryExecutorAccountFromTarget(target) == "" {
+			hasNonArnTarget = true
+			continue
+		}
+		hasArnTarget = true
+	}
+	if hasNonArnTarget && hasArnTarget {
+		return false
+	}
+	if !hasNonArnTarget {
 		return true
 	}
-	return len(emptyStrings(dedupeStrings(approval.Scope.AccountIDs))) == 1
+	return len(scopedAccounts) == 1
 }
 
 // awsRemediationDryRunTargetSet pairs the identity-first and resource-first

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -626,6 +626,68 @@ func TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget(t *testing.T) 
 	}
 }
 
+func TestAWSRemediationDryRunPermissionBoundaryBlocksAmbiguousNonARNAccountScope(t *testing.T) {
+	now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	base := AWSRemediationApprovalEntry{
+		ApprovalID:        "approval-boundary-non-arn",
+		CaseID:            "case-boundary-non-arn",
+		SourceType:        "aws_permission_boundary_scp",
+		IdempotencyKey:    "idk",
+		State:             awsRemediationApprovalStateApproved,
+		ReadyForExecution: true,
+		DiffIntent:        AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+		RBACGates:         []AWSRemediationApprovalRBACGate{{Name: "approver_quorum", Status: "passed"}},
+		Scope: AWSRemediationApprovalScope{
+			IdentityNodeIDs: []string{"aws:identity:role/orders-ci"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		accountIDs []string
+		wantPass   bool
+	}{
+		{name: "empty account scope", accountIDs: nil},
+		{name: "ambiguous account scope", accountIDs: []string{"111111111111", "222222222222"}},
+		{name: "single account scope", accountIDs: []string{"111111111111"}, wantPass: true},
+	} {
+		approval := base
+		approval.Scope.AccountIDs = tc.accountIDs
+		entry := awsRemediationDryRunEntryFromApproval(approval, now)
+		if tc.wantPass {
+			if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || len(entry.FailedPrereqs) != 0 {
+				t.Fatalf("%s: expected scoped non-ARN target to pass, got outcome=%q failed=%+v", tc.name, entry.Outcome, entry.FailedPrereqs)
+			}
+			continue
+		}
+		if entry.Outcome != awsRemediationDryRunOutcomeWouldFail {
+			t.Fatalf("%s: ambiguous non-ARN target must project would_fail, got %q", tc.name, entry.Outcome)
+		}
+		if entry.ReadyForApply {
+			t.Fatalf("%s: ambiguous non-ARN target must not be ready_for_apply: %+v", tc.name, entry)
+		}
+		found := false
+		for _, prereq := range entry.FailedPrereqs {
+			if prereq.Name == "permission_boundary_target_account_scope" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s: expected boundary account-scope failed prerequisite, got %+v", tc.name, entry.FailedPrereqs)
+		}
+		if len(entry.IntendedAPICalls) != 1 || entry.IntendedAPICalls[0].TargetResource != "aws:identity:role/orders-ci" {
+			t.Fatalf("%s: dry-run should still show the reviewed intended target while blocked, got %+v", tc.name, entry.IntendedAPICalls)
+		}
+	}
+
+	arnScoped := base
+	arnScoped.Scope.IdentityNodeIDs = []string{"aws:identity:arn:aws:iam::111111111111:role/orders-ci"}
+	entry := awsRemediationDryRunEntryFromApproval(arnScoped, now)
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || len(entry.FailedPrereqs) != 0 {
+		t.Fatalf("ARN target should carry its own account scope, got outcome=%q failed=%+v", entry.Outcome, entry.FailedPrereqs)
+	}
+}
+
 func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -652,6 +652,14 @@ func TestAWSRemediationDryRunPermissionBoundaryBlocksAmbiguousNonARNAccountScope
 		{name: "ambiguous account scope", accountIDs: []string{"111111111111", "222222222222"}},
 		{name: "single account scope", accountIDs: []string{"111111111111"}, wantPass: true},
 		{
+			name:       "multiple non-ARN targets with one account scope",
+			accountIDs: []string{"111111111111"},
+			identityNodeIDs: []string{
+				"aws:identity:role/dev-role",
+				"aws:identity:user/app-user",
+			},
+		},
+		{
 			name:       "mixed arn/non-arn with one target account",
 			accountIDs: []string{"111111111111"},
 			identityNodeIDs: []string{

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -643,16 +643,28 @@ func TestAWSRemediationDryRunPermissionBoundaryBlocksAmbiguousNonARNAccountScope
 	}
 
 	for _, tc := range []struct {
-		name       string
-		accountIDs []string
-		wantPass   bool
+		name            string
+		accountIDs      []string
+		identityNodeIDs []string
+		wantPass        bool
 	}{
 		{name: "empty account scope", accountIDs: nil},
 		{name: "ambiguous account scope", accountIDs: []string{"111111111111", "222222222222"}},
 		{name: "single account scope", accountIDs: []string{"111111111111"}, wantPass: true},
+		{
+			name:       "mixed arn/non-arn with one target account",
+			accountIDs: []string{"111111111111"},
+			identityNodeIDs: []string{
+				"aws:identity:arn:aws:iam::111111111111:role/app-a",
+				"aws:identity:user/app-user",
+			},
+		},
 	} {
 		approval := base
 		approval.Scope.AccountIDs = tc.accountIDs
+		if tc.identityNodeIDs != nil {
+			approval.Scope.IdentityNodeIDs = tc.identityNodeIDs
+		}
 		entry := awsRemediationDryRunEntryFromApproval(approval, now)
 		if tc.wantPass {
 			if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || len(entry.FailedPrereqs) != 0 {
@@ -675,8 +687,9 @@ func TestAWSRemediationDryRunPermissionBoundaryBlocksAmbiguousNonARNAccountScope
 		if !found {
 			t.Fatalf("%s: expected boundary account-scope failed prerequisite, got %+v", tc.name, entry.FailedPrereqs)
 		}
-		if len(entry.IntendedAPICalls) != 1 || entry.IntendedAPICalls[0].TargetResource != "aws:identity:role/orders-ci" {
-			t.Fatalf("%s: dry-run should still show the reviewed intended target while blocked, got %+v", tc.name, entry.IntendedAPICalls)
+		expectedTarget := awsRemediationDryRunFirstNode(approval.Scope.IdentityNodeIDs)
+		if len(entry.IntendedAPICalls) != 1 || entry.IntendedAPICalls[0].TargetResource != expectedTarget {
+			t.Fatalf("%s: dry-run should still show the reviewed intended target while blocked, expected=%q got %+v", tc.name, expectedTarget, entry.IntendedAPICalls)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #1689 post-merge review.
- Add a dry-run prerequisite that blocks permission-boundary targets unless each target has a concrete account from its IAM ARN or the approval scope has exactly one account.
- Keep intended calls visible for review while preventing ambiguous non-ARN targets from reporting `would_succeed` / `ready_for_apply`.

No issue: this PR resolves a post-merge dry-run scope safety issue for permission-boundary processing.

## Root Cause
Permission-boundary dry-runs emitted per-target IAM boundary calls after #1689, but non-ARN identity node IDs such as `aws:identity:role/...` do not encode an AWS account. When approval scope carried no accounts or multiple de-duped accounts, the dry-run could still look successful even though the executor later blocked the same target for missing canary scope.

## Validation
- `go test ./internal/api -run 'TestAWSRemediationDryRunPermissionBoundaryBlocksAmbiguousNonARNAccountScope|TestAWSRemediationDryRunPermissionBoundaryEmitsCallPerTarget|TestAWSPermissionBoundaryExecutor'`\n- `go test ./internal/api`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks ambiguous permission-boundary dry-runs when targets don’t resolve to a single account or when mixed ARN and non-ARN targets would force guessing. For non-ARN fallback, require exactly one approval account and exactly one supported target; still show the reviewed intended IAM call but don’t mark success or ready to apply.

- **Bug Fixes**
  - Add a dry-run prerequisite: each target must include an account in its ARN; otherwise allow non-ARN targets only if the approval scope has one account and there is exactly one supported target; block mixed ARN/non-ARN.
  - When this prerequisite fails, set outcome to would_fail, keep ready_for_apply false, and restrict IntendedAPICalls to the single reviewed target.

<sup>Written for commit cff7315ae7c1b5b860b1d5c59286fbbd56cac2b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

