### PR TITLE
Implement AWS advisory authorization decision API (#1543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
   execution as `warn`, and everything else as `allow` with advisory
   monitoring. Adds
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization`
-  with filters for connector, account, region, principal, action,
-  outcome, severity, source type, case ID, verification ID, and
-  free-text search. OpenAPI schemas and authz wiring follow the
+  with filters for connector, fixture state, account, region,
+  principal, action, outcome, severity, source type, case ID,
+  verification ID, and free-text search. OpenAPI schemas and authz wiring follow the
   neighboring wave-8 endpoints. The AWS Runtime app surface now shows
   an **AWS advisory authorization** panel with the decision title,
   outcome pill, policy rule, principal, action, severity, and next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   (`allow`|`warn`|`require_approval`|`recommend_deny`|`quarantine`),
   the principal node ID/ARN/type, the projected AWS API action and
   resource scope, a deterministic input hash (case ID, lifecycle,
-  approval state, verification state, policy version), provenance
+  approval state, approval requirement, severity, verification state,
+  kill-switch state, policy version), provenance
   (policy version and rule name), evidence refs, an audit trail, and a
   next-action string. Policy ordering makes safety signals win over
   approval state: kill-switch and verification-failed always classify
@@ -19,10 +20,10 @@
   execution as `warn`, and everything else as `allow` with advisory
   monitoring. Adds
   `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization`
-  with filters for connector, fixture state, account, region,
-  principal, action, outcome, severity, source type, case ID,
-  verification ID, and free-text search. OpenAPI schemas and authz wiring follow the
-  neighboring wave-8 endpoints. The AWS Runtime app surface now shows
+  with filters for `connector_id`, `fixture_state`, `account_id`, `region`,
+  `principal_id`, `action`, `outcome`, `severity`, `source_type`, `case_id`,
+  `verification_id`, and `search`. OpenAPI schemas and authz wiring follow
+  the neighboring wave-8 endpoints. The AWS Runtime app surface now shows
   an **AWS advisory authorization** panel with the decision title,
   outcome pill, policy rule, principal, action, severity, and next
   action. Identrail never enforces the recommendation at this layer;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS advisory authorization decision API** (#1543). Adds an
+  advisory-only projection that joins remediation cases (#1529) with the
+  post-remediation verification and rollback executor (#1542) and
+  returns one deterministic authorization recommendation per case.
+  Each decision carries an `outcome`
+  (`allow`|`warn`|`require_approval`|`recommend_deny`|`quarantine`),
+  the principal node ID/ARN/type, the projected AWS API action and
+  resource scope, a deterministic input hash (case ID, lifecycle,
+  approval state, verification state, policy version), provenance
+  (policy version and rule name), evidence refs, an audit trail, and a
+  next-action string. Policy ordering makes safety signals win over
+  approval state: kill-switch and verification-failed always classify
+  as `quarantine`, verification-verified as `allow`, blocked
+  verification as `recommend_deny`, approved-but-not-verified as
+  `require_approval`, high/critical severity without an in-flight
+  execution as `warn`, and everything else as `allow` with advisory
+  monitoring. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization`
+  with filters for connector, account, region, principal, action,
+  outcome, severity, source type, case ID, verification ID, and
+  free-text search. OpenAPI schemas and authz wiring follow the
+  neighboring wave-8 endpoints. The AWS Runtime app surface now shows
+  an **AWS advisory authorization** panel with the decision title,
+  outcome pill, policy rule, principal, action, severity, and next
+  action. Identrail never enforces the recommendation at this layer;
+  live enforcement belongs to downstream governance executors and
+  their own feature flags.
 - Add **AWS post-remediation verification and rollback** (#1542). Adds a
   read-only projection that joins every approved wave-8 executor
   (low-risk live remediation #1538, trust-policy hardening executor

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS approved SCP guardrail executor: `aws-scp-guardrail-executor.md`
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
 - AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
+- AWS advisory authorization decision API: `aws-advisory-authorization.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-advisory-authorization.md
+++ b/docs/aws-advisory-authorization.md
@@ -1,0 +1,76 @@
+# AWS advisory authorization decision API
+
+Issue #1543 adds a metadata-only projection of deterministic advisory
+authorization decisions. Each decision joins one remediation case (#1529)
+with its corresponding post-remediation verification and rollback record
+(#1542) and returns a recommended outcome plus provenance.
+
+The endpoint is advisory-only. Identrail never enforces the recommendation
+at this layer and never calls IAM, STS, or Organizations write APIs. Live
+enforcement belongs to downstream governance executors and their own feature
+flags.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/advisory-authorization`
+
+Response shape: `{ "advisory_authorization": AWSAdvisoryAuthorizationResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`principal_id`, `action`, `outcome`, `severity`, `source_type`, `case_id`,
+`verification_id`, and `search`.
+
+## Decision shape
+
+Each decision carries:
+
+- `outcome`: one of `allow`, `warn`, `require_approval`, `recommend_deny`,
+  `quarantine`.
+- `mode`: currently always `advisory`. Identrail does not enforce.
+- `principal_node_id`, `principal_arn`, `principal_type`, `action`,
+  `resource_scope`: the subject of the recommendation.
+- `provenance.policy_version` and `provenance.policy_rule`: the deterministic
+  policy rule name that produced the outcome. Every change to the policy
+  bumps the version so operators can trace drift.
+- `input_hash`: deterministic hash of the inputs (case ID, lifecycle, approval
+  state, verification state, policy version). Log it on both sides of a
+  policy decision point to detect drift.
+- `evidence`, `evidence_links`: metadata refs only. No rendered policy
+  bodies, secret values, or workload payloads.
+- `audit_trail`: immutable rows including the projection event.
+
+## Outcome policy
+
+Ordered so safety signals win over general approval state:
+
+1. `verification.kill_switch_engaged=true` → `quarantine`.
+2. Verification state `verification_failed` or `rollback_planned` →
+   `quarantine`.
+3. Verification state `verification_verified` → `allow`.
+4. Verification state `blocked` → `recommend_deny`.
+5. Case lifecycle `resolved` → `allow`.
+6. Case `approval_state=blocked` → `recommend_deny`.
+7. Case `approval_state=approved` (not yet applied+verified) →
+   `require_approval`.
+8. Case `approval_required=true` → `require_approval`.
+9. Case severity `critical` or `high` with no in-flight execution → `warn`.
+10. Otherwise → `allow` with advisory monitoring.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS advisory authorization** panel showing
+the decision title, outcome pill, policy rule, principal, action, severity,
+and next action. The panel exposes loading, empty, blocked, degraded, and
+error states without operators needing to read logs or database rows.
+
+## Safety, evidence, and out of scope
+
+- Advisory-only. No IAM/STS/Organizations write APIs are called at this
+  layer.
+- Kill-switch and verification-failed states always classify as `quarantine`
+  regardless of upstream approval state, so a compromised or reverted
+  execution can never be recorded as `allow`.
+- Tenant, workspace, project, connector, account, and region boundaries are
+  preserved.
+- Unknown, permission-denied, and partial-failure states are surfaced as
+  explicit states, not as successful findings.

--- a/docs/aws-advisory-authorization.md
+++ b/docs/aws-advisory-authorization.md
@@ -32,29 +32,34 @@ Each decision carries:
 - `provenance.policy_version` and `provenance.policy_rule`: the deterministic
   policy rule name that produced the outcome. Every change to the policy
   bumps the version so operators can trace drift.
-- `input_hash`: deterministic hash of the inputs (case ID, lifecycle, approval
-  state, verification state, policy version). Log it on both sides of a
-  policy decision point to detect drift.
+- `input_hash`: deterministic hash of every input the classifier reads
+  (case ID, lifecycle, approval state, approval-required flag, severity,
+  verification state, kill-switch flag, policy version). Log it on both
+  sides of a policy decision point to detect drift.
 - `evidence`, `evidence_links`: metadata refs only. No rendered policy
   bodies, secret values, or workload payloads.
 - `audit_trail`: immutable rows including the projection event.
 
 ## Outcome policy
 
-Ordered so safety signals win over general approval state:
+Ordered so safety signals win over general approval state. Any present
+verification entry is evaluated before the case-only rules so a
+projected-but-not-yet-verified execution can never be recorded as `allow`:
 
 1. `verification.kill_switch_engaged=true` → `quarantine`.
 2. Verification state `verification_failed` or `rollback_planned` →
    `quarantine`.
 3. Verification state `verification_verified` → `allow`.
 4. Verification state `blocked` → `recommend_deny`.
-5. Case lifecycle `resolved` → `allow`.
-6. Case `approval_state=blocked` → `recommend_deny`.
-7. Case `approval_state=approved` (not yet applied+verified) →
+5. Verification state `verification_pending` → `require_approval`.
+6. Verification state `not_ready` or `skipped` → `warn`.
+7. Case lifecycle `resolved` (no verification present) → `allow`.
+8. Case `approval_state=blocked` → `recommend_deny`.
+9. Case `approval_state=approved` (not yet applied+verified) →
    `require_approval`.
-8. Case `approval_required=true` → `require_approval`.
-9. Case severity `critical` or `high` with no in-flight execution → `warn`.
-10. Otherwise → `allow` with advisory monitoring.
+10. Case `approval_required=true` → `require_approval`.
+11. Case severity `critical` or `high` with no in-flight execution → `warn`.
+12. Otherwise → `allow` with advisory monitoring.
 
 ## App Surface
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -609,6 +609,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/advisory-authorization
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5721,6 +5726,91 @@ paths:
                     $ref: "#/components/schemas/AWSPostRemediationVerificationResult"
         "400":
           description: Invalid AWS post-remediation verification request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/advisory-authorization:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS advisory authorization decisions
+      operationId: getAWSProjectAdvisoryAuthorization
+      description: Projects deterministic advisory authorization decisions by joining remediation cases with the post-remediation verification and rollback executor. Each decision records the recommended outcome (allow, warn, require_approval, recommend_deny, quarantine), the deterministic input hash, the policy version and rule that produced the recommendation, and an immutable audit trail. The endpoint is advisory-only; Identrail never enforces the outcome at this layer.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: principal_id
+          schema: { type: string }
+          description: Optional principal node ID or ARN filter.
+        - in: query
+          name: action
+          schema: { type: string }
+          description: Optional AWS API action filter (e.g. iam:PutRolePolicy).
+        - in: query
+          name: outcome
+          schema:
+            type: string
+            enum: [allow, warn, require_approval, recommend_deny, quarantine]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: source_type
+          schema: { type: string }
+          description: Optional upstream remediation case source type filter.
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: verification_id
+          schema: { type: string }
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS advisory authorization contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  advisory_authorization:
+                    $ref: "#/components/schemas/AWSAdvisoryAuthorizationResult"
+        "400":
+          description: Invalid AWS advisory authorization request
           content:
             application/json:
               schema:
@@ -15907,6 +15997,186 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPostRemediationVerificationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAdvisoryAuthorizationEvidence:
+      type: object
+      properties:
+        source: { type: string }
+        label: { type: string }
+        evidence_ref: { type: string }
+    AWSAdvisoryAuthorizationInputHash:
+      type: object
+      properties:
+        value: { type: string }
+        components:
+          type: array
+          items: { type: string }
+    AWSAdvisoryAuthorizationProvenance:
+      type: object
+      properties:
+        policy_version: { type: string }
+        policy_rule: { type: string }
+        source_types:
+          type: array
+          items: { type: string }
+        signals:
+          type: array
+          items: { type: string }
+    AWSAdvisoryAuthorizationRelationship:
+      type: object
+      properties:
+        decision_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAdvisoryAuthorizationDecision:
+      type: object
+      properties:
+        decision_id: { type: string }
+        calculation_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        outcome:
+          type: string
+          enum: [allow, warn, require_approval, recommend_deny, quarantine]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        severity: { type: string }
+        score: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        rationale: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        principal_node_id: { type: string }
+        principal_arn: { type: string }
+        principal_type: { type: string }
+        action: { type: string }
+        resource_scope:
+          type: array
+          items: { type: string }
+        source_type: { type: string }
+        case_id: { type: string }
+        verification_id: { type: string }
+        input_hash:
+          $ref: "#/components/schemas/AWSAdvisoryAuthorizationInputHash"
+        provenance:
+          $ref: "#/components/schemas/AWSAdvisoryAuthorizationProvenance"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAdvisoryAuthorizationEvidence"
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        kill_switch_engaged: { type: boolean }
+        read_only_projection: { type: boolean }
+        next_action: { type: string }
+        decided_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAdvisoryAuthorizationSummary:
+      type: object
+      properties:
+        total_decisions: { type: integer }
+        filtered_decisions: { type: integer }
+        outcome_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        allow_count: { type: integer }
+        warn_count: { type: integer }
+        require_approval_count: { type: integer }
+        recommend_deny_count: { type: integer }
+        quarantine_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSAdvisoryAuthorizationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSAdvisoryAuthorizationSummary"
+        decisions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAdvisoryAuthorizationDecision"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAdvisoryAuthorizationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -16076,6 +16076,10 @@ components:
         summary: { type: string }
         rationale: { type: string }
         account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+          description: Full set of accounts the underlying remediation case affects. Account filters match this list in addition to `account_id`.
         region: { type: string }
         principal_node_id: { type: string }
         principal_arn: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -772,6 +772,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/low-risk-live-remediation", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -301,12 +301,16 @@ func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationB
 }
 
 func awsAdvisoryAuthorizationDecisionsFromCase(c AWSRemediationCase, verifications []AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
-	if targets := awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c); len(targets) > 1 {
+	if targets := awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c); len(targets) > 0 {
 		decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(targets))
 		for _, target := range targets {
 			scoped := awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c, target)
 			verification := awsAdvisoryAuthorizationVerificationForTarget(verifications, target)
-			decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCaseWithScope(scoped, verification, now, target))
+			decisionScope := ""
+			if len(targets) > 1 {
+				decisionScope = target
+			}
+			decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCaseWithScope(scoped, verification, now, decisionScope))
 		}
 		return decisions
 	}

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -304,7 +304,7 @@ func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationB
 }
 
 func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) AWSAdvisoryAuthorizationDecision {
-	action := awsAdvisoryAuthorizationActionForDiffKind(c.DiffIntent.Kind, c.SourceType)
+	action := awsAdvisoryAuthorizationActionForCase(c)
 	outcome, rule, rationale, confidence := awsAdvisoryAuthorizationClassify(c, verification)
 	decisionID := "aws-advisory-authorization:" + stableAWSBlastRadiusToken("decision", c.CaseID, action)
 	principalNodeID := firstNonEmptyAWSValue(c.IdentityNodeID, firstString(c.ResourceNodeIDs))
@@ -417,12 +417,17 @@ func awsAdvisoryAuthorizationVerificationSeverityRank(entry AWSPostRemediationVe
 		return 90
 	case awsPostRemediationVerificationStateBlocked:
 		return 80
+	// verification_pending outranks not_ready and skipped: pending
+	// classifies as the stricter require_approval, while not_ready and
+	// skipped classify as warn. Keeping pending on top of a per-case
+	// tie ensures the case-level decision matches the in-flight state
+	// rather than understating it.
+	case awsPostRemediationVerificationStatePending:
+		return 50
 	case awsPostRemediationVerificationStateNotReady:
 		return 40
-	case awsPostRemediationVerificationStatePending:
-		return 30
 	case awsPostRemediationVerificationStateSkipped:
-		return 20
+		return 30
 	case awsPostRemediationVerificationStateVerified:
 		return 10
 	}
@@ -466,13 +471,26 @@ func awsAdvisoryAuthorizationClassify(c AWSRemediationCase, verification AWSPost
 	return awsAdvisoryAuthorizationOutcomeAllow, "no_active_risk", "No active risk finding or in-flight execution blocks the projected authorization; allow with advisory monitoring.", 0.7
 }
 
-func awsAdvisoryAuthorizationActionForDiffKind(kind, sourceType string) string {
-	switch strings.ToLower(strings.TrimSpace(kind)) {
+// awsAdvisoryAuthorizationActionForCase derives the AWS API action the
+// downstream dry-run/executor will project for the case, honoring the
+// case's IAM principal kind so IAM-user targets surface the `PutUser*`
+// variant instead of the role-only default. Callers filter by `action`,
+// so returning the wrong variant would silently drop the decision from
+// drill-downs.
+func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
+	isUser := strings.EqualFold(c.IdentityType, "iam_user")
+	switch strings.ToLower(strings.TrimSpace(c.DiffIntent.Kind)) {
 	case "iam_policy_diff", "iac_iam_policy_pr":
+		if isUser {
+			return "iam:PutUserPolicy"
+		}
 		return "iam:PutRolePolicy"
 	case "iam_trust_diff", "iac_trust_policy_pr":
 		return "iam:UpdateAssumeRolePolicy"
 	case "permission_boundary_diff":
+		if isUser {
+			return "iam:PutUserPermissionsBoundary"
+		}
 		return "iam:PutRolePermissionsBoundary"
 	case "scp_diff":
 		return "organizations:AttachPolicy"
@@ -485,10 +503,16 @@ func awsAdvisoryAuthorizationActionForDiffKind(kind, sourceType string) string {
 	case "ai_agent_scope_change":
 		return "bedrock-agent:UpdateAgent"
 	}
-	switch strings.ToLower(strings.TrimSpace(sourceType)) {
+	switch strings.ToLower(strings.TrimSpace(c.SourceType)) {
 	case "least_privilege":
+		if isUser {
+			return "iam:PutUserPolicy"
+		}
 		return "iam:PutRolePolicy"
 	case "aws_permission_boundary_scp":
+		if isUser {
+			return "iam:PutUserPermissionsBoundary"
+		}
 		return "iam:PutRolePermissionsBoundary"
 	case "trust_policy_hardening":
 		return "iam:UpdateAssumeRolePolicy"

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -485,20 +485,14 @@ func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
 	if c.DiffIntent.NoOp {
 		return "advisory:review"
 	}
-	isUser := strings.EqualFold(c.IdentityType, "iam_user")
+	kind := awsAdvisoryAuthorizationCasePrincipalKind(c)
 	switch strings.ToLower(strings.TrimSpace(c.DiffIntent.Kind)) {
 	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr":
-		if isUser {
-			return "iam:PutUserPolicy"
-		}
-		return "iam:PutRolePolicy"
+		return awsAdvisoryAuthorizationPutPolicyAction(kind)
 	case "iam_trust_diff", "iac_trust_policy_pr":
 		return "iam:UpdateAssumeRolePolicy"
 	case "permission_boundary_diff":
-		if isUser {
-			return "iam:PutUserPermissionsBoundary"
-		}
-		return "iam:PutRolePermissionsBoundary"
+		return awsAdvisoryAuthorizationPutBoundaryAction(kind)
 	case "scp_diff":
 		return "organizations:AttachPolicy"
 	case "kms_grant_diff":
@@ -512,15 +506,9 @@ func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
 	}
 	switch strings.ToLower(strings.TrimSpace(c.SourceType)) {
 	case "least_privilege":
-		if isUser {
-			return "iam:PutUserPolicy"
-		}
-		return "iam:PutRolePolicy"
+		return awsAdvisoryAuthorizationPutPolicyAction(kind)
 	case "aws_permission_boundary_scp":
-		if isUser {
-			return "iam:PutUserPermissionsBoundary"
-		}
-		return "iam:PutRolePermissionsBoundary"
+		return awsAdvisoryAuthorizationPutBoundaryAction(kind)
 	case "trust_policy_hardening":
 		return "iam:UpdateAssumeRolePolicy"
 	case "aws_secret_key_rotation":
@@ -529,6 +517,54 @@ func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
 		return "iam:UpdateAccessKey"
 	}
 	return "advisory:review"
+}
+
+// awsAdvisoryAuthorizationCasePrincipalKind returns "user", "group", or
+// "role" for the case's IAM principal. It prefers the case's declared
+// IdentityType (`iam_user`, `iam_group`, `iam_role`) and falls back to
+// parsing the identity node ID or ARN with the same helper the dry-run
+// uses, so cases that store a generic IdentityType (for example
+// `iam_identity`) still route to the correct Put*Policy variant.
+func awsAdvisoryAuthorizationCasePrincipalKind(c AWSRemediationCase) string {
+	switch strings.ToLower(strings.TrimSpace(c.IdentityType)) {
+	case "iam_user":
+		return "user"
+	case "iam_group":
+		return "group"
+	case "iam_role":
+		return "role"
+	}
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityNodeID); kind != "" {
+		return kind
+	}
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityARN); kind != "" {
+		return kind
+	}
+	return "role"
+}
+
+func awsAdvisoryAuthorizationPutPolicyAction(kind string) string {
+	switch kind {
+	case "user":
+		return "iam:PutUserPolicy"
+	case "group":
+		return "iam:PutGroupPolicy"
+	}
+	return "iam:PutRolePolicy"
+}
+
+// awsAdvisoryAuthorizationPutBoundaryAction routes to a permission-boundary
+// API only when the principal is an IAM user or role; groups cannot receive
+// permission boundaries, so a group principal falls back to `advisory:review`
+// rather than advertising a call AWS would reject.
+func awsAdvisoryAuthorizationPutBoundaryAction(kind string) string {
+	switch kind {
+	case "user":
+		return "iam:PutUserPermissionsBoundary"
+	case "group":
+		return "advisory:review"
+	}
+	return "iam:PutRolePermissionsBoundary"
 }
 
 func awsAdvisoryAuthorizationEvidenceFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry) []AWSAdvisoryAuthorizationEvidence {

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -478,9 +478,16 @@ func awsAdvisoryAuthorizationClassify(c AWSRemediationCase, verification AWSPost
 // so returning the wrong variant would silently drop the decision from
 // drill-downs.
 func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
+	// No-op diffs (manual review, owner assignment) never project a live
+	// AWS write; the dry-run collapses them to `manual_review:noop`.
+	// Reporting `iam:PutRolePolicy` here would advertise an IAM write
+	// operators would never see and would mis-scope action drill-downs.
+	if c.DiffIntent.NoOp {
+		return "advisory:review"
+	}
 	isUser := strings.EqualFold(c.IdentityType, "iam_user")
 	switch strings.ToLower(strings.TrimSpace(c.DiffIntent.Kind)) {
-	case "iam_policy_diff", "iac_iam_policy_pr":
+	case "iam_policy_diff", "role_scope_diff", "iac_iam_policy_pr":
 		if isUser {
 			return "iam:PutUserPolicy"
 		}

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -95,6 +95,7 @@ type AWSAdvisoryAuthorizationDecision struct {
 	Summary            string                               `json:"summary"`
 	Rationale          string                               `json:"rationale"`
 	AccountID          string                               `json:"account_id,omitempty"`
+	TargetAccountIDs   []string                             `json:"target_account_ids,omitempty"`
 	Region             string                               `json:"region,omitempty"`
 	PrincipalNodeID    string                               `json:"principal_node_id,omitempty"`
 	PrincipalARN       string                               `json:"principal_arn,omitempty"`
@@ -208,15 +209,19 @@ func (s *Service) GetAWSAdvisoryAuthorization(ctx context.Context, workspaceID s
 		return AWSAdvisoryAuthorizationResult{}, fmt.Errorf("advisory authorization verification: %w", err)
 	}
 
+	// When one case fans out into multiple verification records (per-target
+	// splits, retries), keep the most safety-critical entry per case so a
+	// kill-switch or verification failure on any target still classifies the
+	// decision correctly.
 	verificationByCase := map[string]AWSPostRemediationVerificationEntry{}
 	for _, entry := range verification.Entries {
 		if strings.TrimSpace(entry.CaseID) == "" {
 			continue
 		}
-		if _, ok := verificationByCase[entry.CaseID]; ok {
-			continue
+		existing, ok := verificationByCase[entry.CaseID]
+		if !ok || awsAdvisoryAuthorizationVerificationSeverityRank(entry) > awsAdvisoryAuthorizationVerificationSeverityRank(existing) {
+			verificationByCase[entry.CaseID] = entry
 		}
-		verificationByCase[entry.CaseID] = entry
 	}
 
 	decisions := awsAdvisoryAuthorizationDecisions(cases.Cases, verificationByCase, now)
@@ -337,6 +342,7 @@ func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification
 		Summary:            fmt.Sprintf("Advisory-only authorization decision for %s (outcome=%s). Identrail records the recommendation, provenance, and audit only; no live IAM/STS/Organizations write API is called at this layer.", firstNonEmptyAWSValue(principalNodeID, c.CaseID), outcome),
 		Rationale:          rationale,
 		AccountID:          firstNonEmptyAWSValue(c.AccountID, firstString(c.TargetAccountIDs)),
+		TargetAccountIDs:   emptyStrings(dedupeStrings(append(append([]string{}, c.TargetAccountIDs...), c.AccountID))),
 		Region:             c.Region,
 		PrincipalNodeID:    principalNodeID,
 		PrincipalARN:       c.IdentityARN,
@@ -371,6 +377,32 @@ func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification
 // safety-critical states (kill switch, verification failed) win over general
 // approval state so a compromised or reverted execution can never be recorded
 // as `allow`.
+// awsAdvisoryAuthorizationVerificationSeverityRank orders verification entries
+// so the most safety-critical wins when multiple entries share a case ID.
+// Higher rank = more severe. The order mirrors awsAdvisoryAuthorizationClassify
+// so the entry that would produce a `quarantine` or `recommend_deny` decision
+// takes precedence over one that would produce `allow` or `verification_pending`.
+func awsAdvisoryAuthorizationVerificationSeverityRank(entry AWSPostRemediationVerificationEntry) int {
+	if entry.KillSwitchEngaged {
+		return 100
+	}
+	switch entry.State {
+	case awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateRollback:
+		return 90
+	case awsPostRemediationVerificationStateBlocked:
+		return 80
+	case awsPostRemediationVerificationStateNotReady:
+		return 40
+	case awsPostRemediationVerificationStatePending:
+		return 30
+	case awsPostRemediationVerificationStateSkipped:
+		return 20
+	case awsPostRemediationVerificationStateVerified:
+		return 10
+	}
+	return 0
+}
+
 func awsAdvisoryAuthorizationClassify(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry) (outcome, rule, rationale string, confidence float64) {
 	if verification.KillSwitchEngaged {
 		return awsAdvisoryAuthorizationOutcomeQuarantine, "kill_switch_engaged", "Tenant remediation kill switch is engaged; recommend quarantining new authorization until the switch is disabled.", 0.95
@@ -604,10 +636,10 @@ func filterAWSAdvisoryAuthorizationDecisions(decisions []AWSAdvisoryAuthorizatio
 	}
 	filtered := make([]AWSAdvisoryAuthorizationDecision, 0, len(decisions))
 	for _, decision := range decisions {
-		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(decision.AccountID)) {
+		if filters["account_id"] != "" && !awsAdvisoryAuthorizationAccountMatch(decision, filters["account_id"]) {
 			continue
 		}
-		if filters["region"] != "" && strings.TrimSpace(decision.Region) != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(decision.Region)) {
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(decision.Region)) {
 			continue
 		}
 		if filters["principal_id"] != "" && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(decision.PrincipalNodeID)) && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(decision.PrincipalARN)) {
@@ -639,6 +671,22 @@ func filterAWSAdvisoryAuthorizationDecisions(decisions []AWSAdvisoryAuthorizatio
 	return filtered, applied
 }
 
+func awsAdvisoryAuthorizationAccountMatch(decision AWSAdvisoryAuthorizationDecision, accountID string) bool {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(decision.AccountID), accountID) {
+		return true
+	}
+	for _, target := range decision.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), accountID) {
+			return true
+		}
+	}
+	return false
+}
+
 func awsAdvisoryAuthorizationSearchMatch(decision AWSAdvisoryAuthorizationDecision, needle string) bool {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
@@ -651,6 +699,7 @@ func awsAdvisoryAuthorizationSearchMatch(decision AWSAdvisoryAuthorizationDecisi
 		decision.Provenance.PolicyRule, decision.Provenance.PolicyVersion,
 	}
 	values = append(values, decision.ResourceScope...)
+	values = append(values, decision.TargetAccountIDs...)
 	values = append(values, decision.Provenance.SourceTypes...)
 	values = append(values, decision.Provenance.Signals...)
 	values = append(values, decision.EvidenceLinks...)

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -337,14 +337,7 @@ func awsAdvisoryAuthorizationVerificationForTarget(verifications []AWSPostRemedi
 }
 
 func awsAdvisoryAuthorizationVerificationMatchesTarget(entry AWSPostRemediationVerificationEntry, target string) bool {
-	targets := []string{entry.TargetResource}
-	targets = append(targets, entry.ImpactedNodes...)
-	for _, candidate := range targets {
-		if awsAdvisoryAuthorizationTargetsEqual(candidate, target) {
-			return true
-		}
-	}
-	return false
+	return awsAdvisoryAuthorizationTargetsEqual(entry.TargetResource, target)
 }
 
 func awsAdvisoryAuthorizationTargetsEqual(a, b string) bool {

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -298,15 +298,60 @@ func normalizeAWSAdvisoryAuthorizationFixtureState(requested string, connection 
 func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationByCase map[string]AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
 	decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(cases))
 	for _, c := range cases {
-		decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCase(c, verificationByCase[c.CaseID], now))
+		decisions = append(decisions, awsAdvisoryAuthorizationDecisionsFromCase(c, verificationByCase[c.CaseID], now)...)
 	}
 	return decisions
 }
 
+func awsAdvisoryAuthorizationDecisionsFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
+	if targets := awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c); len(targets) > 1 {
+		decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(targets))
+		for _, target := range targets {
+			scoped := awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c, target)
+			decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCaseWithScope(scoped, verification, now, target))
+		}
+		return decisions
+	}
+	return []AWSAdvisoryAuthorizationDecision{awsAdvisoryAuthorizationDecisionFromCase(c, verification, now)}
+}
+
+func awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c AWSRemediationCase) []string {
+	if c.DiffIntent.NoOp {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.DiffIntent.Kind), "permission_boundary_diff") && !strings.EqualFold(c.SourceType, "aws_permission_boundary_scp") {
+		return nil
+	}
+	return awsPermissionBoundaryExecutorSupportedTargets(c.ResourceNodeIDs)
+}
+
+func awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c AWSRemediationCase, target string) AWSRemediationCase {
+	scoped := c
+	scoped.IdentityNodeID = target
+	if strings.Contains(strings.ToLower(target), "arn:") {
+		scoped.IdentityARN = strings.TrimSpace(target)
+	}
+	scoped.IdentityName = firstNonEmptyAWSValue(shortAWSARN(target), target)
+	scoped.IdentityType = awsRemediationPermissionBoundaryIdentityType(target)
+	scoped.ResourceNodeIDs = []string{target}
+	scoped.ImpactedNodes = dedupeStrings(append([]string{target}, c.ImpactedNodes...))
+	accountFallback := []string(nil)
+	if len(awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c)) == 1 {
+		accountFallback = c.TargetAccountIDs
+	}
+	scoped.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets([]string{target}, accountFallback)
+	scoped.AccountID = firstString(scoped.TargetAccountIDs)
+	return scoped
+}
+
 func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) AWSAdvisoryAuthorizationDecision {
+	return awsAdvisoryAuthorizationDecisionFromCaseWithScope(c, verification, now, "")
+}
+
+func awsAdvisoryAuthorizationDecisionFromCaseWithScope(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time, decisionScope string) AWSAdvisoryAuthorizationDecision {
 	action := awsAdvisoryAuthorizationActionForCase(c)
 	outcome, rule, rationale, confidence := awsAdvisoryAuthorizationClassify(c, verification)
-	decisionID := "aws-advisory-authorization:" + stableAWSBlastRadiusToken("decision", c.CaseID, action)
+	decisionID := "aws-advisory-authorization:" + stableAWSBlastRadiusToken("decision", c.CaseID, action, decisionScope)
 	principalNodeID := firstNonEmptyAWSValue(c.IdentityNodeID, firstString(c.ResourceNodeIDs))
 	resourceScope := emptyStrings(dedupeStrings(c.ResourceNodeIDs))
 	if len(resourceScope) == 0 {
@@ -520,12 +565,17 @@ func awsAdvisoryAuthorizationActionForCase(c AWSRemediationCase) string {
 }
 
 // awsAdvisoryAuthorizationCasePrincipalKind returns "user", "group", or
-// "role" for the case's IAM principal. It prefers the case's declared
-// IdentityType (`iam_user`, `iam_group`, `iam_role`) and falls back to
-// parsing the identity node ID or ARN with the same helper the dry-run
-// uses, so cases that store a generic IdentityType (for example
-// `iam_identity`) still route to the correct Put*Policy variant.
+// "role" for the case's IAM principal. It parses the concrete identity node ID
+// or ARN first, matching the dry-run router, because some upstream builders use
+// a generic or hard-coded IdentityType while the target itself carries the true
+// IAM principal kind.
 func awsAdvisoryAuthorizationCasePrincipalKind(c AWSRemediationCase) string {
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityNodeID); kind != "" {
+		return kind
+	}
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityARN); kind != "" {
+		return kind
+	}
 	switch strings.ToLower(strings.TrimSpace(c.IdentityType)) {
 	case "iam_user":
 		return "user"
@@ -533,12 +583,6 @@ func awsAdvisoryAuthorizationCasePrincipalKind(c AWSRemediationCase) string {
 		return "group"
 	case "iam_role":
 		return "role"
-	}
-	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityNodeID); kind != "" {
-		return kind
-	}
-	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(c.IdentityARN); kind != "" {
-		return kind
 	}
 	return "role"
 }

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -210,18 +210,15 @@ func (s *Service) GetAWSAdvisoryAuthorization(ctx context.Context, workspaceID s
 	}
 
 	// When one case fans out into multiple verification records (per-target
-	// splits, retries), keep the most safety-critical entry per case so a
-	// kill-switch or verification failure on any target still classifies the
-	// decision correctly.
-	verificationByCase := map[string]AWSPostRemediationVerificationEntry{}
+	// splits, retries), keep all entries grouped by case. Non-split cases
+	// still choose the most safety-critical entry, while split advisory rows
+	// can join to their target-specific verification record first.
+	verificationByCase := map[string][]AWSPostRemediationVerificationEntry{}
 	for _, entry := range verification.Entries {
 		if strings.TrimSpace(entry.CaseID) == "" {
 			continue
 		}
-		existing, ok := verificationByCase[entry.CaseID]
-		if !ok || awsAdvisoryAuthorizationVerificationSeverityRank(entry) > awsAdvisoryAuthorizationVerificationSeverityRank(existing) {
-			verificationByCase[entry.CaseID] = entry
-		}
+		verificationByCase[entry.CaseID] = append(verificationByCase[entry.CaseID], entry)
 	}
 
 	decisions := awsAdvisoryAuthorizationDecisions(cases.Cases, verificationByCase, now)
@@ -295,7 +292,7 @@ func normalizeAWSAdvisoryAuthorizationFixtureState(requested string, connection 
 	}
 }
 
-func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationByCase map[string]AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
+func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationByCase map[string][]AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
 	decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(cases))
 	for _, c := range cases {
 		decisions = append(decisions, awsAdvisoryAuthorizationDecisionsFromCase(c, verificationByCase[c.CaseID], now)...)
@@ -303,16 +300,65 @@ func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationB
 	return decisions
 }
 
-func awsAdvisoryAuthorizationDecisionsFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
+func awsAdvisoryAuthorizationDecisionsFromCase(c AWSRemediationCase, verifications []AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
 	if targets := awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c); len(targets) > 1 {
 		decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(targets))
 		for _, target := range targets {
 			scoped := awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c, target)
+			verification := awsAdvisoryAuthorizationVerificationForTarget(verifications, target)
 			decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCaseWithScope(scoped, verification, now, target))
 		}
 		return decisions
 	}
-	return []AWSAdvisoryAuthorizationDecision{awsAdvisoryAuthorizationDecisionFromCase(c, verification, now)}
+	return []AWSAdvisoryAuthorizationDecision{awsAdvisoryAuthorizationDecisionFromCase(c, awsAdvisoryAuthorizationMostSevereVerification(verifications), now)}
+}
+
+func awsAdvisoryAuthorizationMostSevereVerification(verifications []AWSPostRemediationVerificationEntry) AWSPostRemediationVerificationEntry {
+	var selected AWSPostRemediationVerificationEntry
+	for _, entry := range verifications {
+		if selected.VerificationID == "" || awsAdvisoryAuthorizationVerificationSeverityRank(entry) > awsAdvisoryAuthorizationVerificationSeverityRank(selected) {
+			selected = entry
+		}
+	}
+	return selected
+}
+
+func awsAdvisoryAuthorizationVerificationForTarget(verifications []AWSPostRemediationVerificationEntry, target string) AWSPostRemediationVerificationEntry {
+	matches := []AWSPostRemediationVerificationEntry{}
+	for _, entry := range verifications {
+		if awsAdvisoryAuthorizationVerificationMatchesTarget(entry, target) {
+			matches = append(matches, entry)
+		}
+	}
+	if len(matches) > 0 {
+		return awsAdvisoryAuthorizationMostSevereVerification(matches)
+	}
+	return awsAdvisoryAuthorizationMostSevereVerification(verifications)
+}
+
+func awsAdvisoryAuthorizationVerificationMatchesTarget(entry AWSPostRemediationVerificationEntry, target string) bool {
+	targets := []string{entry.TargetResource}
+	targets = append(targets, entry.ImpactedNodes...)
+	for _, candidate := range targets {
+		if awsAdvisoryAuthorizationTargetsEqual(candidate, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsAdvisoryAuthorizationTargetsEqual(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	aARN := awsAdvisoryAuthorizationARNFromTarget(a)
+	bARN := awsAdvisoryAuthorizationARNFromTarget(b)
+	return aARN != "" && bARN != "" && strings.EqualFold(aARN, bARN)
 }
 
 func awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c AWSRemediationCase) []string {
@@ -328,8 +374,8 @@ func awsAdvisoryAuthorizationSplitPermissionBoundaryTargets(c AWSRemediationCase
 func awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c AWSRemediationCase, target string) AWSRemediationCase {
 	scoped := c
 	scoped.IdentityNodeID = target
-	if strings.Contains(strings.ToLower(target), "arn:") {
-		scoped.IdentityARN = strings.TrimSpace(target)
+	if arn := awsAdvisoryAuthorizationARNFromTarget(target); arn != "" {
+		scoped.IdentityARN = arn
 	}
 	scoped.IdentityName = firstNonEmptyAWSValue(shortAWSARN(target), target)
 	scoped.IdentityType = awsRemediationPermissionBoundaryIdentityType(target)
@@ -342,6 +388,14 @@ func awsAdvisoryAuthorizationCaseForPermissionBoundaryTarget(c AWSRemediationCas
 	scoped.TargetAccountIDs = awsPermissionBoundaryExecutorScopedAccountsForTargets([]string{target}, accountFallback)
 	scoped.AccountID = firstString(scoped.TargetAccountIDs)
 	return scoped
+}
+
+func awsAdvisoryAuthorizationARNFromTarget(target string) string {
+	trimmed := strings.TrimSpace(target)
+	if idx := strings.Index(strings.ToLower(trimmed), "arn:"); idx >= 0 {
+		return trimmed[idx:]
+	}
+	return ""
 }
 
 func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) AWSAdvisoryAuthorizationDecision {

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -1,0 +1,744 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsAdvisoryAuthorizationCurrentIssue = 1543
+	awsAdvisoryAuthorizationVersion      = "aws-advisory-authorization-v1"
+	awsAdvisoryAuthorizationPolicyID     = "aws-advisory-authorization-policy-v1"
+
+	awsAdvisoryAuthorizationOutcomeAllow           = "allow"
+	awsAdvisoryAuthorizationOutcomeWarn            = "warn"
+	awsAdvisoryAuthorizationOutcomeRequireApproval = "require_approval"
+	awsAdvisoryAuthorizationOutcomeRecommendDeny   = "recommend_deny"
+	awsAdvisoryAuthorizationOutcomeQuarantine      = "quarantine"
+
+	awsAdvisoryAuthorizationModeAdvisory = "advisory"
+)
+
+// AWSAdvisoryAuthorizationRequest scopes the advisory authorization decision
+// projection to one AWS connector plus optional operator drill-down filters.
+type AWSAdvisoryAuthorizationRequest struct {
+	ConnectorID    string `json:"connector_id,omitempty"`
+	FixtureState   string `json:"fixture_state,omitempty"`
+	AccountID      string `json:"account_id,omitempty"`
+	Region         string `json:"region,omitempty"`
+	PrincipalID    string `json:"principal_id,omitempty"`
+	Action         string `json:"action,omitempty"`
+	Outcome        string `json:"outcome,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	SourceType     string `json:"source_type,omitempty"`
+	CaseID         string `json:"case_id,omitempty"`
+	VerificationID string `json:"verification_id,omitempty"`
+	Search         string `json:"search,omitempty"`
+}
+
+type AWSAdvisoryAuthorizationAuditEntry = AWSRemediationApprovalAuditEntry
+type AWSAdvisoryAuthorizationCoverageGap = AWSRemediationApprovalCoverageGap
+type AWSAdvisoryAuthorizationDiagnostic = AWSRemediationApprovalDiagnostic
+
+// AWSAdvisoryAuthorizationEvidence is one metadata reference the decision
+// engine used to reach its recommendation. No rendered policy bodies or
+// secret material is inlined.
+type AWSAdvisoryAuthorizationEvidence struct {
+	Source      string `json:"source"`
+	Label       string `json:"label"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSAdvisoryAuthorizationInputHash records the deterministic hash of the
+// inputs that produced the decision. Operators use this to detect drift when
+// upstream signals change.
+type AWSAdvisoryAuthorizationInputHash struct {
+	Value      string   `json:"value"`
+	Components []string `json:"components,omitempty"`
+}
+
+// AWSAdvisoryAuthorizationProvenance records the deterministic derivation
+// path: which upstream sources contributed, which policy version was applied,
+// and the operator-visible policy rule name that produced the outcome.
+type AWSAdvisoryAuthorizationProvenance struct {
+	PolicyVersion string   `json:"policy_version"`
+	PolicyRule    string   `json:"policy_rule"`
+	SourceTypes   []string `json:"source_types"`
+	Signals       []string `json:"signals,omitempty"`
+}
+
+// AWSAdvisoryAuthorizationRelationship surfaces decision→graph node edges.
+type AWSAdvisoryAuthorizationRelationship struct {
+	DecisionID  string `json:"decision_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSAdvisoryAuthorizationDecision is the persisted-record-shaped contract
+// for one advisory authorization decision. Identrail never enforces the
+// decision at this layer; downstream governance executors and operator
+// workflows decide whether and how to act on the recommendation.
+type AWSAdvisoryAuthorizationDecision struct {
+	DecisionID         string                               `json:"decision_id"`
+	CalculationVersion string                               `json:"calculation_version"`
+	Mode               string                               `json:"mode"`
+	Outcome            string                               `json:"outcome"`
+	Confidence         float64                              `json:"confidence"`
+	Severity           string                               `json:"severity"`
+	Score              int                                  `json:"score"`
+	Title              string                               `json:"title"`
+	Summary            string                               `json:"summary"`
+	Rationale          string                               `json:"rationale"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	PrincipalNodeID    string                               `json:"principal_node_id,omitempty"`
+	PrincipalARN       string                               `json:"principal_arn,omitempty"`
+	PrincipalType      string                               `json:"principal_type,omitempty"`
+	Action             string                               `json:"action"`
+	ResourceScope      []string                             `json:"resource_scope,omitempty"`
+	SourceType         string                               `json:"source_type"`
+	CaseID             string                               `json:"case_id,omitempty"`
+	VerificationID     string                               `json:"verification_id,omitempty"`
+	InputHash          AWSAdvisoryAuthorizationInputHash    `json:"input_hash"`
+	Provenance         AWSAdvisoryAuthorizationProvenance   `json:"provenance"`
+	Evidence           []AWSAdvisoryAuthorizationEvidence   `json:"evidence"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	EvidenceBoundary   string                               `json:"evidence_boundary"`
+	AuditTrail         []AWSAdvisoryAuthorizationAuditEntry `json:"audit_trail"`
+	KillSwitchEngaged  bool                                 `json:"kill_switch_engaged"`
+	ReadOnlyProjection bool                                 `json:"read_only_projection"`
+	NextAction         string                               `json:"next_action"`
+	DecidedAt          time.Time                            `json:"decided_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// AWSAdvisoryAuthorizationSummary aggregates the unfiltered/filtered set.
+type AWSAdvisoryAuthorizationSummary struct {
+	TotalDecisions         int            `json:"total_decisions"`
+	FilteredDecisions      int            `json:"filtered_decisions"`
+	OutcomeCounts          map[string]int `json:"outcome_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	SourceTypeCounts       map[string]int `json:"source_type_counts"`
+	AllowCount             int            `json:"allow_count"`
+	WarnCount              int            `json:"warn_count"`
+	RequireApprovalCount   int            `json:"require_approval_count"`
+	RecommendDenyCount     int            `json:"recommend_deny_count"`
+	QuarantineCount        int            `json:"quarantine_count"`
+	KillSwitchEngagedCount int            `json:"kill_switch_engaged_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+// AWSAdvisoryAuthorizationResult is the deterministic endpoint envelope.
+type AWSAdvisoryAuthorizationResult struct {
+	TenantID           string                                 `json:"tenant_id"`
+	WorkspaceID        string                                 `json:"workspace_id"`
+	ProjectID          string                                 `json:"project_id"`
+	ConnectorID        string                                 `json:"connector_id,omitempty"`
+	AccountID          string                                 `json:"account_id,omitempty"`
+	Region             string                                 `json:"region,omitempty"`
+	ParentIssueNumber  int                                    `json:"parent_issue_number"`
+	ParentIssueRef     string                                 `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                    `json:"current_issue_number"`
+	CurrentIssueRef    string                                 `json:"current_issue_ref"`
+	Version            string                                 `json:"version"`
+	Status             string                                 `json:"status"`
+	FixtureState       string                                 `json:"fixture_state,omitempty"`
+	Confidence         float64                                `json:"confidence"`
+	CalculationVersion string                                 `json:"calculation_version"`
+	PolicyVersion      string                                 `json:"policy_version"`
+	Mode               string                                 `json:"mode"`
+	AppliedFilters     map[string]string                      `json:"applied_filters"`
+	Summary            AWSAdvisoryAuthorizationSummary        `json:"summary"`
+	Decisions          []AWSAdvisoryAuthorizationDecision     `json:"decisions"`
+	Relationships      []AWSAdvisoryAuthorizationRelationship `json:"relationships"`
+	Caveats            []string                               `json:"caveats"`
+	FailureReasons     []string                               `json:"failure_reasons"`
+	RemediationHints   []string                               `json:"remediation_hints"`
+	EvidenceLinks      []string                               `json:"evidence_links"`
+	CoverageGaps       []AWSAdvisoryAuthorizationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSAdvisoryAuthorizationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                              `json:"generated_at"`
+	UpdatedAt          time.Time                              `json:"updated_at"`
+}
+
+// GetAWSAdvisoryAuthorization projects deterministic advisory authorization
+// decisions from the remediation-case engine (#1529) joined with the
+// post-remediation verification and rollback executor (#1542). Each decision
+// records the recommended outcome (allow, warn, require_approval,
+// recommend_deny, quarantine), the deterministic input hash, the policy
+// version and rule that produced the recommendation, and an immutable audit
+// trail. The endpoint is advisory-only: Identrail never enforces the decision
+// at this layer.
+func (s *Service) GetAWSAdvisoryAuthorization(ctx context.Context, workspaceID string, projectID string, request AWSAdvisoryAuthorizationRequest) (AWSAdvisoryAuthorizationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAdvisoryAuthorizationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAdvisoryAuthorizationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSAdvisoryAuthorizationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAdvisoryAuthorizationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSAdvisoryAuthorizationResult{}, fmt.Errorf("advisory authorization cases: %w", err)
+	}
+	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSAdvisoryAuthorizationResult{}, fmt.Errorf("advisory authorization verification: %w", err)
+	}
+
+	verificationByCase := map[string]AWSPostRemediationVerificationEntry{}
+	for _, entry := range verification.Entries {
+		if strings.TrimSpace(entry.CaseID) == "" {
+			continue
+		}
+		if _, ok := verificationByCase[entry.CaseID]; ok {
+			continue
+		}
+		verificationByCase[entry.CaseID] = entry
+	}
+
+	decisions := awsAdvisoryAuthorizationDecisions(cases.Cases, verificationByCase, now)
+	sort.SliceStable(decisions, func(i, j int) bool {
+		if decisions[i].Score == decisions[j].Score {
+			return decisions[i].DecisionID < decisions[j].DecisionID
+		}
+		return decisions[i].Score > decisions[j].Score
+	})
+	filtered, applied := filterAWSAdvisoryAuthorizationDecisions(decisions, request)
+	relationships := awsAdvisoryAuthorizationRelationships(filtered)
+	diagnostics := awsAdvisoryAuthorizationDiagnostics(cases.Diagnostics, verification.Diagnostics)
+	coverageGaps := awsAdvisoryAuthorizationCoverageGaps(cases.CoverageGaps, verification.CoverageGaps)
+	status, confidence := summarizeAWSAdvisoryAuthorizationStatus(cases.Status, verification.Status, filtered, diagnostics)
+
+	return AWSAdvisoryAuthorizationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAdvisoryAuthorizationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAdvisoryAuthorizationCurrentIssue),
+		Version:            awsAdvisoryAuthorizationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsAdvisoryAuthorizationVersion,
+		PolicyVersion:      awsAdvisoryAuthorizationPolicyID,
+		Mode:               awsAdvisoryAuthorizationModeAdvisory,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSAdvisoryAuthorizationDecisions(decisions, filtered, relationships),
+		Decisions:          filtered,
+		Relationships:      relationships,
+		Caveats:            awsAdvisoryAuthorizationCaveats(),
+		FailureReasons:     dedupeStrings(append(append([]string{}, cases.FailureReasons...), verification.FailureReasons...)),
+		RemediationHints:   awsAdvisoryAuthorizationRemediationHints(append(cases.RemediationHints, verification.RemediationHints...)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAdvisoryAuthorizationCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+			"/docs/aws-advisory-authorization",
+			"/docs/aws-remediation-cases",
+			"/docs/aws-post-remediation-verification",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSAdvisoryAuthorizationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsAdvisoryAuthorizationDecisions(cases []AWSRemediationCase, verificationByCase map[string]AWSPostRemediationVerificationEntry, now time.Time) []AWSAdvisoryAuthorizationDecision {
+	decisions := make([]AWSAdvisoryAuthorizationDecision, 0, len(cases))
+	for _, c := range cases {
+		decisions = append(decisions, awsAdvisoryAuthorizationDecisionFromCase(c, verificationByCase[c.CaseID], now))
+	}
+	return decisions
+}
+
+func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, now time.Time) AWSAdvisoryAuthorizationDecision {
+	action := awsAdvisoryAuthorizationActionForDiffKind(c.DiffIntent.Kind, c.SourceType)
+	outcome, rule, rationale, confidence := awsAdvisoryAuthorizationClassify(c, verification)
+	decisionID := "aws-advisory-authorization:" + stableAWSBlastRadiusToken("decision", c.CaseID, action)
+	principalNodeID := firstNonEmptyAWSValue(c.IdentityNodeID, firstString(c.ResourceNodeIDs))
+	resourceScope := emptyStrings(dedupeStrings(c.ResourceNodeIDs))
+	if len(resourceScope) == 0 {
+		resourceScope = emptyStrings(dedupeStrings(c.ImpactedNodes))
+	}
+	sourceTypes := dedupeStrings([]string{c.SourceType})
+	signals := dedupeStrings([]string{"remediation_case", c.Lifecycle, c.ApprovalState})
+	if verification.VerificationID != "" {
+		sourceTypes = append(sourceTypes, "post_remediation_verification")
+		signals = append(signals, "verification:"+verification.State)
+	}
+	evidence := awsAdvisoryAuthorizationEvidenceFromCase(c, verification)
+	evidenceLinks := awsAdvisoryAuthorizationEvidenceLinksFromCase(c, verification)
+	inputHash := AWSAdvisoryAuthorizationInputHash{
+		Value: stableAWSBlastRadiusToken("input", c.CaseID, c.Lifecycle, c.ApprovalState, verification.State, verification.VerificationID, awsAdvisoryAuthorizationVersion, awsAdvisoryAuthorizationPolicyID),
+		Components: []string{
+			"case_id=" + c.CaseID,
+			"lifecycle=" + c.Lifecycle,
+			"approval_state=" + c.ApprovalState,
+			"verification_state=" + verification.State,
+			"policy_version=" + awsAdvisoryAuthorizationPolicyID,
+		},
+	}
+	return AWSAdvisoryAuthorizationDecision{
+		DecisionID:         decisionID,
+		CalculationVersion: awsAdvisoryAuthorizationVersion,
+		Mode:               awsAdvisoryAuthorizationModeAdvisory,
+		Outcome:            outcome,
+		Confidence:         confidence,
+		Severity:           c.Severity,
+		Score:              c.Score,
+		Title:              fmt.Sprintf("Advisory decision: %s", firstNonEmptyAWSValue(c.Title, c.CaseID)),
+		Summary:            fmt.Sprintf("Advisory-only authorization decision for %s (outcome=%s). Identrail records the recommendation, provenance, and audit only; no live IAM/STS/Organizations write API is called at this layer.", firstNonEmptyAWSValue(principalNodeID, c.CaseID), outcome),
+		Rationale:          rationale,
+		AccountID:          firstNonEmptyAWSValue(c.AccountID, firstString(c.TargetAccountIDs)),
+		Region:             c.Region,
+		PrincipalNodeID:    principalNodeID,
+		PrincipalARN:       c.IdentityARN,
+		PrincipalType:      c.IdentityType,
+		Action:             action,
+		ResourceScope:      resourceScope,
+		SourceType:         c.SourceType,
+		CaseID:             c.CaseID,
+		VerificationID:     verification.VerificationID,
+		InputHash:          inputHash,
+		Provenance: AWSAdvisoryAuthorizationProvenance{
+			PolicyVersion: awsAdvisoryAuthorizationPolicyID,
+			PolicyRule:    rule,
+			SourceTypes:   dedupeStrings(sourceTypes),
+			Signals:       dedupeStrings(signals),
+		},
+		Evidence:           evidence,
+		EvidenceLinks:      evidenceLinks,
+		EvidenceBoundary:   awsAdvisoryAuthorizationEvidenceBoundary(),
+		AuditTrail:         awsAdvisoryAuthorizationAuditTrail(c, verification, outcome, rule, now),
+		KillSwitchEngaged:  verification.KillSwitchEngaged,
+		ReadOnlyProjection: true,
+		NextAction:         awsAdvisoryAuthorizationNextAction(outcome),
+		DecidedAt:          now,
+		UpdatedAt:          now,
+	}
+}
+
+// awsAdvisoryAuthorizationClassify is the deterministic decision policy. It
+// maps upstream case + verification state to one of the advertised outcomes
+// and returns the operator-visible rule name plus rationale. Ordering matters:
+// safety-critical states (kill switch, verification failed) win over general
+// approval state so a compromised or reverted execution can never be recorded
+// as `allow`.
+func awsAdvisoryAuthorizationClassify(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry) (outcome, rule, rationale string, confidence float64) {
+	if verification.KillSwitchEngaged {
+		return awsAdvisoryAuthorizationOutcomeQuarantine, "kill_switch_engaged", "Tenant remediation kill switch is engaged; recommend quarantining new authorization until the switch is disabled.", 0.95
+	}
+	switch verification.State {
+	case awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateRollback:
+		return awsAdvisoryAuthorizationOutcomeQuarantine, "verification_failed", "Post-remediation verification failed; recommend quarantining the principal until the rollback record is applied and evidence is refreshed.", 0.9
+	case awsPostRemediationVerificationStateVerified:
+		return awsAdvisoryAuthorizationOutcomeAllow, "verification_verified", "Post-remediation verification confirmed the intended state; allow the projected authorization.", 0.9
+	case awsPostRemediationVerificationStateBlocked:
+		return awsAdvisoryAuthorizationOutcomeRecommendDeny, "verification_blocked", "Verification is blocked by a safety gate or an unresolved upstream precondition; recommend deny until the failing gate clears.", 0.85
+	}
+	if strings.EqualFold(c.Lifecycle, "resolved") {
+		return awsAdvisoryAuthorizationOutcomeAllow, "case_resolved", "Remediation case is resolved and no active risk finding is present; allow the projected authorization.", 0.85
+	}
+	if strings.EqualFold(c.ApprovalState, "blocked") {
+		return awsAdvisoryAuthorizationOutcomeRecommendDeny, "approval_blocked", "Approval workflow blocked the change; recommend deny until the failing gate is satisfied.", 0.85
+	}
+	if strings.EqualFold(c.ApprovalState, "approved") {
+		return awsAdvisoryAuthorizationOutcomeRequireApproval, "approved_awaiting_apply", "Change is approved but has not been applied and verified; require approval workflow to reach live execution before allowing the new posture.", 0.82
+	}
+	if c.ApprovalRequired {
+		return awsAdvisoryAuthorizationOutcomeRequireApproval, "approval_required", "Case still requires approval before it can be executed; require approval before altering authorization.", 0.8
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Severity)) {
+	case "critical", "high":
+		return awsAdvisoryAuthorizationOutcomeWarn, "high_severity_finding", "Upstream risk finding is high severity but no execution is in flight; warn operators and prioritize case triage.", 0.75
+	}
+	return awsAdvisoryAuthorizationOutcomeAllow, "no_active_risk", "No active risk finding or in-flight execution blocks the projected authorization; allow with advisory monitoring.", 0.7
+}
+
+func awsAdvisoryAuthorizationActionForDiffKind(kind, sourceType string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "iam_policy_diff", "iac_iam_policy_pr":
+		return "iam:PutRolePolicy"
+	case "iam_trust_diff", "iac_trust_policy_pr":
+		return "iam:UpdateAssumeRolePolicy"
+	case "permission_boundary_diff":
+		return "iam:PutRolePermissionsBoundary"
+	case "scp_diff":
+		return "organizations:AttachPolicy"
+	case "kms_grant_diff":
+		return "kms:PutKeyPolicy"
+	case "secret_rotation":
+		return "secretsmanager:RotateSecret"
+	case "access_key_quarantine":
+		return "iam:UpdateAccessKey"
+	case "ai_agent_scope_change":
+		return "bedrock-agent:UpdateAgent"
+	}
+	switch strings.ToLower(strings.TrimSpace(sourceType)) {
+	case "least_privilege":
+		return "iam:PutRolePolicy"
+	case "aws_permission_boundary_scp":
+		return "iam:PutRolePermissionsBoundary"
+	case "trust_policy_hardening":
+		return "iam:UpdateAssumeRolePolicy"
+	case "aws_secret_key_rotation":
+		return "secretsmanager:RotateSecret"
+	case "aws_access_key_quarantine":
+		return "iam:UpdateAccessKey"
+	}
+	return "advisory:review"
+}
+
+func awsAdvisoryAuthorizationEvidenceFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry) []AWSAdvisoryAuthorizationEvidence {
+	out := []AWSAdvisoryAuthorizationEvidence{
+		{Source: "remediation_case", Label: c.SourceType, EvidenceRef: awsAdvisoryAuthorizationCaseEvidenceRef(c)},
+	}
+	if verification.VerificationID != "" {
+		out = append(out, AWSAdvisoryAuthorizationEvidence{
+			Source:      "post_remediation_verification",
+			Label:       verification.State,
+			EvidenceRef: firstString(verification.EvidenceLinks),
+		})
+	}
+	return out
+}
+
+func awsAdvisoryAuthorizationCaseEvidenceRef(c AWSRemediationCase) string {
+	if ref := strings.TrimSpace(c.DiffIntent.BeforeRef); ref != "" {
+		return ref
+	}
+	for _, evidence := range c.Evidence {
+		if ref := strings.TrimSpace(evidence.EvidenceRef); ref != "" {
+			return ref
+		}
+	}
+	return ""
+}
+
+func awsAdvisoryAuthorizationEvidenceLinksFromCase(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry) []string {
+	links := []string{}
+	if ref := awsAdvisoryAuthorizationCaseEvidenceRef(c); ref != "" {
+		links = append(links, ref)
+	}
+	for _, link := range verification.EvidenceLinks {
+		if link != "" {
+			links = append(links, link)
+		}
+	}
+	links = append(links, "/docs/aws-advisory-authorization")
+	return dedupeStrings(links)
+}
+
+func awsAdvisoryAuthorizationAuditTrail(c AWSRemediationCase, verification AWSPostRemediationVerificationEntry, outcome, rule string, now time.Time) []AWSAdvisoryAuthorizationAuditEntry {
+	trail := []AWSAdvisoryAuthorizationAuditEntry{}
+	trail = append(trail, AWSAdvisoryAuthorizationAuditEntry{
+		EventID:    stableAWSBlastRadiusToken("advisory-decision-projected", c.CaseID, outcome, rule),
+		Actor:      "identrail-advisory-authorization-engine",
+		EventType:  "advisory_decision_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Case=%s outcome=%s rule=%s policy_version=%s verification=%s; Identrail did not call any AWS write API at this layer.", c.CaseID, outcome, rule, awsAdvisoryAuthorizationPolicyID, verification.State),
+	})
+	return trail
+}
+
+func awsAdvisoryAuthorizationNextAction(outcome string) string {
+	switch outcome {
+	case awsAdvisoryAuthorizationOutcomeAllow:
+		return "Recommendation is `allow`. Continue advisory monitoring; no operator action is required unless upstream signals change."
+	case awsAdvisoryAuthorizationOutcomeWarn:
+		return "Recommendation is `warn`. Prioritize case triage; consider raising the case severity or scheduling remediation."
+	case awsAdvisoryAuthorizationOutcomeRequireApproval:
+		return "Recommendation is `require_approval`. Advance the approval workflow and let the wave-8 apply runtime complete verification before treating the authorization as safe."
+	case awsAdvisoryAuthorizationOutcomeRecommendDeny:
+		return "Recommendation is `recommend_deny`. Do not extend or renew the authorization until the failing gate clears and the case is re-projected."
+	case awsAdvisoryAuthorizationOutcomeQuarantine:
+		return "Recommendation is `quarantine`. Disable the projected authorization until verification succeeds, rollback is applied, or the tenant kill switch is cleared."
+	}
+	return "Inspect the decision entry for the projected next action."
+}
+
+func awsAdvisoryAuthorizationRelationships(decisions []AWSAdvisoryAuthorizationDecision) []AWSAdvisoryAuthorizationRelationship {
+	relationships := []AWSAdvisoryAuthorizationRelationship{}
+	for _, decision := range decisions {
+		if strings.TrimSpace(decision.PrincipalNodeID) != "" {
+			relationships = append(relationships, AWSAdvisoryAuthorizationRelationship{
+				DecisionID:  decision.DecisionID,
+				Type:        "advises_principal",
+				FromNodeID:  decision.DecisionID,
+				ToNodeID:    decision.PrincipalNodeID,
+				EvidenceRef: firstString(decision.EvidenceLinks),
+			})
+		}
+		if strings.TrimSpace(decision.CaseID) != "" {
+			relationships = append(relationships, AWSAdvisoryAuthorizationRelationship{
+				DecisionID: decision.DecisionID,
+				Type:       "derives_from_case",
+				FromNodeID: decision.DecisionID,
+				ToNodeID:   decision.CaseID,
+			})
+		}
+		if strings.TrimSpace(decision.VerificationID) != "" {
+			relationships = append(relationships, AWSAdvisoryAuthorizationRelationship{
+				DecisionID: decision.DecisionID,
+				Type:       "derives_from_verification",
+				FromNodeID: decision.DecisionID,
+				ToNodeID:   decision.VerificationID,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSAdvisoryAuthorizationDecisions(all, filtered []AWSAdvisoryAuthorizationDecision, relationships []AWSAdvisoryAuthorizationRelationship) AWSAdvisoryAuthorizationSummary {
+	summary := AWSAdvisoryAuthorizationSummary{
+		TotalDecisions:    len(all),
+		FilteredDecisions: len(filtered),
+		OutcomeCounts:     map[string]int{},
+		SeverityCounts:    map[string]int{},
+		SourceTypeCounts:  map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, decision := range filtered {
+		summary.OutcomeCounts[decision.Outcome]++
+		if decision.Severity != "" {
+			summary.SeverityCounts[decision.Severity]++
+		}
+		if decision.SourceType != "" {
+			summary.SourceTypeCounts[decision.SourceType]++
+		}
+		switch decision.Outcome {
+		case awsAdvisoryAuthorizationOutcomeAllow:
+			summary.AllowCount++
+		case awsAdvisoryAuthorizationOutcomeWarn:
+			summary.WarnCount++
+		case awsAdvisoryAuthorizationOutcomeRequireApproval:
+			summary.RequireApprovalCount++
+		case awsAdvisoryAuthorizationOutcomeRecommendDeny:
+			summary.RecommendDenyCount++
+		case awsAdvisoryAuthorizationOutcomeQuarantine:
+			summary.QuarantineCount++
+		}
+		if decision.KillSwitchEngaged {
+			summary.KillSwitchEngagedCount++
+		}
+		if decision.Score > summary.HighestScore {
+			summary.HighestScore = decision.Score
+		}
+		confidenceTotal += decision.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSAdvisoryAuthorizationDecisions(decisions []AWSAdvisoryAuthorizationDecision, request AWSAdvisoryAuthorizationRequest) ([]AWSAdvisoryAuthorizationDecision, map[string]string) {
+	filters := map[string]string{
+		"account_id":      strings.TrimSpace(request.AccountID),
+		"region":          strings.TrimSpace(request.Region),
+		"principal_id":    strings.TrimSpace(request.PrincipalID),
+		"action":          strings.TrimSpace(request.Action),
+		"outcome":         normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"severity":        normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"source_type":     strings.ToLower(strings.TrimSpace(request.SourceType)),
+		"case_id":         strings.TrimSpace(request.CaseID),
+		"verification_id": strings.TrimSpace(request.VerificationID),
+		"search":          strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSAdvisoryAuthorizationDecision, 0, len(decisions))
+	for _, decision := range decisions {
+		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(decision.AccountID)) {
+			continue
+		}
+		if filters["region"] != "" && strings.TrimSpace(decision.Region) != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(decision.Region)) {
+			continue
+		}
+		if filters["principal_id"] != "" && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(decision.PrincipalNodeID)) && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(decision.PrincipalARN)) {
+			continue
+		}
+		if filters["action"] != "" && !strings.EqualFold(filters["action"], strings.TrimSpace(decision.Action)) {
+			continue
+		}
+		if filters["outcome"] != "" && filters["outcome"] != normalizeAWSRuntimeEventFilterToken(decision.Outcome) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(decision.Severity) {
+			continue
+		}
+		if filters["source_type"] != "" && !strings.EqualFold(filters["source_type"], decision.SourceType) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], decision.CaseID) {
+			continue
+		}
+		if filters["verification_id"] != "" && !strings.EqualFold(filters["verification_id"], decision.VerificationID) {
+			continue
+		}
+		if filters["search"] != "" && !awsAdvisoryAuthorizationSearchMatch(decision, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, decision)
+	}
+	return filtered, applied
+}
+
+func awsAdvisoryAuthorizationSearchMatch(decision AWSAdvisoryAuthorizationDecision, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		decision.DecisionID, decision.Outcome, decision.Severity, decision.Title, decision.Summary,
+		decision.Rationale, decision.PrincipalNodeID, decision.PrincipalARN, decision.PrincipalType,
+		decision.Action, decision.SourceType, decision.CaseID, decision.VerificationID, decision.NextAction,
+		decision.Provenance.PolicyRule, decision.Provenance.PolicyVersion,
+	}
+	values = append(values, decision.ResourceScope...)
+	values = append(values, decision.Provenance.SourceTypes...)
+	values = append(values, decision.Provenance.Signals...)
+	values = append(values, decision.EvidenceLinks...)
+	values = append(values, decision.InputHash.Components...)
+	for _, evidence := range decision.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef)
+	}
+	for _, audit := range decision.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSAdvisoryAuthorizationStatus(caseStatus, verificationStatus string, filtered []AWSAdvisoryAuthorizationDecision, diagnostics []AWSAdvisoryAuthorizationDiagnostic) (string, float64) {
+	if caseStatus == awsPlatformDependencyStatusBlocked || verificationStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if caseStatus == awsPlatformDependencyStatusDegraded || verificationStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsAdvisoryAuthorizationCaveats() []string {
+	return []string{
+		"Advisory authorization decisions are read-only recommendations; Identrail never enforces the outcome at this layer.",
+		"Every decision carries a deterministic input hash and policy version so operators can detect drift when upstream signals change.",
+		"Kill-switch and verification-failed states always classify as quarantine; the policy prevents a compromised or reverted execution from being recorded as `allow`.",
+	}
+}
+
+func awsAdvisoryAuthorizationRemediationHints(source []string) []string {
+	hints := []string{
+		"Treat this endpoint as advisory input to policy decision points; downstream governance executors decide whether and how to enforce.",
+		"If a decision moves to `quarantine`, investigate the upstream verification/kill-switch signal before making any live change.",
+		"When the policy version changes, expect decision IDs and input hashes to change; log both for audit.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsAdvisoryAuthorizationDiagnostics(caseDiag []AWSRemediationCaseDiagnostic, verifDiag []AWSPostRemediationVerificationDiagnostic) []AWSAdvisoryAuthorizationDiagnostic {
+	out := []AWSAdvisoryAuthorizationDiagnostic{}
+	for _, diagnostic := range caseDiag {
+		out = append(out, AWSAdvisoryAuthorizationDiagnostic{
+			Collector:   diagnostic.Collector,
+			SourceID:    diagnostic.SourceID,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: diagnostic.Remediation,
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	for _, diagnostic := range verifDiag {
+		out = append(out, AWSAdvisoryAuthorizationDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsAdvisoryAuthorizationCoverageGaps(caseGaps []AWSRemediationCaseCoverageGap, verifGaps []AWSPostRemediationVerificationCoverageGap) []AWSAdvisoryAuthorizationCoverageGap {
+	out := []AWSAdvisoryAuthorizationCoverageGap{}
+	for _, gap := range caseGaps {
+		out = append(out, AWSAdvisoryAuthorizationCoverageGap{
+			Capability:  gap.Capability,
+			Status:      gap.Status,
+			Reason:      gap.Reason,
+			Remediation: gap.Remediation,
+		})
+	}
+	for _, gap := range verifGaps {
+		out = append(out, AWSAdvisoryAuthorizationCoverageGap(gap))
+	}
+	return out
+}
+
+func awsAdvisoryAuthorizationEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_advisory_authorization.go
+++ b/internal/api/aws_advisory_authorization.go
@@ -320,13 +320,39 @@ func awsAdvisoryAuthorizationDecisionFromCase(c AWSRemediationCase, verification
 	}
 	evidence := awsAdvisoryAuthorizationEvidenceFromCase(c, verification)
 	evidenceLinks := awsAdvisoryAuthorizationEvidenceLinksFromCase(c, verification)
+	// Hash every input the classifier reads. If any of these change the
+	// outcome/rationale can change, so operators must be able to detect the
+	// drift by comparing hashes across runs.
+	killSwitchToken := "false"
+	if verification.KillSwitchEngaged {
+		killSwitchToken = "true"
+	}
+	approvalRequiredToken := "false"
+	if c.ApprovalRequired {
+		approvalRequiredToken = "true"
+	}
 	inputHash := AWSAdvisoryAuthorizationInputHash{
-		Value: stableAWSBlastRadiusToken("input", c.CaseID, c.Lifecycle, c.ApprovalState, verification.State, verification.VerificationID, awsAdvisoryAuthorizationVersion, awsAdvisoryAuthorizationPolicyID),
+		Value: stableAWSBlastRadiusToken(
+			"input",
+			c.CaseID,
+			c.Lifecycle,
+			c.ApprovalState,
+			approvalRequiredToken,
+			c.Severity,
+			verification.State,
+			verification.VerificationID,
+			killSwitchToken,
+			awsAdvisoryAuthorizationVersion,
+			awsAdvisoryAuthorizationPolicyID,
+		),
 		Components: []string{
 			"case_id=" + c.CaseID,
 			"lifecycle=" + c.Lifecycle,
 			"approval_state=" + c.ApprovalState,
+			"approval_required=" + approvalRequiredToken,
+			"severity=" + c.Severity,
 			"verification_state=" + verification.State,
+			"kill_switch_engaged=" + killSwitchToken,
 			"policy_version=" + awsAdvisoryAuthorizationPolicyID,
 		},
 	}
@@ -414,6 +440,12 @@ func awsAdvisoryAuthorizationClassify(c AWSRemediationCase, verification AWSPost
 		return awsAdvisoryAuthorizationOutcomeAllow, "verification_verified", "Post-remediation verification confirmed the intended state; allow the projected authorization.", 0.9
 	case awsPostRemediationVerificationStateBlocked:
 		return awsAdvisoryAuthorizationOutcomeRecommendDeny, "verification_blocked", "Verification is blocked by a safety gate or an unresolved upstream precondition; recommend deny until the failing gate clears.", 0.85
+	case awsPostRemediationVerificationStatePending:
+		return awsAdvisoryAuthorizationOutcomeRequireApproval, "verification_pending", "Execution is projected but post-remediation verification has not recorded outcomes yet; require approval workflow to reach a verified state before allowing the new posture.", 0.8
+	case awsPostRemediationVerificationStateNotReady:
+		return awsAdvisoryAuthorizationOutcomeWarn, "verification_not_ready", "Upstream executor has not declared ready_for_live_apply; warn operators and refresh planner/dry-run evidence before allowing the projected authorization.", 0.75
+	case awsPostRemediationVerificationStateSkipped:
+		return awsAdvisoryAuthorizationOutcomeWarn, "verification_skipped", "Upstream executor did not project a live-apply record; warn operators and re-run planner/dry-run before allowing the projected authorization.", 0.75
 	}
 	if strings.EqualFold(c.Lifecycle, "resolved") {
 		return awsAdvisoryAuthorizationOutcomeAllow, "case_resolved", "Remediation case is resolved and no active risk finding is present; allow the projected authorization.", 0.85

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -144,6 +144,59 @@ func TestAWSAdvisoryAuthorizationClassifyPolicyOrder(t *testing.T) {
 	}
 }
 
+func TestAWSAdvisoryAuthorizationClassifyBlocksAllowOnNonTerminalVerification(t *testing.T) {
+	resolved := AWSRemediationCase{CaseID: "case-resolved", Lifecycle: "resolved", Severity: "low"}
+	low := AWSRemediationCase{CaseID: "case-low", Lifecycle: "proposed", Severity: "low"}
+
+	pending := AWSPostRemediationVerificationEntry{VerificationID: "v-1", State: awsPostRemediationVerificationStatePending}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(resolved, pending); out != awsAdvisoryAuthorizationOutcomeRequireApproval || rule != "verification_pending" {
+		t.Fatalf("pending verification must not let a resolved case be allowed: outcome=%s rule=%s", out, rule)
+	}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(low, pending); out != awsAdvisoryAuthorizationOutcomeRequireApproval || rule != "verification_pending" {
+		t.Fatalf("pending verification must gate low-severity cases: outcome=%s rule=%s", out, rule)
+	}
+
+	notReady := AWSPostRemediationVerificationEntry{VerificationID: "v-2", State: awsPostRemediationVerificationStateNotReady}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(resolved, notReady); out != awsAdvisoryAuthorizationOutcomeWarn || rule != "verification_not_ready" {
+		t.Fatalf("not-ready verification must warn even on resolved case: outcome=%s rule=%s", out, rule)
+	}
+
+	skipped := AWSPostRemediationVerificationEntry{VerificationID: "v-3", State: awsPostRemediationVerificationStateSkipped}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(low, skipped); out != awsAdvisoryAuthorizationOutcomeWarn || rule != "verification_skipped" {
+		t.Fatalf("skipped verification must warn even for low-severity cases: outcome=%s rule=%s", out, rule)
+	}
+}
+
+func TestAWSAdvisoryAuthorizationInputHashCoversAllClassifierInputs(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	base := AWSRemediationCase{
+		CaseID:        "case-hash",
+		Lifecycle:     "proposed",
+		ApprovalState: "pending_approver",
+		Severity:      "low",
+	}
+	baseVerify := AWSPostRemediationVerificationEntry{VerificationID: "v-hash", State: awsPostRemediationVerificationStatePending}
+	baseHash := awsAdvisoryAuthorizationDecisionFromCase(base, baseVerify, now).InputHash.Value
+
+	killed := baseVerify
+	killed.KillSwitchEngaged = true
+	if h := awsAdvisoryAuthorizationDecisionFromCase(base, killed, now).InputHash.Value; h == baseHash {
+		t.Fatalf("kill_switch_engaged must be part of the input hash so drift is detectable: %s", h)
+	}
+
+	severityChanged := base
+	severityChanged.Severity = "critical"
+	if h := awsAdvisoryAuthorizationDecisionFromCase(severityChanged, baseVerify, now).InputHash.Value; h == baseHash {
+		t.Fatalf("severity change must move the input hash: %s", h)
+	}
+
+	approvalRequired := base
+	approvalRequired.ApprovalRequired = true
+	if h := awsAdvisoryAuthorizationDecisionFromCase(approvalRequired, baseVerify, now).InputHash.Value; h == baseHash {
+		t.Fatalf("approval_required toggle must move the input hash: %s", h)
+	}
+}
+
 func TestAWSAdvisoryAuthorizationVerificationSeverityRankPrefersSafetySignals(t *testing.T) {
 	pending := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStatePending}
 	verified := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateVerified}

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -199,6 +199,8 @@ func TestAWSAdvisoryAuthorizationInputHashCoversAllClassifierInputs(t *testing.T
 
 func TestAWSAdvisoryAuthorizationVerificationSeverityRankPrefersSafetySignals(t *testing.T) {
 	pending := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStatePending}
+	notReady := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateNotReady}
+	skipped := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateSkipped}
 	verified := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateVerified}
 	failed := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateFailed}
 	killed := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStatePending, KillSwitchEngaged: true}
@@ -211,6 +213,61 @@ func TestAWSAdvisoryAuthorizationVerificationSeverityRankPrefersSafetySignals(t 
 	}
 	if awsAdvisoryAuthorizationVerificationSeverityRank(pending) <= awsAdvisoryAuthorizationVerificationSeverityRank(verified) {
 		t.Fatalf("pending must outrank verified so a not-yet-verified execution isn't classified as allow: pending=%d verified=%d", awsAdvisoryAuthorizationVerificationSeverityRank(pending), awsAdvisoryAuthorizationVerificationSeverityRank(verified))
+	}
+	if awsAdvisoryAuthorizationVerificationSeverityRank(pending) <= awsAdvisoryAuthorizationVerificationSeverityRank(notReady) {
+		t.Fatalf("pending must outrank not_ready so an in-flight verification is not understated as warn: pending=%d not_ready=%d", awsAdvisoryAuthorizationVerificationSeverityRank(pending), awsAdvisoryAuthorizationVerificationSeverityRank(notReady))
+	}
+	if awsAdvisoryAuthorizationVerificationSeverityRank(pending) <= awsAdvisoryAuthorizationVerificationSeverityRank(skipped) {
+		t.Fatalf("pending must outrank skipped: pending=%d skipped=%d", awsAdvisoryAuthorizationVerificationSeverityRank(pending), awsAdvisoryAuthorizationVerificationSeverityRank(skipped))
+	}
+}
+
+func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) {
+	cases := []struct {
+		name       string
+		c          AWSRemediationCase
+		wantAction string
+	}{
+		{
+			name: "permission boundary on IAM user projects PutUser variant",
+			c: AWSRemediationCase{
+				SourceType:   "aws_permission_boundary_scp",
+				IdentityType: "iam_user",
+				DiffIntent:   AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+			},
+			wantAction: "iam:PutUserPermissionsBoundary",
+		},
+		{
+			name: "permission boundary on IAM role projects PutRole variant",
+			c: AWSRemediationCase{
+				SourceType:   "aws_permission_boundary_scp",
+				IdentityType: "iam_role",
+				DiffIntent:   AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+			},
+			wantAction: "iam:PutRolePermissionsBoundary",
+		},
+		{
+			name: "iam policy diff on IAM user projects PutUserPolicy",
+			c: AWSRemediationCase{
+				SourceType:   "least_privilege",
+				IdentityType: "iam_user",
+				DiffIntent:   AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantAction: "iam:PutUserPolicy",
+		},
+		{
+			name: "source-type fallthrough on IAM user still projects PutUser variant",
+			c: AWSRemediationCase{
+				SourceType:   "aws_permission_boundary_scp",
+				IdentityType: "iam_user",
+			},
+			wantAction: "iam:PutUserPermissionsBoundary",
+		},
+	}
+	for _, tc := range cases {
+		if got := awsAdvisoryAuthorizationActionForCase(tc.c); got != tc.wantAction {
+			t.Fatalf("%s: got %q want %q", tc.name, got, tc.wantAction)
+		}
 	}
 }
 

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -263,6 +263,31 @@ func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) 
 			},
 			wantAction: "iam:PutUserPermissionsBoundary",
 		},
