### PR TITLE
Implement AgentCore gateway policy advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS AgentCore gateway policy advisory** (#1545). Adds an
+  advisory-only projection that derives AgentCore gateway/tool policy
+  recommendations from the AI agent risk engine (#1528). Each advisory
+  carries an `outcome` (`allow_tools` | `warn` | `require_approval` |
+  `restrict_tools` | `block_tools`), the agent runtime identity, a
+  disjoint partition of the finding's tool namespace into
+  allowed/restricted/blocked buckets, the sensitive-reachability set,
+  operator-facing `recommended_actions`, provenance (policy version +
+  rule name), a deterministic input hash covering finding ID, agent
+  node ID, risk type, severity, status, tool count, sensitive count,
+  outcome, and policy version, evidence refs, and an immutable audit
+  trail. Policy ordering makes safety signals win: critical-severity
+  findings with sensitive reachability always classify as
+  `block_tools`, external-credential findings as `require_approval`,
+  broad-tool-access and sensitive-reachability findings as
+  `restrict_tools`, ownerless-agent findings as `warn`, remaining
+  critical/high-severity findings as `require_approval`, findings
+  with no resolved tool namespace as `warn`, and everything else as
+  `allow_tools` with advisory monitoring. Prompt text, tool payloads,
+  and workload data are never inlined; tool restrictions reference
+  the tool namespace by name only. Each advisory also exposes
+  `pilot_state` and `enforcement_state`; enforcement remains
+  `advisory_only` in this wave. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory`
+  with filters for connector, fixture state, account, region, agent ID,
+  outcome, risk type, severity, finding ID, and free-text search.
+  OpenAPI schemas and authz wiring follow the neighboring wave-9
+  endpoints. The AWS Runtime app surface now shows an **AWS AgentCore
+  gateway policy advisory** panel with the advisory title, agent,
+  outcome pill, restricted/blocked tool counts, sensitive-reachability
+  count, and severity/outcome status pill. Identrail never enforces
+  the recommendation at this layer.
 - Add **AWS session policy recommendation path** (#1544). Adds an
   advisory-only projection that derives session-policy recommendations
   from the least-privilege recommendation engine (#1522). Each entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   findings map to the restriction rule, and advisory `input_hash` values
   include normalized tool-name and sensitive-resource digests so same-count
   scope replacements are detectable.
+- Extend AgentCore gateway policy advisory classification for the remaining
+  upstream runtime/backing-role review tokens: `undeclared_tool_runtime` and
+  `backing_role_mismatch` now require approval, while `runtime_tool_anomaly`,
+  `declared_unused_tool`, and `backing_role_scope` restrict the affected tool
+  scope instead of falling through to `allow_tools`.
 - Add **AWS session policy recommendation path** (#1544). Adds an
   advisory-only projection that derives session-policy recommendations
   from the least-privilege recommendation engine (#1522). Each entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
   outcome pill, restricted/blocked tool counts, sensitive-reachability
   count, and severity/outcome status pill. Identrail never enforces
   the recommendation at this layer.
+- Tighten the AgentCore gateway policy advisory classifier/hash contract
+  after review: upstream `external_credential_exposure` findings now map
+  to the dedicated approval rule, upstream `sensitive_data_reachability`
+  findings map to the restriction rule, and advisory `input_hash` values
+  include normalized tool-name and sensitive-resource digests so same-count
+  scope replacements are detectable.
 - Add **AWS session policy recommendation path** (#1544). Adds an
   advisory-only projection that derives session-policy recommendations
   from the least-privilege recommendation engine (#1522). Each entry

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
 - AWS advisory authorization decision API: `aws-advisory-authorization.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
+- AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
 - AWS risk engine: `aws-risk-engine.md`
 

--- a/docs/aws-agentcore-gateway-policy-advisory.md
+++ b/docs/aws-agentcore-gateway-policy-advisory.md
@@ -1,0 +1,91 @@
+# AWS AgentCore gateway policy advisory
+
+Issue #1545 adds a metadata-only projection of advisory AgentCore
+gateway/tool policy recommendations. Each advisory derives from an AI
+agent risk finding (#1528) and projects the tool-namespace scope operators
+should apply through the AgentCore gateway policy decision point.
+
+The endpoint is advisory-only. Identrail never enforces the recommendation
+at this layer and never inlines prompt text, tool payloads, or workload
+data. Tool restrictions, approvals, and warnings reference the agent's
+tool namespace by name only.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agentcore-gateway-policy-advisory`
+
+Response shape:
+`{ "agentcore_gateway_policy_advisory": AWSAgentCoreGatewayPolicyAdvisoryResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`agent_id`, `outcome`, `risk_type`, `severity`, `finding_id`, and `search`.
+
+## Advisory shape
+
+Each advisory carries:
+
+- `outcome`: one of `allow_tools`, `warn`, `require_approval`,
+  `restrict_tools`, `block_tools`.
+- `pilot_state` / `enforcement_state`: governance posture for the
+  recommendation. This wave remains advisory-only, so enforcement is always
+  `advisory_only`; pilot state is `candidate`, `operator_review`, or
+  `blocked` based on the projected outcome.
+- `agent_node_id`, `agent_id`, `agent_name`, `agent_type`, `provider`,
+  `runtime_role_arn`, `runtime_role_node_id`: the target agent gateway
+  runtime.
+- `allowed_tool_names`, `restricted_tool_names`, `blocked_tool_names`:
+  disjoint partition of the finding's tool namespace based on the
+  recommended outcome.
+- `sensitive_resources`: the sensitive-reachability set that scoped the
+  recommendation.
+- `recommended_actions`: operator-facing directives derived from the
+  outcome and the affected tool/resource scope.
+- `provenance.policy_version` / `provenance.policy_rule`: the deterministic
+  rule that produced the advisory. Every policy change bumps the version.
+- `input_hash`: deterministic hash of the classifier inputs (finding ID,
+  agent node ID, risk type, severity, status, tool count, sensitive
+  reachability count, outcome, policy version). Log both sides of a
+  gateway policy decision to detect drift.
+- `evidence`, `impacted_nodes`, `impacted_path`: metadata refs only. No
+  prompt text or tool payloads.
+- `audit_trail`: immutable projection audit row.
+
+## Outcome policy
+
+Ordered so safety signals win over general tool-scope warnings:
+
+1. Severity `critical` AND at least one sensitive reachability →
+   `block_tools`.
+2. Risk type `external_credential` / `external_credentials` →
+   `require_approval`.
+3. Risk type `broad_tool_access` / `broad_tool_scope` → `restrict_tools`.
+4. Risk type `sensitive_reachability` → `restrict_tools`.
+5. Risk type `ownerless_agent` → `warn`.
+6. Severity `critical` or `high` without matching risk type →
+   `require_approval`.
+7. Finding carries no resolved tool namespace → `warn`.
+8. Otherwise → `allow_tools` with advisory monitoring.
+
+## Admission
+
+The projection only admits findings that carry an addressable
+`agent_node_id`. Findings without an agent target cannot be surfaced as
+a gateway policy recommendation because there is no gateway to advise on.
+
+## Safety, evidence, and out of scope
+
+- Advisory-only. No gateway or IAM write APIs are called at this layer.
+- Critical-severity findings with sensitive reachability always classify
+  as `block_tools` regardless of any other signal so a compromised
+  gateway can never be recorded as `allow_tools`.
+- Tenant, workspace, project, connector, account, and region boundaries
+  are preserved.
+- Unknown, permission-denied, and partial-failure states are surfaced as
+  explicit states, not as successful findings.
+
+## App Surface
+
+The AWS Runtime page renders an **AWS AgentCore gateway policy advisory**
+panel showing the advisory title, agent, outcome pill, restricted/blocked
+tool counts, sensitive reachability count, severity/outcome status pill,
+and next action.

--- a/docs/aws-agentcore-gateway-policy-advisory.md
+++ b/docs/aws-agentcore-gateway-policy-advisory.md
@@ -43,9 +43,10 @@ Each advisory carries:
 - `provenance.policy_version` / `provenance.policy_rule`: the deterministic
   rule that produced the advisory. Every policy change bumps the version.
 - `input_hash`: deterministic hash of the classifier inputs (finding ID,
-  agent node ID, risk type, severity, status, tool count, sensitive
-  reachability count, outcome, policy version). Log both sides of a
-  gateway policy decision to detect drift.
+  agent node ID, risk type, severity, status, tool count, normalized
+  tool-name digest, sensitive reachability count, normalized sensitive
+  resource digest, outcome, policy version). Log both sides of a gateway
+  policy decision to detect drift.
 - `evidence`, `impacted_nodes`, `impacted_path`: metadata refs only. No
   prompt text or tool payloads.
 - `audit_trail`: immutable projection audit row.
@@ -56,10 +57,11 @@ Ordered so safety signals win over general tool-scope warnings:
 
 1. Severity `critical` AND at least one sensitive reachability →
    `block_tools`.
-2. Risk type `external_credential` / `external_credentials` →
-   `require_approval`.
+2. Risk type `external_credential`, `external_credentials`, or upstream
+   `external_credential_exposure` → `require_approval`.
 3. Risk type `broad_tool_access` / `broad_tool_scope` → `restrict_tools`.
-4. Risk type `sensitive_reachability` → `restrict_tools`.
+4. Risk type `sensitive_reachability` or upstream
+   `sensitive_data_reachability` → `restrict_tools`.
 5. Risk type `ownerless_agent` → `warn`.
 6. Severity `critical` or `high` without matching risk type →
    `require_approval`.

--- a/docs/aws-agentcore-gateway-policy-advisory.md
+++ b/docs/aws-agentcore-gateway-policy-advisory.md
@@ -62,11 +62,15 @@ Ordered so safety signals win over general tool-scope warnings:
 3. Risk type `broad_tool_access` / `broad_tool_scope` → `restrict_tools`.
 4. Risk type `sensitive_reachability` or upstream
    `sensitive_data_reachability` → `restrict_tools`.
-5. Risk type `ownerless_agent` → `warn`.
-6. Severity `critical` or `high` without matching risk type →
+5. Risk type `undeclared_tool_runtime` or `backing_role_mismatch` →
    `require_approval`.
-7. Finding carries no resolved tool namespace → `warn`.
-8. Otherwise → `allow_tools` with advisory monitoring.
+6. Risk type `runtime_tool_anomaly`, `declared_unused_tool`, or
+   `backing_role_scope` → `restrict_tools`.
+7. Risk type `ownerless_agent` → `warn`.
+8. Severity `critical` or `high` without matching risk type →
+   `require_approval`.
+9. Finding carries no resolved tool namespace → `warn`.
+10. Otherwise → `allow_tools` with advisory monitoring.
 
 ## Admission
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -619,6 +619,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agentcore-gateway-policy-advisory
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/secret-key-rotation
     action: tenancy.read
     resource_type: project
@@ -5890,6 +5895,83 @@ paths:
                     $ref: "#/components/schemas/AWSSessionPolicyRecommendationResult"
         "400":
           description: Invalid AWS session policy recommendation request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agentcore-gateway-policy-advisory:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS AgentCore gateway policy advisories
+      operationId: getAWSProjectAgentCoreGatewayPolicyAdvisory
+      description: Projects deterministic advisory AgentCore gateway/tool policy recommendations from the AI agent risk engine. Each advisory records the recommended outcome (allow_tools, warn, require_approval, restrict_tools, block_tools), the tool namespace subject to the recommendation, sensitive resource scope, deterministic input hash, provenance, and audit trail. The endpoint is advisory-only; Identrail never enforces the recommendation at this layer and never inlines prompt text, tool payloads, or workload data.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: agent_id
+          schema: { type: string }
+          description: Optional agent identifier or agent node ID filter.
+        - in: query
+          name: outcome
+          schema:
+            type: string
+            enum: [allow_tools, warn, require_approval, restrict_tools, block_tools]
+        - in: query
+          name: risk_type
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: finding_id
+          schema: { type: string }
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS AgentCore gateway policy advisory contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agentcore_gateway_policy_advisory:
+                    $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisoryResult"
+        "400":
+          description: Invalid AWS AgentCore gateway policy advisory request
           content:
             application/json:
               schema:
@@ -16455,6 +16537,213 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSSessionPolicyRecommendationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAgentCoreGatewayPolicyAdvisoryProvenance:
+      type: object
+      properties:
+        policy_version: { type: string }
+        policy_rule: { type: string }
+        signals:
+          type: array
+          items: { type: string }
+    AWSAgentCoreGatewayPolicyAdvisoryInputHash:
+      type: object
+      properties:
+        value: { type: string }
+        components:
+          type: array
+          items: { type: string }
+    AWSAgentCoreGatewayPolicyAdvisoryRelationship:
+      type: object
+      properties:
+        advisory_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSAgentCoreGatewayPolicyAdvisoryEntry:
+      type: object
+      properties:
+        advisory_id: { type: string }
+        calculation_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        outcome:
+          type: string
+          enum: [allow_tools, warn, require_approval, restrict_tools, block_tools]
+        pilot_state:
+          type: string
+          enum: [candidate, operator_review, blocked]
+        enforcement_state:
+          type: string
+          enum: [advisory_only]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        severity: { type: string }
+        score: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        rationale: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        agent_node_id: { type: string }
+        agent_id: { type: string }
+        agent_name: { type: string }
+        agent_type: { type: string }
+        provider: { type: string }
+        runtime_role_arn: { type: string }
+        runtime_role_node_id: { type: string }
+        finding_id: { type: string }
+        risk_type: { type: string }
+        allowed_tool_names:
+          type: array
+          items: { type: string }
+        restricted_tool_names:
+          type: array
+          items: { type: string }
+        blocked_tool_names:
+          type: array
+          items: { type: string }
+        sensitive_resources:
+          type: array
+          items: { type: string }
+        recommended_actions:
+          type: array
+          items: { type: string }
+        provenance:
+          $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisoryProvenance"
+        input_hash:
+          $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisoryInputHash"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeEvidence"
+        evidence_boundary: { type: string }
+        impacted_nodes:
+          type: array
+          items: { type: string }
+        impacted_path:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegePathStep"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        read_only_projection: { type: boolean }
+        source_signals:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAgentCoreGatewayPolicyAdvisorySummary:
+      type: object
+      properties:
+        total_advisories: { type: integer }
+        filtered_advisories: { type: integer }
+        outcome_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        risk_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        allow_tools_count: { type: integer }
+        warn_count: { type: integer }
+        require_approval_count: { type: integer }
+        restrict_tools_count: { type: integer }
+        block_tools_count: { type: integer }
+        restricted_tool_count: { type: integer }
+        sensitive_resource_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSAgentCoreGatewayPolicyAdvisoryResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        mode:
+          type: string
+          enum: [advisory]
+        pilot_state:
+          type: string
+          enum: [candidate, operator_review, blocked]
+        enforcement_state:
+          type: string
+          enum: [advisory_only]
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisorySummary"
+        advisories:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisoryEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentCoreGatewayPolicyAdvisoryRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -774,6 +774,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/least-privilege", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/unused-dormant-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_agentcore_gateway_policy_advisory.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory.go
@@ -384,6 +384,10 @@ func awsAgentCoreGatewayPolicyAdvisoryClassify(finding AWSAIAgentRiskFinding) (o
 		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "broad_tool_access", "Agent exposes a broad tool namespace; recommend restricting the tool scope to the observed usage set.", 0.85
 	case "sensitive_reachability", "sensitive_data_reachability":
 		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "sensitive_reachability", "Agent gateway can reach sensitive resources; recommend restricting the tool scope and requiring approvals on the exposed tool calls.", 0.85
+	case "undeclared_tool_runtime", "backing_role_mismatch":
+		return awsAgentCoreGatewayPolicyOutcomeRequireApproval, "runtime_governance_review", "Agent runtime evidence does not match the declared gateway or backing-role model; require operator approval before allowing the affected tool calls.", 0.82
+	case "runtime_tool_anomaly", "declared_unused_tool", "backing_role_scope":
+		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "runtime_tool_scope_review", "Agent runtime or backing-role evidence requires review; restrict the affected tool scope until the risk-engine finding is resolved.", 0.8
 	case "ownerless_agent":
 		return awsAgentCoreGatewayPolicyOutcomeWarn, "ownerless_agent", "Agent has no assigned owner; warn operators and assign an owner before broadening the tool scope.", 0.78
 	}

--- a/internal/api/aws_agentcore_gateway_policy_advisory.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -376,11 +378,11 @@ func awsAgentCoreGatewayPolicyAdvisoryClassify(finding AWSAIAgentRiskFinding) (o
 		return awsAgentCoreGatewayPolicyOutcomeBlockTools, "critical_sensitive_reachability", "Critical-severity finding reaches sensitive resources; recommend blocking the affected tool calls until the reachability is remediated.", 0.92
 	}
 	switch riskType {
-	case "external_credential", "external_credentials":
+	case "external_credential", "external_credentials", "external_credential_exposure":
 		return awsAgentCoreGatewayPolicyOutcomeRequireApproval, "external_credential_use", "Agent runtime uses external credentials; require operator approval before allowing gateway tool calls.", 0.88
 	case "broad_tool_access", "broad_tool_scope":
 		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "broad_tool_access", "Agent exposes a broad tool namespace; recommend restricting the tool scope to the observed usage set.", 0.85
-	case "sensitive_reachability":
+	case "sensitive_reachability", "sensitive_data_reachability":
 		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "sensitive_reachability", "Agent gateway can reach sensitive resources; recommend restricting the tool scope and requiring approvals on the exposed tool calls.", 0.85
 	case "ownerless_agent":
 		return awsAgentCoreGatewayPolicyOutcomeWarn, "ownerless_agent", "Agent has no assigned owner; warn operators and assign an owner before broadening the tool scope.", 0.78
@@ -467,8 +469,10 @@ func awsAgentCoreGatewayPolicyAdvisoryRecommendedActions(outcome string, restric
 }
 
 func awsAgentCoreGatewayPolicyAdvisoryInputHash(finding AWSAIAgentRiskFinding, outcome string) AWSAgentCoreGatewayPolicyAdvisoryInputHash {
-	toolCount := len(emptyStrings(finding.ToolNames))
-	sensitiveCount := len(emptyStrings(finding.SensitiveResources))
+	toolsDigest := awsAgentCoreGatewayPolicyAdvisoryListDigest(finding.ToolNames)
+	sensitiveDigest := awsAgentCoreGatewayPolicyAdvisoryListDigest(finding.SensitiveResources)
+	toolCount := len(normalizeOrderedStringList(dedupeStrings(finding.ToolNames)))
+	sensitiveCount := len(normalizeOrderedStringList(dedupeStrings(finding.SensitiveResources)))
 	value := stableAWSBlastRadiusToken(
 		"agentcore-input",
 		finding.FindingID,
@@ -477,7 +481,9 @@ func awsAgentCoreGatewayPolicyAdvisoryInputHash(finding AWSAIAgentRiskFinding, o
 		finding.Severity,
 		finding.Status,
 		fmt.Sprintf("tools=%d", toolCount),
+		"tools_digest="+toolsDigest,
 		fmt.Sprintf("sensitive=%d", sensitiveCount),
+		"sensitive_digest="+sensitiveDigest,
 		outcome,
 		awsAgentCoreGatewayPolicyAdvisoryVersion,
 		awsAgentCoreGatewayPolicyAdvisoryPolicyID,
@@ -491,10 +497,23 @@ func awsAgentCoreGatewayPolicyAdvisoryInputHash(finding AWSAIAgentRiskFinding, o
 			"severity=" + finding.Severity,
 			"status=" + finding.Status,
 			fmt.Sprintf("tool_count=%d", toolCount),
+			"tool_names_sha256=" + toolsDigest,
 			fmt.Sprintf("sensitive_count=%d", sensitiveCount),
+			"sensitive_resources_sha256=" + sensitiveDigest,
 			"policy_version=" + awsAgentCoreGatewayPolicyAdvisoryPolicyID,
 		},
 	}
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryListDigest(values []string) string {
+	normalized := normalizeOrderedStringList(dedupeStrings(values))
+	sort.Strings(normalized)
+	sum := sha256.New()
+	for _, value := range normalized {
+		sum.Write([]byte(value))
+		sum.Write([]byte{0})
+	}
+	return hex.EncodeToString(sum.Sum(nil))
 }
 
 func awsAgentCoreGatewayPolicyAdvisoryNextAction(outcome string) string {

--- a/internal/api/aws_agentcore_gateway_policy_advisory.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory.go
@@ -1,0 +1,749 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsAgentCoreGatewayPolicyAdvisoryCurrentIssue = 1545
+	awsAgentCoreGatewayPolicyAdvisoryVersion      = "aws-agentcore-gateway-policy-advisory-v1"
+	awsAgentCoreGatewayPolicyAdvisoryPolicyID     = "aws-agentcore-gateway-policy-advisory-policy-v1"
+	awsAgentCoreGatewayPolicyAdvisoryModeAdvisory = "advisory"
+	awsAgentCoreGatewayPolicyPilotStateCandidate  = "candidate"
+	awsAgentCoreGatewayPolicyPilotStateReview     = "operator_review"
+	awsAgentCoreGatewayPolicyPilotStateBlocked    = "blocked"
+	awsAgentCoreGatewayPolicyEnforcementAdvisory  = "advisory_only"
+
+	awsAgentCoreGatewayPolicyOutcomeAllowTools      = "allow_tools"
+	awsAgentCoreGatewayPolicyOutcomeWarn            = "warn"
+	awsAgentCoreGatewayPolicyOutcomeRequireApproval = "require_approval"
+	awsAgentCoreGatewayPolicyOutcomeRestrictTools   = "restrict_tools"
+	awsAgentCoreGatewayPolicyOutcomeBlockTools      = "block_tools"
+)
+
+// AWSAgentCoreGatewayPolicyAdvisoryRequest scopes the AgentCore gateway
+// policy advisory projection to one AWS connector plus optional operator
+// drill-down filters.
+type AWSAgentCoreGatewayPolicyAdvisoryRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	Outcome      string `json:"outcome,omitempty"`
+	RiskType     string `json:"risk_type,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	FindingID    string `json:"finding_id,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSAgentCoreGatewayPolicyAdvisoryEvidence = AWSLeastPrivilegeEvidence
+type AWSAgentCoreGatewayPolicyAdvisoryPathStep = AWSLeastPrivilegePathStep
+type AWSAgentCoreGatewayPolicyAdvisoryDiagnostic = AWSLeastPrivilegeDiagnostic
+type AWSAgentCoreGatewayPolicyAdvisoryCoverageGap = AWSLeastPrivilegeCoverageGap
+type AWSAgentCoreGatewayPolicyAdvisoryAuditEntry = AWSRemediationApprovalAuditEntry
+
+// AWSAgentCoreGatewayPolicyAdvisoryProvenance records the deterministic
+// derivation path so operators can trace which policy version and rule
+// produced the advisory.
+type AWSAgentCoreGatewayPolicyAdvisoryProvenance struct {
+	PolicyVersion string   `json:"policy_version"`
+	PolicyRule    string   `json:"policy_rule"`
+	Signals       []string `json:"signals,omitempty"`
+}
+
+// AWSAgentCoreGatewayPolicyAdvisoryInputHash records the deterministic
+// hash of the inputs that produced the advisory. Operators use this to
+// detect drift when upstream signals change.
+type AWSAgentCoreGatewayPolicyAdvisoryInputHash struct {
+	Value      string   `json:"value"`
+	Components []string `json:"components,omitempty"`
+}
+
+// AWSAgentCoreGatewayPolicyAdvisoryRelationship surfaces advisory→graph
+// node edges for downstream UI and audit consumers.
+type AWSAgentCoreGatewayPolicyAdvisoryRelationship struct {
+	AdvisoryID  string `json:"advisory_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSAgentCoreGatewayPolicyAdvisoryEntry is the persisted-record-shaped
+// contract for one AgentCore gateway policy advisory. It never inlines
+// prompt text, tool payloads, or workload data; tool restrictions,
+// approvals, and warnings reference the agent's tool namespace by name.
+type AWSAgentCoreGatewayPolicyAdvisoryEntry struct {
+	AdvisoryID          string                                        `json:"advisory_id"`
+	CalculationVersion  string                                        `json:"calculation_version"`
+	Mode                string                                        `json:"mode"`
+	Outcome             string                                        `json:"outcome"`
+	PilotState          string                                        `json:"pilot_state"`
+	EnforcementState    string                                        `json:"enforcement_state"`
+	Confidence          float64                                       `json:"confidence"`
+	Severity            string                                        `json:"severity"`
+	Score               int                                           `json:"score"`
+	Title               string                                        `json:"title"`
+	Summary             string                                        `json:"summary"`
+	Rationale           string                                        `json:"rationale"`
+	AccountID           string                                        `json:"account_id,omitempty"`
+	Region              string                                        `json:"region,omitempty"`
+	AgentNodeID         string                                        `json:"agent_node_id"`
+	AgentID             string                                        `json:"agent_id,omitempty"`
+	AgentName           string                                        `json:"agent_name,omitempty"`
+	AgentType           string                                        `json:"agent_type,omitempty"`
+	Provider            string                                        `json:"provider,omitempty"`
+	RuntimeRoleARN      string                                        `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleNodeID   string                                        `json:"runtime_role_node_id,omitempty"`
+	FindingID           string                                        `json:"finding_id"`
+	RiskType            string                                        `json:"risk_type"`
+	AllowedToolNames    []string                                      `json:"allowed_tool_names,omitempty"`
+	RestrictedToolNames []string                                      `json:"restricted_tool_names,omitempty"`
+	BlockedToolNames    []string                                      `json:"blocked_tool_names,omitempty"`
+	SensitiveResources  []string                                      `json:"sensitive_resources,omitempty"`
+	RecommendedActions  []string                                      `json:"recommended_actions"`
+	Provenance          AWSAgentCoreGatewayPolicyAdvisoryProvenance   `json:"provenance"`
+	InputHash           AWSAgentCoreGatewayPolicyAdvisoryInputHash    `json:"input_hash"`
+	Evidence            []AWSAgentCoreGatewayPolicyAdvisoryEvidence   `json:"evidence"`
+	EvidenceBoundary    string                                        `json:"evidence_boundary"`
+	ImpactedNodes       []string                                      `json:"impacted_nodes"`
+	ImpactedPath        []AWSAgentCoreGatewayPolicyAdvisoryPathStep   `json:"impacted_path"`
+	AuditTrail          []AWSAgentCoreGatewayPolicyAdvisoryAuditEntry `json:"audit_trail"`
+	ReadOnlyProjection  bool                                          `json:"read_only_projection"`
+	SourceSignals       []string                                      `json:"source_signals"`
+	NextAction          string                                        `json:"next_action"`
+	ProjectedAt         time.Time                                     `json:"projected_at"`
+	CreatedAt           time.Time                                     `json:"created_at"`
+	UpdatedAt           time.Time                                     `json:"updated_at"`
+}
+
+// AWSAgentCoreGatewayPolicyAdvisorySummary aggregates the unfiltered and
+// filtered advisory set.
+type AWSAgentCoreGatewayPolicyAdvisorySummary struct {
+	TotalAdvisories        int            `json:"total_advisories"`
+	FilteredAdvisories     int            `json:"filtered_advisories"`
+	OutcomeCounts          map[string]int `json:"outcome_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	RiskTypeCounts         map[string]int `json:"risk_type_counts"`
+	AllowToolsCount        int            `json:"allow_tools_count"`
+	WarnCount              int            `json:"warn_count"`
+	RequireApprovalCount   int            `json:"require_approval_count"`
+	RestrictToolsCount     int            `json:"restrict_tools_count"`
+	BlockToolsCount        int            `json:"block_tools_count"`
+	RestrictedToolCount    int            `json:"restricted_tool_count"`
+	SensitiveResourceCount int            `json:"sensitive_resource_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+// AWSAgentCoreGatewayPolicyAdvisoryResult is the deterministic endpoint envelope.
+type AWSAgentCoreGatewayPolicyAdvisoryResult struct {
+	TenantID           string                                          `json:"tenant_id"`
+	WorkspaceID        string                                          `json:"workspace_id"`
+	ProjectID          string                                          `json:"project_id"`
+	ConnectorID        string                                          `json:"connector_id,omitempty"`
+	AccountID          string                                          `json:"account_id,omitempty"`
+	Region             string                                          `json:"region,omitempty"`
+	ParentIssueNumber  int                                             `json:"parent_issue_number"`
+	ParentIssueRef     string                                          `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                             `json:"current_issue_number"`
+	CurrentIssueRef    string                                          `json:"current_issue_ref"`
+	Version            string                                          `json:"version"`
+	Status             string                                          `json:"status"`
+	FixtureState       string                                          `json:"fixture_state,omitempty"`
+	Confidence         float64                                         `json:"confidence"`
+	CalculationVersion string                                          `json:"calculation_version"`
+	PolicyVersion      string                                          `json:"policy_version"`
+	Mode               string                                          `json:"mode"`
+	PilotState         string                                          `json:"pilot_state"`
+	EnforcementState   string                                          `json:"enforcement_state"`
+	AppliedFilters     map[string]string                               `json:"applied_filters"`
+	Summary            AWSAgentCoreGatewayPolicyAdvisorySummary        `json:"summary"`
+	Advisories         []AWSAgentCoreGatewayPolicyAdvisoryEntry        `json:"advisories"`
+	Relationships      []AWSAgentCoreGatewayPolicyAdvisoryRelationship `json:"relationships"`
+	Caveats            []string                                        `json:"caveats"`
+	FailureReasons     []string                                        `json:"failure_reasons"`
+	RemediationHints   []string                                        `json:"remediation_hints"`
+	EvidenceLinks      []string                                        `json:"evidence_links"`
+	CoverageGaps       []AWSAgentCoreGatewayPolicyAdvisoryCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSAgentCoreGatewayPolicyAdvisoryDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                                       `json:"generated_at"`
+	UpdatedAt          time.Time                                       `json:"updated_at"`
+}
+
+// GetAWSAgentCoreGatewayPolicyAdvisory projects deterministic advisory
+// AgentCore gateway/tool policy recommendations from the AI agent risk
+// engine (#1528). Each advisory records the recommended outcome
+// (allow_tools, warn, require_approval, restrict_tools, block_tools),
+// the tool namespace subject to the recommendation, sensitive resource
+// scope, deterministic input hash, provenance, and an immutable audit
+// trail. The endpoint is advisory-only; Identrail never enforces the
+// recommendation at this layer.
+func (s *Service) GetAWSAgentCoreGatewayPolicyAdvisory(ctx context.Context, workspaceID string, projectID string, request AWSAgentCoreGatewayPolicyAdvisoryRequest) (AWSAgentCoreGatewayPolicyAdvisoryResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAgentCoreGatewayPolicyAdvisoryResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAgentCoreGatewayPolicyAdvisoryResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSAgentCoreGatewayPolicyAdvisoryFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAgentCoreGatewayPolicyAdvisoryResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	upstream, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSAgentCoreGatewayPolicyAdvisoryResult{}, fmt.Errorf("agentcore gateway policy advisory upstream: %w", err)
+	}
+
+	advisories := awsAgentCoreGatewayPolicyAdvisoryEntries(upstream.Findings, now)
+	sort.SliceStable(advisories, func(i, j int) bool {
+		if advisories[i].Score == advisories[j].Score {
+			return advisories[i].AdvisoryID < advisories[j].AdvisoryID
+		}
+		return advisories[i].Score > advisories[j].Score
+	})
+	filtered, applied := filterAWSAgentCoreGatewayPolicyAdvisories(advisories, request)
+	relationships := awsAgentCoreGatewayPolicyAdvisoryRelationships(filtered)
+	diagnostics := awsAgentCoreGatewayPolicyAdvisoryDiagnostics(upstream.Diagnostics)
+	coverageGaps := awsAgentCoreGatewayPolicyAdvisoryCoverageGaps(upstream.CoverageGaps)
+	status, confidence := summarizeAWSAgentCoreGatewayPolicyAdvisoryStatus(upstream.Status, filtered, diagnostics)
+
+	return AWSAgentCoreGatewayPolicyAdvisoryResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsAgentCoreGatewayPolicyAdvisoryCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsAgentCoreGatewayPolicyAdvisoryCurrentIssue),
+		Version:            awsAgentCoreGatewayPolicyAdvisoryVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsAgentCoreGatewayPolicyAdvisoryVersion,
+		PolicyVersion:      awsAgentCoreGatewayPolicyAdvisoryPolicyID,
+		Mode:               awsAgentCoreGatewayPolicyAdvisoryModeAdvisory,
+		PilotState:         summarizeAWSAgentCoreGatewayPolicyPilotState(filtered),
+		EnforcementState:   awsAgentCoreGatewayPolicyEnforcementAdvisory,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSAgentCoreGatewayPolicyAdvisories(advisories, filtered, relationships),
+		Advisories:         filtered,
+		Relationships:      relationships,
+		Caveats:            awsAgentCoreGatewayPolicyAdvisoryCaveats(),
+		FailureReasons:     dedupeStrings(upstream.FailureReasons),
+		RemediationHints:   awsAgentCoreGatewayPolicyAdvisoryHints(upstream.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsAgentCoreGatewayPolicyAdvisoryCurrentIssue),
+			awsIssueURL(awsAIAgentRiskCurrentIssue),
+			"/docs/aws-agentcore-gateway-policy-advisory",
+			"/docs/aws-ai-agent-risk-engine",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: coverageGaps,
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSAgentCoreGatewayPolicyAdvisoryFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryEntries(findings []AWSAIAgentRiskFinding, now time.Time) []AWSAgentCoreGatewayPolicyAdvisoryEntry {
+	entries := make([]AWSAgentCoreGatewayPolicyAdvisoryEntry, 0, len(findings))
+	for _, finding := range findings {
+		if !awsAgentCoreGatewayPolicyAdvisoryAdmits(finding) {
+			continue
+		}
+		entries = append(entries, awsAgentCoreGatewayPolicyAdvisoryFromFinding(finding, now))
+	}
+	return entries
+}
+
+// awsAgentCoreGatewayPolicyAdvisoryAdmits requires an addressable agent so
+// the advisory has a subject to attach to; findings without an agent node
+// ID cannot be surfaced as a gateway policy recommendation.
+func awsAgentCoreGatewayPolicyAdvisoryAdmits(finding AWSAIAgentRiskFinding) bool {
+	return strings.TrimSpace(finding.AgentNodeID) != ""
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryFromFinding(finding AWSAIAgentRiskFinding, now time.Time) AWSAgentCoreGatewayPolicyAdvisoryEntry {
+	outcome, rule, rationale, confidence := awsAgentCoreGatewayPolicyAdvisoryClassify(finding)
+	toolNames := emptyStrings(dedupeStrings(finding.ToolNames))
+	sensitiveResources := emptyStrings(dedupeStrings(finding.SensitiveResources))
+	allowed, restricted, blocked := awsAgentCoreGatewayPolicyAdvisoryToolPartition(outcome, toolNames)
+	recommended := awsAgentCoreGatewayPolicyAdvisoryRecommendedActions(outcome, restricted, blocked, sensitiveResources)
+	advisoryID := "aws-agentcore-gateway-policy-advisory:" + stableAWSBlastRadiusToken("advisory", finding.FindingID, finding.AgentNodeID)
+	inputHash := awsAgentCoreGatewayPolicyAdvisoryInputHash(finding, outcome)
+	provenance := AWSAgentCoreGatewayPolicyAdvisoryProvenance{
+		PolicyVersion: awsAgentCoreGatewayPolicyAdvisoryPolicyID,
+		PolicyRule:    rule,
+		Signals: dedupeStrings([]string{
+			"risk_type=" + finding.RiskType,
+			"severity=" + finding.Severity,
+			"status=" + finding.Status,
+		}),
+	}
+	return AWSAgentCoreGatewayPolicyAdvisoryEntry{
+		AdvisoryID:          advisoryID,
+		CalculationVersion:  awsAgentCoreGatewayPolicyAdvisoryVersion,
+		Mode:                awsAgentCoreGatewayPolicyAdvisoryModeAdvisory,
+		Outcome:             outcome,
+		PilotState:          awsAgentCoreGatewayPolicyAdvisoryPilotState(outcome),
+		EnforcementState:    awsAgentCoreGatewayPolicyEnforcementAdvisory,
+		Confidence:          confidence,
+		Severity:            finding.Severity,
+		Score:               finding.Score,
+		Title:               fmt.Sprintf("AgentCore gateway policy advisory: %s", firstNonEmptyAWSValue(finding.AgentName, finding.AgentID, finding.AgentNodeID)),
+		Summary:             fmt.Sprintf("Advisory-only AgentCore gateway policy recommendation for agent %s (outcome=%s). Identrail records the recommendation, provenance, and audit only; no live gateway or IAM write API is called at this layer.", firstNonEmptyAWSValue(finding.AgentNodeID, finding.AgentID), outcome),
+		Rationale:           rationale,
+		AccountID:           finding.AccountID,
+		Region:              finding.Region,
+		AgentNodeID:         finding.AgentNodeID,
+		AgentID:             finding.AgentID,
+		AgentName:           finding.AgentName,
+		AgentType:           finding.AgentType,
+		Provider:            finding.Provider,
+		RuntimeRoleARN:      finding.RuntimeRoleARN,
+		RuntimeRoleNodeID:   finding.RuntimeRoleNodeID,
+		FindingID:           finding.FindingID,
+		RiskType:            finding.RiskType,
+		AllowedToolNames:    allowed,
+		RestrictedToolNames: restricted,
+		BlockedToolNames:    blocked,
+		SensitiveResources:  sensitiveResources,
+		RecommendedActions:  recommended,
+		Provenance:          provenance,
+		InputHash:           inputHash,
+		Evidence:            finding.Evidence,
+		EvidenceBoundary:    awsAgentCoreGatewayPolicyAdvisoryEvidenceBoundary(),
+		ImpactedNodes:       emptyStrings(dedupeStrings(finding.ImpactedNodes)),
+		ImpactedPath:        finding.ImpactedPath,
+		AuditTrail:          awsAgentCoreGatewayPolicyAdvisoryAuditTrail(finding, outcome, rule, now),
+		ReadOnlyProjection:  true,
+		SourceSignals:       dedupeStrings(append([]string{"ai_agent_risk", "agentcore_gateway_policy_advisory"}, finding.SourceSignals...)),
+		NextAction:          awsAgentCoreGatewayPolicyAdvisoryNextAction(outcome),
+		ProjectedAt:         now,
+		CreatedAt:           firstNonZeroAWSAgentCoreGatewayPolicyAdvisoryTime(finding.CreatedAt, now),
+		UpdatedAt:           now,
+	}
+}
+
+// awsAgentCoreGatewayPolicyAdvisoryClassify is the deterministic policy.
+// Ordering matters: high-severity confirmed exposure wins over general
+// tool-scope warnings so a compromised gateway is never recorded as
+// `allow_tools`.
+func awsAgentCoreGatewayPolicyAdvisoryClassify(finding AWSAIAgentRiskFinding) (outcome, rule, rationale string, confidence float64) {
+	severity := strings.ToLower(strings.TrimSpace(finding.Severity))
+	riskType := strings.ToLower(strings.TrimSpace(finding.RiskType))
+	sensitiveCount := len(emptyStrings(finding.SensitiveResources))
+	toolCount := len(emptyStrings(finding.ToolNames))
+
+	if severity == "critical" && sensitiveCount > 0 {
+		return awsAgentCoreGatewayPolicyOutcomeBlockTools, "critical_sensitive_reachability", "Critical-severity finding reaches sensitive resources; recommend blocking the affected tool calls until the reachability is remediated.", 0.92
+	}
+	switch riskType {
+	case "external_credential", "external_credentials":
+		return awsAgentCoreGatewayPolicyOutcomeRequireApproval, "external_credential_use", "Agent runtime uses external credentials; require operator approval before allowing gateway tool calls.", 0.88
+	case "broad_tool_access", "broad_tool_scope":
+		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "broad_tool_access", "Agent exposes a broad tool namespace; recommend restricting the tool scope to the observed usage set.", 0.85
+	case "sensitive_reachability":
+		return awsAgentCoreGatewayPolicyOutcomeRestrictTools, "sensitive_reachability", "Agent gateway can reach sensitive resources; recommend restricting the tool scope and requiring approvals on the exposed tool calls.", 0.85
+	case "ownerless_agent":
+		return awsAgentCoreGatewayPolicyOutcomeWarn, "ownerless_agent", "Agent has no assigned owner; warn operators and assign an owner before broadening the tool scope.", 0.78
+	}
+	if severity == "critical" || severity == "high" {
+		return awsAgentCoreGatewayPolicyOutcomeRequireApproval, "high_severity_finding", "High-severity agent risk finding; require operator approval before allowing gateway tool calls.", 0.8
+	}
+	if toolCount == 0 {
+		return awsAgentCoreGatewayPolicyOutcomeWarn, "unknown_tool_scope", "Agent finding does not carry a resolved tool namespace; warn operators and refresh runtime evidence before allowing tool calls.", 0.72
+	}
+	return awsAgentCoreGatewayPolicyOutcomeAllowTools, "no_active_risk", "No active elevated risk on the agent gateway; allow the observed tool namespace with advisory monitoring.", 0.75
+}
+
+// awsAgentCoreGatewayPolicyAdvisoryToolPartition splits the finding's tool
+// namespace into allowed, restricted, and blocked buckets based on outcome.
+// The buckets stay disjoint so the app UI and downstream consumers can render
+// the recommendation without overlap.
+func awsAgentCoreGatewayPolicyAdvisoryToolPartition(outcome string, tools []string) (allowed, restricted, blocked []string) {
+	switch outcome {
+	case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		return nil, nil, tools
+	case awsAgentCoreGatewayPolicyOutcomeRestrictTools, awsAgentCoreGatewayPolicyOutcomeRequireApproval:
+		return nil, tools, nil
+	case awsAgentCoreGatewayPolicyOutcomeWarn:
+		return tools, nil, nil
+	case awsAgentCoreGatewayPolicyOutcomeAllowTools:
+		return tools, nil, nil
+	}
+	return tools, nil, nil
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryPilotState(outcome string) string {
+	switch outcome {
+	case awsAgentCoreGatewayPolicyOutcomeAllowTools:
+		return awsAgentCoreGatewayPolicyPilotStateCandidate
+	case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		return awsAgentCoreGatewayPolicyPilotStateBlocked
+	default:
+		return awsAgentCoreGatewayPolicyPilotStateReview
+	}
+}
+
+func summarizeAWSAgentCoreGatewayPolicyPilotState(entries []AWSAgentCoreGatewayPolicyAdvisoryEntry) string {
+	for _, entry := range entries {
+		if entry.PilotState == awsAgentCoreGatewayPolicyPilotStateBlocked {
+			return awsAgentCoreGatewayPolicyPilotStateBlocked
+		}
+	}
+	for _, entry := range entries {
+		if entry.PilotState == awsAgentCoreGatewayPolicyPilotStateReview {
+			return awsAgentCoreGatewayPolicyPilotStateReview
+		}
+	}
+	return awsAgentCoreGatewayPolicyPilotStateCandidate
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryRecommendedActions(outcome string, restricted, blocked, sensitiveResources []string) []string {
+	actions := []string{}
+	switch outcome {
+	case awsAgentCoreGatewayPolicyOutcomeAllowTools:
+		actions = append(actions, "Continue advisory monitoring of gateway tool calls; no operator action is required unless upstream signals change.")
+	case awsAgentCoreGatewayPolicyOutcomeWarn:
+		actions = append(actions, "Prioritize agent risk triage; refresh runtime evidence and assign an owner before broadening the tool scope.")
+	case awsAgentCoreGatewayPolicyOutcomeRequireApproval:
+		actions = append(actions, "Require operator approval on the affected gateway tool calls before allowing new sessions.")
+		if len(restricted) > 0 {
+			actions = append(actions, "Scope the approval to the affected tool namespace: "+strings.Join(restricted, ", "))
+		}
+	case awsAgentCoreGatewayPolicyOutcomeRestrictTools:
+		actions = append(actions, "Restrict the gateway tool scope to the observed usage set only.")
+		if len(restricted) > 0 {
+			actions = append(actions, "Affected tools: "+strings.Join(restricted, ", "))
+		}
+	case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		actions = append(actions, "Block the affected gateway tool calls until the sensitive reachability is remediated.")
+		if len(blocked) > 0 {
+			actions = append(actions, "Blocked tools: "+strings.Join(blocked, ", "))
+		}
+	}
+	if len(sensitiveResources) > 0 && outcome != awsAgentCoreGatewayPolicyOutcomeAllowTools {
+		actions = append(actions, "Sensitive reachability: "+strings.Join(sensitiveResources, ", "))
+	}
+	return actions
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryInputHash(finding AWSAIAgentRiskFinding, outcome string) AWSAgentCoreGatewayPolicyAdvisoryInputHash {
+	toolCount := len(emptyStrings(finding.ToolNames))
+	sensitiveCount := len(emptyStrings(finding.SensitiveResources))
+	value := stableAWSBlastRadiusToken(
+		"agentcore-input",
+		finding.FindingID,
+		finding.AgentNodeID,
+		finding.RiskType,
+		finding.Severity,
+		finding.Status,
+		fmt.Sprintf("tools=%d", toolCount),
+		fmt.Sprintf("sensitive=%d", sensitiveCount),
+		outcome,
+		awsAgentCoreGatewayPolicyAdvisoryVersion,
+		awsAgentCoreGatewayPolicyAdvisoryPolicyID,
+	)
+	return AWSAgentCoreGatewayPolicyAdvisoryInputHash{
+		Value: value,
+		Components: []string{
+			"finding_id=" + finding.FindingID,
+			"agent_node_id=" + finding.AgentNodeID,
+			"risk_type=" + finding.RiskType,
+			"severity=" + finding.Severity,
+			"status=" + finding.Status,
+			fmt.Sprintf("tool_count=%d", toolCount),
+			fmt.Sprintf("sensitive_count=%d", sensitiveCount),
+			"policy_version=" + awsAgentCoreGatewayPolicyAdvisoryPolicyID,
+		},
+	}
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryNextAction(outcome string) string {
+	switch outcome {
+	case awsAgentCoreGatewayPolicyOutcomeAllowTools:
+		return "Recommendation is `allow_tools`. Continue advisory monitoring; no operator action is required unless upstream signals change."
+	case awsAgentCoreGatewayPolicyOutcomeWarn:
+		return "Recommendation is `warn`. Prioritize agent risk triage and refresh runtime evidence before broadening the tool scope."
+	case awsAgentCoreGatewayPolicyOutcomeRequireApproval:
+		return "Recommendation is `require_approval`. Route the agent gateway session through the operator approval workflow before allowing tool calls."
+	case awsAgentCoreGatewayPolicyOutcomeRestrictTools:
+		return "Recommendation is `restrict_tools`. Constrain the gateway tool scope to the observed usage set before allowing new sessions."
+	case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		return "Recommendation is `block_tools`. Disable the affected gateway tool calls until sensitive reachability is remediated."
+	}
+	return "Inspect the advisory entry for the projected next action."
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryAuditTrail(finding AWSAIAgentRiskFinding, outcome, rule string, now time.Time) []AWSAgentCoreGatewayPolicyAdvisoryAuditEntry {
+	return []AWSAgentCoreGatewayPolicyAdvisoryAuditEntry{{
+		EventID:    stableAWSBlastRadiusToken("agentcore-advisory-projected", finding.FindingID, outcome, rule),
+		Actor:      "identrail-agentcore-gateway-policy-advisor",
+		EventType:  "agentcore_gateway_policy_advisory_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Finding=%s outcome=%s rule=%s policy_version=%s; Identrail did not call any AWS write API at this layer.", finding.FindingID, outcome, rule, awsAgentCoreGatewayPolicyAdvisoryPolicyID),
+	}}
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryRelationships(entries []AWSAgentCoreGatewayPolicyAdvisoryEntry) []AWSAgentCoreGatewayPolicyAdvisoryRelationship {
+	relationships := []AWSAgentCoreGatewayPolicyAdvisoryRelationship{}
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.AgentNodeID) != "" {
+			relationships = append(relationships, AWSAgentCoreGatewayPolicyAdvisoryRelationship{
+				AdvisoryID: entry.AdvisoryID,
+				Type:       "advises_agent_gateway",
+				FromNodeID: entry.AdvisoryID,
+				ToNodeID:   entry.AgentNodeID,
+			})
+		}
+		if strings.TrimSpace(entry.RuntimeRoleNodeID) != "" {
+			relationships = append(relationships, AWSAgentCoreGatewayPolicyAdvisoryRelationship{
+				AdvisoryID: entry.AdvisoryID,
+				Type:       "advises_runtime_role",
+				FromNodeID: entry.AdvisoryID,
+				ToNodeID:   entry.RuntimeRoleNodeID,
+			})
+		}
+		for _, resource := range entry.SensitiveResources {
+			if strings.TrimSpace(resource) == "" {
+				continue
+			}
+			relationships = append(relationships, AWSAgentCoreGatewayPolicyAdvisoryRelationship{
+				AdvisoryID: entry.AdvisoryID,
+				Type:       "scopes_sensitive_resource",
+				FromNodeID: entry.AdvisoryID,
+				ToNodeID:   resource,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSAgentCoreGatewayPolicyAdvisories(all, filtered []AWSAgentCoreGatewayPolicyAdvisoryEntry, relationships []AWSAgentCoreGatewayPolicyAdvisoryRelationship) AWSAgentCoreGatewayPolicyAdvisorySummary {
+	summary := AWSAgentCoreGatewayPolicyAdvisorySummary{
+		TotalAdvisories:    len(all),
+		FilteredAdvisories: len(filtered),
+		OutcomeCounts:      map[string]int{},
+		SeverityCounts:     map[string]int{},
+		RiskTypeCounts:     map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.OutcomeCounts[entry.Outcome]++
+		if entry.Severity != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.RiskType != "" {
+			summary.RiskTypeCounts[entry.RiskType]++
+		}
+		switch entry.Outcome {
+		case awsAgentCoreGatewayPolicyOutcomeAllowTools:
+			summary.AllowToolsCount++
+		case awsAgentCoreGatewayPolicyOutcomeWarn:
+			summary.WarnCount++
+		case awsAgentCoreGatewayPolicyOutcomeRequireApproval:
+			summary.RequireApprovalCount++
+		case awsAgentCoreGatewayPolicyOutcomeRestrictTools:
+			summary.RestrictToolsCount++
+		case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+			summary.BlockToolsCount++
+		}
+		summary.RestrictedToolCount += len(entry.RestrictedToolNames) + len(entry.BlockedToolNames)
+		summary.SensitiveResourceCount += len(entry.SensitiveResources)
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSAgentCoreGatewayPolicyAdvisories(entries []AWSAgentCoreGatewayPolicyAdvisoryEntry, request AWSAgentCoreGatewayPolicyAdvisoryRequest) ([]AWSAgentCoreGatewayPolicyAdvisoryEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id": strings.TrimSpace(request.AccountID),
+		"region":     strings.TrimSpace(request.Region),
+		"agent_id":   strings.TrimSpace(request.AgentID),
+		"outcome":    normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"risk_type":  strings.ToLower(strings.TrimSpace(request.RiskType)),
+		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"finding_id": strings.TrimSpace(request.FindingID),
+		"search":     strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSAgentCoreGatewayPolicyAdvisoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && !strings.EqualFold(filters["account_id"], strings.TrimSpace(entry.AccountID)) {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(entry.Region)) {
+			continue
+		}
+		if filters["agent_id"] != "" && !strings.EqualFold(filters["agent_id"], strings.TrimSpace(entry.AgentID)) && !strings.EqualFold(filters["agent_id"], strings.TrimSpace(entry.AgentNodeID)) {
+			continue
+		}
+		if filters["outcome"] != "" && filters["outcome"] != normalizeAWSRuntimeEventFilterToken(entry.Outcome) {
+			continue
+		}
+		if filters["risk_type"] != "" && !strings.EqualFold(filters["risk_type"], entry.RiskType) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["finding_id"] != "" && !strings.EqualFold(filters["finding_id"], entry.FindingID) {
+			continue
+		}
+		if filters["search"] != "" && !awsAgentCoreGatewayPolicyAdvisorySearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsAgentCoreGatewayPolicyAdvisorySearchMatch(entry AWSAgentCoreGatewayPolicyAdvisoryEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.AdvisoryID, entry.Outcome, entry.Severity, entry.Title, entry.Summary,
+		entry.Rationale, entry.AgentNodeID, entry.AgentID, entry.AgentName, entry.AgentType,
+		entry.Provider, entry.RuntimeRoleARN, entry.RuntimeRoleNodeID, entry.FindingID,
+		entry.RiskType, entry.NextAction, entry.Provenance.PolicyRule, entry.Provenance.PolicyVersion,
+	}
+	values = append(values, entry.AllowedToolNames...)
+	values = append(values, entry.RestrictedToolNames...)
+	values = append(values, entry.BlockedToolNames...)
+	values = append(values, entry.SensitiveResources...)
+	values = append(values, entry.RecommendedActions...)
+	values = append(values, entry.SourceSignals...)
+	values = append(values, entry.Provenance.Signals...)
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSAgentCoreGatewayPolicyAdvisoryStatus(upstream string, filtered []AWSAgentCoreGatewayPolicyAdvisoryEntry, diagnostics []AWSAgentCoreGatewayPolicyAdvisoryDiagnostic) (string, float64) {
+	if upstream == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if upstream == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryCaveats() []string {
+	return []string{
+		"AgentCore gateway policy advisories are read-only recommendations; Identrail never enforces the outcome at this layer.",
+		"Prompt text, tool payloads, and workload data are never inlined; tool restrictions reference the tool namespace by name only.",
+		"Critical-severity findings that reach sensitive resources always classify as block_tools; the policy prevents a compromised gateway from being recorded as allow_tools.",
+	}
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryHints(source []string) []string {
+	hints := []string{
+		"Treat this endpoint as advisory input to AgentCore gateway policy decision points; downstream governance executors decide whether and how to enforce.",
+		"If a recommendation moves to `block_tools`, investigate the sensitive reachability finding before re-opening the tool namespace.",
+		"When the policy version changes, expect advisory IDs and input hashes to change; log both for audit.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryDiagnostics(source []AWSAIAgentRiskDiagnostic) []AWSAgentCoreGatewayPolicyAdvisoryDiagnostic {
+	out := make([]AWSAgentCoreGatewayPolicyAdvisoryDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSAgentCoreGatewayPolicyAdvisoryDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryCoverageGaps(source []AWSAIAgentRiskCoverageGap) []AWSAgentCoreGatewayPolicyAdvisoryCoverageGap {
+	out := make([]AWSAgentCoreGatewayPolicyAdvisoryCoverageGap, 0, len(source))
+	for _, gap := range source {
+		out = append(out, AWSAgentCoreGatewayPolicyAdvisoryCoverageGap(gap))
+	}
+	return out
+}
+
+func awsAgentCoreGatewayPolicyAdvisoryEvidenceBoundary() string {
+	return "metadata_only_no_prompt_text_no_tool_payloads_no_workload_data_tenant_workspace_project_connector_account_region_scoped"
+}
+
+func firstNonZeroAWSAgentCoreGatewayPolicyAdvisoryTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/aws_agentcore_gateway_policy_advisory_test.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory_test.go
@@ -122,6 +122,26 @@ func TestAWSAgentCoreGatewayPolicyAdvisoryClassifyPolicyOrder(t *testing.T) {
 		t.Fatalf("upstream sensitive data reachability must classify as restrict_tools: %s / %s", out, rule)
 	}
 
+	for _, riskType := range []string{"undeclared_tool_runtime", "backing_role_mismatch"} {
+		finding := base
+		finding.RiskType = riskType
+		finding.ToolNames = []string{"tool-a"}
+		finding.SensitiveResources = []string{"arn:aws:s3:::sensitive-target"}
+		if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(finding); out != awsAgentCoreGatewayPolicyOutcomeRequireApproval || rule != "runtime_governance_review" {
+			t.Fatalf("%s must classify as require_approval: %s / %s", riskType, out, rule)
+		}
+	}
+
+	for _, riskType := range []string{"runtime_tool_anomaly", "declared_unused_tool", "backing_role_scope"} {
+		finding := base
+		finding.RiskType = riskType
+		finding.ToolNames = []string{"tool-a"}
+		finding.SensitiveResources = []string{"arn:aws:s3:::sensitive-target"}
+		if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(finding); out != awsAgentCoreGatewayPolicyOutcomeRestrictTools || rule != "runtime_tool_scope_review" {
+			t.Fatalf("%s must classify as restrict_tools: %s / %s", riskType, out, rule)
+		}
+	}
+
 	ownerless := base
 	ownerless.RiskType = "ownerless_agent"
 	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(ownerless); out != awsAgentCoreGatewayPolicyOutcomeWarn || rule != "ownerless_agent" {

--- a/internal/api/aws_agentcore_gateway_policy_advisory_test.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory_test.go
@@ -1,0 +1,287 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAgentCoreGatewayPolicyAdvisoryService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSAgentCoreGatewayPolicyAdvisoryBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	svc, ws := newAgentCoreGatewayPolicyAdvisoryService(t, "project-agentcore-gateway-policy-advisory", now)
+
+	result, err := svc.GetAWSAgentCoreGatewayPolicyAdvisory(defaultScopeContext(), ws, "project-agentcore-gateway-policy-advisory", AWSAgentCoreGatewayPolicyAdvisoryRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get agentcore gateway policy advisory: %v", err)
+	}
+	if result.CurrentIssueRef != "#1545" || result.Version != awsAgentCoreGatewayPolicyAdvisoryVersion || result.Mode != awsAgentCoreGatewayPolicyAdvisoryModeAdvisory {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.PolicyVersion != awsAgentCoreGatewayPolicyAdvisoryPolicyID {
+		t.Fatalf("expected stable policy version, got %q", result.PolicyVersion)
+	}
+	if result.PilotState == "" || result.EnforcementState != awsAgentCoreGatewayPolicyEnforcementAdvisory {
+		t.Fatalf("expected explicit pilot/enforcement state, got pilot=%q enforcement=%q", result.PilotState, result.EnforcementState)
+	}
+	if len(result.Advisories) == 0 {
+		t.Fatalf("expected advisories to be projected from AI agent risk source: %+v", result.Summary)
+	}
+	for _, advisory := range result.Advisories {
+		if advisory.AdvisoryID == "" || advisory.CalculationVersion != awsAgentCoreGatewayPolicyAdvisoryVersion {
+			t.Fatalf("advisory missing stable metadata: %+v", advisory)
+		}
+		if advisory.Mode != awsAgentCoreGatewayPolicyAdvisoryModeAdvisory {
+			t.Fatalf("advisory must remain advisory: %+v", advisory)
+		}
+		if advisory.PilotState == "" || advisory.EnforcementState != awsAgentCoreGatewayPolicyEnforcementAdvisory {
+			t.Fatalf("advisory missing explicit governance state: %+v", advisory)
+		}
+		switch advisory.Outcome {
+		case awsAgentCoreGatewayPolicyOutcomeAllowTools, awsAgentCoreGatewayPolicyOutcomeWarn, awsAgentCoreGatewayPolicyOutcomeRequireApproval, awsAgentCoreGatewayPolicyOutcomeRestrictTools, awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		default:
+			t.Fatalf("advisory has unknown outcome: %+v", advisory)
+		}
+		if advisory.AgentNodeID == "" {
+			t.Fatalf("advisory must reference an agent_node_id: %+v", advisory)
+		}
+		if advisory.FindingID == "" {
+			t.Fatalf("advisory must reference its source finding: %+v", advisory)
+		}
+		if advisory.EvidenceBoundary != awsAgentCoreGatewayPolicyAdvisoryEvidenceBoundary() {
+			t.Fatalf("advisory crossed evidence boundary: %+v", advisory)
+		}
+		if !advisory.ReadOnlyProjection {
+			t.Fatalf("advisory must remain read-only: %+v", advisory)
+		}
+		if advisory.Provenance.PolicyVersion == "" || advisory.Provenance.PolicyRule == "" {
+			t.Fatalf("advisory missing provenance: %+v", advisory.Provenance)
+		}
+		if advisory.InputHash.Value == "" {
+			t.Fatalf("advisory missing input hash: %+v", advisory.InputHash)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"prompt\"", "\"tool_payload\"", "\"completion\"", "\"secret_access_key\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("agentcore gateway policy advisory serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryClassifyPolicyOrder(t *testing.T) {
+	base := AWSAIAgentRiskFinding{FindingID: "f-1", AgentNodeID: "aws:agent:111111111111:us-east-1:agent/x", Severity: "medium", RiskType: "unknown"}
+
+	critical := base
+	critical.Severity = "critical"
+	critical.SensitiveResources = []string{"arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key"}
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(critical); out != awsAgentCoreGatewayPolicyOutcomeBlockTools || rule != "critical_sensitive_reachability" {
+		t.Fatalf("critical + sensitive reachability must classify as block_tools: %s / %s", out, rule)
+	}
+
+	externalCred := base
+	externalCred.RiskType = "external_credential"
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(externalCred); out != awsAgentCoreGatewayPolicyOutcomeRequireApproval || rule != "external_credential_use" {
+		t.Fatalf("external credential must classify as require_approval: %s / %s", out, rule)
+	}
+
+	broad := base
+	broad.RiskType = "broad_tool_access"
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(broad); out != awsAgentCoreGatewayPolicyOutcomeRestrictTools || rule != "broad_tool_access" {
+		t.Fatalf("broad tool access must classify as restrict_tools: %s / %s", out, rule)
+	}
+
+	ownerless := base
+	ownerless.RiskType = "ownerless_agent"
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(ownerless); out != awsAgentCoreGatewayPolicyOutcomeWarn || rule != "ownerless_agent" {
+		t.Fatalf("ownerless agent must classify as warn: %s / %s", out, rule)
+	}
+
+	highGeneric := base
+	highGeneric.Severity = "high"
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(highGeneric); out != awsAgentCoreGatewayPolicyOutcomeRequireApproval || rule != "high_severity_finding" {
+		t.Fatalf("high severity without matching risk type must require approval: %s / %s", out, rule)
+	}
+
+	unknownTools := AWSAIAgentRiskFinding{FindingID: "f-2", AgentNodeID: "aws:agent:x", Severity: "medium", RiskType: "unknown"}
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(unknownTools); out != awsAgentCoreGatewayPolicyOutcomeWarn || rule != "unknown_tool_scope" {
+		t.Fatalf("no tools must classify as warn: %s / %s", out, rule)
+	}
+
+	fine := AWSAIAgentRiskFinding{FindingID: "f-3", AgentNodeID: "aws:agent:x", Severity: "low", RiskType: "unknown", ToolNames: []string{"tool-a"}}
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(fine); out != awsAgentCoreGatewayPolicyOutcomeAllowTools || rule != "no_active_risk" {
+		t.Fatalf("no active risk must allow tools: %s / %s", out, rule)
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryToolPartition(t *testing.T) {
+	tools := []string{"tool-a", "tool-b"}
+
+	allow, restrict, block := awsAgentCoreGatewayPolicyAdvisoryToolPartition(awsAgentCoreGatewayPolicyOutcomeBlockTools, tools)
+	if len(allow) != 0 || len(restrict) != 0 || len(block) != 2 {
+		t.Fatalf("block_tools must put all tools in blocked bucket: allow=%+v restrict=%+v block=%+v", allow, restrict, block)
+	}
+
+	allow, restrict, block = awsAgentCoreGatewayPolicyAdvisoryToolPartition(awsAgentCoreGatewayPolicyOutcomeRestrictTools, tools)
+	if len(allow) != 0 || len(restrict) != 2 || len(block) != 0 {
+		t.Fatalf("restrict_tools must put all tools in restricted bucket: allow=%+v restrict=%+v block=%+v", allow, restrict, block)
+	}
+
+	allow, restrict, block = awsAgentCoreGatewayPolicyAdvisoryToolPartition(awsAgentCoreGatewayPolicyOutcomeAllowTools, tools)
+	if len(allow) != 2 || len(restrict) != 0 || len(block) != 0 {
+		t.Fatalf("allow_tools must put all tools in allowed bucket: allow=%+v restrict=%+v block=%+v", allow, restrict, block)
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryPilotState(t *testing.T) {
+	if got := awsAgentCoreGatewayPolicyAdvisoryPilotState(awsAgentCoreGatewayPolicyOutcomeAllowTools); got != awsAgentCoreGatewayPolicyPilotStateCandidate {
+		t.Fatalf("allow_tools must be a pilot candidate, got %q", got)
+	}
+	if got := awsAgentCoreGatewayPolicyAdvisoryPilotState(awsAgentCoreGatewayPolicyOutcomeRestrictTools); got != awsAgentCoreGatewayPolicyPilotStateReview {
+		t.Fatalf("restrict_tools must require operator review, got %q", got)
+	}
+	if got := awsAgentCoreGatewayPolicyAdvisoryPilotState(awsAgentCoreGatewayPolicyOutcomeBlockTools); got != awsAgentCoreGatewayPolicyPilotStateBlocked {
+		t.Fatalf("block_tools must be blocked, got %q", got)
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryAdmitsRequiresAgentNode(t *testing.T) {
+	if awsAgentCoreGatewayPolicyAdvisoryAdmits(AWSAIAgentRiskFinding{FindingID: "f-1"}) {
+		t.Fatalf("finding without agent_node_id must not be admitted")
+	}
+	if !awsAgentCoreGatewayPolicyAdvisoryAdmits(AWSAIAgentRiskFinding{FindingID: "f-1", AgentNodeID: "aws:agent:x"}) {
+		t.Fatalf("finding with agent_node_id must be admitted")
+	}
+}
+
+func TestFilterAWSAgentCoreGatewayPolicyAdvisories(t *testing.T) {
+	entries := []AWSAgentCoreGatewayPolicyAdvisoryEntry{
+		{
+			AdvisoryID:  "adv-block",
+			Outcome:     awsAgentCoreGatewayPolicyOutcomeBlockTools,
+			Severity:    "critical",
+			AccountID:   "111111111111",
+			Region:      "us-east-1",
+			AgentNodeID: "aws:agent:111111111111:us-east-1:agent/a",
+			AgentID:     "agent-a",
+			RiskType:    "sensitive_reachability",
+			FindingID:   "aws-ai-agent-risk:a",
+		},
+		{
+			AdvisoryID:  "adv-warn",
+			Outcome:     awsAgentCoreGatewayPolicyOutcomeWarn,
+			Severity:    "medium",
+			AccountID:   "222222222222",
+			Region:      "us-west-2",
+			AgentNodeID: "aws:agent:222222222222:us-west-2:agent/b",
+			AgentID:     "agent-b",
+			RiskType:    "ownerless_agent",
+			FindingID:   "aws-ai-agent-risk:b",
+		},
+	}
+
+	filtered, applied := filterAWSAgentCoreGatewayPolicyAdvisories(entries, AWSAgentCoreGatewayPolicyAdvisoryRequest{Outcome: "block_tools"})
+	if applied["outcome"] != normalizeAWSRuntimeEventFilterToken("block_tools") || len(filtered) != 1 || filtered[0].AdvisoryID != "adv-block" {
+		t.Fatalf("outcome filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSAgentCoreGatewayPolicyAdvisories(entries, AWSAgentCoreGatewayPolicyAdvisoryRequest{AgentID: "agent-b"})
+	if applied["agent_id"] != "agent-b" || len(filtered) != 1 || filtered[0].AdvisoryID != "adv-warn" {
+		t.Fatalf("agent_id filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSAgentCoreGatewayPolicyAdvisories(entries, AWSAgentCoreGatewayPolicyAdvisoryRequest{RiskType: "sensitive_reachability"})
+	if applied["risk_type"] != "sensitive_reachability" || len(filtered) != 1 || filtered[0].AdvisoryID != "adv-block" {
+		t.Fatalf("risk_type filter did not scope entries: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSAgentCoreGatewayPolicyAdvisories(entries, AWSAgentCoreGatewayPolicyAdvisoryRequest{Search: "ownerless"})
+	if applied["search"] != "ownerless" || len(filtered) != 1 || filtered[0].AdvisoryID != "adv-warn" {
+		t.Fatalf("search must reach risk_type / rationale: applied=%+v filtered=%+v", applied, filtered)
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 0, 0, 0, time.UTC)
+	svc, ws := newAgentCoreGatewayPolicyAdvisoryService(t, "project-agentcore-gateway-policy-advisory-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSAgentCoreGatewayPolicyAdvisory(defaultScopeContext(), ws, "project-agentcore-gateway-policy-advisory-fixture", AWSAgentCoreGatewayPolicyAdvisoryRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestAWSAgentCoreGatewayPolicyAdvisoryInputHashCoversAllInputs(t *testing.T) {
+	base := AWSAIAgentRiskFinding{FindingID: "f-hash", AgentNodeID: "aws:agent:x", Severity: "medium", RiskType: "unknown", Status: "action_required", ToolNames: []string{"a"}}
+	baseHash := awsAgentCoreGatewayPolicyAdvisoryInputHash(base, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value
+
+	sevChanged := base
+	sevChanged.Severity = "critical"
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(sevChanged, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
+		t.Fatalf("severity change must move input hash")
+	}
+
+	riskChanged := base
+	riskChanged.RiskType = "external_credential"
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(riskChanged, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
+		t.Fatalf("risk_type change must move input hash")
+	}
+
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(base, awsAgentCoreGatewayPolicyOutcomeBlockTools).Value == baseHash {
+		t.Fatalf("outcome change must move input hash")
+	}
+
+	extraSensitive := base
+	extraSensitive.SensitiveResources = []string{"arn:aws:s3:::sensitive"}
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(extraSensitive, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
+		t.Fatalf("sensitive count change must move input hash")
+	}
+}
+
+func TestRouterAWSAgentCoreGatewayPolicyAdvisory(t *testing.T) {
+	now := time.Date(2026, 7, 3, 14, 0, 0, 0, time.UTC)
+	svc, _ := newAgentCoreGatewayPolicyAdvisoryService(t, "project-agentcore-gateway-policy-advisory-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-agentcore-gateway-policy-advisory-route/aws/agentcore-gateway-policy-advisory?connector_id=aws-prod&fixture_state=success", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Advisory AWSAgentCoreGatewayPolicyAdvisoryResult `json:"agentcore_gateway_policy_advisory"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Advisory.CurrentIssueRef != "#1545" || body.Advisory.PolicyVersion != awsAgentCoreGatewayPolicyAdvisoryPolicyID {
+		t.Fatalf("unexpected route payload: %+v", body.Advisory)
+	}
+}

--- a/internal/api/aws_agentcore_gateway_policy_advisory_test.go
+++ b/internal/api/aws_agentcore_gateway_policy_advisory_test.go
@@ -102,10 +102,24 @@ func TestAWSAgentCoreGatewayPolicyAdvisoryClassifyPolicyOrder(t *testing.T) {
 		t.Fatalf("external credential must classify as require_approval: %s / %s", out, rule)
 	}
 
+	externalCredExposure := base
+	externalCredExposure.RiskType = "external_credential_exposure"
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(externalCredExposure); out != awsAgentCoreGatewayPolicyOutcomeRequireApproval || rule != "external_credential_use" {
+		t.Fatalf("upstream external credential exposure must classify as require_approval: %s / %s", out, rule)
+	}
+
 	broad := base
 	broad.RiskType = "broad_tool_access"
 	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(broad); out != awsAgentCoreGatewayPolicyOutcomeRestrictTools || rule != "broad_tool_access" {
 		t.Fatalf("broad tool access must classify as restrict_tools: %s / %s", out, rule)
+	}
+
+	sensitiveDataReachability := base
+	sensitiveDataReachability.RiskType = "sensitive_data_reachability"
+	sensitiveDataReachability.ToolNames = []string{"tool-a"}
+	sensitiveDataReachability.SensitiveResources = []string{"arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key"}
+	if out, rule, _, _ := awsAgentCoreGatewayPolicyAdvisoryClassify(sensitiveDataReachability); out != awsAgentCoreGatewayPolicyOutcomeRestrictTools || rule != "sensitive_reachability" {
+		t.Fatalf("upstream sensitive data reachability must classify as restrict_tools: %s / %s", out, rule)
 	}
 
 	ownerless := base
@@ -240,7 +254,7 @@ func TestAWSAgentCoreGatewayPolicyAdvisoryFixtureStates(t *testing.T) {
 }
 
 func TestAWSAgentCoreGatewayPolicyAdvisoryInputHashCoversAllInputs(t *testing.T) {
-	base := AWSAIAgentRiskFinding{FindingID: "f-hash", AgentNodeID: "aws:agent:x", Severity: "medium", RiskType: "unknown", Status: "action_required", ToolNames: []string{"a"}}
+	base := AWSAIAgentRiskFinding{FindingID: "f-hash", AgentNodeID: "aws:agent:x", Severity: "medium", RiskType: "unknown", Status: "action_required", ToolNames: []string{"a"}, SensitiveResources: []string{"arn:aws:s3:::sensitive-a"}}
 	baseHash := awsAgentCoreGatewayPolicyAdvisoryInputHash(base, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value
 
 	sevChanged := base
@@ -260,9 +274,21 @@ func TestAWSAgentCoreGatewayPolicyAdvisoryInputHashCoversAllInputs(t *testing.T)
 	}
 
 	extraSensitive := base
-	extraSensitive.SensitiveResources = []string{"arn:aws:s3:::sensitive"}
+	extraSensitive.SensitiveResources = []string{"arn:aws:s3:::sensitive-a", "arn:aws:s3:::sensitive-b"}
 	if awsAgentCoreGatewayPolicyAdvisoryInputHash(extraSensitive, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
 		t.Fatalf("sensitive count change must move input hash")
+	}
+
+	toolScopeChanged := base
+	toolScopeChanged.ToolNames = []string{"b"}
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(toolScopeChanged, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
+		t.Fatalf("same-count tool scope change must move input hash")
+	}
+
+	sensitiveScopeChanged := base
+	sensitiveScopeChanged.SensitiveResources = []string{"arn:aws:s3:::sensitive-b"}
+	if awsAgentCoreGatewayPolicyAdvisoryInputHash(sensitiveScopeChanged, awsAgentCoreGatewayPolicyOutcomeAllowTools).Value == baseHash {
+		t.Fatalf("same-count sensitive resource scope change must move input hash")
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3387,6 +3387,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"session_policy_recommendations": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAgentCoreGatewayPolicyAdvisory(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAgentCoreGatewayPolicyAdvisoryRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			AgentID:      strings.TrimSpace(c.Query("agent_id")),
+			Outcome:      strings.TrimSpace(c.Query("outcome")),
+			RiskType:     strings.TrimSpace(c.Query("risk_type")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			FindingID:    strings.TrimSpace(c.Query("finding_id")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws agentcore gateway policy advisory request"})
+			default:
+				logger.Error("get aws agentcore gateway policy advisory",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws agentcore gateway policy advisory"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"agentcore_gateway_policy_advisory": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/secret-key-rotation", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -2243,4 +2243,44 @@ describe('apiClient', () => {
     expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
+
+  it('gets AWS AgentCore gateway policy advisory with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ agentcore_gateway_policy_advisory: { status: 'ready', advisories: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectAgentCoreGatewayPolicyAdvisory(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'partial_failure',
+        accountID: '111111111111',
+        region: 'us-east-1',
+        agentID: 'agent/a',
+        outcome: 'restrict_tools',
+        riskType: 'broad_tool_access',
+        severity: 'high',
+        findingID: 'finding/a',
+        search: 'payments gateway'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/agentcore-gateway-policy-advisory?connector_id=aws-prod&fixture_state=partial_failure&account_id=111111111111&region=us-east-1&agent_id=agent%2Fa&outcome=restrict_tools&risk_type=broad_tool_access&severity=high&finding_id=finding%2Fa&search=payments+gateway'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4146,6 +4146,146 @@ export type AWSSessionPolicyRecommendationQuery = {
   search?: string;
 };
 
+export type AWSAgentCoreGatewayPolicyAdvisoryStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSAgentCoreGatewayPolicyAdvisoryFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSAgentCoreGatewayPolicyAdvisoryOutcome =
+  | 'allow_tools'
+  | 'warn'
+  | 'require_approval'
+  | 'restrict_tools'
+  | 'block_tools'
+  | string;
+export type AWSAgentCoreGatewayPolicyAdvisoryPilotState = 'candidate' | 'operator_review' | 'blocked' | string;
+export type AWSAgentCoreGatewayPolicyAdvisoryEnforcementState = 'advisory_only' | string;
+
+export type AWSAgentCoreGatewayPolicyAdvisoryProvenance = {
+  policy_version: string;
+  policy_rule: string;
+  signals?: string[];
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisoryInputHash = {
+  value: string;
+  components?: string[];
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisoryRelationship = {
+  advisory_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisoryEntry = {
+  advisory_id: string;
+  calculation_version: string;
+  mode: 'advisory' | string;
+  outcome: AWSAgentCoreGatewayPolicyAdvisoryOutcome;
+  pilot_state: AWSAgentCoreGatewayPolicyAdvisoryPilotState;
+  enforcement_state: AWSAgentCoreGatewayPolicyAdvisoryEnforcementState;
+  confidence: number;
+  severity: string;
+  score: number;
+  title: string;
+  summary: string;
+  rationale: string;
+  account_id?: string;
+  region?: string;
+  agent_node_id: string;
+  agent_id?: string;
+  agent_name?: string;
+  agent_type?: string;
+  provider?: string;
+  runtime_role_arn?: string;
+  runtime_role_node_id?: string;
+  finding_id: string;
+  risk_type: string;
+  allowed_tool_names?: string[];
+  restricted_tool_names?: string[];
+  blocked_tool_names?: string[];
+  sensitive_resources?: string[];
+  recommended_actions: string[];
+  provenance: AWSAgentCoreGatewayPolicyAdvisoryProvenance;
+  input_hash: AWSAgentCoreGatewayPolicyAdvisoryInputHash;
+  evidence: AWSLeastPrivilegeEvidence[];
+  evidence_boundary: string;
+  impacted_nodes: string[];
+  impacted_path: AWSLeastPrivilegePathStep[];
+  audit_trail: AWSRemediationAuditEntry[];
+  read_only_projection: boolean;
+  source_signals: string[];
+  next_action: string;
+  projected_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisorySummary = {
+  total_advisories: number;
+  filtered_advisories: number;
+  outcome_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  risk_type_counts: Record<string, number>;
+  allow_tools_count: number;
+  warn_count: number;
+  require_approval_count: number;
+  restrict_tools_count: number;
+  block_tools_count: number;
+  restricted_tool_count: number;
+  sensitive_resource_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisoryResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAgentCoreGatewayPolicyAdvisoryStatus;
+  fixture_state?: AWSAgentCoreGatewayPolicyAdvisoryFixtureState;
+  confidence: number;
+  calculation_version: string;
+  policy_version: string;
+  mode: 'advisory' | string;
+  pilot_state: AWSAgentCoreGatewayPolicyAdvisoryPilotState;
+  enforcement_state: AWSAgentCoreGatewayPolicyAdvisoryEnforcementState;
+  applied_filters: Record<string, string>;
+  summary: AWSAgentCoreGatewayPolicyAdvisorySummary;
+  advisories: AWSAgentCoreGatewayPolicyAdvisoryEntry[];
+  relationships: AWSAgentCoreGatewayPolicyAdvisoryRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSAgentCoreGatewayPolicyAdvisoryQuery = {
+  connectorID?: string;
+  fixtureState?: AWSAgentCoreGatewayPolicyAdvisoryFixtureState;
+  accountID?: string;
+  region?: string;
+  agentID?: string;
+  outcome?: string;
+  riskType?: string;
+  severity?: string;
+  findingID?: string;
+  search?: string;
+};
+
 export type AWSSecretKeyRotationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSecretKeyRotationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSecretKeyRotationType = 'provider_key' | 'secrets_manager_secret' | 'kms_related' | string;
@@ -9496,6 +9636,28 @@ export const apiClient = {
         recommendation_id: query?.recommendationID,
         decision: query?.decision,
         severity: query?.severity,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAgentCoreGatewayPolicyAdvisory(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSAgentCoreGatewayPolicyAdvisoryQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ agentcore_gateway_policy_advisory: AWSAgentCoreGatewayPolicyAdvisoryResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/agentcore-gateway-policy-advisory${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        agent_id: query?.agentID,
+        outcome: query?.outcome,
+        risk_type: query?.riskType,
+        severity: query?.severity,
+        finding_id: query?.findingID,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4125,6 +4125,41 @@ describe('Domain-first app routes', () => {
 	        diagnostics: []
 	      } as any
 	    });
+	    const getAgentCoreGatewayPolicyAdvisory = vi.spyOn(api.apiClient, 'getAWSProjectAgentCoreGatewayPolicyAdvisory').mockResolvedValue({
+	      agentcore_gateway_policy_advisory: {
+	        status: 'ready',
+	        mode: 'advisory',
+	        policy_version: 'aws-agentcore-gateway-policy-advisory-policy-v1',
+	        pilot_state: 'candidate',
+	        enforcement_state: 'advisory_only',
+	        advisories: [],
+	        relationships: [],
+	        applied_filters: {},
+	        summary: {
+	          total_advisories: 0,
+	          filtered_advisories: 0,
+	          outcome_counts: {},
+	          severity_counts: {},
+	          risk_type_counts: {},
+	          allow_tools_count: 0,
+	          warn_count: 0,
+	          require_approval_count: 0,
+	          restrict_tools_count: 0,
+	          block_tools_count: 0,
+	          restricted_tool_count: 0,
+	          sensitive_resource_count: 0,
+	          relationship_count: 0,
+	          highest_score: 0,
+	          average_confidence_pct: 0
+	        },
+	        caveats: ['AgentCore gateway policy advisories are read-only recommendations.'],
+	        failure_reasons: [],
+	        remediation_hints: [],
+	        evidence_links: [],
+	        coverage_gaps: [],
+	        diagnostics: []
+	      } as any
+	    });
 	    const getSecretKeyRotation = vi.spyOn(api.apiClient, 'getAWSProjectSecretKeyRotationPlans').mockResolvedValue({
       plans: {
         status: 'ready',
@@ -4804,6 +4839,12 @@ describe('Domain-first app routes', () => {
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
     expect(getSessionPolicyRecommendations).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getAgentCoreGatewayPolicyAdvisory).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -87,6 +87,8 @@ import {
   type AWSAdvisoryAuthorizationResult,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
+  type AWSAgentCoreGatewayPolicyAdvisoryEntry,
+  type AWSAgentCoreGatewayPolicyAdvisoryResult,
   type AWSTrustPolicyHardeningExecutorEntry,
   type AWSTrustPolicyHardeningExecutorResult,
   type AWSBlastRadiusFinding,
@@ -11516,6 +11518,82 @@ function AWSSessionPolicyRecommendationContent({
   );
 }
 
+function awsAgentCoreGatewayPolicyAdvisoryStage(entry: AWSAgentCoreGatewayPolicyAdvisoryEntry): AWSCapabilityStage {
+  switch (entry.outcome) {
+    case 'block_tools':
+      return 'not-available';
+    case 'allow_tools':
+      return 'wired';
+    default:
+      return 'coming';
+  }
+}
+
+function awsAgentCoreGatewayPolicyAdvisoryToolLabel(entry: AWSAgentCoreGatewayPolicyAdvisoryEntry): string {
+  const allow = entry.allowed_tool_names?.length ?? 0;
+  const restrict = entry.restricted_tool_names?.length ?? 0;
+  const block = entry.blocked_tool_names?.length ?? 0;
+  return `${allow} allow · ${restrict} restrict · ${block} block`;
+}
+
+function AWSAgentCoreGatewayPolicyAdvisoryContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSAgentCoreGatewayPolicyAdvisoryResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_advisories} total · ${result.summary.allow_tools_count} allow · ${result.summary.warn_count} warn · ${result.summary.require_approval_count} require approval · ${result.summary.restrict_tools_count} restrict · ${result.summary.block_tools_count} block`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.advisories,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <AWSExecutorProjectionPanel<AWSAgentCoreGatewayPolicyAdvisoryEntry>
+      result={panelResult}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS AgentCore gateway policy advisory"
+      heading="AWS AgentCore gateway policy advisory"
+      description={`Advisory-only projection that derives AgentCore gateway/tool policy recommendations from AI agent risk findings. Each entry records the target agent, projected tool restrictions/approvals/warnings, sensitive reachability, provenance, and audit rows. Identrail never enforces the recommendation at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS AgentCore gateway policy advisory"
+      loadingTitle="Projecting AgentCore gateway policy advisories"
+      loadingBody="Identrail is joining AI agent risk findings with AgentCore gateway policy rules to project deterministic advisory recommendations."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No advisories')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'AgentCore gateway policy advisory needs approved agent risk evidence' : 'No AgentCore gateway policy advisories projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No AI agent risk finding carried an addressable agent gateway for this environment.'}
+      tableLabel="AWS AgentCore gateway policy advisories"
+      getRowKey={(row) => row.advisory_id}
+      columns={[
+        { key: 'advisory', header: 'Advisory', render: (row) => <strong>{row.title}</strong> },
+        { key: 'agent', header: 'Agent', render: (row) => row.agent_name ?? row.agent_id ?? row.agent_node_id },
+        { key: 'outcome', header: 'Outcome', render: (row) => formatTokenLabel(row.outcome) },
+        { key: 'tools', header: 'Tools', render: (row) => awsAgentCoreGatewayPolicyAdvisoryToolLabel(row) },
+        { key: 'sensitive', header: 'Sensitive', render: (row) => `${row.sensitive_resources?.length ?? 0} resources` },
+        { key: 'policy', header: 'Policy', render: (row) => `${formatTokenLabel(row.pilot_state)} / ${formatTokenLabel(row.enforcement_state)}` },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill stage={awsAgentCoreGatewayPolicyAdvisoryStage(row)} label={`${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.outcome)}`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSecretKeyRotationStage(plan: AWSSecretKeyRotationPlan): AWSCapabilityStage {
   if (!plan.owner_handoff.assigned || plan.severity === 'critical') {
     return 'not-available';
@@ -13752,6 +13830,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
   const sessionPolicyRecommendationsRequestRef = useRef(0);
+  const [agentCoreGatewayPolicyAdvisory, setAgentCoreGatewayPolicyAdvisory] = useState<AWSAgentCoreGatewayPolicyAdvisoryResult | null>(null);
+  const [agentCoreGatewayPolicyAdvisoryLoading, setAgentCoreGatewayPolicyAdvisoryLoading] = useState(false);
+  const [agentCoreGatewayPolicyAdvisoryError, setAgentCoreGatewayPolicyAdvisoryError] = useState('');
+  const agentCoreGatewayPolicyAdvisoryRequestRef = useRef(0);
   const [secretKeyRotation, setSecretKeyRotation] = useState<AWSSecretKeyRotationResult | null>(null);
   const [secretKeyRotationLoading, setSecretKeyRotationLoading] = useState(false);
   const [secretKeyRotationError, setSecretKeyRotationError] = useState('');
@@ -14496,6 +14578,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       sessionPolicyRecommendationsRequestRef.current += 1;
     };
   }, [loadSessionPolicyRecommendations]);
+
+  const loadAgentCoreGatewayPolicyAdvisory = useCallback(async () => {
+    const requestID = ++agentCoreGatewayPolicyAdvisoryRequestRef.current;
+    setAgentCoreGatewayPolicyAdvisory(null);
+    setAgentCoreGatewayPolicyAdvisoryError('');
+    if (routeID !== 'runtime' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setAgentCoreGatewayPolicyAdvisoryLoading(false);
+      return;
+    }
+    setAgentCoreGatewayPolicyAdvisoryLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAgentCoreGatewayPolicyAdvisory(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== agentCoreGatewayPolicyAdvisoryRequestRef.current) {
+        return;
+      }
+      setAgentCoreGatewayPolicyAdvisory(response.agentcore_gateway_policy_advisory);
+    } catch (error) {
+      if (requestID !== agentCoreGatewayPolicyAdvisoryRequestRef.current) {
+        return;
+      }
+      setAgentCoreGatewayPolicyAdvisoryError(formatAPIError(error, 'Unable to load AWS AgentCore gateway policy advisory.'));
+    } finally {
+      if (requestID === agentCoreGatewayPolicyAdvisoryRequestRef.current) {
+        setAgentCoreGatewayPolicyAdvisoryLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadAgentCoreGatewayPolicyAdvisory();
+    return () => {
+      agentCoreGatewayPolicyAdvisoryRequestRef.current += 1;
+    };
+  }, [loadAgentCoreGatewayPolicyAdvisory]);
 
   const loadSecretKeyRotation = useCallback(async () => {
     const requestID = ++secretKeyRotationRequestRef.current;
@@ -15375,6 +15505,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={sessionPolicyRecommendationsLoading}
             error={sessionPolicyRecommendationsError}
             onRetry={loadSessionPolicyRecommendations}
+          />
+        ) : null}
+        {routeID === 'runtime' ? (
+          <AWSAgentCoreGatewayPolicyAdvisoryContent
+            result={agentCoreGatewayPolicyAdvisory}
+            loading={agentCoreGatewayPolicyAdvisoryLoading}
+            error={agentCoreGatewayPolicyAdvisoryError}
+            onRetry={loadAgentCoreGatewayPolicyAdvisory}
           />
         ) : null}
         {routeID === 'runtime' ? (


### PR DESCRIPTION
## Summary
- Add the AgentCore gateway policy advisory API for issue #1545, derived from the existing AI agent risk engine and kept advisory-only.
- Expose deterministic advisory outcomes, pilot/enforcement state, provenance, input hashes, evidence refs, audit trail, filters, route authz, and OpenAPI docs.
- Wire the TypeScript client and AWS Runtime app surface with focused client/UI/backend coverage.

## Validation
- go test ./internal/api -run 'TestGetAWSAgentCoreGatewayPolicyAdvisory|TestAWSAgentCoreGatewayPolicyAdvisory|TestRouterAWSAgentCoreGatewayPolicyAdvisory|TestDefaultBuiltInRoutePolicyDefinitions'
- go test ./internal/api
- python3 YAML parse for docs/openapi-v1.yaml
- npm test -- --run src/api/client.test.ts src/productShell.test.tsx
- npm run build

Closes #1545

AI disclosure: No
