### PR TITLE
Implement SCP guardrail executor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
 - AWS low-risk live remediation: `aws-low-risk-live-remediation.md`
 - AWS approved permission boundary executor: `aws-permission-boundary-executor.md`
+- AWS approved SCP guardrail executor: `aws-scp-guardrail-executor.md`
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`

--- a/docs/aws-permission-boundary-executor.md
+++ b/docs/aws-permission-boundary-executor.md
@@ -41,8 +41,8 @@ ready, breakage is `low`, scope is captured, and no kill switch is engaged.
 - `blocked`: a safety gate failed, the tenant kill switch is engaged, the
   operation is unsupported, or the dry-run is blocked.
 
-SCP plans are intentionally excluded; org-level SCP execution belongs to the
-dedicated SCP executor issue.
+SCP plans are intentionally excluded; org-level SCP execution is projected by
+the dedicated SCP guardrail executor.
 
 ## App Surface
 

--- a/docs/aws-remediation-dry-run-executor.md
+++ b/docs/aws-remediation-dry-run-executor.md
@@ -49,7 +49,8 @@ Each `AWSRemediationDryRunEntry` includes:
   derived from the source type — for example IAM `PutRolePolicy` for
   least-privilege diffs, IAM `UpdateAssumeRolePolicy` for trust hardening,
   Secrets Manager `RotateSecret` for secret rotation, IAM `UpdateAccessKey`
-  for quarantine, and `bedrock-agent:UpdateAgent` for AI-agent risk
+  for quarantine, Organizations `AttachPolicy` for SCP guardrails, and
+  `bedrock-agent:UpdateAgent` for AI-agent risk
 - `affected_resources` with change kind and before/after metadata refs
 - `satisfied_prerequisites` and `failed_prerequisites` covering approval
   state, kill switch, ready-for-execution, every RBAC gate, and every

--- a/docs/aws-scp-guardrail-executor.md
+++ b/docs/aws-scp-guardrail-executor.md
@@ -1,0 +1,52 @@
+# AWS approved SCP guardrail executor
+
+Issue #1541 adds a metadata-only projection of approved AWS Organizations SCP
+guardrail execution records. Each entry joins the dry-run executor (#1537) with
+the permission boundary/SCP planner (#1532) for cases whose `source_type` is
+`aws_permission_boundary_scp`, whose planner kind is `scp`, and whose dry-run
+diff kind is `scp_diff`.
+
+The endpoint is read-only. It never calls IAM or Organizations write APIs and
+never reads, exposes, logs, or persists rendered policy documents, secret
+values, customer payloads, prompts, completions, browser pages,
+code-interpreter output, database rows, or object contents.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/scp-guardrail-executor`
+
+Response shape: `{ "scp_guardrail_executor": AWSScpGuardrailExecutorResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`dry_run_id`, `case_id`, `plan_id`, `operation`, `state`, `severity`, and
+`search`.
+
+## Entry Shape
+
+Each entry includes stable source IDs, target account/OU scope, projected AWS
+Organizations `AttachPolicy` or `CreatePolicy` intent, idempotency key,
+statement snippets, breakage projection, preconditions, SCP simulation refs,
+rollback and verification plans, audit trail, relationships, and
+`ready_for_live_apply`.
+
+`ready_for_live_apply` is true only when every safety precondition passes, the
+upstream dry-run is `would_succeed` and `ready_for_apply`, the planner is ready,
+breakage is `low`, account or OU target scope is captured, and no kill switch is
+engaged.
+
+## States
+
+- `projected`: ready for the wave-8 apply runtime when its feature flag opens.
+- `precondition_failed`: upstream evidence exists but is not ready, such as
+  non-low breakage or a planner/dry-run readiness gate.
+- `blocked`: a safety gate failed, the tenant kill switch is engaged, the
+  operation is unsupported, or the dry-run is blocked.
+
+Permission boundary plans are intentionally excluded; identity-level IAM
+permission-boundary execution is projected by the permission boundary executor.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS approved SCP guardrail executor** panel
+with execution title, Organizations operation, account/OU target counts,
+precondition counts, simulation outcome, readiness, and severity/state pill.

--- a/docs/aws-scp-guardrail-executor.md
+++ b/docs/aws-scp-guardrail-executor.md
@@ -18,12 +18,12 @@ code-interpreter output, database rows, or object contents.
 Response shape: `{ "scp_guardrail_executor": AWSScpGuardrailExecutorResult }`.
 
 Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
-`dry_run_id`, `case_id`, `plan_id`, `operation`, `state`, `severity`, and
-`search`.
+`dry_run_id`, `case_id`, `plan_id`, `operation`, `target_scope`, `state`,
+`severity`, and `search`. `target_scope` accepts `account`, `ou`, or `root`.
 
 ## Entry Shape
 
-Each entry includes stable source IDs, target account/OU scope, projected AWS
+Each entry includes stable source IDs, one target account/OU/root scope, projected AWS
 Organizations `AttachPolicy` or `CreatePolicy` intent, idempotency key,
 statement snippets, breakage projection, preconditions, SCP simulation refs,
 rollback and verification plans, audit trail, relationships, and

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -599,6 +599,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/scp-guardrail-executor
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5532,6 +5537,90 @@ paths:
                     $ref: "#/components/schemas/AWSPermissionBoundaryExecutorResult"
         "400":
           description: Invalid AWS permission boundary executor request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/scp-guardrail-executor:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS approved SCP guardrail executor projections
+      operationId: getAWSProjectScpGuardrailExecutor
+      description: Joins approved remediation dry-run entries with SCP planner metadata to project controlled AWS Organizations SCP guardrail execution records. Each record carries idempotency, dry-run/apply/verify metadata, target accounts/OUs, preconditions, SCP simulator refs, rollback and verification plans, immutable audit entries, and graph relationships. This endpoint is metadata-only and never calls IAM or Organizations write APIs.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: dry_run_id
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: plan_id
+          schema: { type: string }
+        - in: query
+          name: operation
+          schema:
+            type: string
+            enum: [AttachPolicy, CreatePolicy]
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [projected, precondition_failed, blocked]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across execution IDs, plan IDs, target accounts/OUs, intended API call, preconditions, simulator metadata, verification, audit, and evidence refs.
+      responses:
+        "200":
+          description: AWS SCP guardrail executor contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  scp_guardrail_executor:
+                    $ref: "#/components/schemas/AWSScpGuardrailExecutorResult"
+        "400":
+          description: Invalid AWS SCP guardrail executor request
           content:
             application/json:
               schema:
@@ -14120,7 +14209,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [iam_policy_diff, iam_trust_diff, role_scope_diff, secret_rotation, kms_grant_diff, permission_boundary_diff, ai_agent_scope_change, owner_assignment, manual_review]
+          enum: [iam_policy_diff, iam_trust_diff, role_scope_diff, secret_rotation, kms_grant_diff, permission_boundary_diff, scp_diff, ai_agent_scope_change, owner_assignment, manual_review]
         before_ref: { type: string }
         after_ref: { type: string }
         diff_summary: { type: string }
@@ -15308,6 +15397,215 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPermissionBoundaryExecutorRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSScpGuardrailExecutorPrecondition:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSScpGuardrailExecutorSimulation:
+      type: object
+      properties:
+        simulation_ref: { type: string }
+        outcome: { type: string }
+        before_ref: { type: string }
+        after_ref: { type: string }
+        denied_action_count: { type: integer }
+        target_account_count: { type: integer }
+        target_ou_count: { type: integer }
+        signals:
+          type: array
+          items: { type: string }
+    AWSScpGuardrailExecutorVerification:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        status: { type: string }
+        description: { type: string }
+    AWSScpGuardrailExecutorRelationship:
+      type: object
+      properties:
+        execution_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSScpGuardrailExecutorEntry:
+      type: object
+      properties:
+        execution_id: { type: string }
+        calculation_version: { type: string }
+        dry_run_id: { type: string }
+        approval_id: { type: string }
+        case_id: { type: string }
+        plan_id: { type: string }
+        source_artifact_id: { type: string }
+        state:
+          type: string
+          enum: [projected, precondition_failed, blocked]
+        severity: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        operation:
+          type: string
+          enum: [AttachPolicy, CreatePolicy]
+        idempotency_key: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        target_ou_paths:
+          type: array
+          items: { type: string }
+        prevented_behavior: { type: string }
+        statement_snippets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionBoundarySCPStatementSnippet"
+        breakage_projection:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPBreakageProjection"
+        intended_api_call:
+          $ref: "#/components/schemas/AWSRemediationDryRunIntendedAPICall"
+        preconditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSScpGuardrailExecutorPrecondition"
+        boundary_simulation:
+          $ref: "#/components/schemas/AWSScpGuardrailExecutorSimulation"
+        verifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSScpGuardrailExecutorVerification"
+        rollback_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPRollbackPlan"
+        verification_plan:
+          $ref: "#/components/schemas/AWSPermissionBoundarySCPVerificationPlan"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        kill_switch_engaged: { type: boolean }
+        ready_for_live_apply: { type: boolean }
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSScpGuardrailExecutorSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        operation_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        ready_for_live_apply_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_precondition_count: { type: integer }
+        target_account_count: { type: integer }
+        target_ou_count: { type: integer }
+        verification_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSScpGuardrailExecutorResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSScpGuardrailExecutorSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSScpGuardrailExecutorEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSScpGuardrailExecutorRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5596,6 +5596,12 @@ paths:
             type: string
             enum: [AttachPolicy, CreatePolicy]
         - in: query
+          name: target_scope
+          schema:
+            type: string
+            enum: [account, ou, root]
+          description: Optional target-scope filter for per-target SCP execution projections.
+        - in: query
           name: state
           schema:
             type: string

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -763,6 +763,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-scp", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/permission-boundary-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/scp-guardrail-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/access-key-quarantine", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/iac-remediation-plans", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_remediation_approval.go
+++ b/internal/api/aws_remediation_approval.go
@@ -434,7 +434,7 @@ func awsRemediationApprovalScope(source AWSRemediationCase, connectorID string) 
 		identityNodes = append(identityNodes, source.IdentityNodeID)
 	}
 	resourceNodes := emptyStrings(dedupeStrings(source.ResourceNodeIDs))
-	if strings.EqualFold(source.SourceType, "aws_permission_boundary_scp") {
+	if strings.EqualFold(source.SourceType, "aws_permission_boundary_scp") && !strings.EqualFold(source.DiffIntent.Kind, "scp_diff") {
 		scopeType = "identity"
 		identityNodes = awsPermissionBoundaryExecutorSupportedTargets(append(identityNodes, source.ResourceNodeIDs...))
 		resourceNodes = nil

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -370,6 +370,9 @@ func awsRemediationCases(sources awsRemediationCaseSources, now time.Time) []AWS
 		if c, ok := awsRemediationCaseFromPermissionBoundary(plan, now); ok {
 			cases = append(cases, c)
 		}
+		if c, ok := awsRemediationCaseFromSCPGuardrail(plan, now); ok {
+			cases = append(cases, c)
+		}
 	}
 	return awsRemediationCaseDedupe(cases)
 }
@@ -779,6 +782,69 @@ func awsRemediationPermissionBoundaryIdentityType(target string) string {
 	return "iam_role"
 }
 
+func awsRemediationCaseFromSCPGuardrail(plan AWSPermissionBoundarySCPPlan, now time.Time) (AWSRemediationCase, bool) {
+	if plan.PlanID == "" || !strings.EqualFold(plan.Kind, awsSCPKind) {
+		return AWSRemediationCase{}, false
+	}
+	targetAccounts := emptyStrings(dedupeStrings(plan.TargetAccountIDs))
+	targetOUs := emptyStrings(dedupeStrings(plan.TargetOUPaths))
+	if len(targetAccounts) == 0 && len(targetOUs) == 0 {
+		return AWSRemediationCase{}, false
+	}
+	caseID := "aws-remediation-case:" + stableAWSBlastRadiusToken("scp-guardrail", plan.PlanID)
+	evidenceRef := firstString(awsRemediationEvidenceRefs(plan.Evidence))
+	deniedActions := awsRemediationSCPDeniedActions(plan)
+	diff := AWSRemediationDiffIntent{
+		Kind:               "scp_diff",
+		BeforeRef:          evidenceRef,
+		AfterRef:           "scp://" + plan.PlanID + "/approved-guardrail",
+		DiffSummary:        fmt.Sprintf("Apply SCP guardrail plan %s to %d account(s) and %d OU/root scope(s); deny %s before live execution.", plan.PlanID, len(targetAccounts), len(targetOUs), firstNonEmptyAWSValue(strings.Join(deniedActions, ", "), "the projected cross-account trust pattern")),
+		ReadOnlyProjection: true,
+	}
+	owner, ownerAssigned := "iam-platform", true
+	approvalRequired := awsRemediationApprovalRequired(plan.Severity, diff.Kind)
+	approvalState := awsRemediationApprovalState(approvalRequired, ownerAssigned, plan.Status)
+	if plan.ReadyForApply && normalizeAWSRuntimeEventFilterToken(plan.Status) == "action-required" {
+		approvalState = "approved"
+	}
+	lifecycle := awsRemediationLifecycle(plan.Status, plan.Confidence, ownerAssigned, approvalState, diff)
+	resourceNodes := awsRemediationResourceNodes(targetOUs, targetAccounts)
+	c := AWSRemediationCase{
+		CaseID:             caseID,
+		CalculationVersion: awsRemediationCaseVersion,
+		SourceType:         "aws_permission_boundary_scp",
+		SourceFindingID:    plan.PlanID,
+		Lifecycle:          lifecycle,
+		Severity:           plan.Severity,
+		Status:             plan.Status,
+		Score:              plan.Score,
+		Confidence:         plan.Confidence,
+		Title:              fmt.Sprintf("SCP guardrail executor for %s", firstNonEmptyAWSValue(plan.Service, firstString(targetOUs), firstString(targetAccounts), plan.PlanID)),
+		Summary:            plan.Summary,
+		AccountID:          firstString(targetAccounts),
+		TargetAccountIDs:   targetAccounts,
+		Region:             plan.Region,
+		ResourceNodeIDs:    resourceNodes,
+		Owner:              owner,
+		OwnerAssigned:      ownerAssigned,
+		ApprovalRequired:   approvalRequired,
+		ApprovalState:      approvalState,
+		DiffIntent:         diff,
+		Tradeoffs:          awsRemediationTradeoffsForPermissionBoundary(plan),
+		RollbackPlan:       awsRemediationRollbackFromSCPGuardrail(plan, evidenceRef),
+		VerificationPlan:   awsRemediationVerificationFromSCPGuardrail(plan, evidenceRef),
+		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "scp", "scp_guardrail"}, plan.SourceSignals...)),
+		Evidence:           plan.Evidence,
+		EvidenceBoundary:   awsRemediationCaseEvidenceBoundary(),
+		ImpactedNodes:      dedupeStrings(append(append([]string{}, resourceNodes...), plan.ImpactedNodes...)),
+		ImpactedPath:       plan.ImpactedPath,
+		NextActions:        awsRemediationNextActionList(plan.NextAction, diff),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return finalizeAWSRemediationCase(c, now), true
+}
+
 func finalizeAWSRemediationCase(c AWSRemediationCase, now time.Time) AWSRemediationCase {
 	c.SourceSignals = dedupeStrings(c.SourceSignals)
 	c.ImpactedNodes = emptyStrings(dedupeStrings(c.ImpactedNodes))
@@ -916,7 +982,7 @@ func awsRemediationApprovalRequired(severity, diffKind string) bool {
 		return true
 	}
 	switch diffKind {
-	case "secret_rotation", "iam_trust_diff", "kms_grant_diff", "permission_boundary_diff":
+	case "secret_rotation", "iam_trust_diff", "kms_grant_diff", "permission_boundary_diff", "scp_diff":
 		return true
 	}
 	return false
@@ -1100,6 +1166,8 @@ func awsRemediationRollbackForDiff(diff AWSRemediationDiffIntent, evidenceRef st
 		return AWSRemediationRollbackPlan{Strategy: "restore_grant", Steps: []string{"Restore the previous KMS grant or key policy statement.", "Re-run KMS-decrypt reachability to confirm the rollback."}, EvidenceRef: evidenceRef}
 	case "permission_boundary_diff":
 		return AWSRemediationRollbackPlan{Strategy: "detach_permission_boundary", Steps: []string{"Detach the projected permission boundary from the captured identity targets.", "Re-run least-privilege and IAM policy simulation to confirm the rollback."}, EvidenceRef: evidenceRef}
+	case "scp_diff":
+		return AWSRemediationRollbackPlan{Strategy: "detach_scp", Steps: []string{"Detach the projected SCP from the captured account or OU targets.", "Re-run cross-account trust and SCP simulation checks to confirm the rollback."}, EvidenceRef: evidenceRef}
 	case "ai_agent_scope_change":
 		return AWSRemediationRollbackPlan{Strategy: "re_enable_tool", Steps: []string{"Re-enable the removed tool or capability scope on the AI agent definition.", "Re-run runtime/tool-call correlation."}, EvidenceRef: evidenceRef}
 	case "owner_assignment":
@@ -1253,12 +1321,52 @@ func awsRemediationVerificationFromPermissionBoundary(plan AWSPermissionBoundary
 	}
 }
 
+func awsRemediationRollbackFromSCPGuardrail(plan AWSPermissionBoundarySCPPlan, evidenceRef string) AWSRemediationRollbackPlan {
+	rollback := plan.RollbackPlan
+	if len(rollback.Steps) == 0 {
+		return AWSRemediationRollbackPlan{
+			Strategy:    "detach_scp",
+			Steps:       []string{"Detach the projected SCP from the captured account or OU target.", "Re-run cross-account-trust to confirm the previous reachability only returns if the rollback is intended."},
+			EvidenceRef: evidenceRef,
+		}
+	}
+	return AWSRemediationRollbackPlan{
+		Strategy:    firstNonEmptyAWSValue(rollback.Strategy, "detach_scp"),
+		Steps:       rollback.Steps,
+		EvidenceRef: firstNonEmptyAWSValue(rollback.EvidenceRef, evidenceRef),
+	}
+}
+
+func awsRemediationVerificationFromSCPGuardrail(plan AWSPermissionBoundarySCPPlan, evidenceRef string) AWSRemediationVerificationPlan {
+	verification := plan.VerificationPlan
+	if len(verification.Steps) == 0 {
+		return AWSRemediationVerificationPlan{
+			Strategy:       "scp_guardrail_re_evaluate",
+			Steps:          []string{"Confirm the SCP policy is attached to every captured account or OU target.", "Re-run cross-account-trust and Access Analyzer to confirm the finding is resolved without new external trust."},
+			SuccessSignals: []string{"cross_account_trust:finding-resolved", "access_analyzer:no-new-external-findings"},
+			FailureSignals: []string{"cross_account_trust:finding-unchanged", "access_analyzer:new-external-finding"},
+			EvidenceRef:    evidenceRef,
+		}
+	}
+	return AWSRemediationVerificationPlan{
+		Strategy:       firstNonEmptyAWSValue(verification.Strategy, "scp_guardrail_re_evaluate"),
+		Steps:          verification.Steps,
+		SuccessSignals: verification.SuccessSignals,
+		FailureSignals: verification.FailureSignals,
+		EvidenceRef:    firstNonEmptyAWSValue(verification.EvidenceRef, evidenceRef),
+	}
+}
+
 func awsRemediationPermissionBoundaryDeniedActions(plan AWSPermissionBoundarySCPPlan) []string {
 	out := []string{}
 	for _, snippet := range plan.StatementSnippets {
 		out = append(out, snippet.DeniedActions...)
 	}
 	return emptyStrings(dedupeStrings(out))
+}
+
+func awsRemediationSCPDeniedActions(plan AWSPermissionBoundarySCPPlan) []string {
+	return awsRemediationPermissionBoundaryDeniedActions(plan)
 }
 
 func awsRemediationResourceNodes(values ...interface{}) []string {

--- a/internal/api/aws_remediation_cases.go
+++ b/internal/api/aws_remediation_cases.go
@@ -830,7 +830,7 @@ func awsRemediationCaseFromSCPGuardrail(plan AWSPermissionBoundarySCPPlan, now t
 		ApprovalRequired:   approvalRequired,
 		ApprovalState:      approvalState,
 		DiffIntent:         diff,
-		Tradeoffs:          awsRemediationTradeoffsForPermissionBoundary(plan),
+		Tradeoffs:          awsRemediationTradeoffsForSCPGuardrail(plan),
 		RollbackPlan:       awsRemediationRollbackFromSCPGuardrail(plan, evidenceRef),
 		VerificationPlan:   awsRemediationVerificationFromSCPGuardrail(plan, evidenceRef),
 		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "scp", "scp_guardrail"}, plan.SourceSignals...)),
@@ -1154,6 +1154,20 @@ func awsRemediationTradeoffsForPermissionBoundary(plan AWSPermissionBoundarySCPP
 	return out
 }
 
+func awsRemediationTradeoffsForSCPGuardrail(plan AWSPermissionBoundarySCPPlan) []AWSRemediationTradeoff {
+	targetAccountCount := len(emptyStrings(plan.TargetAccountIDs))
+	targetOUCount := len(emptyStrings(plan.TargetOUPaths))
+	out := []AWSRemediationTradeoff{
+		{Dimension: "downstream_blast_radius", Direction: "improves", Description: fmt.Sprintf("Applying the SCP guardrail prevents re-introduction of the blocked behavior across %d account target(s) and %d OU/root scope(s).", targetAccountCount, targetOUCount), Severity: plan.Severity},
+	}
+	if strings.EqualFold(plan.BreakageProjection.Level, "low") {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "neutral", Description: plan.BreakageProjection.Rationale, Severity: "low"})
+	} else {
+		out = append(out, AWSRemediationTradeoff{Dimension: "breakage_risk", Direction: "worsens", Description: plan.BreakageProjection.Rationale, Severity: firstNonEmptyAWSValue(plan.BreakageProjection.Level, "medium")})
+	}
+	return out
+}
+
 func awsRemediationRollbackForDiff(diff AWSRemediationDiffIntent, evidenceRef string) AWSRemediationRollbackPlan {
 	switch diff.Kind {
 	case "iam_policy_diff", "role_scope_diff":
@@ -1342,9 +1356,9 @@ func awsRemediationVerificationFromSCPGuardrail(plan AWSPermissionBoundarySCPPla
 	if len(verification.Steps) == 0 {
 		return AWSRemediationVerificationPlan{
 			Strategy:       "scp_guardrail_re_evaluate",
-			Steps:          []string{"Confirm the SCP policy is attached to every captured account or OU target.", "Re-run cross-account-trust and Access Analyzer to confirm the finding is resolved without new external trust."},
-			SuccessSignals: []string{"cross_account_trust:finding-resolved", "access_analyzer:no-new-external-findings"},
-			FailureSignals: []string{"cross_account_trust:finding-unchanged", "access_analyzer:new-external-finding"},
+			Steps:          []string{"Confirm the SCP policy is attached to every captured account or OU target.", "Confirm each target effective SCP includes the intended guardrail statement metadata ref before re-running cross-account trust analysis."},
+			SuccessSignals: []string{"organizations:scp-attached", "organizations:effective-policy-matches", "cross_account_trust:finding-resolved"},
+			FailureSignals: []string{"organizations:scp-missing", "organizations:effective-policy-mismatch", "cross_account_trust:finding-unchanged"},
 			EvidenceRef:    evidenceRef,
 		}
 	}

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -85,6 +85,11 @@ func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
 				if c.IdentityType != "" || (len(c.TargetAccountIDs) == 0 && len(c.ResourceNodeIDs) == 0) {
 					t.Fatalf("scp guardrail case must stay scoped to account/OU resources: %+v", c)
 				}
+				for _, tradeoff := range c.Tradeoffs {
+					if strings.Contains(strings.ToLower(tradeoff.Description), "permission boundary") || strings.Contains(strings.ToLower(tradeoff.Description), "identity target") {
+						t.Fatalf("scp guardrail tradeoff must not use permission-boundary identity wording: %+v", c.Tradeoffs)
+					}
+				}
 			default:
 				t.Fatalf("permission-boundary/SCP source emitted unsupported diff kind: %+v", c)
 			}

--- a/internal/api/aws_remediation_cases_test.go
+++ b/internal/api/aws_remediation_cases_test.go
@@ -75,8 +75,19 @@ func TestGetAWSRemediationCasesBuildsContract(t *testing.T) {
 		if c.SourceType == "trust_policy_hardening" && (c.IdentityType != "iam_role" || c.DiffIntent.Kind != "iam_trust_diff") {
 			t.Fatalf("trust-policy hardening case must stay scoped to IAM role trust diffs: %+v", c)
 		}
-		if c.SourceType == "aws_permission_boundary_scp" && ((c.IdentityType != "iam_role" && c.IdentityType != "iam_user") || c.DiffIntent.Kind != "permission_boundary_diff") {
-			t.Fatalf("permission-boundary case must stay scoped to IAM identity boundary diffs: %+v", c)
+		if c.SourceType == "aws_permission_boundary_scp" {
+			switch c.DiffIntent.Kind {
+			case "permission_boundary_diff":
+				if c.IdentityType != "iam_role" && c.IdentityType != "iam_user" {
+					t.Fatalf("permission-boundary case must stay scoped to IAM identity targets: %+v", c)
+				}
+			case "scp_diff":
+				if c.IdentityType != "" || (len(c.TargetAccountIDs) == 0 && len(c.ResourceNodeIDs) == 0) {
+					t.Fatalf("scp guardrail case must stay scoped to account/OU resources: %+v", c)
+				}
+			default:
+				t.Fatalf("permission-boundary/SCP source emitted unsupported diff kind: %+v", c)
+			}
 		}
 		if len(c.AuditTrail) == 0 || c.AuditTrail[0].EventType != "proposed" {
 			t.Fatalf("case missing proposed audit entry: %+v", c.AuditTrail)
@@ -677,6 +688,7 @@ func TestAWSRemediationDiffIsExecutable(t *testing.T) {
 	}{
 		{"executable iam_policy_diff", AWSRemediationDiffIntent{Kind: "iam_policy_diff"}, true},
 		{"executable secret_rotation", AWSRemediationDiffIntent{Kind: "secret_rotation"}, true},
+		{"executable scp_diff", AWSRemediationDiffIntent{Kind: "scp_diff"}, true},
 		{"manual review", AWSRemediationDiffIntent{Kind: "manual_review"}, false},
 		{"no-op owner assignment", AWSRemediationDiffIntent{Kind: "owner_assignment", NoOp: true}, false},
 		{"no-op fallthrough", AWSRemediationDiffIntent{Kind: "iam_policy_diff", NoOp: true}, false},

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -528,6 +528,15 @@ func awsRemediationDryRunCallForDiffKind(diff AWSRemediationDiffIntent, targets 
 			Idempotent:       true,
 			RequiresApproval: true,
 		}, true
+	case "scp_diff":
+		return AWSRemediationDryRunIntendedAPICall{
+			Service:          "organizations",
+			Operation:        "AttachPolicy",
+			TargetResource:   targets.resource,
+			ParameterRefs:    []string{idempotencyKey, "scp_ref://" + caseID + "/after"},
+			Idempotent:       true,
+			RequiresApproval: true,
+		}, true
 	}
 	return AWSRemediationDryRunIntendedAPICall{}, false
 }
@@ -786,6 +795,11 @@ func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry
 		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "kms", Signal: "grant_policy_applied", Description: "Confirm the projected KMS key-policy change applied and the broad decrypt/admin reachability is gone."})
 	case "ai_agent_scope_change":
 		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "bedrock-agent", Signal: "agent_scope_applied", Description: "Confirm the agent scope change applied and the narrowed tool/capability surface is reflected in runtime evidence."})
+	case "scp_diff":
+		checks = append(checks,
+			AWSRemediationDryRunVerificationCheck{Source: "organizations", Signal: "scp_attached", Description: "Confirm the projected SCP is attached to each captured account or OU target."},
+			AWSRemediationDryRunVerificationCheck{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer after live execution to confirm no new external-trust findings."},
+		)
 	}
 	if strings.EqualFold(approval.SourceType, "trust_policy_hardening") || strings.EqualFold(approval.SourceType, "blast_radius") {
 		checks = append(checks, AWSRemediationDryRunVerificationCheck{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer after live execution to confirm no new external-trust findings."})

--- a/internal/api/aws_remediation_dry_run.go
+++ b/internal/api/aws_remediation_dry_run.go
@@ -848,7 +848,7 @@ func awsRemediationDryRunVerificationChecks(approval AWSRemediationApprovalEntry
 	case "scp_diff":
 		checks = append(checks,
 			AWSRemediationDryRunVerificationCheck{Source: "organizations", Signal: "scp_attached", Description: "Confirm the projected SCP is attached to each captured account or OU target."},
-			AWSRemediationDryRunVerificationCheck{Source: "access_analyzer", Signal: "no_new_external_findings", Description: "Re-run Access Analyzer after live execution to confirm no new external-trust findings."},
+			AWSRemediationDryRunVerificationCheck{Source: "organizations", Signal: "effective_policy_matches", Description: "Confirm the target account or OU effective SCP includes the intended guardrail statement metadata ref."},
 		)
 	}
 	if strings.EqualFold(approval.SourceType, "trust_policy_hardening") || strings.EqualFold(approval.SourceType, "blast_radius") {

--- a/internal/api/aws_remediation_dry_run_test.go
+++ b/internal/api/aws_remediation_dry_run_test.go
@@ -715,6 +715,7 @@ func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *tes
 		approval      AWSRemediationApprovalEntry
 		wantSimulator bool
 		wantSignal    string
+		forbidSignal  string
 	}{
 		{
 			name: "iam_policy_diff includes simulator",
@@ -751,6 +752,13 @@ func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *tes
 			wantSignal:    "agent_scope_applied",
 		},
 		{
+			name:          "scp_diff skips simulator and verifies organizations effective policy",
+			approval:      AWSRemediationApprovalEntry{SourceType: "aws_permission_boundary_scp", DiffIntent: AWSRemediationDiffIntent{Kind: "scp_diff"}},
+			wantSimulator: false,
+			wantSignal:    "effective_policy_matches",
+			forbidSignal:  "no_new_external_findings",
+		},
+		{
 			name:          "access_key_quarantine skips simulator and keeps last-used verification",
 			approval:      AWSRemediationApprovalEntry{SourceType: "aws_access_key_quarantine", DiffIntent: AWSRemediationDiffIntent{Kind: "access_key_quarantine"}},
 			wantSimulator: false,
@@ -777,6 +785,9 @@ func TestAWSRemediationDryRunVerificationChecksGateIAMSimulatorByDiffKind(t *tes
 			}
 			if tc.wantSignal != "" && check.Signal == tc.wantSignal {
 				sawSignal = true
+			}
+			if tc.forbidSignal != "" && check.Signal == tc.forbidSignal {
+				t.Fatalf("%s: saw forbidden signal %q in checks=%+v", tc.name, tc.forbidSignal, checks)
 			}
 		}
 		if sawSimulator != tc.wantSimulator {

--- a/internal/api/aws_scp_guardrail_executor.go
+++ b/internal/api/aws_scp_guardrail_executor.go
@@ -28,6 +28,7 @@ type AWSScpGuardrailExecutorRequest struct {
 	CaseID       string `json:"case_id,omitempty"`
 	PlanID       string `json:"plan_id,omitempty"`
 	Operation    string `json:"operation,omitempty"`
+	TargetScope  string `json:"target_scope,omitempty"`
 	State        string `json:"state,omitempty"`
 	Severity     string `json:"severity,omitempty"`
 	Search       string `json:"search,omitempty"`
@@ -38,6 +39,11 @@ type AWSScpGuardrailExecutorPathStep = AWSPermissionBoundarySCPPathStep
 type AWSScpGuardrailExecutorDiagnostic = AWSPermissionBoundarySCPDiagnostic
 type AWSScpGuardrailExecutorCoverageGap = AWSPermissionBoundarySCPCoverageGap
 type AWSScpGuardrailExecutorAuditEntry = AWSRemediationApprovalAuditEntry
+
+type awsScpGuardrailExecutorTarget struct {
+	Scope string
+	ID    string
+}
 
 // AWSScpGuardrailExecutorPrecondition is one safety check that must pass
 // before the executor marks a record ready_for_live_apply.
@@ -324,10 +330,21 @@ func awsScpGuardrailExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
 }
 
 func awsScpGuardrailExecutorEntriesFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSScpGuardrailExecutorEntry {
-	if len(emptyStrings(plan.TargetAccountIDs)) == 0 && len(emptyStrings(plan.TargetOUPaths)) == 0 {
+	targets := awsScpGuardrailExecutorPlanTargets(plan)
+	if len(targets) == 0 {
 		return nil
 	}
-	return []AWSScpGuardrailExecutorEntry{awsScpGuardrailExecutorEntryFromDryRunWithCall(entry, plan, awsScpGuardrailExecutorIntendedCallForPlan(entry, plan), now)}
+	entries := make([]AWSScpGuardrailExecutorEntry, 0, len(targets))
+	for _, target := range targets {
+		scopedEntry := entry
+		scopedEntry.IdempotencyKey = awsScpGuardrailExecutorScopedIdempotencyKey(entry, target)
+		scopedPlan := awsScpGuardrailExecutorScopedPlan(plan, target)
+		call := awsScpGuardrailExecutorIntendedCallForTarget(scopedEntry, scopedPlan, target)
+		out := awsScpGuardrailExecutorEntryFromDryRunWithCall(scopedEntry, scopedPlan, call, now)
+		out.ExecutionID = "aws-scp-guardrail-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID, target.Scope, target.ID)
+		entries = append(entries, out)
+	}
+	return entries
 }
 
 func awsScpGuardrailExecutorEntryFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) AWSScpGuardrailExecutorEntry {
@@ -386,6 +403,43 @@ func awsScpGuardrailExecutorEntryFromDryRunWithCall(entry AWSRemediationDryRunEn
 	return out
 }
 
+func awsScpGuardrailExecutorPlanTargets(plan AWSPermissionBoundarySCPPlan) []awsScpGuardrailExecutorTarget {
+	targets := []awsScpGuardrailExecutorTarget{}
+	for _, ou := range emptyStrings(dedupeStrings(plan.TargetOUPaths)) {
+		scope := "ou"
+		if strings.TrimSpace(ou) == "/" {
+			scope = "root"
+		}
+		targets = append(targets, awsScpGuardrailExecutorTarget{Scope: scope, ID: ou})
+	}
+	for _, accountID := range emptyStrings(dedupeStrings(plan.TargetAccountIDs)) {
+		targets = append(targets, awsScpGuardrailExecutorTarget{Scope: "account", ID: accountID})
+	}
+	return targets
+}
+
+func awsScpGuardrailExecutorScopedPlan(plan AWSPermissionBoundarySCPPlan, target awsScpGuardrailExecutorTarget) AWSPermissionBoundarySCPPlan {
+	scoped := plan
+	switch target.Scope {
+	case "account":
+		scoped.TargetAccountIDs = []string{target.ID}
+		scoped.TargetOUPaths = nil
+	default:
+		scoped.TargetAccountIDs = nil
+		scoped.TargetOUPaths = []string{target.ID}
+	}
+	scoped.ImpactedNodes = dedupeStrings(append([]string{target.ID}, plan.ImpactedNodes...))
+	return scoped
+}
+
+func awsScpGuardrailExecutorScopedIdempotencyKey(entry AWSRemediationDryRunEntry, target awsScpGuardrailExecutorTarget) string {
+	key := strings.TrimSpace(entry.IdempotencyKey)
+	if key == "" {
+		return ""
+	}
+	return key + "#" + stableAWSBlastRadiusToken("scp-target", target.Scope, target.ID)
+}
+
 func awsScpGuardrailExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRemediationDryRunIntendedAPICall {
 	if len(entry.IntendedAPICalls) > 0 {
 		call := entry.IntendedAPICalls[0]
@@ -404,11 +458,11 @@ func awsScpGuardrailExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRem
 	}
 }
 
-func awsScpGuardrailExecutorIntendedCallForPlan(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) AWSRemediationDryRunIntendedAPICall {
+func awsScpGuardrailExecutorIntendedCallForTarget(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, target awsScpGuardrailExecutorTarget) AWSRemediationDryRunIntendedAPICall {
 	call := awsScpGuardrailExecutorIntendedCall(entry)
 	call.Service = "organizations"
 	call.Operation = "AttachPolicy"
-	call.TargetResource = firstNonEmptyAWSValue(firstString(emptyStrings(plan.TargetOUPaths)), firstString(emptyStrings(plan.TargetAccountIDs)), call.TargetResource, firstString(entry.ImpactedNodes))
+	call.TargetResource = firstNonEmptyAWSValue(target.ID, firstString(emptyStrings(plan.TargetOUPaths)), firstString(emptyStrings(plan.TargetAccountIDs)), call.TargetResource, firstString(entry.ImpactedNodes))
 	if len(call.ParameterRefs) == 0 {
 		call.ParameterRefs = []string{entry.IdempotencyKey, "scp_ref://" + entry.CaseID + "/after"}
 	} else {
@@ -477,7 +531,7 @@ func awsScpGuardrailExecutorSimulation(entry AWSRemediationDryRunEntry, plan AWS
 func awsScpGuardrailExecutorVerifications(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) []AWSScpGuardrailExecutorVerification {
 	out := []AWSScpGuardrailExecutorVerification{
 		{Source: "cloudtrail", Signal: "expected_api_call_observed", Status: "pending", Description: "After live execution, confirm the Organizations SCP policy attach appears in CloudTrail for the target account or OU."},
-		{Source: "access_analyzer", Signal: "no_new_external_findings", Status: "pending", Description: "Re-run Access Analyzer after live execution and confirm no new external-trust findings are introduced."},
+		{Source: "organizations", Signal: "effective_policy_matches", Status: "pending", Description: "Confirm the effective SCP for the target account or OU includes the intended guardrail statement metadata ref."},
 		{Source: "cross_account_trust", Signal: "finding_resolved", Status: "pending", Description: "Re-run cross-account trust analysis and confirm the source finding is resolved or no longer reintroduced."},
 	}
 	for _, check := range entry.VerificationChecks {
@@ -625,15 +679,16 @@ func summarizeAWSScpGuardrailExecutorEntries(all, filtered []AWSScpGuardrailExec
 
 func filterAWSScpGuardrailExecutorEntries(entries []AWSScpGuardrailExecutorEntry, request AWSScpGuardrailExecutorRequest) ([]AWSScpGuardrailExecutorEntry, map[string]string) {
 	filters := map[string]string{
-		"account_id": strings.TrimSpace(request.AccountID),
-		"region":     strings.TrimSpace(request.Region),
-		"dry_run_id": strings.TrimSpace(request.DryRunID),
-		"case_id":    strings.TrimSpace(request.CaseID),
-		"plan_id":    strings.TrimSpace(request.PlanID),
-		"operation":  normalizeAWSRuntimeEventFilterToken(request.Operation),
-		"state":      normalizeAWSRuntimeEventFilterToken(request.State),
-		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
-		"search":     strings.TrimSpace(request.Search),
+		"account_id":   strings.TrimSpace(request.AccountID),
+		"region":       strings.TrimSpace(request.Region),
+		"dry_run_id":   strings.TrimSpace(request.DryRunID),
+		"case_id":      strings.TrimSpace(request.CaseID),
+		"plan_id":      strings.TrimSpace(request.PlanID),
+		"operation":    normalizeAWSRuntimeEventFilterToken(request.Operation),
+		"target_scope": normalizeAWSRuntimeEventFilterToken(request.TargetScope),
+		"state":        normalizeAWSRuntimeEventFilterToken(request.State),
+		"severity":     normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":       strings.TrimSpace(request.Search),
 	}
 	for key, value := range filters {
 		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
@@ -662,6 +717,9 @@ func filterAWSScpGuardrailExecutorEntries(entries []AWSScpGuardrailExecutorEntry
 			continue
 		}
 		if filters["operation"] != "" && filters["operation"] != normalizeAWSRuntimeEventFilterToken(entry.Operation) {
+			continue
+		}
+		if filters["target_scope"] != "" && filters["target_scope"] != awsScpGuardrailExecutorTargetScope(entry) {
 			continue
 		}
 		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
@@ -703,6 +761,19 @@ func awsScpGuardrailExecutorAccountMatch(entry AWSScpGuardrailExecutorEntry, acc
 		}
 	}
 	return false
+}
+
+func awsScpGuardrailExecutorTargetScope(entry AWSScpGuardrailExecutorEntry) string {
+	if len(emptyStrings(entry.TargetAccountIDs)) > 0 {
+		return "account"
+	}
+	for _, target := range emptyStrings(entry.TargetOUPaths) {
+		if strings.TrimSpace(target) == "/" {
+			return "root"
+		}
+		return "ou"
+	}
+	return ""
 }
 
 func awsScpGuardrailExecutorSearchMatch(entry AWSScpGuardrailExecutorEntry, needle string) bool {

--- a/internal/api/aws_scp_guardrail_executor.go
+++ b/internal/api/aws_scp_guardrail_executor.go
@@ -1,0 +1,834 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsScpGuardrailExecutorCurrentIssue = 1541
+	awsScpGuardrailExecutorVersion      = "aws-scp-guardrail-executor-v1"
+
+	awsScpGuardrailExecutorStateProjected          = "projected"
+	awsScpGuardrailExecutorStatePreconditionFailed = "precondition_failed"
+	awsScpGuardrailExecutorStateBlocked            = "blocked"
+)
+
+// AWSScpGuardrailExecutorRequest scopes the deterministic SCP guardrail
+// executor projection to one AWS connector plus optional drill-down filters.
+type AWSScpGuardrailExecutorRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	DryRunID     string `json:"dry_run_id,omitempty"`
+	CaseID       string `json:"case_id,omitempty"`
+	PlanID       string `json:"plan_id,omitempty"`
+	Operation    string `json:"operation,omitempty"`
+	State        string `json:"state,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSScpGuardrailExecutorEvidence = AWSPermissionBoundarySCPEvidence
+type AWSScpGuardrailExecutorPathStep = AWSPermissionBoundarySCPPathStep
+type AWSScpGuardrailExecutorDiagnostic = AWSPermissionBoundarySCPDiagnostic
+type AWSScpGuardrailExecutorCoverageGap = AWSPermissionBoundarySCPCoverageGap
+type AWSScpGuardrailExecutorAuditEntry = AWSRemediationApprovalAuditEntry
+
+// AWSScpGuardrailExecutorPrecondition is one safety check that must pass
+// before the executor marks a record ready_for_live_apply.
+type AWSScpGuardrailExecutorPrecondition struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSScpGuardrailExecutorSimulation records the metadata-only simulator result
+// used to decide whether an SCP guardrail is safe to apply.
+type AWSScpGuardrailExecutorSimulation struct {
+	SimulationRef      string   `json:"simulation_ref"`
+	Outcome            string   `json:"outcome"`
+	BeforeRef          string   `json:"before_ref"`
+	AfterRef           string   `json:"after_ref"`
+	DeniedActionCount  int      `json:"denied_action_count"`
+	TargetAccountCount int      `json:"target_account_count"`
+	TargetOUCount      int      `json:"target_ou_count"`
+	Signals            []string `json:"signals,omitempty"`
+}
+
+// AWSScpGuardrailExecutorVerification describes one post-apply check a
+// downstream live executor must record before the execution can be considered
+// succeeded.
+type AWSScpGuardrailExecutorVerification struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+// AWSScpGuardrailExecutorRelationship surfaces executor->graph edges.
+type AWSScpGuardrailExecutorRelationship struct {
+	ExecutionID string `json:"execution_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSScpGuardrailExecutorEntry is the persisted-record-shaped contract
+// for an approved SCP guardrail execution projection. It carries metadata refs
+// only and never inlines rendered policy documents, secret values, or workload
+// payloads.
+type AWSScpGuardrailExecutorEntry struct {
+	ExecutionID        string                                     `json:"execution_id"`
+	CalculationVersion string                                     `json:"calculation_version"`
+	DryRunID           string                                     `json:"dry_run_id"`
+	ApprovalID         string                                     `json:"approval_id"`
+	CaseID             string                                     `json:"case_id"`
+	PlanID             string                                     `json:"plan_id"`
+	SourceArtifactID   string                                     `json:"source_artifact_id"`
+	State              string                                     `json:"state"`
+	Severity           string                                     `json:"severity"`
+	Score              int                                        `json:"score"`
+	Confidence         float64                                    `json:"confidence"`
+	Title              string                                     `json:"title"`
+	Summary            string                                     `json:"summary"`
+	AccountID          string                                     `json:"account_id"`
+	Region             string                                     `json:"region"`
+	Operation          string                                     `json:"operation"`
+	IdempotencyKey     string                                     `json:"idempotency_key"`
+	TargetAccountIDs   []string                                   `json:"target_account_ids,omitempty"`
+	TargetOUPaths      []string                                   `json:"target_ou_paths,omitempty"`
+	PreventedBehavior  string                                     `json:"prevented_behavior"`
+	StatementSnippets  []AWSPermissionBoundarySCPStatementSnippet `json:"statement_snippets"`
+	BreakageProjection AWSPermissionBoundarySCPBreakageProjection `json:"breakage_projection"`
+	IntendedAPICall    AWSRemediationDryRunIntendedAPICall        `json:"intended_api_call"`
+	Preconditions      []AWSScpGuardrailExecutorPrecondition      `json:"preconditions"`
+	BoundarySimulation AWSScpGuardrailExecutorSimulation          `json:"boundary_simulation"`
+	Verifications      []AWSScpGuardrailExecutorVerification      `json:"verifications"`
+	RollbackPlan       AWSPermissionBoundarySCPRollbackPlan       `json:"rollback_plan"`
+	VerificationPlan   AWSPermissionBoundarySCPVerificationPlan   `json:"verification_plan"`
+	AuditTrail         []AWSScpGuardrailExecutorAuditEntry        `json:"audit_trail"`
+	KillSwitchEngaged  bool                                       `json:"kill_switch_engaged"`
+	ReadyForLiveApply  bool                                       `json:"ready_for_live_apply"`
+	ReadOnlyProjection bool                                       `json:"read_only_projection"`
+	SourceSignals      []string                                   `json:"source_signals"`
+	Evidence           []AWSScpGuardrailExecutorEvidence          `json:"evidence"`
+	EvidenceBoundary   string                                     `json:"evidence_boundary"`
+	ImpactedNodes      []string                                   `json:"impacted_nodes"`
+	ImpactedPath       []AWSScpGuardrailExecutorPathStep          `json:"impacted_path"`
+	NextAction         string                                     `json:"next_action"`
+	ProjectedAt        time.Time                                  `json:"projected_at"`
+	CreatedAt          time.Time                                  `json:"created_at"`
+	UpdatedAt          time.Time                                  `json:"updated_at"`
+}
+
+// AWSScpGuardrailExecutorSummary aggregates the unfiltered/filtered set.
+type AWSScpGuardrailExecutorSummary struct {
+	TotalEntries            int            `json:"total_entries"`
+	FilteredEntries         int            `json:"filtered_entries"`
+	StateCounts             map[string]int `json:"state_counts"`
+	OperationCounts         map[string]int `json:"operation_counts"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	ReadyForLiveApplyCount  int            `json:"ready_for_live_apply_count"`
+	KillSwitchEngagedCount  int            `json:"kill_switch_engaged_count"`
+	FailedPreconditionCount int            `json:"failed_precondition_count"`
+	TargetAccountCount      int            `json:"target_account_count"`
+	TargetOUCount           int            `json:"target_ou_count"`
+	VerificationCount       int            `json:"verification_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+}
+
+// AWSScpGuardrailExecutorResult is the deterministic endpoint envelope.
+type AWSScpGuardrailExecutorResult struct {
+	TenantID           string                                `json:"tenant_id"`
+	WorkspaceID        string                                `json:"workspace_id"`
+	ProjectID          string                                `json:"project_id"`
+	ConnectorID        string                                `json:"connector_id,omitempty"`
+	AccountID          string                                `json:"account_id,omitempty"`
+	Region             string                                `json:"region,omitempty"`
+	ParentIssueNumber  int                                   `json:"parent_issue_number"`
+	ParentIssueRef     string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                   `json:"current_issue_number"`
+	CurrentIssueRef    string                                `json:"current_issue_ref"`
+	Version            string                                `json:"version"`
+	Status             string                                `json:"status"`
+	FixtureState       string                                `json:"fixture_state,omitempty"`
+	Confidence         float64                               `json:"confidence"`
+	CalculationVersion string                                `json:"calculation_version"`
+	AppliedFilters     map[string]string                     `json:"applied_filters"`
+	Summary            AWSScpGuardrailExecutorSummary        `json:"summary"`
+	Entries            []AWSScpGuardrailExecutorEntry        `json:"entries"`
+	Relationships      []AWSScpGuardrailExecutorRelationship `json:"relationships"`
+	Caveats            []string                              `json:"caveats"`
+	FailureReasons     []string                              `json:"failure_reasons"`
+	RemediationHints   []string                              `json:"remediation_hints"`
+	EvidenceLinks      []string                              `json:"evidence_links"`
+	CoverageGaps       []AWSScpGuardrailExecutorCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSScpGuardrailExecutorDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                             `json:"generated_at"`
+	UpdatedAt          time.Time                             `json:"updated_at"`
+}
+
+// GetAWSScpGuardrailExecutor projects approved SCP guardrail executions by
+// joining remediation dry-run entries (#1537) with SCP planner metadata (#1532).
+// This layer is metadata-only: it records controlled Organizations intent,
+// preconditions, idempotency key, rollback metadata, and verification plan
+// without calling live AWS write APIs.
+func (s *Service) GetAWSScpGuardrailExecutor(ctx context.Context, workspaceID string, projectID string, request AWSScpGuardrailExecutorRequest) (AWSScpGuardrailExecutorResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSScpGuardrailExecutorResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSScpGuardrailExecutorResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSScpGuardrailExecutorFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSScpGuardrailExecutorResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	dryRun, err := s.GetAWSRemediationDryRun(ctx, workspaceID, projectID, AWSRemediationDryRunRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSScpGuardrailExecutorResult{}, fmt.Errorf("scp guardrail executor dry-run: %w", err)
+	}
+	plans, err := s.GetAWSPermissionBoundarySCPPlans(ctx, workspaceID, projectID, AWSPermissionBoundarySCPRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState, Kind: awsSCPKind})
+	if err != nil {
+		return AWSScpGuardrailExecutorResult{}, fmt.Errorf("scp guardrail executor plans: %w", err)
+	}
+
+	planByID := map[string]AWSPermissionBoundarySCPPlan{}
+	for _, plan := range plans.Plans {
+		if strings.EqualFold(plan.Kind, awsSCPKind) {
+			planByID[plan.PlanID] = plan
+		}
+	}
+
+	entries := awsScpGuardrailExecutorEntries(dryRun.Entries, planByID, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].ExecutionID < entries[j].ExecutionID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSScpGuardrailExecutorEntries(entries, request)
+	relationships := awsScpGuardrailExecutorRelationships(filtered)
+	diagnostics := awsScpGuardrailExecutorDiagnostics(dryRun.Diagnostics, plans.Diagnostics)
+	coverageGaps := awsScpGuardrailExecutorCoverageGaps(dryRun.CoverageGaps, plans.CoverageGaps)
+	status, confidence := summarizeAWSScpGuardrailExecutorStatus(dryRun.Status, plans.Status, filtered, diagnostics)
+
+	return AWSScpGuardrailExecutorResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsScpGuardrailExecutorCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsScpGuardrailExecutorCurrentIssue),
+		Version:            awsScpGuardrailExecutorVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsScpGuardrailExecutorVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSScpGuardrailExecutorEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsScpGuardrailExecutorCaveats(),
+		FailureReasons:     dedupeStrings(append(append([]string{}, dryRun.FailureReasons...), plans.FailureReasons...)),
+		RemediationHints:   awsScpGuardrailExecutorRemediationHints(append(dryRun.RemediationHints, plans.RemediationHints...)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsScpGuardrailExecutorCurrentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			awsIssueURL(awsPermissionBoundarySCPCurrentIssue),
+			"/docs/aws-scp-guardrail-executor",
+			"/docs/aws-remediation-dry-run-executor",
+			"/docs/aws-permission-boundary-scp-planner",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSScpGuardrailExecutorFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsScpGuardrailExecutorEntries(dryRunEntries []AWSRemediationDryRunEntry, planByID map[string]AWSPermissionBoundarySCPPlan, now time.Time) []AWSScpGuardrailExecutorEntry {
+	entries := []AWSScpGuardrailExecutorEntry{}
+	for _, entry := range dryRunEntries {
+		if !awsScpGuardrailExecutorAdmits(entry) {
+			continue
+		}
+		plan, ok := planByID[entry.SourceArtifactID]
+		if !ok {
+			continue
+		}
+		entries = append(entries, awsScpGuardrailExecutorEntriesFromDryRun(entry, plan, now)...)
+	}
+	return entries
+}
+
+func awsScpGuardrailExecutorAdmits(entry AWSRemediationDryRunEntry) bool {
+	if !strings.EqualFold(entry.SourceType, "aws_permission_boundary_scp") {
+		return false
+	}
+	if entry.DiffIntent.NoOp {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(entry.DiffIntent.Kind), "scp_diff") {
+		return false
+	}
+	call := awsScpGuardrailExecutorIntendedCall(entry)
+	switch call.Operation {
+	case "CreatePolicy", "AttachPolicy":
+		return true
+	default:
+		return false
+	}
+}
+
+func awsScpGuardrailExecutorEntriesFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSScpGuardrailExecutorEntry {
+	if len(emptyStrings(plan.TargetAccountIDs)) == 0 && len(emptyStrings(plan.TargetOUPaths)) == 0 {
+		return nil
+	}
+	return []AWSScpGuardrailExecutorEntry{awsScpGuardrailExecutorEntryFromDryRunWithCall(entry, plan, awsScpGuardrailExecutorIntendedCallForPlan(entry, plan), now)}
+}
+
+func awsScpGuardrailExecutorEntryFromDryRun(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, now time.Time) AWSScpGuardrailExecutorEntry {
+	return awsScpGuardrailExecutorEntryFromDryRunWithCall(entry, plan, awsScpGuardrailExecutorIntendedCall(entry), now)
+}
+
+func awsScpGuardrailExecutorEntryFromDryRunWithCall(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, call AWSRemediationDryRunIntendedAPICall, now time.Time) AWSScpGuardrailExecutorEntry {
+	preconditions := awsScpGuardrailExecutorPreconditions(entry, plan, call)
+	simulation := awsScpGuardrailExecutorSimulation(entry, plan)
+	verifications := awsScpGuardrailExecutorVerifications(entry, plan)
+	state := awsScpGuardrailExecutorState(entry, preconditions)
+	executionID := "aws-scp-guardrail-executor:" + stableAWSBlastRadiusToken("execution", entry.DryRunID, plan.PlanID)
+	out := AWSScpGuardrailExecutorEntry{
+		ExecutionID:        executionID,
+		CalculationVersion: awsScpGuardrailExecutorVersion,
+		DryRunID:           entry.DryRunID,
+		ApprovalID:         entry.ApprovalID,
+		CaseID:             entry.CaseID,
+		PlanID:             plan.PlanID,
+		SourceArtifactID:   entry.SourceArtifactID,
+		State:              state,
+		Severity:           firstNonEmptyAWSValue(entry.Severity, plan.Severity),
+		Score:              entry.Score,
+		Confidence:         entry.Confidence,
+		Title:              fmt.Sprintf("SCP guardrail execution: %s", firstNonEmptyAWSValue(plan.Title, entry.Title)),
+		Summary:            fmt.Sprintf("Approved SCP guardrail execution record for plan %s (dry-run %s); Identrail records the projected Organizations intent and never calls AWS write APIs at this layer.", plan.PlanID, entry.DryRunID),
+		AccountID:          firstNonEmptyAWSValue(entry.AccountID, plan.AccountID),
+		Region:             firstNonEmptyAWSValue(entry.Region, plan.Region),
+		Operation:          call.Operation,
+		IdempotencyKey:     entry.IdempotencyKey,
+		TargetAccountIDs:   emptyStrings(dedupeStrings(plan.TargetAccountIDs)),
+		TargetOUPaths:      emptyStrings(dedupeStrings(plan.TargetOUPaths)),
+		PreventedBehavior:  plan.PreventedBehavior,
+		StatementSnippets:  plan.StatementSnippets,
+		BreakageProjection: plan.BreakageProjection,
+		IntendedAPICall:    call,
+		Preconditions:      preconditions,
+		BoundarySimulation: simulation,
+		Verifications:      verifications,
+		RollbackPlan:       plan.RollbackPlan,
+		VerificationPlan:   plan.VerificationPlan,
+		AuditTrail:         awsScpGuardrailExecutorAuditTrail(entry, state, plan, now),
+		KillSwitchEngaged:  entry.KillSwitchEngaged,
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings(append([]string{"aws_permission_boundary_scp", "scp", "scp_guardrail_executor", "remediation_dry_run"}, entry.SourceSignals...)),
+		Evidence:           plan.Evidence,
+		EvidenceBoundary:   awsScpGuardrailExecutorEvidenceBoundary(),
+		ImpactedNodes:      dedupeStrings(append(append(append([]string{}, plan.TargetAccountIDs...), plan.TargetOUPaths...), append(entry.ImpactedNodes, plan.ImpactedNodes...)...)),
+		ImpactedPath:       plan.ImpactedPath,
+		NextAction:         awsScpGuardrailExecutorNextAction(state, call.Operation),
+		ProjectedAt:        now,
+		CreatedAt:          firstNonZeroAWSScpGuardrailExecutorTime(entry.CreatedAt, plan.CreatedAt, now),
+		UpdatedAt:          now,
+	}
+	out.ReadyForLiveApply = state == awsScpGuardrailExecutorStateProjected && entry.ReadyForApply && !entry.KillSwitchEngaged
+	return out
+}
+
+func awsScpGuardrailExecutorIntendedCall(entry AWSRemediationDryRunEntry) AWSRemediationDryRunIntendedAPICall {
+	if len(entry.IntendedAPICalls) > 0 {
+		call := entry.IntendedAPICalls[0]
+		if len(call.ParameterRefs) > 0 {
+			call.ParameterRefs = append([]string{}, call.ParameterRefs...)
+		}
+		return call
+	}
+	return AWSRemediationDryRunIntendedAPICall{
+		Service:          "organizations",
+		Operation:        "AttachPolicy",
+		TargetResource:   firstString(entry.ImpactedNodes),
+		ParameterRefs:    []string{entry.IdempotencyKey, "scp_ref://" + entry.CaseID + "/after"},
+		Idempotent:       true,
+		RequiresApproval: true,
+	}
+}
+
+func awsScpGuardrailExecutorIntendedCallForPlan(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) AWSRemediationDryRunIntendedAPICall {
+	call := awsScpGuardrailExecutorIntendedCall(entry)
+	call.Service = "organizations"
+	call.Operation = "AttachPolicy"
+	call.TargetResource = firstNonEmptyAWSValue(firstString(emptyStrings(plan.TargetOUPaths)), firstString(emptyStrings(plan.TargetAccountIDs)), call.TargetResource, firstString(entry.ImpactedNodes))
+	if len(call.ParameterRefs) == 0 {
+		call.ParameterRefs = []string{entry.IdempotencyKey, "scp_ref://" + entry.CaseID + "/after"}
+	} else {
+		call.ParameterRefs[0] = entry.IdempotencyKey
+		if len(call.ParameterRefs) == 1 {
+			call.ParameterRefs = append(call.ParameterRefs, "scp_ref://"+entry.CaseID+"/after")
+		}
+	}
+	call.Idempotent = true
+	call.RequiresApproval = true
+	return call
+}
+
+func awsScpGuardrailExecutorPreconditions(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan, call AWSRemediationDryRunIntendedAPICall) []AWSScpGuardrailExecutorPrecondition {
+	targetScopeCount := len(emptyStrings(plan.TargetAccountIDs)) + len(emptyStrings(plan.TargetOUPaths))
+	preconditions := []AWSScpGuardrailExecutorPrecondition{
+		{Name: "dry_run_would_succeed", Status: awsScpGuardrailExecutorGateStatus(entry.Outcome == awsRemediationDryRunOutcomeWouldSucceed), Rationale: "Upstream dry-run must project would_succeed before any live apply."},
+		{Name: "ready_for_apply", Status: awsScpGuardrailExecutorGateStatus(entry.ReadyForApply), Rationale: "Upstream dry-run must declare ready_for_apply=true before any live apply."},
+		{Name: "kill_switch_off", Status: awsScpGuardrailExecutorGateStatus(!entry.KillSwitchEngaged), Rationale: "Tenant-scoped remediation kill switch must be off."},
+		{Name: "idempotency_key_present", Status: awsScpGuardrailExecutorGateStatus(strings.TrimSpace(entry.IdempotencyKey) != ""), Rationale: "Deterministic idempotency key must be present so retries do not double-apply."},
+		{Name: "scp_guardrail_plan", Status: awsScpGuardrailExecutorGateStatus(strings.EqualFold(plan.Kind, awsSCPKind)), Rationale: "Only SCP guardrail plans are executable here; permission boundary execution belongs to its own executor."},
+		{Name: "plan_ready_for_apply", Status: awsScpGuardrailExecutorGateStatus(plan.ReadyForApply), Rationale: "Upstream SCP guardrail plan must declare ready_for_apply=true."},
+		{Name: "target_scope_captured", Status: awsScpGuardrailExecutorGateStatus(targetScopeCount > 0), Rationale: "At least one captured Organizations account or OU target must be present."},
+		{Name: "breakage_level_low", Status: awsScpGuardrailExecutorGateStatus(strings.EqualFold(plan.BreakageProjection.Level, "low")), Rationale: "SCP guardrail breakage projection must be low before live apply."},
+		{Name: "operation_supported", Status: awsScpGuardrailExecutorGateStatus(call.Service == "organizations" && (call.Operation == "AttachPolicy" || call.Operation == "CreatePolicy")), Rationale: "Executor only supports AWS Organizations SCP policy create/attach operations."},
+	}
+	if len(entry.FailedPrereqs) > 0 {
+		preconditions = append(preconditions, AWSScpGuardrailExecutorPrecondition{
+			Name:      "upstream_prerequisites",
+			Status:    "blocked",
+			Rationale: fmt.Sprintf("Upstream dry-run still has %d failed prerequisite(s); resolve them before retrying.", len(entry.FailedPrereqs)),
+		})
+	}
+	return preconditions
+}
+
+func awsScpGuardrailExecutorGateStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "blocked"
+}
+
+func awsScpGuardrailExecutorSimulation(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) AWSScpGuardrailExecutorSimulation {
+	beforeRef := firstNonEmptyAWSValue(entry.DiffIntent.BeforeRef, "scp_before://"+plan.PlanID)
+	afterRef := firstNonEmptyAWSValue(entry.DiffIntent.AfterRef, "scp_after://"+plan.PlanID)
+	outcome := "would_attach_guardrail"
+	if !strings.EqualFold(plan.BreakageProjection.Level, "low") {
+		outcome = "regression_risk"
+	}
+	if !plan.ReadyForApply {
+		outcome = "pending_planner_evidence"
+	}
+	return AWSScpGuardrailExecutorSimulation{
+		SimulationRef:      fmt.Sprintf("organizations:scp_simulate://%s/scp-guardrail", plan.PlanID),
+		Outcome:            outcome,
+		BeforeRef:          beforeRef,
+		AfterRef:           afterRef,
+		DeniedActionCount:  len(awsRemediationSCPDeniedActions(plan)),
+		TargetAccountCount: len(emptyStrings(plan.TargetAccountIDs)),
+		TargetOUCount:      len(emptyStrings(plan.TargetOUPaths)),
+		Signals:            dedupeStrings(append([]string{"scp_guardrail"}, plan.BreakageProjection.Signals...)),
+	}
+}
+
+func awsScpGuardrailExecutorVerifications(entry AWSRemediationDryRunEntry, plan AWSPermissionBoundarySCPPlan) []AWSScpGuardrailExecutorVerification {
+	out := []AWSScpGuardrailExecutorVerification{
+		{Source: "cloudtrail", Signal: "expected_api_call_observed", Status: "pending", Description: "After live execution, confirm the Organizations SCP policy attach appears in CloudTrail for the target account or OU."},
+		{Source: "access_analyzer", Signal: "no_new_external_findings", Status: "pending", Description: "Re-run Access Analyzer after live execution and confirm no new external-trust findings are introduced."},
+		{Source: "cross_account_trust", Signal: "finding_resolved", Status: "pending", Description: "Re-run cross-account trust analysis and confirm the source finding is resolved or no longer reintroduced."},
+	}
+	for _, check := range entry.VerificationChecks {
+		if check.Source == "" {
+			continue
+		}
+		out = append(out, AWSScpGuardrailExecutorVerification{Source: check.Source, Signal: check.Signal, Status: "pending", Description: check.Description})
+	}
+	for _, signal := range plan.VerificationPlan.SuccessSignals {
+		out = append(out, AWSScpGuardrailExecutorVerification{Source: "planner", Signal: signal, Status: "pending", Description: "Confirm the planner success signal after live execution."})
+	}
+	return out
+}
+
+func awsScpGuardrailExecutorState(entry AWSRemediationDryRunEntry, preconditions []AWSScpGuardrailExecutorPrecondition) string {
+	if entry.KillSwitchEngaged {
+		return awsScpGuardrailExecutorStateBlocked
+	}
+	if entry.Outcome == awsRemediationDryRunOutcomeBlocked || entry.Outcome == awsRemediationDryRunOutcomeKillSwitched {
+		return awsScpGuardrailExecutorStateBlocked
+	}
+	hasBlockedPrecondition := false
+	for _, precondition := range preconditions {
+		if precondition.Status != "blocked" {
+			continue
+		}
+		hasBlockedPrecondition = true
+		if awsScpGuardrailExecutorPreconditionIsSafety(precondition.Name) {
+			return awsScpGuardrailExecutorStateBlocked
+		}
+	}
+	if hasBlockedPrecondition {
+		return awsScpGuardrailExecutorStatePreconditionFailed
+	}
+	if entry.Outcome != awsRemediationDryRunOutcomeWouldSucceed || !entry.ReadyForApply {
+		return awsScpGuardrailExecutorStatePreconditionFailed
+	}
+	return awsScpGuardrailExecutorStateProjected
+}
+
+func awsScpGuardrailExecutorPreconditionIsSafety(name string) bool {
+	switch name {
+	case "kill_switch_off", "idempotency_key_present", "scp_guardrail_plan", "target_scope_captured", "operation_supported":
+		return true
+	}
+	return false
+}
+
+func awsScpGuardrailExecutorNextAction(state, operation string) string {
+	switch state {
+	case awsScpGuardrailExecutorStateProjected:
+		return fmt.Sprintf("SCP guardrail operation=%s is ready for the wave-8 apply runtime once its feature flag opens.", operation)
+	case awsScpGuardrailExecutorStatePreconditionFailed:
+		return "One or more preconditions failed; advance the upstream dry-run or SCP guardrail plan before retrying."
+	case awsScpGuardrailExecutorStateBlocked:
+		return "A safety precondition or the tenant kill switch is blocking this entry; satisfy the failing check before retrying."
+	}
+	return "Inspect this entry for the projected next action."
+}
+
+func awsScpGuardrailExecutorAuditTrail(entry AWSRemediationDryRunEntry, state string, plan AWSPermissionBoundarySCPPlan, now time.Time) []AWSScpGuardrailExecutorAuditEntry {
+	trail := []AWSScpGuardrailExecutorAuditEntry{}
+	trail = append(trail, entry.AuditTrail...)
+	trail = append(trail, AWSScpGuardrailExecutorAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("scp-guardrail-projected", entry.DryRunID, plan.PlanID),
+		Actor:      "identrail-scp-guardrail-executor",
+		EventType:  "scp_guardrail_execution_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Plan=%s state=%s target_accounts=%d target_ous=%d; Identrail did not call any AWS write API at this layer.", plan.PlanID, state, len(emptyStrings(plan.TargetAccountIDs)), len(emptyStrings(plan.TargetOUPaths))),
+	})
+	return trail
+}
+
+func awsScpGuardrailExecutorRelationships(entries []AWSScpGuardrailExecutorEntry) []AWSScpGuardrailExecutorRelationship {
+	relationships := []AWSScpGuardrailExecutorRelationship{}
+	for _, entry := range entries {
+		evidenceRef := awsScpGuardrailExecutorFirstEvidenceRef(entry.Evidence)
+		for _, target := range append(append([]string{}, entry.TargetAccountIDs...), entry.TargetOUPaths...) {
+			if strings.TrimSpace(target) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSScpGuardrailExecutorRelationship{
+				ExecutionID: entry.ExecutionID,
+				Type:        "scp_guardrail_targets_scope",
+				FromNodeID:  entry.ExecutionID,
+				ToNodeID:    target,
+				EvidenceRef: evidenceRef,
+			})
+		}
+	}
+	return relationships
+}
+
+func awsScpGuardrailExecutorFirstEvidenceRef(evidence []AWSScpGuardrailExecutorEvidence) string {
+	for _, item := range evidence {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}
+
+func summarizeAWSScpGuardrailExecutorEntries(all, filtered []AWSScpGuardrailExecutorEntry, relationships []AWSScpGuardrailExecutorRelationship) AWSScpGuardrailExecutorSummary {
+	summary := AWSScpGuardrailExecutorSummary{
+		TotalEntries:    len(all),
+		FilteredEntries: len(filtered),
+		StateCounts:     map[string]int{},
+		OperationCounts: map[string]int{},
+		SeverityCounts:  map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.StateCounts[entry.State]++
+		if strings.TrimSpace(entry.Operation) != "" {
+			summary.OperationCounts[entry.Operation]++
+		}
+		if strings.TrimSpace(entry.Severity) != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.ReadyForLiveApply {
+			summary.ReadyForLiveApplyCount++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		for _, precondition := range entry.Preconditions {
+			if precondition.Status == "blocked" {
+				summary.FailedPreconditionCount++
+			}
+		}
+		summary.TargetAccountCount += len(entry.TargetAccountIDs)
+		summary.TargetOUCount += len(entry.TargetOUPaths)
+		summary.VerificationCount += len(entry.Verifications)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSScpGuardrailExecutorEntries(entries []AWSScpGuardrailExecutorEntry, request AWSScpGuardrailExecutorRequest) ([]AWSScpGuardrailExecutorEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"dry_run_id": strings.TrimSpace(request.DryRunID),
+		"case_id":    strings.TrimSpace(request.CaseID),
+		"plan_id":    strings.TrimSpace(request.PlanID),
+		"operation":  normalizeAWSRuntimeEventFilterToken(request.Operation),
+		"state":      normalizeAWSRuntimeEventFilterToken(request.State),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":     strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSScpGuardrailExecutorEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && !awsScpGuardrailExecutorAccountMatch(entry, filters["account_id"]) {
+			continue
+		}
+		if filters["region"] != "" && !awsScpGuardrailExecutorRegionMatch(entry, filters["region"]) {
+			continue
+		}
+		if filters["dry_run_id"] != "" && !strings.EqualFold(filters["dry_run_id"], entry.DryRunID) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["plan_id"] != "" && !strings.EqualFold(filters["plan_id"], entry.PlanID) {
+			continue
+		}
+		if filters["operation"] != "" && filters["operation"] != normalizeAWSRuntimeEventFilterToken(entry.Operation) {
+			continue
+		}
+		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsScpGuardrailExecutorSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsScpGuardrailExecutorRegionMatch(entry AWSScpGuardrailExecutorEntry, region string) bool {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.Region) == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Region), region)
+}
+
+func awsScpGuardrailExecutorAccountMatch(entry AWSScpGuardrailExecutorEntry, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.TrimSpace(entry.AccountID) == accountID {
+		return true
+	}
+	for _, targetAccountID := range entry.TargetAccountIDs {
+		if strings.TrimSpace(targetAccountID) == accountID {
+			return true
+		}
+	}
+	return false
+}
+
+func awsScpGuardrailExecutorSearchMatch(entry AWSScpGuardrailExecutorEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.ExecutionID, entry.DryRunID, entry.ApprovalID, entry.CaseID, entry.PlanID,
+		entry.SourceArtifactID, entry.State, entry.Severity, entry.Title, entry.Summary,
+		entry.Operation, entry.IdempotencyKey, entry.PreventedBehavior, entry.NextAction,
+		entry.IntendedAPICall.Service, entry.IntendedAPICall.Operation, entry.IntendedAPICall.TargetResource,
+		entry.BoundarySimulation.SimulationRef, entry.BoundarySimulation.Outcome, entry.BoundarySimulation.BeforeRef, entry.BoundarySimulation.AfterRef,
+		entry.BreakageProjection.Level, entry.BreakageProjection.Rationale,
+	}
+	values = append(values, entry.TargetAccountIDs...)
+	values = append(values, entry.TargetOUPaths...)
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.IntendedAPICall.ParameterRefs...)
+	values = append(values, entry.BoundarySimulation.Signals...)
+	for _, snippet := range entry.StatementSnippets {
+		values = append(values, snippet.StatementSID, snippet.Effect, snippet.ChangeKind, snippet.BeforeRef, snippet.AfterRef, snippet.Rationale)
+		values = append(values, snippet.DeniedActions...)
+		values = append(values, snippet.AllowedActions...)
+		values = append(values, snippet.ResourceScope...)
+		values = append(values, snippet.ConditionKeys...)
+	}
+	for _, precondition := range entry.Preconditions {
+		values = append(values, precondition.Name, precondition.Status, precondition.Rationale)
+	}
+	for _, verification := range entry.Verifications {
+		values = append(values, verification.Source, verification.Signal, verification.Status, verification.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef, evidence.Relationship)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSScpGuardrailExecutorStatus(dryRunStatus, planStatus string, filtered []AWSScpGuardrailExecutorEntry, diagnostics []AWSScpGuardrailExecutorDiagnostic) (string, float64) {
+	if dryRunStatus == awsPlatformDependencyStatusBlocked || planStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if dryRunStatus == awsPlatformDependencyStatusDegraded || planStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsScpGuardrailExecutorCaveats() []string {
+	return []string{
+		"SCP guardrail executor entries are read-only projections; Identrail never calls IAM/Organizations write APIs at this layer.",
+		"Every precondition (approval dry-run readiness, planner readiness, bounded account/OU scope, low breakage, idempotency key) must pass before ready_for_live_apply becomes true.",
+		"Rendered SCP policy documents stay behind metadata refs; this endpoint exposes scope, audit, rollback, and verification metadata only.",
+	}
+}
+
+func awsScpGuardrailExecutorRemediationHints(source []string) []string {
+	hints := []string{
+		"Resolve any failed precondition before retrying; the dry-run and SCP planner upstreams own those gates.",
+		"Use the idempotency key recorded here as the deterministic id when the wave-8 apply runtime creates or attaches the Organizations SCP.",
+		"If the simulation outcome is `regression_risk`, reduce scope or refresh cross-account-trust evidence before live apply.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsScpGuardrailExecutorDiagnostics(dryRun []AWSRemediationApprovalDiagnostic, planner []AWSPermissionBoundarySCPDiagnostic) []AWSScpGuardrailExecutorDiagnostic {
+	out := make([]AWSScpGuardrailExecutorDiagnostic, 0, len(dryRun)+len(planner))
+	for _, diagnostic := range dryRun {
+		out = append(out, AWSScpGuardrailExecutorDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: diagnostic.Remediation,
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	for _, diagnostic := range planner {
+		out = append(out, AWSScpGuardrailExecutorDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsScpGuardrailExecutorCoverageGaps(dryRun []AWSRemediationApprovalCoverageGap, planner []AWSPermissionBoundarySCPCoverageGap) []AWSScpGuardrailExecutorCoverageGap {
+	gaps := []AWSScpGuardrailExecutorCoverageGap{}
+	for _, gap := range dryRun {
+		gaps = append(gaps, AWSScpGuardrailExecutorCoverageGap{
+			Capability:  gap.Capability,
+			Status:      gap.Status,
+			Reason:      gap.Reason,
+			Remediation: gap.Remediation,
+		})
+	}
+	for _, gap := range planner {
+		gaps = append(gaps, AWSScpGuardrailExecutorCoverageGap(gap))
+	}
+	return gaps
+}
+
+func awsScpGuardrailExecutorEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSScpGuardrailExecutorTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_scp_guardrail_executor_test.go
+++ b/internal/api/aws_scp_guardrail_executor_test.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newScpGuardrailExecutorService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSScpGuardrailExecutorBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	svc, ws := newScpGuardrailExecutorService(t, "project-scp-guardrail-executor", now)
+
+	result, err := svc.GetAWSScpGuardrailExecutor(defaultScopeContext(), ws, "project-scp-guardrail-executor", AWSScpGuardrailExecutorRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get scp guardrail executor: %v", err)
+	}
+	if result.CurrentIssueRef != "#1541" || result.Version != awsScpGuardrailExecutorVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Entries) == 0 {
+		t.Fatalf("expected scp dry-run entries to join to planner records: summary=%+v", result.Summary)
+	}
+	for _, entry := range result.Entries {
+		if entry.ExecutionID == "" || entry.CalculationVersion != awsScpGuardrailExecutorVersion {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.DryRunID == "" || entry.PlanID == "" || entry.CaseID == "" {
+			t.Fatalf("entry missing source IDs: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if entry.IntendedAPICall.Service != "organizations" || entry.IntendedAPICall.Operation != "AttachPolicy" {
+			t.Fatalf("entry must project Organizations SCP attach calls: %+v", entry.IntendedAPICall)
+		}
+		if len(entry.TargetAccountIDs)+len(entry.TargetOUPaths) == 0 || len(entry.Preconditions) == 0 {
+			t.Fatalf("entry missing target scope or preconditions: %+v", entry)
+		}
+		if entry.BoundarySimulation.SimulationRef == "" || entry.BoundarySimulation.DeniedActionCount == 0 {
+			t.Fatalf("entry missing scp simulation: %+v", entry.BoundarySimulation)
+		}
+		if entry.EvidenceBoundary != awsScpGuardrailExecutorEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("scp guardrail executor serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSScpGuardrailExecutorAdmitsOnlySCPDryRuns(t *testing.T) {
+	cases := []struct {
+		name      string
+		entry     AWSRemediationDryRunEntry
+		wantAdmit bool
+	}{
+		{
+			name: "scp dry-run is admitted",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "scp_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "organizations", Operation: "AttachPolicy"}},
+			},
+			wantAdmit: true,
+		},
+		{
+			name: "permission boundary dry-run is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePermissionsBoundary"}},
+			},
+		},
+		{
+			name: "wrong operation is excluded",
+			entry: AWSRemediationDryRunEntry{
+				SourceType:       "aws_permission_boundary_scp",
+				DiffIntent:       AWSRemediationDiffIntent{Kind: "scp_diff"},
+				IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "iam", Operation: "PutRolePolicy"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		if got := awsScpGuardrailExecutorAdmits(tc.entry); got != tc.wantAdmit {
+			t.Fatalf("%s: admit=%v want %v", tc.name, got, tc.wantAdmit)
+		}
+	}
+}
+
+func TestAWSScpGuardrailExecutorStateHonorsScopeAndPreconditions(t *testing.T) {
+	now := time.Date(2026, 7, 1, 10, 30, 0, 0, time.UTC)
+	readyPlan := AWSPermissionBoundarySCPPlan{
+		PlanID:             "scp-plan-ready",
+		Kind:               awsSCPKind,
+		ReadyForApply:      true,
+		TargetAccountIDs:   []string{"111111111111"},
+		TargetOUPaths:      []string{"/engineering"},
+		BreakageProjection: AWSPermissionBoundarySCPBreakageProjection{Level: "low"},
+		StatementSnippets:  []AWSPermissionBoundarySCPStatementSnippet{{DeniedActions: []string{"sts:AssumeRole"}}},
+	}
+	entry := AWSRemediationDryRunEntry{
+		DryRunID:         "dr-scp-ready",
+		CaseID:           "case-scp-ready",
+		SourceType:       "aws_permission_boundary_scp",
+		SourceArtifactID: "scp-plan-ready",
+		Outcome:          awsRemediationDryRunOutcomeWouldSucceed,
+		ReadyForApply:    true,
+		IdempotencyKey:   "idk",
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "scp_diff"},
+		IntendedAPICalls: []AWSRemediationDryRunIntendedAPICall{{Service: "organizations", Operation: "AttachPolicy"}},
+	}
+	out := awsScpGuardrailExecutorEntryFromDryRun(entry, readyPlan, now)
+	if out.State != awsScpGuardrailExecutorStateProjected || !out.ReadyForLiveApply {
+		t.Fatalf("ready scp plan should project live-apply readiness: %+v", out)
+	}
+
+	noScope := readyPlan
+	noScope.TargetAccountIDs = nil
+	noScope.TargetOUPaths = nil
+	if entries := awsScpGuardrailExecutorEntriesFromDryRun(entry, noScope, now); len(entries) != 0 {
+		t.Fatalf("scp plan without account or OU scope must not produce entries: %+v", entries)
+	}
+
+	highBreakage := readyPlan
+	highBreakage.BreakageProjection.Level = "high"
+	out = awsScpGuardrailExecutorEntryFromDryRun(entry, highBreakage, now)
+	if out.State != awsScpGuardrailExecutorStatePreconditionFailed || out.ReadyForLiveApply {
+		t.Fatalf("high-breakage scp plan should fail preconditions: %+v", out)
+	}
+}
+
+func TestFilterAWSScpGuardrailExecutorEntriesMatchesTargetScope(t *testing.T) {
+	entries := []AWSScpGuardrailExecutorEntry{
+		{
+			ExecutionID:      "exec-ou",
+			Region:           "",
+			State:            awsScpGuardrailExecutorStateProjected,
+			Severity:         "high",
+			Operation:        "AttachPolicy",
+			TargetAccountIDs: []string{"111111111111", "222222222222"},
+			TargetOUPaths:    []string{"/engineering"},
+		},
+		{
+			ExecutionID:      "exec-other",
+			Region:           "us-west-2",
+			State:            awsScpGuardrailExecutorStateBlocked,
+			Severity:         "medium",
+			Operation:        "AttachPolicy",
+			TargetAccountIDs: []string{"333333333333"},
+		},
+	}
+
+	filtered, applied := filterAWSScpGuardrailExecutorEntries(entries, AWSScpGuardrailExecutorRequest{AccountID: "222222222222", Region: "us-east-1"})
+	if applied["account_id"] != "222222222222" || applied["region"] != "us-east-1" {
+		t.Fatalf("expected applied account and region filters, got %+v", applied)
+	}
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-ou" {
+		t.Fatalf("expected matching target account and multi-region entry: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSScpGuardrailExecutorEntries(entries, AWSScpGuardrailExecutorRequest{Search: "engineering"})
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-ou" {
+		t.Fatalf("expected search to match target OU path: %+v", filtered)
+	}
+}
+
+func TestRouterAWSScpGuardrailExecutor(t *testing.T) {
+	now := time.Date(2026, 7, 1, 11, 0, 0, 0, time.UTC)
+	svc, _ := newScpGuardrailExecutorService(t, "project-scp-guardrail-executor-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-scp-guardrail-executor-route/aws/scp-guardrail-executor?connector_id=aws-prod&fixture_state=success", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Executor AWSScpGuardrailExecutorResult `json:"scp_guardrail_executor"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Executor.CurrentIssueRef != "#1541" || len(body.Executor.Entries) == 0 {
+		t.Fatalf("unexpected route payload: %+v", body.Executor)
+	}
+}