+		{
+			name: "no-op diff never advertises an IAM write even for least-privilege sources",
+			c: AWSRemediationCase{
+				SourceType: "least_privilege",
+				DiffIntent: AWSRemediationDiffIntent{Kind: "manual_review", NoOp: true},
+			},
+			wantAction: "advisory:review",
+		},
+		{
+			name: "role_scope_diff routes to Put*Policy like iam_policy_diff for ai_agent_risk",
+			c: AWSRemediationCase{
+				SourceType: "ai_agent_risk",
+				DiffIntent: AWSRemediationDiffIntent{Kind: "role_scope_diff"},
+			},
+			wantAction: "iam:PutRolePolicy",
+		},
+		{
+			name: "role_scope_diff on IAM user projects PutUserPolicy",
+			c: AWSRemediationCase{
+				SourceType:   "blast_radius",
+				IdentityType: "iam_user",
+				DiffIntent:   AWSRemediationDiffIntent{Kind: "role_scope_diff"},
+			},
+			wantAction: "iam:PutUserPolicy",
+		},
 	}
 	for _, tc := range cases {
 		if got := awsAdvisoryAuthorizationActionForCase(tc.c); got != tc.wantAction {

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -337,8 +337,10 @@ func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) 
 
 func TestAWSAdvisoryAuthorizationSplitsMixedPermissionBoundaryTargets(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
-	roleTarget := "arn:aws:iam::111111111111:role/app"
-	userTarget := "arn:aws:iam::222222222222:user/operator"
+	roleARN := "arn:aws:iam::111111111111:role/app"
+	userARN := "arn:aws:iam::222222222222:user/operator"
+	roleTarget := "aws:identity:" + roleARN
+	userTarget := "aws:identity:" + userARN
 	c := AWSRemediationCase{
 		CaseID:          "case-boundary-mixed",
 		SourceType:      "aws_permission_boundary_scp",
@@ -349,7 +351,7 @@ func TestAWSAdvisoryAuthorizationSplitsMixedPermissionBoundaryTargets(t *testing
 		DiffIntent:      AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
 	}
 
-	decisions := awsAdvisoryAuthorizationDecisionsFromCase(c, AWSPostRemediationVerificationEntry{}, now)
+	decisions := awsAdvisoryAuthorizationDecisionsFromCase(c, nil, now)
 	if len(decisions) != 2 {
 		t.Fatalf("mixed permission-boundary targets must produce one decision per supported target, got %d: %+v", len(decisions), decisions)
 	}
@@ -366,15 +368,58 @@ func TestAWSAdvisoryAuthorizationSplitsMixedPermissionBoundaryTargets(t *testing
 	}
 
 	roleDecision := byAction["iam:PutRolePermissionsBoundary"]
-	if roleDecision.PrincipalNodeID != roleTarget || roleDecision.AccountID != "111111111111" {
+	if roleDecision.PrincipalNodeID != roleTarget || roleDecision.PrincipalARN != roleARN || roleDecision.AccountID != "111111111111" {
 		t.Fatalf("role boundary decision scoped to wrong target/account: %+v", roleDecision)
 	}
 	userDecision := byAction["iam:PutUserPermissionsBoundary"]
-	if userDecision.PrincipalNodeID != userTarget || userDecision.AccountID != "222222222222" {
+	if userDecision.PrincipalNodeID != userTarget || userDecision.PrincipalARN != userARN || userDecision.AccountID != "222222222222" {
 		t.Fatalf("user boundary decision scoped to wrong target/account: %+v", userDecision)
 	}
 	if roleDecision.DecisionID == userDecision.DecisionID {
 		t.Fatalf("split boundary decisions must have distinct decision IDs: role=%s user=%s", roleDecision.DecisionID, userDecision.DecisionID)
+	}
+}
+
+func TestAWSAdvisoryAuthorizationSplitTargetsUseMatchingVerification(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 0, 0, 0, time.UTC)
+	roleTarget := "aws:identity:arn:aws:iam::111111111111:role/app"
+	userTarget := "aws:identity:arn:aws:iam::222222222222:user/operator"
+	c := AWSRemediationCase{
+		CaseID:          "case-boundary-verification",
+		SourceType:      "aws_permission_boundary_scp",
+		Severity:        "medium",
+		IdentityNodeID:  roleTarget,
+		ResourceNodeIDs: []string{roleTarget, userTarget},
+		DiffIntent:      AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+	}
+	verifications := []AWSPostRemediationVerificationEntry{
+		{
+			VerificationID: "v-role",
+			CaseID:         c.CaseID,
+			State:          awsPostRemediationVerificationStateVerified,
+			TargetResource: roleTarget,
+		},
+		{
+			VerificationID: "v-user",
+			CaseID:         c.CaseID,
+			State:          awsPostRemediationVerificationStatePending,
+			TargetResource: "arn:aws:iam::222222222222:user/operator",
+		},
+	}
+
+	decisions := awsAdvisoryAuthorizationDecisionsFromCase(c, verifications, now)
+	byAction := map[string]AWSAdvisoryAuthorizationDecision{}
+	for _, decision := range decisions {
+		byAction[decision.Action] = decision
+	}
+
+	roleDecision := byAction["iam:PutRolePermissionsBoundary"]
+	if roleDecision.VerificationID != "v-role" || roleDecision.Outcome != awsAdvisoryAuthorizationOutcomeAllow {
+		t.Fatalf("role split decision must use role verification, got %+v", roleDecision)
+	}
+	userDecision := byAction["iam:PutUserPermissionsBoundary"]
+	if userDecision.VerificationID != "v-user" || userDecision.Outcome != awsAdvisoryAuthorizationOutcomeRequireApproval {
+		t.Fatalf("user split decision must use user verification, got %+v", userDecision)
 	}
 }
 

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -288,6 +288,35 @@ func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) 
 			},
 			wantAction: "iam:PutUserPolicy",
 		},
