### PR TITLE
Implement AWS session policy recommendation path (#1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS session policy recommendation path** (#1544). Adds an
+  advisory-only projection that derives session-policy recommendations
+  from the least-privilege recommendation engine (#1522). Each entry
+  carries the target principal, a `session_policy_ref` metadata
+  reference to the recommended STS session-policy JSON, the projected
+  allow-list and deny-list, resource scope, expected allow/deny/
+  observed action counts, deterministic runtime and analyzer
+  validation signals (observed-action coverage, projected
+  removed-action count, breakage prediction), provenance (policy
+  version and source rule name), evidence refs, and an immutable
+  audit trail. The projection only admits least-privilege
+  recommendations whose decision is `remove` or `review` and that
+  carry an observed-usage profile so operators never see
+  session-policy recommendations that would scope to zero actions.
+  Rendered session-policy JSON is never inlined; the recommended
+  policy body stays behind the metadata reference and downstream
+  apply runtime is responsible for attaching the policy to STS
+  `AssumeRole` calls. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations`
+  with filters for connector, fixture state, account, region,
+  principal, recommendation ID, decision, severity, and free-text
+  search. OpenAPI schemas and authz wiring follow the neighboring
+  wave-9 endpoints. The AWS Runtime app surface now shows an **AWS
+  session policy recommendations** panel with the recommendation
+  title, decision pill, principal, projected allow/deny counts,
+  breakage prediction, and severity/decision status pill. Identrail
+  never calls IAM/STS write APIs at this layer.
 - Add **AWS advisory authorization decision API** (#1543). Adds an
   advisory-only projection that joins remediation cases (#1529) with the
   post-remediation verification and rollback executor (#1542) and

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
 - AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
 - AWS advisory authorization decision API: `aws-advisory-authorization.md`
+- AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-session-policy-recommendation.md
+++ b/docs/aws-session-policy-recommendation.md
@@ -1,0 +1,76 @@
+# AWS session policy recommendation path
+
+Issue #1544 adds a metadata-only projection of advisory AWS STS session-policy
+recommendations. Each entry derives from a least-privilege recommendation
+(#1522) and projects the scope (allow list, deny list, resource scope) an
+operator should attach on STS `AssumeRole` / `AssumeRoleWithWebIdentity` to
+constrain downstream sessions.
+
+The endpoint is advisory-only. Identrail never calls IAM or STS write APIs at
+this layer and never inlines rendered session-policy JSON. The recommended
+policy body stays behind a `session_policy_ref` metadata reference the
+downstream apply runtime can resolve when a controlled execution runs.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations`
+
+Response shape: `{ "session_policy_recommendations": AWSSessionPolicyRecommendationResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`principal_id`, `recommendation_id`, `decision`, `severity`, and `search`.
+
+## Entry shape
+
+Each entry carries:
+
+- `decision`: `remove` (unused actions can be dropped from the session) or
+  `review` (surface for operator review before enabling).
+- `principal_node_id`, `principal_arn`, `principal_display_name`: the target
+  IAM principal.
+- `session_policy_ref`: metadata reference to the recommended session-policy
+  JSON. The policy body is never inlined here.
+- `session_duration_hint`: baseline session duration (`3600s`) operators can
+  pair with the recommended policy.
+- `allow_actions`, `deny_actions`, `resource_scope`, `condition_keys`: the
+  projected session-policy shape.
+- `expected_behavior`: `allowed_action_count`, `denied_action_count`, and
+  `observed_action_count` so operators can compare projected outcome against
+  runtime evidence at a glance.
+- `validation_signals`: deterministic runtime and analyzer signals
+  (observed-action coverage, projected removed-action count, breakage
+  prediction) that back the recommendation.
+- `provenance.policy_version` / `provenance.source_rule_name`: the
+  deterministic rule that produced the recommendation. Every policy change
+  bumps the version so operators can trace drift.
+- `evidence`, `impacted_nodes`, `impacted_path`: metadata refs only. No
+  rendered policy bodies, secret values, or workload payloads.
+- `audit_trail`: immutable projection audit row.
+
+## Admission
+
+The projection only admits least-privilege recommendations whose decision is
+`remove` or `review` and that carry either a `KeepActions` list or an
+`ObservedActions` list. Records without an actionable observed-usage profile
+are skipped so operators never see session-policy recommendations that would
+scope to zero actions.
+
+## Safety, evidence, and out of scope
+
+- Advisory-only. No IAM or STS write APIs are called at this layer.
+- Rendered session-policy JSON is never inlined; the endpoint exposes scope,
+  expected behavior, validation signals, and audit metadata only.
+- Downstream apply runtime is responsible for attaching the policy to STS
+  `AssumeRole` calls; the recommendation itself never mutates AWS.
+- Tenant, workspace, project, connector, account, and region boundaries are
+  preserved.
+- Unknown, permission-denied, and partial-failure states are surfaced as
+  explicit states, not as successful findings.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS session policy recommendations** panel
+with the recommendation title, decision pill, principal, projected allow/deny
+counts, breakage prediction, and severity/decision status pill. The panel
+exposes loading, empty, blocked, degraded, and error states without operators
+needing to read logs or database rows.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -614,6 +614,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5811,6 +5816,80 @@ paths:
                     $ref: "#/components/schemas/AWSAdvisoryAuthorizationResult"
         "400":
           description: Invalid AWS advisory authorization request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS session policy recommendations
+      operationId: getAWSProjectSessionPolicyRecommendations
+      description: Projects deterministic advisory session policy recommendations from the least-privilege recommendation engine. Each entry records the recommended STS session-policy scope (allow-list, deny-list, resource scope), expected allow/deny behavior, runtime validation signals, provenance, and audit trail. This endpoint is advisory-only; Identrail never calls IAM/STS write APIs and never inlines rendered policy JSON.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: principal_id
+          schema: { type: string }
+          description: Optional principal node ID or ARN filter.
+        - in: query
+          name: recommendation_id
+          schema: { type: string }
+        - in: query
+          name: decision
+          schema:
+            type: string
+            enum: [remove, review]
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS session policy recommendations contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  session_policy_recommendations:
+                    $ref: "#/components/schemas/AWSSessionPolicyRecommendationResult"
+        "400":
+          description: Invalid AWS session policy recommendation request
           content:
             application/json:
               schema:
@@ -16181,6 +16260,201 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAdvisoryAuthorizationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSessionPolicyRecommendationValidationSignal:
+      type: object
+      properties:
+        source: { type: string }
+        signal: { type: string }
+        status: { type: string }
+        count: { type: integer }
+        description: { type: string }
+    AWSSessionPolicyRecommendationExpectedBehavior:
+      type: object
+      properties:
+        allowed_action_count: { type: integer }
+        denied_action_count: { type: integer }
+        observed_action_count: { type: integer }
+    AWSSessionPolicyRecommendationProvenance:
+      type: object
+      properties:
+        policy_version: { type: string }
+        source_rule_name: { type: string }
+        signals:
+          type: array
+          items: { type: string }
+    AWSSessionPolicyRecommendationRelationship:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSSessionPolicyRecommendationEntry:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        calculation_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        decision:
+          type: string
+          enum: [remove, review]
+        severity: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        title: { type: string }
+        summary: { type: string }
+        rationale: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        principal_node_id: { type: string }
+        principal_arn: { type: string }
+        principal_display_name: { type: string }
+        session_policy_ref:
+          type: string
+          description: Metadata reference to the recommended session-policy JSON. Rendered policy bodies are never inlined.
+        session_duration_hint: { type: string }
+        allow_actions:
+          type: array
+          items: { type: string }
+        deny_actions:
+          type: array
+          items: { type: string }
+        resource_scope:
+          type: array
+          items: { type: string }
+        condition_keys:
+          type: array
+          items: { type: string }
+        expected_behavior:
+          $ref: "#/components/schemas/AWSSessionPolicyRecommendationExpectedBehavior"
+        validation_signals:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSessionPolicyRecommendationValidationSignal"
+        provenance:
+          $ref: "#/components/schemas/AWSSessionPolicyRecommendationProvenance"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSSessionPolicyRecommendationSummary:
+      type: object
+      properties:
+        total_recommendations: { type: integer }
+        filtered_recommendations: { type: integer }
+        decision_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        allow_action_count: { type: integer }
+        deny_action_count: { type: integer }
+        observed_action_count: { type: integer }
+        validation_signal_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSSessionPolicyRecommendationResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSSessionPolicyRecommendationSummary"
+        recommendations:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSessionPolicyRecommendationEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSSessionPolicyRecommendationRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -773,6 +773,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -1,0 +1,672 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsSessionPolicyRecommendationCurrentIssue = 1544
+	awsSessionPolicyRecommendationVersion      = "aws-session-policy-recommendation-v1"
+	awsSessionPolicyRecommendationPolicyID     = "aws-session-policy-recommendation-policy-v1"
+	awsSessionPolicyRecommendationModeAdvisory = "advisory"
+)
+
+// AWSSessionPolicyRecommendationRequest scopes the deterministic session
+// policy recommendation projection to one AWS connector plus optional
+// operator drill-down filters.
+type AWSSessionPolicyRecommendationRequest struct {
+	ConnectorID      string `json:"connector_id,omitempty"`
+	FixtureState     string `json:"fixture_state,omitempty"`
+	AccountID        string `json:"account_id,omitempty"`
+	Region           string `json:"region,omitempty"`
+	PrincipalID      string `json:"principal_id,omitempty"`
+	RecommendationID string `json:"recommendation_id,omitempty"`
+	Decision         string `json:"decision,omitempty"`
+	Severity         string `json:"severity,omitempty"`
+	Search           string `json:"search,omitempty"`
+}
+
+type AWSSessionPolicyRecommendationEvidence = AWSLeastPrivilegeEvidence
+type AWSSessionPolicyRecommendationPathStep = AWSLeastPrivilegePathStep
+type AWSSessionPolicyRecommendationDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSSessionPolicyRecommendationCoverageGap = AWSLeastPrivilegeCoverageGap
+type AWSSessionPolicyRecommendationAuditEntry = AWSRemediationApprovalAuditEntry
+
+// AWSSessionPolicyRecommendationValidationSignal records one deterministic
+// runtime or analyzer signal that validated (or would invalidate) the
+// recommended session policy. Counts are metadata only; observed action
+// payloads and rendered policy bodies are never inlined.
+type AWSSessionPolicyRecommendationValidationSignal struct {
+	Source      string `json:"source"`
+	Signal      string `json:"signal"`
+	Status      string `json:"status"`
+	Count       int    `json:"count,omitempty"`
+	Description string `json:"description"`
+}
+
+// AWSSessionPolicyRecommendationExpectedBehavior projects the allow/deny
+// outcome operators should see after applying the recommended session
+// policy. Actions live in the entry's allow/deny lists; this record
+// summarizes the counts and the observed evidence that justifies them.
+type AWSSessionPolicyRecommendationExpectedBehavior struct {
+	AllowedActionCount  int `json:"allowed_action_count"`
+	DeniedActionCount   int `json:"denied_action_count"`
+	ObservedActionCount int `json:"observed_action_count"`
+}
+
+// AWSSessionPolicyRecommendationProvenance records the deterministic
+// derivation path so operators can trace which policy version and source
+// signals produced the recommendation.
+type AWSSessionPolicyRecommendationProvenance struct {
+	PolicyVersion  string   `json:"policy_version"`
+	SourceRuleName string   `json:"source_rule_name"`
+	Signals        []string `json:"signals,omitempty"`
+}
+
+// AWSSessionPolicyRecommendationRelationship surfaces recommendation→graph
+// node edges for downstream UI and audit consumers.
+type AWSSessionPolicyRecommendationRelationship struct {
+	RecommendationID string `json:"recommendation_id"`
+	Type             string `json:"type"`
+	FromNodeID       string `json:"from_node_id"`
+	ToNodeID         string `json:"to_node_id"`
+	EvidenceRef      string `json:"evidence_ref,omitempty"`
+}
+
+// AWSSessionPolicyRecommendationEntry is the persisted-record-shaped contract
+// for one session policy recommendation. It never inlines rendered JSON
+// policy bodies; the recommended policy is exposed as a metadata reference
+// (`session_policy_ref`) the downstream apply runtime can resolve when a
+// controlled execution runs.
+type AWSSessionPolicyRecommendationEntry struct {
+	RecommendationID     string                                           `json:"recommendation_id"`
+	CalculationVersion   string                                           `json:"calculation_version"`
+	Mode                 string                                           `json:"mode"`
+	Decision             string                                           `json:"decision"`
+	Severity             string                                           `json:"severity"`
+	Score                int                                              `json:"score"`
+	Confidence           float64                                          `json:"confidence"`
+	Title                string                                           `json:"title"`
+	Summary              string                                           `json:"summary"`
+	Rationale            string                                           `json:"rationale"`
+	AccountID            string                                           `json:"account_id,omitempty"`
+	Region               string                                           `json:"region,omitempty"`
+	PrincipalNodeID      string                                           `json:"principal_node_id"`
+	PrincipalARN         string                                           `json:"principal_arn,omitempty"`
+	PrincipalDisplayName string                                           `json:"principal_display_name,omitempty"`
+	SessionPolicyRef     string                                           `json:"session_policy_ref"`
+	SessionDurationHint  string                                           `json:"session_duration_hint,omitempty"`
+	AllowActions         []string                                         `json:"allow_actions"`
+	DenyActions          []string                                         `json:"deny_actions,omitempty"`
+	ResourceScope        []string                                         `json:"resource_scope,omitempty"`
+	ConditionKeys        []string                                         `json:"condition_keys,omitempty"`
+	ExpectedBehavior     AWSSessionPolicyRecommendationExpectedBehavior   `json:"expected_behavior"`
+	ValidationSignals    []AWSSessionPolicyRecommendationValidationSignal `json:"validation_signals"`
+	Provenance           AWSSessionPolicyRecommendationProvenance         `json:"provenance"`
+	Evidence             []AWSSessionPolicyRecommendationEvidence         `json:"evidence"`
+	EvidenceBoundary     string                                           `json:"evidence_boundary"`
+	ImpactedNodes        []string                                         `json:"impacted_nodes"`
+	ImpactedPath         []AWSSessionPolicyRecommendationPathStep         `json:"impacted_path"`
+	AuditTrail           []AWSSessionPolicyRecommendationAuditEntry       `json:"audit_trail"`
+	ReadOnlyProjection   bool                                             `json:"read_only_projection"`
+	SourceSignals        []string                                         `json:"source_signals"`
+	NextAction           string                                           `json:"next_action"`
+	ProjectedAt          time.Time                                        `json:"projected_at"`
+	CreatedAt            time.Time                                        `json:"created_at"`
+	UpdatedAt            time.Time                                        `json:"updated_at"`
+}
+
+// AWSSessionPolicyRecommendationSummary aggregates the unfiltered/filtered
+// recommendation set.
+type AWSSessionPolicyRecommendationSummary struct {
+	TotalRecommendations    int            `json:"total_recommendations"`
+	FilteredRecommendations int            `json:"filtered_recommendations"`
+	DecisionCounts          map[string]int `json:"decision_counts"`
+	SeverityCounts          map[string]int `json:"severity_counts"`
+	AllowActionCount        int            `json:"allow_action_count"`
+	DenyActionCount         int            `json:"deny_action_count"`
+	ObservedActionCount     int            `json:"observed_action_count"`
+	ValidationSignalCount   int            `json:"validation_signal_count"`
+	RelationshipCount       int            `json:"relationship_count"`
+	HighestScore            int            `json:"highest_score"`
+	AverageConfidencePct    int            `json:"average_confidence_pct"`
+}
+
+// AWSSessionPolicyRecommendationResult is the deterministic endpoint envelope.
+type AWSSessionPolicyRecommendationResult struct {
+	TenantID           string                                       `json:"tenant_id"`
+	WorkspaceID        string                                       `json:"workspace_id"`
+	ProjectID          string                                       `json:"project_id"`
+	ConnectorID        string                                       `json:"connector_id,omitempty"`
+	AccountID          string                                       `json:"account_id,omitempty"`
+	Region             string                                       `json:"region,omitempty"`
+	ParentIssueNumber  int                                          `json:"parent_issue_number"`
+	ParentIssueRef     string                                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                          `json:"current_issue_number"`
+	CurrentIssueRef    string                                       `json:"current_issue_ref"`
+	Version            string                                       `json:"version"`
+	Status             string                                       `json:"status"`
+	FixtureState       string                                       `json:"fixture_state,omitempty"`
+	Confidence         float64                                      `json:"confidence"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	PolicyVersion      string                                       `json:"policy_version"`
+	Mode               string                                       `json:"mode"`
+	AppliedFilters     map[string]string                            `json:"applied_filters"`
+	Summary            AWSSessionPolicyRecommendationSummary        `json:"summary"`
+	Recommendations    []AWSSessionPolicyRecommendationEntry        `json:"recommendations"`
+	Relationships      []AWSSessionPolicyRecommendationRelationship `json:"relationships"`
+	Caveats            []string                                     `json:"caveats"`
+	FailureReasons     []string                                     `json:"failure_reasons"`
+	RemediationHints   []string                                     `json:"remediation_hints"`
+	EvidenceLinks      []string                                     `json:"evidence_links"`
+	CoverageGaps       []AWSSessionPolicyRecommendationCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSSessionPolicyRecommendationDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                    `json:"generated_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+// GetAWSSessionPolicyRecommendations projects deterministic advisory session
+// policy recommendations from the least-privilege recommendation engine
+// (#1522). Each entry pairs an observed-usage profile with the recommended
+// STS session-policy scope operators can attach on AssumeRole to constrain
+// downstream sessions. The endpoint is advisory-only; Identrail never calls
+// IAM/STS write APIs at this layer and never inlines rendered policy JSON.
+func (s *Service) GetAWSSessionPolicyRecommendations(ctx context.Context, workspaceID string, projectID string, request AWSSessionPolicyRecommendationRequest) (AWSSessionPolicyRecommendationResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSSessionPolicyRecommendationResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSSessionPolicyRecommendationResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSSessionPolicyRecommendationFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSSessionPolicyRecommendationResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	upstream, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSSessionPolicyRecommendationResult{}, fmt.Errorf("session policy recommendations upstream: %w", err)
+	}
+
+	recommendations := awsSessionPolicyRecommendationEntries(upstream.Recommendations, now)
+	sort.SliceStable(recommendations, func(i, j int) bool {
+		if recommendations[i].Score == recommendations[j].Score {
+			return recommendations[i].RecommendationID < recommendations[j].RecommendationID
+		}
+		return recommendations[i].Score > recommendations[j].Score
+	})
+	filtered, applied := filterAWSSessionPolicyRecommendations(recommendations, request)
+	relationships := awsSessionPolicyRecommendationRelationships(filtered)
+	diagnostics := awsSessionPolicyRecommendationDiagnostics(upstream.Diagnostics)
+	coverageGaps := awsSessionPolicyRecommendationCoverageGaps(upstream.CoverageGaps)
+	status, confidence := summarizeAWSSessionPolicyRecommendationStatus(upstream.Status, filtered, diagnostics)
+
+	return AWSSessionPolicyRecommendationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsSessionPolicyRecommendationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsSessionPolicyRecommendationCurrentIssue),
+		Version:            awsSessionPolicyRecommendationVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsSessionPolicyRecommendationVersion,
+		PolicyVersion:      awsSessionPolicyRecommendationPolicyID,
+		Mode:               awsSessionPolicyRecommendationModeAdvisory,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSSessionPolicyRecommendations(recommendations, filtered, relationships),
+		Recommendations:    filtered,
+		Relationships:      relationships,
+		Caveats:            awsSessionPolicyRecommendationCaveats(),
+		FailureReasons:     dedupeStrings(upstream.FailureReasons),
+		RemediationHints:   awsSessionPolicyRecommendationHints(upstream.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsSessionPolicyRecommendationCurrentIssue),
+			awsIssueURL(awsLeastPrivilegeCurrentIssue),
+			"/docs/aws-session-policy-recommendation",
+			"/docs/aws-least-privilege",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSSessionPolicyRecommendationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// awsSessionPolicyRecommendationEntries admits only least-privilege
+// recommendations that carry an actionable observed-usage profile. `keep`
+// decisions carry no reduction to apply, and records without observed or
+// keep actions produce no session-policy scope operators could reason about.
+func awsSessionPolicyRecommendationEntries(source []AWSLeastPrivilegeRecommendation, now time.Time) []AWSSessionPolicyRecommendationEntry {
+	entries := make([]AWSSessionPolicyRecommendationEntry, 0, len(source))
+	for _, rec := range source {
+		if !awsSessionPolicyRecommendationAdmits(rec) {
+			continue
+		}
+		entries = append(entries, awsSessionPolicyRecommendationFromLeastPrivilege(rec, now))
+	}
+	return entries
+}
+
+func awsSessionPolicyRecommendationAdmits(rec AWSLeastPrivilegeRecommendation) bool {
+	decision := strings.ToLower(strings.TrimSpace(rec.Decision))
+	if decision != "remove" && decision != "review" {
+		return false
+	}
+	if strings.TrimSpace(rec.IdentityNodeID) == "" {
+		return false
+	}
+	if len(emptyStrings(rec.KeepActions)) == 0 && len(emptyStrings(rec.ObservedActions)) == 0 {
+		return false
+	}
+	return true
+}
+
+func awsSessionPolicyRecommendationFromLeastPrivilege(rec AWSLeastPrivilegeRecommendation, now time.Time) AWSSessionPolicyRecommendationEntry {
+	allow := awsSessionPolicyRecommendationAllowActions(rec)
+	deny := emptyStrings(dedupeStrings(rec.RemoveActions))
+	resourceScope := awsSessionPolicyRecommendationResourceScope(rec)
+	sessionPolicyRef := "session-policy://" + rec.RecommendationID + "/proposed"
+	recommendationID := "aws-session-policy-recommendation:" + stableAWSBlastRadiusToken("session-policy", rec.RecommendationID, rec.IdentityNodeID)
+	validation := awsSessionPolicyRecommendationValidationSignals(rec)
+	provenance := AWSSessionPolicyRecommendationProvenance{
+		PolicyVersion:  awsSessionPolicyRecommendationPolicyID,
+		SourceRuleName: awsSessionPolicyRecommendationRuleName(rec),
+		Signals:        awsSessionPolicyRecommendationSignals(rec),
+	}
+	return AWSSessionPolicyRecommendationEntry{
+		RecommendationID:     recommendationID,
+		CalculationVersion:   awsSessionPolicyRecommendationVersion,
+		Mode:                 awsSessionPolicyRecommendationModeAdvisory,
+		Decision:             strings.ToLower(strings.TrimSpace(rec.Decision)),
+		Severity:             rec.Severity,
+		Score:                rec.Score,
+		Confidence:           rec.Confidence,
+		Title:                fmt.Sprintf("Session policy recommendation: %s", firstNonEmptyAWSValue(rec.DisplayName, rec.IdentityNodeID)),
+		Summary:              fmt.Sprintf("Advisory session-policy scope derived from observed usage. Attach on STS AssumeRole to constrain sessions for %s. No live IAM/STS write API is called at this layer; the recommended policy stays behind %s.", firstNonEmptyAWSValue(rec.DisplayName, rec.IdentityNodeID), sessionPolicyRef),
+		Rationale:            rec.Rationale,
+		AccountID:            rec.AccountID,
+		Region:               rec.Region,
+		PrincipalNodeID:      rec.IdentityNodeID,
+		PrincipalARN:         rec.PrincipalARN,
+		PrincipalDisplayName: rec.DisplayName,
+		SessionPolicyRef:     sessionPolicyRef,
+		SessionDurationHint:  "3600s",
+		AllowActions:         allow,
+		DenyActions:          deny,
+		ResourceScope:        resourceScope,
+		ConditionKeys:        nil,
+		ExpectedBehavior: AWSSessionPolicyRecommendationExpectedBehavior{
+			AllowedActionCount:  len(allow),
+			DeniedActionCount:   len(deny),
+			ObservedActionCount: len(emptyStrings(rec.ObservedActions)),
+		},
+		ValidationSignals:  validation,
+		Provenance:         provenance,
+		Evidence:           rec.Evidence,
+		EvidenceBoundary:   awsSessionPolicyRecommendationEvidenceBoundary(),
+		ImpactedNodes:      emptyStrings(dedupeStrings(rec.ImpactedNodes)),
+		ImpactedPath:       rec.ImpactedPath,
+		AuditTrail:         awsSessionPolicyRecommendationAuditTrail(rec, now),
+		ReadOnlyProjection: true,
+		SourceSignals:      dedupeStrings([]string{"least_privilege", "session_policy_recommendation"}),
+		NextAction:         awsSessionPolicyRecommendationNextAction(rec.Decision),
+		ProjectedAt:        now,
+		CreatedAt:          firstNonZeroAWSSessionPolicyRecommendationTime(rec.CreatedAt, now),
+		UpdatedAt:          now,
+	}
+}
+
+// awsSessionPolicyRecommendationAllowActions prefers the least-privilege
+// keep-list; when the upstream carries no explicit keep list the observed
+// action set is the safest baseline for the recommended session-policy
+// allow-list.
+func awsSessionPolicyRecommendationAllowActions(rec AWSLeastPrivilegeRecommendation) []string {
+	if keep := emptyStrings(dedupeStrings(rec.KeepActions)); len(keep) > 0 {
+		return keep
+	}
+	return emptyStrings(dedupeStrings(rec.ObservedActions))
+}
+
+func awsSessionPolicyRecommendationResourceScope(rec AWSLeastPrivilegeRecommendation) []string {
+	scope := []string{}
+	if arn := strings.TrimSpace(rec.ResourceARN); arn != "" {
+		scope = append(scope, arn)
+	}
+	if node := strings.TrimSpace(rec.ResourceNodeID); node != "" {
+		scope = append(scope, node)
+	}
+	if len(scope) == 0 {
+		scope = append(scope, "*")
+	}
+	return emptyStrings(dedupeStrings(scope))
+}
+
+func awsSessionPolicyRecommendationValidationSignals(rec AWSLeastPrivilegeRecommendation) []AWSSessionPolicyRecommendationValidationSignal {
+	signals := []AWSSessionPolicyRecommendationValidationSignal{
+		{
+			Source:      "runtime",
+			Signal:      "observed_action_coverage",
+			Status:      awsSessionPolicyRecommendationSignalStatus(len(emptyStrings(rec.ObservedActions)) > 0),
+			Count:       len(emptyStrings(rec.ObservedActions)),
+			Description: "Observed action set from runtime evidence covering the projected session-policy allow-list.",
+		},
+		{
+			Source:      "least_privilege",
+			Signal:      "removed_action_projection",
+			Status:      awsSessionPolicyRecommendationSignalStatus(len(emptyStrings(rec.RemoveActions)) > 0),
+			Count:       len(emptyStrings(rec.RemoveActions)),
+			Description: "Actions the upstream least-privilege analyzer projects as safe to remove for this principal.",
+		},
+		{
+			Source:      "breakage_prediction",
+			Signal:      "expected_breakage_level",
+			Status:      awsSessionPolicyRecommendationBreakageStatus(rec.BreakagePrediction),
+			Description: fmt.Sprintf("Breakage prediction=%s. %s", rec.BreakagePrediction, rec.BreakageRationale),
+		},
+	}
+	return signals
+}
+
+func awsSessionPolicyRecommendationSignalStatus(ok bool) string {
+	if ok {
+		return "passed"
+	}
+	return "pending"
+}
+
+func awsSessionPolicyRecommendationBreakageStatus(prediction string) string {
+	switch strings.ToLower(strings.TrimSpace(prediction)) {
+	case "low":
+		return "passed"
+	case "unknown", "":
+		return "pending"
+	}
+	return "warn"
+}
+
+func awsSessionPolicyRecommendationRuleName(rec AWSLeastPrivilegeRecommendation) string {
+	switch strings.ToLower(strings.TrimSpace(rec.Decision)) {
+	case "remove":
+		return "constrain_unused_actions"
+	case "review":
+		return "surface_review_candidates"
+	}
+	return "advisory_review"
+}
+
+func awsSessionPolicyRecommendationSignals(rec AWSLeastPrivilegeRecommendation) []string {
+	signals := []string{
+		"decision=" + strings.ToLower(strings.TrimSpace(rec.Decision)),
+	}
+	if strings.TrimSpace(rec.RecommendationType) != "" {
+		signals = append(signals, "recommendation_type="+rec.RecommendationType)
+	}
+	if strings.TrimSpace(rec.BreakagePrediction) != "" {
+		signals = append(signals, "breakage="+rec.BreakagePrediction)
+	}
+	return dedupeStrings(signals)
+}
+
+func awsSessionPolicyRecommendationNextAction(decision string) string {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "remove":
+		return "Attach the recommended session policy on STS AssumeRole/AssumeRoleWithWebIdentity for this principal to constrain downstream sessions. This endpoint records the intent; no live IAM/STS write is performed here."
+	case "review":
+		return "Surface the recommended session policy to operators for review before enabling on AssumeRole call sites. Refresh runtime evidence if the observed-action set is empty."
+	}
+	return "Advisory only; inspect the recommendation entry for the projected session-policy scope."
+}
+
+func awsSessionPolicyRecommendationAuditTrail(rec AWSLeastPrivilegeRecommendation, now time.Time) []AWSSessionPolicyRecommendationAuditEntry {
+	return []AWSSessionPolicyRecommendationAuditEntry{{
+		EventID:    stableAWSBlastRadiusToken("session-policy-projected", rec.RecommendationID, awsSessionPolicyRecommendationPolicyID),
+		Actor:      "identrail-session-policy-recommender",
+		EventType:  "session_policy_recommendation_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("RecommendationID=%s decision=%s policy_version=%s; Identrail did not call any AWS write API at this layer.", rec.RecommendationID, rec.Decision, awsSessionPolicyRecommendationPolicyID),
+	}}
+}
+
+func awsSessionPolicyRecommendationRelationships(entries []AWSSessionPolicyRecommendationEntry) []AWSSessionPolicyRecommendationRelationship {
+	relationships := []AWSSessionPolicyRecommendationRelationship{}
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.PrincipalNodeID) != "" {
+			relationships = append(relationships, AWSSessionPolicyRecommendationRelationship{
+				RecommendationID: entry.RecommendationID,
+				Type:             "recommends_session_policy_for_principal",
+				FromNodeID:       entry.RecommendationID,
+				ToNodeID:         entry.PrincipalNodeID,
+				EvidenceRef:      entry.SessionPolicyRef,
+			})
+		}
+		for _, node := range entry.ResourceScope {
+			if strings.TrimSpace(node) == "" || node == "*" {
+				continue
+			}
+			relationships = append(relationships, AWSSessionPolicyRecommendationRelationship{
+				RecommendationID: entry.RecommendationID,
+				Type:             "scopes_session_policy_to_resource",
+				FromNodeID:       entry.RecommendationID,
+				ToNodeID:         node,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSSessionPolicyRecommendations(all, filtered []AWSSessionPolicyRecommendationEntry, relationships []AWSSessionPolicyRecommendationRelationship) AWSSessionPolicyRecommendationSummary {
+	summary := AWSSessionPolicyRecommendationSummary{
+		TotalRecommendations:    len(all),
+		FilteredRecommendations: len(filtered),
+		DecisionCounts:          map[string]int{},
+		SeverityCounts:          map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		if entry.Decision != "" {
+			summary.DecisionCounts[entry.Decision]++
+		}
+		if entry.Severity != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		summary.AllowActionCount += len(entry.AllowActions)
+		summary.DenyActionCount += len(entry.DenyActions)
+		summary.ObservedActionCount += entry.ExpectedBehavior.ObservedActionCount
+		summary.ValidationSignalCount += len(entry.ValidationSignals)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSSessionPolicyRecommendations(entries []AWSSessionPolicyRecommendationEntry, request AWSSessionPolicyRecommendationRequest) ([]AWSSessionPolicyRecommendationEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":        strings.TrimSpace(request.AccountID),
+		"region":            strings.TrimSpace(request.Region),
+		"principal_id":      strings.TrimSpace(request.PrincipalID),
+		"recommendation_id": strings.TrimSpace(request.RecommendationID),
+		"decision":          normalizeAWSRuntimeEventFilterToken(request.Decision),
+		"severity":          normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":            strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSSessionPolicyRecommendationEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(entry.AccountID)) {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(entry.Region)) {
+			continue
+		}
+		if filters["principal_id"] != "" && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(entry.PrincipalNodeID)) && !strings.EqualFold(filters["principal_id"], strings.TrimSpace(entry.PrincipalARN)) {
+			continue
+		}
+		if filters["recommendation_id"] != "" && !strings.EqualFold(filters["recommendation_id"], entry.RecommendationID) {
+			continue
+		}
+		if filters["decision"] != "" && filters["decision"] != normalizeAWSRuntimeEventFilterToken(entry.Decision) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsSessionPolicyRecommendationSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsSessionPolicyRecommendationSearchMatch(entry AWSSessionPolicyRecommendationEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.RecommendationID, entry.Decision, entry.Severity, entry.Title, entry.Summary,
+		entry.Rationale, entry.PrincipalNodeID, entry.PrincipalARN, entry.PrincipalDisplayName,
+		entry.SessionPolicyRef, entry.NextAction, entry.Provenance.SourceRuleName,
+	}
+	values = append(values, entry.AllowActions...)
+	values = append(values, entry.DenyActions...)
+	values = append(values, entry.ResourceScope...)
+	values = append(values, entry.ConditionKeys...)
+	values = append(values, entry.ImpactedNodes...)
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.Provenance.Signals...)
+	for _, signal := range entry.ValidationSignals {
+		values = append(values, signal.Source, signal.Signal, signal.Status, signal.Description)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSSessionPolicyRecommendationStatus(upstream string, filtered []AWSSessionPolicyRecommendationEntry, diagnostics []AWSSessionPolicyRecommendationDiagnostic) (string, float64) {
+	if upstream == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if upstream == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsSessionPolicyRecommendationCaveats() []string {
+	return []string{
+		"Session-policy recommendations are advisory-only; Identrail never calls IAM/STS write APIs at this layer.",
+		"Rendered session-policy JSON stays behind session_policy_ref metadata references; this endpoint exposes scope, expected behavior, validation signals, and audit metadata only.",
+		"Downstream apply runtime is responsible for attaching the policy to STS AssumeRole calls; the recommendation itself never mutates AWS.",
+	}
+}
+
+func awsSessionPolicyRecommendationHints(source []string) []string {
+	hints := []string{
+		"Refresh runtime action evidence before applying so the observed-usage baseline captures current workload behavior.",
+		"Roll out session-policy attachment to one AssumeRole call site first and expand only after the projected allow/deny counts hold.",
+		"If breakage prediction is `unknown`, keep the recommendation in review until runtime evidence lifts confidence.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsSessionPolicyRecommendationDiagnostics(source []AWSLeastPrivilegeDiagnostic) []AWSSessionPolicyRecommendationDiagnostic {
+	out := make([]AWSSessionPolicyRecommendationDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSSessionPolicyRecommendationDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsSessionPolicyRecommendationCoverageGaps(source []AWSLeastPrivilegeCoverageGap) []AWSSessionPolicyRecommendationCoverageGap {
+	out := make([]AWSSessionPolicyRecommendationCoverageGap, 0, len(source))
+	for _, gap := range source {
+		out = append(out, AWSSessionPolicyRecommendationCoverageGap(gap))
+	}
+	return out
+}
+
+func awsSessionPolicyRecommendationEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSSessionPolicyRecommendationTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -257,13 +257,15 @@ func (s *Service) GetAWSSessionPolicyRecommendations(ctx context.Context, worksp
 }
 
 func normalizeAWSSessionPolicyRecommendationFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	// Mirror the upstream least-privilege normalizer so an explicit
+	// `success`/`ready` fixture never advertises success when the
+	// connection has been downgraded to permission_denied; the two
+	// endpoints must return consistent fixture metadata.
 	switch strings.ToLower(strings.TrimSpace(requested)) {
-	case "":
+	case "", "success", "ready":
 		if !hasConnection || !connection.Connected {
 			return "permission_denied"
 		}
-		return "success"
-	case "success", "ready":
 		return "success"
 	case "empty", "degraded", "partial_failure", "permission_denied":
 		return strings.ToLower(strings.TrimSpace(requested))
@@ -295,7 +297,10 @@ func awsSessionPolicyRecommendationAdmits(rec AWSLeastPrivilegeRecommendation) b
 	if strings.TrimSpace(rec.IdentityNodeID) == "" {
 		return false
 	}
-	if len(emptyStrings(rec.KeepActions)) == 0 && len(emptyStrings(rec.ObservedActions)) == 0 {
+	// Use dedupeStrings (trims and drops empty entries) so whitespace-only
+	// KeepActions/ObservedActions do not pass admission and then produce
+	// an empty allow_actions projection downstream.
+	if len(dedupeStrings(rec.KeepActions)) == 0 && len(dedupeStrings(rec.ObservedActions)) == 0 {
 		return false
 	}
 	return true

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -421,18 +421,34 @@ func awsSessionPolicyRecommendationAllowActions(rec AWSLeastPrivilegeRecommendat
 	return awsSessionPolicyRecommendationValidIAMActions(rec.ObservedActions)
 }
 
+// awsSessionPolicyRecommendationResourceScope returns only values a
+// downstream renderer can place in an IAM `Resource` element: real ARNs or
+// the `*` wildcard. Graph node IDs (aws:resource:..., aws:identity:...) are
+// dropped here — they surface through impacted_nodes and relationships, not
+// through the session-policy resource scope.
 func awsSessionPolicyRecommendationResourceScope(rec AWSLeastPrivilegeRecommendation) []string {
 	scope := []string{}
-	if arn := strings.TrimSpace(rec.ResourceARN); arn != "" {
+	if arn := strings.TrimSpace(rec.ResourceARN); awsSessionPolicyRecommendationIsValidResource(arn) {
 		scope = append(scope, arn)
 	}
-	if node := strings.TrimSpace(rec.ResourceNodeID); node != "" {
+	if node := strings.TrimSpace(rec.ResourceNodeID); awsSessionPolicyRecommendationIsValidResource(node) {
 		scope = append(scope, node)
 	}
 	if len(scope) == 0 {
 		scope = append(scope, "*")
 	}
-	return emptyStrings(dedupeStrings(scope))
+	return dedupeStrings(scope)
+}
+
+func awsSessionPolicyRecommendationIsValidResource(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if value == "*" {
+		return true
+	}
+	return strings.HasPrefix(value, "arn:")
 }
 
 func awsSessionPolicyRecommendationValidationSignals(rec AWSLeastPrivilegeRecommendation) []AWSSessionPolicyRecommendationValidationSignal {

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -297,10 +297,57 @@ func awsSessionPolicyRecommendationAdmits(rec AWSLeastPrivilegeRecommendation) b
 	if strings.TrimSpace(rec.IdentityNodeID) == "" {
 		return false
 	}
-	// Use dedupeStrings (trims and drops empty entries) so whitespace-only
-	// KeepActions/ObservedActions do not pass admission and then produce
-	// an empty allow_actions projection downstream.
-	if len(dedupeStrings(rec.KeepActions)) == 0 && len(dedupeStrings(rec.ObservedActions)) == 0 {
+	// Session policies attach to STS AssumeRole calls and can only carry
+	// AWS IAM `service:action` values. Reject records whose actionable
+	// set does not contain a valid IAM action after synthetic prefixes
+	// (agent-tool, etc.) are filtered out — a downstream renderer could
+	// not build a valid session policy from those inputs. Whitespace-only
+	// entries are trimmed by awsSessionPolicyRecommendationValidIAMActions.
+	if len(awsSessionPolicyRecommendationValidIAMActions(rec.KeepActions)) == 0 && len(awsSessionPolicyRecommendationValidIAMActions(rec.ObservedActions)) == 0 {
+		return false
+	}
+	return true
+}
+
+// awsSessionPolicyRecommendationValidIAMActions keeps only entries shaped
+// like a real AWS IAM `service:action` value. It drops empty and
+// whitespace-only entries and rejects known synthetic prefixes (currently
+// `agent-tool:`, emitted by agent-runtime least-privilege records) that
+// cannot appear in an IAM `Action` element.
+func awsSessionPolicyRecommendationValidIAMActions(actions []string) []string {
+	out := make([]string, 0, len(actions))
+	seen := map[string]struct{}{}
+	for _, action := range actions {
+		trimmed := strings.TrimSpace(action)
+		if trimmed == "" {
+			continue
+		}
+		if !awsSessionPolicyRecommendationIsValidIAMAction(trimmed) {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func awsSessionPolicyRecommendationIsValidIAMAction(action string) bool {
+	if action == "*" {
+		return true
+	}
+	// Must be `service:action` with a non-empty service prefix.
+	idx := strings.Index(action, ":")
+	if idx <= 0 || idx == len(action)-1 {
+		return false
+	}
+	service := strings.ToLower(action[:idx])
+	// Reject known synthetic prefixes. `agent-tool:*` comes from
+	// agent-runtime least-privilege records and is not an AWS IAM service.
+	switch service {
+	case "agent-tool":
 		return false
 	}
 	return true
@@ -308,7 +355,7 @@ func awsSessionPolicyRecommendationAdmits(rec AWSLeastPrivilegeRecommendation) b
 
 func awsSessionPolicyRecommendationFromLeastPrivilege(rec AWSLeastPrivilegeRecommendation, now time.Time) AWSSessionPolicyRecommendationEntry {
 	allow := awsSessionPolicyRecommendationAllowActions(rec)
-	deny := emptyStrings(dedupeStrings(rec.RemoveActions))
+	deny := awsSessionPolicyRecommendationValidIAMActions(rec.RemoveActions)
 	resourceScope := awsSessionPolicyRecommendationResourceScope(rec)
 	sessionPolicyRef := "session-policy://" + rec.RecommendationID + "/proposed"
 	recommendationID := "aws-session-policy-recommendation:" + stableAWSBlastRadiusToken("session-policy", rec.RecommendationID, rec.IdentityNodeID)
@@ -364,12 +411,14 @@ func awsSessionPolicyRecommendationFromLeastPrivilege(rec AWSLeastPrivilegeRecom
 // awsSessionPolicyRecommendationAllowActions prefers the least-privilege
 // keep-list; when the upstream carries no explicit keep list the observed
 // action set is the safest baseline for the recommended session-policy
-// allow-list.
+// allow-list. Synthetic action names (agent-tool, etc.) are filtered out so
+// the projected allow-list only contains values a downstream renderer can
+// place in an IAM `Action` element.
 func awsSessionPolicyRecommendationAllowActions(rec AWSLeastPrivilegeRecommendation) []string {
-	if keep := emptyStrings(dedupeStrings(rec.KeepActions)); len(keep) > 0 {
+	if keep := awsSessionPolicyRecommendationValidIAMActions(rec.KeepActions); len(keep) > 0 {
 		return keep
 	}
-	return emptyStrings(dedupeStrings(rec.ObservedActions))
+	return awsSessionPolicyRecommendationValidIAMActions(rec.ObservedActions)
 }
 
 func awsSessionPolicyRecommendationResourceScope(rec AWSLeastPrivilegeRecommendation) []string {

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -369,10 +369,13 @@ func awsSessionPolicyRecommendationIsValidIAMAction(action string) bool {
 		return false
 	}
 	service := strings.ToLower(action[:idx])
-	// Reject known synthetic prefixes. `agent-tool:*` comes from
-	// agent-runtime least-privilege records and is not an AWS IAM service.
+	// Reject known synthetic prefixes. Neither belongs in an IAM Action
+	// element: `agent-tool:*` comes from agent-runtime least-privilege
+	// records; `aws-service:*` is the upstream placeholder emitted by
+	// awsLeastPrivilegeServiceAction when an IAM-last-used signal lacks a
+	// resolvable target service.
 	switch service {
-	case "agent-tool":
+	case "agent-tool", "aws-service":
 		return false
 	}
 	return true

--- a/internal/api/aws_session_policy_recommendation.go
+++ b/internal/api/aws_session_policy_recommendation.go
@@ -297,16 +297,41 @@ func awsSessionPolicyRecommendationAdmits(rec AWSLeastPrivilegeRecommendation) b
 	if strings.TrimSpace(rec.IdentityNodeID) == "" {
 		return false
 	}
-	// Session policies attach to STS AssumeRole calls and can only carry
-	// AWS IAM `service:action` values. Reject records whose actionable
-	// set does not contain a valid IAM action after synthetic prefixes
-	// (agent-tool, etc.) are filtered out — a downstream renderer could
-	// not build a valid session policy from those inputs. Whitespace-only
-	// entries are trimmed by awsSessionPolicyRecommendationValidIAMActions.
+	// Session policies attach to STS AssumeRole calls and only make sense
+	// for assumable role identities. Reject IAM users, groups, external
+	// principals, and any identity whose kind cannot be parsed — the
+	// downstream apply path has no valid place to attach the recommendation
+	// for those.
+	if !awsSessionPolicyRecommendationIsAssumableRole(rec) {
+		return false
+	}
+	// Session policies can only carry AWS IAM `service:action` values.
+	// Reject records whose actionable set does not contain a valid IAM
+	// action after synthetic prefixes (agent-tool, etc.) are filtered out
+	// — a downstream renderer could not build a valid session policy from
+	// those inputs. Whitespace-only entries are trimmed by
+	// awsSessionPolicyRecommendationValidIAMActions.
 	if len(awsSessionPolicyRecommendationValidIAMActions(rec.KeepActions)) == 0 && len(awsSessionPolicyRecommendationValidIAMActions(rec.ObservedActions)) == 0 {
 		return false
 	}
 	return true
+}
+
+// awsSessionPolicyRecommendationIsAssumableRole reports whether the record's
+// target is an IAM role (or assumed-role) identity that STS AssumeRole can
+// bind a session policy to. It parses the identity node ID and ARN with the
+// dry-run principal-kind helper so records that classify as `user` or
+// `group` are rejected; records where neither field parses to `role` are
+// also rejected because emitting STS guidance for an unassumable principal
+// would mislead operators.
+func awsSessionPolicyRecommendationIsAssumableRole(rec AWSLeastPrivilegeRecommendation) bool {
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(rec.IdentityNodeID); kind != "" {
+		return kind == "role"
+	}
+	if kind := awsRemediationDryRunClassifiedIAMPrincipalKind(rec.PrincipalARN); kind != "" {
+		return kind == "role"
+	}
+	return false
 }
 
 // awsSessionPolicyRecommendationValidIAMActions keeps only entries shaped
@@ -425,19 +450,37 @@ func awsSessionPolicyRecommendationAllowActions(rec AWSLeastPrivilegeRecommendat
 // downstream renderer can place in an IAM `Resource` element: real ARNs or
 // the `*` wildcard. Graph node IDs (aws:resource:..., aws:identity:...) are
 // dropped here — they surface through impacted_nodes and relationships, not
-// through the session-policy resource scope.
+// through the session-policy resource scope. When the record targets an S3
+// bucket ARN it is expanded to include the `/*` object scope so object-level
+// actions like `s3:GetObject` still match the recommended policy.
 func awsSessionPolicyRecommendationResourceScope(rec AWSLeastPrivilegeRecommendation) []string {
 	scope := []string{}
 	if arn := strings.TrimSpace(rec.ResourceARN); awsSessionPolicyRecommendationIsValidResource(arn) {
 		scope = append(scope, arn)
-	}
-	if node := strings.TrimSpace(rec.ResourceNodeID); awsSessionPolicyRecommendationIsValidResource(node) {
-		scope = append(scope, node)
+		if object := awsSessionPolicyRecommendationS3ObjectScope(arn); object != "" {
+			scope = append(scope, object)
+		}
 	}
 	if len(scope) == 0 {
 		scope = append(scope, "*")
 	}
 	return dedupeStrings(scope)
+}
+
+// awsSessionPolicyRecommendationS3ObjectScope returns `arn:aws:s3:::<bucket>/*`
+// when the input is an S3 bucket ARN so object-level allow-list actions
+// still match. Bucket ARNs never contain `/`; object/prefix ARNs already do
+// and are returned unchanged (empty).
+func awsSessionPolicyRecommendationS3ObjectScope(arn string) string {
+	const prefix = "arn:aws:s3:::"
+	if !strings.HasPrefix(arn, prefix) {
+		return ""
+	}
+	bucket := strings.TrimPrefix(arn, prefix)
+	if bucket == "" || strings.Contains(bucket, "/") {
+		return ""
+	}
+	return arn + "/*"
 }
 
 func awsSessionPolicyRecommendationIsValidResource(value string) bool {

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -241,6 +241,61 @@ func TestAWSSessionPolicyRecommendationFiltersSyntheticActions(t *testing.T) {
 	}
 }
 
+func TestAWSSessionPolicyRecommendationResourceScopeExcludesGraphNodes(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 50, 0, 0, time.UTC)
+
+	graphOnly := AWSLeastPrivilegeRecommendation{
+		RecommendationID: "lp-graph-only",
+		Decision:         "remove",
+		IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/app",
+		ResourceNodeID:   "aws:resource:secrets-manager-secret:openai/api-key",
+		KeepActions:      []string{"secretsmanager:GetSecretValue"},
+	}
+	out := awsSessionPolicyRecommendationFromLeastPrivilege(graphOnly, now)
+	if len(out.ResourceScope) != 1 || out.ResourceScope[0] != "*" {
+		t.Fatalf("graph-node-only records must fall back to `*` for the session-policy resource scope: %+v", out.ResourceScope)
+	}
+
+	mixed := AWSLeastPrivilegeRecommendation{
+		RecommendationID: "lp-mixed",
+		Decision:         "remove",
+		IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/app",
+		ResourceARN:      "arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key",
+		ResourceNodeID:   "aws:resource:secrets-manager-secret:openai/api-key",
+		KeepActions:      []string{"secretsmanager:GetSecretValue"},
+	}
+	out = awsSessionPolicyRecommendationFromLeastPrivilege(mixed, now)
+	if len(out.ResourceScope) != 1 || out.ResourceScope[0] != "arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key" {
+		t.Fatalf("mixed records must keep only ARNs in the session-policy resource scope: %+v", out.ResourceScope)
+	}
+	for _, value := range out.ResourceScope {
+		if strings.HasPrefix(value, "aws:") {
+			t.Fatalf("session-policy resource scope must not carry graph node IDs: %+v", out.ResourceScope)
+		}
+	}
+}
+
+func TestAWSSessionPolicyRecommendationIsValidResource(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"arn:aws:s3:::payments-prod", true},
+		{"arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key", true},
+		{"*", true},
+		{"aws:resource:secrets-manager-secret:openai/api-key", false},
+		{"aws:identity:arn:aws:iam::111111111111:role/app", false},
+		{"", false},
+		{"   ", false},
+		{"my-bucket", false},
+	}
+	for _, tc := range cases {
+		if got := awsSessionPolicyRecommendationIsValidResource(tc.value); got != tc.want {
+			t.Fatalf("value=%q got %v want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
 func TestAWSSessionPolicyRecommendationIsValidIAMAction(t *testing.T) {
 	cases := []struct {
 		action string

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -96,6 +96,16 @@ func TestAWSSessionPolicyRecommendationAdmitsOnlyActionableRecords(t *testing.T)
 			want: true,
 		},
 		{
+			name: "whitespace-only observed and keep actions is not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/app",
+				KeepActions:     []string{"   ", ""},
+				ObservedActions: []string{"\t"},
+			},
+			want: false,
+		},
+		{
 			name: "review decision with keep actions is admitted",
 			rec: AWSLeastPrivilegeRecommendation{
 				Decision:       "review",
@@ -210,19 +220,43 @@ func TestFilterAWSSessionPolicyRecommendations(t *testing.T) {
 		t.Fatalf("decision filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
 	}
 
-	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{AccountID: "111111111111"})
-	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
-		t.Fatalf("account_id filter did not scope entries: %+v", filtered)
+	filtered, applied = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{AccountID: "111111111111"})
+	if applied["account_id"] != "111111111111" || len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
+		t.Fatalf("account_id filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
 	}
 
-	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{PrincipalID: "arn:aws:iam::111111111111:role/a"})
-	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
-		t.Fatalf("principal_id filter must match either node ID or ARN: %+v", filtered)
+	filtered, applied = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{PrincipalID: "arn:aws:iam::111111111111:role/a"})
+	if applied["principal_id"] != "arn:aws:iam::111111111111:role/a" || len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
+		t.Fatalf("principal_id filter must match either node ID or ARN and echo applied: applied=%+v filtered=%+v", applied, filtered)
 	}
 
-	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{Search: "listbucket"})
-	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":two") {
-		t.Fatalf("search must reach allow_actions: %+v", filtered)
+	filtered, applied = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{Search: "listbucket"})
+	if applied["search"] != "listbucket" || len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":two") {
+		t.Fatalf("search must reach allow_actions and echo applied: applied=%+v filtered=%+v", applied, filtered)
+	}
+}
+
+func TestAWSSessionPolicyRecommendationFixtureNormalizerRespectsConnectionState(t *testing.T) {
+	disconnected := AWSConnectionStatus{Connected: false}
+	connected := AWSConnectionStatus{Connected: true}
+
+	// Explicit success/ready must degrade to permission_denied when the
+	// connection is down so this endpoint's fixture metadata stays in
+	// sync with the upstream least-privilege source.
+	if got := normalizeAWSSessionPolicyRecommendationFixtureState("success", disconnected, true); got != "permission_denied" {
+		t.Fatalf("explicit success on disconnected connection must degrade: got %q", got)
+	}
+	if got := normalizeAWSSessionPolicyRecommendationFixtureState("ready", disconnected, false); got != "permission_denied" {
+		t.Fatalf("explicit ready with no connection must degrade: got %q", got)
+	}
+	if got := normalizeAWSSessionPolicyRecommendationFixtureState("success", connected, true); got != "success" {
+		t.Fatalf("explicit success on live connection must stay success: got %q", got)
+	}
+	if got := normalizeAWSSessionPolicyRecommendationFixtureState("permission_denied", connected, true); got != "permission_denied" {
+		t.Fatalf("explicit permission_denied must pass through: got %q", got)
+	}
+	if got := normalizeAWSSessionPolicyRecommendationFixtureState("bogus", connected, true); got != "" {
+		t.Fatalf("unknown fixture state must return empty for invalid request: got %q", got)
 	}
 }
 

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newSessionPolicyRecommendationService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSSessionPolicyRecommendationsBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	svc, ws := newSessionPolicyRecommendationService(t, "project-session-policy-recommendation", now)
+
+	result, err := svc.GetAWSSessionPolicyRecommendations(defaultScopeContext(), ws, "project-session-policy-recommendation", AWSSessionPolicyRecommendationRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get session policy recommendations: %v", err)
+	}
+	if result.CurrentIssueRef != "#1544" || result.Version != awsSessionPolicyRecommendationVersion || result.Mode != awsSessionPolicyRecommendationModeAdvisory {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.PolicyVersion != awsSessionPolicyRecommendationPolicyID {
+		t.Fatalf("expected stable policy version, got %q", result.PolicyVersion)
+	}
+	if len(result.Recommendations) == 0 {
+		t.Fatalf("expected recommendations to be projected from least-privilege source: %+v", result.Summary)
+	}
+	for _, rec := range result.Recommendations {
+		if rec.RecommendationID == "" || rec.CalculationVersion != awsSessionPolicyRecommendationVersion {
+			t.Fatalf("recommendation missing stable metadata: %+v", rec)
+		}
+		if rec.Mode != awsSessionPolicyRecommendationModeAdvisory {
+			t.Fatalf("recommendation must remain advisory: %+v", rec)
+		}
+		switch rec.Decision {
+		case "remove", "review":
+		default:
+			t.Fatalf("recommendation has unsupported decision: %+v", rec)
+		}
+		if !strings.HasPrefix(rec.SessionPolicyRef, "session-policy://") {
+			t.Fatalf("recommendation must carry a metadata session_policy_ref: %+v", rec)
+		}
+		if rec.PrincipalNodeID == "" {
+			t.Fatalf("recommendation must carry a principal_node_id: %+v", rec)
+		}
+		if len(rec.AllowActions) == 0 {
+			t.Fatalf("recommendation must carry an allow-list derived from observed usage: %+v", rec)
+		}
+		if rec.EvidenceBoundary != awsSessionPolicyRecommendationEvidenceBoundary() {
+			t.Fatalf("recommendation crossed evidence boundary: %+v", rec)
+		}
+		if !rec.ReadOnlyProjection {
+			t.Fatalf("recommendation must remain read-only: %+v", rec)
+		}
+		if rec.Provenance.PolicyVersion == "" || rec.Provenance.SourceRuleName == "" {
+			t.Fatalf("recommendation missing provenance: %+v", rec.Provenance)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\"", "\"session_policy_body\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("session policy recommendation serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSSessionPolicyRecommendationAdmitsOnlyActionableRecords(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  AWSLeastPrivilegeRecommendation
+		want bool
+	}{
+		{
+			name: "remove decision with observed actions is admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/app",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: true,
+		},
+		{
+			name: "review decision with keep actions is admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:       "review",
+				IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:role/app",
+				KeepActions:    []string{"s3:GetObject"},
+			},
+			want: true,
+		},
+		{
+			name: "keep decision is not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "keep",
+				IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/app",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: false,
+		},
+		{
+			name: "no principal is not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: false,
+		},
+		{
+			name: "no observed or keep actions is not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:       "remove",
+				IdentityNodeID: "aws:identity:arn:aws:iam::111111111111:role/app",
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		if got := awsSessionPolicyRecommendationAdmits(tc.rec); got != tc.want {
+			t.Fatalf("%s: admit=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestAWSSessionPolicyRecommendationFromLeastPrivilegeShape(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 30, 0, 0, time.UTC)
+	rec := AWSLeastPrivilegeRecommendation{
+		RecommendationID:   "lp-1",
+		Decision:           "remove",
+		Severity:           "medium",
+		Score:              72,
+		Confidence:         0.85,
+		AccountID:          "111111111111",
+		Region:             "us-east-1",
+		IdentityNodeID:     "aws:identity:arn:aws:iam::111111111111:role/app",
+		PrincipalARN:       "arn:aws:iam::111111111111:role/app",
+		ResourceARN:        "arn:aws:s3:::payments/*",
+		BreakagePrediction: "low",
+		BreakageRationale:  "no observed use for six weeks",
+		KeepActions:        []string{"s3:GetObject", "s3:ListBucket"},
+		RemoveActions:      []string{"s3:DeleteObject"},
+		ObservedActions:    []string{"s3:GetObject", "s3:ListBucket"},
+	}
+	out := awsSessionPolicyRecommendationFromLeastPrivilege(rec, now)
+	if len(out.AllowActions) != 2 || out.AllowActions[0] != "s3:GetObject" {
+		t.Fatalf("allow list must come from KeepActions when present: %+v", out.AllowActions)
+	}
+	if len(out.DenyActions) != 1 || out.DenyActions[0] != "s3:DeleteObject" {
+		t.Fatalf("deny list must mirror RemoveActions: %+v", out.DenyActions)
+	}
+	if out.ExpectedBehavior.ObservedActionCount != 2 {
+		t.Fatalf("expected observed count to reflect ObservedActions: %+v", out.ExpectedBehavior)
+	}
+	if out.SessionPolicyRef == "" || out.Provenance.SourceRuleName != "constrain_unused_actions" {
+		t.Fatalf("remove decision must map to constrain_unused_actions rule: %+v", out.Provenance)
+	}
+
+	fallback := rec
+	fallback.KeepActions = nil
+	fallback.Decision = "review"
+	back := awsSessionPolicyRecommendationFromLeastPrivilege(fallback, now)
+	if len(back.AllowActions) != 2 || back.AllowActions[0] != "s3:GetObject" {
+		t.Fatalf("allow list must fall back to ObservedActions when KeepActions is empty: %+v", back.AllowActions)
+	}
+	if back.Provenance.SourceRuleName != "surface_review_candidates" {
+		t.Fatalf("review decision must map to surface_review_candidates rule: %+v", back.Provenance)
+	}
+}
+
+func TestFilterAWSSessionPolicyRecommendations(t *testing.T) {
+	entries := []AWSSessionPolicyRecommendationEntry{
+		{
+			RecommendationID: "aws-session-policy-recommendation:one",
+			Decision:         "remove",
+			Severity:         "high",
+			AccountID:        "111111111111",
+			Region:           "us-east-1",
+			PrincipalNodeID:  "aws:identity:arn:aws:iam::111111111111:role/a",
+			PrincipalARN:     "arn:aws:iam::111111111111:role/a",
+			AllowActions:     []string{"s3:GetObject"},
+		},
+		{
+			RecommendationID: "aws-session-policy-recommendation:two",
+			Decision:         "review",
+			Severity:         "medium",
+			AccountID:        "222222222222",
+			Region:           "us-west-2",
+			PrincipalNodeID:  "aws:identity:arn:aws:iam::222222222222:role/b",
+			AllowActions:     []string{"s3:ListBucket"},
+		},
+	}
+
+	filtered, applied := filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{Decision: "review"})
+	if applied["decision"] != normalizeAWSRuntimeEventFilterToken("review") || len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":two") {
+		t.Fatalf("decision filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{AccountID: "111111111111"})
+	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
+		t.Fatalf("account_id filter did not scope entries: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{PrincipalID: "arn:aws:iam::111111111111:role/a"})
+	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":one") {
+		t.Fatalf("principal_id filter must match either node ID or ARN: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSSessionPolicyRecommendations(entries, AWSSessionPolicyRecommendationRequest{Search: "listbucket"})
+	if len(filtered) != 1 || !strings.HasSuffix(filtered[0].RecommendationID, ":two") {
+		t.Fatalf("search must reach allow_actions: %+v", filtered)
+	}
+}
+
+func TestAWSSessionPolicyRecommendationFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	svc, ws := newSessionPolicyRecommendationService(t, "project-session-policy-recommendation-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSSessionPolicyRecommendations(defaultScopeContext(), ws, "project-session-policy-recommendation-fixture", AWSSessionPolicyRecommendationRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestRouterAWSSessionPolicyRecommendations(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	svc, _ := newSessionPolicyRecommendationService(t, "project-session-policy-recommendation-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-session-policy-recommendation-route/aws/session-policy-recommendations?connector_id=aws-prod&fixture_state=success", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Recs AWSSessionPolicyRecommendationResult `json:"session_policy_recommendations"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Recs.CurrentIssueRef != "#1544" || body.Recs.PolicyVersion != awsSessionPolicyRecommendationPolicyID {
+		t.Fatalf("unexpected route payload: %+v", body.Recs)
+	}
+}

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -126,6 +126,34 @@ func TestAWSSessionPolicyRecommendationAdmitsOnlyActionableRecords(t *testing.T)
 			want: true,
 		},
 		{
+			name: "IAM user principal is not admitted (STS AssumeRole requires a role)",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "arn:aws:iam::111111111111:user/actor",
+				PrincipalARN:    "arn:aws:iam::111111111111:user/actor",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: false,
+		},
+		{
+			name: "IAM group principal is not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "arn:aws:iam::111111111111:group/analysts",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: false,
+		},
+		{
+			name: "unparseable identity is not admitted (avoid misleading STS guidance)",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "some-opaque-node-id",
+				ObservedActions: []string{"s3:GetObject"},
+			},
+			want: false,
+		},
+		{
 			name: "review decision with keep actions is admitted",
 			rec: AWSLeastPrivilegeRecommendation{
 				Decision:       "review",
@@ -271,6 +299,63 @@ func TestAWSSessionPolicyRecommendationResourceScopeExcludesGraphNodes(t *testin
 	for _, value := range out.ResourceScope {
 		if strings.HasPrefix(value, "aws:") {
 			t.Fatalf("session-policy resource scope must not carry graph node IDs: %+v", out.ResourceScope)
+		}
+	}
+}
+
+func TestAWSSessionPolicyRecommendationExpandsS3BucketScope(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 55, 0, 0, time.UTC)
+
+	bucketOnly := AWSLeastPrivilegeRecommendation{
+		RecommendationID: "lp-s3-bucket",
+		Decision:         "remove",
+		IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/reader",
+		Service:          "s3",
+		ResourceARN:      "arn:aws:s3:::payments-prod",
+		KeepActions:      []string{"s3:GetObject", "s3:ListBucket"},
+	}
+	out := awsSessionPolicyRecommendationFromLeastPrivilege(bucketOnly, now)
+	if len(out.ResourceScope) != 2 {
+		t.Fatalf("S3 bucket ARN must expand to include object scope: %+v", out.ResourceScope)
+	}
+	sawBucket, sawObject := false, false
+	for _, value := range out.ResourceScope {
+		if value == "arn:aws:s3:::payments-prod" {
+			sawBucket = true
+		}
+		if value == "arn:aws:s3:::payments-prod/*" {
+			sawObject = true
+		}
+	}
+	if !sawBucket || !sawObject {
+		t.Fatalf("S3 scope must contain both the bucket ARN and the /* object ARN: %+v", out.ResourceScope)
+	}
+
+	objectARN := bucketOnly
+	objectARN.RecommendationID = "lp-s3-object"
+	objectARN.ResourceARN = "arn:aws:s3:::payments-prod/reports/*"
+	out = awsSessionPolicyRecommendationFromLeastPrivilege(objectARN, now)
+	if len(out.ResourceScope) != 1 || out.ResourceScope[0] != "arn:aws:s3:::payments-prod/reports/*" {
+		t.Fatalf("already-object-scoped S3 ARN must not double-expand: %+v", out.ResourceScope)
+	}
+}
+
+func TestAWSSessionPolicyRecommendationS3ObjectScope(t *testing.T) {
+	cases := []struct {
+		arn  string
+		want string
+	}{
+		{"arn:aws:s3:::payments-prod", "arn:aws:s3:::payments-prod/*"},
+		{"arn:aws:s3:::my-bucket-123", "arn:aws:s3:::my-bucket-123/*"},
+		{"arn:aws:s3:::payments-prod/*", ""},
+		{"arn:aws:s3:::payments-prod/reports/*", ""},
+		{"arn:aws:s3:::", ""},
+		{"arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key", ""},
+		{"*", ""},
+	}
+	for _, tc := range cases {
+		if got := awsSessionPolicyRecommendationS3ObjectScope(tc.arn); got != tc.want {
+			t.Fatalf("arn=%q got %q want %q", tc.arn, got, tc.want)
 		}
 	}
 }

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -116,6 +116,16 @@ func TestAWSSessionPolicyRecommendationAdmitsOnlyActionableRecords(t *testing.T)
 			want: false,
 		},
 		{
+			name: "aws-service placeholder actions are not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "arn:aws:iam::111111111111:role/stale-service",
+				KeepActions:     []string{"aws-service:*"},
+				ObservedActions: []string{"aws-service:*"},
+			},
+			want: false,
+		},
+		{
 			name: "mixed valid and synthetic actions are admitted (only IAM actions kept)",
 			rec: AWSLeastPrivilegeRecommendation{
 				Decision:        "remove",
@@ -391,6 +401,8 @@ func TestAWSSessionPolicyRecommendationIsValidIAMAction(t *testing.T) {
 		{"iam:PutRolePolicy", true},
 		{"*", true},
 		{"agent-tool:filesystem", false},
+		{"aws-service:*", false},
+		{"aws-service:lambda", false},
 		{"", false},
 		{"noservice", false},
 		{":action", false},

--- a/internal/api/aws_session_policy_recommendation_test.go
+++ b/internal/api/aws_session_policy_recommendation_test.go
@@ -106,6 +106,26 @@ func TestAWSSessionPolicyRecommendationAdmitsOnlyActionableRecords(t *testing.T)
 			want: false,
 		},
 		{
+			name: "agent-tool synthetic actions are not admitted",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/agent-runtime",
+				KeepActions:     []string{"agent-tool:filesystem"},
+				ObservedActions: []string{"agent-tool:web"},
+			},
+			want: false,
+		},
+		{
+			name: "mixed valid and synthetic actions are admitted (only IAM actions kept)",
+			rec: AWSLeastPrivilegeRecommendation{
+				Decision:        "remove",
+				IdentityNodeID:  "aws:identity:arn:aws:iam::111111111111:role/agent-runtime",
+				KeepActions:     []string{"agent-tool:filesystem", "s3:GetObject"},
+				ObservedActions: []string{},
+			},
+			want: true,
+		},
+		{
 			name: "review decision with keep actions is admitted",
 			rec: AWSLeastPrivilegeRecommendation{
 				Decision:       "review",
@@ -189,6 +209,57 @@ func TestAWSSessionPolicyRecommendationFromLeastPrivilegeShape(t *testing.T) {
 	}
 	if back.Provenance.SourceRuleName != "surface_review_candidates" {
 		t.Fatalf("review decision must map to surface_review_candidates rule: %+v", back.Provenance)
+	}
+}
+
+func TestAWSSessionPolicyRecommendationFiltersSyntheticActions(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 45, 0, 0, time.UTC)
+	rec := AWSLeastPrivilegeRecommendation{
+		RecommendationID: "lp-agent",
+		Decision:         "remove",
+		IdentityNodeID:   "aws:identity:arn:aws:iam::111111111111:role/agent-runtime",
+		KeepActions:      []string{"agent-tool:filesystem", "s3:GetObject", "  ", "kms:Decrypt"},
+		RemoveActions:    []string{"agent-tool:web", "iam:DeleteRole"},
+		ObservedActions:  []string{"agent-tool:filesystem"},
+	}
+	out := awsSessionPolicyRecommendationFromLeastPrivilege(rec, now)
+	for _, action := range out.AllowActions {
+		if strings.HasPrefix(action, "agent-tool:") {
+			t.Fatalf("allow_actions must not contain synthetic agent-tool actions: %+v", out.AllowActions)
+		}
+	}
+	if len(out.AllowActions) != 2 || out.AllowActions[0] != "s3:GetObject" || out.AllowActions[1] != "kms:Decrypt" {
+		t.Fatalf("allow_actions must retain valid IAM actions in order: %+v", out.AllowActions)
+	}
+	for _, action := range out.DenyActions {
+		if strings.HasPrefix(action, "agent-tool:") {
+			t.Fatalf("deny_actions must not contain synthetic agent-tool actions: %+v", out.DenyActions)
+		}
+	}
+	if len(out.DenyActions) != 1 || out.DenyActions[0] != "iam:DeleteRole" {
+		t.Fatalf("deny_actions must retain valid IAM actions: %+v", out.DenyActions)
+	}
+}
+
+func TestAWSSessionPolicyRecommendationIsValidIAMAction(t *testing.T) {
+	cases := []struct {
+		action string
+		want   bool
+	}{
+		{"s3:GetObject", true},
+		{"kms:Decrypt", true},
+		{"iam:PutRolePolicy", true},
+		{"*", true},
+		{"agent-tool:filesystem", false},
+		{"", false},
+		{"noservice", false},
+		{":action", false},
+		{"service:", false},
+	}
+	for _, tc := range cases {
+		if got := awsSessionPolicyRecommendationIsValidIAMAction(tc.action); got != tc.want {
+			t.Fatalf("action=%q got %v want %v", tc.action, got, tc.want)
+		}
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3352,6 +3352,41 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"advisory_authorization": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSSessionPolicyRecommendations(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSSessionPolicyRecommendationRequest{
+			ConnectorID:      strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:     strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:        strings.TrimSpace(c.Query("account_id")),
+			Region:           strings.TrimSpace(c.Query("region")),
+			PrincipalID:      strings.TrimSpace(c.Query("principal_id")),
+			RecommendationID: strings.TrimSpace(c.Query("recommendation_id")),
+			Decision:         strings.TrimSpace(c.Query("decision")),
+			Severity:         strings.TrimSpace(c.Query("severity")),
+			Search:           strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws session policy recommendation request"})
+			default:
+				logger.Error("get aws session policy recommendations",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws session policy recommendations"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"session_policy_recommendations": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4018,6 +4018,134 @@ export type AWSAdvisoryAuthorizationQuery = {
   search?: string;
 };
 
+export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
+
+export type AWSSessionPolicyRecommendationValidationSignal = {
+  source: string;
+  signal: string;
+  status: string;
+  count?: number;
+  description: string;
+};
+
+export type AWSSessionPolicyRecommendationExpectedBehavior = {
+  allowed_action_count: number;
+  denied_action_count: number;
+  observed_action_count: number;
+};
+
+export type AWSSessionPolicyRecommendationProvenance = {
+  policy_version: string;
+  source_rule_name: string;
+  signals?: string[];
+};
+
+export type AWSSessionPolicyRecommendationRelationship = {
+  recommendation_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSSessionPolicyRecommendationEntry = {
+  recommendation_id: string;
+  calculation_version: string;
+  mode: 'advisory' | string;
+  decision: AWSSessionPolicyRecommendationDecision;
+  severity: string;
+  score: number;
+  confidence: number;
+  title: string;
+  summary: string;
+  rationale: string;
+  account_id?: string;
+  region?: string;
+  principal_node_id: string;
+  principal_arn?: string;
+  principal_display_name?: string;
+  session_policy_ref: string;
+  session_duration_hint?: string;
+  allow_actions: string[];
+  deny_actions?: string[];
+  resource_scope?: string[];
+  condition_keys?: string[];
+  expected_behavior: AWSSessionPolicyRecommendationExpectedBehavior;
+  validation_signals: AWSSessionPolicyRecommendationValidationSignal[];
+  provenance: AWSSessionPolicyRecommendationProvenance;
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  audit_trail: AWSRemediationAuditEntry[];
+  read_only_projection: boolean;
+  source_signals: string[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSSessionPolicyRecommendationSummary = {
+  total_recommendations: number;
+  filtered_recommendations: number;
+  decision_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  allow_action_count: number;
+  deny_action_count: number;
+  observed_action_count: number;
+  validation_signal_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSSessionPolicyRecommendationResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSSessionPolicyRecommendationStatus;
+  fixture_state?: AWSSessionPolicyRecommendationFixtureState;
+  confidence: number;
+  calculation_version: string;
+  policy_version: string;
+  mode: 'advisory' | string;
+  applied_filters: Record<string, string>;
+  summary: AWSSessionPolicyRecommendationSummary;
+  recommendations: AWSSessionPolicyRecommendationEntry[];
+  relationships: AWSSessionPolicyRecommendationRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSSessionPolicyRecommendationQuery = {
+  connectorID?: string;
+  fixtureState?: AWSSessionPolicyRecommendationFixtureState;
+  accountID?: string;
+  region?: string;
+  principalID?: string;
+  recommendationID?: string;
+  decision?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -9347,6 +9475,27 @@ export const apiClient = {
         source_type: query?.sourceType,
         case_id: query?.caseID,
         verification_id: query?.verificationID,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectSessionPolicyRecommendations(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSSessionPolicyRecommendationQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ session_policy_recommendations: AWSSessionPolicyRecommendationResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/session-policy-recommendations${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        principal_id: query?.principalID,
+        recommendation_id: query?.recommendationID,
+        decision: query?.decision,
+        severity: query?.severity,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4096,6 +4096,35 @@ describe('Domain-first app routes', () => {
 	        diagnostics: []
 	      } as any
 	    });
+	    const getSessionPolicyRecommendations = vi.spyOn(api.apiClient, 'getAWSProjectSessionPolicyRecommendations').mockResolvedValue({
+	      session_policy_recommendations: {
+	        status: 'ready',
+	        mode: 'advisory',
+	        policy_version: 'aws-session-policy-recommendation-policy-v1',
+	        recommendations: [],
+	        relationships: [],
+	        applied_filters: {},
+	        summary: {
+	          total_recommendations: 0,
+	          filtered_recommendations: 0,
+	          decision_counts: {},
+	          severity_counts: {},
+	          allow_action_count: 0,
+	          deny_action_count: 0,
+	          observed_action_count: 0,
+	          validation_signal_count: 0,
+	          relationship_count: 0,
+	          highest_score: 0,
+	          average_confidence_pct: 0
+	        },
+	        caveats: ['Session-policy recommendations are advisory-only.'],
+	        failure_reasons: [],
+	        remediation_hints: [],
+	        evidence_links: [],
+	        coverage_gaps: [],
+	        diagnostics: []
+	      } as any
+	    });
 	    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
@@ -4769,6 +4798,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getAdvisoryAuthorization).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getSessionPolicyRecommendations).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -85,6 +85,8 @@ import {
   type AWSPostRemediationVerificationResult,
   type AWSAdvisoryAuthorizationDecision,
   type AWSAdvisoryAuthorizationResult,
+  type AWSSessionPolicyRecommendationEntry,
+  type AWSSessionPolicyRecommendationResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11447,6 +11449,73 @@ function AWSAdvisoryAuthorizationContent({
   );
 }
 
+function awsSessionPolicyRecommendationStage(entry: AWSSessionPolicyRecommendationEntry): AWSCapabilityStage {
+  if (entry.decision === 'remove' && entry.expected_behavior.observed_action_count > 0) {
+    return 'wired';
+  }
+  if (entry.decision === 'review') {
+    return 'coming';
+  }
+  return 'coming';
+}
+
+function AWSSessionPolicyRecommendationContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSSessionPolicyRecommendationResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_recommendations} total · ${result.summary.allow_action_count} allowed · ${result.summary.deny_action_count} denied · ${result.summary.observed_action_count} observed`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.recommendations,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <AWSExecutorProjectionPanel<AWSSessionPolicyRecommendationEntry>
+      result={panelResult}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS session policy recommendations"
+      heading="AWS session policy recommendations"
+      description={`Advisory-only projection that derives STS session-policy scope from least-privilege recommendations. Each entry records the target principal, projected allow/deny lists, resource scope, runtime validation signals, and audit rows. Identrail never enforces the recommendation at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS session policy recommendations"
+      loadingTitle="Projecting session policy recommendations"
+      loadingBody="Identrail is deriving session-policy scope from least-privilege recommendations for this connector."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No session policy recommendations')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Session policy recommendations need approved least-privilege evidence' : 'No session policy recommendations projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No least-privilege recommendation carried an actionable observed-usage profile for this environment.'}
+      tableLabel="AWS session policy recommendations"
+      getRowKey={(row) => row.recommendation_id}
+      columns={[
+        { key: 'recommendation', header: 'Recommendation', render: (row) => <strong>{row.title}</strong> },
+        { key: 'principal', header: 'Principal', render: (row) => row.principal_display_name ?? row.principal_node_id },
+        { key: 'decision', header: 'Decision', render: (row) => formatTokenLabel(row.decision) },
+        { key: 'allow_deny', header: 'Allow / Deny', render: (row) => `${row.expected_behavior.allowed_action_count} allow · ${row.expected_behavior.denied_action_count} deny` },
+        { key: 'observed', header: 'Observed', render: (row) => `${row.expected_behavior.observed_action_count} actions` },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsSessionPolicyRecommendationStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.decision)}`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13679,6 +13748,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [advisoryAuthorizationLoading, setAdvisoryAuthorizationLoading] = useState(false);
   const [advisoryAuthorizationError, setAdvisoryAuthorizationError] = useState('');
   const advisoryAuthorizationRequestRef = useRef(0);
+  const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
+  const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
+  const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
+  const sessionPolicyRecommendationsRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -14375,6 +14448,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       advisoryAuthorizationRequestRef.current += 1;
     };
   }, [loadAdvisoryAuthorization]);
+
+  const loadSessionPolicyRecommendations = useCallback(async () => {
+    const requestID = ++sessionPolicyRecommendationsRequestRef.current;
+    setSessionPolicyRecommendations(null);
+    setSessionPolicyRecommendationsError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setSessionPolicyRecommendationsLoading(false);
+      return;
+    }
+    setSessionPolicyRecommendationsLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectSessionPolicyRecommendations(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== sessionPolicyRecommendationsRequestRef.current) {
+        return;
+      }
+      setSessionPolicyRecommendations(response.session_policy_recommendations);
+    } catch (error) {
+      if (requestID !== sessionPolicyRecommendationsRequestRef.current) {
+        return;
+      }
+      setSessionPolicyRecommendationsError(formatAPIError(error, 'Unable to load AWS session policy recommendations.'));
+    } finally {
+      if (requestID === sessionPolicyRecommendationsRequestRef.current) {
+        setSessionPolicyRecommendationsLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadSessionPolicyRecommendations();
+    return () => {
+      sessionPolicyRecommendationsRequestRef.current += 1;
+    };
+  }, [loadSessionPolicyRecommendations]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -15246,6 +15367,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={advisoryAuthorizationLoading}
             error={advisoryAuthorizationError}
             onRetry={loadAdvisoryAuthorization}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSSessionPolicyRecommendationContent
+            result={sessionPolicyRecommendations}
+            loading={sessionPolicyRecommendationsLoading}
+            error={sessionPolicyRecommendationsError}
+            onRetry={loadSessionPolicyRecommendations}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- implement the AWS session policy recommendation path for issue #1544
- derive advisory STS session-policy scope from least-privilege recommendations (#1522), keeping rendered policy JSON behind a session_policy_ref metadata reference
- wire the endpoint into API routing, authz, OpenAPI, docs, CHANGELOG, and the AWS Runtime app surface
- advisory-only: no IAM/STS write API calls; no rendered policy bodies or observed-action payloads; only records with an actionable observed-usage profile are admitted

## Validation
- go test ./internal/api/...
- make fmt-check && make vet
- ./scripts/check_api_example_contract.sh && ./scripts/check_web_route_integrity.sh
- npx vitest run src/productShell.test.tsx (169 passing)
- npx tsc -b clean

## AI disclosure
AI-assisted: no

Closes #1544

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an advisory AWS STS session‑policy recommendation path that derives scopes from least‑privilege and exposes them via a new API and an AWS Runtime UI panel. Only IAM roles are admitted, and S3 bucket ARNs expand to include object scope. Addresses #1544 with read‑only recommendations that never call IAM/STS or inline policy JSON.

- **New Features**
  - Added GET /v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations with filters for connector, fixture state, account, region, principal, recommendation ID, decision, severity, and search.
  - Projection derives session‑policy scope from least‑privilege (#1522) and only admits `remove`/`review` entries with observed usage or a keep list. Returns allow/deny lists, resource scope, expected behavior counts, validation signals, provenance, and an audit trail. Policy body stays behind `session_policy_ref` (advisory‑only; no IAM/STS writes).
  - Web: added `apiClient.getAWSProjectSessionPolicyRecommendations` and a new “AWS session policy recommendations” panel on the AWS Runtime page showing title, decision, principal, allow/deny counts, observed actions, and severity/decision status.
  - Wired route authz and OpenAPI schemas, plus docs and tests.

- **Bug Fixes**
  - Filtered synthetic action prefixes (`agent-tool:*`, `aws-service:*`) from allow/deny inputs and admission; recommendations now require at least one valid IAM `service:action` (or `*`) after filtering.
  - Rejected whitespace‑only `KeepActions`/`ObservedActions` so recommendations never yield an empty `allow_actions`.
  - Restricted `resource_scope` to valid IAM Resource values (ARNs or `*`); graph node IDs are excluded and shown via relationships instead.
  - Required assumable IAM role principals; users, groups, and unparseable identities are rejected at admission.
  - Expanded S3 bucket ARNs in `resource_scope` to also include `bucket/*` for object‑level actions; object‑scoped ARNs pass through unchanged.
  - Aligned fixture normalization with least‑privilege: explicit `success`/`ready` degrade to `permission_denied` when the connection is down.
  - Strengthened filtering contract and tests to assert the applied filter map for `account_id`, `principal_id`, and `search`.

<sup>Written for commit f44ebed9440c235ba49b515d49a1bfd4e5dc1f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

