### PR TITLE
Add AWS limited enforcement framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS limited enforcement framework** (#1546). Adds a
+  metadata-only governance projection that joins advisory authorization
+  decisions (#1543) and AgentCore gateway policy advisories (#1545) with
+  explicit feature-flag, cohort, canary, kill-switch, rollback, confidence,
+  and audit gates. The framework supports `warn_only`, `advisory`,
+  `approval_required`, and `limited_enforce` modes, but limited enforcement
+  is never marked ready from defaults: operators must provide explicit
+  safety config before an entry can become `canary_ready` or
+  `limited_enforce_ready`. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement`
+  with filters for connector, fixture state, account, region, mode,
+  enforcement state, source decision/advisory ID, source type, outcome,
+  cohort, feature flag, kill switch, canary percentage, and free-text
+  search. The AWS Governance app surface now shows an **AWS limited
+  enforcement framework** panel with mode, source, state, cohort, gate
+  readiness, outcome, and canary percentage. Identrail never calls AWS write
+  APIs or enforces the projection at this layer.
 - Add **AWS AgentCore gateway policy advisory** (#1545). Adds an
   advisory-only projection that derives AgentCore gateway/tool policy
   recommendations from the AI agent risk engine (#1528). Each advisory

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
 - AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
 - AWS advisory authorization decision API: `aws-advisory-authorization.md`
+- AWS limited enforcement framework: `aws-limited-enforcement.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`

--- a/docs/aws-limited-enforcement.md
+++ b/docs/aws-limited-enforcement.md
@@ -1,0 +1,81 @@
+# AWS limited enforcement framework
+
+Issue #1546 adds a metadata-only framework for moving AWS machine-identity
+governance from warn-only and advisory behavior toward controlled limited
+enforcement. It joins advisory authorization decisions (#1543) and AgentCore
+gateway policy advisories (#1545), then records the safety config operators
+must satisfy before any downstream executor can act.
+
+The endpoint does not enforce. Identrail never calls IAM, STS,
+Organizations, Bedrock, or AgentCore write APIs at this layer.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement`
+
+Response shape: `{ "limited_enforcement": AWSLimitedEnforcementResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`mode`, `enforcement_state`, `decision_id`, `source_type`, `outcome`,
+`cohort`, `feature_flag`, `kill_switch`, `canary_percent`, and `search`.
+
+## Modes and states
+
+Supported modes:
+
+- `warn_only`: surface warning behavior only.
+- `advisory`: record recommendation and evidence without enforcement.
+- `approval_required`: require an operator approval workflow before any
+  downstream control change.
+- `limited_enforce`: mark a scoped canary or full limited-enforcement rollout
+  as ready only when every safety gate passes.
+
+Important states:
+
+- `blocked_by_safety_config`: requested limited enforcement is missing an
+  explicit feature flag, cohort, canary percentage, rollback, audit, or
+  confidence gate.
+- `blocked_by_kill_switch`: the tenant or source kill switch is active.
+- `rollback_required`: upstream advisory state says quarantine or block.
+- `canary_ready`: feature flag, cohort, canary, confidence, rollback, audit,
+  and kill-switch gates are satisfied for a bounded rollout.
+- `limited_enforce_ready`: all gates are satisfied with a 100 percent canary.
+
+## Safety gates
+
+Every entry records:
+
+- feature flag state;
+- tenant/source kill-switch state;
+- canary percentage and cohort;
+- rollback metadata;
+- audit metadata;
+- confidence floor;
+- unsafe-outcome blocker.
+
+Limited enforcement is never marked ready from defaults. Operators must
+provide explicit safety config before the framework can leave advisory mode.
+
+## Evidence boundary
+
+Entries include source decision/advisory IDs, policy version, input hash,
+confidence, evidence refs, rollback intent, gates, and audit rows. They do
+not include rendered policy bodies, secret values, prompts, completions,
+database rows, object contents, browser pages, or workload payloads.
+
+Tenant, workspace, project, connector, account, and region boundaries are
+preserved in the API route, authz policy, and app surface.
+
+## App surface
+
+The AWS Governance page renders an **AWS limited enforcement framework**
+panel showing each entry's mode, source, enforcement state, cohort, gate
+readiness, outcome, and canary percentage. Loading, empty, blocked,
+degraded, permission-denied, and error states are explicit.
+
+## Out of scope
+
+- No live AWS mutation.
+- No broad scanner behavior.
+- No secret or customer payload collection.
+- No downstream executor implementation beyond framework readiness metadata.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -614,6 +614,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
     action: tenancy.read
     resource_type: project
@@ -5821,6 +5826,100 @@ paths:
                     $ref: "#/components/schemas/AWSAdvisoryAuthorizationResult"
         "400":
           description: Invalid AWS advisory authorization request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS limited enforcement framework entries
+      operationId: getAWSProjectLimitedEnforcement
+      description: Projects the feature-flagged limited enforcement framework by joining advisory authorization and AgentCore gateway policy advisory signals with explicit safety config. Each entry records mode, canary, cohort, kill switch, rollback, audit, confidence, policy version, evidence refs, and readiness gates. The endpoint is metadata-only; Identrail never calls AWS write APIs or enforces the projection at this layer.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: mode
+          schema:
+            type: string
+            enum: [warn_only, advisory, approval_required, limited_enforce]
+        - in: query
+          name: enforcement_state
+          schema:
+            type: string
+            enum: [warn_only, advisory_only, approval_required, canary_ready, limited_enforce_ready, blocked_by_safety_config, blocked_by_kill_switch, rollback_required]
+        - in: query
+          name: decision_id
+          schema: { type: string }
+          description: Optional source decision/advisory ID or framework entry ID filter.
+        - in: query
+          name: source_type
+          schema:
+            type: string
+            enum: [advisory_authorization, agentcore_gateway_policy_advisory]
+        - in: query
+          name: outcome
+          schema: { type: string }
+        - in: query
+          name: cohort
+          schema: { type: string }
+        - in: query
+          name: feature_flag
+          schema: { type: boolean }
+        - in: query
+          name: kill_switch
+          schema: { type: boolean }
+        - in: query
+          name: canary_percent
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 100
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS limited enforcement framework contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  limited_enforcement:
+                    $ref: "#/components/schemas/AWSLimitedEnforcementResult"
+        "400":
+          description: Invalid AWS limited enforcement request
           content:
             application/json:
               schema:
@@ -16342,6 +16441,211 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSAdvisoryAuthorizationRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLimitedEnforcementSafetyConfig:
+      type: object
+      properties:
+        feature_flag_enabled: { type: boolean }
+        kill_switch_engaged: { type: boolean }
+        canary_percent:
+          type: integer
+          minimum: 0
+          maximum: 100
+        cohort: { type: string }
+        rollback_required: { type: boolean }
+        audit_required: { type: boolean }
+    AWSLimitedEnforcementGate:
+      type: object
+      properties:
+        name: { type: string }
+        status:
+          type: string
+          enum: [passed, failed]
+        rationale: { type: string }
+    AWSLimitedEnforcementEvidence:
+      type: object
+      properties:
+        source: { type: string }
+        label: { type: string }
+        evidence_ref: { type: string }
+    AWSLimitedEnforcementRollback:
+      type: object
+      properties:
+        strategy: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        state: { type: string }
+        rationale: { type: string }
+    AWSLimitedEnforcementRelationship:
+      type: object
+      properties:
+        enforcement_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSLimitedEnforcementEntry:
+      type: object
+      properties:
+        enforcement_id: { type: string }
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        source_type:
+          type: string
+          enum: [advisory_authorization, agentcore_gateway_policy_advisory]
+        source_id: { type: string }
+        mode:
+          type: string
+          enum: [warn_only, advisory, approval_required, limited_enforce]
+        enforcement_state:
+          type: string
+          enum: [warn_only, advisory_only, approval_required, canary_ready, limited_enforce_ready, blocked_by_safety_config, blocked_by_kill_switch, rollback_required]
+        outcome: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        severity: { type: string }
+        score: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        region: { type: string }
+        principal_node_id: { type: string }
+        action: { type: string }
+        target_scope:
+          type: array
+          items: { type: string }
+        safety_config:
+          $ref: "#/components/schemas/AWSLimitedEnforcementSafetyConfig"
+        gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementGate"
+        rollback:
+          $ref: "#/components/schemas/AWSLimitedEnforcementRollback"
+        evidence:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementEvidence"
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        input_hash: { type: string }
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        read_only_projection: { type: boolean }
+        ready_for_canary: { type: boolean }
+        ready_for_enforcement: { type: boolean }
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLimitedEnforcementSummary:
+      type: object
+      properties:
+        total_entries: { type: integer }
+        filtered_entries: { type: integer }
+        mode_counts:
+          type: object
+          additionalProperties: { type: integer }
+        enforcement_state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        outcome_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        warn_only_count: { type: integer }
+        advisory_count: { type: integer }
+        approval_required_count: { type: integer }
+        limited_enforce_count: { type: integer }
+        canary_ready_count: { type: integer }
+        ready_for_enforcement_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_gate_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSLimitedEnforcementResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        safety_config:
+          $ref: "#/components/schemas/AWSLimitedEnforcementSafetyConfig"
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSLimitedEnforcementSummary"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementEntry"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -773,6 +773,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/trust-policy-hardening-executor", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_limited_enforcement.go
+++ b/internal/api/aws_limited_enforcement.go
@@ -1,0 +1,829 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	awsLimitedEnforcementCurrentIssue = 1546
+	awsLimitedEnforcementVersion      = "aws-limited-enforcement-v1"
+	awsLimitedEnforcementPolicyID     = "aws-limited-enforcement-policy-v1"
+
+	awsLimitedEnforcementModeWarnOnly         = "warn_only"
+	awsLimitedEnforcementModeAdvisory         = "advisory"
+	awsLimitedEnforcementModeApprovalRequired = "approval_required"
+	awsLimitedEnforcementModeLimitedEnforce   = "limited_enforce"
+
+	awsLimitedEnforcementStateWarnOnly              = "warn_only"
+	awsLimitedEnforcementStateAdvisoryOnly          = "advisory_only"
+	awsLimitedEnforcementStateApprovalRequired      = "approval_required"
+	awsLimitedEnforcementStateCanaryReady           = "canary_ready"
+	awsLimitedEnforcementStateLimitedEnforceReady   = "limited_enforce_ready"
+	awsLimitedEnforcementStateBlockedBySafetyConfig = "blocked_by_safety_config"
+	awsLimitedEnforcementStateBlockedByKillSwitch   = "blocked_by_kill_switch"
+	awsLimitedEnforcementStateRollbackRequired      = "rollback_required"
+)
+
+// AWSLimitedEnforcementRequest scopes the limited-enforcement framework to
+// one AWS connector plus optional operator drill-down and safety-config
+// filters. The safety config is explicit so enforcement cannot activate from
+// defaults.
+type AWSLimitedEnforcementRequest struct {
+	ConnectorID      string `json:"connector_id,omitempty"`
+	FixtureState     string `json:"fixture_state,omitempty"`
+	AccountID        string `json:"account_id,omitempty"`
+	Region           string `json:"region,omitempty"`
+	Mode             string `json:"mode,omitempty"`
+	EnforcementState string `json:"enforcement_state,omitempty"`
+	DecisionID       string `json:"decision_id,omitempty"`
+	SourceType       string `json:"source_type,omitempty"`
+	Outcome          string `json:"outcome,omitempty"`
+	Cohort           string `json:"cohort,omitempty"`
+	FeatureFlag      string `json:"feature_flag,omitempty"`
+	KillSwitch       string `json:"kill_switch,omitempty"`
+	CanaryPercent    int    `json:"canary_percent,omitempty"`
+	Search           string `json:"search,omitempty"`
+}
+
+type AWSLimitedEnforcementAuditEntry = AWSRemediationApprovalAuditEntry
+type AWSLimitedEnforcementCoverageGap = AWSRemediationApprovalCoverageGap
+type AWSLimitedEnforcementDiagnostic = AWSRemediationApprovalDiagnostic
+
+type AWSLimitedEnforcementSafetyConfig struct {
+	FeatureFlagEnabled bool   `json:"feature_flag_enabled"`
+	KillSwitchEngaged  bool   `json:"kill_switch_engaged"`
+	CanaryPercent      int    `json:"canary_percent"`
+	Cohort             string `json:"cohort,omitempty"`
+	RollbackRequired   bool   `json:"rollback_required"`
+	AuditRequired      bool   `json:"audit_required"`
+}
+
+type AWSLimitedEnforcementGate struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+type AWSLimitedEnforcementEvidence struct {
+	Source      string `json:"source"`
+	Label       string `json:"label"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+type AWSLimitedEnforcementRollback struct {
+	Strategy    string   `json:"strategy"`
+	Steps       []string `json:"steps"`
+	EvidenceRef string   `json:"evidence_ref,omitempty"`
+	State       string   `json:"state"`
+	Rationale   string   `json:"rationale"`
+}
+
+type AWSLimitedEnforcementRelationship struct {
+	EnforcementID string `json:"enforcement_id"`
+	Type          string `json:"type"`
+	FromNodeID    string `json:"from_node_id"`
+	ToNodeID      string `json:"to_node_id"`
+	EvidenceRef   string `json:"evidence_ref,omitempty"`
+}
+
+// AWSLimitedEnforcementEntry is the persisted-record-shaped contract for one
+// limited-enforcement framework projection. It records the safety config,
+// canary/cohort gate, rollback intent, audit row, policy version, confidence,
+// and evidence references without calling AWS write APIs.
+type AWSLimitedEnforcementEntry struct {
+	EnforcementID       string                              `json:"enforcement_id"`
+	CalculationVersion  string                              `json:"calculation_version"`
+	PolicyVersion       string                              `json:"policy_version"`
+	SourceType          string                              `json:"source_type"`
+	SourceID            string                              `json:"source_id"`
+	Mode                string                              `json:"mode"`
+	EnforcementState    string                              `json:"enforcement_state"`
+	Outcome             string                              `json:"outcome"`
+	Confidence          float64                             `json:"confidence"`
+	Severity            string                              `json:"severity"`
+	Score               int                                 `json:"score"`
+	Title               string                              `json:"title"`
+	Summary             string                              `json:"summary"`
+	AccountID           string                              `json:"account_id,omitempty"`
+	TargetAccountIDs    []string                            `json:"target_account_ids,omitempty"`
+	Region              string                              `json:"region,omitempty"`
+	PrincipalNodeID     string                              `json:"principal_node_id,omitempty"`
+	Action              string                              `json:"action,omitempty"`
+	TargetScope         []string                            `json:"target_scope,omitempty"`
+	SafetyConfig        AWSLimitedEnforcementSafetyConfig   `json:"safety_config"`
+	Gates               []AWSLimitedEnforcementGate         `json:"gates"`
+	Rollback            AWSLimitedEnforcementRollback       `json:"rollback"`
+	Evidence            []AWSLimitedEnforcementEvidence     `json:"evidence"`
+	EvidenceLinks       []string                            `json:"evidence_links"`
+	EvidenceBoundary    string                              `json:"evidence_boundary"`
+	InputHash           string                              `json:"input_hash"`
+	AuditTrail          []AWSLimitedEnforcementAuditEntry   `json:"audit_trail"`
+	Relationships       []AWSLimitedEnforcementRelationship `json:"relationships,omitempty"`
+	ReadOnlyProjection  bool                                `json:"read_only_projection"`
+	ReadyForCanary      bool                                `json:"ready_for_canary"`
+	ReadyForEnforcement bool                                `json:"ready_for_enforcement"`
+	NextAction          string                              `json:"next_action"`
+	ProjectedAt         time.Time                           `json:"projected_at"`
+	UpdatedAt           time.Time                           `json:"updated_at"`
+}
+
+type AWSLimitedEnforcementSummary struct {
+	TotalEntries             int            `json:"total_entries"`
+	FilteredEntries          int            `json:"filtered_entries"`
+	ModeCounts               map[string]int `json:"mode_counts"`
+	EnforcementStateCounts   map[string]int `json:"enforcement_state_counts"`
+	OutcomeCounts            map[string]int `json:"outcome_counts"`
+	SourceTypeCounts         map[string]int `json:"source_type_counts"`
+	WarnOnlyCount            int            `json:"warn_only_count"`
+	AdvisoryCount            int            `json:"advisory_count"`
+	ApprovalRequiredCount    int            `json:"approval_required_count"`
+	LimitedEnforceCount      int            `json:"limited_enforce_count"`
+	CanaryReadyCount         int            `json:"canary_ready_count"`
+	ReadyForEnforcementCount int            `json:"ready_for_enforcement_count"`
+	KillSwitchEngagedCount   int            `json:"kill_switch_engaged_count"`
+	FailedGateCount          int            `json:"failed_gate_count"`
+	RelationshipCount        int            `json:"relationship_count"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+}
+
+type AWSLimitedEnforcementResult struct {
+	TenantID           string                              `json:"tenant_id"`
+	WorkspaceID        string                              `json:"workspace_id"`
+	ProjectID          string                              `json:"project_id"`
+	ConnectorID        string                              `json:"connector_id,omitempty"`
+	AccountID          string                              `json:"account_id,omitempty"`
+	Region             string                              `json:"region,omitempty"`
+	ParentIssueNumber  int                                 `json:"parent_issue_number"`
+	ParentIssueRef     string                              `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                 `json:"current_issue_number"`
+	CurrentIssueRef    string                              `json:"current_issue_ref"`
+	Version            string                              `json:"version"`
+	Status             string                              `json:"status"`
+	FixtureState       string                              `json:"fixture_state,omitempty"`
+	Confidence         float64                             `json:"confidence"`
+	CalculationVersion string                              `json:"calculation_version"`
+	PolicyVersion      string                              `json:"policy_version"`
+	SafetyConfig       AWSLimitedEnforcementSafetyConfig   `json:"safety_config"`
+	AppliedFilters     map[string]string                   `json:"applied_filters"`
+	Summary            AWSLimitedEnforcementSummary        `json:"summary"`
+	Entries            []AWSLimitedEnforcementEntry        `json:"entries"`
+	Relationships      []AWSLimitedEnforcementRelationship `json:"relationships"`
+	Caveats            []string                            `json:"caveats"`
+	FailureReasons     []string                            `json:"failure_reasons"`
+	RemediationHints   []string                            `json:"remediation_hints"`
+	EvidenceLinks      []string                            `json:"evidence_links"`
+	CoverageGaps       []AWSLimitedEnforcementCoverageGap  `json:"coverage_gaps"`
+	Diagnostics        []AWSLimitedEnforcementDiagnostic   `json:"diagnostics"`
+	GeneratedAt        time.Time                           `json:"generated_at"`
+	UpdatedAt          time.Time                           `json:"updated_at"`
+}
+
+// GetAWSLimitedEnforcement projects a feature-flagged limited-enforcement
+// framework over advisory authorization (#1543) and AgentCore gateway policy
+// advisories (#1545). It is metadata-only: the endpoint records canary,
+// cohort, kill-switch, rollback, confidence, and audit state but never calls
+// IAM, STS, Organizations, Bedrock, or AgentCore write APIs.
+func (s *Service) GetAWSLimitedEnforcement(ctx context.Context, workspaceID string, projectID string, request AWSLimitedEnforcementRequest) (AWSLimitedEnforcementResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSLimitedEnforcementResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSLimitedEnforcementResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSLimitedEnforcementFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSLimitedEnforcementResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	safety := awsLimitedEnforcementSafetyConfig(request)
+
+	advisory, err := s.GetAWSAdvisoryAuthorization(ctx, workspaceID, projectID, AWSAdvisoryAuthorizationRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSLimitedEnforcementResult{}, fmt.Errorf("limited enforcement advisory authorization: %w", err)
+	}
+	agentcore, err := s.GetAWSAgentCoreGatewayPolicyAdvisory(ctx, workspaceID, projectID, AWSAgentCoreGatewayPolicyAdvisoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSLimitedEnforcementResult{}, fmt.Errorf("limited enforcement agentcore gateway policy advisory: %w", err)
+	}
+
+	entries := awsLimitedEnforcementEntries(advisory.Decisions, agentcore.Advisories, safety, request, now)
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Score == entries[j].Score {
+			return entries[i].EnforcementID < entries[j].EnforcementID
+		}
+		return entries[i].Score > entries[j].Score
+	})
+	filtered, applied := filterAWSLimitedEnforcementEntries(entries, request)
+	relationships := awsLimitedEnforcementRelationships(filtered)
+	diagnostics := awsLimitedEnforcementDiagnostics(advisory.Diagnostics, agentcore.Diagnostics)
+	status, confidence := summarizeAWSLimitedEnforcementStatus(advisory.Status, agentcore.Status, filtered, diagnostics)
+	return AWSLimitedEnforcementResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsLimitedEnforcementCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsLimitedEnforcementCurrentIssue),
+		Version:            awsLimitedEnforcementVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsLimitedEnforcementVersion,
+		PolicyVersion:      awsLimitedEnforcementPolicyID,
+		SafetyConfig:       safety,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSLimitedEnforcementEntries(entries, filtered, relationships),
+		Entries:            filtered,
+		Relationships:      relationships,
+		Caveats:            awsLimitedEnforcementCaveats(),
+		FailureReasons:     dedupeStrings(append(append([]string{}, advisory.FailureReasons...), agentcore.FailureReasons...)),
+		RemediationHints:   awsLimitedEnforcementRemediationHints(append(advisory.RemediationHints, agentcore.RemediationHints...)),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsLimitedEnforcementCurrentIssue),
+			awsIssueURL(awsAdvisoryAuthorizationCurrentIssue),
+			awsIssueURL(awsAgentCoreGatewayPolicyAdvisoryCurrentIssue),
+			"/docs/aws-limited-enforcement",
+			"/docs/aws-advisory-authorization",
+			"/docs/aws-agentcore-gateway-policy-advisory",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: awsLimitedEnforcementCoverageGaps(advisory.CoverageGaps, agentcore.CoverageGaps),
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSLimitedEnforcementFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "ready":
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsLimitedEnforcementSafetyConfig(request AWSLimitedEnforcementRequest) AWSLimitedEnforcementSafetyConfig {
+	return AWSLimitedEnforcementSafetyConfig{
+		FeatureFlagEnabled: normalizeAWSLimitedEnforcementBool(request.FeatureFlag),
+		KillSwitchEngaged:  normalizeAWSLimitedEnforcementBool(request.KillSwitch),
+		CanaryPercent:      clampAWSLimitedEnforcementCanary(request.CanaryPercent),
+		Cohort:             strings.TrimSpace(request.Cohort),
+		RollbackRequired:   true,
+		AuditRequired:      true,
+	}
+}
+
+func normalizeAWSLimitedEnforcementBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on", "enabled":
+		return true
+	}
+	return false
+}
+
+func clampAWSLimitedEnforcementCanary(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func parseAWSLimitedEnforcementCanary(value string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0
+	}
+	return clampAWSLimitedEnforcementCanary(parsed)
+}
+
+func awsLimitedEnforcementEntries(decisions []AWSAdvisoryAuthorizationDecision, advisories []AWSAgentCoreGatewayPolicyAdvisoryEntry, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest, now time.Time) []AWSLimitedEnforcementEntry {
+	entries := make([]AWSLimitedEnforcementEntry, 0, len(decisions)+len(advisories))
+	for _, decision := range decisions {
+		entries = append(entries, awsLimitedEnforcementEntryFromDecision(decision, safety, request, now))
+	}
+	for _, advisory := range advisories {
+		entries = append(entries, awsLimitedEnforcementEntryFromAgentCoreAdvisory(advisory, safety, request, now))
+	}
+	return entries
+}
+
+func awsLimitedEnforcementEntryFromDecision(decision AWSAdvisoryAuthorizationDecision, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest, now time.Time) AWSLimitedEnforcementEntry {
+	mode, state := awsLimitedEnforcementClassifyDecision(decision, safety, request)
+	enforcementID := "aws-limited-enforcement:" + stableAWSBlastRadiusToken("decision", decision.DecisionID, mode, state, safety.Cohort, fmt.Sprint(safety.CanaryPercent))
+	gates := awsLimitedEnforcementGates(mode, state, safety, decision.Confidence, decision.KillSwitchEngaged, decision.Outcome)
+	readyCanary := mode == awsLimitedEnforcementModeLimitedEnforce && awsLimitedEnforcementGatePassed(gates, "canary_configured") && !awsLimitedEnforcementHasFailedGate(gates)
+	readyEnforce := mode == awsLimitedEnforcementModeLimitedEnforce && state == awsLimitedEnforcementStateLimitedEnforceReady && !awsLimitedEnforcementHasFailedGate(gates)
+	rollback := awsLimitedEnforcementRollback("advisory_authorization", firstString(decision.EvidenceLinks), state)
+	evidence := []AWSLimitedEnforcementEvidence{{Source: "advisory_authorization", Label: decision.Outcome, EvidenceRef: firstString(decision.EvidenceLinks)}}
+	for _, item := range decision.Evidence {
+		evidence = append(evidence, AWSLimitedEnforcementEvidence(item))
+	}
+	return AWSLimitedEnforcementEntry{
+		EnforcementID:       enforcementID,
+		CalculationVersion:  awsLimitedEnforcementVersion,
+		PolicyVersion:       awsLimitedEnforcementPolicyID,
+		SourceType:          "advisory_authorization",
+		SourceID:            decision.DecisionID,
+		Mode:                mode,
+		EnforcementState:    state,
+		Outcome:             decision.Outcome,
+		Confidence:          decision.Confidence,
+		Severity:            decision.Severity,
+		Score:               decision.Score,
+		Title:               fmt.Sprintf("Limited enforcement framework: %s", decision.Title),
+		Summary:             fmt.Sprintf("Framework projection for advisory authorization decision %s. Identrail records feature flag, cohort, canary, kill-switch, rollback, and audit gates; no live AWS write API is called.", decision.DecisionID),
+		AccountID:           decision.AccountID,
+		TargetAccountIDs:    decision.TargetAccountIDs,
+		Region:              decision.Region,
+		PrincipalNodeID:     decision.PrincipalNodeID,
+		Action:              decision.Action,
+		TargetScope:         decision.ResourceScope,
+		SafetyConfig:        safety,
+		Gates:               gates,
+		Rollback:            rollback,
+		Evidence:            evidence,
+		EvidenceLinks:       dedupeStrings(append(append([]string{}, decision.EvidenceLinks...), "/docs/aws-limited-enforcement")),
+		EvidenceBoundary:    awsLimitedEnforcementEvidenceBoundary(),
+		InputHash:           stableAWSBlastRadiusToken("limited-enforcement-input", decision.InputHash.Value, mode, state, safety.Cohort, fmt.Sprint(safety.CanaryPercent), awsLimitedEnforcementPolicyID),
+		AuditTrail:          awsLimitedEnforcementAuditTrail(enforcementID, decision.DecisionID, mode, state, now),
+		ReadOnlyProjection:  true,
+		ReadyForCanary:      readyCanary,
+		ReadyForEnforcement: readyEnforce,
+		NextAction:          awsLimitedEnforcementNextAction(mode, state),
+		ProjectedAt:         now,
+		UpdatedAt:           now,
+	}
+}
+
+func awsLimitedEnforcementEntryFromAgentCoreAdvisory(advisory AWSAgentCoreGatewayPolicyAdvisoryEntry, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest, now time.Time) AWSLimitedEnforcementEntry {
+	mode, state := awsLimitedEnforcementClassifyAgentCoreAdvisory(advisory, safety, request)
+	enforcementID := "aws-limited-enforcement:" + stableAWSBlastRadiusToken("agentcore", advisory.AdvisoryID, mode, state, safety.Cohort, fmt.Sprint(safety.CanaryPercent))
+	gates := awsLimitedEnforcementGates(mode, state, safety, advisory.Confidence, false, advisory.Outcome)
+	readyCanary := mode == awsLimitedEnforcementModeLimitedEnforce && awsLimitedEnforcementGatePassed(gates, "canary_configured") && !awsLimitedEnforcementHasFailedGate(gates)
+	readyEnforce := mode == awsLimitedEnforcementModeLimitedEnforce && state == awsLimitedEnforcementStateLimitedEnforceReady && !awsLimitedEnforcementHasFailedGate(gates)
+	evidenceLinks := awsLimitedEnforcementAgentCoreEvidenceLinks(advisory)
+	evidence := []AWSLimitedEnforcementEvidence{{Source: "agentcore_gateway_policy_advisory", Label: advisory.Outcome, EvidenceRef: firstString(evidenceLinks)}}
+	for _, item := range advisory.Evidence {
+		evidence = append(evidence, AWSLimitedEnforcementEvidence{Source: item.Source, Label: item.Label, EvidenceRef: item.EvidenceRef})
+	}
+	return AWSLimitedEnforcementEntry{
+		EnforcementID:       enforcementID,
+		CalculationVersion:  awsLimitedEnforcementVersion,
+		PolicyVersion:       awsLimitedEnforcementPolicyID,
+		SourceType:          "agentcore_gateway_policy_advisory",
+		SourceID:            advisory.AdvisoryID,
+		Mode:                mode,
+		EnforcementState:    state,
+		Outcome:             advisory.Outcome,
+		Confidence:          advisory.Confidence,
+		Severity:            advisory.Severity,
+		Score:               advisory.Score,
+		Title:               fmt.Sprintf("Limited enforcement framework: %s", advisory.Title),
+		Summary:             fmt.Sprintf("Framework projection for AgentCore gateway advisory %s. Identrail records feature flag, cohort, canary, kill-switch, rollback, and audit gates; no live AgentCore or IAM write API is called.", advisory.AdvisoryID),
+		AccountID:           advisory.AccountID,
+		TargetAccountIDs:    emptyStrings([]string{advisory.AccountID}),
+		Region:              advisory.Region,
+		PrincipalNodeID:     advisory.AgentNodeID,
+		Action:              "agentcore:GatewayPolicy",
+		TargetScope:         dedupeStrings(append(append(append([]string{}, advisory.AllowedToolNames...), append(advisory.RestrictedToolNames, advisory.BlockedToolNames...)...), advisory.SensitiveResources...)),
+		SafetyConfig:        safety,
+		Gates:               gates,
+		Rollback:            awsLimitedEnforcementRollback("agentcore_gateway_policy_advisory", firstString(evidenceLinks), state),
+		Evidence:            evidence,
+		EvidenceLinks:       dedupeStrings(append(evidenceLinks, "/docs/aws-limited-enforcement")),
+		EvidenceBoundary:    awsLimitedEnforcementEvidenceBoundary(),
+		InputHash:           stableAWSBlastRadiusToken("limited-enforcement-input", advisory.InputHash.Value, mode, state, safety.Cohort, fmt.Sprint(safety.CanaryPercent), awsLimitedEnforcementPolicyID),
+		AuditTrail:          awsLimitedEnforcementAuditTrail(enforcementID, advisory.AdvisoryID, mode, state, now),
+		ReadOnlyProjection:  true,
+		ReadyForCanary:      readyCanary,
+		ReadyForEnforcement: readyEnforce,
+		NextAction:          awsLimitedEnforcementNextAction(mode, state),
+		ProjectedAt:         now,
+		UpdatedAt:           now,
+	}
+}
+
+func awsLimitedEnforcementClassifyDecision(decision AWSAdvisoryAuthorizationDecision, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest) (string, string) {
+	if safety.KillSwitchEngaged || decision.KillSwitchEngaged {
+		return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateBlockedByKillSwitch
+	}
+	switch decision.Outcome {
+	case awsAdvisoryAuthorizationOutcomeQuarantine:
+		return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateRollbackRequired
+	case awsAdvisoryAuthorizationOutcomeRequireApproval:
+		return awsLimitedEnforcementModeApprovalRequired, awsLimitedEnforcementStateApprovalRequired
+	case awsAdvisoryAuthorizationOutcomeWarn:
+		return awsLimitedEnforcementModeWarnOnly, awsLimitedEnforcementStateWarnOnly
+	case awsAdvisoryAuthorizationOutcomeRecommendDeny:
+		return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateAdvisoryOnly
+	}
+	return awsLimitedEnforcementRequestedEnforcementMode(request, safety, decision.Confidence)
+}
+
+func awsLimitedEnforcementClassifyAgentCoreAdvisory(advisory AWSAgentCoreGatewayPolicyAdvisoryEntry, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest) (string, string) {
+	if safety.KillSwitchEngaged {
+		return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateBlockedByKillSwitch
+	}
+	switch advisory.Outcome {
+	case awsAgentCoreGatewayPolicyOutcomeBlockTools:
+		return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateRollbackRequired
+	case awsAgentCoreGatewayPolicyOutcomeRequireApproval:
+		return awsLimitedEnforcementModeApprovalRequired, awsLimitedEnforcementStateApprovalRequired
+	case awsAgentCoreGatewayPolicyOutcomeWarn:
+		return awsLimitedEnforcementModeWarnOnly, awsLimitedEnforcementStateWarnOnly
+	}
+	return awsLimitedEnforcementRequestedEnforcementMode(request, safety, advisory.Confidence)
+}
+
+func awsLimitedEnforcementAgentCoreEvidenceLinks(advisory AWSAgentCoreGatewayPolicyAdvisoryEntry) []string {
+	links := []string{}
+	for _, evidence := range advisory.Evidence {
+		if strings.TrimSpace(evidence.EvidenceRef) != "" {
+			links = append(links, evidence.EvidenceRef)
+		}
+	}
+	links = append(links, "/docs/aws-agentcore-gateway-policy-advisory")
+	return dedupeStrings(links)
+}
+
+func awsLimitedEnforcementRequestedEnforcementMode(request AWSLimitedEnforcementRequest, safety AWSLimitedEnforcementSafetyConfig, confidence float64) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(request.Mode)) {
+	case awsLimitedEnforcementModeWarnOnly:
+		return awsLimitedEnforcementModeWarnOnly, awsLimitedEnforcementStateWarnOnly
+	case awsLimitedEnforcementModeApprovalRequired:
+		return awsLimitedEnforcementModeApprovalRequired, awsLimitedEnforcementStateApprovalRequired
+	case awsLimitedEnforcementModeLimitedEnforce:
+		if !safety.FeatureFlagEnabled || safety.CanaryPercent <= 0 || strings.TrimSpace(safety.Cohort) == "" || confidence < 0.8 {
+			return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateBlockedBySafetyConfig
+		}
+		if safety.CanaryPercent < 100 {
+			return awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateCanaryReady
+		}
+		return awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateLimitedEnforceReady
+	}
+	return awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateAdvisoryOnly
+}
+
+func awsLimitedEnforcementGates(mode, state string, safety AWSLimitedEnforcementSafetyConfig, confidence float64, sourceKillSwitch bool, outcome string) []AWSLimitedEnforcementGate {
+	return []AWSLimitedEnforcementGate{
+		{Name: "feature_flag_enabled", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || safety.FeatureFlagEnabled), Rationale: "Limited enforcement requires an explicit feature flag before any canary can be marked ready."},
+		{Name: "kill_switch_off", Status: awsLimitedEnforcementGateStatus(!safety.KillSwitchEngaged && !sourceKillSwitch), Rationale: "Tenant and source kill switches must be off before enforcement can leave advisory mode."},
+		{Name: "canary_configured", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || (safety.CanaryPercent > 0 && strings.TrimSpace(safety.Cohort) != "")), Rationale: "Limited enforcement requires a non-empty cohort and a canary percentage greater than zero."},
+		{Name: "rollback_ready", Status: awsLimitedEnforcementGateStatus(safety.RollbackRequired), Rationale: "Every limited-enforcement entry records rollback metadata before it can be used by a downstream executor."},
+		{Name: "audit_ready", Status: awsLimitedEnforcementGateStatus(safety.AuditRequired), Rationale: "Every mode transition must emit an immutable audit record."},
+		{Name: "confidence_floor", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || confidence >= 0.8), Rationale: "Limited enforcement requires at least 80 percent confidence in the upstream advisory signal."},
+		{Name: "unsafe_outcome_blocked", Status: awsLimitedEnforcementGateStatus(state != awsLimitedEnforcementStateRollbackRequired && state != awsLimitedEnforcementStateBlockedByKillSwitch), Rationale: fmt.Sprintf("Outcome %s cannot activate enforcement while rollback or kill-switch state is present.", outcome)},
+	}
+}
+
+func awsLimitedEnforcementGateStatus(passed bool) string {
+	if passed {
+		return "passed"
+	}
+	return "failed"
+}
+
+func awsLimitedEnforcementHasFailedGate(gates []AWSLimitedEnforcementGate) bool {
+	for _, gate := range gates {
+		if gate.Status == "failed" {
+			return true
+		}
+	}
+	return false
+}
+
+func awsLimitedEnforcementGatePassed(gates []AWSLimitedEnforcementGate, name string) bool {
+	for _, gate := range gates {
+		if gate.Name == name && gate.Status == "passed" {
+			return true
+		}
+	}
+	return false
+}
+
+func awsLimitedEnforcementRollback(sourceType, evidenceRef, state string) AWSLimitedEnforcementRollback {
+	rollbackState := "available"
+	if state == awsLimitedEnforcementStateAdvisoryOnly || state == awsLimitedEnforcementStateWarnOnly {
+		rollbackState = "not_required"
+	}
+	return AWSLimitedEnforcementRollback{
+		Strategy:    "disable_limited_enforcement_and_revert_to_advisory",
+		Steps:       []string{"Engage the tenant kill switch or set the feature flag off.", "Return the affected cohort to advisory mode.", "Refresh advisory authorization and AgentCore gateway policy evidence before re-enabling any canary."},
+		EvidenceRef: evidenceRef,
+		State:       rollbackState,
+		Rationale:   fmt.Sprintf("Rollback is metadata-only for %s; downstream executors must use the audit row and safety config before any live control change.", sourceType),
+	}
+}
+
+func awsLimitedEnforcementAuditTrail(enforcementID, sourceID, mode, state string, now time.Time) []AWSLimitedEnforcementAuditEntry {
+	return []AWSLimitedEnforcementAuditEntry{{
+		EventID:    stableAWSBlastRadiusToken("limited-enforcement-projected", enforcementID, sourceID, mode, state),
+		Actor:      "identrail-limited-enforcement-framework",
+		EventType:  "limited_enforcement_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Source=%s mode=%s state=%s policy_version=%s; Identrail did not call any AWS write API at this layer.", sourceID, mode, state, awsLimitedEnforcementPolicyID),
+	}}
+}
+
+func awsLimitedEnforcementNextAction(mode, state string) string {
+	switch state {
+	case awsLimitedEnforcementStateBlockedByKillSwitch:
+		return "Keep enforcement disabled until the kill switch is cleared and advisory evidence is refreshed."
+	case awsLimitedEnforcementStateBlockedBySafetyConfig:
+		return "Provide explicit feature flag, cohort, canary percentage, confidence, rollback, and audit config before limited enforcement can activate."
+	case awsLimitedEnforcementStateRollbackRequired:
+		return "Keep this entry out of enforcement and follow rollback or quarantine guidance from the upstream advisory."
+	case awsLimitedEnforcementStateCanaryReady:
+		return "Canary configuration is ready for a downstream executor; monitor the cohort before expanding rollout."
+	case awsLimitedEnforcementStateLimitedEnforceReady:
+		return "Safety gates are ready for limited enforcement; downstream executors still own any live control change."
+	case awsLimitedEnforcementStateApprovalRequired:
+		return "Advance operator approval before moving this decision beyond advisory governance."
+	case awsLimitedEnforcementStateWarnOnly:
+		return "Keep warn-only behavior and refresh evidence if runtime or remediation state changes."
+	}
+	if mode == awsLimitedEnforcementModeAdvisory {
+		return "Keep advisory mode until operators explicitly configure a canary and feature flag."
+	}
+	return "Inspect the limited-enforcement entry for the next action."
+}
+
+func awsLimitedEnforcementRelationships(entries []AWSLimitedEnforcementEntry) []AWSLimitedEnforcementRelationship {
+	relationships := []AWSLimitedEnforcementRelationship{}
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.SourceID)
+		if source != "" {
+			relationships = append(relationships, AWSLimitedEnforcementRelationship{
+				EnforcementID: entry.EnforcementID,
+				Type:          "derives_from_source",
+				FromNodeID:    entry.EnforcementID,
+				ToNodeID:      source,
+				EvidenceRef:   firstString(entry.EvidenceLinks),
+			})
+		}
+		if principal := strings.TrimSpace(entry.PrincipalNodeID); principal != "" {
+			relationships = append(relationships, AWSLimitedEnforcementRelationship{
+				EnforcementID: entry.EnforcementID,
+				Type:          "governs_principal",
+				FromNodeID:    entry.EnforcementID,
+				ToNodeID:      principal,
+				EvidenceRef:   firstString(entry.EvidenceLinks),
+			})
+		}
+		for _, target := range entry.TargetScope {
+			if strings.TrimSpace(target) == "" || strings.EqualFold(target, entry.PrincipalNodeID) {
+				continue
+			}
+			relationships = append(relationships, AWSLimitedEnforcementRelationship{
+				EnforcementID: entry.EnforcementID,
+				Type:          "scopes_target",
+				FromNodeID:    entry.EnforcementID,
+				ToNodeID:      target,
+				EvidenceRef:   firstString(entry.EvidenceLinks),
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSLimitedEnforcementEntries(all, filtered []AWSLimitedEnforcementEntry, relationships []AWSLimitedEnforcementRelationship) AWSLimitedEnforcementSummary {
+	summary := AWSLimitedEnforcementSummary{
+		TotalEntries:           len(all),
+		FilteredEntries:        len(filtered),
+		ModeCounts:             map[string]int{},
+		EnforcementStateCounts: map[string]int{},
+		OutcomeCounts:          map[string]int{},
+		SourceTypeCounts:       map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		summary.ModeCounts[entry.Mode]++
+		summary.EnforcementStateCounts[entry.EnforcementState]++
+		summary.OutcomeCounts[entry.Outcome]++
+		summary.SourceTypeCounts[entry.SourceType]++
+		switch entry.Mode {
+		case awsLimitedEnforcementModeWarnOnly:
+			summary.WarnOnlyCount++
+		case awsLimitedEnforcementModeAdvisory:
+			summary.AdvisoryCount++
+		case awsLimitedEnforcementModeApprovalRequired:
+			summary.ApprovalRequiredCount++
+		case awsLimitedEnforcementModeLimitedEnforce:
+			summary.LimitedEnforceCount++
+		}
+		if entry.ReadyForCanary {
+			summary.CanaryReadyCount++
+		}
+		if entry.ReadyForEnforcement {
+			summary.ReadyForEnforcementCount++
+		}
+		if entry.SafetyConfig.KillSwitchEngaged || entry.EnforcementState == awsLimitedEnforcementStateBlockedByKillSwitch {
+			summary.KillSwitchEngagedCount++
+		}
+		for _, gate := range entry.Gates {
+			if gate.Status == "failed" {
+				summary.FailedGateCount++
+			}
+		}
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSLimitedEnforcementEntries(entries []AWSLimitedEnforcementEntry, request AWSLimitedEnforcementRequest) ([]AWSLimitedEnforcementEntry, map[string]string) {
+	filters := map[string]string{
+		"account_id":        strings.TrimSpace(request.AccountID),
+		"region":            strings.TrimSpace(request.Region),
+		"mode":              normalizeAWSRuntimeEventFilterToken(request.Mode),
+		"enforcement_state": normalizeAWSRuntimeEventFilterToken(request.EnforcementState),
+		"decision_id":       strings.TrimSpace(request.DecisionID),
+		"source_type":       normalizeAWSRuntimeEventFilterToken(request.SourceType),
+		"outcome":           normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"cohort":            strings.TrimSpace(request.Cohort),
+		"search":            strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSLimitedEnforcementEntry, 0, len(entries))
+	for _, entry := range entries {
+		if filters["account_id"] != "" && !awsLimitedEnforcementAccountMatch(entry, filters["account_id"]) {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
+			continue
+		}
+		if filters["mode"] != "" && filters["mode"] != normalizeAWSRuntimeEventFilterToken(entry.Mode) {
+			continue
+		}
+		if filters["enforcement_state"] != "" && filters["enforcement_state"] != normalizeAWSRuntimeEventFilterToken(entry.EnforcementState) {
+			continue
+		}
+		if filters["decision_id"] != "" && !strings.EqualFold(filters["decision_id"], entry.SourceID) && !strings.EqualFold(filters["decision_id"], entry.EnforcementID) {
+			continue
+		}
+		if filters["source_type"] != "" && filters["source_type"] != normalizeAWSRuntimeEventFilterToken(entry.SourceType) {
+			continue
+		}
+		if filters["outcome"] != "" && filters["outcome"] != normalizeAWSRuntimeEventFilterToken(entry.Outcome) {
+			continue
+		}
+		if filters["cohort"] != "" && !strings.EqualFold(filters["cohort"], entry.SafetyConfig.Cohort) {
+			continue
+		}
+		if filters["search"] != "" && !awsLimitedEnforcementSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+func awsLimitedEnforcementAccountMatch(entry AWSLimitedEnforcementEntry, accountID string) bool {
+	if strings.EqualFold(strings.TrimSpace(entry.AccountID), strings.TrimSpace(accountID)) {
+		return true
+	}
+	for _, target := range entry.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), strings.TrimSpace(accountID)) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsLimitedEnforcementSearchMatch(entry AWSLimitedEnforcementEntry, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.EnforcementID, entry.SourceID, entry.SourceType, entry.Mode, entry.EnforcementState,
+		entry.Outcome, entry.Severity, entry.Title, entry.Summary, entry.PrincipalNodeID, entry.Action,
+		entry.SafetyConfig.Cohort, entry.Rollback.Strategy, entry.Rollback.State, entry.NextAction, entry.InputHash,
+	}
+	values = append(values, entry.TargetScope...)
+	values = append(values, entry.TargetAccountIDs...)
+	values = append(values, entry.EvidenceLinks...)
+	for _, gate := range entry.Gates {
+		values = append(values, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, evidence := range entry.Evidence {
+		values = append(values, evidence.Source, evidence.Label, evidence.EvidenceRef)
+	}
+	for _, audit := range entry.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSLimitedEnforcementStatus(advisoryStatus, agentcoreStatus string, filtered []AWSLimitedEnforcementEntry, diagnostics []AWSLimitedEnforcementDiagnostic) (string, float64) {
+	if advisoryStatus == awsPlatformDependencyStatusBlocked || agentcoreStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if advisoryStatus == awsPlatformDependencyStatusDegraded || agentcoreStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsLimitedEnforcementDiagnostics(advisory []AWSAdvisoryAuthorizationDiagnostic, agentcore []AWSAgentCoreGatewayPolicyAdvisoryDiagnostic) []AWSLimitedEnforcementDiagnostic {
+	out := []AWSLimitedEnforcementDiagnostic{}
+	for _, diagnostic := range advisory {
+		out = append(out, AWSLimitedEnforcementDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range agentcore {
+		out = append(out, AWSLimitedEnforcementDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsLimitedEnforcementCoverageGaps(advisory []AWSAdvisoryAuthorizationCoverageGap, agentcore []AWSAgentCoreGatewayPolicyAdvisoryCoverageGap) []AWSLimitedEnforcementCoverageGap {
+	out := []AWSLimitedEnforcementCoverageGap{}
+	for _, gap := range advisory {
+		out = append(out, AWSLimitedEnforcementCoverageGap(gap))
+	}
+	for _, gap := range agentcore {
+		out = append(out, AWSLimitedEnforcementCoverageGap(gap))
+	}
+	return out
+}
+
+func awsLimitedEnforcementCaveats() []string {
+	return []string{
+		"Limited enforcement framework entries are read-only projections; Identrail does not call AWS write APIs at this layer.",
+		"Limited enforcement requires explicit feature flag, cohort, canary percentage, rollback, audit, confidence, and kill-switch gates before it can be marked ready.",
+		"Warn-only, advisory, approval-required, and limited-enforce modes are represented as explicit states so unsupported or blocked paths cannot appear successful.",
+	}
+}
+
+func awsLimitedEnforcementRemediationHints(source []string) []string {
+	hints := []string{
+		"Start in warn_only or advisory mode, then enable a narrow cohort and canary only after upstream advisory and AgentCore evidence is current.",
+		"Use the tenant kill switch to return all entries to advisory-only behavior before troubleshooting failed verification or rollback signals.",
+		"Log the policy version, input hash, cohort, canary percentage, and source decision for every downstream enforcement transition.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsLimitedEnforcementEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_limited_enforcement.go
+++ b/internal/api/aws_limited_enforcement.go
@@ -320,12 +320,18 @@ func clampAWSLimitedEnforcementCanary(value int) int {
 	return value
 }
 
-func parseAWSLimitedEnforcementCanary(value string) int {
+func parseAWSLimitedEnforcementCanary(value string) (int, bool) {
+	if strings.TrimSpace(value) == "" {
+		return 0, true
+	}
 	parsed, err := strconv.Atoi(strings.TrimSpace(value))
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return clampAWSLimitedEnforcementCanary(parsed)
+	if parsed < 0 || parsed > 100 {
+		return 0, false
+	}
+	return parsed, true
 }
 
 func awsLimitedEnforcementEntries(decisions []AWSAdvisoryAuthorizationDecision, advisories []AWSAgentCoreGatewayPolicyAdvisoryEntry, safety AWSLimitedEnforcementSafetyConfig, request AWSLimitedEnforcementRequest, now time.Time) []AWSLimitedEnforcementEntry {
@@ -497,13 +503,14 @@ func awsLimitedEnforcementRequestedEnforcementMode(request AWSLimitedEnforcement
 }
 
 func awsLimitedEnforcementGates(mode, state string, safety AWSLimitedEnforcementSafetyConfig, confidence float64, sourceKillSwitch bool, outcome string) []AWSLimitedEnforcementGate {
+	requiresLimitedSafety := mode == awsLimitedEnforcementModeLimitedEnforce || state == awsLimitedEnforcementStateBlockedBySafetyConfig
 	return []AWSLimitedEnforcementGate{
-		{Name: "feature_flag_enabled", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || safety.FeatureFlagEnabled), Rationale: "Limited enforcement requires an explicit feature flag before any canary can be marked ready."},
+		{Name: "feature_flag_enabled", Status: awsLimitedEnforcementGateStatus(!requiresLimitedSafety || safety.FeatureFlagEnabled), Rationale: "Limited enforcement requires an explicit feature flag before any canary can be marked ready."},
 		{Name: "kill_switch_off", Status: awsLimitedEnforcementGateStatus(!safety.KillSwitchEngaged && !sourceKillSwitch), Rationale: "Tenant and source kill switches must be off before enforcement can leave advisory mode."},
-		{Name: "canary_configured", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || (safety.CanaryPercent > 0 && strings.TrimSpace(safety.Cohort) != "")), Rationale: "Limited enforcement requires a non-empty cohort and a canary percentage greater than zero."},
+		{Name: "canary_configured", Status: awsLimitedEnforcementGateStatus(!requiresLimitedSafety || (safety.CanaryPercent > 0 && strings.TrimSpace(safety.Cohort) != "")), Rationale: "Limited enforcement requires a non-empty cohort and a canary percentage greater than zero."},
 		{Name: "rollback_ready", Status: awsLimitedEnforcementGateStatus(safety.RollbackRequired), Rationale: "Every limited-enforcement entry records rollback metadata before it can be used by a downstream executor."},
 		{Name: "audit_ready", Status: awsLimitedEnforcementGateStatus(safety.AuditRequired), Rationale: "Every mode transition must emit an immutable audit record."},
-		{Name: "confidence_floor", Status: awsLimitedEnforcementGateStatus(mode != awsLimitedEnforcementModeLimitedEnforce || confidence >= 0.8), Rationale: "Limited enforcement requires at least 80 percent confidence in the upstream advisory signal."},
+		{Name: "confidence_floor", Status: awsLimitedEnforcementGateStatus(!requiresLimitedSafety || confidence >= 0.8), Rationale: "Limited enforcement requires at least 80 percent confidence in the upstream advisory signal."},
 		{Name: "unsafe_outcome_blocked", Status: awsLimitedEnforcementGateStatus(state != awsLimitedEnforcementStateRollbackRequired && state != awsLimitedEnforcementStateBlockedByKillSwitch), Rationale: fmt.Sprintf("Outcome %s cannot activate enforcement while rollback or kill-switch state is present.", outcome)},
 	}
 }

--- a/internal/api/aws_limited_enforcement.go
+++ b/internal/api/aws_limited_enforcement.go
@@ -705,7 +705,7 @@ func filterAWSLimitedEnforcementEntries(entries []AWSLimitedEnforcementEntry, re
 		if filters["region"] != "" && !strings.EqualFold(filters["region"], entry.Region) {
 			continue
 		}
-		if filters["mode"] != "" && filters["mode"] != normalizeAWSRuntimeEventFilterToken(entry.Mode) {
+		if filters["mode"] != "" && !awsLimitedEnforcementModeFilterMatch(entry, filters["mode"]) {
 			continue
 		}
 		if filters["enforcement_state"] != "" && filters["enforcement_state"] != normalizeAWSRuntimeEventFilterToken(entry.EnforcementState) {
@@ -729,6 +729,23 @@ func filterAWSLimitedEnforcementEntries(entries []AWSLimitedEnforcementEntry, re
 		filtered = append(filtered, entry)
 	}
 	return filtered, applied
+}
+
+func awsLimitedEnforcementModeFilterMatch(entry AWSLimitedEnforcementEntry, mode string) bool {
+	if mode == normalizeAWSRuntimeEventFilterToken(entry.Mode) {
+		return true
+	}
+	if mode != normalizeAWSRuntimeEventFilterToken(awsLimitedEnforcementModeLimitedEnforce) {
+		return false
+	}
+	switch normalizeAWSRuntimeEventFilterToken(entry.EnforcementState) {
+	case normalizeAWSRuntimeEventFilterToken(awsLimitedEnforcementStateBlockedBySafetyConfig),
+		normalizeAWSRuntimeEventFilterToken(awsLimitedEnforcementStateBlockedByKillSwitch),
+		normalizeAWSRuntimeEventFilterToken(awsLimitedEnforcementStateRollbackRequired):
+		return true
+	default:
+		return false
+	}
 }
 
 func awsLimitedEnforcementAccountMatch(entry AWSLimitedEnforcementEntry, accountID string) bool {

--- a/internal/api/aws_limited_enforcement_test.go
+++ b/internal/api/aws_limited_enforcement_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newLimitedEnforcementService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSLimitedEnforcementBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementService(t, "project-limited-enforcement", now)
+
+	result, err := svc.GetAWSLimitedEnforcement(defaultScopeContext(), ws, "project-limited-enforcement", AWSLimitedEnforcementRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get limited enforcement: %v", err)
+	}
+	if result.CurrentIssueRef != "#1546" || result.Version != awsLimitedEnforcementVersion || result.PolicyVersion != awsLimitedEnforcementPolicyID {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Entries) == 0 {
+		t.Fatalf("expected limited enforcement entries from advisory sources: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("relationship count mismatch: %+v", result.Summary)
+	}
+	for _, entry := range result.Entries {
+		if entry.EnforcementID == "" || entry.CalculationVersion != awsLimitedEnforcementVersion {
+			t.Fatalf("entry missing stable metadata: %+v", entry)
+		}
+		if entry.PolicyVersion != awsLimitedEnforcementPolicyID || strings.TrimSpace(entry.InputHash) == "" {
+			t.Fatalf("entry missing policy/hash metadata: %+v", entry)
+		}
+		if !entry.ReadOnlyProjection || entry.ReadyForEnforcement {
+			t.Fatalf("default framework must stay read-only advisory unless safety config is explicit: %+v", entry)
+		}
+		if entry.EvidenceBoundary != awsLimitedEnforcementEvidenceBoundary() {
+			t.Fatalf("entry crossed evidence boundary: %+v", entry)
+		}
+		if len(entry.Gates) == 0 || len(entry.AuditTrail) == 0 || entry.Rollback.Strategy == "" {
+			t.Fatalf("entry missing gates/audit/rollback: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\"", "\"prompt\"", "\"completion\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("limited enforcement serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSLimitedEnforcementRequiresExplicitSafetyConfig(t *testing.T) {
+	decision := AWSAdvisoryAuthorizationDecision{
+		DecisionID:         "decision-1",
+		Outcome:            awsAdvisoryAuthorizationOutcomeAllow,
+		Confidence:         0.9,
+		Score:              80,
+		SourceType:         "advisory_authorization",
+		InputHash:          AWSAdvisoryAuthorizationInputHash{Value: "input-a"},
+		ReadOnlyProjection: true,
+	}
+	safety := AWSLimitedEnforcementSafetyConfig{RollbackRequired: true, AuditRequired: true}
+	entry := awsLimitedEnforcementEntryFromDecision(decision, safety, AWSLimitedEnforcementRequest{Mode: awsLimitedEnforcementModeLimitedEnforce}, time.Now().UTC())
+	if entry.Mode != awsLimitedEnforcementModeAdvisory || entry.EnforcementState != awsLimitedEnforcementStateBlockedBySafetyConfig || entry.ReadyForEnforcement {
+		t.Fatalf("missing safety config must block limited enforcement: %+v", entry)
+	}
+
+	safety.FeatureFlagEnabled = true
+	safety.CanaryPercent = 10
+	safety.Cohort = "pilot-a"
+	entry = awsLimitedEnforcementEntryFromDecision(decision, safety, AWSLimitedEnforcementRequest{Mode: awsLimitedEnforcementModeLimitedEnforce}, time.Now().UTC())
+	if entry.Mode != awsLimitedEnforcementModeLimitedEnforce || entry.EnforcementState != awsLimitedEnforcementStateCanaryReady || !entry.ReadyForCanary || entry.ReadyForEnforcement {
+		t.Fatalf("partial canary config should be canary-ready only: %+v", entry)
+	}
+
+	safety.CanaryPercent = 100
+	entry = awsLimitedEnforcementEntryFromDecision(decision, safety, AWSLimitedEnforcementRequest{Mode: awsLimitedEnforcementModeLimitedEnforce}, time.Now().UTC())
+	if entry.EnforcementState != awsLimitedEnforcementStateLimitedEnforceReady || !entry.ReadyForEnforcement {
+		t.Fatalf("complete safety config should mark enforcement ready: %+v", entry)
+	}
+}
+
+func TestAWSLimitedEnforcementKillSwitchWins(t *testing.T) {
+	decision := AWSAdvisoryAuthorizationDecision{
+		DecisionID: "decision-kill",
+		Outcome:    awsAdvisoryAuthorizationOutcomeAllow,
+		Confidence: 0.95,
+		Score:      90,
+		InputHash:  AWSAdvisoryAuthorizationInputHash{Value: "input-kill"},
+	}
+	safety := AWSLimitedEnforcementSafetyConfig{
+		FeatureFlagEnabled: true,
+		KillSwitchEngaged:  true,
+		CanaryPercent:      100,
+		Cohort:             "pilot-a",
+		RollbackRequired:   true,
+		AuditRequired:      true,
+	}
+	entry := awsLimitedEnforcementEntryFromDecision(decision, safety, AWSLimitedEnforcementRequest{Mode: awsLimitedEnforcementModeLimitedEnforce}, time.Now().UTC())
+	if entry.EnforcementState != awsLimitedEnforcementStateBlockedByKillSwitch || entry.ReadyForCanary || entry.ReadyForEnforcement {
+		t.Fatalf("kill switch must block canary and enforcement readiness: %+v", entry)
+	}
+}
+
+func TestAWSLimitedEnforcementFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementService(t, "project-limited-enforcement-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSLimitedEnforcement(defaultScopeContext(), ws, "project-limited-enforcement-fixture", AWSLimitedEnforcementRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestRouterAWSLimitedEnforcement(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	svc, _ := newLimitedEnforcementService(t, "project-limited-enforcement-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-route/aws/limited-enforcement?connector_id=aws-prod&fixture_state=success&mode=limited_enforce&feature_flag=true&canary_percent=25&cohort=pilot-a", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Framework AWSLimitedEnforcementResult `json:"limited_enforcement"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Framework.CurrentIssueRef != "#1546" || body.Framework.PolicyVersion != awsLimitedEnforcementPolicyID {
+		t.Fatalf("unexpected route payload: %+v", body.Framework)
+	}
+	if body.Framework.SafetyConfig.CanaryPercent != 25 || body.Framework.SafetyConfig.Cohort != "pilot-a" || !body.Framework.SafetyConfig.FeatureFlagEnabled {
+		t.Fatalf("route did not preserve safety config: %+v", body.Framework.SafetyConfig)
+	}
+}

--- a/internal/api/aws_limited_enforcement_test.go
+++ b/internal/api/aws_limited_enforcement_test.go
@@ -81,6 +81,11 @@ func TestAWSLimitedEnforcementRequiresExplicitSafetyConfig(t *testing.T) {
 	if entry.Mode != awsLimitedEnforcementModeAdvisory || entry.EnforcementState != awsLimitedEnforcementStateBlockedBySafetyConfig || entry.ReadyForEnforcement {
 		t.Fatalf("missing safety config must block limited enforcement: %+v", entry)
 	}
+	for _, gateName := range []string{"feature_flag_enabled", "canary_configured"} {
+		if got := awsLimitedEnforcementTestGateStatus(entry.Gates, gateName); got != "failed" {
+			t.Fatalf("%s gate must report failed when safety config blocks enforcement, got %s gates=%+v", gateName, got, entry.Gates)
+		}
+	}
 
 	safety.FeatureFlagEnabled = true
 	safety.CanaryPercent = 10
@@ -161,4 +166,26 @@ func TestRouterAWSLimitedEnforcement(t *testing.T) {
 	if body.Framework.SafetyConfig.CanaryPercent != 25 || body.Framework.SafetyConfig.Cohort != "pilot-a" || !body.Framework.SafetyConfig.FeatureFlagEnabled {
 		t.Fatalf("route did not preserve safety config: %+v", body.Framework.SafetyConfig)
 	}
+}
+
+func TestRouterAWSLimitedEnforcementRejectsInvalidCanaryPercent(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 30, 0, 0, time.UTC)
+	svc, _ := newLimitedEnforcementService(t, "project-limited-enforcement-bad-canary", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	for _, raw := range []string{"not-a-number", "-1", "101"} {
+		resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-bad-canary/aws/limited-enforcement?connector_id=aws-prod&fixture_state=success&canary_percent="+raw, "")
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("%s: expected 400 for invalid canary_percent, got %d body=%s", raw, resp.Code, resp.Body.String())
+		}
+	}
+}
+
+func awsLimitedEnforcementTestGateStatus(gates []AWSLimitedEnforcementGate, name string) string {
+	for _, gate := range gates {
+		if gate.Name == name {
+			return gate.Status
+		}
+	}
+	return ""
 }

--- a/internal/api/aws_limited_enforcement_test.go
+++ b/internal/api/aws_limited_enforcement_test.go
@@ -168,6 +168,44 @@ func TestRouterAWSLimitedEnforcement(t *testing.T) {
 	}
 }
 
+func TestRouterAWSLimitedEnforcementPreservesBlockedLimitedEnforceEntries(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 15, 0, 0, time.UTC)
+	svc, _ := newLimitedEnforcementService(t, "project-limited-enforcement-blocked-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-blocked-route/aws/limited-enforcement?connector_id=aws-prod&fixture_state=success&mode=limited_enforce", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Framework AWSLimitedEnforcementResult `json:"limited_enforcement"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Framework.Entries) == 0 {
+		t.Fatalf("mode=limited_enforce must preserve blocked entries so operators can see failed gates: %+v", body.Framework.Summary)
+	}
+	foundBlocked := false
+	for _, entry := range body.Framework.Entries {
+		if entry.EnforcementState != awsLimitedEnforcementStateBlockedBySafetyConfig {
+			continue
+		}
+		foundBlocked = true
+		if entry.Mode != awsLimitedEnforcementModeAdvisory {
+			t.Fatalf("blocked safety entry should remain advisory output mode: %+v", entry)
+		}
+		for _, gateName := range []string{"feature_flag_enabled", "canary_configured"} {
+			if got := awsLimitedEnforcementTestGateStatus(entry.Gates, gateName); got != "failed" {
+				t.Fatalf("%s gate must explain why limited enforcement is blocked, got %s entry=%+v", gateName, got, entry)
+			}
+		}
+	}
+	if !foundBlocked {
+		t.Fatalf("expected at least one blocked_by_safety_config entry for missing safety config: %+v", body.Framework.Entries)
+	}
+}
+
 func TestRouterAWSLimitedEnforcementRejectsInvalidCanaryPercent(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 30, 0, 0, time.UTC)
 	svc, _ := newLimitedEnforcementService(t, "project-limited-enforcement-bad-canary", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3357,6 +3357,11 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			tenancyServiceUnavailable(c)
 			return
 		}
+		canaryPercent, canaryOK := parseAWSLimitedEnforcementCanary(c.Query("canary_percent"))
+		if !canaryOK {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws limited enforcement request"})
+			return
+		}
 		record, err := svc.GetAWSLimitedEnforcement(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSLimitedEnforcementRequest{
 			ConnectorID:      strings.TrimSpace(c.Query("connector_id")),
 			FixtureState:     strings.TrimSpace(c.Query("fixture_state")),
@@ -3370,7 +3375,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			Cohort:           strings.TrimSpace(c.Query("cohort")),
 			FeatureFlag:      strings.TrimSpace(c.Query("feature_flag")),
 			KillSwitch:       strings.TrimSpace(c.Query("kill_switch")),
-			CanaryPercent:    parseAWSLimitedEnforcementCanary(c.Query("canary_percent")),
+			CanaryPercent:    canaryPercent,
 			Search:           strings.TrimSpace(c.Query("search")),
 		})
 		if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3352,6 +3352,46 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"advisory_authorization": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSLimitedEnforcement(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSLimitedEnforcementRequest{
+			ConnectorID:      strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:     strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:        strings.TrimSpace(c.Query("account_id")),
+			Region:           strings.TrimSpace(c.Query("region")),
+			Mode:             strings.TrimSpace(c.Query("mode")),
+			EnforcementState: strings.TrimSpace(c.Query("enforcement_state")),
+			DecisionID:       strings.TrimSpace(c.Query("decision_id")),
+			SourceType:       strings.TrimSpace(c.Query("source_type")),
+			Outcome:          strings.TrimSpace(c.Query("outcome")),
+			Cohort:           strings.TrimSpace(c.Query("cohort")),
+			FeatureFlag:      strings.TrimSpace(c.Query("feature_flag")),
+			KillSwitch:       strings.TrimSpace(c.Query("kill_switch")),
+			CanaryPercent:    parseAWSLimitedEnforcementCanary(c.Query("canary_percent")),
+			Search:           strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws limited enforcement request"})
+			default:
+				logger.Error("get aws limited enforcement",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws limited enforcement"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"limited_enforcement": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -2244,6 +2244,50 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS limited enforcement framework with scoped headers and safety filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ limited_enforcement: { status: 'ready', entries: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectLimitedEnforcement(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'partial_failure',
+        accountID: '111111111111',
+        region: 'us-east-1',
+        mode: 'limited_enforce',
+        enforcementState: 'canary_ready',
+        decisionID: 'decision/a',
+        sourceType: 'advisory_authorization',
+        outcome: 'allow',
+        cohort: 'pilot-a',
+        featureFlag: true,
+        killSwitch: false,
+        canaryPercent: 25,
+        search: 'payments gateway'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/limited-enforcement?connector_id=aws-prod&fixture_state=partial_failure&account_id=111111111111&region=us-east-1&mode=limited_enforce&enforcement_state=canary_ready&decision_id=decision%2Fa&source_type=advisory_authorization&outcome=allow&cohort=pilot-a&feature_flag=true&kill_switch=false&canary_percent=25&search=payments+gateway'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS AgentCore gateway policy advisory with scoped headers and filters', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4018,6 +4018,162 @@ export type AWSAdvisoryAuthorizationQuery = {
   search?: string;
 };
 
+export type AWSLimitedEnforcementStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSLimitedEnforcementFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSLimitedEnforcementMode = 'warn_only' | 'advisory' | 'approval_required' | 'limited_enforce' | string;
+export type AWSLimitedEnforcementState =
+  | 'warn_only'
+  | 'advisory_only'
+  | 'approval_required'
+  | 'canary_ready'
+  | 'limited_enforce_ready'
+  | 'blocked_by_safety_config'
+  | 'blocked_by_kill_switch'
+  | 'rollback_required'
+  | string;
+
+export type AWSLimitedEnforcementSafetyConfig = {
+  feature_flag_enabled: boolean;
+  kill_switch_engaged: boolean;
+  canary_percent: number;
+  cohort?: string;
+  rollback_required: boolean;
+  audit_required: boolean;
+};
+
+export type AWSLimitedEnforcementGate = {
+  name: string;
+  status: string;
+  rationale: string;
+};
+
+export type AWSLimitedEnforcementEvidence = {
+  source: string;
+  label: string;
+  evidence_ref?: string;
+};
+
+export type AWSLimitedEnforcementRollback = {
+  strategy: string;
+  steps: string[];
+  evidence_ref?: string;
+  state: string;
+  rationale: string;
+};
+
+export type AWSLimitedEnforcementRelationship = {
+  enforcement_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSLimitedEnforcementEntry = {
+  enforcement_id: string;
+  calculation_version: string;
+  policy_version: string;
+  source_type: string;
+  source_id: string;
+  mode: AWSLimitedEnforcementMode;
+  enforcement_state: AWSLimitedEnforcementState;
+  outcome: string;
+  confidence: number;
+  severity: string;
+  score: number;
+  title: string;
+  summary: string;
+  account_id?: string;
+  target_account_ids?: string[];
+  region?: string;
+  principal_node_id?: string;
+  action?: string;
+  target_scope?: string[];
+  safety_config: AWSLimitedEnforcementSafetyConfig;
+  gates: AWSLimitedEnforcementGate[];
+  rollback: AWSLimitedEnforcementRollback;
+  evidence: AWSLimitedEnforcementEvidence[];
+  evidence_links: string[];
+  evidence_boundary: string;
+  input_hash: string;
+  audit_trail: AWSRemediationAuditEntry[];
+  read_only_projection: boolean;
+  ready_for_canary: boolean;
+  ready_for_enforcement: boolean;
+  next_action: string;
+  projected_at: string;
+  updated_at: string;
+};
+
+export type AWSLimitedEnforcementSummary = {
+  total_entries: number;
+  filtered_entries: number;
+  mode_counts: Record<string, number>;
+  enforcement_state_counts: Record<string, number>;
+  outcome_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  warn_only_count: number;
+  advisory_count: number;
+  approval_required_count: number;
+  limited_enforce_count: number;
+  canary_ready_count: number;
+  ready_for_enforcement_count: number;
+  kill_switch_engaged_count: number;
+  failed_gate_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSLimitedEnforcementResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSLimitedEnforcementStatus;
+  fixture_state?: AWSLimitedEnforcementFixtureState;
+  confidence: number;
+  calculation_version: string;
+  policy_version: string;
+  safety_config: AWSLimitedEnforcementSafetyConfig;
+  applied_filters: Record<string, string>;
+  summary: AWSLimitedEnforcementSummary;
+  entries: AWSLimitedEnforcementEntry[];
+  relationships: AWSLimitedEnforcementRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSLimitedEnforcementQuery = {
+  connectorID?: string;
+  fixtureState?: AWSLimitedEnforcementFixtureState;
+  accountID?: string;
+  region?: string;
+  mode?: string;
+  enforcementState?: string;
+  decisionID?: string;
+  sourceType?: string;
+  outcome?: string;
+  cohort?: string;
+  featureFlag?: boolean;
+  killSwitch?: boolean;
+  canaryPercent?: number;
+  search?: string;
+};
+
 export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
@@ -9615,6 +9771,32 @@ export const apiClient = {
         source_type: query?.sourceType,
         case_id: query?.caseID,
         verification_id: query?.verificationID,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectLimitedEnforcement(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSLimitedEnforcementQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ limited_enforcement: AWSLimitedEnforcementResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/limited-enforcement${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        mode: query?.mode,
+        enforcement_state: query?.enforcementState,
+        decision_id: query?.decisionID,
+        source_type: query?.sourceType,
+        outcome: query?.outcome,
+        cohort: query?.cohort,
+        feature_flag: query?.featureFlag,
+        kill_switch: query?.killSwitch,
+        canary_percent: query?.canaryPercent,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4886,6 +4886,138 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('shows AWS limited enforcement framework on the governance route', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getLimitedEnforcement = vi.spyOn(api.apiClient, 'getAWSProjectLimitedEnforcement').mockResolvedValue({
+      limited_enforcement: {
+        status: 'ready',
+        policy_version: 'aws-limited-enforcement-policy-v1',
+        safety_config: {
+          feature_flag_enabled: true,
+          kill_switch_engaged: false,
+          canary_percent: 25,
+          cohort: 'pilot-a',
+          rollback_required: true,
+          audit_required: true
+        },
+        entries: [
+          {
+            enforcement_id: 'aws-limited-enforcement:orders',
+            calculation_version: 'aws-limited-enforcement-v1',
+            policy_version: 'aws-limited-enforcement-policy-v1',
+            source_type: 'advisory_authorization',
+            source_id: 'aws-advisory-authorization:orders',
+            mode: 'limited_enforce',
+            enforcement_state: 'canary_ready',
+            outcome: 'allow',
+            confidence: 0.9,
+            severity: 'high',
+            score: 80,
+            title: 'Limited enforcement framework: orders deployer',
+            summary: 'Canary-ready limited enforcement framework projection.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            principal_node_id: 'aws:identity:orders-deployer',
+            action: 'iam:PutRolePolicy',
+            target_scope: ['aws:identity:orders-deployer'],
+            safety_config: {
+              feature_flag_enabled: true,
+              kill_switch_engaged: false,
+              canary_percent: 25,
+              cohort: 'pilot-a',
+              rollback_required: true,
+              audit_required: true
+            },
+            gates: [
+              { name: 'feature_flag_enabled', status: 'passed', rationale: 'Feature flag is enabled.' },
+              { name: 'canary_configured', status: 'passed', rationale: 'Pilot cohort is scoped.' }
+            ],
+            rollback: {
+              strategy: 'disable_limited_enforcement_and_revert_to_advisory',
+              steps: ['Disable feature flag.'],
+              state: 'available',
+              rationale: 'Rollback remains available.'
+            },
+            evidence: [],
+            evidence_links: ['/docs/aws-limited-enforcement'],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            input_hash: 'hash-a',
+            audit_trail: [],
+            read_only_projection: true,
+            ready_for_canary: true,
+            ready_for_enforcement: false,
+            next_action: 'Monitor the canary.',
+            projected_at: '2026-07-03T10:00:00Z',
+            updated_at: '2026-07-03T10:00:00Z'
+          }
+        ],
+        relationships: [],
+        applied_filters: {},
+        summary: {
+          total_entries: 1,
+          filtered_entries: 1,
+          mode_counts: { limited_enforce: 1 },
+          enforcement_state_counts: { canary_ready: 1 },
+          outcome_counts: { allow: 1 },
+          source_type_counts: { advisory_authorization: 1 },
+          warn_only_count: 0,
+          advisory_count: 0,
+          approval_required_count: 0,
+          limited_enforce_count: 1,
+          canary_ready_count: 1,
+          ready_for_enforcement_count: 0,
+          kill_switch_engaged_count: 0,
+          failed_gate_count: 0,
+          relationship_count: 0,
+          highest_score: 80,
+          average_confidence_pct: 90
+        },
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
+
+    const { ProductAWSGovernancePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/governance?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/governance" element={<ProductAWSGovernancePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Governance' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS limited enforcement framework entries' })).toBeInTheDocument();
+    expect(screen.getByText(/Limited enforcement framework: orders deployer/i)).toBeInTheDocument();
+    expect(screen.getByText(/pilot-a/i)).toBeInTheDocument();
+    expect(getLimitedEnforcement).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+  });
+
   it('passes AWS findings filters to secret-permission equivalence queries', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -85,6 +85,8 @@ import {
   type AWSPostRemediationVerificationResult,
   type AWSAdvisoryAuthorizationDecision,
   type AWSAdvisoryAuthorizationResult,
+  type AWSLimitedEnforcementEntry,
+  type AWSLimitedEnforcementResult,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
   type AWSAgentCoreGatewayPolicyAdvisoryEntry,
@@ -11451,6 +11453,82 @@ function AWSAdvisoryAuthorizationContent({
   );
 }
 
+function awsLimitedEnforcementStage(entry: AWSLimitedEnforcementEntry): AWSCapabilityStage {
+  if (entry.enforcement_state === 'blocked_by_kill_switch' || entry.enforcement_state === 'rollback_required') {
+    return 'not-available';
+  }
+  if (entry.ready_for_enforcement || entry.ready_for_canary) {
+    return 'wired';
+  }
+  if (entry.enforcement_state === 'blocked_by_safety_config' || entry.mode === 'approval_required') {
+    return 'coming';
+  }
+  return 'coming';
+}
+
+function awsLimitedEnforcementGateLabel(entry: AWSLimitedEnforcementEntry): string {
+  const failed = entry.gates.filter((gate) => gate.status === 'failed').length;
+  return `${entry.gates.length - failed}/${entry.gates.length} gates`;
+}
+
+function AWSLimitedEnforcementContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSLimitedEnforcementResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_entries} total · ${result.summary.warn_only_count} warn-only · ${result.summary.advisory_count} advisory · ${result.summary.approval_required_count} approval · ${result.summary.canary_ready_count} canary-ready · ${result.summary.kill_switch_engaged_count} kill switch`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.entries,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <AWSExecutorProjectionPanel<AWSLimitedEnforcementEntry>
+      result={panelResult}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS limited enforcement framework"
+      heading="AWS limited enforcement framework"
+      description={`Feature-flagged framework that joins advisory authorization and AgentCore gateway policy signals with explicit canary, cohort, kill-switch, rollback, confidence, and audit gates. Identrail never enforces the projection at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS limited enforcement framework"
+      loadingTitle="Projecting limited enforcement framework"
+      loadingBody="Identrail is joining advisory decisions with safety config, canary, rollback, and audit gates."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No enforcement entries')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Limited enforcement needs advisory evidence' : 'No limited enforcement framework entries projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No advisory authorization or AgentCore gateway policy signal was available for this environment.'}
+      tableLabel="AWS limited enforcement framework entries"
+      getRowKey={(row) => row.enforcement_id}
+      columns={[
+        { key: 'entry', header: 'Entry', render: (row) => <strong>{row.title}</strong> },
+        { key: 'mode', header: 'Mode', render: (row) => formatTokenLabel(row.mode) },
+        { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+        { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.enforcement_state) },
+        { key: 'cohort', header: 'Cohort', render: (row) => row.safety_config.cohort ?? 'none' },
+        { key: 'gates', header: 'Gates', render: (row) => awsLimitedEnforcementGateLabel(row) },
+        {
+          key: 'readiness',
+          header: 'Readiness',
+          render: (row) => (
+            <AWSInventoryPill stage={awsLimitedEnforcementStage(row)} label={`${formatTokenLabel(row.outcome)} / ${row.safety_config.canary_percent}%`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSessionPolicyRecommendationStage(entry: AWSSessionPolicyRecommendationEntry): AWSCapabilityStage {
   if (entry.decision === 'remove' && entry.expected_behavior.observed_action_count > 0) {
     return 'wired';
@@ -13826,6 +13904,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [advisoryAuthorizationLoading, setAdvisoryAuthorizationLoading] = useState(false);
   const [advisoryAuthorizationError, setAdvisoryAuthorizationError] = useState('');
   const advisoryAuthorizationRequestRef = useRef(0);
+  const [limitedEnforcement, setLimitedEnforcement] = useState<AWSLimitedEnforcementResult | null>(null);
+  const [limitedEnforcementLoading, setLimitedEnforcementLoading] = useState(false);
+  const [limitedEnforcementError, setLimitedEnforcementError] = useState('');
+  const limitedEnforcementRequestRef = useRef(0);
   const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
@@ -14530,6 +14612,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       advisoryAuthorizationRequestRef.current += 1;
     };
   }, [loadAdvisoryAuthorization]);
+
+  const loadLimitedEnforcement = useCallback(async () => {
+    const requestID = ++limitedEnforcementRequestRef.current;
+    setLimitedEnforcement(null);
+    setLimitedEnforcementError('');
+    if (routeID !== 'governance' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setLimitedEnforcementLoading(false);
+      return;
+    }
+    setLimitedEnforcementLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectLimitedEnforcement(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== limitedEnforcementRequestRef.current) {
+        return;
+      }
+      setLimitedEnforcement(response.limited_enforcement);
+    } catch (error) {
+      if (requestID !== limitedEnforcementRequestRef.current) {
+        return;
+      }
+      setLimitedEnforcementError(formatAPIError(error, 'Unable to load AWS limited enforcement framework.'));
+    } finally {
+      if (requestID === limitedEnforcementRequestRef.current) {
+        setLimitedEnforcementLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadLimitedEnforcement();
+    return () => {
+      limitedEnforcementRequestRef.current += 1;
+    };
+  }, [loadLimitedEnforcement]);
 
   const loadSessionPolicyRecommendations = useCallback(async () => {
     const requestID = ++sessionPolicyRecommendationsRequestRef.current;
@@ -15645,6 +15775,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         ) : null}
         {routeID === 'governance' ? (
           <AWSGovernanceContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+        ) : null}
+        {routeID === 'governance' ? (
+          <AWSLimitedEnforcementContent
+            result={limitedEnforcement}
+            loading={limitedEnforcementLoading}
+            error={limitedEnforcementError}
+            onRetry={loadLimitedEnforcement}
+          />
         ) : null}
       </div>
     </DomainPageShell>


### PR DESCRIPTION
## Summary
- Add the AWS limited enforcement framework endpoint for issue #1546, joining advisory authorization and AgentCore gateway policy advisory signals into explicit warn-only, advisory, approval-required, and limited-enforce modes.
- Require explicit safety config before limited enforcement can become ready: feature flag, cohort, canary percentage, kill switch off, rollback metadata, audit metadata, and confidence gates.
- Surface the framework in the AWS Governance app path with mode, source, state, cohort, gates, outcome, and canary readiness, plus typed client/OpenAPI/docs coverage.

## Safety
- Metadata-only projection; no IAM, STS, Organizations, Bedrock, or AgentCore write APIs are called.
- No rendered policy bodies, secret values, prompts, completions, object contents, database rows, or workload payloads are collected or returned.
- Unknown, permission-denied, kill-switch, rollback, and missing-safety-config states remain explicit and do not appear as successful enforcement.

## Validation
- `go test ./internal/api -run 'TestGetAWSLimitedEnforcement|TestAWSLimitedEnforcement|TestRouterAWSLimitedEnforcement'`
- `go test ./internal/api`
- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx`
- `npm run build`
- `git diff --check`

AI disclosure: No

Closes #1546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS limited enforcement framework with a new GET endpoint and a Governance panel; tightens safety validation and ensures limited_enforce mode still shows blocked entries so operators can see failed gates. Implements #1546.

- **New Features**
  - API: `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement` with filters for connector, fixture state, account, region, mode, enforcement state, decision/advisory ID, source type, outcome, cohort, feature flag, kill switch, canary percent, and search; validates `canary_percent` (0–100) and returns 400 on invalid input.
  - AuthZ/Spec: Route registered with project tenancy read; OpenAPI v1 updated; result and entry schemas typed.
  - App: AWS Governance page shows an “AWS limited enforcement framework” panel with mode, state, cohort, gate readiness, outcome, and canary percentage.
  - Safety: Requires explicit feature flag, cohort, canary, rollback and audit metadata, and confidence floor (>=0.8); kill switch always blocks canary/enforcement readiness; states like blocked-by-safety-config, blocked-by-kill-switch, and rollback-required remain explicit; no AWS or AgentCore write APIs are called.
  - Behavior: When `mode=limited_enforce` is requested, results include entries in `blocked_by_safety_config`, `blocked_by_kill_switch`, and `rollback_required` so failed gates remain visible.
  - Tooling: New `docs/aws-limited-enforcement.md`; typed web client `apiClient.getAWSProjectLimitedEnforcement`; tests for validation, gating, routing, and preserving blocked results; changelog entry.

<sup>Written for commit 8e4823a96d5d563747d8a3cd1a695b7d16643106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