+		{
+			name: "generic identity type falls back to identity node ID (user)",
+			c: AWSRemediationCase{
+				SourceType:     "least_privilege",
+				IdentityType:   "iam_identity",
+				IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:user/actor",
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantAction: "iam:PutUserPolicy",
+		},
+		{
+			name: "generic identity type falls back to identity ARN (group)",
+			c: AWSRemediationCase{
+				SourceType:   "blast_radius",
+				IdentityType: "iam_identity",
+				IdentityARN:  "arn:aws:iam::111111111111:group/analysts",
+				DiffIntent:   AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantAction: "iam:PutGroupPolicy",
+		},
+		{
+			name: "group principal on permission boundary falls back to advisory:review",
+			c: AWSRemediationCase{
+				SourceType:     "aws_permission_boundary_scp",
+				IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:group/app-group",
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+			},
+			wantAction: "advisory:review",
+		},
 	}
 	for _, tc := range cases {
 		if got := awsAdvisoryAuthorizationActionForCase(tc.c); got != tc.wantAction {

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -299,6 +299,16 @@ func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) 
 			wantAction: "iam:PutUserPolicy",
 		},
 		{
+			name: "hard-coded role identity type still parses user node ID first",
+			c: AWSRemediationCase{
+				SourceType:     "least_privilege",
+				IdentityType:   "iam_role",
+				IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:user/actor",
+				DiffIntent:     AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+			},
+			wantAction: "iam:PutUserPolicy",
+		},
+		{
 			name: "generic identity type falls back to identity ARN (group)",
 			c: AWSRemediationCase{
 				SourceType:   "blast_radius",
@@ -322,6 +332,49 @@ func TestAWSAdvisoryAuthorizationActionForCaseHonorsPrincipalKind(t *testing.T) 
 		if got := awsAdvisoryAuthorizationActionForCase(tc.c); got != tc.wantAction {
 			t.Fatalf("%s: got %q want %q", tc.name, got, tc.wantAction)
 		}
+	}
+}
+
+func TestAWSAdvisoryAuthorizationSplitsMixedPermissionBoundaryTargets(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	roleTarget := "arn:aws:iam::111111111111:role/app"
+	userTarget := "arn:aws:iam::222222222222:user/operator"
+	c := AWSRemediationCase{
+		CaseID:          "case-boundary-mixed",
+		SourceType:      "aws_permission_boundary_scp",
+		Severity:        "medium",
+		IdentityType:    "iam_role",
+		IdentityNodeID:  roleTarget,
+		ResourceNodeIDs: []string{roleTarget, userTarget},
+		DiffIntent:      AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+	}
+
+	decisions := awsAdvisoryAuthorizationDecisionsFromCase(c, AWSPostRemediationVerificationEntry{}, now)
+	if len(decisions) != 2 {
+		t.Fatalf("mixed permission-boundary targets must produce one decision per supported target, got %d: %+v", len(decisions), decisions)
+	}
+
+	byAction := map[string]AWSAdvisoryAuthorizationDecision{}
+	for _, decision := range decisions {
+		if byAction[decision.Action].DecisionID != "" {
+			t.Fatalf("expected distinct action rows for mixed user/role boundary targets: %+v", decisions)
+		}
+		byAction[decision.Action] = decision
+		if len(decision.ResourceScope) != 1 {
+			t.Fatalf("split decision must scope to exactly one boundary target: %+v", decision)
+		}
+	}
+
+	roleDecision := byAction["iam:PutRolePermissionsBoundary"]
+	if roleDecision.PrincipalNodeID != roleTarget || roleDecision.AccountID != "111111111111" {
+		t.Fatalf("role boundary decision scoped to wrong target/account: %+v", roleDecision)
+	}
+	userDecision := byAction["iam:PutUserPermissionsBoundary"]
+	if userDecision.PrincipalNodeID != userTarget || userDecision.AccountID != "222222222222" {
+		t.Fatalf("user boundary decision scoped to wrong target/account: %+v", userDecision)
+	}
+	if roleDecision.DecisionID == userDecision.DecisionID {
+		t.Fatalf("split boundary decisions must have distinct decision IDs: role=%s user=%s", roleDecision.DecisionID, userDecision.DecisionID)
 	}
 }
 

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -380,6 +380,37 @@ func TestAWSAdvisoryAuthorizationSplitsMixedPermissionBoundaryTargets(t *testing
 	}
 }
 
