### PR TITLE
Implement AWS high-confidence limited enforcement pilot (#1547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
 ## Unreleased
+- Add **AWS high-confidence limited enforcement pilot** (#1547). Adds
+  the pilot path over the limited enforcement framework (#1546): every
+  framework entry is evaluated against a stricter, high-confidence-only
+  eligibility rule set (limited-enforce mode, confidence >= 90 percent,
+  every framework gate passed, canary percent within the 25 percent
+  pilot cap, kill switch off, no operator hold) and survivors are
+  marked `pilot_canary_ready` or `pilot_enforce_ready`; everything else
+  is an explicit `ineligible`, `override_hold`, or
+  `blocked_by_kill_switch` state whose rationale names the first failed
+  rule. Every decision carries deterministic rollback thresholds
+  (1 percent denial-regression budget, 24h observation window,
+  kill-switch and operator-override halts), per-decision metrics
+  (eligibility rules and framework gates passed/total, confidence and
+  canary percent), a drift-detecting input hash, and an immutable
+  audit row. `operator_override=hold|pause` pauses every pilot decision
+  and unknown override values are rejected so a typo can never silently
+  resume a held pilot. Adds
+  `GET /v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot`
+  with safety-config passthrough (feature flag, kill switch, cohort,
+  canary percent) plus filters for account, region, pilot state, source
+  type, outcome, enforcement ID, severity, and free-text search.
+  OpenAPI schemas and authz wiring follow the neighboring wave-9
+  endpoints. The AWS Governance app surface now shows an **AWS limited
+  enforcement pilot** panel below the framework panel with the decision
+  title, source, pilot state, eligibility rule counts, confidence, and
+  readiness pill. Identrail never calls AWS write APIs at this layer;
+  downstream executors own any live control change.
 - Add **AWS limited enforcement framework** (#1546). Adds a
   metadata-only governance projection that joins advisory authorization
   decisions (#1543) and AgentCore gateway policy advisories (#1545) with

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
 - AWS advisory authorization decision API: `aws-advisory-authorization.md`
 - AWS limited enforcement framework: `aws-limited-enforcement.md`
+- AWS high-confidence limited enforcement pilot: `aws-limited-enforcement-pilot.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`

--- a/docs/aws-limited-enforcement-pilot.md
+++ b/docs/aws-limited-enforcement-pilot.md
@@ -1,0 +1,101 @@
+# AWS high-confidence limited enforcement pilot
+
+Issue #1547 adds the pilot path over the limited enforcement framework
+(#1546). The pilot evaluates every framework entry against a stricter,
+high-confidence-only rule set and marks the survivors pilot-ready for a
+downstream executor. Everything else is an explicit `ineligible`,
+`override_hold`, or `blocked_by_kill_switch` state.
+
+The endpoint is metadata-only. Identrail never calls AWS write APIs at
+this layer; downstream executors own any live control change.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement-pilot`
+
+Response shape:
+`{ "limited_enforcement_pilot": AWSLimitedEnforcementPilotResult }`.
+
+Safety config (`feature_flag`, `kill_switch`, `cohort`, `canary_percent`)
+is forwarded to the framework so the pilot evaluates the operator's
+explicit configuration; the pilot always requests the framework in
+`limited_enforce` mode. `operator_override=hold|pause` holds every pilot
+decision; unknown override values are rejected with a 400 so a typo can
+never silently resume a held pilot.
+
+Filters: `account_id`, `region`, `pilot_state`, `source_type`, `outcome`,
+`enforcement_id`, `severity`, and `search`.
+
+## Eligibility rules
+
+Every framework entry is evaluated against the full rule set; the first
+failed rule is named in the decision's rationale:
+
+1. `limited_enforce_mode` — the entry reached limited-enforce mode with
+   explicit safety config.
+2. `high_confidence` — upstream confidence >= 90 percent (stricter than
+   the framework's 80 percent gate).
+3. `framework_gates_passed` — every framework gate passed.
+4. `canary_within_pilot_cap` — canary percent is greater than zero and at
+   most 25 percent; broader rollout belongs to a later wave.
+5. `kill_switch_off` — tenant kill switch is off and the entry is not
+   kill-switch blocked.
+6. `operator_override_clear` — no operator hold is active.
+
+## Pilot states
+
+- `pilot_canary_ready`: every rule passed; the entry is enrolled in the
+  pilot canary cohort.
+- `pilot_enforce_ready`: every rule passed and the framework entry is
+  limited-enforce ready within the pilot cap.
+- `ineligible`: at least one eligibility rule failed; the rationale names
+  the rule.
+- `override_hold`: an operator hold pauses the decision until explicitly
+  resumed.
+- `blocked_by_kill_switch`: the tenant kill switch removes every entry
+  from the pilot.
+
+Safety controls order above eligibility: kill switch first, then operator
+hold, then the rule set.
+
+## Rollback thresholds
+
+Every decision carries the deterministic rollback contract a downstream
+executor must honor:
+
+- `max_denial_regression_pct: 1` — auto-rollback the canary when denial
+  regressions exceed 1 percent of canary traffic.
+- `observation_window: 24h` — the canary must hold for the window before
+  expansion.
+- `auto_rollback_on_kill_switch: true` and
+  `operator_override_halts_pilot: true` — either control halts the pilot
+  immediately.
+
+## Metrics and audit
+
+Each decision records deterministic counters (eligibility rules
+passed/total, framework gates passed/total, confidence percent, canary
+percent) and an immutable `limited_enforcement_pilot_projected` audit row
+carrying the enforcement ID, pilot state, override, and policy version.
+The input hash covers the framework entry's input hash, pilot state,
+override, canary percent, cohort, and pilot policy version so operators
+can detect drift.
+
+## Safety, evidence, and out of scope
+
+- Metadata-only projection; no IAM, STS, Organizations, Bedrock, or
+  AgentCore write APIs are called at this layer.
+- The pilot cannot activate from defaults: it inherits the framework's
+  explicit safety config requirement and adds the high-confidence floor,
+  the canary cap, and the override control on top.
+- Tenant, workspace, project, connector, account, and region boundaries
+  are preserved.
+- Unknown, permission-denied, and partial-failure states surface as
+  explicit states, not as successful findings.
+
+## App Surface
+
+The AWS Governance page renders an **AWS limited enforcement pilot**
+panel below the framework panel with the decision title, source,
+pilot state, eligibility rule counts, confidence, and readiness pill,
+including loading, empty, degraded, permission-denied, and error states.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -619,6 +619,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement-pilot
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
     action: tenancy.read
     resource_type: project
@@ -5920,6 +5925,106 @@ paths:
                     $ref: "#/components/schemas/AWSLimitedEnforcementResult"
         "400":
           description: Invalid AWS limited enforcement request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/limited-enforcement-pilot:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS high-confidence limited enforcement pilot decisions
+      operationId: getAWSProjectLimitedEnforcementPilot
+      description: Projects the high-confidence enforcement pilot over the limited-enforcement framework. Only framework entries that pass every pilot eligibility rule (limited-enforce mode, confidence at least 90 percent, all framework gates passed, canary within the pilot cap, kill switch off, no operator hold) are marked pilot-ready. Each decision records eligibility rules, canary criteria, rollback thresholds, override state, per-decision metrics, and an immutable audit trail. The endpoint is metadata-only; Identrail never calls AWS write APIs and downstream executors own any live control change.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: cohort
+          schema: { type: string }
+        - in: query
+          name: feature_flag
+          schema: { type: boolean }
+        - in: query
+          name: kill_switch
+          schema: { type: boolean }
+        - in: query
+          name: canary_percent
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 100
+        - in: query
+          name: operator_override
+          schema:
+            type: string
+            enum: [hold, pause, resume]
+          description: Operator override control. `hold`/`pause` holds every pilot decision until explicitly resumed; unknown values are rejected.
+        - in: query
+          name: pilot_state
+          schema:
+            type: string
+            enum: [pilot_canary_ready, pilot_enforce_ready, ineligible, override_hold, blocked_by_kill_switch]
+        - in: query
+          name: source_type
+          schema:
+            type: string
+            enum: [advisory_authorization, agentcore_gateway_policy_advisory]
+        - in: query
+          name: outcome
+          schema: { type: string }
+        - in: query
+          name: enforcement_id
+          schema: { type: string }
+          description: Optional framework enforcement ID, pilot ID, or source decision ID filter.
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS limited enforcement pilot contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  limited_enforcement_pilot:
+                    $ref: "#/components/schemas/AWSLimitedEnforcementPilotResult"
+        "400":
+          description: Invalid AWS limited enforcement pilot request
           content:
             application/json:
               schema:
@@ -16646,6 +16751,198 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLimitedEnforcementRelationship"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLimitedEnforcementPilotEligibilityRule:
+      type: object
+      properties:
+        name: { type: string }
+        status:
+          type: string
+          enum: [passed, failed]
+        rationale: { type: string }
+    AWSLimitedEnforcementPilotRollbackThresholds:
+      type: object
+      properties:
+        max_denial_regression_pct: { type: integer }
+        observation_window: { type: string }
+        auto_rollback_on_kill_switch: { type: boolean }
+        operator_override_halts_pilot: { type: boolean }
+    AWSLimitedEnforcementPilotMetrics:
+      type: object
+      properties:
+        eligibility_rules_passed: { type: integer }
+        eligibility_rules_total: { type: integer }
+        framework_gates_passed: { type: integer }
+        framework_gates_total: { type: integer }
+        confidence_pct: { type: integer }
+        canary_percent: { type: integer }
+    AWSLimitedEnforcementPilotRelationship:
+      type: object
+      properties:
+        pilot_id: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSLimitedEnforcementPilotDecision:
+      type: object
+      properties:
+        pilot_id: { type: string }
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        mode:
+          type: string
+          enum: [pilot]
+        pilot_state:
+          type: string
+          enum: [pilot_canary_ready, pilot_enforce_ready, ineligible, override_hold, blocked_by_kill_switch]
+        eligible: { type: boolean }
+        enforcement_id: { type: string }
+        source_type: { type: string }
+        source_id: { type: string }
+        outcome: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        severity: { type: string }
+        score: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        rationale: { type: string }
+        account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        region: { type: string }
+        principal_node_id: { type: string }
+        action: { type: string }
+        cohort: { type: string }
+        operator_override: { type: string }
+        eligibility_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementPilotEligibilityRule"
+        rollback_thresholds:
+          $ref: "#/components/schemas/AWSLimitedEnforcementPilotRollbackThresholds"
+        metrics:
+          $ref: "#/components/schemas/AWSLimitedEnforcementPilotMetrics"
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        input_hash: { type: string }
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationApprovalAuditEntry"
+        read_only_projection: { type: boolean }
+        next_action: { type: string }
+        projected_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSLimitedEnforcementPilotSummary:
+      type: object
+      properties:
+        total_decisions: { type: integer }
+        filtered_decisions: { type: integer }
+        pilot_state_counts:
+          type: object
+          additionalProperties: { type: integer }
+        outcome_counts:
+          type: object
+          additionalProperties: { type: integer }
+        source_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        eligible_count: { type: integer }
+        ineligible_count: { type: integer }
+        canary_ready_count: { type: integer }
+        enforce_ready_count: { type: integer }
+        override_hold_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        failed_rule_count: { type: integer }
+        relationship_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSLimitedEnforcementPilotResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        policy_version: { type: string }
+        mode:
+          type: string
+          enum: [pilot]
+        operator_override: { type: string }
+        safety_config:
+          $ref: "#/components/schemas/AWSLimitedEnforcementSafetyConfig"
+        rollback_thresholds:
+          $ref: "#/components/schemas/AWSLimitedEnforcementPilotRollbackThresholds"
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSLimitedEnforcementPilotSummary"
+        decisions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementPilotDecision"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLimitedEnforcementPilotRelationship"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -774,6 +774,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/post-remediation-verification", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/advisory-authorization", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_limited_enforcement_pilot.go
+++ b/internal/api/aws_limited_enforcement_pilot.go
@@ -1,0 +1,692 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsLimitedEnforcementPilotCurrentIssue = 1547
+	awsLimitedEnforcementPilotVersion      = "aws-limited-enforcement-pilot-v1"
+	awsLimitedEnforcementPilotPolicyID     = "aws-limited-enforcement-pilot-policy-v1"
+	awsLimitedEnforcementPilotModePilot    = "pilot"
+
+	// awsLimitedEnforcementPilotConfidenceFloor is intentionally stricter
+	// than the framework's 0.8 gate: the pilot admits high-confidence
+	// signals only.
+	awsLimitedEnforcementPilotConfidenceFloor = 0.9
+	// awsLimitedEnforcementPilotMaxCanaryPercent caps pilot rollout to a
+	// narrow cohort; broader rollout belongs to a later wave.
+	awsLimitedEnforcementPilotMaxCanaryPercent = 25
+
+	awsLimitedEnforcementPilotStateCanaryReady  = "pilot_canary_ready"
+	awsLimitedEnforcementPilotStateEnforceReady = "pilot_enforce_ready"
+	awsLimitedEnforcementPilotStateIneligible   = "ineligible"
+	awsLimitedEnforcementPilotStateOverrideHold = "override_hold"
+	awsLimitedEnforcementPilotStateKillSwitched = "blocked_by_kill_switch"
+)
+
+// AWSLimitedEnforcementPilotRequest scopes the high-confidence enforcement
+// pilot to one AWS connector. The safety config (feature flag, kill switch,
+// cohort, canary percent) is forwarded to the limited-enforcement framework
+// so the pilot evaluates the same explicit configuration; the operator
+// override is a pilot-level control that holds every decision.
+type AWSLimitedEnforcementPilotRequest struct {
+	ConnectorID      string `json:"connector_id,omitempty"`
+	FixtureState     string `json:"fixture_state,omitempty"`
+	AccountID        string `json:"account_id,omitempty"`
+	Region           string `json:"region,omitempty"`
+	Cohort           string `json:"cohort,omitempty"`
+	FeatureFlag      string `json:"feature_flag,omitempty"`
+	KillSwitch       string `json:"kill_switch,omitempty"`
+	CanaryPercent    int    `json:"canary_percent,omitempty"`
+	OperatorOverride string `json:"operator_override,omitempty"`
+	PilotState       string `json:"pilot_state,omitempty"`
+	SourceType       string `json:"source_type,omitempty"`
+	Outcome          string `json:"outcome,omitempty"`
+	EnforcementID    string `json:"enforcement_id,omitempty"`
+	Severity         string `json:"severity,omitempty"`
+	Search           string `json:"search,omitempty"`
+}
+
+type AWSLimitedEnforcementPilotAuditEntry = AWSRemediationApprovalAuditEntry
+type AWSLimitedEnforcementPilotCoverageGap = AWSRemediationApprovalCoverageGap
+type AWSLimitedEnforcementPilotDiagnostic = AWSRemediationApprovalDiagnostic
+
+// AWSLimitedEnforcementPilotEligibilityRule is one deterministic rule the
+// pilot evaluates before a framework entry can enter the pilot cohort.
+type AWSLimitedEnforcementPilotEligibilityRule struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale"`
+}
+
+// AWSLimitedEnforcementPilotRollbackThresholds is the deterministic rollback
+// contract every pilot decision carries. A downstream executor must
+// auto-rollback the canary when any threshold trips.
+type AWSLimitedEnforcementPilotRollbackThresholds struct {
+	MaxDenialRegressionPct int    `json:"max_denial_regression_pct"`
+	ObservationWindow      string `json:"observation_window"`
+	AutoRollbackOnKill     bool   `json:"auto_rollback_on_kill_switch"`
+	OperatorOverrideHalts  bool   `json:"operator_override_halts_pilot"`
+}
+
+// AWSLimitedEnforcementPilotMetrics records deterministic per-decision
+// counters operators use to audit each pilot evaluation. Counts are
+// metadata only; no runtime payloads are collected.
+type AWSLimitedEnforcementPilotMetrics struct {
+	EligibilityRulesPassed int `json:"eligibility_rules_passed"`
+	EligibilityRulesTotal  int `json:"eligibility_rules_total"`
+	FrameworkGatesPassed   int `json:"framework_gates_passed"`
+	FrameworkGatesTotal    int `json:"framework_gates_total"`
+	ConfidencePct          int `json:"confidence_pct"`
+	CanaryPercent          int `json:"canary_percent"`
+}
+
+// AWSLimitedEnforcementPilotRelationship surfaces pilot→graph node edges.
+type AWSLimitedEnforcementPilotRelationship struct {
+	PilotID     string `json:"pilot_id"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// AWSLimitedEnforcementPilotDecision is the persisted-record-shaped contract
+// for one pilot evaluation over a limited-enforcement framework entry. It is
+// metadata-only; the pilot never calls AWS write APIs and downstream
+// executors own any live control change.
+type AWSLimitedEnforcementPilotDecision struct {
+	PilotID            string                                       `json:"pilot_id"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	PolicyVersion      string                                       `json:"policy_version"`
+	Mode               string                                       `json:"mode"`
+	PilotState         string                                       `json:"pilot_state"`
+	Eligible           bool                                         `json:"eligible"`
+	EnforcementID      string                                       `json:"enforcement_id"`
+	SourceType         string                                       `json:"source_type"`
+	SourceID           string                                       `json:"source_id"`
+	Outcome            string                                       `json:"outcome"`
+	Confidence         float64                                      `json:"confidence"`
+	Severity           string                                       `json:"severity"`
+	Score              int                                          `json:"score"`
+	Title              string                                       `json:"title"`
+	Summary            string                                       `json:"summary"`
+	Rationale          string                                       `json:"rationale"`
+	AccountID          string                                       `json:"account_id,omitempty"`
+	TargetAccountIDs   []string                                     `json:"target_account_ids,omitempty"`
+	Region             string                                       `json:"region,omitempty"`
+	PrincipalNodeID    string                                       `json:"principal_node_id,omitempty"`
+	Action             string                                       `json:"action,omitempty"`
+	Cohort             string                                       `json:"cohort,omitempty"`
+	OperatorOverride   string                                       `json:"operator_override,omitempty"`
+	EligibilityRules   []AWSLimitedEnforcementPilotEligibilityRule  `json:"eligibility_rules"`
+	RollbackThresholds AWSLimitedEnforcementPilotRollbackThresholds `json:"rollback_thresholds"`
+	Metrics            AWSLimitedEnforcementPilotMetrics            `json:"metrics"`
+	EvidenceLinks      []string                                     `json:"evidence_links"`
+	EvidenceBoundary   string                                       `json:"evidence_boundary"`
+	InputHash          string                                       `json:"input_hash"`
+	AuditTrail         []AWSLimitedEnforcementPilotAuditEntry       `json:"audit_trail"`
+	ReadOnlyProjection bool                                         `json:"read_only_projection"`
+	NextAction         string                                       `json:"next_action"`
+	ProjectedAt        time.Time                                    `json:"projected_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+// AWSLimitedEnforcementPilotSummary aggregates the unfiltered/filtered set.
+type AWSLimitedEnforcementPilotSummary struct {
+	TotalDecisions         int            `json:"total_decisions"`
+	FilteredDecisions      int            `json:"filtered_decisions"`
+	PilotStateCounts       map[string]int `json:"pilot_state_counts"`
+	OutcomeCounts          map[string]int `json:"outcome_counts"`
+	SourceTypeCounts       map[string]int `json:"source_type_counts"`
+	SeverityCounts         map[string]int `json:"severity_counts"`
+	EligibleCount          int            `json:"eligible_count"`
+	IneligibleCount        int            `json:"ineligible_count"`
+	CanaryReadyCount       int            `json:"canary_ready_count"`
+	EnforceReadyCount      int            `json:"enforce_ready_count"`
+	OverrideHoldCount      int            `json:"override_hold_count"`
+	KillSwitchEngagedCount int            `json:"kill_switch_engaged_count"`
+	FailedRuleCount        int            `json:"failed_rule_count"`
+	RelationshipCount      int            `json:"relationship_count"`
+	HighestScore           int            `json:"highest_score"`
+	AverageConfidencePct   int            `json:"average_confidence_pct"`
+}
+
+// AWSLimitedEnforcementPilotResult is the deterministic endpoint envelope.
+type AWSLimitedEnforcementPilotResult struct {
+	TenantID           string                                       `json:"tenant_id"`
+	WorkspaceID        string                                       `json:"workspace_id"`
+	ProjectID          string                                       `json:"project_id"`
+	ConnectorID        string                                       `json:"connector_id,omitempty"`
+	AccountID          string                                       `json:"account_id,omitempty"`
+	Region             string                                       `json:"region,omitempty"`
+	ParentIssueNumber  int                                          `json:"parent_issue_number"`
+	ParentIssueRef     string                                       `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                          `json:"current_issue_number"`
+	CurrentIssueRef    string                                       `json:"current_issue_ref"`
+	Version            string                                       `json:"version"`
+	Status             string                                       `json:"status"`
+	FixtureState       string                                       `json:"fixture_state,omitempty"`
+	Confidence         float64                                      `json:"confidence"`
+	CalculationVersion string                                       `json:"calculation_version"`
+	PolicyVersion      string                                       `json:"policy_version"`
+	Mode               string                                       `json:"mode"`
+	OperatorOverride   string                                       `json:"operator_override,omitempty"`
+	SafetyConfig       AWSLimitedEnforcementSafetyConfig            `json:"safety_config"`
+	RollbackThresholds AWSLimitedEnforcementPilotRollbackThresholds `json:"rollback_thresholds"`
+	AppliedFilters     map[string]string                            `json:"applied_filters"`
+	Summary            AWSLimitedEnforcementPilotSummary            `json:"summary"`
+	Decisions          []AWSLimitedEnforcementPilotDecision         `json:"decisions"`
+	Relationships      []AWSLimitedEnforcementPilotRelationship     `json:"relationships"`
+	Caveats            []string                                     `json:"caveats"`
+	FailureReasons     []string                                     `json:"failure_reasons"`
+	RemediationHints   []string                                     `json:"remediation_hints"`
+	EvidenceLinks      []string                                     `json:"evidence_links"`
+	CoverageGaps       []AWSLimitedEnforcementPilotCoverageGap      `json:"coverage_gaps"`
+	Diagnostics        []AWSLimitedEnforcementPilotDiagnostic       `json:"diagnostics"`
+	GeneratedAt        time.Time                                    `json:"generated_at"`
+	UpdatedAt          time.Time                                    `json:"updated_at"`
+}
+
+// GetAWSLimitedEnforcementPilot projects the high-confidence enforcement
+// pilot over the limited-enforcement framework (#1546). Only framework
+// entries that pass every pilot eligibility rule (limited-enforce mode,
+// confidence >= 0.9, all framework gates passed, canary within the pilot
+// cap, kill switch off, no operator override) are marked pilot-ready. The
+// endpoint is metadata-only: it records eligibility, canary criteria,
+// rollback thresholds, override state, metrics, and audit rows but never
+// calls AWS write APIs.
+func (s *Service) GetAWSLimitedEnforcementPilot(ctx context.Context, workspaceID string, projectID string, request AWSLimitedEnforcementPilotRequest) (AWSLimitedEnforcementPilotResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSLimitedEnforcementPilotResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSLimitedEnforcementPilotResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSLimitedEnforcementPilotFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSLimitedEnforcementPilotResult{}, ErrInvalidAWSConnectionRequest
+	}
+	override := normalizeAWSLimitedEnforcementPilotOverride(request.OperatorOverride)
+	if override == "" && strings.TrimSpace(request.OperatorOverride) != "" {
+		return AWSLimitedEnforcementPilotResult{}, ErrInvalidAWSConnectionRequest
+	}
+
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	// The pilot always asks the framework for limited-enforce mode so it
+	// evaluates exactly what a downstream executor would see when the
+	// operator's explicit safety config is applied.
+	framework, err := s.GetAWSLimitedEnforcement(ctx, workspaceID, projectID, AWSLimitedEnforcementRequest{
+		ConnectorID:   connectorID,
+		FixtureState:  sourceFixtureState,
+		Mode:          awsLimitedEnforcementModeLimitedEnforce,
+		Cohort:        strings.TrimSpace(request.Cohort),
+		FeatureFlag:   request.FeatureFlag,
+		KillSwitch:    request.KillSwitch,
+		CanaryPercent: request.CanaryPercent,
+	})
+	if err != nil {
+		return AWSLimitedEnforcementPilotResult{}, fmt.Errorf("limited enforcement pilot framework: %w", err)
+	}
+
+	thresholds := awsLimitedEnforcementPilotRollbackThresholds()
+	decisions := awsLimitedEnforcementPilotDecisions(framework.Entries, framework.SafetyConfig, thresholds, override, now)
+	sort.SliceStable(decisions, func(i, j int) bool {
+		if decisions[i].Score == decisions[j].Score {
+			return decisions[i].PilotID < decisions[j].PilotID
+		}
+		return decisions[i].Score > decisions[j].Score
+	})
+	filtered, applied := filterAWSLimitedEnforcementPilotDecisions(decisions, request)
+	relationships := awsLimitedEnforcementPilotRelationships(filtered)
+	diagnostics := awsLimitedEnforcementPilotDiagnostics(framework.Diagnostics)
+	status, confidence := summarizeAWSLimitedEnforcementPilotStatus(framework.Status, filtered, diagnostics)
+
+	return AWSLimitedEnforcementPilotResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsLimitedEnforcementPilotCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsLimitedEnforcementPilotCurrentIssue),
+		Version:            awsLimitedEnforcementPilotVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsLimitedEnforcementPilotVersion,
+		PolicyVersion:      awsLimitedEnforcementPilotPolicyID,
+		Mode:               awsLimitedEnforcementPilotModePilot,
+		OperatorOverride:   override,
+		SafetyConfig:       framework.SafetyConfig,
+		RollbackThresholds: thresholds,
+		AppliedFilters:     applied,
+		Summary:            summarizeAWSLimitedEnforcementPilotDecisions(decisions, filtered, relationships),
+		Decisions:          filtered,
+		Relationships:      relationships,
+		Caveats:            awsLimitedEnforcementPilotCaveats(),
+		FailureReasons:     dedupeStrings(framework.FailureReasons),
+		RemediationHints:   awsLimitedEnforcementPilotRemediationHints(framework.RemediationHints),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsLimitedEnforcementPilotCurrentIssue),
+			awsIssueURL(awsLimitedEnforcementCurrentIssue),
+			"/docs/aws-limited-enforcement-pilot",
+			"/docs/aws-limited-enforcement",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: awsLimitedEnforcementPilotCoverageGaps(framework.CoverageGaps),
+		Diagnostics:  diagnostics,
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func normalizeAWSLimitedEnforcementPilotFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "success", "ready":
+		if !hasConnection || !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// normalizeAWSLimitedEnforcementPilotOverride validates the operator
+// override control. `hold` pauses every pilot decision; `resume` (or empty)
+// lets eligibility drive the state. Unknown values are rejected by the
+// caller so a typo can never silently resume a held pilot.
+func normalizeAWSLimitedEnforcementPilotOverride(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return "resume"
+	case "hold", "pause":
+		return "hold"
+	case "resume":
+		return "resume"
+	default:
+		return ""
+	}
+}
+
+func awsLimitedEnforcementPilotRollbackThresholds() AWSLimitedEnforcementPilotRollbackThresholds {
+	return AWSLimitedEnforcementPilotRollbackThresholds{
+		MaxDenialRegressionPct: 1,
+		ObservationWindow:      "24h",
+		AutoRollbackOnKill:     true,
+		OperatorOverrideHalts:  true,
+	}
+}
+
+func awsLimitedEnforcementPilotDecisions(entries []AWSLimitedEnforcementEntry, safety AWSLimitedEnforcementSafetyConfig, thresholds AWSLimitedEnforcementPilotRollbackThresholds, override string, now time.Time) []AWSLimitedEnforcementPilotDecision {
+	decisions := make([]AWSLimitedEnforcementPilotDecision, 0, len(entries))
+	for _, entry := range entries {
+		decisions = append(decisions, awsLimitedEnforcementPilotDecisionFromEntry(entry, safety, thresholds, override, now))
+	}
+	return decisions
+}
+
+func awsLimitedEnforcementPilotDecisionFromEntry(entry AWSLimitedEnforcementEntry, safety AWSLimitedEnforcementSafetyConfig, thresholds AWSLimitedEnforcementPilotRollbackThresholds, override string, now time.Time) AWSLimitedEnforcementPilotDecision {
+	rules := awsLimitedEnforcementPilotEligibilityRules(entry, safety, override)
+	state, eligible, rationale := awsLimitedEnforcementPilotState(entry, safety, override, rules)
+	pilotID := "aws-limited-enforcement-pilot:" + stableAWSBlastRadiusToken("pilot", entry.EnforcementID, state, override)
+	passed := 0
+	for _, rule := range rules {
+		if rule.Status == "passed" {
+			passed++
+		}
+	}
+	gatesPassed := 0
+	for _, gate := range entry.Gates {
+		if gate.Status == "passed" {
+			gatesPassed++
+		}
+	}
+	return AWSLimitedEnforcementPilotDecision{
+		PilotID:            pilotID,
+		CalculationVersion: awsLimitedEnforcementPilotVersion,
+		PolicyVersion:      awsLimitedEnforcementPilotPolicyID,
+		Mode:               awsLimitedEnforcementPilotModePilot,
+		PilotState:         state,
+		Eligible:           eligible,
+		EnforcementID:      entry.EnforcementID,
+		SourceType:         entry.SourceType,
+		SourceID:           entry.SourceID,
+		Outcome:            entry.Outcome,
+		Confidence:         entry.Confidence,
+		Severity:           entry.Severity,
+		Score:              entry.Score,
+		Title:              fmt.Sprintf("Enforcement pilot: %s", strings.TrimPrefix(entry.Title, "Limited enforcement framework: ")),
+		Summary:            fmt.Sprintf("High-confidence enforcement pilot evaluation for framework entry %s (state=%s). Identrail records eligibility, canary criteria, rollback thresholds, override state, metrics, and audit only; no live AWS write API is called.", entry.EnforcementID, state),
+		Rationale:          rationale,
+		AccountID:          entry.AccountID,
+		TargetAccountIDs:   entry.TargetAccountIDs,
+		Region:             entry.Region,
+		PrincipalNodeID:    entry.PrincipalNodeID,
+		Action:             entry.Action,
+		Cohort:             safety.Cohort,
+		OperatorOverride:   override,
+		EligibilityRules:   rules,
+		RollbackThresholds: thresholds,
+		Metrics: AWSLimitedEnforcementPilotMetrics{
+			EligibilityRulesPassed: passed,
+			EligibilityRulesTotal:  len(rules),
+			FrameworkGatesPassed:   gatesPassed,
+			FrameworkGatesTotal:    len(entry.Gates),
+			ConfidencePct:          int(entry.Confidence*100 + 0.5),
+			CanaryPercent:          safety.CanaryPercent,
+		},
+		EvidenceLinks:      dedupeStrings(append(append([]string{}, entry.EvidenceLinks...), "/docs/aws-limited-enforcement-pilot")),
+		EvidenceBoundary:   awsLimitedEnforcementPilotEvidenceBoundary(),
+		InputHash:          stableAWSBlastRadiusToken("limited-enforcement-pilot-input", entry.InputHash, state, override, fmt.Sprint(safety.CanaryPercent), safety.Cohort, awsLimitedEnforcementPilotPolicyID),
+		AuditTrail:         awsLimitedEnforcementPilotAuditTrail(pilotID, entry.EnforcementID, state, override, now),
+		ReadOnlyProjection: true,
+		NextAction:         awsLimitedEnforcementPilotNextAction(state),
+		ProjectedAt:        now,
+		UpdatedAt:          now,
+	}
+}
+
+// awsLimitedEnforcementPilotEligibilityRules is the deterministic rule set
+// every framework entry is evaluated against before it can enter the pilot.
+func awsLimitedEnforcementPilotEligibilityRules(entry AWSLimitedEnforcementEntry, safety AWSLimitedEnforcementSafetyConfig, override string) []AWSLimitedEnforcementPilotEligibilityRule {
+	return []AWSLimitedEnforcementPilotEligibilityRule{
+		{Name: "limited_enforce_mode", Status: awsLimitedEnforcementGateStatus(entry.Mode == awsLimitedEnforcementModeLimitedEnforce), Rationale: "Only framework entries that reached limited-enforce mode with explicit safety config can enter the pilot."},
+		{Name: "high_confidence", Status: awsLimitedEnforcementGateStatus(entry.Confidence >= awsLimitedEnforcementPilotConfidenceFloor), Rationale: fmt.Sprintf("Pilot admits high-confidence signals only (>= %d percent).", int(awsLimitedEnforcementPilotConfidenceFloor*100))},
+		{Name: "framework_gates_passed", Status: awsLimitedEnforcementGateStatus(!awsLimitedEnforcementHasFailedGate(entry.Gates)), Rationale: "Every limited-enforcement framework gate must pass before the pilot evaluates the entry."},
+		{Name: "canary_within_pilot_cap", Status: awsLimitedEnforcementGateStatus(safety.CanaryPercent > 0 && safety.CanaryPercent <= awsLimitedEnforcementPilotMaxCanaryPercent), Rationale: fmt.Sprintf("Pilot canaries are capped at %d percent of the cohort; broader rollout belongs to a later wave.", awsLimitedEnforcementPilotMaxCanaryPercent)},
+		{Name: "kill_switch_off", Status: awsLimitedEnforcementGateStatus(!safety.KillSwitchEngaged && entry.EnforcementState != awsLimitedEnforcementStateBlockedByKillSwitch), Rationale: "The tenant kill switch immediately removes every entry from the pilot."},
+		{Name: "operator_override_clear", Status: awsLimitedEnforcementGateStatus(override != "hold"), Rationale: "An operator hold pauses every pilot decision until explicitly resumed."},
+	}
+}
+
+// awsLimitedEnforcementPilotState orders safety controls above eligibility:
+// kill switch, then operator hold, then the rule set. Eligible entries map
+// to the framework's canary/enforce readiness.
+func awsLimitedEnforcementPilotState(entry AWSLimitedEnforcementEntry, safety AWSLimitedEnforcementSafetyConfig, override string, rules []AWSLimitedEnforcementPilotEligibilityRule) (string, bool, string) {
+	if safety.KillSwitchEngaged || entry.EnforcementState == awsLimitedEnforcementStateBlockedByKillSwitch {
+		return awsLimitedEnforcementPilotStateKillSwitched, false, "Tenant kill switch is engaged; the pilot holds every decision until it is cleared."
+	}
+	if override == "hold" {
+		return awsLimitedEnforcementPilotStateOverrideHold, false, "Operator override is holding the pilot; resume explicitly after reviewing canary metrics."
+	}
+	for _, rule := range rules {
+		if rule.Status != "passed" {
+			return awsLimitedEnforcementPilotStateIneligible, false, fmt.Sprintf("Entry failed pilot eligibility rule %q: %s", rule.Name, rule.Rationale)
+		}
+	}
+	if entry.EnforcementState == awsLimitedEnforcementStateLimitedEnforceReady {
+		return awsLimitedEnforcementPilotStateEnforceReady, true, "Every eligibility rule passed and the framework entry is limited-enforce ready within the pilot canary cap."
+	}
+	return awsLimitedEnforcementPilotStateCanaryReady, true, "Every eligibility rule passed; the entry is enrolled in the pilot canary cohort."
+}
+
+func awsLimitedEnforcementPilotNextAction(state string) string {
+	switch state {
+	case awsLimitedEnforcementPilotStateCanaryReady:
+		return "Pilot canary is ready for a downstream executor; watch denial-regression metrics against the rollback thresholds before expanding."
+	case awsLimitedEnforcementPilotStateEnforceReady:
+		return "Pilot decision is enforce-ready within the canary cap; downstream executors still own any live control change."
+	case awsLimitedEnforcementPilotStateIneligible:
+		return "Resolve the failed eligibility rule before re-evaluating this entry for the pilot."
+	case awsLimitedEnforcementPilotStateOverrideHold:
+		return "Operator hold is active; resume the pilot explicitly after reviewing canary metrics and rollback thresholds."
+	case awsLimitedEnforcementPilotStateKillSwitched:
+		return "Clear the tenant kill switch and refresh framework evidence before the pilot can re-evaluate."
+	}
+	return "Inspect the pilot decision for the next action."
+}
+
+func awsLimitedEnforcementPilotAuditTrail(pilotID, enforcementID, state, override string, now time.Time) []AWSLimitedEnforcementPilotAuditEntry {
+	return []AWSLimitedEnforcementPilotAuditEntry{{
+		EventID:    stableAWSBlastRadiusToken("limited-enforcement-pilot-projected", pilotID, enforcementID, state, override),
+		Actor:      "identrail-limited-enforcement-pilot",
+		EventType:  "limited_enforcement_pilot_projected",
+		OccurredAt: now,
+		Notes:      fmt.Sprintf("Enforcement=%s pilot_state=%s override=%s policy_version=%s; Identrail did not call any AWS write API at this layer.", enforcementID, state, override, awsLimitedEnforcementPilotPolicyID),
+	}}
+}
+
+func awsLimitedEnforcementPilotRelationships(decisions []AWSLimitedEnforcementPilotDecision) []AWSLimitedEnforcementPilotRelationship {
+	relationships := []AWSLimitedEnforcementPilotRelationship{}
+	for _, decision := range decisions {
+		if strings.TrimSpace(decision.EnforcementID) != "" {
+			relationships = append(relationships, AWSLimitedEnforcementPilotRelationship{
+				PilotID:     decision.PilotID,
+				Type:        "pilots_enforcement_entry",
+				FromNodeID:  decision.PilotID,
+				ToNodeID:    decision.EnforcementID,
+				EvidenceRef: firstString(decision.EvidenceLinks),
+			})
+		}
+		if principal := strings.TrimSpace(decision.PrincipalNodeID); principal != "" {
+			relationships = append(relationships, AWSLimitedEnforcementPilotRelationship{
+				PilotID:    decision.PilotID,
+				Type:       "governs_principal",
+				FromNodeID: decision.PilotID,
+				ToNodeID:   principal,
+			})
+		}
+	}
+	return relationships
+}
+
+func summarizeAWSLimitedEnforcementPilotDecisions(all, filtered []AWSLimitedEnforcementPilotDecision, relationships []AWSLimitedEnforcementPilotRelationship) AWSLimitedEnforcementPilotSummary {
+	summary := AWSLimitedEnforcementPilotSummary{
+		TotalDecisions:    len(all),
+		FilteredDecisions: len(filtered),
+		PilotStateCounts:  map[string]int{},
+		OutcomeCounts:     map[string]int{},
+		SourceTypeCounts:  map[string]int{},
+		SeverityCounts:    map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, decision := range filtered {
+		summary.PilotStateCounts[decision.PilotState]++
+		if decision.Outcome != "" {
+			summary.OutcomeCounts[decision.Outcome]++
+		}
+		if decision.SourceType != "" {
+			summary.SourceTypeCounts[decision.SourceType]++
+		}
+		if decision.Severity != "" {
+			summary.SeverityCounts[decision.Severity]++
+		}
+		if decision.Eligible {
+			summary.EligibleCount++
+		} else {
+			summary.IneligibleCount++
+		}
+		switch decision.PilotState {
+		case awsLimitedEnforcementPilotStateCanaryReady:
+			summary.CanaryReadyCount++
+		case awsLimitedEnforcementPilotStateEnforceReady:
+			summary.EnforceReadyCount++
+		case awsLimitedEnforcementPilotStateOverrideHold:
+			summary.OverrideHoldCount++
+		case awsLimitedEnforcementPilotStateKillSwitched:
+			summary.KillSwitchEngagedCount++
+		}
+		for _, rule := range decision.EligibilityRules {
+			if rule.Status == "failed" {
+				summary.FailedRuleCount++
+			}
+		}
+		if decision.Score > summary.HighestScore {
+			summary.HighestScore = decision.Score
+		}
+		confidenceTotal += decision.Confidence
+	}
+	summary.RelationshipCount = len(relationships)
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func filterAWSLimitedEnforcementPilotDecisions(decisions []AWSLimitedEnforcementPilotDecision, request AWSLimitedEnforcementPilotRequest) ([]AWSLimitedEnforcementPilotDecision, map[string]string) {
+	filters := map[string]string{
+		"account_id":     strings.TrimSpace(request.AccountID),
+		"region":         strings.TrimSpace(request.Region),
+		"pilot_state":    normalizeAWSRuntimeEventFilterToken(request.PilotState),
+		"source_type":    normalizeAWSRuntimeEventFilterToken(request.SourceType),
+		"outcome":        normalizeAWSRuntimeEventFilterToken(request.Outcome),
+		"enforcement_id": strings.TrimSpace(request.EnforcementID),
+		"severity":       normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"search":         strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSLimitedEnforcementPilotDecision, 0, len(decisions))
+	for _, decision := range decisions {
+		if filters["account_id"] != "" && !awsLimitedEnforcementPilotAccountMatch(decision, filters["account_id"]) {
+			continue
+		}
+		if filters["region"] != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(decision.Region)) {
+			continue
+		}
+		if filters["pilot_state"] != "" && filters["pilot_state"] != normalizeAWSRuntimeEventFilterToken(decision.PilotState) {
+			continue
+		}
+		if filters["source_type"] != "" && filters["source_type"] != normalizeAWSRuntimeEventFilterToken(decision.SourceType) {
+			continue
+		}
+		if filters["outcome"] != "" && filters["outcome"] != normalizeAWSRuntimeEventFilterToken(decision.Outcome) {
+			continue
+		}
+		if filters["enforcement_id"] != "" && !strings.EqualFold(filters["enforcement_id"], decision.EnforcementID) && !strings.EqualFold(filters["enforcement_id"], decision.PilotID) && !strings.EqualFold(filters["enforcement_id"], decision.SourceID) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(decision.Severity) {
+			continue
+		}
+		if filters["search"] != "" && !awsLimitedEnforcementPilotSearchMatch(decision, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, decision)
+	}
+	return filtered, applied
+}
+
+func awsLimitedEnforcementPilotAccountMatch(decision AWSLimitedEnforcementPilotDecision, accountID string) bool {
+	if strings.EqualFold(strings.TrimSpace(decision.AccountID), strings.TrimSpace(accountID)) {
+		return true
+	}
+	for _, target := range decision.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), strings.TrimSpace(accountID)) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsLimitedEnforcementPilotSearchMatch(decision AWSLimitedEnforcementPilotDecision, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		decision.PilotID, decision.EnforcementID, decision.SourceID, decision.SourceType,
+		decision.PilotState, decision.Outcome, decision.Severity, decision.Title, decision.Summary,
+		decision.Rationale, decision.PrincipalNodeID, decision.Action, decision.Cohort,
+		decision.OperatorOverride, decision.NextAction, decision.InputHash,
+	}
+	values = append(values, decision.TargetAccountIDs...)
+	values = append(values, decision.EvidenceLinks...)
+	for _, rule := range decision.EligibilityRules {
+		values = append(values, rule.Name, rule.Status, rule.Rationale)
+	}
+	for _, audit := range decision.AuditTrail {
+		values = append(values, audit.EventType, audit.Actor, audit.Notes)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSLimitedEnforcementPilotStatus(frameworkStatus string, filtered []AWSLimitedEnforcementPilotDecision, diagnostics []AWSLimitedEnforcementPilotDiagnostic) (string, float64) {
+	if frameworkStatus == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked, 0.35
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	if frameworkStatus == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(filtered) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsLimitedEnforcementPilotCaveats() []string {
+	return []string{
+		"Enforcement pilot decisions are read-only projections; Identrail never calls AWS write APIs at this layer and downstream executors own any live control change.",
+		"The pilot admits high-confidence signals only: limited-enforce mode, confidence >= 90 percent, every framework gate passed, canary within the pilot cap, kill switch off, and no operator hold.",
+		"Rollback thresholds (denial-regression budget, observation window, kill-switch and override halts) travel with every decision so a downstream executor can auto-rollback deterministically.",
+	}
+}
+
+func awsLimitedEnforcementPilotRemediationHints(source []string) []string {
+	hints := []string{
+		"Keep the pilot canary at or below the cap and expand only after the observation window closes with no denial regressions.",
+		"Use operator_override=hold to pause every pilot decision without touching the tenant kill switch; resume explicitly after review.",
+		"Log the pilot policy version, input hash, cohort, canary percentage, and enforcement ID for every downstream transition.",
+	}
+	hints = append(hints, source...)
+	return dedupeStrings(hints)
+}
+
+func awsLimitedEnforcementPilotDiagnostics(source []AWSLimitedEnforcementDiagnostic) []AWSLimitedEnforcementPilotDiagnostic {
+	out := make([]AWSLimitedEnforcementPilotDiagnostic, 0, len(source))
+	for _, diagnostic := range source {
+		out = append(out, AWSLimitedEnforcementPilotDiagnostic(diagnostic))
+	}
+	return out
+}
+
+func awsLimitedEnforcementPilotCoverageGaps(source []AWSLimitedEnforcementCoverageGap) []AWSLimitedEnforcementPilotCoverageGap {
+	out := make([]AWSLimitedEnforcementPilotCoverageGap, 0, len(source))
+	for _, gap := range source {
+		out = append(out, AWSLimitedEnforcementPilotCoverageGap(gap))
+	}
+	return out
+}
+
+func awsLimitedEnforcementPilotEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_limited_enforcement_pilot_test.go
+++ b/internal/api/aws_limited_enforcement_pilot_test.go
@@ -1,0 +1,352 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newLimitedEnforcementPilotService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSLimitedEnforcementPilotBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 15, 0, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementPilotService(t, "project-limited-enforcement-pilot", now)
+
+	result, err := svc.GetAWSLimitedEnforcementPilot(defaultScopeContext(), ws, "project-limited-enforcement-pilot", AWSLimitedEnforcementPilotRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get limited enforcement pilot: %v", err)
+	}
+	if result.CurrentIssueRef != "#1547" || result.Version != awsLimitedEnforcementPilotVersion || result.Mode != awsLimitedEnforcementPilotModePilot {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if result.PolicyVersion != awsLimitedEnforcementPilotPolicyID {
+		t.Fatalf("expected stable policy version, got %q", result.PolicyVersion)
+	}
+	if result.RollbackThresholds.MaxDenialRegressionPct <= 0 || result.RollbackThresholds.ObservationWindow == "" || !result.RollbackThresholds.AutoRollbackOnKill {
+		t.Fatalf("expected deterministic rollback thresholds: %+v", result.RollbackThresholds)
+	}
+	if len(result.Decisions) == 0 {
+		t.Fatalf("expected pilot decisions projected from framework entries: %+v", result.Summary)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) {
+		t.Fatalf("relationship count mismatch: %+v", result.Summary)
+	}
+	for _, decision := range result.Decisions {
+		if decision.PilotID == "" || decision.CalculationVersion != awsLimitedEnforcementPilotVersion {
+			t.Fatalf("decision missing stable metadata: %+v", decision)
+		}
+		switch decision.PilotState {
+		case awsLimitedEnforcementPilotStateCanaryReady, awsLimitedEnforcementPilotStateEnforceReady, awsLimitedEnforcementPilotStateIneligible, awsLimitedEnforcementPilotStateOverrideHold, awsLimitedEnforcementPilotStateKillSwitched:
+		default:
+			t.Fatalf("decision has unknown pilot state: %+v", decision)
+		}
+		// Without explicit safety config (feature flag, cohort, canary) no
+		// decision may claim pilot readiness.
+		if decision.Eligible {
+			t.Fatalf("pilot must not mark decisions eligible without explicit safety config: %+v", decision)
+		}
+		if decision.EnforcementID == "" {
+			t.Fatalf("decision must reference its framework entry: %+v", decision)
+		}
+		if len(decision.EligibilityRules) == 0 || len(decision.AuditTrail) == 0 {
+			t.Fatalf("decision missing eligibility rules or audit trail: %+v", decision)
+		}
+		if decision.Metrics.EligibilityRulesTotal != len(decision.EligibilityRules) {
+			t.Fatalf("metrics must reflect the evaluated rule set: %+v", decision.Metrics)
+		}
+		if decision.InputHash == "" || !decision.ReadOnlyProjection {
+			t.Fatalf("decision missing input hash or read-only projection: %+v", decision)
+		}
+		if decision.EvidenceBoundary != awsLimitedEnforcementPilotEvidenceBoundary() {
+			t.Fatalf("decision crossed evidence boundary: %+v", decision)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"policy_document_body\"", "\"rendered_policy\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("limited enforcement pilot serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func pilotFrameworkEntry(mode, state string, confidence float64, gates []AWSLimitedEnforcementGate) AWSLimitedEnforcementEntry {
+	if gates == nil {
+		gates = []AWSLimitedEnforcementGate{{Name: "feature_flag_enabled", Status: "passed"}}
+	}
+	return AWSLimitedEnforcementEntry{
+		EnforcementID:    "aws-limited-enforcement:test",
+		SourceType:       "advisory_authorization",
+		SourceID:         "decision-1",
+		Mode:             mode,
+		EnforcementState: state,
+		Outcome:          "allow",
+		Confidence:       confidence,
+		Severity:         "medium",
+		Score:            70,
+		Title:            "Limited enforcement framework: test",
+		Gates:            gates,
+		InputHash:        "hash-1",
+	}
+}
+
+func TestAWSLimitedEnforcementPilotStateOrdering(t *testing.T) {
+	now := time.Date(2026, 7, 3, 15, 30, 0, 0, time.UTC)
+	safety := AWSLimitedEnforcementSafetyConfig{FeatureFlagEnabled: true, CanaryPercent: 10, Cohort: "pilot-cohort", RollbackRequired: true, AuditRequired: true}
+	thresholds := awsLimitedEnforcementPilotRollbackThresholds()
+	eligible := pilotFrameworkEntry(awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateCanaryReady, 0.95, nil)
+
+	decision := awsLimitedEnforcementPilotDecisionFromEntry(eligible, safety, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateCanaryReady || !decision.Eligible {
+		t.Fatalf("eligible canary entry must be pilot_canary_ready: %+v", decision)
+	}
+
+	enforceReady := pilotFrameworkEntry(awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateLimitedEnforceReady, 0.95, nil)
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(enforceReady, safety, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateEnforceReady || !decision.Eligible {
+		t.Fatalf("enforce-ready entry must be pilot_enforce_ready: %+v", decision)
+	}
+
+	killed := safety
+	killed.KillSwitchEngaged = true
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(eligible, killed, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateKillSwitched || decision.Eligible {
+		t.Fatalf("kill switch must override every eligibility rule: %+v", decision)
+	}
+
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(eligible, safety, thresholds, "hold", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateOverrideHold || decision.Eligible {
+		t.Fatalf("operator hold must pause the pilot: %+v", decision)
+	}
+
+	lowConfidence := pilotFrameworkEntry(awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateCanaryReady, 0.85, nil)
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(lowConfidence, safety, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateIneligible || decision.Eligible {
+		t.Fatalf("confidence below the pilot floor must be ineligible: %+v", decision)
+	}
+	if !strings.Contains(decision.Rationale, "high_confidence") {
+		t.Fatalf("ineligible rationale must name the failed rule: %q", decision.Rationale)
+	}
+
+	advisoryMode := pilotFrameworkEntry(awsLimitedEnforcementModeAdvisory, awsLimitedEnforcementStateAdvisoryOnly, 0.95, nil)
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(advisoryMode, safety, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateIneligible || decision.Eligible {
+		t.Fatalf("non-limited-enforce mode must be ineligible: %+v", decision)
+	}
+
+	failedGate := pilotFrameworkEntry(awsLimitedEnforcementModeLimitedEnforce, awsLimitedEnforcementStateCanaryReady, 0.95, []AWSLimitedEnforcementGate{{Name: "confidence_floor", Status: "failed"}})
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(failedGate, safety, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateIneligible || decision.Eligible {
+		t.Fatalf("failed framework gate must be ineligible: %+v", decision)
+	}
+
+	broadCanary := safety
+	broadCanary.CanaryPercent = 50
+	decision = awsLimitedEnforcementPilotDecisionFromEntry(eligible, broadCanary, thresholds, "resume", now)
+	if decision.PilotState != awsLimitedEnforcementPilotStateIneligible || decision.Eligible {
+		t.Fatalf("canary above the pilot cap must be ineligible: %+v", decision)
+	}
+	if !strings.Contains(decision.Rationale, "canary_within_pilot_cap") {
+		t.Fatalf("ineligible rationale must name the canary cap rule: %q", decision.Rationale)
+	}
+}
+
+func TestAWSLimitedEnforcementPilotOverrideNormalization(t *testing.T) {
+	cases := []struct {
+		value string
+		want  string
+	}{
+		{"", "resume"},
+		{"hold", "hold"},
+		{"pause", "hold"},
+		{"HOLD", "hold"},
+		{"resume", "resume"},
+		{"bogus", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeAWSLimitedEnforcementPilotOverride(tc.value); got != tc.want {
+			t.Fatalf("value=%q got %q want %q", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestGetAWSLimitedEnforcementPilotRejectsUnknownOverride(t *testing.T) {
+	now := time.Date(2026, 7, 3, 16, 0, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementPilotService(t, "project-limited-enforcement-pilot-override", now)
+
+	if _, err := svc.GetAWSLimitedEnforcementPilot(defaultScopeContext(), ws, "project-limited-enforcement-pilot-override", AWSLimitedEnforcementPilotRequest{
+		ConnectorID:      "aws-prod",
+		FixtureState:     "success",
+		OperatorOverride: "bogus",
+	}); err == nil {
+		t.Fatalf("unknown operator override must be rejected so a typo can never resume a held pilot")
+	}
+}
+
+func TestGetAWSLimitedEnforcementPilotHighConfidencePath(t *testing.T) {
+	now := time.Date(2026, 7, 3, 16, 30, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementPilotService(t, "project-limited-enforcement-pilot-hc", now)
+
+	result, err := svc.GetAWSLimitedEnforcementPilot(defaultScopeContext(), ws, "project-limited-enforcement-pilot-hc", AWSLimitedEnforcementPilotRequest{
+		ConnectorID:   "aws-prod",
+		FixtureState:  "success",
+		FeatureFlag:   "true",
+		Cohort:        "pilot-cohort",
+		CanaryPercent: 10,
+	})
+	if err != nil {
+		t.Fatalf("get limited enforcement pilot with safety config: %v", err)
+	}
+	for _, decision := range result.Decisions {
+		if !decision.Eligible {
+			continue
+		}
+		if decision.Confidence < awsLimitedEnforcementPilotConfidenceFloor {
+			t.Fatalf("eligible decision below the pilot confidence floor: %+v", decision)
+		}
+		if decision.PilotState != awsLimitedEnforcementPilotStateCanaryReady && decision.PilotState != awsLimitedEnforcementPilotStateEnforceReady {
+			t.Fatalf("eligible decision has non-ready state: %+v", decision)
+		}
+		for _, rule := range decision.EligibilityRules {
+			if rule.Status != "passed" {
+				t.Fatalf("eligible decision carries a failed rule: %+v", decision.EligibilityRules)
+			}
+		}
+	}
+
+	held, err := svc.GetAWSLimitedEnforcementPilot(defaultScopeContext(), ws, "project-limited-enforcement-pilot-hc", AWSLimitedEnforcementPilotRequest{
+		ConnectorID:      "aws-prod",
+		FixtureState:     "success",
+		FeatureFlag:      "true",
+		Cohort:           "pilot-cohort",
+		CanaryPercent:    10,
+		OperatorOverride: "hold",
+	})
+	if err != nil {
+		t.Fatalf("get limited enforcement pilot with hold: %v", err)
+	}
+	if held.OperatorOverride != "hold" {
+		t.Fatalf("expected override echoed on result, got %q", held.OperatorOverride)
+	}
+	for _, decision := range held.Decisions {
+		if decision.PilotState == awsLimitedEnforcementPilotStateKillSwitched {
+			continue
+		}
+		if decision.PilotState != awsLimitedEnforcementPilotStateOverrideHold || decision.Eligible {
+			t.Fatalf("operator hold must pause every pilot decision: %+v", decision)
+		}
+	}
+}
+
+func TestFilterAWSLimitedEnforcementPilotDecisions(t *testing.T) {
+	decisions := []AWSLimitedEnforcementPilotDecision{
+		{
+			PilotID:       "pilot-ready",
+			EnforcementID: "enf-1",
+			SourceType:    "advisory_authorization",
+			PilotState:    awsLimitedEnforcementPilotStateCanaryReady,
+			Outcome:       "allow",
+			Severity:      "medium",
+			AccountID:     "111111111111",
+			Region:        "us-east-1",
+		},
+		{
+			PilotID:          "pilot-ineligible",
+			EnforcementID:    "enf-2",
+			SourceType:       "agentcore_gateway_policy_advisory",
+			PilotState:       awsLimitedEnforcementPilotStateIneligible,
+			Outcome:          "allow_tools",
+			Severity:         "high",
+			AccountID:        "222222222222",
+			Region:           "us-west-2",
+			TargetAccountIDs: []string{"333333333333"},
+			Rationale:        "Entry failed pilot eligibility rule \"high_confidence\"",
+		},
+	}
+
+	filtered, applied := filterAWSLimitedEnforcementPilotDecisions(decisions, AWSLimitedEnforcementPilotRequest{PilotState: "pilot_canary_ready"})
+	if applied["pilot_state"] != normalizeAWSRuntimeEventFilterToken("pilot_canary_ready") || len(filtered) != 1 || filtered[0].PilotID != "pilot-ready" {
+		t.Fatalf("pilot_state filter did not scope decisions: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSLimitedEnforcementPilotDecisions(decisions, AWSLimitedEnforcementPilotRequest{AccountID: "333333333333"})
+	if applied["account_id"] != "333333333333" || len(filtered) != 1 || filtered[0].PilotID != "pilot-ineligible" {
+		t.Fatalf("account_id filter must match target accounts: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSLimitedEnforcementPilotDecisions(decisions, AWSLimitedEnforcementPilotRequest{EnforcementID: "enf-2"})
+	if applied["enforcement_id"] != "enf-2" || len(filtered) != 1 || filtered[0].PilotID != "pilot-ineligible" {
+		t.Fatalf("enforcement_id filter did not scope decisions: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, applied = filterAWSLimitedEnforcementPilotDecisions(decisions, AWSLimitedEnforcementPilotRequest{Search: "high_confidence"})
+	if applied["search"] != "high_confidence" || len(filtered) != 1 || filtered[0].PilotID != "pilot-ineligible" {
+		t.Fatalf("search must reach the rationale: applied=%+v filtered=%+v", applied, filtered)
+	}
+}
+
+func TestAWSLimitedEnforcementPilotFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 17, 0, 0, 0, time.UTC)
+	svc, ws := newLimitedEnforcementPilotService(t, "project-limited-enforcement-pilot-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSLimitedEnforcementPilot(defaultScopeContext(), ws, "project-limited-enforcement-pilot-fixture", AWSLimitedEnforcementPilotRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+	}
+}
+
+func TestRouterAWSLimitedEnforcementPilot(t *testing.T) {
+	now := time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC)
+	svc, _ := newLimitedEnforcementPilotService(t, "project-limited-enforcement-pilot-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-pilot-route/aws/limited-enforcement-pilot?connector_id=aws-prod&fixture_state=success&operator_override=hold", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Pilot AWSLimitedEnforcementPilotResult `json:"limited_enforcement_pilot"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Pilot.CurrentIssueRef != "#1547" || body.Pilot.PolicyVersion != awsLimitedEnforcementPilotPolicyID || body.Pilot.OperatorOverride != "hold" {
+		t.Fatalf("unexpected route payload: %+v", body.Pilot)
+	}
+
+	badOverride := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-pilot-route/aws/limited-enforcement-pilot?connector_id=aws-prod&fixture_state=success&operator_override=bogus", "")
+	if badOverride.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown override, got %d body=%s", badOverride.Code, badOverride.Body.String())
+	}
+
+	badCanary := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-limited-enforcement-pilot-route/aws/limited-enforcement-pilot?connector_id=aws-prod&fixture_state=success&canary_percent=200", "")
+	if badCanary.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for out-of-range canary, got %d body=%s", badCanary.Code, badCanary.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3397,6 +3397,52 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"limited_enforcement": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		canaryPercent, canaryOK := parseAWSLimitedEnforcementCanary(c.Query("canary_percent"))
+		if !canaryOK {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws limited enforcement pilot request"})
+			return
+		}
+		record, err := svc.GetAWSLimitedEnforcementPilot(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSLimitedEnforcementPilotRequest{
+			ConnectorID:      strings.TrimSpace(c.Query("connector_id")),
+			FixtureState:     strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:        strings.TrimSpace(c.Query("account_id")),
+			Region:           strings.TrimSpace(c.Query("region")),
+			Cohort:           strings.TrimSpace(c.Query("cohort")),
+			FeatureFlag:      strings.TrimSpace(c.Query("feature_flag")),
+			KillSwitch:       strings.TrimSpace(c.Query("kill_switch")),
+			CanaryPercent:    canaryPercent,
+			OperatorOverride: strings.TrimSpace(c.Query("operator_override")),
+			PilotState:       strings.TrimSpace(c.Query("pilot_state")),
+			SourceType:       strings.TrimSpace(c.Query("source_type")),
+			Outcome:          strings.TrimSpace(c.Query("outcome")),
+			EnforcementID:    strings.TrimSpace(c.Query("enforcement_id")),
+			Severity:         strings.TrimSpace(c.Query("severity")),
+			Search:           strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws limited enforcement pilot request"})
+			default:
+				logger.Error("get aws limited enforcement pilot",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws limited enforcement pilot"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"limited_enforcement_pilot": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4174,6 +4174,155 @@ export type AWSLimitedEnforcementQuery = {
   search?: string;
 };
 
+export type AWSLimitedEnforcementPilotStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSLimitedEnforcementPilotFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+export type AWSLimitedEnforcementPilotState =
+  | 'pilot_canary_ready'
+  | 'pilot_enforce_ready'
+  | 'ineligible'
+  | 'override_hold'
+  | 'blocked_by_kill_switch'
+  | string;
+
+export type AWSLimitedEnforcementPilotEligibilityRule = {
+  name: string;
+  status: 'passed' | 'failed' | string;
+  rationale: string;
+};
+
+export type AWSLimitedEnforcementPilotRollbackThresholds = {
+  max_denial_regression_pct: number;
+  observation_window: string;
+  auto_rollback_on_kill_switch: boolean;
+  operator_override_halts_pilot: boolean;
+};
+
+export type AWSLimitedEnforcementPilotMetrics = {
+  eligibility_rules_passed: number;
+  eligibility_rules_total: number;
+  framework_gates_passed: number;
+  framework_gates_total: number;
+  confidence_pct: number;
+  canary_percent: number;
+};
+
+export type AWSLimitedEnforcementPilotRelationship = {
+  pilot_id: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSLimitedEnforcementPilotDecision = {
+  pilot_id: string;
+  calculation_version: string;
+  policy_version: string;
+  mode: 'pilot' | string;
+  pilot_state: AWSLimitedEnforcementPilotState;
+  eligible: boolean;
+  enforcement_id: string;
+  source_type: string;
+  source_id: string;
+  outcome: string;
+  confidence: number;
+  severity: string;
+  score: number;
+  title: string;
+  summary: string;
+  rationale: string;
+  account_id?: string;
+  target_account_ids?: string[];
+  region?: string;
+  principal_node_id?: string;
+  action?: string;
+  cohort?: string;
+  operator_override?: string;
+  eligibility_rules: AWSLimitedEnforcementPilotEligibilityRule[];
+  rollback_thresholds: AWSLimitedEnforcementPilotRollbackThresholds;
+  metrics: AWSLimitedEnforcementPilotMetrics;
+  evidence_links: string[];
+  evidence_boundary: string;
+  input_hash: string;
+  audit_trail: AWSRemediationAuditEntry[];
+  read_only_projection: boolean;
+  next_action: string;
+  projected_at: string;
+  updated_at: string;
+};
+
+export type AWSLimitedEnforcementPilotSummary = {
+  total_decisions: number;
+  filtered_decisions: number;
+  pilot_state_counts: Record<string, number>;
+  outcome_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  eligible_count: number;
+  ineligible_count: number;
+  canary_ready_count: number;
+  enforce_ready_count: number;
+  override_hold_count: number;
+  kill_switch_engaged_count: number;
+  failed_rule_count: number;
+  relationship_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSLimitedEnforcementPilotResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSLimitedEnforcementPilotStatus;
+  fixture_state?: AWSLimitedEnforcementPilotFixtureState;
+  confidence: number;
+  calculation_version: string;
+  policy_version: string;
+  mode: 'pilot' | string;
+  operator_override?: string;
+  safety_config: AWSLimitedEnforcementSafetyConfig;
+  rollback_thresholds: AWSLimitedEnforcementPilotRollbackThresholds;
+  applied_filters: Record<string, string>;
+  summary: AWSLimitedEnforcementPilotSummary;
+  decisions: AWSLimitedEnforcementPilotDecision[];
+  relationships: AWSLimitedEnforcementPilotRelationship[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSLimitedEnforcementPilotQuery = {
+  connectorID?: string;
+  fixtureState?: AWSLimitedEnforcementPilotFixtureState;
+  accountID?: string;
+  region?: string;
+  cohort?: string;
+  featureFlag?: boolean;
+  killSwitch?: boolean;
+  canaryPercent?: number;
+  operatorOverride?: string;
+  pilotState?: string;
+  sourceType?: string;
+  outcome?: string;
+  enforcementID?: string;
+  severity?: string;
+  search?: string;
+};
+
 export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
@@ -9797,6 +9946,33 @@ export const apiClient = {
         feature_flag: query?.featureFlag,
         kill_switch: query?.killSwitch,
         canary_percent: query?.canaryPercent,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectLimitedEnforcementPilot(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSLimitedEnforcementPilotQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ limited_enforcement_pilot: AWSLimitedEnforcementPilotResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/limited-enforcement-pilot${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        cohort: query?.cohort,
+        feature_flag: query?.featureFlag,
+        kill_switch: query?.killSwitch,
+        canary_percent: query?.canaryPercent,
+        operator_override: query?.operatorOverride,
+        pilot_state: query?.pilotState,
+        source_type: query?.sourceType,
+        outcome: query?.outcome,
+        enforcement_id: query?.enforcementID,
+        severity: query?.severity,
         search: query?.search
       })}`,
       auth

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4995,6 +4995,106 @@ describe('Domain-first app routes', () => {
         diagnostics: []
       } as any
     });
+    const getLimitedEnforcementPilot = vi.spyOn(api.apiClient, 'getAWSProjectLimitedEnforcementPilot').mockResolvedValue({
+      limited_enforcement_pilot: {
+        status: 'ready',
+        mode: 'pilot',
+        policy_version: 'aws-limited-enforcement-pilot-policy-v1',
+        operator_override: 'resume',
+        safety_config: {
+          feature_flag_enabled: true,
+          kill_switch_engaged: false,
+          canary_percent: 10,
+          cohort: 'pilot-a',
+          rollback_required: true,
+          audit_required: true
+        },
+        rollback_thresholds: {
+          max_denial_regression_pct: 1,
+          observation_window: '24h',
+          auto_rollback_on_kill_switch: true,
+          operator_override_halts_pilot: true
+        },
+        decisions: [
+          {
+            pilot_id: 'aws-limited-enforcement-pilot:orders',
+            calculation_version: 'aws-limited-enforcement-pilot-v1',
+            policy_version: 'aws-limited-enforcement-pilot-policy-v1',
+            mode: 'pilot',
+            pilot_state: 'pilot_canary_ready',
+            eligible: true,
+            enforcement_id: 'aws-limited-enforcement:orders',
+            source_type: 'advisory_authorization',
+            source_id: 'aws-advisory-authorization:orders',
+            outcome: 'allow',
+            confidence: 0.95,
+            severity: 'high',
+            score: 80,
+            title: 'Enforcement pilot: orders deployer',
+            summary: 'Pilot canary-ready decision.',
+            rationale: 'Every eligibility rule passed.',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            principal_node_id: 'aws:identity:orders-deployer',
+            action: 'iam:PutRolePolicy',
+            cohort: 'pilot-a',
+            operator_override: 'resume',
+            eligibility_rules: [
+              { name: 'limited_enforce_mode', status: 'passed', rationale: 'Limited-enforce mode.' },
+              { name: 'high_confidence', status: 'passed', rationale: 'Confidence above the pilot floor.' }
+            ],
+            rollback_thresholds: {
+              max_denial_regression_pct: 1,
+              observation_window: '24h',
+              auto_rollback_on_kill_switch: true,
+              operator_override_halts_pilot: true
+            },
+            metrics: {
+              eligibility_rules_passed: 2,
+              eligibility_rules_total: 2,
+              framework_gates_passed: 2,
+              framework_gates_total: 2,
+              confidence_pct: 95,
+              canary_percent: 10
+            },
+            evidence_links: ['/docs/aws-limited-enforcement-pilot'],
+            evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads',
+            input_hash: 'pilot-hash-a',
+            audit_trail: [],
+            read_only_projection: true,
+            next_action: 'Watch denial-regression metrics.',
+            projected_at: '2026-07-03T10:00:00Z',
+            updated_at: '2026-07-03T10:00:00Z'
+          }
+        ],
+        relationships: [],
+        applied_filters: {},
+        summary: {
+          total_decisions: 1,
+          filtered_decisions: 1,
+          pilot_state_counts: { pilot_canary_ready: 1 },
+          outcome_counts: { allow: 1 },
+          source_type_counts: { advisory_authorization: 1 },
+          severity_counts: { high: 1 },
+          eligible_count: 1,
+          ineligible_count: 0,
+          canary_ready_count: 1,
+          enforce_ready_count: 0,
+          override_hold_count: 0,
+          kill_switch_engaged_count: 0,
+          failed_rule_count: 0,
+          relationship_count: 0,
+          highest_score: 80,
+          average_confidence_pct: 95
+        },
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
+    });
 
     const { ProductAWSGovernancePage } = await import('./productShell');
 
@@ -5011,6 +5111,14 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/Limited enforcement framework: orders deployer/i)).toBeInTheDocument();
     expect(screen.getByText(/pilot-a/i)).toBeInTheDocument();
     expect(getLimitedEnforcement).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(await screen.findByRole('table', { name: 'AWS limited enforcement pilot decisions' })).toBeInTheDocument();
+    expect(screen.getByText(/Enforcement pilot: orders deployer/i)).toBeInTheDocument();
+    expect(getLimitedEnforcementPilot).toHaveBeenCalledWith(
       'workspace-a',
       'production',
       expect.objectContaining({ connectorID: 'aws-connector-1' }),

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -87,6 +87,8 @@ import {
   type AWSAdvisoryAuthorizationResult,
   type AWSLimitedEnforcementEntry,
   type AWSLimitedEnforcementResult,
+  type AWSLimitedEnforcementPilotDecision,
+  type AWSLimitedEnforcementPilotResult,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
   type AWSAgentCoreGatewayPolicyAdvisoryEntry,
@@ -11529,6 +11531,79 @@ function AWSLimitedEnforcementContent({
   );
 }
 
+function awsLimitedEnforcementPilotStage(decision: AWSLimitedEnforcementPilotDecision): AWSCapabilityStage {
+  switch (decision.pilot_state) {
+    case 'blocked_by_kill_switch':
+      return 'not-available';
+    case 'pilot_canary_ready':
+    case 'pilot_enforce_ready':
+      return 'wired';
+    default:
+      return 'coming';
+  }
+}
+
+function awsLimitedEnforcementPilotRuleLabel(decision: AWSLimitedEnforcementPilotDecision): string {
+  return `${decision.metrics.eligibility_rules_passed}/${decision.metrics.eligibility_rules_total} rules`;
+}
+
+function AWSLimitedEnforcementPilotContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSLimitedEnforcementPilotResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.total_decisions} total · ${result.summary.eligible_count} eligible · ${result.summary.canary_ready_count} canary-ready · ${result.summary.enforce_ready_count} enforce-ready · ${result.summary.override_hold_count} held · ${result.summary.kill_switch_engaged_count} kill switch`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.decisions,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <AWSExecutorProjectionPanel<AWSLimitedEnforcementPilotDecision>
+      result={panelResult}
+      loading={loading}
+      error={error}
+      onRetry={onRetry}
+      ariaLabel="AWS limited enforcement pilot"
+      heading="AWS limited enforcement pilot"
+      description={`High-confidence pilot over the limited enforcement framework: only entries that pass every eligibility rule (limited-enforce mode, confidence ≥ 90%, all framework gates, canary within the pilot cap, kill switch off, no operator hold) are marked pilot-ready. Rollback thresholds and audit rows travel with every decision; Identrail never enforces at this layer. ${summaryLine}`}
+      errorTitle="Couldn't load AWS limited enforcement pilot"
+      loadingTitle="Projecting limited enforcement pilot"
+      loadingBody="Identrail is evaluating framework entries against the pilot's high-confidence eligibility rules."
+      emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No pilot decisions')}
+      emptyTitle={(current) => (current.status === 'blocked' ? 'Enforcement pilot needs framework evidence' : 'No limited enforcement pilot decisions projected')}
+      emptyBody={(current) => current.failure_reasons[0] ?? 'No limited enforcement framework entry was available to evaluate for this environment.'}
+      tableLabel="AWS limited enforcement pilot decisions"
+      getRowKey={(row) => row.pilot_id}
+      columns={[
+        { key: 'decision', header: 'Decision', render: (row) => <strong>{row.title}</strong> },
+        { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+        { key: 'state', header: 'Pilot state', render: (row) => formatTokenLabel(row.pilot_state) },
+        { key: 'rules', header: 'Eligibility', render: (row) => awsLimitedEnforcementPilotRuleLabel(row) },
+        { key: 'confidence', header: 'Confidence', render: (row) => `${row.metrics.confidence_pct}%` },
+        {
+          key: 'readiness',
+          header: 'Readiness',
+          render: (row) => (
+            <AWSInventoryPill stage={awsLimitedEnforcementPilotStage(row)} label={`${formatTokenLabel(row.outcome)} / ${row.metrics.canary_percent}%`} />
+          )
+        }
+      ]}
+    />
+  );
+}
+
 function awsSessionPolicyRecommendationStage(entry: AWSSessionPolicyRecommendationEntry): AWSCapabilityStage {
   if (entry.decision === 'remove' && entry.expected_behavior.observed_action_count > 0) {
     return 'wired';
@@ -13908,6 +13983,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [limitedEnforcementLoading, setLimitedEnforcementLoading] = useState(false);
   const [limitedEnforcementError, setLimitedEnforcementError] = useState('');
   const limitedEnforcementRequestRef = useRef(0);
+  const [limitedEnforcementPilot, setLimitedEnforcementPilot] = useState<AWSLimitedEnforcementPilotResult | null>(null);
+  const [limitedEnforcementPilotLoading, setLimitedEnforcementPilotLoading] = useState(false);
+  const [limitedEnforcementPilotError, setLimitedEnforcementPilotError] = useState('');
+  const limitedEnforcementPilotRequestRef = useRef(0);
   const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
@@ -14660,6 +14739,54 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       limitedEnforcementRequestRef.current += 1;
     };
   }, [loadLimitedEnforcement]);
+
+  const loadLimitedEnforcementPilot = useCallback(async () => {
+    const requestID = ++limitedEnforcementPilotRequestRef.current;
+    setLimitedEnforcementPilot(null);
+    setLimitedEnforcementPilotError('');
+    if (routeID !== 'governance' || !scope || !selectedEnvironmentID || !connection?.connected) {
+      setLimitedEnforcementPilotLoading(false);
+      return;
+    }
+    setLimitedEnforcementPilotLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectLimitedEnforcementPilot(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== limitedEnforcementPilotRequestRef.current) {
+        return;
+      }
+      setLimitedEnforcementPilot(response.limited_enforcement_pilot);
+    } catch (error) {
+      if (requestID !== limitedEnforcementPilotRequestRef.current) {
+        return;
+      }
+      setLimitedEnforcementPilotError(formatAPIError(error, 'Unable to load AWS limited enforcement pilot.'));
+    } finally {
+      if (requestID === limitedEnforcementPilotRequestRef.current) {
+        setLimitedEnforcementPilotLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadLimitedEnforcementPilot();
+    return () => {
+      limitedEnforcementPilotRequestRef.current += 1;
+    };
+  }, [loadLimitedEnforcementPilot]);
 
   const loadSessionPolicyRecommendations = useCallback(async () => {
     const requestID = ++sessionPolicyRecommendationsRequestRef.current;
@@ -15782,6 +15909,14 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             loading={limitedEnforcementLoading}
             error={limitedEnforcementError}
             onRetry={loadLimitedEnforcement}
+          />
+        ) : null}
+        {routeID === 'governance' ? (
+          <AWSLimitedEnforcementPilotContent
+            result={limitedEnforcementPilot}
+            loading={limitedEnforcementPilotLoading}
+            error={limitedEnforcementPilotError}
+            onRetry={loadLimitedEnforcementPilot}
           />
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- implement the high-confidence limited authorization enforcement pilot for issue #1547
- evaluate every limited-enforcement framework entry (#1546) against a stricter, high-confidence-only eligibility rule set: limited-enforce mode, confidence >= 90%, all framework gates passed, canary within the 25% pilot cap, kill switch off, no operator hold
- carry deterministic rollback thresholds (1% denial-regression budget, 24h observation window, kill-switch and override halts), per-decision metrics, drift-detecting input hashes, and immutable audit rows on every pilot decision
- add operator override controls (`operator_override=hold|pause|resume`); unknown values are rejected with a 400 so a typo can never silently resume a held pilot
- wire the endpoint into API routing, authz, OpenAPI, docs, CHANGELOG, and the AWS Governance app surface below the framework panel
- metadata-only: no AWS write API calls; downstream executors own any live control change

## Validation
- go test ./internal/api/...
- make fmt-check && make vet
- ./scripts/check_api_example_contract.sh && ./scripts/check_web_route_integrity.sh
- npx vitest run src/productShell.test.tsx src/api/client.test.ts (247 passing)
- npx tsc -b clean

## AI disclosure
AI-assisted: no

Closes #1547

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the AWS high-confidence limited enforcement pilot (issue #1547), adding a metadata-only API and UI panel that mark framework entries pilot-ready only when strict rules are met and record rollback thresholds, metrics, input hashes, and audit for every decision.

- **New Features**
  - New API: GET `/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot` with filters (account, region, pilot state, source type, outcome, enforcement ID, severity, search); wired in OpenAPI, authz, and router.
  - Eligibility: limited-enforce mode, confidence ≥ 90%, all framework gates passed, canary > 0 and ≤ 25%, kill switch off, no operator hold. States: `pilot_canary_ready`, `pilot_enforce_ready`, `ineligible`, `override_hold`, `blocked_by_kill_switch`.
  - Operator control: `operator_override=hold|pause|resume`; unknown values return 400.
  - Safety and evidence: deterministic rollback thresholds (1% denial regression, 24h window, kill-switch/override halts), per-decision metrics, drift-detecting input hash, immutable audit; metadata-only (no AWS write APIs).
  - App: AWS Governance page shows an “AWS limited enforcement pilot” panel under the framework panel with decision details and readiness.
  - Docs: `aws-limited-enforcement-pilot.md`; CHANGELOG and OpenAPI updated.

<sup>Written for commit 75b7493f6e4bcd22f12e6963e1e9a30980b87d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