--- a/internal/api/aws_scp_guardrail_executor_test.go
+++ b/internal/api/aws_scp_guardrail_executor_test.go
@@ -49,8 +49,14 @@ func TestGetAWSScpGuardrailExecutorBuildsContract(t *testing.T) {
 		if entry.IntendedAPICall.Service != "organizations" || entry.IntendedAPICall.Operation != "AttachPolicy" {
 			t.Fatalf("entry must project Organizations SCP attach calls: %+v", entry.IntendedAPICall)
 		}
+		if entry.IntendedAPICall.TargetResource == "" {
+			t.Fatalf("entry must carry a per-target intended call: %+v", entry.IntendedAPICall)
+		}
 		if len(entry.TargetAccountIDs)+len(entry.TargetOUPaths) == 0 || len(entry.Preconditions) == 0 {
 			t.Fatalf("entry missing target scope or preconditions: %+v", entry)
+		}
+		if len(entry.TargetAccountIDs)+len(entry.TargetOUPaths) != 1 {
+			t.Fatalf("entry must be scoped to exactly one account or OU/root target: %+v", entry)
 		}
 		if entry.BoundarySimulation.SimulationRef == "" || entry.BoundarySimulation.DeniedActionCount == 0 {
 			t.Fatalf("entry missing scp simulation: %+v", entry.BoundarySimulation)
@@ -137,6 +143,26 @@ func TestAWSScpGuardrailExecutorStateHonorsScopeAndPreconditions(t *testing.T) {
 	if out.State != awsScpGuardrailExecutorStateProjected || !out.ReadyForLiveApply {
 		t.Fatalf("ready scp plan should project live-apply readiness: %+v", out)
 	}
+	scopedEntries := awsScpGuardrailExecutorEntriesFromDryRun(entry, readyPlan, now)
+	if len(scopedEntries) != 2 {
+		t.Fatalf("expected one execution entry per account/OU target, got %+v", scopedEntries)
+	}
+	seenTargets := map[string]bool{}
+	seenIdempotency := map[string]bool{}
+	for _, scoped := range scopedEntries {
+		target := firstNonEmptyAWSValue(firstString(scoped.TargetAccountIDs), firstString(scoped.TargetOUPaths))
+		if target == "" || scoped.IntendedAPICall.TargetResource != target {
+			t.Fatalf("scoped execution must target exactly its account/OU: %+v", scoped)
+		}
+		if scoped.IdempotencyKey == entry.IdempotencyKey || seenIdempotency[scoped.IdempotencyKey] {
+			t.Fatalf("scoped executions must have distinct idempotency keys: %+v", scopedEntries)
+		}
+		seenTargets[target] = true
+		seenIdempotency[scoped.IdempotencyKey] = true
+	}
+	if !seenTargets["111111111111"] || !seenTargets["/engineering"] {
+		t.Fatalf("missing scoped targets: %+v", scopedEntries)
+	}
 
 	noScope := readyPlan
 	noScope.TargetAccountIDs = nil
@@ -156,13 +182,20 @@ func TestAWSScpGuardrailExecutorStateHonorsScopeAndPreconditions(t *testing.T) {
 func TestFilterAWSScpGuardrailExecutorEntriesMatchesTargetScope(t *testing.T) {
 	entries := []AWSScpGuardrailExecutorEntry{
 		{
-			ExecutionID:      "exec-ou",
+			ExecutionID:   "exec-ou",
+			Region:        "",
+			State:         awsScpGuardrailExecutorStateProjected,
+			Severity:      "high",
+			Operation:     "AttachPolicy",
+			TargetOUPaths: []string{"/engineering"},
+		},
+		{
+			ExecutionID:      "exec-account",
 			Region:           "",
 			State:            awsScpGuardrailExecutorStateProjected,
 			Severity:         "high",
 			Operation:        "AttachPolicy",
-			TargetAccountIDs: []string{"111111111111", "222222222222"},
-			TargetOUPaths:    []string{"/engineering"},
+			TargetAccountIDs: []string{"222222222222"},
 		},
 		{
 			ExecutionID:      "exec-other",
@@ -178,13 +211,23 @@ func TestFilterAWSScpGuardrailExecutorEntriesMatchesTargetScope(t *testing.T) {
 	if applied["account_id"] != "222222222222" || applied["region"] != "us-east-1" {
 		t.Fatalf("expected applied account and region filters, got %+v", applied)
 	}
-	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-ou" {
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-account" {
 		t.Fatalf("expected matching target account and multi-region entry: %+v", filtered)
 	}
 
 	filtered, _ = filterAWSScpGuardrailExecutorEntries(entries, AWSScpGuardrailExecutorRequest{Search: "engineering"})
 	if len(filtered) != 1 || filtered[0].ExecutionID != "exec-ou" {
 		t.Fatalf("expected search to match target OU path: %+v", filtered)
+	}
+
+	filtered, applied = filterAWSScpGuardrailExecutorEntries(entries, AWSScpGuardrailExecutorRequest{TargetScope: "account", AccountID: "222222222222"})
+	if applied["target_scope"] != "account" || len(filtered) != 1 || filtered[0].ExecutionID != "exec-account" {
+		t.Fatalf("expected target_scope=account to match only account-scoped entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSScpGuardrailExecutorEntries(entries, AWSScpGuardrailExecutorRequest{TargetScope: "ou"})
+	if applied["target_scope"] != "ou" || len(filtered) != 1 || filtered[0].ExecutionID != "exec-ou" {
+		t.Fatalf("expected target_scope=ou to match only OU-scoped entries: applied=%+v filtered=%+v", applied, filtered)
 	}
 }
 
@@ -193,7 +236,7 @@ func TestRouterAWSScpGuardrailExecutor(t *testing.T) {
 	svc, _ := newScpGuardrailExecutorService(t, "project-scp-guardrail-executor-route", now)
 	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
 
-	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-scp-guardrail-executor-route/aws/scp-guardrail-executor?connector_id=aws-prod&fixture_state=success", "")
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-scp-guardrail-executor-route/aws/scp-guardrail-executor?connector_id=aws-prod&fixture_state=success&target_scope=ou", "")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
 	}
@@ -205,5 +248,13 @@ func TestRouterAWSScpGuardrailExecutor(t *testing.T) {
 	}
 	if body.Executor.CurrentIssueRef != "#1541" || len(body.Executor.Entries) == 0 {
 		t.Fatalf("unexpected route payload: %+v", body.Executor)
+	}
+	if body.Executor.AppliedFilters["target_scope"] != "ou" {
+		t.Fatalf("expected route to apply target_scope filter: %+v", body.Executor.AppliedFilters)
+	}
+	for _, entry := range body.Executor.Entries {
+		if awsScpGuardrailExecutorTargetScope(entry) != "ou" {
+			t.Fatalf("target_scope=ou route returned non-OU entry: %+v", entry)
+		}
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3252,6 +3252,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			CaseID:       strings.TrimSpace(c.Query("case_id")),
 			PlanID:       strings.TrimSpace(c.Query("plan_id")),
 			Operation:    strings.TrimSpace(c.Query("operation")),
+			TargetScope:  firstNonEmptyAWSValue(c.Query("target_scope"), c.Query("scope")),
 			State:        strings.TrimSpace(c.Query("state")),
 			Severity:     strings.TrimSpace(c.Query("severity")),
 			Search:       strings.TrimSpace(c.Query("search")),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3238,6 +3238,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"permission_boundary_executor": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/scp-guardrail-executor", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSScpGuardrailExecutor(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSScpGuardrailExecutorRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			DryRunID:     strings.TrimSpace(c.Query("dry_run_id")),
+			CaseID:       strings.TrimSpace(c.Query("case_id")),
+			PlanID:       strings.TrimSpace(c.Query("plan_id")),
+			Operation:    strings.TrimSpace(c.Query("operation")),
+			State:        strings.TrimSpace(c.Query("state")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws scp guardrail executor request"})
+			default:
+				logger.Error("get aws scp guardrail executor",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws scp guardrail executor"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"scp_guardrail_executor": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1789,6 +1789,48 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS SCP guardrail executor with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ scp_guardrail_executor: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectScpGuardrailExecutor(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'success',
+        accountID: '123456789012',
+        region: 'us-east-1',
+        dryRunID: 'aws-remediation-dry-run:scp-1',
+        caseID: 'aws-remediation-case:scp-1',
+        planID: 'aws-permission-boundary-scp:scp-1',
+        operation: 'AttachPolicy',
+        state: 'projected',
+        severity: 'high',
+        search: 'scp guardrail'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/scp-guardrail-executor?');
+    expect(url).toContain('operation=AttachPolicy');
+    expect(url).toContain('plan_id=aws-permission-boundary-scp%3Ascp-1');
+    expect(url).toContain('state=projected');
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS secret/key rotation plans with scoped headers and filters', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1808,6 +1808,7 @@ describe('apiClient', () => {
         caseID: 'aws-remediation-case:scp-1',
         planID: 'aws-permission-boundary-scp:scp-1',
         operation: 'AttachPolicy',
+        targetScope: 'ou',
         state: 'projected',
         severity: 'high',
         search: 'scp guardrail'
@@ -1822,6 +1823,7 @@ describe('apiClient', () => {
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/scp-guardrail-executor?');
     expect(url).toContain('operation=AttachPolicy');
+    expect(url).toContain('target_scope=ou');
     expect(url).toContain('plan_id=aws-permission-boundary-scp%3Ascp-1');
     expect(url).toContain('state=projected');
     expect(options.method ?? 'GET').toBe('GET');

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3730,6 +3730,7 @@ export type AWSScpGuardrailExecutorQuery = {
   caseID?: string;
   planID?: string;
   operation?: string;
+  targetScope?: string;
   state?: string;
   severity?: string;
   search?: string;
@@ -9013,6 +9014,7 @@ export const apiClient = {
         case_id: query?.caseID,
         plan_id: query?.planID,
         operation: query?.operation,
+        target_scope: query?.targetScope,
         state: query?.state,
         severity: query?.severity,
         search: query?.search

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3611,6 +3611,130 @@ export type AWSPermissionBoundaryExecutorQuery = {
   search?: string;
 };
 
+export type AWSScpGuardrailExecutorStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSScpGuardrailExecutorFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSScpGuardrailExecutorState = 'projected' | 'precondition_failed' | 'blocked' | string;
+
+export type AWSScpGuardrailExecutorPrecondition = AWSPermissionBoundaryExecutorPrecondition;
+export type AWSScpGuardrailExecutorVerification = AWSPermissionBoundaryExecutorVerification;
+export type AWSScpGuardrailExecutorRelationship = AWSPermissionBoundaryExecutorRelationship;
+
+export type AWSScpGuardrailExecutorSimulation = {
+  simulation_ref: string;
+  outcome: string;
+  before_ref: string;
+  after_ref: string;
+  denied_action_count: number;
+  target_account_count: number;
+  target_ou_count: number;
+  signals?: string[];
+};
+
+export type AWSScpGuardrailExecutorEntry = {
+  execution_id: string;
+  calculation_version: string;
+  dry_run_id: string;
+  approval_id: string;
+  case_id: string;
+  plan_id: string;
+  source_artifact_id: string;
+  state: AWSScpGuardrailExecutorState;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id: string;
+  region: string;
+  operation: string;
+  idempotency_key: string;
+  target_account_ids?: string[];
+  target_ou_paths?: string[];
+  prevented_behavior: string;
+  statement_snippets: AWSPermissionBoundarySCPStatementSnippet[];
+  breakage_projection: AWSPermissionBoundarySCPBreakageProjection;
+  intended_api_call: AWSRemediationDryRunIntendedAPICall;
+  preconditions: AWSScpGuardrailExecutorPrecondition[];
+  boundary_simulation: AWSScpGuardrailExecutorSimulation;
+  verifications: AWSScpGuardrailExecutorVerification[];
+  rollback_plan: AWSPermissionBoundarySCPRollbackPlan;
+  verification_plan: AWSPermissionBoundarySCPVerificationPlan;
+  audit_trail: AWSRemediationAuditEntry[];
+  kill_switch_engaged: boolean;
+  ready_for_live_apply: boolean;
+  read_only_projection: boolean;
+  source_signals: string[];
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSScpGuardrailExecutorSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  state_counts: Record<string, number>;
+  operation_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  ready_for_live_apply_count: number;
+  kill_switch_engaged_count: number;
+  failed_precondition_count: number;
+  target_account_count: number;
+  target_ou_count: number;
+  verification_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSScpGuardrailExecutorResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSScpGuardrailExecutorStatus;
+  fixture_state?: AWSScpGuardrailExecutorFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSScpGuardrailExecutorSummary;
+  entries: AWSScpGuardrailExecutorEntry[];
+  relationships: AWSScpGuardrailExecutorRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSScpGuardrailExecutorQuery = {
+  connectorID?: string;
+  fixtureState?: AWSScpGuardrailExecutorFixtureState;
+  accountID?: string;
+  region?: string;
+  dryRunID?: string;
+  caseID?: string;
+  planID?: string;
+  operation?: string;
+  state?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -8858,6 +8982,29 @@ export const apiClient = {
   ) {
     return request<{ permission_boundary_executor: AWSPermissionBoundaryExecutorResult }>(
       `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/permission-boundary-executor${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        dry_run_id: query?.dryRunID,
+        case_id: query?.caseID,
+        plan_id: query?.planID,
+        operation: query?.operation,
+        state: query?.state,
+        severity: query?.severity,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectScpGuardrailExecutor(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSScpGuardrailExecutorQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ scp_guardrail_executor: AWSScpGuardrailExecutorResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/scp-guardrail-executor${buildQuery({
         connector_id: query?.connectorID,
         fixture_state: query?.fixtureState,
         account_id: query?.accountID,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3773,8 +3773,8 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
-    const getPermissionBoundaryExecutor = vi.spyOn(api.apiClient, 'getAWSProjectPermissionBoundaryExecutor').mockResolvedValue({
-      permission_boundary_executor: {
+	    const getPermissionBoundaryExecutor = vi.spyOn(api.apiClient, 'getAWSProjectPermissionBoundaryExecutor').mockResolvedValue({
+	      permission_boundary_executor: {
         status: 'ready',
         entries: [
           {
@@ -3901,10 +3901,138 @@ describe('Domain-first app routes', () => {
         remediation_hints: [],
         evidence_links: [],
         coverage_gaps: [],
-        diagnostics: []
-      } as any
-    });
-    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
+	        diagnostics: []
+	      } as any
+	    });
+	    const getScpGuardrailExecutor = vi.spyOn(api.apiClient, 'getAWSProjectScpGuardrailExecutor').mockResolvedValue({
+	      scp_guardrail_executor: {
+	        status: 'ready',
+	        entries: [
+	          {
+	            execution_id: 'aws-scp-guardrail-executor:external-trust',
+	            calculation_version: 'aws-scp-guardrail-executor-v1',
+	            dry_run_id: 'aws-remediation-dry-run:external-trust',
+	            approval_id: 'aws-remediation-approval:external-trust',
+	            case_id: 'aws-remediation-case:external-trust',
+	            plan_id: 'aws-permission-boundary-scp:external-trust',
+	            source_artifact_id: 'aws-permission-boundary-scp:external-trust',
+	            state: 'projected',
+	            severity: 'high',
+	            score: 81,
+	            confidence: 0.91,
+	            title: 'SCP guardrail execution: external trust guardrail',
+	            summary: 'Approved SCP guardrail execution record for the external trust plan.',
+	            account_id: '111111111111',
+	            region: 'us-east-1',
+	            operation: 'AttachPolicy',
+	            idempotency_key: 'idempotency://external-trust',
+	            target_account_ids: ['111111111111', '222222222222'],
+	            target_ou_paths: ['/engineering'],
+	            prevented_behavior: 'Re-create the unconditioned external trust pattern.',
+	            statement_snippets: [
+	              {
+	                statement_sid: 'scp-projection',
+	                effect: 'Deny',
+	                change_kind: 'deny_external_trust',
+	                before_ref: 'evidence://trust/external',
+	                after_ref: 'scp://external/scoped-projection',
+	                denied_actions: ['iam:UpdateAssumeRolePolicy'],
+	                allowed_actions: [],
+	                resource_scope: ['arn:aws:iam::111111111111:role/orders'],
+	                rationale: 'Block re-introduction of the flagged external trust pattern.'
+	              }
+	            ],
+	            breakage_projection: {
+	              level: 'low',
+	              rationale: 'Runtime and analyzer evidence both confirm the caller set.',
+	              affected_identities: 0,
+	              affected_accounts: 2,
+	              affected_ous: 1,
+	              signals: ['affected_accounts:2', 'affected_ous:1']
+	            },
+	            intended_api_call: {
+	              service: 'organizations',
+	              operation: 'AttachPolicy',
+	              target_resource: '/engineering',
+	              parameter_refs: ['idempotency://external-trust', 'scp_ref://aws-remediation-case:external-trust/after'],
+	              idempotent: true,
+	              requires_approval: true
+	            },
+	            preconditions: [
+	              { name: 'dry_run_would_succeed', status: 'passed', rationale: 'Dry-run passed.' },
+	              { name: 'target_scope_captured', status: 'passed', rationale: 'Target scope captured.' }
+	            ],
+	            boundary_simulation: {
+	              simulation_ref: 'organizations:scp_simulate://aws-permission-boundary-scp:external-trust/scp-guardrail',
+	              outcome: 'would_attach_guardrail',
+	              before_ref: 'evidence://trust/external',
+	              after_ref: 'scp://external/scoped-projection',
+	              denied_action_count: 1,
+	              target_account_count: 2,
+	              target_ou_count: 1,
+	              signals: ['scp_guardrail', 'affected_accounts:2']
+	            },
+	            verifications: [
+	              {
+	                source: 'access_analyzer',
+	                signal: 'no_new_external_findings',
+	                status: 'pending',
+	                description: 'Re-run Access Analyzer after live execution.'
+	              }
+	            ],
+	            rollback_plan: {
+	              strategy: 'detach_scp',
+	              steps: ['Detach the projected SCP from the captured OU.'],
+	              evidence_ref: 'evidence://trust/external'
+	            },
+	            verification_plan: {
+	              strategy: 'scp_simulate',
+	              steps: ['Confirm the SCP denies the prevented behavior.'],
+	              success_signals: ['cross_account_trust:finding-resolved'],
+	              failure_signals: ['cross_account_trust:finding-unchanged'],
+	              evidence_ref: 'evidence://trust/external'
+	            },
+	            audit_trail: [],
+	            kill_switch_engaged: false,
+	            ready_for_live_apply: true,
+	            read_only_projection: true,
+	            source_signals: ['aws_permission_boundary_scp', 'scp'],
+	            evidence: [],
+	            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+	            impacted_nodes: ['111111111111', '/engineering'],
+	            impacted_path: [],
+	            next_action: 'SCP guardrail operation=AttachPolicy is ready for the wave-8 apply runtime once its feature flag opens.',
+	            projected_at: '2026-07-01T10:00:00Z',
+	            created_at: '2026-07-01T10:00:00Z',
+	            updated_at: '2026-07-01T10:00:00Z'
+	          }
+	        ],
+	        summary: {
+	          total_entries: 1,
+	          filtered_entries: 1,
+	          state_counts: { projected: 1 },
+	          operation_counts: { AttachPolicy: 1 },
+	          severity_counts: { high: 1 },
+	          ready_for_live_apply_count: 1,
+	          kill_switch_engaged_count: 0,
+	          failed_precondition_count: 0,
+	          target_account_count: 2,
+	          target_ou_count: 1,
+	          verification_count: 1,
+	          relationship_count: 3,
+	          highest_score: 81,
+	          average_confidence_pct: 91
+	        },
+	        relationships: [],
+	        caveats: ['SCP guardrail executor entries are read-only projections.'],
+	        failure_reasons: [],
+	        remediation_hints: [],
+	        evidence_links: [],
+	        coverage_gaps: [],
+	        diagnostics: []
+	      } as any
+	    });
+	    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
         plans: [
@@ -4494,6 +4622,9 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('table', { name: 'AWS permission boundary executor entries' })).toBeInTheDocument();
     expect(screen.getByText(/Permission boundary execution: deny s3:DeleteObject/i)).toBeInTheDocument();
     expect(screen.getAllByText(/PutRolePermissionsBoundary/i).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('table', { name: 'AWS SCP guardrail executor entries' })).toBeInTheDocument();
+    expect(screen.getByText(/SCP guardrail execution: external trust guardrail/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/AttachPolicy/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS secret/key rotation plans' })).toBeInTheDocument();
     expect(screen.getByText(/Provider key rotation: openai\/api-key/i)).toBeInTheDocument();
     expect(screen.getAllByText(/ai-platform · Pending approver/i).length).toBeGreaterThan(0);
@@ -4556,6 +4687,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getPermissionBoundaryExecutor).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getScpGuardrailExecutor).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3926,7 +3926,7 @@ describe('Domain-first app routes', () => {
 	            region: 'us-east-1',
 	            operation: 'AttachPolicy',
 	            idempotency_key: 'idempotency://external-trust',
-	            target_account_ids: ['111111111111', '222222222222'],
+	            target_account_ids: [],
 	            target_ou_paths: ['/engineering'],
 	            prevented_behavior: 'Re-create the unconditioned external trust pattern.',
 	            statement_snippets: [
@@ -3968,16 +3968,16 @@ describe('Domain-first app routes', () => {
 	              before_ref: 'evidence://trust/external',
 	              after_ref: 'scp://external/scoped-projection',
 	              denied_action_count: 1,
-	              target_account_count: 2,
+	              target_account_count: 0,
 	              target_ou_count: 1,
 	              signals: ['scp_guardrail', 'affected_accounts:2']
 	            },
 	            verifications: [
 	              {
-	                source: 'access_analyzer',
-	                signal: 'no_new_external_findings',
+	                source: 'organizations',
+	                signal: 'effective_policy_matches',
 	                status: 'pending',
-	                description: 'Re-run Access Analyzer after live execution.'
+	                description: 'Confirm the effective SCP includes the intended guardrail statement metadata ref.'
 	              }
 	            ],
 	            rollback_plan: {
@@ -4016,7 +4016,7 @@ describe('Domain-first app routes', () => {
 	          ready_for_live_apply_count: 1,
 	          kill_switch_engaged_count: 0,
 	          failed_precondition_count: 0,
-	          target_account_count: 2,
+	          target_account_count: 0,
 	          target_ou_count: 1,
 	          verification_count: 1,
 	          relationship_count: 3,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -187,6 +187,7 @@ import {
   DomainStatusBadge,
   DomainStatusPanel,
   DomainTimeline,
+  type DomainDataTableColumn,
   type DomainTimelineEntry
 } from './components/app/DomainFoundation';
 import { getDomainAsset, type DomainAssetKey } from './design/domainAssets';
@@ -11086,33 +11087,56 @@ function awsPermissionBoundaryExecutorReadinessLabel(entry: AWSPermissionBoundar
   return formatTokenLabel(entry.state);
 }
 
-function AWSPermissionBoundaryExecutorContent({
+type AWSExecutorProjectionResult<Row> = {
+  status: string;
+  entries: Row[];
+  caveats: string[];
+  failure_reasons: string[];
+};
+
+function AWSExecutorProjectionPanel<Row>({
   result,
   loading,
   error,
-  onRetry
+  onRetry,
+  ariaLabel,
+  heading,
+  description,
+  errorTitle,
+  loadingTitle,
+  loadingBody,
+  emptyEyebrow,
+  emptyTitle,
+  emptyBody,
+  tableLabel,
+  getRowKey,
+  columns
 }: {
-  result: AWSPermissionBoundaryExecutorResult | null;
+  result: AWSExecutorProjectionResult<Row> | null;
   loading: boolean;
   error: string;
   onRetry: () => void;
+  ariaLabel: string;
+  heading: string;
+  description: string;
+  errorTitle: string;
+  loadingTitle: string;
+  loadingBody: string;
+  emptyEyebrow: (result: AWSExecutorProjectionResult<Row>) => string;
+  emptyTitle: (result: AWSExecutorProjectionResult<Row>) => string;
+  emptyBody: (result: AWSExecutorProjectionResult<Row>) => string;
+  tableLabel: string;
+  getRowKey: (row: Row) => string;
+  columns: DomainDataTableColumn<Row>[];
 }) {
   const rows = result?.entries ?? [];
-  const summaryLine = result
-    ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.summary.failed_precondition_count} blocked preconditions · ${result.summary.target_identity_count} identities`
-    : '';
   return (
-    <section className="idt-aws-runtime-correlation" aria-label="AWS approved permission boundary executor">
-      <h3>AWS approved permission boundary executor</h3>
-      <p className="idt-app-kicker">
-        Read-only projection that joins dry-run readiness with permission-boundary planner metadata. Each entry records
-        the idempotency key, intended IAM permission-boundary call, target identity scope, simulator metadata,
-        preconditions, rollback plan, verification records, and audit trail. Identrail never calls IAM write APIs at this
-        layer. {summaryLine}
-      </p>
+    <section className="idt-aws-runtime-correlation" aria-label={ariaLabel}>
+      <h3>{heading}</h3>
+      <p className="idt-app-kicker">{description}</p>
       {error ? (
         <DomainErrorState
-          title="Couldn't load AWS permission boundary executor"
+          title={errorTitle}
           body={error}
           retryAction={{ label: 'Retry', onClick: onRetry }}
         />
@@ -11120,15 +11144,15 @@ function AWSPermissionBoundaryExecutorContent({
       {!error && loading ? (
         <DomainEmptyState
           eyebrow="Loading"
-          title="Projecting permission boundary execution"
-          body="Identrail is joining dry-run readiness with permission boundary planner metadata to project execution records."
+          title={loadingTitle}
+          body={loadingBody}
         />
       ) : null}
       {!error && !loading && result && rows.length === 0 ? (
         <DomainEmptyState
-          eyebrow={result.status === 'blocked' ? 'Permission required' : 'No permission boundary executor entries'}
-          title={result.status === 'blocked' ? 'Permission boundary executor needs approved dry-run and planner evidence' : 'No permission boundary executor entries projected'}
-          body={result.failure_reasons[0] ?? 'No upstream dry-run entry joined a permission boundary plan for this environment.'}
+          eyebrow={emptyEyebrow(result)}
+          title={emptyTitle(result)}
+          body={emptyBody(result)}
         />
       ) : null}
       {!error && !loading && result && result.caveats.length > 0 ? (
@@ -11140,27 +11164,63 @@ function AWSPermissionBoundaryExecutorContent({
       ) : null}
       {rows.length > 0 ? (
         <DomainDataTable
-          label="AWS permission boundary executor entries"
+          label={tableLabel}
           rows={rows}
-          getRowKey={(row) => row.execution_id}
-          columns={[
-            { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
-            { key: 'operation', header: 'Operation', render: (row) => row.operation },
-            { key: 'target', header: 'Target', render: (row) => awsPermissionBoundaryExecutorTargetLabel(row) },
-            { key: 'preconditions', header: 'Preconditions', render: (row) => awsPermissionBoundaryExecutorPreconditionLabel(row) },
-            { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
-            { key: 'state', header: 'State', render: (row) => awsPermissionBoundaryExecutorReadinessLabel(row) },
-            {
-              key: 'severity',
-              header: 'Severity',
-              render: (row) => (
-                <AWSInventoryPill stage={awsPermissionBoundaryExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
-              )
-            }
-          ]}
+          getRowKey={getRowKey}
+          columns={columns}
         />
       ) : null}
     </section>
+  );
+}
+
+function AWSPermissionBoundaryExecutorContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSPermissionBoundaryExecutorResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.summary.failed_precondition_count} blocked preconditions · ${result.summary.target_identity_count} identities`
+    : '';
+  return (
+    <AWSExecutorProjectionPanel
+      result={result}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS approved permission boundary executor"
+      heading="AWS approved permission boundary executor"
+      description={`Read-only projection that joins dry-run readiness with permission-boundary planner metadata. Each entry records the idempotency key, intended IAM permission-boundary call, target identity scope, simulator metadata, preconditions, rollback plan, verification records, and audit trail. Identrail never calls IAM write APIs at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS permission boundary executor"
+      loadingTitle="Projecting permission boundary execution"
+      loadingBody="Identrail is joining dry-run readiness with permission boundary planner metadata to project execution records."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No permission boundary executor entries')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Permission boundary executor needs approved dry-run and planner evidence' : 'No permission boundary executor entries projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No upstream dry-run entry joined a permission boundary plan for this environment.'}
+      tableLabel="AWS permission boundary executor entries"
+      getRowKey={(row) => row.execution_id}
+      columns={[
+        { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
+        { key: 'operation', header: 'Operation', render: (row) => row.operation },
+        { key: 'target', header: 'Target', render: (row) => awsPermissionBoundaryExecutorTargetLabel(row) },
+        { key: 'preconditions', header: 'Preconditions', render: (row) => awsPermissionBoundaryExecutorPreconditionLabel(row) },
+        { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
+        { key: 'state', header: 'State', render: (row) => awsPermissionBoundaryExecutorReadinessLabel(row) },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsPermissionBoundaryExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+          )
+        }
+      ]}
+    />
   );
 }
 
@@ -11204,70 +11264,42 @@ function AWSScpGuardrailExecutorContent({
   error: string;
   onRetry: () => void;
 }) {
-  const rows = result?.entries ?? [];
   const summaryLine = result
     ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.summary.failed_precondition_count} blocked preconditions · ${result.summary.target_account_count} accounts · ${result.summary.target_ou_count} OUs`
     : '';
   return (
-    <section className="idt-aws-runtime-correlation" aria-label="AWS approved SCP guardrail executor">
-      <h3>AWS approved SCP guardrail executor</h3>
-      <p className="idt-app-kicker">
-        Read-only projection that joins dry-run readiness with SCP planner metadata. Each entry records the idempotency
-        key, intended Organizations SCP attach, account/OU target scope, simulator metadata, preconditions, rollback
-        plan, verification records, and audit trail. Identrail never calls Organizations write APIs at this layer.{' '}
-        {summaryLine}
-      </p>
-      {error ? (
-        <DomainErrorState
-          title="Couldn't load AWS SCP guardrail executor"
-          body={error}
-          retryAction={{ label: 'Retry', onClick: onRetry }}
-        />
-      ) : null}
-      {!error && loading ? (
-        <DomainEmptyState
-          eyebrow="Loading"
-          title="Projecting SCP guardrail execution"
-          body="Identrail is joining dry-run readiness with SCP planner metadata to project execution records."
-        />
-      ) : null}
-      {!error && !loading && result && rows.length === 0 ? (
-        <DomainEmptyState
-          eyebrow={result.status === 'blocked' ? 'Permission required' : 'No SCP guardrail executor entries'}
-          title={result.status === 'blocked' ? 'SCP guardrail executor needs approved dry-run and planner evidence' : 'No SCP guardrail executor entries projected'}
-          body={result.failure_reasons[0] ?? 'No upstream dry-run entry joined an SCP plan for this environment.'}
-        />
-      ) : null}
-      {!error && !loading && result && result.caveats.length > 0 ? (
-        <ul className="idt-aws-runtime-correlation-caveats">
-          {result.caveats.slice(0, 3).map((caveat) => (
-            <li key={caveat}>{caveat}</li>
-          ))}
-        </ul>
-      ) : null}
-      {rows.length > 0 ? (
-        <DomainDataTable
-          label="AWS SCP guardrail executor entries"
-          rows={rows}
-          getRowKey={(row) => row.execution_id}
-          columns={[
-            { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
-            { key: 'operation', header: 'Operation', render: (row) => row.operation },
-            { key: 'target', header: 'Target', render: (row) => awsScpGuardrailExecutorTargetLabel(row) },
-            { key: 'preconditions', header: 'Preconditions', render: (row) => awsScpGuardrailExecutorPreconditionLabel(row) },
-            { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
-            { key: 'state', header: 'State', render: (row) => awsScpGuardrailExecutorReadinessLabel(row) },
-            {
-              key: 'severity',
-              header: 'Severity',
-              render: (row) => (
-                <AWSInventoryPill stage={awsScpGuardrailExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
-              )
-            }
-          ]}
-        />
-      ) : null}
-    </section>
+    <AWSExecutorProjectionPanel
+      result={result}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS approved SCP guardrail executor"
+      heading="AWS approved SCP guardrail executor"
+      description={`Read-only projection that joins dry-run readiness with SCP planner metadata. Each entry records the idempotency key, intended Organizations SCP attach, account/OU target scope, simulator metadata, preconditions, rollback plan, verification records, and audit trail. Identrail never calls Organizations write APIs at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS SCP guardrail executor"
+      loadingTitle="Projecting SCP guardrail execution"
+      loadingBody="Identrail is joining dry-run readiness with SCP planner metadata to project execution records."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No SCP guardrail executor entries')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'SCP guardrail executor needs approved dry-run and planner evidence' : 'No SCP guardrail executor entries projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No upstream dry-run entry joined an SCP plan for this environment.'}
+      tableLabel="AWS SCP guardrail executor entries"
+      getRowKey={(row) => row.execution_id}
+      columns={[
+        { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
+        { key: 'operation', header: 'Operation', render: (row) => row.operation },
+        { key: 'target', header: 'Target', render: (row) => awsScpGuardrailExecutorTargetLabel(row) },
+        { key: 'preconditions', header: 'Preconditions', render: (row) => awsScpGuardrailExecutorPreconditionLabel(row) },
+        { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
+        { key: 'state', header: 'State', render: (row) => awsScpGuardrailExecutorReadinessLabel(row) },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsScpGuardrailExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+          )
+        }
+      ]}
+    />
   );
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -79,6 +79,8 @@ import {
   type AWSLowRiskRemediationResult,
   type AWSPermissionBoundaryExecutorEntry,
   type AWSPermissionBoundaryExecutorResult,
+  type AWSScpGuardrailExecutorEntry,
+  type AWSScpGuardrailExecutorResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11162,6 +11164,113 @@ function AWSPermissionBoundaryExecutorContent({
   );
 }
 
+function awsScpGuardrailExecutorStage(entry: AWSScpGuardrailExecutorEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.state === 'blocked') {
+    return 'not-available';
+  }
+  if (entry.state !== 'projected' || !entry.ready_for_live_apply) {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsScpGuardrailExecutorTargetLabel(entry: AWSScpGuardrailExecutorEntry): string {
+  const accounts = entry.target_account_ids?.length ?? 0;
+  const ous = entry.target_ou_paths?.length ?? 0;
+  return `${accounts} accounts · ${ous} OUs`;
+}
+
+function awsScpGuardrailExecutorPreconditionLabel(entry: AWSScpGuardrailExecutorEntry): string {
+  const passed = entry.preconditions.filter((precondition) => precondition.status === 'passed').length;
+  const blocked = entry.preconditions.length - passed;
+  return `${passed} passed · ${blocked} blocked`;
+}
+
+function awsScpGuardrailExecutorReadinessLabel(entry: AWSScpGuardrailExecutorEntry): string {
+  if (entry.ready_for_live_apply) {
+    return `ready · ${entry.verifications.length} verifications`;
+  }
+  return formatTokenLabel(entry.state);
+}
+
+function AWSScpGuardrailExecutorContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSScpGuardrailExecutorResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const rows = result?.entries ?? [];
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.ready_for_live_apply_count} ready · ${result.summary.failed_precondition_count} blocked preconditions · ${result.summary.target_account_count} accounts · ${result.summary.target_ou_count} OUs`
+    : '';
+  return (
+    <section className="idt-aws-runtime-correlation" aria-label="AWS approved SCP guardrail executor">
+      <h3>AWS approved SCP guardrail executor</h3>
+      <p className="idt-app-kicker">
+        Read-only projection that joins dry-run readiness with SCP planner metadata. Each entry records the idempotency
+        key, intended Organizations SCP attach, account/OU target scope, simulator metadata, preconditions, rollback
+        plan, verification records, and audit trail. Identrail never calls Organizations write APIs at this layer.{' '}
+        {summaryLine}
+      </p>
+      {error ? (
+        <DomainErrorState
+          title="Couldn't load AWS SCP guardrail executor"
+          body={error}
+          retryAction={{ label: 'Retry', onClick: onRetry }}
+        />
+      ) : null}
+      {!error && loading ? (
+        <DomainEmptyState
+          eyebrow="Loading"
+          title="Projecting SCP guardrail execution"
+          body="Identrail is joining dry-run readiness with SCP planner metadata to project execution records."
+        />
+      ) : null}
+      {!error && !loading && result && rows.length === 0 ? (
+        <DomainEmptyState
+          eyebrow={result.status === 'blocked' ? 'Permission required' : 'No SCP guardrail executor entries'}
+          title={result.status === 'blocked' ? 'SCP guardrail executor needs approved dry-run and planner evidence' : 'No SCP guardrail executor entries projected'}
+          body={result.failure_reasons[0] ?? 'No upstream dry-run entry joined an SCP plan for this environment.'}
+        />
+      ) : null}
+      {!error && !loading && result && result.caveats.length > 0 ? (
+        <ul className="idt-aws-runtime-correlation-caveats">
+          {result.caveats.slice(0, 3).map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rows.length > 0 ? (
+        <DomainDataTable
+          label="AWS SCP guardrail executor entries"
+          rows={rows}
+          getRowKey={(row) => row.execution_id}
+          columns={[
+            { key: 'execution', header: 'Execution', render: (row) => <strong>{row.title}</strong> },
+            { key: 'operation', header: 'Operation', render: (row) => row.operation },
+            { key: 'target', header: 'Target', render: (row) => awsScpGuardrailExecutorTargetLabel(row) },
+            { key: 'preconditions', header: 'Preconditions', render: (row) => awsScpGuardrailExecutorPreconditionLabel(row) },
+            { key: 'simulation', header: 'Simulation', render: (row) => `${formatTokenLabel(row.boundary_simulation.outcome)} · ${row.boundary_simulation.denied_action_count} denied` },
+            { key: 'state', header: 'State', render: (row) => awsScpGuardrailExecutorReadinessLabel(row) },
+            {
+              key: 'severity',
+              header: 'Severity',
+              render: (row) => (
+                <AWSInventoryPill stage={awsScpGuardrailExecutorStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+              )
+            }
+          ]}
+        />
+      ) : null}
+    </section>
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13382,6 +13491,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [permissionBoundaryExecutorLoading, setPermissionBoundaryExecutorLoading] = useState(false);
   const [permissionBoundaryExecutorError, setPermissionBoundaryExecutorError] = useState('');
   const permissionBoundaryExecutorRequestRef = useRef(0);
+  const [scpGuardrailExecutor, setScpGuardrailExecutor] = useState<AWSScpGuardrailExecutorResult | null>(null);
+  const [scpGuardrailExecutorLoading, setScpGuardrailExecutorLoading] = useState(false);
+  const [scpGuardrailExecutorError, setScpGuardrailExecutorError] = useState('');
+  const scpGuardrailExecutorRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -13934,6 +14047,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       permissionBoundaryExecutorRequestRef.current += 1;
     };
   }, [loadPermissionBoundaryExecutor]);
+
+  const loadScpGuardrailExecutor = useCallback(async () => {
+    const requestID = ++scpGuardrailExecutorRequestRef.current;
+    setScpGuardrailExecutor(null);
+    setScpGuardrailExecutorError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setScpGuardrailExecutorLoading(false);
+      return;
+    }
+    setScpGuardrailExecutorLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectScpGuardrailExecutor(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== scpGuardrailExecutorRequestRef.current) {
+        return;
+      }
+      setScpGuardrailExecutor(response.scp_guardrail_executor);
+    } catch (error) {
+      if (requestID !== scpGuardrailExecutorRequestRef.current) {
+        return;
+      }
+      setScpGuardrailExecutorError(formatAPIError(error, 'Unable to load AWS SCP guardrail executor.'));
+    } finally {
+      if (requestID === scpGuardrailExecutorRequestRef.current) {
+        setScpGuardrailExecutorLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadScpGuardrailExecutor();
+    return () => {
+      scpGuardrailExecutorRequestRef.current += 1;
+    };
+  }, [loadScpGuardrailExecutor]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -14781,6 +14942,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={permissionBoundaryExecutorLoading}
             error={permissionBoundaryExecutorError}
             onRetry={loadPermissionBoundaryExecutor}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSScpGuardrailExecutorContent
+            result={scpGuardrailExecutor}
+            loading={scpGuardrailExecutorLoading}
+            error={scpGuardrailExecutorError}
+            onRetry={loadScpGuardrailExecutor}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- add the metadata-only AWS SCP guardrail executor for issue #1541, joining approved dry-run entries to SCP planner records with idempotency, target account/OU scope, preconditions, simulation metadata, rollback, verification, audit trail, and graph relationships
- wire the executor through backend routing, authz metadata, OpenAPI, the TypeScript API client, and the AWS Runtime page
- split remediation-case and dry-run behavior so permission-boundary diffs and SCP guardrail diffs stay distinct while sharing the approved planner source
- document the new executor and update related remediation docs

## Safety
- confirms blockers #1537 and #1532 are closed
- keeps the endpoint metadata-only; it does not call IAM or Organizations write APIs
- preserves tenant/workspace/project/connector/account/region scoping and explicit empty/degraded/blocked/error states
- keeps rendered policy bodies, secret values, customer payloads, prompts, completions, browser pages, database rows, object contents, and workload payloads out of the contract

## Validation
- go test ./internal/api
- npm test -- --run src/api/client.test.ts src/productShell.test.tsx
- npm run build
- ruby -e 'require "yaml"; YAML.load_file("docs/openapi-v1.yaml"); puts "openapi yaml ok"'
- git diff --check

AI disclosure: No

Closes #1541

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS SCP guardrail executor that projects approved org-level SCP changes into a deterministic executor feed. Implements #1541 and wires it through backend auth, OpenAPI, the web `apiClient`, and the AWS Runtime UI.

- **New Features**
  - New read-only endpoint: GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/scp-guardrail-executor with filters: `connector_id`, `fixture_state`, `account_id`, `region`, `dry_run_id`, `case_id`, `plan_id`, `operation`, `target_scope`, `state`, `severity`, `search`.
  - Joins approved dry-run entries to `aws_permission_boundary_scp` plans (kind `scp`) with idempotency, account/OU targeting, preconditions, simulation refs, rollback, verification, audit trail, and graph links.
  - Metadata-only: no IAM/Organizations writes; no rendered policy bodies or sensitive payloads are exposed.
  - Adds route authorization, OpenAPI schema, tests, and docs (`docs/aws-scp-guardrail-executor.md`).
  - Exposes `apiClient.getAWSProjectScpGuardrailExecutor` and renders results in the AWS Runtime page.

- **Refactors**
  - Splits remediation-case and dry-run paths so permission-boundary diffs and SCP guardrail diffs are distinct while sharing the planner source.
  - Adds `scp_diff` intent mapped to Organizations AttachPolicy in the dry-run executor.
  - Updates approval scoping to avoid treating SCP diffs as identity-bound actions.

<sup>Written for commit 3c76cc5bef25ce60d5b23153a77e137fdc6ef745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