+func TestAWSAdvisoryAuthorizationNormalizesSinglePermissionBoundaryTargetARN(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 30, 0, 0, time.UTC)
+	roleARN := "arn:aws:iam::111111111111:role/single-app"
+	roleTarget := "aws:identity:" + roleARN
+	c := AWSRemediationCase{
+		CaseID:           "case-boundary-single",
+		SourceType:       "aws_permission_boundary_scp",
+		Severity:         "medium",
+		IdentityNodeID:   roleTarget,
+		ResourceNodeIDs:  []string{roleTarget},
+		TargetAccountIDs: []string{"111111111111"},
+		DiffIntent:       AWSRemediationDiffIntent{Kind: "permission_boundary_diff"},
+	}
+
+	decisions := awsAdvisoryAuthorizationDecisionsFromCase(c, nil, now)
+	if len(decisions) != 1 {
+		t.Fatalf("single permission-boundary target must stay one advisory decision, got %d: %+v", len(decisions), decisions)
+	}
+	decision := decisions[0]
+	if decision.PrincipalNodeID != roleTarget || decision.PrincipalARN != roleARN {
+		t.Fatalf("single boundary target must preserve node ID and expose embedded ARN: %+v", decision)
+	}
+	if decision.Action != "iam:PutRolePermissionsBoundary" || decision.AccountID != "111111111111" {
+		t.Fatalf("single boundary decision scoped to wrong action/account: %+v", decision)
+	}
+	wantID := "aws-advisory-authorization:" + stableAWSBlastRadiusToken("decision", c.CaseID, decision.Action)
+	if decision.DecisionID != wantID {
+		t.Fatalf("single boundary decision ID should not add a split target scope: got %q want %q", decision.DecisionID, wantID)
+	}
+}
+
 func TestAWSAdvisoryAuthorizationSplitTargetsUseMatchingVerification(t *testing.T) {
 	now := time.Date(2026, 7, 3, 13, 0, 0, 0, time.UTC)
 	roleTarget := "aws:identity:arn:aws:iam::111111111111:role/app"

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -144,6 +144,61 @@ func TestAWSAdvisoryAuthorizationClassifyPolicyOrder(t *testing.T) {
 	}
 }
 
