### PR TITLE
Implement AWS post-remediation verification and rollback (#1542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS post-remediation verification and rollback** (#1542). Adds a
+  read-only projection that joins every approved wave-8 executor
+  (low-risk live remediation #1538, trust-policy hardening executor
+  #1539, permission boundary executor #1540, SCP guardrail executor
+  #1541) with the deterministic verification and rollback contract
+  Identrail records before any live apply. Each entry carries the
+  upstream execution ID, dry-run/approval/case identifiers, the intended
+  operation and idempotency key, precondition gates (upstream projected,
+  kill-switch-off, ready-for-live-apply, idempotency-key-present,
+  rollback-plan-present, verification-plan-present, upstream
+  prerequisites), pending verification checks (CloudTrail expected API
+  call, graph state re-check, runtime denial watch, and any planner
+  success/failure signals), a rollback record mirroring the upstream
+  planner rollback plan with an explicit `ready`, `not_available`, or
+  `blocked_by_kill_switch` state, and an immutable audit trail. Entry
+  state is `verification_pending` when the upstream executor is
+  projected and ready; `blocked` when a safety gate fails, an upstream
+  precondition is unresolved, or the tenant kill switch is engaged;
+  `not_ready` when the upstream executor has not yet declared
+  `ready_for_live_apply`. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification`
+  with filters for connector, account, region, source type, execution
+  ID, dry-run ID, case ID, state, severity, operation, and free-text
+  search. OpenAPI schemas and authz wiring follow the neighboring wave-8
+  endpoints. The AWS Runtime app surface now shows an **AWS
+  post-remediation verification and rollback** panel with execution
+  title, upstream source, verification check pass/fail/pending counts,
+  rollback strategy/state, severity, and state pill. Identrail never
+  calls IAM/STS/Organizations write APIs at this layer.
 - Add **AWS approved trust-policy hardening executor** (#1539). Adds a
   read-only projection that joins the dry-run executor (#1537) with the
   trust-policy hardening planner (#1531) for cases whose source_type is

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS approved permission boundary executor: `aws-permission-boundary-executor.md`
 - AWS approved SCP guardrail executor: `aws-scp-guardrail-executor.md`
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
+- AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-post-remediation-verification.md
+++ b/docs/aws-post-remediation-verification.md
@@ -1,0 +1,74 @@
+# AWS post-remediation verification and rollback
+
+Issue #1542 adds a metadata-only projection of the deterministic post-apply
+verification and rollback contract Identrail generates for every approved
+wave-8 executor: low-risk live remediation (#1538), trust-policy hardening
+executor (#1539), permission boundary executor (#1540), and SCP guardrail
+executor (#1541).
+
+The endpoint is read-only. It never calls IAM, STS, or Organizations write
+APIs and never reads, exposes, logs, or persists rendered policy documents,
+secret values, customer payloads, prompts, completions, browser pages,
+code-interpreter output, database rows, or object contents.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/post-remediation-verification`
+
+Response shape: `{ "post_remediation_verification": AWSPostRemediationVerificationResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`source_type`, `execution_id`, `dry_run_id`, `case_id`, `state`, `severity`,
+`operation`, and `search`.
+
+## Entry Shape
+
+Each entry pairs one upstream executor projection with:
+
+- Deterministic verification checks (CloudTrail, graph re-normalization, and
+  runtime denial checks; plus planner success/failure signals). Checks stay in
+  the `pending` state until the wave-8 apply runtime records the observed
+  outcome.
+- A rollback record that mirrors the upstream planner rollback plan
+  (`strategy`, `steps`, `evidence_ref`, success/failure signals) and carries a
+  state (`ready`, `not_available`, or `blocked_by_kill_switch`).
+- Precondition gates: upstream projection status, kill-switch off,
+  ready-for-live-apply, idempotency key present, rollback plan present,
+  verification plan present, and any propagated upstream precondition failures.
+- Immutable audit trail (the upstream executor's audit rows plus the
+  verification-projected row).
+- Graph relationships tying the verification record to the upstream execution
+  and any impacted graph nodes.
+
+## States
+
+- `verification_pending`: upstream executor is projected and ready; the apply
+  runtime should record check outcomes and advance to verified or failed.
+- `verification_verified`: all checks have passed.
+- `verification_failed`: at least one check failed; follow the rollback record
+  and refresh upstream evidence before retrying.
+- `rollback_planned`: verification failed and rollback is queued.
+- `blocked`: a safety gate failed, the tenant kill switch is engaged, or an
+  upstream precondition failed.
+- `not_ready`: upstream executor has not projected `ready_for_live_apply`.
+- `skipped`: the upstream executor did not project a live-apply record.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS post-remediation verification and
+rollback** panel that shows the execution title, upstream source, verification
+check pass/fail/pending counts, rollback strategy/state, severity, and state
+pill. The panel exposes loading, empty, blocked, degraded, and error states
+without operators needing to read logs or database rows.
+
+## Safety, evidence, and out of scope
+
+- Metadata-only projection. No IAM/STS/Organizations write APIs are called at
+  this layer; live execution belongs to the wave-8 apply runtime and its own
+  feature flag.
+- Rollback records mirror the upstream planner metadata; they never carry
+  rendered policy bodies or secret values.
+- Tenant, workspace, project, connector, account, and region boundaries are
+  preserved at every layer.
+- Unknown, permission-denied, and partial-failure states are surfaced as
+  explicit states, not as successful findings.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -604,6 +604,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/post-remediation-verification
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5627,6 +5632,95 @@ paths:
                     $ref: "#/components/schemas/AWSScpGuardrailExecutorResult"
         "400":
           description: Invalid AWS SCP guardrail executor request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/post-remediation-verification:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS post-remediation verification and rollback projections
+      operationId: getAWSProjectPostRemediationVerification
+      description: Projects deterministic post-remediation verification and rollback contracts by joining every approved wave-8 executor (low-risk live remediation, trust-policy hardening executor, permission boundary executor, SCP guardrail executor). Each entry records verification checks, rollback intent, precondition gates, and immutable audit rows. This endpoint is metadata-only and never calls IAM, STS, or Organizations write APIs and never reads or persists rendered policy bodies, secret values, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: source_type
+          schema:
+            type: string
+            enum: [aws_low_risk_live_remediation, aws_trust_policy_hardening, aws_permission_boundary_executor, aws_scp_guardrail_executor]
+          description: Optional upstream executor source filter.
+        - in: query
+          name: execution_id
+          schema: { type: string }
+          description: Optional verification or upstream execution ID filter.
+        - in: query
+          name: dry_run_id
+          schema: { type: string }
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: state
+          schema:
+            type: string
+            enum: [verification_pending, verification_verified, verification_failed, rollback_planned, skipped, blocked, not_ready]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: operation
+          schema: { type: string }
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Optional free-text search across verification IDs, source execution IDs, target resource, rollback metadata, preconditions, checks, and audit entries.
+      responses:
+        "200":
+          description: AWS post-remediation verification and rollback contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  post_remediation_verification:
+                    $ref: "#/components/schemas/AWSPostRemediationVerificationResult"
+        "400":
+          description: Invalid AWS post-remediation verification request
           content:
             application/json:
               schema:
@@ -15612,6 +15706,203 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSScpGuardrailExecutorRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPostRemediationVerificationGate:
+      type: object
+      properties:
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSPostRemediationVerificationCheck:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        status:
+          type: string
+          enum: [pending, passed, failed]
+        description: { type: string }
+    AWSPostRemediationVerificationRollback:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        success_signals:
+          type: array
+          items: { type: string }
+        failure_signals:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        state:
+          type: string
+          enum: [ready, not_available, blocked_by_kill_switch, applied, skipped]
+        rationale: { type: string }
+    AWSPostRemediationVerificationRelationship:
+      type: object
+      properties:
+        verification_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSPostRemediationVerificationEntry:
+      type: object
+      properties:
+        verification_id: { type: string }
+        calculation_version: { type: string }
+        source_type:
+          type: string
+          enum: [aws_low_risk_live_remediation, aws_trust_policy_hardening, aws_permission_boundary_executor, aws_scp_guardrail_executor]
+        source_execution_id: { type: string }
+        dry_run_id: { type: string }
+        approval_id: { type: string }
+        case_id: { type: string }
+        plan_id: { type: string }
+        source_artifact_id: { type: string }
+        state:
+          type: string
+          enum: [verification_pending, verification_verified, verification_failed, rollback_planned, skipped, blocked, not_ready]
+        severity: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        operation: { type: string }
+        idempotency_key: { type: string }
+        target_resource: { type: string }
+        ready_for_live_apply: { type: boolean }
+        kill_switch_engaged: { type: boolean }
+        read_only_projection: { type: boolean }
+        preconditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPostRemediationVerificationGate"
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPostRemediationVerificationCheck"
+        rollback:
+          $ref: "#/components/schemas/AWSPostRemediationVerificationRollback"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        source_signals:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPostRemediationVerificationSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        verified_count: { type: integer }
+        pending_count: { type: integer }
+        failed_count: { type: integer }
+        rollback_planned_count: { type: integer }
+        blocked_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_precondition_count: { type: integer }
+        check_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSPostRemediationVerificationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSPostRemediationVerificationSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPostRemediationVerificationEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPostRemediationVerificationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -15799,6 +15799,10 @@ components:
         title: { type: string }
         summary: { type: string }
         account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+          description: Per-target account IDs projected from upstream permission-boundary and SCP executor entries. Account filters match this list in addition to `account_id`.
         region: { type: string }
         operation: { type: string }
         idempotency_key: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -771,6 +771,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-dry-run", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_post_remediation_verification.go
+++ b/internal/api/aws_post_remediation_verification.go
@@ -1,0 +1,994 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsPostRemediationVerificationCurrentIssue = 1542
+	awsPostRemediationVerificationVersion      = "aws-post-remediation-verification-v1"
+
+	awsPostRemediationVerificationStatePending  = "verification_pending"
+	awsPostRemediationVerificationStateVerified = "verification_verified"
+	awsPostRemediationVerificationStateFailed   = "verification_failed"
+	awsPostRemediationVerificationStateRollback = "rollback_planned"
+	awsPostRemediationVerificationStateSkipped  = "skipped"
+	awsPostRemediationVerificationStateBlocked  = "blocked"
+	awsPostRemediationVerificationStateNotReady = "not_ready"
+
+	awsPostRemediationVerificationCheckStatusPending = "pending"
+	awsPostRemediationVerificationCheckStatusPassed  = "passed"
+	awsPostRemediationVerificationCheckStatusFailed  = "failed"
+)
+
+// AWSPostRemediationVerificationRequest scopes the deterministic
+// post-remediation verification/rollback projection to one AWS connector plus
+// optional operator drill-down filters.
+type AWSPostRemediationVerificationRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	SourceType   string `json:"source_type,omitempty"`
+	ExecutionID  string `json:"execution_id,omitempty"`
+	DryRunID     string `json:"dry_run_id,omitempty"`
+	CaseID       string `json:"case_id,omitempty"`
+	State        string `json:"state,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Operation    string `json:"operation,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSPostRemediationVerificationAuditEntry = AWSRemediationApprovalAuditEntry
+type AWSPostRemediationVerificationCoverageGap = AWSRemediationApprovalCoverageGap
+type AWSPostRemediationVerificationDiagnostic = AWSRemediationApprovalDiagnostic
+
+// AWSPostRemediationVerificationCheck is one deterministic post-apply signal
+// the downstream apply runtime must record. Statuses are `pending` until the
+// live executor writes an observed outcome, then `passed`/`failed`.
+type AWSPostRemediationVerificationCheck struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+// AWSPostRemediationVerificationRollback describes the deterministic rollback
+// contract for one upstream execution. The record is metadata-only and never
+// carries rendered policy bodies or secret material.
+type AWSPostRemediationVerificationRollback struct {
+	Strategy       string   `json:"strategy"`
+	Steps          []string `json:"steps"`
+	SuccessSignals []string `json:"success_signals,omitempty"`
+	FailureSignals []string `json:"failure_signals,omitempty"`
+	EvidenceRef    string   `json:"evidence_ref,omitempty"`
+	State          string   `json:"state"`
+	Rationale      string   `json:"rationale"`
+}
+
+// AWSPostRemediationVerificationGate documents one precondition the
+// verification executor evaluates before advancing state.
+type AWSPostRemediationVerificationGate struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSPostRemediationVerificationRelationship surfaces verification→graph edges
+// used by downstream operator UIs and audit consumers.
+type AWSPostRemediationVerificationRelationship struct {
+	VerificationID string `json:"verification_id"`
+	Type           string `json:"type"`
+	FromNodeID     string `json:"from_node_id"`
+	ToNodeID       string `json:"to_node_id"`
+	EvidenceRef    string `json:"evidence_ref,omitempty"`
+}
+
+// AWSPostRemediationVerificationEntry is the persisted-record-shaped contract
+// emitted per approved upstream executor projection. It records deterministic
+// verification checks, rollback metadata, gating preconditions, and immutable
+// audit rows without calling any AWS write APIs.
+type AWSPostRemediationVerificationEntry struct {
+	VerificationID     string                                     `json:"verification_id"`
+	CalculationVersion string                                     `json:"calculation_version"`
+	SourceType         string                                     `json:"source_type"`
+	SourceExecutionID  string                                     `json:"source_execution_id"`
+	DryRunID           string                                     `json:"dry_run_id"`
+	ApprovalID         string                                     `json:"approval_id"`
+	CaseID             string                                     `json:"case_id"`
+	PlanID             string                                     `json:"plan_id,omitempty"`
+	SourceArtifactID   string                                     `json:"source_artifact_id,omitempty"`
+	State              string                                     `json:"state"`
+	Severity           string                                     `json:"severity"`
+	Score              int                                        `json:"score"`
+	Confidence         float64                                    `json:"confidence"`
+	Title              string                                     `json:"title"`
+	Summary            string                                     `json:"summary"`
+	AccountID          string                                     `json:"account_id,omitempty"`
+	Region             string                                     `json:"region,omitempty"`
+	Operation          string                                     `json:"operation,omitempty"`
+	IdempotencyKey     string                                     `json:"idempotency_key,omitempty"`
+	TargetResource     string                                     `json:"target_resource,omitempty"`
+	ReadyForLiveApply  bool                                       `json:"ready_for_live_apply"`
+	KillSwitchEngaged  bool                                       `json:"kill_switch_engaged"`
+	ReadOnlyProjection bool                                       `json:"read_only_projection"`
+	Preconditions      []AWSPostRemediationVerificationGate       `json:"preconditions"`
+	Checks             []AWSPostRemediationVerificationCheck      `json:"checks"`
+	Rollback           AWSPostRemediationVerificationRollback     `json:"rollback"`
+	AuditTrail         []AWSPostRemediationVerificationAuditEntry `json:"audit_trail"`
+	SourceSignals      []string                                   `json:"source_signals"`
+	EvidenceLinks      []string                                   `json:"evidence_links"`
+	EvidenceBoundary   string                                     `json:"evidence_boundary"`
+	ImpactedNodes      []string                                   `json:"impacted_nodes"`
+	NextAction         string                                     `json:"next_action"`
+	ProjectedAt        time.Time                                  `json:"projected_at"`
+	CreatedAt          time.Time                                  `json:"created_at"`
+	UpdatedAt          time.Time                                  `json:"updated_at"`
+}
+
+// AWSPostRemediationVerificationSummary aggregates the unfiltered/filtered set.
+type AWSPostRemediationVerificationSummary struct {
+	TotalEntries            int            `json:"total_entries"`
+	FilteredEntries         int            `json:"filtered_entries"`
+	StateCounts             map[string]int `json:"state_counts"`
+	SourceTypeCounts        map[string]int `json:"source_type_counts"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	VerifiedCount           int            `json:"verified_count"`
+	PendingCount            int            `json:"pending_count"`
+	FailedCount             int            `json:"failed_count"`
+	RollbackPlannedCount    int            `json:"rollback_planned_count"`
+	BlockedCount            int            `json:"blocked_count"`
+	KillSwitchEngagedCount  int            `json:"kill_switch_engaged_count"`
+	FailedPreconditionCount int            `json:"failed_precondition_count"`
+	CheckCount              int            `json:"check_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+}
+
+// AWSPostRemediationVerificationResult is the deterministic endpoint envelope.
+type AWSPostRemediationVerificationResult struct {
+	TenantID           string                                       `json:"tenant_id"`
+	WorkspaceID        string                                       `json:"workspace_id"`
+	ProjectID          string                                       `json:"project_id"`
+	ConnectorID        string                                       `json:"connector_id,omitempty"`
+	AccountID          string                                       `json:"account_id,omitempty"`
+	Region             string                                       `json:"region,omitempty"`
+	ParentIssueNumber  int                                          `json:"parent_issue_number"`
+	ParentIssueRef     string                                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                          `json:"current_issue_number"`
+	CurrentIssueRef    string                                       `json:"current_issue_ref"`
+	Version            string                                       `json:"version"`
+	Status             string                                       `json:"status"`
+	FixtureState       string                                       `json:"fixture_state,omitempty"`
+	Confidence         float64                                      `json:"confidence"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	AppliedFilters     map[string]string                            `json:"applied_filters"`
+	Summary            AWSPostRemediationVerificationSummary        `json:"summary"`
+	Entries            []AWSPostRemediationVerificationEntry        `json:"entries"`
+	Relationships      []AWSPostRemediationVerificationRelationship `json:"relationships"`
+	Caveats            []string                                     `json:"caveats"`
+	FailureReasons     []string                                     `json:"failure_reasons"`
+	RemediationHints   []string                                     `json:"remediation_hints"`
+	EvidenceLinks      []string                                     `json:"evidence_links"`
+	CoverageGaps       []AWSPostRemediationVerificationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSPostRemediationVerificationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                    `json:"generated_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+// awsPostRemediationVerificationSource is the deterministic in-memory shape
+// each upstream executor is projected into before the verification/rollback
+// record is built. Every upstream executor contributes one record per approved
+// entry; unsupported sources are not projected.
+type awsPostRemediationVerificationSource struct {
+	SourceType        string
+	SourceExecutionID string
+	DryRunID          string
+	ApprovalID        string
+	CaseID            string
+	PlanID            string
+	SourceArtifactID  string
+	UpstreamState     string
+	Severity          string
+	Score             int
+	Confidence        float64
+	Title             string
+	AccountID         string
+	Region            string
+	Operation         string
+	IdempotencyKey    string
+	TargetResource    string
+	ReadyForLiveApply bool
+	KillSwitchEngaged bool
+	SourceSignals     []string
+	ImpactedNodes     []string
+	AuditTrail        []AWSPostRemediationVerificationAuditEntry
+	RollbackStrategy  string
+	RollbackSteps     []string
+	RollbackEvidence  string
+	SuccessSignals    []string
+	FailureSignals    []string
+	VerificationSteps []string
+	FailedPreconds    int
+	CreatedAt         time.Time
+}
+
+// GetAWSPostRemediationVerification projects deterministic post-remediation
+// verification and rollback records from every approved wave-8 executor
+// (low-risk live remediation #1538, trust-policy hardening executor #1539,
+// permission boundary executor #1540, SCP guardrail executor #1541). The
+// endpoint is metadata-only: it never calls IAM, STS, or Organizations write
+// APIs and never reads or persists rendered policy bodies, secret values, or
+// workload payloads.
+func (s *Service) GetAWSPostRemediationVerification(ctx context.Context, workspaceID string, projectID string, request AWSPostRemediationVerificationRequest) (AWSPostRemediationVerificationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSPostRemediationVerificationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSPostRemediationVerificationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSPostRemediationVerificationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSPostRemediationVerificationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	sources, upstreamStatus, failureReasons, remediationHints, coverageGaps, diagnostics, err := s.awsPostRemediationVerificationSources(ctx, workspaceID, projectID, connectorID, sourceFixtureState)
+	if err != nil {
+		return AWSPostRemediationVerificationResult{}, err
+	}
+
+	entries := awsPostRemediationVerificationEntries(sources, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].VerificationID < entries[j].VerificationID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSPostRemediationVerificationEntries(entries, request)
+	relationships := awsPostRemediationVerificationRelationships(filtered)
+	status, confidence := summarizeAWSPostRemediationVerificationStatus(upstreamStatus, filtered, diagnostics)
+
+	return AWSPostRemediationVerificationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPostRemediationVerificationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPostRemediationVerificationCurrentIssue),
+		Version:            awsPostRemediationVerificationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPostRemediationVerificationVersion,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSPostRemediationVerificationEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsPostRemediationVerificationCaveats(),
+		FailureReasons:     dedupeStrings(failureReasons),
+		RemediationHints:   awsPostRemediationVerificationRemediationHints(remediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+			awsIssueURL(awsLowRiskRemediationCurrentIssue),
+			awsIssueURL(awsTrustPolicyHardeningExecutorCurrentIssue),
+			awsIssueURL(awsPermissionBoundaryExecutorCurrentIssue),
+			awsIssueURL(awsScpGuardrailExecutorCurrentIssue),
+			"/docs/aws-post-remediation-verification",
+			"/docs/aws-remediation-dry-run-executor",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSPostRemediationVerificationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// awsPostRemediationVerificationSources fans out to each upstream wave-8
+// executor and normalizes its projected entries into a single source shape.
+// Upstream status/failure/coverage/diagnostic signals are merged so this
+// endpoint stays deterministic when any upstream degrades.
+func (s *Service) awsPostRemediationVerificationSources(ctx context.Context, workspaceID, projectID, connectorID, fixtureState string) ([]awsPostRemediationVerificationSource, string, []string, []string, []AWSPostRemediationVerificationCoverageGap, []AWSPostRemediationVerificationDiagnostic, error) {
+	sources := []awsPostRemediationVerificationSource{}
+	failureReasons := []string{}
+	remediationHints := []string{}
+	coverageGaps := []AWSPostRemediationVerificationCoverageGap{}
+	diagnostics := []AWSPostRemediationVerificationDiagnostic{}
+	upstreamStatuses := []string{}
+
+	lowRisk, err := s.GetAWSLowRiskRemediation(ctx, workspaceID, projectID, AWSLowRiskRemediationRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return nil, "", nil, nil, nil, nil, fmt.Errorf("post-remediation verification low-risk source: %w", err)
+	}
+	upstreamStatuses = append(upstreamStatuses, lowRisk.Status)
+	failureReasons = append(failureReasons, lowRisk.FailureReasons...)
+	remediationHints = append(remediationHints, lowRisk.RemediationHints...)
+	for _, gap := range lowRisk.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSPostRemediationVerificationCoverageGap(gap))
+	}
+	for _, diag := range lowRisk.Diagnostics {
+		diagnostics = append(diagnostics, AWSPostRemediationVerificationDiagnostic(diag))
+	}
+	for _, entry := range lowRisk.Entries {
+		sources = append(sources, awsPostRemediationVerificationFromLowRisk(entry))
+	}
+
+	trust, err := s.GetAWSTrustPolicyHardeningExecutor(ctx, workspaceID, projectID, AWSTrustPolicyHardeningExecutorRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return nil, "", nil, nil, nil, nil, fmt.Errorf("post-remediation verification trust source: %w", err)
+	}
+	upstreamStatuses = append(upstreamStatuses, trust.Status)
+	failureReasons = append(failureReasons, trust.FailureReasons...)
+	remediationHints = append(remediationHints, trust.RemediationHints...)
+	for _, gap := range trust.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSPostRemediationVerificationCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	for _, diag := range trust.Diagnostics {
+		diagnostics = append(diagnostics, AWSPostRemediationVerificationDiagnostic{Collector: diag.Collector, SourceID: diag.SourceID, Code: diag.Code, Message: diag.Message, Remediation: diag.Remediation, Retryable: diag.Retryable})
+	}
+	for _, entry := range trust.Entries {
+		sources = append(sources, awsPostRemediationVerificationFromTrust(entry))
+	}
+
+	boundary, err := s.GetAWSPermissionBoundaryExecutor(ctx, workspaceID, projectID, AWSPermissionBoundaryExecutorRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return nil, "", nil, nil, nil, nil, fmt.Errorf("post-remediation verification boundary source: %w", err)
+	}
+	upstreamStatuses = append(upstreamStatuses, boundary.Status)
+	failureReasons = append(failureReasons, boundary.FailureReasons...)
+	remediationHints = append(remediationHints, boundary.RemediationHints...)
+	for _, gap := range boundary.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSPostRemediationVerificationCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	for _, diag := range boundary.Diagnostics {
+		diagnostics = append(diagnostics, AWSPostRemediationVerificationDiagnostic{Collector: diag.Collector, SourceID: diag.SourceID, Code: diag.Code, Message: diag.Message, Remediation: diag.Remediation, Retryable: diag.Retryable})
+	}
+	for _, entry := range boundary.Entries {
+		sources = append(sources, awsPostRemediationVerificationFromBoundary(entry))
+	}
+
+	scp, err := s.GetAWSScpGuardrailExecutor(ctx, workspaceID, projectID, AWSScpGuardrailExecutorRequest{ConnectorID: connectorID, FixtureState: fixtureState})
+	if err != nil {
+		return nil, "", nil, nil, nil, nil, fmt.Errorf("post-remediation verification scp source: %w", err)
+	}
+	upstreamStatuses = append(upstreamStatuses, scp.Status)
+	failureReasons = append(failureReasons, scp.FailureReasons...)
+	remediationHints = append(remediationHints, scp.RemediationHints...)
+	for _, gap := range scp.CoverageGaps {
+		coverageGaps = append(coverageGaps, AWSPostRemediationVerificationCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	for _, diag := range scp.Diagnostics {
+		diagnostics = append(diagnostics, AWSPostRemediationVerificationDiagnostic{Collector: diag.Collector, SourceID: diag.SourceID, Code: diag.Code, Message: diag.Message, Remediation: diag.Remediation, Retryable: diag.Retryable})
+	}
+	for _, entry := range scp.Entries {
+		sources = append(sources, awsPostRemediationVerificationFromScp(entry))
+	}
+
+	return sources, mergeAWSPostRemediationVerificationStatuses(upstreamStatuses), failureReasons, remediationHints, coverageGaps, diagnostics, nil
+}
+
+func mergeAWSPostRemediationVerificationStatuses(statuses []string) string {
+	worst := awsPlatformDependencyStatusReady
+	for _, status := range statuses {
+		switch status {
+		case awsPlatformDependencyStatusBlocked:
+			return awsPlatformDependencyStatusBlocked
+		case awsPlatformDependencyStatusDegraded:
+			worst = awsPlatformDependencyStatusDegraded
+		}
+	}
+	return worst
+}
+
+func awsPostRemediationVerificationFromLowRisk(entry AWSLowRiskRemediationEntry) awsPostRemediationVerificationSource {
+	failed := 0
+	for _, preflight := range entry.Preflights {
+		if preflight.Status == "blocked" {
+			failed++
+		}
+	}
+	return awsPostRemediationVerificationSource{
+		SourceType:        "aws_low_risk_live_remediation",
+		SourceExecutionID: entry.ExecutionID,
+		DryRunID:          entry.DryRunID,
+		ApprovalID:        entry.ApprovalID,
+		CaseID:            entry.CaseID,
+		SourceArtifactID:  entry.SourceArtifactID,
+		UpstreamState:     entry.State,
+		Severity:          entry.Severity,
+		Score:             entry.Score,
+		Confidence:        entry.Confidence,
+		Title:             entry.Title,
+		AccountID:         entry.AccountID,
+		Region:            entry.Region,
+		Operation:         entry.Mutation.Operation,
+		IdempotencyKey:    entry.IdempotencyKey,
+		TargetResource:    entry.Mutation.TargetResource,
+		ReadyForLiveApply: entry.ReadyForLiveApply,
+		KillSwitchEngaged: entry.KillSwitchEngaged,
+		SourceSignals:     entry.SourceSignals,
+		ImpactedNodes:     entry.ImpactedNodes,
+		AuditTrail:        entry.AuditTrail,
+		RollbackStrategy:  entry.RollbackPlan.Strategy,
+		RollbackSteps:     entry.RollbackPlan.Steps,
+		RollbackEvidence:  entry.RollbackPlan.EvidenceRef,
+		SuccessSignals:    entry.VerificationPlan.SuccessSignals,
+		FailureSignals:    entry.VerificationPlan.FailureSignals,
+		VerificationSteps: entry.VerificationPlan.Steps,
+		FailedPreconds:    failed,
+		CreatedAt:         entry.CreatedAt,
+	}
+}
+
+func awsPostRemediationVerificationFromTrust(entry AWSTrustPolicyHardeningExecutorEntry) awsPostRemediationVerificationSource {
+	failed := 0
+	for _, gate := range entry.Preconditions {
+		if gate.Status == "blocked" {
+			failed++
+		}
+	}
+	return awsPostRemediationVerificationSource{
+		SourceType:        "aws_trust_policy_hardening",
+		SourceExecutionID: entry.ExecutionID,
+		DryRunID:          entry.DryRunID,
+		ApprovalID:        entry.ApprovalID,
+		CaseID:            entry.CaseID,
+		PlanID:            entry.PlanID,
+		SourceArtifactID:  entry.SourceArtifactID,
+		UpstreamState:     entry.State,
+		Severity:          entry.Severity,
+		Score:             entry.Score,
+		Confidence:        entry.Confidence,
+		Title:             entry.Title,
+		AccountID:         entry.AccountID,
+		Region:            entry.Region,
+		Operation:         entry.IntendedAPICall.Operation,
+		IdempotencyKey:    entry.IdempotencyKey,
+		TargetResource:    entry.IntendedAPICall.TargetResource,
+		ReadyForLiveApply: entry.ReadyForLiveApply,
+		KillSwitchEngaged: entry.KillSwitchEngaged,
+		SourceSignals:     entry.SourceSignals,
+		ImpactedNodes:     entry.ImpactedNodes,
+		AuditTrail:        entry.AuditTrail,
+		RollbackStrategy:  entry.RollbackPlan.Strategy,
+		RollbackSteps:     entry.RollbackPlan.Steps,
+		RollbackEvidence:  entry.RollbackPlan.EvidenceRef,
+		SuccessSignals:    entry.VerificationPlan.SuccessSignals,
+		FailureSignals:    entry.VerificationPlan.FailureSignals,
+		VerificationSteps: entry.VerificationPlan.Steps,
+		FailedPreconds:    failed,
+		CreatedAt:         entry.CreatedAt,
+	}
+}
+
+func awsPostRemediationVerificationFromBoundary(entry AWSPermissionBoundaryExecutorEntry) awsPostRemediationVerificationSource {
+	failed := 0
+	for _, gate := range entry.Preconditions {
+		if gate.Status == "blocked" {
+			failed++
+		}
+	}
+	return awsPostRemediationVerificationSource{
+		SourceType:        "aws_permission_boundary_executor",
+		SourceExecutionID: entry.ExecutionID,
+		DryRunID:          entry.DryRunID,
+		ApprovalID:        entry.ApprovalID,
+		CaseID:            entry.CaseID,
+		PlanID:            entry.PlanID,
+		SourceArtifactID:  entry.SourceArtifactID,
+		UpstreamState:     entry.State,
+		Severity:          entry.Severity,
+		Score:             entry.Score,
+		Confidence:        entry.Confidence,
+		Title:             entry.Title,
+		AccountID:         entry.AccountID,
+		Region:            entry.Region,
+		Operation:         entry.Operation,
+		IdempotencyKey:    entry.IdempotencyKey,
+		TargetResource:    entry.IntendedAPICall.TargetResource,
+		ReadyForLiveApply: entry.ReadyForLiveApply,
+		KillSwitchEngaged: entry.KillSwitchEngaged,
+		SourceSignals:     entry.SourceSignals,
+		ImpactedNodes:     entry.ImpactedNodes,
+		AuditTrail:        entry.AuditTrail,
+		RollbackStrategy:  entry.RollbackPlan.Strategy,
+		RollbackSteps:     entry.RollbackPlan.Steps,
+		RollbackEvidence:  entry.RollbackPlan.EvidenceRef,
+		SuccessSignals:    entry.VerificationPlan.SuccessSignals,
+		FailureSignals:    entry.VerificationPlan.FailureSignals,
+		VerificationSteps: entry.VerificationPlan.Steps,
+		FailedPreconds:    failed,
+		CreatedAt:         entry.CreatedAt,
+	}
+}
+
+func awsPostRemediationVerificationFromScp(entry AWSScpGuardrailExecutorEntry) awsPostRemediationVerificationSource {
+	failed := 0
+	for _, gate := range entry.Preconditions {
+		if gate.Status == "blocked" {
+			failed++
+		}
+	}
+	return awsPostRemediationVerificationSource{
+		SourceType:        "aws_scp_guardrail_executor",
+		SourceExecutionID: entry.ExecutionID,
+		DryRunID:          entry.DryRunID,
+		ApprovalID:        entry.ApprovalID,
+		CaseID:            entry.CaseID,
+		PlanID:            entry.PlanID,
+		SourceArtifactID:  entry.SourceArtifactID,
+		UpstreamState:     entry.State,
+		Severity:          entry.Severity,
+		Score:             entry.Score,
+		Confidence:        entry.Confidence,
+		Title:             entry.Title,
+		AccountID:         entry.AccountID,
+		Region:            entry.Region,
+		Operation:         entry.Operation,
+		IdempotencyKey:    entry.IdempotencyKey,
+		TargetResource:    entry.IntendedAPICall.TargetResource,
+		ReadyForLiveApply: entry.ReadyForLiveApply,
+		KillSwitchEngaged: entry.KillSwitchEngaged,
+		SourceSignals:     entry.SourceSignals,
+		ImpactedNodes:     entry.ImpactedNodes,
+		AuditTrail:        entry.AuditTrail,
+		RollbackStrategy:  entry.RollbackPlan.Strategy,
+		RollbackSteps:     entry.RollbackPlan.Steps,
+		RollbackEvidence:  entry.RollbackPlan.EvidenceRef,
+		SuccessSignals:    entry.VerificationPlan.SuccessSignals,
+		FailureSignals:    entry.VerificationPlan.FailureSignals,
+		VerificationSteps: entry.VerificationPlan.Steps,
+		FailedPreconds:    failed,
+		CreatedAt:         entry.CreatedAt,
+	}
+}
+
+func awsPostRemediationVerificationEntries(sources []awsPostRemediationVerificationSource, now time.Time) []AWSPostRemediationVerificationEntry {
+	entries := make([]AWSPostRemediationVerificationEntry, 0, len(sources))
+	for _, source := range sources {
+		entries = append(entries, awsPostRemediationVerificationEntryFromSource(source, now))
+	}
+	return entries
+}
+
+func awsPostRemediationVerificationEntryFromSource(source awsPostRemediationVerificationSource, now time.Time) AWSPostRemediationVerificationEntry {
+	preconditions := awsPostRemediationVerificationPreconditions(source)
+	checks := awsPostRemediationVerificationChecks(source)
+	rollback := awsPostRemediationVerificationRollbackRecord(source)
+	state := awsPostRemediationVerificationState(source, preconditions)
+	verificationID := "aws-post-remediation-verification:" + stableAWSBlastRadiusToken("verification", source.SourceType, source.SourceExecutionID)
+	return AWSPostRemediationVerificationEntry{
+		VerificationID:     verificationID,
+		CalculationVersion: awsPostRemediationVerificationVersion,
+		SourceType:         source.SourceType,
+		SourceExecutionID:  source.SourceExecutionID,
+		DryRunID:           source.DryRunID,
+		ApprovalID:         source.ApprovalID,
+		CaseID:             source.CaseID,
+		PlanID:             source.PlanID,
+		SourceArtifactID:   source.SourceArtifactID,
+		State:              state,
+		Severity:           source.Severity,
+		Score:              source.Score,
+		Confidence:         source.Confidence,
+		Title:              fmt.Sprintf("Post-remediation verification: %s", firstNonEmptyAWSValue(source.Title, source.SourceExecutionID)),
+		Summary:            awsPostRemediationVerificationSummaryText(source, state),
+		AccountID:          source.AccountID,
+		Region:             source.Region,
+		Operation:          source.Operation,
+		IdempotencyKey:     source.IdempotencyKey,
+		TargetResource:     source.TargetResource,
+		ReadyForLiveApply:  source.ReadyForLiveApply,
+		KillSwitchEngaged:  source.KillSwitchEngaged,
+		ReadOnlyProjection: true,
+		Preconditions:      preconditions,
+		Checks:             checks,
+		Rollback:           rollback,
+		AuditTrail:         awsPostRemediationVerificationAuditTrail(source, state, now),
+		SourceSignals:      dedupeStrings(append([]string{source.SourceType, "post_remediation_verification"}, source.SourceSignals...)),
+		EvidenceLinks:      awsPostRemediationVerificationEvidenceLinks(source),
+		EvidenceBoundary:   awsPostRemediationVerificationEvidenceBoundary(),
+		ImpactedNodes:      emptyStrings(dedupeStrings(source.ImpactedNodes)),
+		NextAction:         awsPostRemediationVerificationNextAction(state),
+		ProjectedAt:        now,
+		CreatedAt:          firstNonZeroAWSPostRemediationVerificationTime(source.CreatedAt, now),
+		UpdatedAt:          now,
+	}
+}
+
+func awsPostRemediationVerificationPreconditions(source awsPostRemediationVerificationSource) []AWSPostRemediationVerificationGate {
+	gates := []AWSPostRemediationVerificationGate{
+		{Name: "upstream_executor_projected", Status: awsPostRemediationVerificationGateStatus(source.UpstreamState == "projected"), Rationale: "Upstream executor must project the record before a verification/rollback contract is generated."},
+		{Name: "kill_switch_off", Status: awsPostRemediationVerificationGateStatus(!source.KillSwitchEngaged), Rationale: "Tenant-scoped remediation kill switch must be off before verification runs."},
+		{Name: "upstream_ready_for_live_apply", Status: awsPostRemediationVerificationGateStatus(source.ReadyForLiveApply), Rationale: "Upstream executor must declare ready_for_live_apply=true before verification begins."},
+		{Name: "idempotency_key_present", Status: awsPostRemediationVerificationGateStatus(strings.TrimSpace(source.IdempotencyKey) != ""), Rationale: "Deterministic idempotency key must be present so verification and rollback replay safely."},
+		{Name: "rollback_plan_present", Status: awsPostRemediationVerificationGateStatus(strings.TrimSpace(source.RollbackStrategy) != "" && len(source.RollbackSteps) > 0), Rationale: "Every verifiable execution must carry a rollback strategy and steps before it can be considered safe to apply."},
+		{Name: "verification_plan_present", Status: awsPostRemediationVerificationGateStatus(len(source.VerificationSteps) > 0), Rationale: "Every verifiable execution must carry deterministic verification steps."},
+	}
+	if source.FailedPreconds > 0 {
+		gates = append(gates, AWSPostRemediationVerificationGate{
+			Name:      "upstream_preconditions",
+			Status:    "blocked",
+			Rationale: fmt.Sprintf("Upstream executor still has %d failed precondition(s); resolve them before verification can advance.", source.FailedPreconds),
+		})
+	}
+	return gates
+}
+
+func awsPostRemediationVerificationGateStatus(ok bool) string {
+	if ok {
+		return awsPostRemediationVerificationCheckStatusPassed
+	}
+	return "blocked"
+}
+
+func awsPostRemediationVerificationChecks(source awsPostRemediationVerificationSource) []AWSPostRemediationVerificationCheck {
+	checks := []AWSPostRemediationVerificationCheck{
+		{Source: "cloudtrail", Signal: "expected_api_call_observed", Status: awsPostRemediationVerificationCheckStatusPending, Description: "After live execution, confirm the intended AWS API call appears in CloudTrail for the target account and region."},
+		{Source: "graph", Signal: "expected_state_matches", Status: awsPostRemediationVerificationCheckStatusPending, Description: "Re-normalize the impacted graph nodes and confirm they match the projected post-execution state."},
+		{Source: "runtime", Signal: "no_unexpected_denials_observed", Status: awsPostRemediationVerificationCheckStatusPending, Description: "Watch runtime denials for the affected principals for the configured settling window and confirm no unexpected denials appear."},
+	}
+	for _, signal := range dedupeStrings(source.SuccessSignals) {
+		checks = append(checks, AWSPostRemediationVerificationCheck{Source: "planner", Signal: signal, Status: awsPostRemediationVerificationCheckStatusPending, Description: "Confirm the upstream planner success signal after live execution."})
+	}
+	for _, signal := range dedupeStrings(source.FailureSignals) {
+		checks = append(checks, AWSPostRemediationVerificationCheck{Source: "planner", Signal: signal, Status: awsPostRemediationVerificationCheckStatusPending, Description: "Watch for the planner failure signal after live execution; treat as verification failure if observed."})
+	}
+	return checks
+}
+
+func awsPostRemediationVerificationRollbackRecord(source awsPostRemediationVerificationSource) AWSPostRemediationVerificationRollback {
+	strategy := strings.TrimSpace(source.RollbackStrategy)
+	steps := emptyStrings(source.RollbackSteps)
+	state := "ready"
+	rationale := "Rollback contract mirrors the upstream planner rollback plan and is ready to execute if verification fails."
+	if strategy == "" || len(steps) == 0 {
+		state = "not_available"
+		rationale = "Upstream planner did not carry a rollback plan; a verification failure requires manual recovery."
+	}
+	if source.KillSwitchEngaged {
+		state = "blocked_by_kill_switch"
+		rationale = "Tenant kill switch is engaged; rollback stays gated until the switch is disabled."
+	}
+	return AWSPostRemediationVerificationRollback{
+		Strategy:       strategy,
+		Steps:          steps,
+		SuccessSignals: dedupeStrings(source.SuccessSignals),
+		FailureSignals: dedupeStrings(source.FailureSignals),
+		EvidenceRef:    strings.TrimSpace(source.RollbackEvidence),
+		State:          state,
+		Rationale:      rationale,
+	}
+}
+
+func awsPostRemediationVerificationState(source awsPostRemediationVerificationSource, preconditions []AWSPostRemediationVerificationGate) string {
+	if source.KillSwitchEngaged {
+		return awsPostRemediationVerificationStateBlocked
+	}
+	for _, gate := range preconditions {
+		if gate.Status != "blocked" {
+			continue
+		}
+		if awsPostRemediationVerificationSafetyGate(gate.Name) {
+			return awsPostRemediationVerificationStateBlocked
+		}
+	}
+	if source.UpstreamState != "projected" || !source.ReadyForLiveApply {
+		return awsPostRemediationVerificationStateNotReady
+	}
+	if source.FailedPreconds > 0 {
+		return awsPostRemediationVerificationStateBlocked
+	}
+	return awsPostRemediationVerificationStatePending
+}
+
+func awsPostRemediationVerificationSafetyGate(name string) bool {
+	switch name {
+	case "kill_switch_off", "idempotency_key_present", "rollback_plan_present", "verification_plan_present":
+		return true
+	}
+	return false
+}
+
+func awsPostRemediationVerificationSummaryText(source awsPostRemediationVerificationSource, state string) string {
+	return fmt.Sprintf("Post-remediation verification contract for %s execution %s (state=%s); Identrail records verification checks, rollback intent, and audit only, and never calls AWS write APIs at this layer.", source.SourceType, source.SourceExecutionID, state)
+}
+
+func awsPostRemediationVerificationNextAction(state string) string {
+	switch state {
+	case awsPostRemediationVerificationStatePending:
+		return "Verification contract is projected; the wave-8 apply runtime records observed check outcomes and advances to verified or failed."
+	case awsPostRemediationVerificationStateVerified:
+		return "All verification checks passed; the execution is recorded as verified."
+	case awsPostRemediationVerificationStateFailed:
+		return "One or more verification checks failed; follow the rollback plan and refresh upstream evidence before retrying."
+	case awsPostRemediationVerificationStateRollback:
+		return "Verification failed; rollback plan is queued. Confirm rollback completes and re-run planner/dry-run before retrying."
+	case awsPostRemediationVerificationStateBlocked:
+		return "A safety gate or the tenant kill switch is blocking verification; satisfy the failing gate before retrying."
+	case awsPostRemediationVerificationStateSkipped:
+		return "Verification was skipped because the upstream executor did not project a live-apply record."
+	case awsPostRemediationVerificationStateNotReady:
+		return "Upstream executor has not projected ready_for_live_apply; verification cannot advance yet."
+	}
+	return "Inspect this entry for the projected next action."
+}
+
+func awsPostRemediationVerificationEvidenceLinks(source awsPostRemediationVerificationSource) []string {
+	links := []string{}
+	if ref := strings.TrimSpace(source.RollbackEvidence); ref != "" {
+		links = append(links, ref)
+	}
+	links = append(links, "/docs/aws-post-remediation-verification")
+	return dedupeStrings(links)
+}
+
+func awsPostRemediationVerificationAuditTrail(source awsPostRemediationVerificationSource, state string, now time.Time) []AWSPostRemediationVerificationAuditEntry {
+	trail := []AWSPostRemediationVerificationAuditEntry{}
+	trail = append(trail, source.AuditTrail...)
+	trail = append(trail, AWSPostRemediationVerificationAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("post-remediation-verification-projected", source.SourceType, source.SourceExecutionID),
+		Actor:      "identrail-post-remediation-verification-executor",
+		EventType:  "post_remediation_verification_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Source=%s execution=%s state=%s; Identrail did not call any AWS write API at this layer.", source.SourceType, source.SourceExecutionID, state),
+	})
+	return trail
+}
+
+func awsPostRemediationVerificationRelationships(entries []AWSPostRemediationVerificationEntry) []AWSPostRemediationVerificationRelationship {
+	relationships := []AWSPostRemediationVerificationRelationship{}
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.SourceExecutionID) == "" {
+			continue
+		}
+		relationships = append(relationships, AWSPostRemediationVerificationRelationship{
+			VerificationID: entry.VerificationID,
+			Type:           "verifies_execution",
+			FromNodeID:     entry.VerificationID,
+			ToNodeID:       entry.SourceExecutionID,
+			EvidenceRef:    firstString(entry.EvidenceLinks),
+		})
+		for _, node := range entry.ImpactedNodes {
+			if strings.TrimSpace(node) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSPostRemediationVerificationRelationship{
+				VerificationID: entry.VerificationID,
+				Type:           "verifies_impacted_node",
+				FromNodeID:     entry.VerificationID,
+				ToNodeID:       node,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSPostRemediationVerificationEntries(all, filtered []AWSPostRemediationVerificationEntry, relationships []AWSPostRemediationVerificationRelationship) AWSPostRemediationVerificationSummary {
+	summary := AWSPostRemediationVerificationSummary{
+		TotalEntries:     len(all),
+		FilteredEntries:  len(filtered),
+		StateCounts:      map[string]int{},
+		SourceTypeCounts: map[string]int{},
+		SeverityCounts:   map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.StateCounts[entry.State]++
+		if strings.TrimSpace(entry.SourceType) != "" {
+			summary.SourceTypeCounts[entry.SourceType]++
+		}
+		if strings.TrimSpace(entry.Severity) != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		switch entry.State {
+		case awsPostRemediationVerificationStateVerified:
+			summary.VerifiedCount++
+		case awsPostRemediationVerificationStatePending:
+			summary.PendingCount++
+		case awsPostRemediationVerificationStateFailed:
+			summary.FailedCount++
+		case awsPostRemediationVerificationStateRollback:
+			summary.RollbackPlannedCount++
+		case awsPostRemediationVerificationStateBlocked:
+			summary.BlockedCount++
+		}
+		for _, gate := range entry.Preconditions {
+			if gate.Status == "blocked" {
+				summary.FailedPreconditionCount++
+			}
+		}
+		summary.CheckCount += len(entry.Checks)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSPostRemediationVerificationEntries(entries []AWSPostRemediationVerificationEntry, request AWSPostRemediationVerificationRequest) ([]AWSPostRemediationVerificationEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":   strings.TrimSpace(request.AccountID),
+		"region":       strings.TrimSpace(request.Region),
+		"source_type":  strings.TrimSpace(strings.ToLower(request.SourceType)),
+		"execution_id": strings.TrimSpace(request.ExecutionID),
+		"dry_run_id":   strings.TrimSpace(request.DryRunID),
+		"case_id":      strings.TrimSpace(request.CaseID),
+		"state":        normalizeAWSRuntimeEventFilterToken(request.State),
+		"severity":     normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"operation":    normalizeAWSRuntimeEventFilterToken(request.Operation),
+		"search":       strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSPostRemediationVerificationEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(entry.AccountID)) {
+			continue
+		}
+		if filters["region"] != "" && strings.TrimSpace(entry.Region) != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(entry.Region)) {
+			continue
+		}
+		if filters["source_type"] != "" && !strings.EqualFold(filters["source_type"], entry.SourceType) {
+			continue
+		}
+		if filters["execution_id"] != "" && !strings.EqualFold(filters["execution_id"], entry.SourceExecutionID) && !strings.EqualFold(filters["execution_id"], entry.VerificationID) {
+			continue
+		}
+		if filters["dry_run_id"] != "" && !strings.EqualFold(filters["dry_run_id"], entry.DryRunID) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if filters["state"] != "" && filters["state"] != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["operation"] != "" && filters["operation"] != normalizeAWSRuntimeEventFilterToken(entry.Operation) {
+			continue
+		}
+		if filters["search"] != "" && !awsPostRemediationVerificationSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsPostRemediationVerificationSearchMatch(entry AWSPostRemediationVerificationEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.VerificationID, entry.SourceExecutionID, entry.DryRunID, entry.ApprovalID, entry.CaseID,
+		entry.PlanID, entry.SourceArtifactID, entry.SourceType, entry.State, entry.Severity, entry.Title,
+		entry.Summary, entry.Operation, entry.IdempotencyKey, entry.TargetResource, entry.NextAction,
+		entry.Rollback.Strategy, entry.Rollback.State, entry.Rollback.Rationale, entry.Rollback.EvidenceRef,
+	}
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.ImpactedNodes...)
+	values = append(values, entry.EvidenceLinks...)
+	values = append(values, entry.Rollback.Steps...)
+	values = append(values, entry.Rollback.SuccessSignals...)
+	values = append(values, entry.Rollback.FailureSignals...)
+	for _, gate := range entry.Preconditions {
+		values = append(values, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, check := range entry.Checks {
+		values = append(values, check.Source, check.Signal, check.Status, check.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSPostRemediationVerificationStatus(upstreamStatus string, filtered []AWSPostRemediationVerificationEntry, diagnostics []AWSPostRemediationVerificationDiagnostic) (string, float64) {
+	if upstreamStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if upstreamStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsPostRemediationVerificationCaveats() []string {
+	return []string{
+		"Post-remediation verification entries are read-only projections; Identrail never calls IAM, STS, or Organizations write APIs at this layer.",
+		"Verification checks stay in the `pending` state until the wave-8 apply runtime writes the observed outcome. This endpoint does not observe live AWS behavior itself.",
+		"Rollback records mirror the upstream planner metadata; they never contain rendered policy bodies or secret values.",
+	}
+}
+
+func awsPostRemediationVerificationRemediationHints(source []string) []string {
+	hints := []string{
+		"Resolve any failed upstream precondition before verification can advance; upstream dry-run and executor entries own those gates.",
+		"Use the idempotency key recorded here so verification and rollback replay against the same AWS write intent.",
+		"If any verification check fails, follow the rollback record and refresh planner evidence before retrying.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsPostRemediationVerificationEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSPostRemediationVerificationTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_post_remediation_verification.go
+++ b/internal/api/aws_post_remediation_verification.go
@@ -109,6 +109,7 @@ type AWSPostRemediationVerificationEntry struct {
 	Title              string                                     `json:"title"`
 	Summary            string                                     `json:"summary"`
 	AccountID          string                                     `json:"account_id,omitempty"`
+	TargetAccountIDs   []string                                   `json:"target_account_ids,omitempty"`
 	Region             string                                     `json:"region,omitempty"`
 	Operation          string                                     `json:"operation,omitempty"`
 	IdempotencyKey     string                                     `json:"idempotency_key,omitempty"`
@@ -199,6 +200,7 @@ type awsPostRemediationVerificationSource struct {
 	Confidence        float64
 	Title             string
 	AccountID         string
+	TargetAccountIDs  []string
 	Region            string
 	Operation         string
 	IdempotencyKey    string
@@ -519,6 +521,7 @@ func awsPostRemediationVerificationFromBoundary(entry AWSPermissionBoundaryExecu
 		Confidence:        entry.Confidence,
 		Title:             entry.Title,
 		AccountID:         entry.AccountID,
+		TargetAccountIDs:  entry.TargetAccountIDs,
 		Region:            entry.Region,
 		Operation:         entry.Operation,
 		IdempotencyKey:    entry.IdempotencyKey,
@@ -560,6 +563,7 @@ func awsPostRemediationVerificationFromScp(entry AWSScpGuardrailExecutorEntry) a
 		Confidence:        entry.Confidence,
 		Title:             entry.Title,
 		AccountID:         entry.AccountID,
+		TargetAccountIDs:  entry.TargetAccountIDs,
 		Region:            entry.Region,
 		Operation:         entry.Operation,
 		IdempotencyKey:    entry.IdempotencyKey,
@@ -611,6 +615,7 @@ func awsPostRemediationVerificationEntryFromSource(source awsPostRemediationVeri
 		Title:              fmt.Sprintf("Post-remediation verification: %s", firstNonEmptyAWSValue(source.Title, source.SourceExecutionID)),
 		Summary:            awsPostRemediationVerificationSummaryText(source, state),
 		AccountID:          source.AccountID,
+		TargetAccountIDs:   emptyStrings(dedupeStrings(source.TargetAccountIDs)),
 		Region:             source.Region,
 		Operation:          source.Operation,
 		IdempotencyKey:     source.IdempotencyKey,
@@ -710,11 +715,21 @@ func awsPostRemediationVerificationState(source awsPostRemediationVerificationSo
 			return awsPostRemediationVerificationStateBlocked
 		}
 	}
-	if source.UpstreamState != "projected" || !source.ReadyForLiveApply {
-		return awsPostRemediationVerificationStateNotReady
+	// Classify explicit upstream terminal states before the generic
+	// not-ready fallback so `blocked`, `skipped`, and any failed upstream
+	// precondition surface as their own verification states rather than
+	// collapsing to `not_ready`.
+	switch strings.ToLower(strings.TrimSpace(source.UpstreamState)) {
+	case "blocked":
+		return awsPostRemediationVerificationStateBlocked
+	case "skipped":
+		return awsPostRemediationVerificationStateSkipped
 	}
 	if source.FailedPreconds > 0 {
 		return awsPostRemediationVerificationStateBlocked
+	}
+	if source.UpstreamState != "projected" || !source.ReadyForLiveApply {
+		return awsPostRemediationVerificationStateNotReady
 	}
 	return awsPostRemediationVerificationStatePending
 }
@@ -875,7 +890,7 @@ func filterAWSPostRemediationVerificationEntries(entries []AWSPostRemediationVer
 	}
 	filtered := make([]AWSPostRemediationVerificationEntry, 0, len(entries))
 	for _, entry := range entries {
-		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(entry.AccountID)) {
+		if filters["account_id"] != "" && !awsPostRemediationVerificationAccountMatch(entry, filters["account_id"]) {
 			continue
 		}
 		if filters["region"] != "" && strings.TrimSpace(entry.Region) != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(entry.Region)) {
@@ -910,6 +925,22 @@ func filterAWSPostRemediationVerificationEntries(entries []AWSPostRemediationVer
 	return filtered, applied
 }
 
+func awsPostRemediationVerificationAccountMatch(entry AWSPostRemediationVerificationEntry, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(entry.AccountID), accountID) {
+		return true
+	}
+	for _, target := range entry.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), accountID) {
+			return true
+		}
+	}
+	return false
+}
+
 func awsPostRemediationVerificationSearchMatch(entry AWSPostRemediationVerificationEntry, needle string) bool {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
@@ -923,6 +954,7 @@ func awsPostRemediationVerificationSearchMatch(entry AWSPostRemediationVerificat
 	}
 	values = append(values, entry.SourceSignals...)
 	values = append(values, entry.ImpactedNodes...)
+	values = append(values, entry.TargetAccountIDs...)
 	values = append(values, entry.EvidenceLinks...)
 	values = append(values, entry.Rollback.Steps...)
 	values = append(values, entry.Rollback.SuccessSignals...)

--- a/internal/api/aws_post_remediation_verification_test.go
+++ b/internal/api/aws_post_remediation_verification_test.go
@@ -143,6 +143,64 @@ func TestAWSPostRemediationVerificationStateHonorsGates(t *testing.T) {
 	if entry.State != awsPostRemediationVerificationStateBlocked {
 		t.Fatalf("upstream failed preconds must block verification: %+v", entry)
 	}
+
+	failedNotReady := baseSource
+	failedNotReady.UpstreamState = "precondition_failed"
+	failedNotReady.ReadyForLiveApply = false
+	failedNotReady.FailedPreconds = 3
+	if got := awsPostRemediationVerificationEntryFromSource(failedNotReady, now); got.State != awsPostRemediationVerificationStateBlocked {
+		t.Fatalf("failed upstream preconds must classify as blocked even when the source is also not ready: %+v", got)
+	}
+
+	upstreamBlocked := baseSource
+	upstreamBlocked.UpstreamState = "blocked"
+	upstreamBlocked.ReadyForLiveApply = false
+	if got := awsPostRemediationVerificationEntryFromSource(upstreamBlocked, now); got.State != awsPostRemediationVerificationStateBlocked {
+		t.Fatalf("upstream blocked state must surface as blocked, not not_ready: %+v", got)
+	}
+
+	upstreamSkipped := baseSource
+	upstreamSkipped.UpstreamState = "skipped"
+	upstreamSkipped.ReadyForLiveApply = false
+	if got := awsPostRemediationVerificationEntryFromSource(upstreamSkipped, now); got.State != awsPostRemediationVerificationStateSkipped {
+		t.Fatalf("upstream skipped state must surface as skipped, not not_ready: %+v", got)
+	}
+}
+
+func TestFilterAWSPostRemediationVerificationEntriesMatchesTargetAccounts(t *testing.T) {
+	entries := []AWSPostRemediationVerificationEntry{
+		{
+			VerificationID:    "v-boundary-multi-account",
+			SourceType:        "aws_permission_boundary_executor",
+			SourceExecutionID: "exec-boundary",
+			AccountID:         "111111111111",
+			TargetAccountIDs:  []string{"222222222222", "333333333333"},
+			State:             awsPostRemediationVerificationStatePending,
+		},
+		{
+			VerificationID:    "v-scp-account",
+			SourceType:        "aws_scp_guardrail_executor",
+			SourceExecutionID: "exec-scp",
+			AccountID:         "444444444444",
+			TargetAccountIDs:  []string{"555555555555"},
+			State:             awsPostRemediationVerificationStatePending,
+		},
+	}
+
+	filtered, applied := filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{AccountID: "333333333333"})
+	if applied["account_id"] != "333333333333" || len(filtered) != 1 || filtered[0].VerificationID != "v-boundary-multi-account" {
+		t.Fatalf("account_id filter must match target_account_ids on the entry, not just the connector account: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{AccountID: "555555555555"})
+	if len(filtered) != 1 || filtered[0].VerificationID != "v-scp-account" {
+		t.Fatalf("account_id filter must match SCP target accounts: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{AccountID: "111111111111"})
+	if len(filtered) != 1 || filtered[0].VerificationID != "v-boundary-multi-account" {
+		t.Fatalf("account_id filter must still match the primary AccountID: %+v", filtered)
+	}
 }
 
 func TestFilterAWSPostRemediationVerificationEntries(t *testing.T) {

--- a/internal/api/aws_post_remediation_verification_test.go
+++ b/internal/api/aws_post_remediation_verification_test.go
@@ -1,0 +1,250 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newPostRemediationVerificationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSPostRemediationVerificationBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	svc, ws := newPostRemediationVerificationService(t, "project-post-remediation-verification", now)
+
+	result, err := svc.GetAWSPostRemediationVerification(defaultScopeContext(), ws, "project-post-remediation-verification", AWSPostRemediationVerificationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get post-remediation verification: %v", err)
+	}
+	if result.CurrentIssueRef != "#1542" || result.Version != awsPostRemediationVerificationVersion || result.CalculationVersion != awsPostRemediationVerificationVersion {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.ParentIssueRef != awsIssueRef(awsPlatformDependencyParentIssue) {
+		t.Fatalf("expected parent epic ref: %+v", result)
+	}
+	if len(result.Entries) == 0 {
+		t.Fatalf("expected post-remediation verification entries to project from upstream executors: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: summary=%+v relationships=%+v", result.Summary, result.Relationships)
+	}
+	if len(result.Caveats) == 0 || len(result.EvidenceLinks) == 0 {
+		t.Fatalf("expected caveats and evidence links: %+v", result)
+	}
+	seenSources := map[string]bool{}
+	for _, entry := range result.Entries {
+		if entry.VerificationID == "" || entry.CalculationVersion != awsPostRemediationVerificationVersion {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.SourceType == "" || entry.SourceExecutionID == "" {
+			t.Fatalf("entry missing upstream identifiers: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection {
+			t.Fatalf("entry must remain a read-only projection: %+v", entry)
+		}
+		if len(entry.Preconditions) == 0 || len(entry.Checks) == 0 {
+			t.Fatalf("entry missing preconditions or checks: %+v", entry)
+		}
+		if entry.EvidenceBoundary != awsPostRemediationVerificationEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		switch entry.State {
+		case awsPostRemediationVerificationStatePending, awsPostRemediationVerificationStateVerified, awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateRollback, awsPostRemediationVerificationStateBlocked, awsPostRemediationVerificationStateSkipped, awsPostRemediationVerificationStateNotReady:
+		default:
+			t.Fatalf("entry has unknown state: %+v", entry)
+		}
+		for _, check := range entry.Checks {
+			if check.Status != awsPostRemediationVerificationCheckStatusPending {
+				t.Fatalf("projected checks must stay pending until the apply runtime records outcomes: %+v", check)
+			}
+		}
+		seenSources[entry.SourceType] = true
+	}
+	if !seenSources["aws_permission_boundary_executor"] || !seenSources["aws_scp_guardrail_executor"] || !seenSources["aws_trust_policy_hardening"] {
+		t.Fatalf("expected upstream executors to contribute records at scale: %+v", result.Summary.SourceTypeCounts)
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("post-remediation verification serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSPostRemediationVerificationStateHonorsGates(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 15, 0, 0, time.UTC)
+	baseSource := awsPostRemediationVerificationSource{
+		SourceType:        "aws_permission_boundary_executor",
+		SourceExecutionID: "exec-boundary-1",
+		DryRunID:          "dr-1",
+		CaseID:            "case-1",
+		UpstreamState:     "projected",
+		ReadyForLiveApply: true,
+		IdempotencyKey:    "idk",
+		RollbackStrategy:  "restore_permission_boundary",
+		RollbackSteps:     []string{"Restore prior permission boundary"},
+		VerificationSteps: []string{"Re-run IAM policy simulator"},
+	}
+
+	entry := awsPostRemediationVerificationEntryFromSource(baseSource, now)
+	if entry.State != awsPostRemediationVerificationStatePending {
+		t.Fatalf("projected+ready source should yield verification_pending, got %s", entry.State)
+	}
+	if entry.Rollback.State != "ready" {
+		t.Fatalf("healthy rollback should be ready: %+v", entry.Rollback)
+	}
+
+	killed := baseSource
+	killed.KillSwitchEngaged = true
+	if got := awsPostRemediationVerificationEntryFromSource(killed, now); got.State != awsPostRemediationVerificationStateBlocked {
+		t.Fatalf("kill switch must block verification: %+v", got)
+	}
+	if got := awsPostRemediationVerificationEntryFromSource(killed, now).Rollback.State; got != "blocked_by_kill_switch" {
+		t.Fatalf("kill switch must gate rollback: %s", got)
+	}
+
+	notReady := baseSource
+	notReady.UpstreamState = "precondition_failed"
+	notReady.ReadyForLiveApply = false
+	if got := awsPostRemediationVerificationEntryFromSource(notReady, now); got.State != awsPostRemediationVerificationStateNotReady {
+		t.Fatalf("upstream not ready must yield not_ready state: %+v", got)
+	}
+
+	noRollback := baseSource
+	noRollback.RollbackStrategy = ""
+	noRollback.RollbackSteps = nil
+	entry = awsPostRemediationVerificationEntryFromSource(noRollback, now)
+	if entry.State != awsPostRemediationVerificationStateBlocked {
+		t.Fatalf("missing rollback plan must block verification: %+v", entry)
+	}
+	if entry.Rollback.State != "not_available" {
+		t.Fatalf("missing rollback plan must surface not_available state: %+v", entry.Rollback)
+	}
+
+	failedUpstream := baseSource
+	failedUpstream.FailedPreconds = 2
+	entry = awsPostRemediationVerificationEntryFromSource(failedUpstream, now)
+	if entry.State != awsPostRemediationVerificationStateBlocked {
+		t.Fatalf("upstream failed preconds must block verification: %+v", entry)
+	}
+}
+
+func TestFilterAWSPostRemediationVerificationEntries(t *testing.T) {
+	entries := []AWSPostRemediationVerificationEntry{
+		{
+			VerificationID:    "v1",
+			SourceType:        "aws_permission_boundary_executor",
+			SourceExecutionID: "exec-a",
+			DryRunID:          "dr-1",
+			CaseID:            "case-1",
+			State:             awsPostRemediationVerificationStatePending,
+			Severity:          "high",
+			Operation:         "PutRolePermissionsBoundary",
+			AccountID:         "111111111111",
+			Region:            "us-east-1",
+		},
+		{
+			VerificationID:    "v2",
+			SourceType:        "aws_scp_guardrail_executor",
+			SourceExecutionID: "exec-b",
+			DryRunID:          "dr-2",
+			CaseID:            "case-2",
+			State:             awsPostRemediationVerificationStateBlocked,
+			Severity:          "medium",
+			Operation:         "AttachPolicy",
+			AccountID:         "222222222222",
+			Region:            "us-west-2",
+			Rollback:          AWSPostRemediationVerificationRollback{Strategy: "restore_scp"},
+		},
+	}
+
+	filtered, applied := filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{SourceType: "aws_scp_guardrail_executor"})
+	if applied["source_type"] != "aws_scp_guardrail_executor" || len(filtered) != 1 || filtered[0].VerificationID != "v2" {
+		t.Fatalf("source_type filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{AccountID: "111111111111"})
+	if len(filtered) != 1 || filtered[0].AccountID != "111111111111" {
+		t.Fatalf("account_id filter did not scope entries: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{ExecutionID: "exec-a"})
+	if len(filtered) != 1 || filtered[0].VerificationID != "v1" {
+		t.Fatalf("execution_id filter must match upstream source execution: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{Search: "restore_scp"})
+	if len(filtered) != 1 || filtered[0].VerificationID != "v2" {
+		t.Fatalf("search must reach rollback metadata: %+v", filtered)
+	}
+
+	filtered, applied = filterAWSPostRemediationVerificationEntries(entries, AWSPostRemediationVerificationRequest{State: "verification_pending"})
+	if applied["state"] != normalizeAWSRuntimeEventFilterToken("verification_pending") || len(filtered) != 1 || filtered[0].VerificationID != "v1" {
+		t.Fatalf("state filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+}
+
+func TestAWSPostRemediationVerificationFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 45, 0, 0, time.UTC)
+	svc, ws := newPostRemediationVerificationService(t, "project-post-remediation-verification-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSPostRemediationVerification(defaultScopeContext(), ws, "project-post-remediation-verification-fixture", AWSPostRemediationVerificationRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestRouterAWSPostRemediationVerification(t *testing.T) {
+	now := time.Date(2026, 7, 1, 13, 0, 0, 0, time.UTC)
+	svc, _ := newPostRemediationVerificationService(t, "project-post-remediation-verification-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-post-remediation-verification-route/aws/post-remediation-verification?connector_id=aws-prod&fixture_state=success&source_type=aws_scp_guardrail_executor", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Executor AWSPostRemediationVerificationResult `json:"post_remediation_verification"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Executor.CurrentIssueRef != "#1542" {
+		t.Fatalf("unexpected route payload: %+v", body.Executor)
+	}
+	if body.Executor.AppliedFilters["source_type"] != "aws_scp_guardrail_executor" {
+		t.Fatalf("expected route to apply source_type filter: %+v", body.Executor.AppliedFilters)
+	}
+	for _, entry := range body.Executor.Entries {
+		if entry.SourceType != "aws_scp_guardrail_executor" {
+			t.Fatalf("source_type filter returned wrong entry: %+v", entry)
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3276,6 +3276,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"scp_guardrail_executor": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPostRemediationVerification(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPostRemediationVerificationRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			SourceType:   strings.TrimSpace(c.Query("source_type")),
+			ExecutionID:  strings.TrimSpace(c.Query("execution_id")),
+			DryRunID:     strings.TrimSpace(c.Query("dry_run_id")),
+			CaseID:       strings.TrimSpace(c.Query("case_id")),
+			State:        strings.TrimSpace(c.Query("state")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Operation:    strings.TrimSpace(c.Query("operation")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws post-remediation verification request"})
+			default:
+				logger.Error("get aws post-remediation verification",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws post-remediation verification"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"post_remediation_verification": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3802,6 +3802,7 @@ export type AWSPostRemediationVerificationEntry = {
   title: string;
   summary: string;
   account_id?: string;
+  target_account_ids?: string[];
   region?: string;
   operation?: string;
   idempotency_key?: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3736,6 +3736,157 @@ export type AWSScpGuardrailExecutorQuery = {
   search?: string;
 };
 
+export type AWSPostRemediationVerificationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSPostRemediationVerificationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSPostRemediationVerificationState =
+  | 'verification_pending'
+  | 'verification_verified'
+  | 'verification_failed'
+  | 'rollback_planned'
+  | 'skipped'
+  | 'blocked'
+  | 'not_ready'
+  | string;
+export type AWSPostRemediationVerificationSourceType =
+  | 'aws_low_risk_live_remediation'
+  | 'aws_trust_policy_hardening'
+  | 'aws_permission_boundary_executor'
+  | 'aws_scp_guardrail_executor'
+  | string;
+
+export type AWSPostRemediationVerificationGate = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSPostRemediationVerificationCheck = {
+  source: string;
+  signal: string;
+  status: 'pending' | 'passed' | 'failed' | string;
+  description: string;
+};
+
+export type AWSPostRemediationVerificationRollback = {
+  strategy: string;
+  steps: string[];
+  success_signals?: string[];
+  failure_signals?: string[];
+  evidence_ref?: string;
+  state: string;
+  rationale: string;
+};
+
+export type AWSPostRemediationVerificationRelationship = {
+  verification_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSPostRemediationVerificationEntry = {
+  verification_id: string;
+  calculation_version: string;
+  source_type: AWSPostRemediationVerificationSourceType;
+  source_execution_id: string;
+  dry_run_id: string;
+  approval_id: string;
+  case_id: string;
+  plan_id?: string;
+  source_artifact_id?: string;
+  state: AWSPostRemediationVerificationState;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  account_id?: string;
+  region?: string;
+  operation?: string;
+  idempotency_key?: string;
+  target_resource?: string;
+  ready_for_live_apply: boolean;
+  kill_switch_engaged: boolean;
+  read_only_projection: boolean;
+  preconditions: AWSPostRemediationVerificationGate[];
+  checks: AWSPostRemediationVerificationCheck[];
+  rollback: AWSPostRemediationVerificationRollback;
+  audit_trail: AWSRemediationAuditEntry[];
+  source_signals: string[];
+  evidence_links: string[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSPostRemediationVerificationSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  state_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  verified_count: number;
+  pending_count: number;
+  failed_count: number;
+  rollback_planned_count: number;
+  blocked_count: number;
+  kill_switch_engaged_count: number;
+  failed_precondition_count: number;
+  check_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSPostRemediationVerificationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSPostRemediationVerificationStatus;
+  fixture_state?: AWSPostRemediationVerificationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSPostRemediationVerificationSummary;
+  entries: AWSPostRemediationVerificationEntry[];
+  relationships: AWSPostRemediationVerificationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSPostRemediationVerificationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSPostRemediationVerificationFixtureState;
+  accountID?: string;
+  region?: string;
+  sourceType?: string;
+  executionID?: string;
+  dryRunID?: string;
+  caseID?: string;
+  state?: string;
+  severity?: string;
+  operation?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -9017,6 +9168,30 @@ export const apiClient = {
         target_scope: query?.targetScope,
         state: query?.state,
         severity: query?.severity,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectPostRemediationVerification(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSPostRemediationVerificationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ post_remediation_verification: AWSPostRemediationVerificationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/post-remediation-verification${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        source_type: query?.sourceType,
+        execution_id: query?.executionID,
+        dry_run_id: query?.dryRunID,
+        case_id: query?.caseID,
+        state: query?.state,
+        severity: query?.severity,
+        operation: query?.operation,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4032,6 +4032,38 @@ describe('Domain-first app routes', () => {
 	        diagnostics: []
 	      } as any
 	    });
+	    const getPostRemediationVerification = vi.spyOn(api.apiClient, 'getAWSProjectPostRemediationVerification').mockResolvedValue({
+	      post_remediation_verification: {
+	        status: 'ready',
+	        entries: [],
+	        relationships: [],
+	        applied_filters: {},
+	        summary: {
+	          total_entries: 0,
+	          filtered_entries: 0,
+	          state_counts: {},
+	          source_type_counts: {},
+	          severity_counts: {},
+	          verified_count: 0,
+	          pending_count: 0,
+	          failed_count: 0,
+	          rollback_planned_count: 0,
+	          blocked_count: 0,
+	          kill_switch_engaged_count: 0,
+	          failed_precondition_count: 0,
+	          check_count: 0,
+	          relationship_count: 0,
+	          highest_score: 0,
+	          average_confidence_pct: 0
+	        },
+	        caveats: ['Post-remediation verification entries are read-only projections.'],
+	        failure_reasons: [],
+	        remediation_hints: [],
+	        evidence_links: [],
+	        coverage_gaps: [],
+	        diagnostics: []
+	      } as any
+	    });
 	    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
@@ -4693,6 +4725,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getScpGuardrailExecutor).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getPostRemediationVerification).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -81,6 +81,8 @@ import {
   type AWSPermissionBoundaryExecutorResult,
   type AWSScpGuardrailExecutorEntry,
   type AWSScpGuardrailExecutorResult,
+  type AWSPostRemediationVerificationEntry,
+  type AWSPostRemediationVerificationResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11303,6 +11305,77 @@ function AWSScpGuardrailExecutorContent({
   );
 }
 
+function awsPostRemediationVerificationStage(entry: AWSPostRemediationVerificationEntry): AWSCapabilityStage {
+  if (entry.kill_switch_engaged || entry.state === 'blocked' || entry.state === 'verification_failed') {
+    return 'not-available';
+  }
+  if (entry.state === 'verification_verified') {
+    return 'wired';
+  }
+  return 'coming';
+}
+
+function awsPostRemediationVerificationChecksLabel(entry: AWSPostRemediationVerificationEntry): string {
+  const passed = entry.checks.filter((check) => check.status === 'passed').length;
+  const failed = entry.checks.filter((check) => check.status === 'failed').length;
+  const pending = entry.checks.length - passed - failed;
+  return `${passed} passed · ${failed} failed · ${pending} pending`;
+}
+
+function awsPostRemediationVerificationRollbackLabel(entry: AWSPostRemediationVerificationEntry): string {
+  const strategy = entry.rollback.strategy ? formatTokenLabel(entry.rollback.strategy) : 'none';
+  return `${strategy} · ${formatTokenLabel(entry.rollback.state)}`;
+}
+
+function AWSPostRemediationVerificationContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSPostRemediationVerificationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.pending_count} pending · ${result.summary.verified_count} verified · ${result.summary.failed_count} failed · ${result.summary.rollback_planned_count} rollbacks · ${result.summary.blocked_count} blocked`
+    : '';
+  return (
+    <AWSExecutorProjectionPanel
+      result={result}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS post-remediation verification and rollback"
+      heading="AWS post-remediation verification and rollback"
+      description={`Read-only projection that joins every approved wave-8 executor with the deterministic verification and rollback contract Identrail records before any live apply. Each entry captures precondition gates, check statuses, rollback intent, and audit rows. Identrail never calls IAM, STS, or Organizations write APIs at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS post-remediation verification"
+      loadingTitle="Projecting post-remediation verification"
+      loadingBody="Identrail is joining every approved executor with its verification and rollback contract."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No post-remediation verification entries')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Post-remediation verification needs approved executor evidence' : 'No post-remediation verification entries projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No upstream executor projected an approved execution for this environment.'}
+      tableLabel="AWS post-remediation verification entries"
+      getRowKey={(row) => row.verification_id}
+      columns={[
+        { key: 'verification', header: 'Verification', render: (row) => <strong>{row.title}</strong> },
+        { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+        { key: 'checks', header: 'Checks', render: (row) => awsPostRemediationVerificationChecksLabel(row) },
+        { key: 'rollback', header: 'Rollback', render: (row) => awsPostRemediationVerificationRollbackLabel(row) },
+        { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsPostRemediationVerificationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.state)}`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13527,6 +13600,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [scpGuardrailExecutorLoading, setScpGuardrailExecutorLoading] = useState(false);
   const [scpGuardrailExecutorError, setScpGuardrailExecutorError] = useState('');
   const scpGuardrailExecutorRequestRef = useRef(0);
+  const [postRemediationVerification, setPostRemediationVerification] = useState<AWSPostRemediationVerificationResult | null>(null);
+  const [postRemediationVerificationLoading, setPostRemediationVerificationLoading] = useState(false);
+  const [postRemediationVerificationError, setPostRemediationVerificationError] = useState('');
+  const postRemediationVerificationRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -14127,6 +14204,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       scpGuardrailExecutorRequestRef.current += 1;
     };
   }, [loadScpGuardrailExecutor]);
+
+  const loadPostRemediationVerification = useCallback(async () => {
+    const requestID = ++postRemediationVerificationRequestRef.current;
+    setPostRemediationVerification(null);
+    setPostRemediationVerificationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setPostRemediationVerificationLoading(false);
+      return;
+    }
+    setPostRemediationVerificationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectPostRemediationVerification(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== postRemediationVerificationRequestRef.current) {
+        return;
+      }
+      setPostRemediationVerification(response.post_remediation_verification);
+    } catch (error) {
+      if (requestID !== postRemediationVerificationRequestRef.current) {
+        return;
+      }
+      setPostRemediationVerificationError(formatAPIError(error, 'Unable to load AWS post-remediation verification.'));
+    } finally {
+      if (requestID === postRemediationVerificationRequestRef.current) {
+        setPostRemediationVerificationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadPostRemediationVerification();
+    return () => {
+      postRemediationVerificationRequestRef.current += 1;
+    };
+  }, [loadPostRemediationVerification]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -14982,6 +15107,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={scpGuardrailExecutorLoading}
             error={scpGuardrailExecutorError}
             onRetry={loadScpGuardrailExecutor}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSPostRemediationVerificationContent
+            result={postRemediationVerification}
+            loading={postRemediationVerificationLoading}
+            error={postRemediationVerificationError}
+            onRetry={loadPostRemediationVerification}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- implement AWS post-remediation verification and rollback for issue #1542
- project deterministic verification checks, rollback intent, precondition gates, and audit rows for every approved wave-8 executor (low-risk live remediation #1538, trust-policy hardening executor #1539, permission boundary executor #1540, SCP guardrail executor #1541)
- wire the endpoint into API routing, authz, OpenAPI, docs, CHANGELOG, and the AWS Runtime app surface
- keep the layer strictly metadata-only: no IAM, STS, or Organizations write API calls; no rendered policy bodies or secret values

## Validation
- go test ./...
- make fmt-check && make vet
- ./scripts/check_api_example_contract.sh && ./scripts/check_web_route_integrity.sh
- npm test --prefix web -- --run (455 passing)
- npm run build --prefix web

## AI disclosure
AI-assisted: no

Closes #1542

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS post-remediation verification and rollback projection that joins all approved wave‑8 executors, per issue #1542. Provides a single API and UI panel to track deterministic checks, rollback intent, and safety gates before any live apply.

- **New Features**
  - New endpoint: `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification` with filters for `connector_id`, `fixture_state`, `account_id`, `region`, `source_type`, `execution_id`, `dry_run_id`, `case_id`, `state`, `severity`, `operation`, `search`.
  - Projects verification checks (CloudTrail/API observed, graph re-check, runtime denial watch, planner signals), rollback record, precondition gates, and immutable audit rows. States: `verification_pending`, `verification_verified`, `verification_failed`, `rollback_planned`, `blocked`, `not_ready`, `skipped`.
  - Metadata-only layer; OpenAPI v1 schemas, docs, and route authorized under project `tenancy.read`.
  - Web: typed client `apiClient.getAWSProjectPostRemediationVerification`; AWS Runtime page shows an “AWS post-remediation verification and rollback” panel with check pass/fail/pending counts, rollback strategy/state, severity, and a state pill.

- **Bug Fixes**
  - Preserve upstream `blocked` and `skipped` states by classifying them before `not_ready`; failed upstream preconditions now surface as `blocked`.
  - Match `account_id` against both the primary account and per-target accounts (projected from permission-boundary and SCP executors) so queries by target return affected executions.

<sup>Written for commit 4075ea2005cd73d6759dfb5ecc326f6324950872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