+func TestAWSAdvisoryAuthorizationVerificationSeverityRankPrefersSafetySignals(t *testing.T) {
+	pending := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStatePending}
+	verified := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateVerified}
+	failed := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateFailed}
+	killed := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStatePending, KillSwitchEngaged: true}
+
+	if awsAdvisoryAuthorizationVerificationSeverityRank(killed) <= awsAdvisoryAuthorizationVerificationSeverityRank(failed) {
+		t.Fatalf("kill switch must outrank failed verification: killed=%d failed=%d", awsAdvisoryAuthorizationVerificationSeverityRank(killed), awsAdvisoryAuthorizationVerificationSeverityRank(failed))
+	}
+	if awsAdvisoryAuthorizationVerificationSeverityRank(failed) <= awsAdvisoryAuthorizationVerificationSeverityRank(verified) {
+		t.Fatalf("failed verification must outrank verified: failed=%d verified=%d", awsAdvisoryAuthorizationVerificationSeverityRank(failed), awsAdvisoryAuthorizationVerificationSeverityRank(verified))
+	}
+	if awsAdvisoryAuthorizationVerificationSeverityRank(pending) <= awsAdvisoryAuthorizationVerificationSeverityRank(verified) {
+		t.Fatalf("pending must outrank verified so a not-yet-verified execution isn't classified as allow: pending=%d verified=%d", awsAdvisoryAuthorizationVerificationSeverityRank(pending), awsAdvisoryAuthorizationVerificationSeverityRank(verified))
+	}
+}
+
+func TestAWSAdvisoryAuthorizationAccountFilterMatchesTargetAccounts(t *testing.T) {
+	decisions := []AWSAdvisoryAuthorizationDecision{
+		{
+			DecisionID:       "d-multi",
+			AccountID:        "111111111111",
+			TargetAccountIDs: []string{"111111111111", "222222222222", "333333333333"},
+			Outcome:          awsAdvisoryAuthorizationOutcomeRequireApproval,
+		},
+	}
+
+	filtered, _ := filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{AccountID: "333333333333"})
+	if len(filtered) != 1 || filtered[0].DecisionID != "d-multi" {
+		t.Fatalf("account_id filter must match target_account_ids on the decision, not just the primary account: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{AccountID: "111111111111"})
+	if len(filtered) != 1 {
+		t.Fatalf("primary account match still required: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{AccountID: "999999999999"})
+	if len(filtered) != 0 {
+		t.Fatalf("account filter must exclude decisions with no matching target: %+v", filtered)
+	}
+}
+
+func TestAWSAdvisoryAuthorizationRegionFilterIsStrict(t *testing.T) {
+	decisions := []AWSAdvisoryAuthorizationDecision{
+		{DecisionID: "d-regional", Region: "us-east-1", Outcome: awsAdvisoryAuthorizationOutcomeAllow},
+		{DecisionID: "d-regionless", Region: "", Outcome: awsAdvisoryAuthorizationOutcomeAllow},
+		{DecisionID: "d-other-region", Region: "us-west-2", Outcome: awsAdvisoryAuthorizationOutcomeAllow},
+	}
+	filtered, _ := filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{Region: "us-east-1"})
+	if len(filtered) != 1 || filtered[0].DecisionID != "d-regional" {
+		t.Fatalf("region filter must be strict: regionless and mismatched-region decisions must be excluded: %+v", filtered)
+	}
+}
+
 func TestFilterAWSAdvisoryAuthorizationDecisions(t *testing.T) {
 	decisions := []AWSAdvisoryAuthorizationDecision{
 		{

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -398,12 +398,14 @@ func TestAWSAdvisoryAuthorizationSplitTargetsUseMatchingVerification(t *testing.
 			CaseID:         c.CaseID,
 			State:          awsPostRemediationVerificationStateVerified,
 			TargetResource: roleTarget,
+			ImpactedNodes:  []string{roleTarget, userTarget},
 		},
 		{
 			VerificationID: "v-user",
 			CaseID:         c.CaseID,
 			State:          awsPostRemediationVerificationStatePending,
 			TargetResource: "arn:aws:iam::222222222222:user/operator",
+			ImpactedNodes:  []string{userTarget, roleTarget},
 		},
 	}
 

--- a/internal/api/aws_advisory_authorization_test.go
+++ b/internal/api/aws_advisory_authorization_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAdvisoryAuthorizationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSAdvisoryAuthorizationBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
+	svc, ws := newAdvisoryAuthorizationService(t, "project-advisory-authorization", now)
+
+	result, err := svc.GetAWSAdvisoryAuthorization(defaultScopeContext(), ws, "project-advisory-authorization", AWSAdvisoryAuthorizationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get advisory authorization: %v", err)
+	}
+	if result.CurrentIssueRef != "#1543" || result.Version != awsAdvisoryAuthorizationVersion || result.Mode != awsAdvisoryAuthorizationModeAdvisory {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.PolicyVersion != awsAdvisoryAuthorizationPolicyID {
+		t.Fatalf("expected policy version to be stable, got %q", result.PolicyVersion)
+	}
+	if len(result.Decisions) == 0 {
+		t.Fatalf("expected advisory decisions to be projected from remediation cases: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("expected relationship count to match: %+v", result.Summary)
+	}
+	for _, decision := range result.Decisions {
+		if decision.DecisionID == "" || decision.CalculationVersion != awsAdvisoryAuthorizationVersion {
+			t.Fatalf("decision missing stable metadata: %+v", decision)
+		}
+		if decision.Mode != awsAdvisoryAuthorizationModeAdvisory {
+			t.Fatalf("decision must remain advisory: %+v", decision)
+		}
+		switch decision.Outcome {
+		case awsAdvisoryAuthorizationOutcomeAllow, awsAdvisoryAuthorizationOutcomeWarn, awsAdvisoryAuthorizationOutcomeRequireApproval, awsAdvisoryAuthorizationOutcomeRecommendDeny, awsAdvisoryAuthorizationOutcomeQuarantine:
+		default:
+			t.Fatalf("decision has unknown outcome: %+v", decision)
+		}
+		if strings.TrimSpace(decision.Provenance.PolicyVersion) == "" || strings.TrimSpace(decision.Provenance.PolicyRule) == "" {
+			t.Fatalf("decision missing provenance: %+v", decision.Provenance)
+		}
+		if strings.TrimSpace(decision.InputHash.Value) == "" {
+			t.Fatalf("decision missing input hash: %+v", decision.InputHash)
+		}
+		if decision.CaseID == "" {
+			t.Fatalf("decision must reference its source case: %+v", decision)
+		}
+		if decision.EvidenceBoundary != awsAdvisoryAuthorizationEvidenceBoundary() {
+			t.Fatalf("decision crossed evidence boundary: %+v", decision)
+		}
+		if !decision.ReadOnlyProjection {
+			t.Fatalf("decision must remain a read-only projection: %+v", decision)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("advisory authorization serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSAdvisoryAuthorizationClassifyPolicyOrder(t *testing.T) {
+	baseCase := AWSRemediationCase{
+		CaseID:        "case-1",
+		Severity:      "high",
+		Lifecycle:     "proposed",
+		ApprovalState: "pending_approver",
+		DiffIntent:    AWSRemediationDiffIntent{Kind: "iam_policy_diff"},
+	}
+
+	killed := AWSPostRemediationVerificationEntry{KillSwitchEngaged: true, State: awsPostRemediationVerificationStateBlocked}
+	out, rule, _, _ := awsAdvisoryAuthorizationClassify(baseCase, killed)
+	if out != awsAdvisoryAuthorizationOutcomeQuarantine || rule != "kill_switch_engaged" {
+		t.Fatalf("kill switch must override every other signal: %s / %s", out, rule)
+	}
+
+	failed := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateFailed}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(baseCase, failed); out != awsAdvisoryAuthorizationOutcomeQuarantine || rule != "verification_failed" {
+		t.Fatalf("failed verification must classify as quarantine: %s / %s", out, rule)
+	}
+
+	verified := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateVerified}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(baseCase, verified); out != awsAdvisoryAuthorizationOutcomeAllow || rule != "verification_verified" {
+		t.Fatalf("verified verification must classify as allow: %s / %s", out, rule)
+	}
+
+	blockedVerify := AWSPostRemediationVerificationEntry{State: awsPostRemediationVerificationStateBlocked}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(baseCase, blockedVerify); out != awsAdvisoryAuthorizationOutcomeRecommendDeny || rule != "verification_blocked" {
+		t.Fatalf("blocked verification must classify as recommend_deny: %s / %s", out, rule)
+	}
+
+	empty := AWSPostRemediationVerificationEntry{}
+	approvedCase := baseCase
+	approvedCase.ApprovalState = "approved"
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(approvedCase, empty); out != awsAdvisoryAuthorizationOutcomeRequireApproval || rule != "approved_awaiting_apply" {
+		t.Fatalf("approved but unverified must require approval: %s / %s", out, rule)
+	}
+
+	blockedApproval := baseCase
+	blockedApproval.ApprovalState = "blocked"
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(blockedApproval, empty); out != awsAdvisoryAuthorizationOutcomeRecommendDeny || rule != "approval_blocked" {
+		t.Fatalf("blocked approval must classify as recommend_deny: %s / %s", out, rule)
+	}
+
+	resolved := baseCase
+	resolved.Lifecycle = "resolved"
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(resolved, empty); out != awsAdvisoryAuthorizationOutcomeAllow || rule != "case_resolved" {
+		t.Fatalf("resolved case must classify as allow: %s / %s", out, rule)
+	}
+
+	approvalRequired := AWSRemediationCase{CaseID: "case-2", Severity: "low", ApprovalRequired: true, ApprovalState: "pending_owner"}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(approvalRequired, empty); out != awsAdvisoryAuthorizationOutcomeRequireApproval || rule != "approval_required" {
+		t.Fatalf("approval-required case must classify as require_approval: %s / %s", out, rule)
+	}
+
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(baseCase, empty); out != awsAdvisoryAuthorizationOutcomeWarn || rule != "high_severity_finding" {
+		t.Fatalf("high severity without in-flight execution must warn: %s / %s", out, rule)
+	}
+
+	low := AWSRemediationCase{CaseID: "case-3", Severity: "low"}
+	if out, rule, _, _ := awsAdvisoryAuthorizationClassify(low, empty); out != awsAdvisoryAuthorizationOutcomeAllow || rule != "no_active_risk" {
+		t.Fatalf("low severity fallthrough must allow: %s / %s", out, rule)
+	}
+}
+
+func TestFilterAWSAdvisoryAuthorizationDecisions(t *testing.T) {
+	decisions := []AWSAdvisoryAuthorizationDecision{
+		{
+			DecisionID:      "d-allow",
+			Outcome:         awsAdvisoryAuthorizationOutcomeAllow,
+			Severity:        "medium",
+			PrincipalNodeID: "aws:identity:arn:aws:iam::111111111111:role/app",
+			AccountID:       "111111111111",
+			Action:          "iam:PutRolePolicy",
+			SourceType:      "least_privilege",
+			CaseID:          "case-1",
+		},
+		{
+			DecisionID:      "d-deny",
+			Outcome:         awsAdvisoryAuthorizationOutcomeRecommendDeny,
+			Severity:        "high",
+			PrincipalNodeID: "aws:identity:arn:aws:iam::222222222222:user/bot",
+			AccountID:       "222222222222",
+			Action:          "iam:UpdateAccessKey",
+			SourceType:      "aws_access_key_quarantine",
+			CaseID:          "case-2",
+		},
+	}
+
+	filtered, applied := filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{Outcome: "recommend_deny"})
+	if applied["outcome"] != normalizeAWSRuntimeEventFilterToken("recommend_deny") || len(filtered) != 1 || filtered[0].DecisionID != "d-deny" {
+		t.Fatalf("outcome filter did not scope decisions: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{PrincipalID: "aws:identity:arn:aws:iam::222222222222:user/bot"})
+	if len(filtered) != 1 || filtered[0].DecisionID != "d-deny" {
+		t.Fatalf("principal_id filter did not scope decisions: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{Action: "iam:PutRolePolicy"})
+	if len(filtered) != 1 || filtered[0].DecisionID != "d-allow" {
+		t.Fatalf("action filter did not scope decisions: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSAdvisoryAuthorizationDecisions(decisions, AWSAdvisoryAuthorizationRequest{Search: "case-2"})
+	if len(filtered) != 1 || filtered[0].DecisionID != "d-deny" {
+		t.Fatalf("search must reach case_id: %+v", filtered)
+	}
+}
+
+func TestAWSAdvisoryAuthorizationFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 2, 11, 0, 0, 0, time.UTC)
+	svc, ws := newAdvisoryAuthorizationService(t, "project-advisory-authorization-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSAdvisoryAuthorization(defaultScopeContext(), ws, "project-advisory-authorization-fixture", AWSAdvisoryAuthorizationRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestRouterAWSAdvisoryAuthorization(t *testing.T) {
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	svc, _ := newAdvisoryAuthorizationService(t, "project-advisory-authorization-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-advisory-authorization-route/aws/advisory-authorization?connector_id=aws-prod&fixture_state=success", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Advisory AWSAdvisoryAuthorizationResult `json:"advisory_authorization"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Advisory.CurrentIssueRef != "#1543" || body.Advisory.PolicyVersion != awsAdvisoryAuthorizationPolicyID {
+		t.Fatalf("unexpected route payload: %+v", body.Advisory)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3314,6 +3314,44 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"post_remediation_verification": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAdvisoryAuthorization(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAdvisoryAuthorizationRequest{
+			ConnectorID:    strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:   strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:      strings.TrimSpace(c.Query("account_id")),
+			Region:         strings.TrimSpace(c.Query("region")),
+			PrincipalID:    strings.TrimSpace(c.Query("principal_id")),
+			Action:         strings.TrimSpace(c.Query("action")),
+			Outcome:        strings.TrimSpace(c.Query("outcome")),
+			Severity:       strings.TrimSpace(c.Query("severity")),
+			SourceType:     strings.TrimSpace(c.Query("source_type")),
+			CaseID:         strings.TrimSpace(c.Query("case_id")),
+			VerificationID: strings.TrimSpace(c.Query("verification_id")),
+			Search:         strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws advisory authorization request"})
+			default:
+				logger.Error("get aws advisory authorization",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws advisory authorization"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"advisory_authorization": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3888,6 +3888,135 @@ export type AWSPostRemediationVerificationQuery = {
   search?: string;
 };
 
+export type AWSAdvisoryAuthorizationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAdvisoryAuthorizationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSAdvisoryAuthorizationOutcome = 'allow' | 'warn' | 'require_approval' | 'recommend_deny' | 'quarantine' | string;
+export type AWSAdvisoryAuthorizationMode = 'advisory' | string;
+
+export type AWSAdvisoryAuthorizationEvidence = {
+  source: string;
+  label: string;
+  evidence_ref?: string;
+};
+
+export type AWSAdvisoryAuthorizationInputHash = {
+  value: string;
+  components?: string[];
+};
+
+export type AWSAdvisoryAuthorizationProvenance = {
+  policy_version: string;
+  policy_rule: string;
+  source_types: string[];
+  signals?: string[];
+};
+
+export type AWSAdvisoryAuthorizationRelationship = {
+  decision_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSAdvisoryAuthorizationDecision = {
+  decision_id: string;
+  calculation_version: string;
+  mode: AWSAdvisoryAuthorizationMode;
+  outcome: AWSAdvisoryAuthorizationOutcome;
+  confidence: number;
+  severity: string;
+  score: number;
+  title: string;
+  summary: string;
+  rationale: string;
+  account_id?: string;
+  region?: string;
+  principal_node_id?: string;
+  principal_arn?: string;
+  principal_type?: string;
+  action: string;
+  resource_scope?: string[];
+  source_type: string;
+  case_id?: string;
+  verification_id?: string;
+  input_hash: AWSAdvisoryAuthorizationInputHash;
+  provenance: AWSAdvisoryAuthorizationProvenance;
+  evidence: AWSAdvisoryAuthorizationEvidence[];
+  evidence_links: string[];
+  evidence_boundary: string;
+  audit_trail: AWSRemediationAuditEntry[];
+  kill_switch_engaged: boolean;
+  read_only_projection: boolean;
+  next_action: string;
+  decided_at: string;
+  updated_at: string;
+};
+
+export type AWSAdvisoryAuthorizationSummary = {
+  total_decisions: number;
+  filtered_decisions: number;
+  outcome_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  allow_count: number;
+  warn_count: number;
+  require_approval_count: number;
+  recommend_deny_count: number;
+  quarantine_count: number;
+  kill_switch_engaged_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSAdvisoryAuthorizationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAdvisoryAuthorizationStatus;
+  fixture_state?: AWSAdvisoryAuthorizationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  policy_version: string;
+  mode: AWSAdvisoryAuthorizationMode;
+  applied_filters: Record<string, string>;
+  summary: AWSAdvisoryAuthorizationSummary;
+  decisions: AWSAdvisoryAuthorizationDecision[];
+  relationships: AWSAdvisoryAuthorizationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSAdvisoryAuthorizationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSAdvisoryAuthorizationFixtureState;
+  accountID?: string;
+  region?: string;
+  principalID?: string;
+  action?: string;
+  outcome?: string;
+  severity?: string;
+  sourceType?: string;
+  caseID?: string;
+  verificationID?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -9193,6 +9322,30 @@ export const apiClient = {
         state: query?.state,
         severity: query?.severity,
         operation: query?.operation,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAdvisoryAuthorization(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSAdvisoryAuthorizationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ advisory_authorization: AWSAdvisoryAuthorizationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/advisory-authorization${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        principal_id: query?.principalID,
+        action: query?.action,
+        outcome: query?.outcome,
+        severity: query?.severity,
+        source_type: query?.sourceType,
+        case_id: query?.caseID,
+        verification_id: query?.verificationID,
         search: query?.search
       })}`,
       auth

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3931,6 +3931,7 @@ export type AWSAdvisoryAuthorizationDecision = {
   summary: string;
   rationale: string;
   account_id?: string;
+  target_account_ids?: string[];
   region?: string;
   principal_node_id?: string;
   principal_arn?: string;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4064,6 +4064,38 @@ describe('Domain-first app routes', () => {
 	        diagnostics: []
 	      } as any
 	    });
+	    const getAdvisoryAuthorization = vi.spyOn(api.apiClient, 'getAWSProjectAdvisoryAuthorization').mockResolvedValue({
+	      advisory_authorization: {
+	        status: 'ready',
+	        mode: 'advisory',
+	        policy_version: 'aws-advisory-authorization-policy-v1',
+	        decisions: [],
+	        relationships: [],
+	        applied_filters: {},
+	        summary: {
+	          total_decisions: 0,
+	          filtered_decisions: 0,
+	          outcome_counts: {},
+	          severity_counts: {},
+	          source_type_counts: {},
+	          allow_count: 0,
+	          warn_count: 0,
+	          require_approval_count: 0,
+	          recommend_deny_count: 0,
+	          quarantine_count: 0,
+	          kill_switch_engaged_count: 0,
+	          relationship_count: 0,
+	          highest_score: 0,
+	          average_confidence_pct: 0
+	        },
+	        caveats: ['Advisory authorization decisions are read-only recommendations.'],
+	        failure_reasons: [],
+	        remediation_hints: [],
+	        evidence_links: [],
+	        coverage_gaps: [],
+	        diagnostics: []
+	      } as any
+	    });
 	    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
@@ -4731,6 +4763,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getPostRemediationVerification).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getAdvisoryAuthorization).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -83,6 +83,8 @@ import {
   type AWSScpGuardrailExecutorResult,
   type AWSPostRemediationVerificationEntry,
   type AWSPostRemediationVerificationResult,
+  type AWSAdvisoryAuthorizationDecision,
+  type AWSAdvisoryAuthorizationResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11376,6 +11378,75 @@ function AWSPostRemediationVerificationContent({
   );
 }
 
+function awsAdvisoryAuthorizationStage(decision: AWSAdvisoryAuthorizationDecision): AWSCapabilityStage {
+  switch (decision.outcome) {
+    case 'quarantine':
+    case 'recommend_deny':
+      return 'not-available';
+    case 'allow':
+      return 'wired';
+    default:
+      return 'coming';
+  }
+}
+
+function AWSAdvisoryAuthorizationContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSAdvisoryAuthorizationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_decisions} total · ${result.summary.allow_count} allow · ${result.summary.warn_count} warn · ${result.summary.require_approval_count} require approval · ${result.summary.recommend_deny_count} recommend deny · ${result.summary.quarantine_count} quarantine`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.decisions,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <AWSExecutorProjectionPanel<AWSAdvisoryAuthorizationDecision>
+      result={panelResult}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS advisory authorization"
+      heading="AWS advisory authorization"
+      description={`Advisory-only projection that joins remediation cases with post-remediation verification to recommend allow, warn, require approval, recommend deny, or quarantine per authorization decision. Identrail never enforces the recommendation at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS advisory authorization"
+      loadingTitle="Projecting advisory authorization decisions"
+      loadingBody="Identrail is joining remediation cases with verification state to project deterministic advisory recommendations."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No advisory decisions')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Advisory authorization needs approved remediation cases' : 'No advisory authorization decisions projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No remediation cases were available to project a decision for this environment.'}
+      tableLabel="AWS advisory authorization decisions"
+      getRowKey={(row) => row.decision_id}
+      columns={[
+        { key: 'decision', header: 'Decision', render: (row) => <strong>{row.title}</strong> },
+        { key: 'outcome', header: 'Outcome', render: (row) => formatTokenLabel(row.outcome) },
+        { key: 'principal', header: 'Principal', render: (row) => row.principal_node_id ?? row.principal_arn ?? '—' },
+        { key: 'action', header: 'Action', render: (row) => row.action },
+        { key: 'policy_rule', header: 'Policy rule', render: (row) => formatTokenLabel(row.provenance.policy_rule) },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsAdvisoryAuthorizationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.outcome)}`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13604,6 +13675,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [postRemediationVerificationLoading, setPostRemediationVerificationLoading] = useState(false);
   const [postRemediationVerificationError, setPostRemediationVerificationError] = useState('');
   const postRemediationVerificationRequestRef = useRef(0);
+  const [advisoryAuthorization, setAdvisoryAuthorization] = useState<AWSAdvisoryAuthorizationResult | null>(null);
+  const [advisoryAuthorizationLoading, setAdvisoryAuthorizationLoading] = useState(false);
+  const [advisoryAuthorizationError, setAdvisoryAuthorizationError] = useState('');
+  const advisoryAuthorizationRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -14252,6 +14327,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       postRemediationVerificationRequestRef.current += 1;
     };
   }, [loadPostRemediationVerification]);
+
+  const loadAdvisoryAuthorization = useCallback(async () => {
+    const requestID = ++advisoryAuthorizationRequestRef.current;
+    setAdvisoryAuthorization(null);
+    setAdvisoryAuthorizationError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAdvisoryAuthorizationLoading(false);
+      return;
+    }
+    setAdvisoryAuthorizationLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAdvisoryAuthorization(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== advisoryAuthorizationRequestRef.current) {
+        return;
+      }
+      setAdvisoryAuthorization(response.advisory_authorization);
+    } catch (error) {
+      if (requestID !== advisoryAuthorizationRequestRef.current) {
+        return;
+      }
+      setAdvisoryAuthorizationError(formatAPIError(error, 'Unable to load AWS advisory authorization.'));
+    } finally {
+      if (requestID === advisoryAuthorizationRequestRef.current) {
+        setAdvisoryAuthorizationLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadAdvisoryAuthorization();
+    return () => {
+      advisoryAuthorizationRequestRef.current += 1;
+    };
+  }, [loadAdvisoryAuthorization]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -15115,6 +15238,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={postRemediationVerificationLoading}
             error={postRemediationVerificationError}
             onRetry={loadPostRemediationVerification}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSAdvisoryAuthorizationContent
+            result={advisoryAuthorization}
+            loading={advisoryAuthorizationLoading}
+            error={advisoryAuthorizationError}
+            onRetry={loadAdvisoryAuthorization}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- implement the AWS advisory authorization decision API for issue #1543
- project deterministic allow/warn/require_approval/recommend_deny/quarantine recommendations by joining remediation cases (#1529) with the post-remediation verification and rollback executor (#1542)
- wire the endpoint into API routing, authz, OpenAPI, docs, CHANGELOG, and the AWS Runtime app surface
- advisory-only: no IAM/STS/Organizations write API calls; no rendered policy bodies or secret values; kill-switch and failed verification always classify as quarantine

## Validation
- go test ./internal/api/...
- make fmt-check && make vet
- ./scripts/check_api_example_contract.sh && ./scripts/check_web_route_integrity.sh
- npm test --prefix web -- --run (455 passing)
- npm run build --prefix web

## AI disclosure
AI-assisted: no

Closes #1543

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS advisory authorization decisions API and a Runtime panel for #1543. It deterministically recommends allow/warn/require_approval/recommend_deny/quarantine by joining remediation cases with post-remediation verification, with no AWS writes or enforcement.

- **New Features**
  - `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization` (OpenAPI, router, auth). Filters: connector, fixture_state, account, region, principal, action, outcome, severity, source type, case/verification IDs, search.
  - Decision payload: principal, action, resource scope, outcome, `policy_version`, `policy_rule`, deterministic `input_hash`, `target_account_ids`, evidence refs/links, audit trail, next action; `mode=advisory`.
  - Web: adds an “AWS advisory authorization” panel on the Runtime page and client method `apiClient.getAWSProjectAdvisoryAuthorization`.

- **Bug Fixes**
  - Preserve safety signals and gate “allow” on verification: kill-switch/failed verification → quarantine; pending → require_approval; not_ready/skipped → warn; expand `input_hash` to include kill-switch, `approval_required`, and severity.
  - Derive action from principal kind (IAM user → `iam:PutUser*`); respect `DiffIntent.NoOp` with `advisory:review`; map `role_scope_diff` to `iam:Put*Policy`.
  - Filtering: `account_id` matches membership in `target_account_ids`; region filter is strict.
  - Split permission-boundary decisions by target account and join each to its per-target, per-resource verification so outcomes and filters reflect exact scope.
  - Normalize single-target permission-boundary cases so split/join and verification behave consistently.

<sup>Written for commit 866045e3c98e93c1cca6f6f2b3ec53899f643580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

