### PR TITLE
Add AWS machine identity detail page

### DIFF
--- a/docs/aws-machine-identity-detail.md
+++ b/docs/aws-machine-identity-detail.md
@@ -1,0 +1,75 @@
+# AWS machine identity detail page
+
+Issue #1549 adds the read-only detail surface for a single AWS machine identity.
+It composes workload bindings, runtime events, least-privilege recommendations,
+secret/resource reachability, remediation cases, and governance decisions into
+one scoped response that backs the app route
+`/app/{tenant_id}/{workspace_id}/aws/identities/detail`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/machine-identity-detail`
+
+Required query parameters:
+
+- `identity`: IAM role ARN, identity node id, or role name to inspect.
+
+Supported optional filters:
+
+- `connector_id`
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
+- `account_id`
+- `region`
+- `tab`: `graph`, `runtime`, `permissions`, `secrets`, `fixes`, or `governance`
+- `service`
+- `resource`
+- `severity`
+- `status`
+
+The response is returned as `{ "detail": ... }` and includes:
+
+- tenant, workspace, project, connector, account, region, issue, version, status, confidence, and applied filters
+- normalized identity metadata with principal ARN, role name, node id, and evidence boundary
+- tab counts for graph, runtime, permissions, secrets, fixes, and governance
+- workload bindings across EC2, ECS, Lambda, CodeBuild, CodePipeline, Step Functions, event-driven roles, managed compute, and EKS
+- runtime events, permission summaries, resources reached, security findings, remediation cases, governance decisions, and graph relationships
+- diagnostics, coverage gaps, failure reasons, remediation hints, and evidence links
+
+## App behavior
+
+The AWS identities inventory links role-bearing rows to the detail route with
+the selected environment and exact identity ARN. The detail page keeps the
+environment selector active and reloads when the environment, identity, or tab
+changes.
+
+The UI exposes six tabs:
+
+- `graph`: workload bindings and graph relationships
+- `runtime`: matching CloudTrail/runtime records
+- `permissions`: least-privilege recommendation summaries
+- `secrets`: reached resources plus secret, blast-radius, and sprawl findings
+- `fixes`: read-only remediation case projections
+- `governance`: advisory, approval, remediation, enforcement, and exception records
+
+## Safety boundaries
+
+The contract is read-only and metadata-only. It must not read, expose, log, or
+persist secret values, decrypted plaintext, policy document bodies, request or
+response payload bodies, prompts, completions, browser pages, code-interpreter
+output, database rows, or customer object contents.
+
+The response evidence boundary is
+`metadata_only_no_secret_values_no_policy_bodies_no_payloads`. Downstream
+collectors may contribute ARNs, names, ids, hashes, timestamps, action names,
+and safe evidence references, but not sensitive values or document bodies.
+
+## Failure states
+
+- `empty`: the identity is valid, but no workload, runtime, permission, secret, remediation, or governance evidence matched.
+- `degraded`: evidence exists, but one or more collectors returned partial or low-confidence data.
+- `partial_failure`: at least one downstream capability failed while retained evidence remains visible.
+- `permission_denied`: the selected connector lacks required read-only metadata permissions.
+
+These states remain visible in the detail page through status panels,
+diagnostics, coverage gaps, and remediation hints rather than being collapsed
+into a successful view.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4750,12 +4750,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [detail]
-                properties:
-                  detail:
-                    type: object
-                    description: Composed AWS machine identity detail result. See docs/aws-machine-identity-detail.md for the full response contract and evidence boundaries.
+                $ref: "#/components/schemas/AWSMachineIdentityDetailResponse"
         "400":
           description: Invalid AWS machine identity detail request
           content:
@@ -13470,6 +13465,262 @@ components:
           type: array
           items: { type: string }
         generated_at:
+          type: string
+          format: date-time
+    AWSMachineIdentityDetailResponse:
+      type: object
+      required: [detail]
+      properties:
+        detail:
+          $ref: "#/components/schemas/AWSMachineIdentityDetailResult"
+    AWSMachineIdentityDetailIdentity:
+      type: object
+      properties:
+        identity: { type: string }
+        identity_node_id: { type: string }
+        principal_arn: { type: string }
+        role_name: { type: string }
+        display_name: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked, empty]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        evidence_boundary: { type: string }
+    AWSMachineIdentityWorkloadBinding:
+      type: object
+      properties:
+        binding_id: { type: string }
+        service: { type: string }
+        workload_id: { type: string }
+        workload_type: { type: string }
+        workload_name: { type: string }
+        role_arn: { type: string }
+        role_name: { type: string }
+        role_kind: { type: string }
+        relationship_type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked, empty]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        collected_at:
+          type: string
+          format: date-time
+    AWSMachineIdentityPermissionSummary:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        decision: { type: string }
+        severity: { type: string }
+        status: { type: string }
+        service: { type: string }
+        resource_arn: { type: string }
+        display_name: { type: string }
+        actions:
+          type: array
+          items: { type: string }
+        rationale: { type: string }
+        next_action: { type: string }
+        score: { type: integer }
+    AWSMachineIdentityResourceSummary:
+      type: object
+      properties:
+        resource_id: { type: string }
+        resource_arn: { type: string }
+        resource_type: { type: string }
+        label: { type: string }
+        source: { type: string }
+        evidence_ref: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+    AWSMachineIdentityFindingSummary:
+      type: object
+      properties:
+        finding_id: { type: string }
+        source: { type: string }
+        finding_type: { type: string }
+        severity: { type: string }
+        status: { type: string }
+        score: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+    AWSMachineIdentityGovernanceDecision:
+      type: object
+      properties:
+        report_id: { type: string }
+        category: { type: string }
+        decision_type: { type: string }
+        state: { type: string }
+        title: { type: string }
+        summary: { type: string }
+        actor: { type: string }
+        approver: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        occurred_at:
+          type: string
+          format: date-time
+    AWSMachineIdentityDetailRelationship:
+      type: object
+      properties:
+        source: { type: string }
+        type: { type: string }
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_ref: { type: string }
+    AWSMachineIdentityDetailTab:
+      type: object
+      properties:
+        id:
+          type: string
+          enum: [graph, runtime, permissions, secrets, fixes, governance]
+        label: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked, empty]
+        count: { type: integer }
+    AWSMachineIdentityDetailDiagnostic:
+      type: object
+      properties:
+        collector: { type: string }
+        source_id: { type: string }
+        code: { type: string }
+        message: { type: string }
+        remediation: { type: string }
+        retryable: { type: boolean }
+    AWSMachineIdentityDetailCoverageGap:
+      type: object
+      properties:
+        capability: { type: string }
+        status: { type: string }
+        reason: { type: string }
+        remediation: { type: string }
+    AWSMachineIdentityDetailSummary:
+      type: object
+      properties:
+        workload_binding_count: { type: integer }
+        runtime_event_count: { type: integer }
+        permission_recommendation_count: { type: integer }
+        secret_finding_count: { type: integer }
+        finding_count: { type: integer }
+        remediation_case_count: { type: integer }
+        governance_decision_count: { type: integer }
+        resource_reached_count: { type: integer }
+        relationship_count: { type: integer }
+        evidence_link_count: { type: integer }
+        diagnostic_count: { type: integer }
+        coverage_gap_count: { type: integer }
+    AWSMachineIdentityDetailResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked, empty]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        policy_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        identity:
+          $ref: "#/components/schemas/AWSMachineIdentityDetailIdentity"
+        summary:
+          $ref: "#/components/schemas/AWSMachineIdentityDetailSummary"
+        tabs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailTab"
+        workload_bindings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityWorkloadBinding"
+        permission_summaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityPermissionSummary"
+        resources_reached:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityResourceSummary"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityFindingSummary"
+        governance_decisions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityGovernanceDecision"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailRelationship"
+        runtime:
+          $ref: "#/components/schemas/AWSRuntimeEventResult"
+        permissions:
+          $ref: "#/components/schemas/AWSLeastPrivilegeResult"
+        secrets:
+          $ref: "#/components/schemas/AWSSecretPermissionEquivalenceResult"
+        blast_radius:
+          $ref: "#/components/schemas/AWSBlastRadiusResult"
+        identity_sprawl:
+          $ref: "#/components/schemas/AWSIdentitySprawlResult"
+        remediation_cases:
+          $ref: "#/components/schemas/AWSRemediationCaseResult"
+        governance:
+          $ref: "#/components/schemas/AWSGovernanceAuditReportingResult"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
           type: string
           format: date-time
     AWSBedrockAgentCoverageGap:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -544,6 +544,11 @@ x-identrail-route-authorizations:
     resource_type: ai_agent_identity
     resource_id_param: agent_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/machine-identity-detail
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents
     action: tenancy.read
     resource_type: project
@@ -4672,6 +4677,87 @@ paths:
                     $ref: "#/components/schemas/AWSAIAgentIdentityInventoryResult"
         "400":
           description: Invalid AWS AI agent identity inventory request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/machine-identity-detail:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS machine identity detail
+      operationId: getAWSProjectMachineIdentityDetail
+      description: Returns one scoped, metadata-only AWS machine identity detail view by composing workload bindings, runtime events, least-privilege recommendations, secret/resource reachability, remediation cases, governance decisions, and graph relationships. The endpoint is read-only and never returns secret values, policy document bodies, payload bodies, object contents, prompts, completions, browser pages, code-interpreter output, or database rows.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: identity
+          required: true
+          schema: { type: string }
+          description: IAM role ARN, identity node id, or role name to inspect.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: tab
+          schema:
+            type: string
+            enum: [graph, runtime, permissions, secrets, fixes, governance]
+          description: Optional detail tab selector used by the app route.
+        - in: query
+          name: service
+          schema: { type: string }
+        - in: query
+          name: resource
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema: { type: string }
+        - in: query
+          name: status
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS machine identity detail contract
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [detail]
+                properties:
+                  detail:
+                    type: object
+                    description: Composed AWS machine identity detail result. See docs/aws-machine-identity-detail.md for the full response contract and evidence boundaries.
+        "400":
+          description: Invalid AWS machine identity detail request
           content:
             application/json:
               schema:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -752,6 +752,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/sagemaker-workload-roles", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities/:agent_id", Action: policyActionTenancyRead, ResourceType: "ai_agent_identity", ResourceIDParam: "agent_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/machine-identity-detail", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -354,12 +354,13 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 		}
 	}
 	identityNodeID := identityScope.NodeID
+	governanceIdentityID := awsMachineIdentityDetailGovernanceIdentityID(identityScope)
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
 		AccountID:    request.AccountID,
 		Region:       request.Region,
-		IdentityID:   identityNodeID,
+		IdentityID:   governanceIdentityID,
 		State:        request.Status,
 	})
 	if err != nil {
@@ -554,6 +555,16 @@ func awsMachineIdentityDetailScopeWithEvidence(scope awsMachineIdentityDetailSco
 	}
 	scope.DownstreamIdentity = firstNonEmptyAWSValue(scope.PrincipalARN, scope.NodeID, scope.RoleName)
 	return scope
+}
+
+func awsMachineIdentityDetailGovernanceIdentityID(scope awsMachineIdentityDetailScope) string {
+	if strings.TrimSpace(scope.NodeID) != "" {
+		return strings.TrimSpace(scope.NodeID)
+	}
+	if strings.HasPrefix(scope.DownstreamIdentity, "aws:identity:unresolved:") {
+		return scope.DownstreamIdentity
+	}
+	return ""
 }
 
 func awsMachineIdentityDetailScopeAccepts(scope awsMachineIdentityDetailScope, principalARN, nodeID, roleName string) bool {

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -353,6 +353,7 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 			return AWSMachineIdentityDetailResult{}, err
 		}
 	}
+	runtime, permissions, secrets, blast, sprawl, cases = awsMachineIdentityDetailFilterDownstreamEvidence(identityScope, runtime, permissions, secrets, blast, sprawl, cases)
 	identityNodeID := identityScope.NodeID
 	governanceIdentityID := awsMachineIdentityDetailGovernanceIdentityID(identityScope)
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
@@ -565,6 +566,236 @@ func awsMachineIdentityDetailGovernanceIdentityID(scope awsMachineIdentityDetail
 		return scope.DownstreamIdentity
 	}
 	return ""
+}
+
+func awsMachineIdentityDetailFilterDownstreamEvidence(scope awsMachineIdentityDetailScope, runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult, cases AWSRemediationCaseResult) (AWSRuntimeEventResult, AWSLeastPrivilegeResult, AWSSecretPermissionEquivalenceResult, AWSBlastRadiusResult, AWSIdentitySprawlResult, AWSRemediationCaseResult) {
+	runtime = awsMachineIdentityDetailFilterRuntimeEvents(scope, runtime)
+	permissions = awsMachineIdentityDetailFilterLeastPrivilege(scope, permissions)
+	secrets = awsMachineIdentityDetailFilterSecrets(scope, secrets)
+	blast = awsMachineIdentityDetailFilterBlastRadius(scope, blast)
+	sprawl = awsMachineIdentityDetailFilterSprawl(scope, sprawl)
+	cases = awsMachineIdentityDetailFilterRemediationCases(scope, cases)
+	return runtime, permissions, secrets, blast, sprawl, cases
+}
+
+func awsMachineIdentityDetailFilterRuntimeEvents(scope awsMachineIdentityDetailScope, result AWSRuntimeEventResult) AWSRuntimeEventResult {
+	records := make([]AWSRuntimeEventRecord, 0, len(result.Records))
+	for _, record := range result.Records {
+		if !awsMachineIdentityDetailScopeMatches(scope,
+			record.ActorPrincipalARN,
+			record.ActorIdentityNodeID,
+			record.Session.PrincipalARN,
+			record.Session.AssumedRoleARN,
+			record.Session.SessionIssuerARN,
+			record.Session.OriginalActorARN,
+			record.Session.OriginalActorNodeID,
+			record.Session.ChainedFromPrincipalARN,
+			record.Session.ChainedFromNodeID,
+		) {
+			continue
+		}
+		records = append(records, record)
+	}
+	result.Records = records
+	result.Relationships = awsRuntimeEventRelationships(records)
+	result.Summary = summarizeAWSRuntimeEvents(records, len(records), len(result.Relationships))
+	return result
+}
+
+func awsMachineIdentityDetailFilterLeastPrivilege(scope awsMachineIdentityDetailScope, result AWSLeastPrivilegeResult) AWSLeastPrivilegeResult {
+	recommendations := make([]AWSLeastPrivilegeRecommendation, 0, len(result.Recommendations))
+	for _, recommendation := range result.Recommendations {
+		if !awsMachineIdentityDetailScopeMatches(scope, awsLeastPrivilegeIdentityMatchValues(recommendation)...) {
+			continue
+		}
+		recommendations = append(recommendations, recommendation)
+	}
+	result.Recommendations = recommendations
+	result.Relationships = awsLeastPrivilegeRelationships(recommendations)
+	result.Summary = summarizeAWSLeastPrivilege(recommendations, recommendations, result.Relationships)
+	return result
+}
+
+func awsMachineIdentityDetailFilterSecrets(scope awsMachineIdentityDetailScope, result AWSSecretPermissionEquivalenceResult) AWSSecretPermissionEquivalenceResult {
+	findings := make([]AWSSecretPermissionEquivalenceFinding, 0, len(result.Findings))
+	for _, finding := range result.Findings {
+		if !awsMachineIdentityDetailScopeMatches(scope, awsMachineIdentityDetailSecretIdentityValues(finding)...) {
+			continue
+		}
+		findings = append(findings, finding)
+	}
+	result.Findings = findings
+	result.Relationships = awsSecretPermissionEquivalenceRelationships(findings)
+	result.Summary = summarizeAWSSecretPermissionEquivalence(findings, findings, result.Relationships)
+	return result
+}
+
+func awsMachineIdentityDetailFilterBlastRadius(scope awsMachineIdentityDetailScope, result AWSBlastRadiusResult) AWSBlastRadiusResult {
+	findings := make([]AWSBlastRadiusFinding, 0, len(result.Findings))
+	for _, finding := range result.Findings {
+		if !awsMachineIdentityDetailScopeMatches(scope, awsBlastRadiusIdentityMatchValues(finding)...) {
+			continue
+		}
+		findings = append(findings, finding)
+	}
+	result.Findings = findings
+	result.Relationships = awsBlastRadiusRelationships(findings)
+	result.Summary = summarizeAWSBlastRadius(findings, findings, result.Relationships)
+	return result
+}
+
+func awsMachineIdentityDetailFilterSprawl(scope awsMachineIdentityDetailScope, result AWSIdentitySprawlResult) AWSIdentitySprawlResult {
+	findings := make([]AWSIdentitySprawlFinding, 0, len(result.Findings))
+	for _, finding := range result.Findings {
+		if !awsMachineIdentityDetailScopeMatches(scope, awsMachineIdentityDetailSprawlIdentityValues(finding)...) {
+			continue
+		}
+		findings = append(findings, finding)
+	}
+	result.Findings = findings
+	result.Clusters = awsMachineIdentityDetailFilterSprawlClusters(scope, result.Clusters, findings)
+	result.Relationships = awsIdentitySprawlRelationships(findings)
+	result.Summary = summarizeAWSIdentitySprawl(findings, result.Clusters, findings, result.Relationships, awsMachineIdentityDetailSprawlAggregates(findings))
+	return result
+}
+
+func awsMachineIdentityDetailFilterRemediationCases(scope awsMachineIdentityDetailScope, result AWSRemediationCaseResult) AWSRemediationCaseResult {
+	cases := make([]AWSRemediationCase, 0, len(result.Cases))
+	for _, c := range result.Cases {
+		if !awsMachineIdentityDetailScopeMatches(scope, awsMachineIdentityDetailRemediationCaseIdentityValues(c)...) {
+			continue
+		}
+		cases = append(cases, c)
+	}
+	result.Cases = cases
+	result.Relationships = awsRemediationCaseRelationships(cases)
+	result.Summary = summarizeAWSRemediationCases(cases, cases, result.Relationships)
+	return result
+}
+
+func awsMachineIdentityDetailScopeMatches(scope awsMachineIdentityDetailScope, values ...string) bool {
+	if strings.TrimSpace(scope.PrincipalARN) != "" {
+		return awsMachineIdentityMatches(scope.PrincipalARN, values...)
+	}
+	if strings.TrimSpace(scope.NodeID) != "" {
+		return awsMachineIdentityMatches(scope.NodeID, values...)
+	}
+	if strings.TrimSpace(scope.RoleName) != "" {
+		return awsMachineIdentityRoleNameMatches(scope.RoleName, values...)
+	}
+	return false
+}
+
+func awsMachineIdentityDetailSecretIdentityValues(finding AWSSecretPermissionEquivalenceFinding) []string {
+	values := []string{
+		finding.IdentityNodeID,
+		finding.PrincipalARN,
+		finding.WorkloadID,
+		finding.WorkloadName,
+		finding.AgentID,
+		finding.AgentName,
+	}
+	for _, step := range finding.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			values = append(values, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(values)
+}
+
+func awsMachineIdentityDetailSprawlIdentityValues(finding AWSIdentitySprawlFinding) []string {
+	values := []string{
+		finding.IdentityNodeID,
+		finding.PrincipalARN,
+		finding.RoleName,
+		finding.DisplayName,
+	}
+	for _, step := range finding.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			values = append(values, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(values)
+}
+
+func awsMachineIdentityDetailRemediationCaseIdentityValues(c AWSRemediationCase) []string {
+	values := []string{
+		c.IdentityNodeID,
+		c.IdentityARN,
+		c.IdentityName,
+	}
+	for _, step := range c.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "identity") {
+			values = append(values, step.NodeID, step.Label)
+		}
+	}
+	return dedupeStrings(values)
+}
+
+func awsMachineIdentityDetailFilterSprawlClusters(scope awsMachineIdentityDetailScope, clusters []AWSIdentitySprawlCluster, findings []AWSIdentitySprawlFinding) []AWSIdentitySprawlCluster {
+	clusterIDs := map[string]struct{}{}
+	identityNodeIDs := map[string]struct{}{}
+	for _, finding := range findings {
+		if finding.ClusterID != "" {
+			clusterIDs[finding.ClusterID] = struct{}{}
+		}
+		if finding.IdentityNodeID != "" {
+			identityNodeIDs[finding.IdentityNodeID] = struct{}{}
+		}
+	}
+	out := make([]AWSIdentitySprawlCluster, 0, len(clusters))
+	for _, cluster := range clusters {
+		if _, ok := clusterIDs[cluster.ClusterID]; !ok {
+			continue
+		}
+		ids := make([]string, 0, len(cluster.IdentityNodeIDs))
+		for _, nodeID := range cluster.IdentityNodeIDs {
+			if _, ok := identityNodeIDs[nodeID]; ok || awsMachineIdentityDetailScopeMatches(scope, nodeID) {
+				ids = append(ids, nodeID)
+			}
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		cluster.IdentityNodeIDs = ids
+		out = append(out, cluster)
+	}
+	return out
+}
+
+func awsMachineIdentityDetailSprawlAggregates(findings []AWSIdentitySprawlFinding) map[string]*identitySprawlAggregate {
+	aggregates := map[string]*identitySprawlAggregate{}
+	for _, finding := range findings {
+		key := firstNonEmptyAWSValue(finding.IdentityNodeID, finding.PrincipalARN, finding.RoleName, finding.DisplayName, finding.FindingID)
+		if key == "" {
+			continue
+		}
+		aggregate, ok := aggregates[key]
+		if !ok {
+			aggregate = &identitySprawlAggregate{
+				roleARN:         finding.PrincipalARN,
+				roleName:        finding.RoleName,
+				accountID:       finding.AccountID,
+				region:          finding.Region,
+				owner:           finding.OwnerLabel,
+				ownerSource:     finding.OwnerSource,
+				workloadNodeIDs: map[string]struct{}{},
+				workloadTypes:   map[string]struct{}{},
+			}
+			aggregates[key] = aggregate
+		}
+		for _, nodeID := range finding.WorkloadNodeIDs {
+			if strings.TrimSpace(nodeID) != "" {
+				aggregate.workloadNodeIDs[nodeID] = struct{}{}
+			}
+		}
+		for _, workloadType := range finding.WorkloadTypes {
+			if strings.TrimSpace(workloadType) != "" {
+				aggregate.workloadTypes[workloadType] = struct{}{}
+			}
+		}
+	}
+	return aggregates
 }
 
 func awsMachineIdentityDetailScopeAccepts(scope awsMachineIdentityDetailScope, principalARN, nodeID, roleName string) bool {

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -345,7 +345,6 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 		AccountID:    request.AccountID,
 		Region:       request.Region,
 		IdentityID:   identityNodeID,
-		Category:     request.Tab,
 		State:        request.Status,
 	})
 	if err != nil {

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -1,0 +1,1136 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsMachineIdentityDetailCurrentIssue = 1549
+	awsMachineIdentityDetailVersion      = "aws-machine-identity-detail-page-v1"
+	awsMachineIdentityDetailPolicyID     = "aws-machine-identity-detail-policy-v1"
+)
+
+// AWSMachineIdentityDetailRequest scopes the read-only machine identity detail
+// page to one identity plus the operator filters shared by downstream surfaces.
+type AWSMachineIdentityDetailRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Tab          string `json:"tab,omitempty"`
+	Service      string `json:"service,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+type AWSMachineIdentityDetailIdentity struct {
+	Identity         string  `json:"identity"`
+	IdentityNodeID   string  `json:"identity_node_id"`
+	PrincipalARN     string  `json:"principal_arn,omitempty"`
+	RoleName         string  `json:"role_name,omitempty"`
+	DisplayName      string  `json:"display_name"`
+	AccountID        string  `json:"account_id,omitempty"`
+	Region           string  `json:"region,omitempty"`
+	Status           string  `json:"status"`
+	Confidence       float64 `json:"confidence"`
+	EvidenceBoundary string  `json:"evidence_boundary"`
+}
+
+type AWSMachineIdentityWorkloadBinding struct {
+	BindingID        string    `json:"binding_id"`
+	Service          string    `json:"service"`
+	WorkloadID       string    `json:"workload_id,omitempty"`
+	WorkloadType     string    `json:"workload_type,omitempty"`
+	WorkloadName     string    `json:"workload_name,omitempty"`
+	RoleARN          string    `json:"role_arn,omitempty"`
+	RoleName         string    `json:"role_name,omitempty"`
+	RoleKind         string    `json:"role_kind,omitempty"`
+	RelationshipType string    `json:"relationship_type,omitempty"`
+	FromNodeID       string    `json:"from_node_id,omitempty"`
+	ToNodeID         string    `json:"to_node_id,omitempty"`
+	EvidenceRef      string    `json:"evidence_ref,omitempty"`
+	Status           string    `json:"status"`
+	Confidence       float64   `json:"confidence"`
+	CollectedAt      time.Time `json:"collected_at,omitzero"`
+}
+
+type AWSMachineIdentityPermissionSummary struct {
+	RecommendationID string   `json:"recommendation_id"`
+	Decision         string   `json:"decision"`
+	Severity         string   `json:"severity"`
+	Status           string   `json:"status"`
+	Service          string   `json:"service"`
+	ResourceARN      string   `json:"resource_arn,omitempty"`
+	DisplayName      string   `json:"display_name"`
+	Actions          []string `json:"actions,omitempty"`
+	Rationale        string   `json:"rationale"`
+	NextAction       string   `json:"next_action"`
+	Score            int      `json:"score"`
+}
+
+type AWSMachineIdentityResourceSummary struct {
+	ResourceID   string    `json:"resource_id"`
+	ResourceARN  string    `json:"resource_arn,omitempty"`
+	ResourceType string    `json:"resource_type,omitempty"`
+	Label        string    `json:"label"`
+	Source       string    `json:"source"`
+	EvidenceRef  string    `json:"evidence_ref,omitempty"`
+	ObservedAt   time.Time `json:"observed_at,omitzero"`
+}
+
+type AWSMachineIdentityFindingSummary struct {
+	FindingID    string   `json:"finding_id"`
+	Source       string   `json:"source"`
+	FindingType  string   `json:"finding_type"`
+	Severity     string   `json:"severity"`
+	Status       string   `json:"status"`
+	Score        int      `json:"score"`
+	Title        string   `json:"title"`
+	Summary      string   `json:"summary"`
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+	NextAction   string   `json:"next_action"`
+}
+
+type AWSMachineIdentityGovernanceDecision struct {
+	ReportID     string    `json:"report_id"`
+	Category     string    `json:"category"`
+	DecisionType string    `json:"decision_type"`
+	State        string    `json:"state"`
+	Title        string    `json:"title"`
+	Summary      string    `json:"summary"`
+	Actor        string    `json:"actor,omitempty"`
+	Approver     string    `json:"approver,omitempty"`
+	EvidenceRefs []string  `json:"evidence_refs,omitempty"`
+	OccurredAt   time.Time `json:"occurred_at,omitzero"`
+}
+
+type AWSMachineIdentityDetailRelationship struct {
+	Source      string `json:"source"`
+	Type        string `json:"type"`
+	FromNodeID  string `json:"from_node_id"`
+	ToNodeID    string `json:"to_node_id"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+type AWSMachineIdentityDetailTab struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+type AWSMachineIdentityDetailDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+type AWSMachineIdentityDetailCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSMachineIdentityDetailSummary struct {
+	WorkloadBindingCount          int `json:"workload_binding_count"`
+	RuntimeEventCount             int `json:"runtime_event_count"`
+	PermissionRecommendationCount int `json:"permission_recommendation_count"`
+	SecretFindingCount            int `json:"secret_finding_count"`
+	FindingCount                  int `json:"finding_count"`
+	RemediationCaseCount          int `json:"remediation_case_count"`
+	GovernanceDecisionCount       int `json:"governance_decision_count"`
+	ResourceReachedCount          int `json:"resource_reached_count"`
+	RelationshipCount             int `json:"relationship_count"`
+	EvidenceLinkCount             int `json:"evidence_link_count"`
+	DiagnosticCount               int `json:"diagnostic_count"`
+	CoverageGapCount              int `json:"coverage_gap_count"`
+}
+
+type AWSMachineIdentityDetailResult struct {
+	TenantID            string                                 `json:"tenant_id"`
+	WorkspaceID         string                                 `json:"workspace_id"`
+	ProjectID           string                                 `json:"project_id"`
+	ConnectorID         string                                 `json:"connector_id,omitempty"`
+	AccountID           string                                 `json:"account_id,omitempty"`
+	Region              string                                 `json:"region,omitempty"`
+	ParentIssueNumber   int                                    `json:"parent_issue_number"`
+	ParentIssueRef      string                                 `json:"parent_issue_ref"`
+	CurrentIssueNumber  int                                    `json:"current_issue_number"`
+	CurrentIssueRef     string                                 `json:"current_issue_ref"`
+	Version             string                                 `json:"version"`
+	Status              string                                 `json:"status"`
+	FixtureState        string                                 `json:"fixture_state,omitempty"`
+	Confidence          float64                                `json:"confidence"`
+	PolicyVersion       string                                 `json:"policy_version"`
+	AppliedFilters      map[string]string                      `json:"applied_filters"`
+	Identity            AWSMachineIdentityDetailIdentity       `json:"identity"`
+	Summary             AWSMachineIdentityDetailSummary        `json:"summary"`
+	Tabs                []AWSMachineIdentityDetailTab          `json:"tabs"`
+	WorkloadBindings    []AWSMachineIdentityWorkloadBinding    `json:"workload_bindings"`
+	PermissionSummaries []AWSMachineIdentityPermissionSummary  `json:"permission_summaries"`
+	ResourcesReached    []AWSMachineIdentityResourceSummary    `json:"resources_reached"`
+	Findings            []AWSMachineIdentityFindingSummary     `json:"findings"`
+	GovernanceDecisions []AWSMachineIdentityGovernanceDecision `json:"governance_decisions"`
+	Relationships       []AWSMachineIdentityDetailRelationship `json:"relationships"`
+	Runtime             AWSRuntimeEventResult                  `json:"runtime"`
+	Permissions         AWSLeastPrivilegeResult                `json:"permissions"`
+	Secrets             AWSSecretPermissionEquivalenceResult   `json:"secrets"`
+	BlastRadius         AWSBlastRadiusResult                   `json:"blast_radius"`
+	IdentitySprawl      AWSIdentitySprawlResult                `json:"identity_sprawl"`
+	RemediationCases    AWSRemediationCaseResult               `json:"remediation_cases"`
+	Governance          AWSGovernanceAuditReportingResult      `json:"governance"`
+	FailureReasons      []string                               `json:"failure_reasons"`
+	RemediationHints    []string                               `json:"remediation_hints"`
+	EvidenceLinks       []string                               `json:"evidence_links"`
+	CoverageGaps        []AWSMachineIdentityDetailCoverageGap  `json:"coverage_gaps"`
+	Diagnostics         []AWSMachineIdentityDetailDiagnostic   `json:"diagnostics"`
+	GeneratedAt         time.Time                              `json:"generated_at"`
+	UpdatedAt           time.Time                              `json:"updated_at"`
+}
+
+func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID string, projectID string, request AWSMachineIdentityDetailRequest) (AWSMachineIdentityDetailResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, err
+	}
+	identity := strings.TrimSpace(request.Identity)
+	if identity == "" {
+		return AWSMachineIdentityDetailResult{}, ErrInvalidAWSConnectionRequest
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSMachineIdentityDetailFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSMachineIdentityDetailResult{}, ErrInvalidAWSConnectionRequest
+	}
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	identityNodeID := awsMachineIdentityDetailNodeID(identity)
+
+	ec2, err := s.GetAWSEC2InstanceProfileInventory(ctx, workspaceID, projectID, AWSEC2InstanceProfileInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail ec2 inventory: %w", err)
+	}
+	ecs, err := s.GetAWSECSTaskRoleInventory(ctx, workspaceID, projectID, AWSECSTaskRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail ecs inventory: %w", err)
+	}
+	lambda, err := s.GetAWSLambdaExecutionRoleInventory(ctx, workspaceID, projectID, AWSLambdaExecutionRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail lambda inventory: %w", err)
+	}
+	codeBuild, err := s.GetAWSCodeBuildServiceRoleInventory(ctx, workspaceID, projectID, AWSCodeBuildServiceRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail codebuild inventory: %w", err)
+	}
+	codePipeline, err := s.GetAWSCodePipelineDeploymentRoleInventory(ctx, workspaceID, projectID, AWSCodePipelineDeploymentRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail codepipeline inventory: %w", err)
+	}
+	stepFunctions, err := s.GetAWSStepFunctionsStateMachineRoleInventory(ctx, workspaceID, projectID, AWSStepFunctionsStateMachineRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail stepfunctions inventory: %w", err)
+	}
+	eventDriven, err := s.GetAWSEventDrivenRoleInventory(ctx, workspaceID, projectID, AWSEventDrivenRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail event-driven inventory: %w", err)
+	}
+	managedCompute, err := s.GetAWSManagedComputeRoleInventory(ctx, workspaceID, projectID, AWSManagedComputeRoleInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail managed compute inventory: %w", err)
+	}
+	eks, err := s.GetAWSEKSWorkloadIdentityInventory(ctx, workspaceID, projectID, AWSEKSWorkloadIdentityInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail eks inventory: %w", err)
+	}
+
+	downstreamIdentity := awsMachineIdentityDetailFilterToken(identity)
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Resource:     request.Resource,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail runtime: %w", err)
+	}
+	permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Resource:     request.Resource,
+		Service:      request.Service,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail permissions: %w", err)
+	}
+	secrets, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Secret:       request.Resource,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail secrets: %w", err)
+	}
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Resource:     request.Resource,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail blast radius: %w", err)
+	}
+	sprawl, err := s.GetAWSIdentitySprawl(ctx, workspaceID, projectID, AWSIdentitySprawlRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail sprawl: %w", err)
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     downstreamIdentity,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail remediation cases: %w", err)
+	}
+	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		IdentityID:   identityNodeID,
+		Category:     request.Tab,
+		State:        request.Status,
+	})
+	if err != nil {
+		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail governance: %w", err)
+	}
+
+	bindings := awsMachineIdentityDetailBindings(identity, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks)
+	permissionSummaries := awsMachineIdentityPermissionSummaries(permissions.Recommendations)
+	resourcesReached := awsMachineIdentityResourcesReached(runtime, permissions, secrets, blast)
+	findings := awsMachineIdentityFindingSummaries(secrets, blast, sprawl)
+	governanceDecisions := awsMachineIdentityGovernanceDecisions(governance.Records)
+	relationships := awsMachineIdentityDetailRelationships(bindings, runtime, permissions, secrets, blast, sprawl, cases, governance)
+	diagnostics := awsMachineIdentityDetailDiagnostics(ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks, runtime, permissions, secrets, blast, sprawl, cases, governance)
+	coverageGaps := awsMachineIdentityDetailCoverageGaps(runtime, permissions, secrets, blast, sprawl, cases, governance)
+	evidenceLinks := awsMachineIdentityDetailEvidenceLinks(identity, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks, runtime, permissions, secrets, blast, sprawl, cases, governance)
+	status, confidence, failures, remediations := summarizeAWSMachineIdentityDetail(fixtureState, bindings, runtime, permissions, secrets, blast, sprawl, cases, governance, diagnostics)
+	identitySummary := awsMachineIdentityDetailIdentity(identity, identityNodeID, accountID, region, status, confidence, bindings, runtime, permissions, secrets, blast, sprawl, cases)
+	summary := AWSMachineIdentityDetailSummary{
+		WorkloadBindingCount:          len(bindings),
+		RuntimeEventCount:             len(runtime.Records),
+		PermissionRecommendationCount: len(permissions.Recommendations),
+		SecretFindingCount:            len(secrets.Findings),
+		FindingCount:                  len(findings),
+		RemediationCaseCount:          len(cases.Cases),
+		GovernanceDecisionCount:       len(governanceDecisions),
+		ResourceReachedCount:          len(resourcesReached),
+		RelationshipCount:             len(relationships),
+		EvidenceLinkCount:             len(evidenceLinks),
+		DiagnosticCount:               len(diagnostics),
+		CoverageGapCount:              len(coverageGaps),
+	}
+
+	return AWSMachineIdentityDetailResult{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		AccountID:           accountID,
+		Region:              region,
+		ParentIssueNumber:   awsPlatformDependencyParentIssue,
+		ParentIssueRef:      awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:  awsMachineIdentityDetailCurrentIssue,
+		CurrentIssueRef:     awsIssueRef(awsMachineIdentityDetailCurrentIssue),
+		Version:             awsMachineIdentityDetailVersion,
+		Status:              status,
+		FixtureState:        fixtureState,
+		Confidence:          confidence,
+		PolicyVersion:       awsMachineIdentityDetailPolicyID,
+		AppliedFilters:      awsMachineIdentityDetailAppliedFilters(request, identityNodeID),
+		Identity:            identitySummary,
+		Summary:             summary,
+		Tabs:                awsMachineIdentityDetailTabs(summary, status),
+		WorkloadBindings:    bindings,
+		PermissionSummaries: permissionSummaries,
+		ResourcesReached:    resourcesReached,
+		Findings:            findings,
+		GovernanceDecisions: governanceDecisions,
+		Relationships:       relationships,
+		Runtime:             runtime,
+		Permissions:         permissions,
+		Secrets:             secrets,
+		BlastRadius:         blast,
+		IdentitySprawl:      sprawl,
+		RemediationCases:    cases,
+		Governance:          governance,
+		FailureReasons:      dedupeStrings(append(failures, awsMachineIdentityDetailFailureReasons(runtime, permissions, secrets, blast, sprawl, cases, governance)...)),
+		RemediationHints:    dedupeStrings(append(remediations, awsMachineIdentityDetailRemediationHints(runtime, permissions, secrets, blast, sprawl, cases, governance)...)),
+		EvidenceLinks:       evidenceLinks,
+		CoverageGaps:        coverageGaps,
+		Diagnostics:         diagnostics,
+		GeneratedAt:         now,
+		UpdatedAt:           now,
+	}, nil
+}
+
+func normalizeAWSMachineIdentityDetailFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+func awsMachineIdentityDetailNodeID(identity string) string {
+	identity = strings.TrimSpace(identity)
+	if strings.HasPrefix(strings.ToLower(identity), "arn:") {
+		return awsIdentityNodeIDForAPI(identity)
+	}
+	return identity
+}
+
+func awsMachineIdentityDetailFilterToken(identity string) string {
+	identity = strings.TrimSpace(identity)
+	if strings.HasPrefix(strings.ToLower(identity), "arn:") {
+		return firstNonEmptyAWSValue(shortAWSARN(identity), identity)
+	}
+	if strings.HasPrefix(strings.ToLower(identity), "aws:identity:arn:") {
+		arn := strings.TrimPrefix(identity, "aws:identity:")
+		return firstNonEmptyAWSValue(shortAWSARN(arn), identity)
+	}
+	return identity
+}
+
+func awsMachineIdentityDetailAppliedFilters(request AWSMachineIdentityDetailRequest, identityNodeID string) map[string]string {
+	filters := map[string]string{
+		"connector_id":     strings.TrimSpace(request.ConnectorID),
+		"fixture_state":    strings.TrimSpace(request.FixtureState),
+		"identity":         strings.TrimSpace(request.Identity),
+		"identity_node_id": strings.TrimSpace(identityNodeID),
+		"account_id":       strings.TrimSpace(request.AccountID),
+		"region":           strings.TrimSpace(request.Region),
+		"tab":              normalizeAWSRuntimeEventFilterToken(request.Tab),
+		"service":          normalizeAWSRuntimeEventFilterToken(request.Service),
+		"resource":         strings.TrimSpace(request.Resource),
+		"severity":         normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"status":           normalizeAWSRuntimeEventFilterToken(request.Status),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	return filters
+}
+
+func awsMachineIdentityDetailBindings(
+	identity string,
+	ec2 AWSEC2InstanceProfileInventoryResult,
+	ecs AWSECSTaskRoleInventoryResult,
+	lambda AWSLambdaExecutionRoleInventoryResult,
+	codeBuild AWSCodeBuildServiceRoleInventoryResult,
+	codePipeline AWSCodePipelineDeploymentRoleInventoryResult,
+	stepFunctions AWSStepFunctionsStateMachineRoleInventoryResult,
+	eventDriven AWSEventDrivenRoleInventoryResult,
+	managedCompute AWSManagedComputeRoleInventoryResult,
+	eks AWSEKSWorkloadIdentityInventoryResult,
+) []AWSMachineIdentityWorkloadBinding {
+	bindings := []AWSMachineIdentityWorkloadBinding{}
+	for _, record := range ec2.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.InstanceProfileARN, record.InstanceProfileName, record.WorkloadID, record.WorkloadName) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("ec2", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.InstanceName, record.LaunchTemplateName, record.WorkloadName), record.RoleARN, record.RoleName, "instance_profile", "runs_as", record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range ecs.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TaskRoleARN, record.ExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.ServiceName, record.TaskDefinitionFamily) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("ecs", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.ServiceName, record.TaskDefinitionFamily, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range lambda.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.FunctionARN, record.FunctionName, record.WorkloadID, record.WorkloadName) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("lambda", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.FunctionName, record.WorkloadName), record.RoleARN, record.RoleName, "execution_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range codeBuild.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.ProjectARN, record.ProjectName, record.WorkloadID, record.WorkloadName) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("codebuild", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.ProjectName, record.WorkloadName), record.RoleARN, record.RoleName, "service_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range codePipeline.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.PipelineARN, record.PipelineName, record.WorkloadID, record.WorkloadName) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("codepipeline", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.PipelineName, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range stepFunctions.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.StateMachineARN, record.StateMachineName, record.WorkloadID, record.WorkloadName) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("stepfunctions", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.StateMachineName, record.WorkloadName), record.RoleARN, record.RoleName, "state_machine_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range eventDriven.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.TargetARN) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding(record.Service, record.WorkloadID, record.WorkloadType, record.WorkloadName, record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range managedCompute.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.ResourceARN) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding(record.Service, record.WorkloadID, record.WorkloadType, record.WorkloadName, record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	for _, record := range eks.Records {
+		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TargetRoleARN, record.NodeRoleARN, record.PodExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.KubernetesSubject, record.ServiceAccount) {
+			continue
+		}
+		bindings = append(bindings, awsMachineIdentityBinding("eks", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.KubernetesSubject, record.ServiceAccount, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
+	}
+	sort.SliceStable(bindings, func(i, j int) bool {
+		if bindings[i].Service == bindings[j].Service {
+			return bindings[i].BindingID < bindings[j].BindingID
+		}
+		return bindings[i].Service < bindings[j].Service
+	})
+	return bindings
+}
+
+func awsMachineIdentityBinding(service, workloadID, workloadType, workloadName, roleARN, roleName, roleKind, relationshipType, fromNodeID, toNodeID, evidenceRef, status string, confidence float64, collectedAt time.Time) AWSMachineIdentityWorkloadBinding {
+	return AWSMachineIdentityWorkloadBinding{
+		BindingID:        "aws-machine-identity-binding:" + stableAWSBlastRadiusToken(service, workloadID, roleARN, roleName, fromNodeID, toNodeID, evidenceRef),
+		Service:          service,
+		WorkloadID:       workloadID,
+		WorkloadType:     workloadType,
+		WorkloadName:     workloadName,
+		RoleARN:          roleARN,
+		RoleName:         roleName,
+		RoleKind:         roleKind,
+		RelationshipType: relationshipType,
+		FromNodeID:       fromNodeID,
+		ToNodeID:         toNodeID,
+		EvidenceRef:      evidenceRef,
+		Status:           status,
+		Confidence:       confidence,
+		CollectedAt:      collectedAt,
+	}
+}
+
+func awsMachineIdentityMatches(identity string, candidates ...string) bool {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return true
+	}
+	identityLower := strings.ToLower(identity)
+	nodeIDLower := strings.ToLower(awsMachineIdentityDetailNodeID(identity))
+	shortLower := strings.ToLower(awsMachineIdentityDetailFilterToken(identity))
+	for _, candidate := range candidates {
+		candidateLower := strings.ToLower(strings.TrimSpace(candidate))
+		if candidateLower == "" {
+			continue
+		}
+		if candidateLower == identityLower || candidateLower == nodeIDLower || candidateLower == shortLower {
+			return true
+		}
+		if strings.HasPrefix(identityLower, "arn:") && strings.HasPrefix(candidateLower, "aws:identity:") && strings.TrimPrefix(candidateLower, "aws:identity:") == identityLower {
+			return true
+		}
+	}
+	if strings.HasPrefix(identityLower, "arn:") || strings.HasPrefix(identityLower, "aws:identity:") {
+		return false
+	}
+	return awsRuntimeEventMatchesAny(identity, candidates...)
+}
+
+func awsMachineIdentityPermissionSummaries(recommendations []AWSLeastPrivilegeRecommendation) []AWSMachineIdentityPermissionSummary {
+	out := make([]AWSMachineIdentityPermissionSummary, 0, len(recommendations))
+	for _, recommendation := range recommendations {
+		actions := dedupeStrings(append(append(append([]string{}, recommendation.GrantedActions...), recommendation.ObservedActions...), append(recommendation.KeepActions, recommendation.RemoveActions...)...))
+		out = append(out, AWSMachineIdentityPermissionSummary{
+			RecommendationID: recommendation.RecommendationID,
+			Decision:         recommendation.Decision,
+			Severity:         recommendation.Severity,
+			Status:           recommendation.Status,
+			Service:          recommendation.Service,
+			ResourceARN:      recommendation.ResourceARN,
+			DisplayName:      recommendation.DisplayName,
+			Actions:          actions,
+			Rationale:        recommendation.Rationale,
+			NextAction:       recommendation.NextAction,
+			Score:            recommendation.Score,
+		})
+	}
+	return out
+}
+
+func awsMachineIdentityResourcesReached(runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult) []AWSMachineIdentityResourceSummary {
+	out := []AWSMachineIdentityResourceSummary{}
+	seen := map[string]bool{}
+	add := func(source, id, arn, resourceType, label, evidenceRef string, observedAt time.Time) {
+		key := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(id, arn, label)))
+		if key == "" || seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, AWSMachineIdentityResourceSummary{ResourceID: id, ResourceARN: arn, ResourceType: resourceType, Label: firstNonEmptyAWSValue(label, shortAWSARN(arn), id), Source: source, EvidenceRef: evidenceRef, ObservedAt: observedAt})
+	}
+	for _, record := range runtime.Records {
+		add("runtime", record.ResourceNodeID, record.TargetResourceARN, record.TargetResourceType, record.TargetResourceName, record.EvidenceRef, record.ObservedAt)
+	}
+	for _, recommendation := range permissions.Recommendations {
+		add("permissions", recommendation.ResourceNodeID, recommendation.ResourceARN, recommendation.Service, recommendation.DisplayName, firstLeastPrivilegeEvidenceRef(recommendation.Evidence), recommendation.UpdatedAt)
+	}
+	for _, finding := range secrets.Findings {
+		add("secrets", finding.SecretNodeID, finding.SecretARN, "secret", finding.SecretLabel, firstLeastPrivilegeEvidenceRef(finding.Evidence), finding.UpdatedAt)
+	}
+	for _, finding := range blast.Findings {
+		for _, node := range finding.SensitiveNodes {
+			add("blast_radius", node, "", "sensitive_resource", node, firstBlastRadiusEvidenceRef(finding.Evidence), finding.UpdatedAt)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Source == out[j].Source {
+			return out[i].Label < out[j].Label
+		}
+		return out[i].Source < out[j].Source
+	})
+	return out
+}
+
+func awsMachineIdentityFindingSummaries(secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult) []AWSMachineIdentityFindingSummary {
+	out := []AWSMachineIdentityFindingSummary{}
+	for _, finding := range blast.Findings {
+		out = append(out, AWSMachineIdentityFindingSummary{
+			FindingID:    finding.FindingID,
+			Source:       "blast_radius",
+			FindingType:  finding.RiskType,
+			Severity:     finding.Severity,
+			Status:       finding.Status,
+			Score:        finding.Score,
+			Title:        finding.DisplayName,
+			Summary:      finding.Rationale,
+			EvidenceRefs: awsBlastRadiusEvidenceRefs(finding.Evidence),
+			NextAction:   finding.NextAction,
+		})
+	}
+	for _, finding := range sprawl.Findings {
+		out = append(out, AWSMachineIdentityFindingSummary{
+			FindingID:    finding.FindingID,
+			Source:       "identity_sprawl",
+			FindingType:  finding.FindingType,
+			Severity:     finding.Severity,
+			Status:       finding.Status,
+			Score:        finding.Score,
+			Title:        finding.DisplayName,
+			Summary:      finding.Rationale,
+			EvidenceRefs: awsLeastPrivilegeEvidenceRefs(finding.Evidence),
+			NextAction:   finding.NextAction,
+		})
+	}
+	for _, finding := range secrets.Findings {
+		out = append(out, AWSMachineIdentityFindingSummary{
+			FindingID:    finding.FindingID,
+			Source:       "secret_permission_equivalence",
+			FindingType:  finding.EquivalenceType,
+			Severity:     finding.Severity,
+			Status:       finding.Status,
+			Score:        finding.Score,
+			Title:        finding.SecretLabel,
+			Summary:      finding.Rationale,
+			EvidenceRefs: awsLeastPrivilegeEvidenceRefs(finding.Evidence),
+			NextAction:   finding.NextAction,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].FindingID < out[j].FindingID
+		}
+		return out[i].Score > out[j].Score
+	})
+	return out
+}
+
+func awsMachineIdentityGovernanceDecisions(records []AWSGovernanceAuditReportRecord) []AWSMachineIdentityGovernanceDecision {
+	out := make([]AWSMachineIdentityGovernanceDecision, 0, len(records))
+	for _, record := range records {
+		out = append(out, AWSMachineIdentityGovernanceDecision{
+			ReportID:     record.ReportID,
+			Category:     record.Category,
+			DecisionType: record.DecisionType,
+			State:        record.State,
+			Title:        record.Title,
+			Summary:      record.Summary,
+			Actor:        record.Actor,
+			Approver:     record.Approver,
+			EvidenceRefs: append([]string{}, record.EvidenceLinks...),
+			OccurredAt:   record.OccurredAt,
+		})
+	}
+	return out
+}
+
+func awsMachineIdentityDetailRelationships(bindings []AWSMachineIdentityWorkloadBinding, runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult) []AWSMachineIdentityDetailRelationship {
+	out := []AWSMachineIdentityDetailRelationship{}
+	add := func(source, typ, from, to, evidence string) {
+		if strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" {
+			return
+		}
+		out = append(out, AWSMachineIdentityDetailRelationship{Source: source, Type: typ, FromNodeID: from, ToNodeID: to, EvidenceRef: evidence})
+	}
+	for _, binding := range bindings {
+		add("workload_binding", firstNonEmptyAWSValue(binding.RelationshipType, "runs_as"), binding.FromNodeID, binding.ToNodeID, binding.EvidenceRef)
+	}
+	for _, rel := range runtime.Relationships {
+		add("runtime", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, rel := range permissions.Relationships {
+		add("permissions", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, rel := range secrets.Relationships {
+		add("secrets", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, rel := range blast.Relationships {
+		add("blast_radius", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, rel := range sprawl.Relationships {
+		add("identity_sprawl", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, rel := range cases.Relationships {
+		add("remediation_cases", rel.Type, rel.FromNodeID, rel.ToNodeID, rel.EvidenceRef)
+	}
+	for _, record := range governance.Records {
+		for _, evidence := range record.EvidenceLinks {
+			add("governance", record.Category, record.IdentityNodeID, record.SourceID, evidence)
+		}
+	}
+	return awsMachineIdentityDedupeRelationships(out)
+}
+
+func awsMachineIdentityDedupeRelationships(items []AWSMachineIdentityDetailRelationship) []AWSMachineIdentityDetailRelationship {
+	seen := map[string]bool{}
+	out := []AWSMachineIdentityDetailRelationship{}
+	for _, item := range items {
+		key := strings.Join([]string{item.Source, item.Type, item.FromNodeID, item.ToNodeID, item.EvidenceRef}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func awsMachineIdentityDetailIdentity(identity string, identityNodeID string, accountID string, region string, status string, confidence float64, bindings []AWSMachineIdentityWorkloadBinding, runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult, cases AWSRemediationCaseResult) AWSMachineIdentityDetailIdentity {
+	principalARN := ""
+	roleName := ""
+	if strings.HasPrefix(strings.ToLower(identity), "arn:") {
+		principalARN = identity
+	}
+	for _, binding := range bindings {
+		principalARN = firstNonEmptyAWSValue(principalARN, binding.RoleARN)
+		roleName = firstNonEmptyAWSValue(roleName, binding.RoleName)
+	}
+	for _, record := range runtime.Records {
+		principalARN = firstNonEmptyAWSValue(principalARN, record.ActorPrincipalARN, record.Session.SessionIssuerARN, record.Session.AssumedRoleARN)
+	}
+	for _, recommendation := range permissions.Recommendations {
+		principalARN = firstNonEmptyAWSValue(principalARN, recommendation.PrincipalARN)
+		roleName = firstNonEmptyAWSValue(roleName, shortAWSARN(recommendation.PrincipalARN))
+	}
+	for _, finding := range secrets.Findings {
+		principalARN = firstNonEmptyAWSValue(principalARN, finding.PrincipalARN)
+	}
+	for _, finding := range blast.Findings {
+		principalARN = firstNonEmptyAWSValue(principalARN, finding.PrincipalARN)
+	}
+	for _, finding := range sprawl.Findings {
+		principalARN = firstNonEmptyAWSValue(principalARN, finding.PrincipalARN)
+		roleName = firstNonEmptyAWSValue(roleName, finding.RoleName)
+	}
+	for _, c := range cases.Cases {
+		principalARN = firstNonEmptyAWSValue(principalARN, c.IdentityARN)
+		roleName = firstNonEmptyAWSValue(roleName, c.IdentityName)
+	}
+	roleName = firstNonEmptyAWSValue(roleName, shortAWSARN(principalARN), shortAWSARN(identity))
+	displayName := firstNonEmptyAWSValue(roleName, principalARN, identityNodeID, identity)
+	return AWSMachineIdentityDetailIdentity{
+		Identity:         identity,
+		IdentityNodeID:   identityNodeID,
+		PrincipalARN:     principalARN,
+		RoleName:         roleName,
+		DisplayName:      displayName,
+		AccountID:        accountID,
+		Region:           region,
+		Status:           status,
+		Confidence:       confidence,
+		EvidenceBoundary: "metadata_only_no_secret_values_no_policy_bodies_no_payloads",
+	}
+}
+
+func summarizeAWSMachineIdentityDetail(fixtureState string, bindings []AWSMachineIdentityWorkloadBinding, runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult, diagnostics []AWSMachineIdentityDetailDiagnostic) (string, float64, []string, []string) {
+	dataCount := len(bindings) + len(runtime.Records) + len(permissions.Recommendations) + len(secrets.Findings) + len(blast.Findings) + len(sprawl.Findings) + len(cases.Cases) + len(governance.Records)
+	statuses := []string{runtime.Status, permissions.Status, secrets.Status, blast.Status, sprawl.Status, cases.Status, governance.Status}
+	failures := []string{}
+	hints := []string{}
+	if fixtureState == "permission_denied" {
+		failures = append(failures, "Identity detail evidence is blocked by AWS permission checks for this connector.")
+		hints = append(hints, "Validate the connector role permissions and retry the detail page.")
+		return "blocked", 0.35, failures, hints
+	}
+	if dataCount == 0 {
+		return "empty", 0.72, []string{"No matching workload, runtime, risk, remediation, or governance evidence was found for this identity."}, []string{"Check the identity ARN or select a role from the AWS identity inventory."}
+	}
+	for _, status := range statuses {
+		if normalizeAWSRuntimeEventFilterToken(status) == "blocked" {
+			return "degraded", 0.62, failures, hints
+		}
+	}
+	for _, status := range statuses {
+		if normalizeAWSRuntimeEventFilterToken(status) == "degraded" {
+			return "degraded", 0.72, failures, hints
+		}
+	}
+	if len(diagnostics) > 0 || fixtureState == "degraded" || fixtureState == "partial_failure" {
+		return "degraded", 0.74, failures, hints
+	}
+	return "ready", 0.91, failures, hints
+}
+
+func awsMachineIdentityDetailTabs(summary AWSMachineIdentityDetailSummary, status string) []AWSMachineIdentityDetailTab {
+	tabStatus := func(count int) string {
+		if count == 0 {
+			return "empty"
+		}
+		return status
+	}
+	return []AWSMachineIdentityDetailTab{
+		{ID: "graph", Label: "Graph", Status: tabStatus(summary.RelationshipCount), Count: summary.RelationshipCount},
+		{ID: "runtime", Label: "Runtime", Status: tabStatus(summary.RuntimeEventCount), Count: summary.RuntimeEventCount},
+		{ID: "permissions", Label: "Permissions", Status: tabStatus(summary.PermissionRecommendationCount), Count: summary.PermissionRecommendationCount},
+		{ID: "secrets", Label: "Secrets", Status: tabStatus(summary.SecretFindingCount), Count: summary.SecretFindingCount},
+		{ID: "fixes", Label: "Fixes", Status: tabStatus(summary.RemediationCaseCount), Count: summary.RemediationCaseCount},
+		{ID: "governance", Label: "Governance", Status: tabStatus(summary.GovernanceDecisionCount), Count: summary.GovernanceDecisionCount},
+	}
+}
+
+func awsMachineIdentityDetailEvidenceLinks(identity string, inventories ...interface{}) []string {
+	links := []string{
+		awsIssueURL(awsPlatformDependencyParentIssue),
+		awsIssueURL(awsMachineIdentityDetailCurrentIssue),
+		"/docs/aws-machine-identity-detail",
+		"/docs/aws-service-collector-contract",
+	}
+	for _, item := range inventories {
+		switch v := item.(type) {
+		case AWSEC2InstanceProfileInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSECSTaskRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSLambdaExecutionRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSCodeBuildServiceRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSCodePipelineDeploymentRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSStepFunctionsStateMachineRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSEventDrivenRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSManagedComputeRoleInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSEKSWorkloadIdentityInventoryResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSRuntimeEventResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSLeastPrivilegeResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSSecretPermissionEquivalenceResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSBlastRadiusResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSIdentitySprawlResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSRemediationCaseResult:
+			links = append(links, v.EvidenceLinks...)
+		case AWSGovernanceAuditReportingResult:
+			links = append(links, v.EvidenceLinks...)
+		}
+	}
+	links = append(links, identity, awsMachineIdentityDetailNodeID(identity))
+	return dedupeStrings(links)
+}
+
+func awsMachineIdentityDetailFailureReasons(results ...interface{}) []string {
+	out := []string{}
+	for _, item := range results {
+		switch v := item.(type) {
+		case AWSRuntimeEventResult:
+			out = append(out, v.FailureReasons...)
+		case AWSLeastPrivilegeResult:
+			out = append(out, v.FailureReasons...)
+		case AWSSecretPermissionEquivalenceResult:
+			out = append(out, v.FailureReasons...)
+		case AWSBlastRadiusResult:
+			out = append(out, v.FailureReasons...)
+		case AWSIdentitySprawlResult:
+			out = append(out, v.FailureReasons...)
+		case AWSRemediationCaseResult:
+			out = append(out, v.FailureReasons...)
+		case AWSGovernanceAuditReportingResult:
+			out = append(out, v.FailureReasons...)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func awsMachineIdentityDetailRemediationHints(results ...interface{}) []string {
+	out := []string{}
+	for _, item := range results {
+		switch v := item.(type) {
+		case AWSRuntimeEventResult:
+			out = append(out, v.RemediationHints...)
+		case AWSLeastPrivilegeResult:
+			out = append(out, v.RemediationHints...)
+		case AWSSecretPermissionEquivalenceResult:
+			out = append(out, v.RemediationHints...)
+		case AWSBlastRadiusResult:
+			out = append(out, v.RemediationHints...)
+		case AWSIdentitySprawlResult:
+			out = append(out, v.RemediationHints...)
+		case AWSRemediationCaseResult:
+			out = append(out, v.RemediationHints...)
+		case AWSGovernanceAuditReportingResult:
+			out = append(out, v.RemediationHints...)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func awsMachineIdentityDetailDiagnostics(results ...interface{}) []AWSMachineIdentityDetailDiagnostic {
+	out := []AWSMachineIdentityDetailDiagnostic{}
+	add := func(collector, sourceID, code, message, remediation string, retryable bool) {
+		if strings.TrimSpace(code) == "" && strings.TrimSpace(message) == "" {
+			return
+		}
+		out = append(out, AWSMachineIdentityDetailDiagnostic{Collector: collector, SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: retryable})
+	}
+	for _, item := range results {
+		switch v := item.(type) {
+		case AWSEC2InstanceProfileInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSECSTaskRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSLambdaExecutionRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSCodeBuildServiceRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSCodePipelineDeploymentRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSStepFunctionsStateMachineRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSEventDrivenRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSManagedComputeRoleInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSEKSWorkloadIdentityInventoryResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSRuntimeEventResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSLeastPrivilegeResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSSecretPermissionEquivalenceResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSBlastRadiusResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSIdentitySprawlResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSRemediationCaseResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		case AWSGovernanceAuditReportingResult:
+			for _, d := range v.Diagnostics {
+				add(d.Collector, d.SourceID, d.Code, d.Message, d.Remediation, d.Retryable)
+			}
+		}
+	}
+	return awsMachineIdentityDedupeDiagnostics(out)
+}
+
+func awsMachineIdentityDedupeDiagnostics(items []AWSMachineIdentityDetailDiagnostic) []AWSMachineIdentityDetailDiagnostic {
+	seen := map[string]bool{}
+	out := []AWSMachineIdentityDetailDiagnostic{}
+	for _, item := range items {
+		key := strings.Join([]string{strings.ToLower(item.Collector), strings.ToLower(item.SourceID), strings.ToLower(item.Code), strings.ToLower(item.Message)}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func awsMachineIdentityDetailCoverageGaps(results ...interface{}) []AWSMachineIdentityDetailCoverageGap {
+	out := []AWSMachineIdentityDetailCoverageGap{}
+	seen := map[string]bool{}
+	add := func(capability, status, reason, remediation string) {
+		if strings.TrimSpace(capability) == "" && strings.TrimSpace(reason) == "" {
+			return
+		}
+		key := strings.Join([]string{
+			strings.ToLower(strings.TrimSpace(capability)),
+			strings.ToLower(strings.TrimSpace(status)),
+			strings.ToLower(strings.TrimSpace(reason)),
+			strings.ToLower(strings.TrimSpace(remediation)),
+		}, "\x00")
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, AWSMachineIdentityDetailCoverageGap{Capability: capability, Status: status, Reason: reason, Remediation: remediation})
+	}
+	for _, item := range results {
+		switch v := item.(type) {
+		case AWSRuntimeEventResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSLeastPrivilegeResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSSecretPermissionEquivalenceResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSBlastRadiusResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSIdentitySprawlResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSRemediationCaseResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		case AWSGovernanceAuditReportingResult:
+			for _, gap := range v.CoverageGaps {
+				add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+			}
+		}
+	}
+	return out
+}
+
+func awsLeastPrivilegeEvidenceRefs(items []AWSLeastPrivilegeEvidence) []string {
+	out := []string{}
+	for _, item := range items {
+		out = append(out, item.EvidenceRef)
+	}
+	return dedupeStrings(out)
+}
+
+func awsBlastRadiusEvidenceRefs(items []AWSBlastRadiusEvidence) []string {
+	out := []string{}
+	for _, item := range items {
+		out = append(out, item.EvidenceRef)
+	}
+	return dedupeStrings(out)
+}
+
+func firstBlastRadiusEvidenceRef(items []AWSBlastRadiusEvidence) string {
+	for _, item := range items {
+		if strings.TrimSpace(item.EvidenceRef) != "" {
+			return item.EvidenceRef
+		}
+	}
+	return ""
+}

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -223,8 +223,6 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
-	identityNodeID := awsMachineIdentityDetailNodeID(identity)
-
 	ec2, err := s.GetAWSEC2InstanceProfileInventory(ctx, workspaceID, projectID, AWSEC2InstanceProfileInventoryRequest{ConnectorID: connectorID, FixtureState: sourceFixtureState})
 	if err != nil {
 		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail ec2 inventory: %w", err)
@@ -262,83 +260,100 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail eks inventory: %w", err)
 	}
 
-	downstreamIdentity := awsMachineIdentityDetailFilterToken(identity)
-	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Resource:     request.Resource,
-		Status:       request.Status,
-	})
-	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail runtime: %w", err)
+	bindings := awsMachineIdentityDetailBindings(identity, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks)
+	identityScope := awsMachineIdentityDetailScopeFor(identity, bindings)
+	loadDownstream := func(downstreamIdentity string) (AWSRuntimeEventResult, AWSLeastPrivilegeResult, AWSSecretPermissionEquivalenceResult, AWSBlastRadiusResult, AWSIdentitySprawlResult, AWSRemediationCaseResult, error) {
+		runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Resource:     request.Resource,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail runtime: %w", err)
+		}
+		permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Resource:     request.Resource,
+			Service:      request.Service,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail permissions: %w", err)
+		}
+		secrets, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Secret:       request.Resource,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail secrets: %w", err)
+		}
+		blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Resource:     request.Resource,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail blast radius: %w", err)
+		}
+		sprawl, err := s.GetAWSIdentitySprawl(ctx, workspaceID, projectID, AWSIdentitySprawlRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail sprawl: %w", err)
+		}
+		cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			Identity:     downstreamIdentity,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSRuntimeEventResult{}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{}, fmt.Errorf("machine identity detail remediation cases: %w", err)
+		}
+		return runtime, permissions, secrets, blast, sprawl, cases, nil
 	}
-	permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Resource:     request.Resource,
-		Service:      request.Service,
-		Severity:     request.Severity,
-		Status:       request.Status,
-	})
+	downstreamIdentity := identityScope.DownstreamIdentity
+	runtime, permissions, secrets, blast, sprawl, cases, err := loadDownstream(downstreamIdentity)
 	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail permissions: %w", err)
+		return AWSMachineIdentityDetailResult{}, err
 	}
-	secrets, err := s.GetAWSSecretPermissionEquivalence(ctx, workspaceID, projectID, AWSSecretPermissionEquivalenceRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Secret:       request.Resource,
-		Severity:     request.Severity,
-		Status:       request.Status,
-	})
-	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail secrets: %w", err)
+	identityScope = awsMachineIdentityDetailScopeWithEvidence(identityScope, runtime, permissions, secrets, blast, sprawl, cases)
+	if identityScope.DownstreamIdentity != "" && identityScope.DownstreamIdentity != downstreamIdentity {
+		runtime, permissions, secrets, blast, sprawl, cases, err = loadDownstream(identityScope.DownstreamIdentity)
+		if err != nil {
+			return AWSMachineIdentityDetailResult{}, err
+		}
 	}
-	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Resource:     request.Resource,
-		Severity:     request.Severity,
-		Status:       request.Status,
-	})
-	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail blast radius: %w", err)
-	}
-	sprawl, err := s.GetAWSIdentitySprawl(ctx, workspaceID, projectID, AWSIdentitySprawlRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Severity:     request.Severity,
-		Status:       request.Status,
-	})
-	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail sprawl: %w", err)
-	}
-	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
-		ConnectorID:  connectorID,
-		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Identity:     downstreamIdentity,
-		Severity:     request.Severity,
-		Status:       request.Status,
-	})
-	if err != nil {
-		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail remediation cases: %w", err)
-	}
+	identityNodeID := identityScope.NodeID
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -351,7 +366,6 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail governance: %w", err)
 	}
 
-	bindings := awsMachineIdentityDetailBindings(identity, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks)
 	permissionSummaries := awsMachineIdentityPermissionSummaries(permissions.Recommendations)
 	resourcesReached := awsMachineIdentityResourcesReached(runtime, permissions, secrets, blast)
 	findings := awsMachineIdentityFindingSummaries(secrets, blast, sprawl)
@@ -445,13 +459,137 @@ func awsMachineIdentityDetailNodeID(identity string) string {
 func awsMachineIdentityDetailFilterToken(identity string) string {
 	identity = strings.TrimSpace(identity)
 	if strings.HasPrefix(strings.ToLower(identity), "arn:") {
-		return firstNonEmptyAWSValue(shortAWSARN(identity), identity)
+		return identity
 	}
 	if strings.HasPrefix(strings.ToLower(identity), "aws:identity:arn:") {
 		arn := strings.TrimPrefix(identity, "aws:identity:")
-		return firstNonEmptyAWSValue(shortAWSARN(arn), identity)
+		return firstNonEmptyAWSValue(arn, identity)
 	}
 	return identity
+}
+
+type awsMachineIdentityDetailScope struct {
+	NodeID             string
+	PrincipalARN       string
+	RoleName           string
+	DownstreamIdentity string
+}
+
+func awsMachineIdentityDetailScopeFor(identity string, bindings []AWSMachineIdentityWorkloadBinding) awsMachineIdentityDetailScope {
+	identity = strings.TrimSpace(identity)
+	nodeID := ""
+	principalARN := ""
+	roleName := ""
+	switch {
+	case strings.HasPrefix(strings.ToLower(identity), "arn:"):
+		nodeID = awsIdentityNodeIDForAPI(identity)
+		principalARN = identity
+		roleName = shortAWSARN(identity)
+	case strings.HasPrefix(strings.ToLower(identity), "aws:identity:arn:"):
+		nodeID = identity
+		arn := strings.TrimPrefix(identity, "aws:identity:")
+		principalARN = arn
+		roleName = shortAWSARN(arn)
+	default:
+		roleName = identity
+	}
+	for _, binding := range bindings {
+		principalARN = firstNonEmptyAWSValue(principalARN, binding.RoleARN)
+		nodeID = firstNonEmptyAWSValue(nodeID, binding.ToNodeID)
+		roleName = firstNonEmptyAWSValue(roleName, binding.RoleName, shortAWSARN(binding.RoleARN))
+	}
+	if nodeID == "" && principalARN != "" {
+		nodeID = awsIdentityNodeIDForAPI(principalARN)
+	}
+	downstreamIdentity := firstNonEmptyAWSValue(principalARN, nodeID, roleName, identity)
+	return awsMachineIdentityDetailScope{
+		NodeID:             nodeID,
+		PrincipalARN:       principalARN,
+		RoleName:           roleName,
+		DownstreamIdentity: downstreamIdentity,
+	}
+}
+
+func awsMachineIdentityDetailScopeWithEvidence(scope awsMachineIdentityDetailScope, runtime AWSRuntimeEventResult, permissions AWSLeastPrivilegeResult, secrets AWSSecretPermissionEquivalenceResult, blast AWSBlastRadiusResult, sprawl AWSIdentitySprawlResult, cases AWSRemediationCaseResult) awsMachineIdentityDetailScope {
+	add := func(principalARN, nodeID, roleName string) {
+		if scope.PrincipalARN != "" && scope.NodeID != "" {
+			return
+		}
+		if !awsMachineIdentityDetailScopeAccepts(scope, principalARN, nodeID, roleName) {
+			return
+		}
+		scope.PrincipalARN = firstNonEmptyAWSValue(scope.PrincipalARN, principalARN)
+		scope.NodeID = firstNonEmptyAWSValue(scope.NodeID, nodeID)
+		scope.RoleName = firstNonEmptyAWSValue(scope.RoleName, roleName, shortAWSARN(principalARN))
+	}
+	for _, record := range runtime.Records {
+		add(record.ActorPrincipalARN, record.ActorIdentityNodeID, shortAWSARN(record.ActorPrincipalARN))
+		add(record.Session.PrincipalARN, "", shortAWSARN(record.Session.PrincipalARN))
+		add(record.Session.AssumedRoleARN, "", shortAWSARN(record.Session.AssumedRoleARN))
+		add(record.Session.OriginalActorARN, record.Session.OriginalActorNodeID, shortAWSARN(record.Session.OriginalActorARN))
+		add(record.Session.SessionIssuerARN, record.Session.OriginalActorNodeID, shortAWSARN(record.Session.SessionIssuerARN))
+		add(record.Session.ChainedFromPrincipalARN, record.Session.ChainedFromNodeID, shortAWSARN(record.Session.ChainedFromPrincipalARN))
+	}
+	for _, recommendation := range permissions.Recommendations {
+		add(recommendation.PrincipalARN, recommendation.IdentityNodeID, shortAWSARN(recommendation.PrincipalARN))
+	}
+	for _, finding := range secrets.Findings {
+		add(finding.PrincipalARN, finding.IdentityNodeID, "")
+	}
+	for _, finding := range blast.Findings {
+		add(finding.PrincipalARN, finding.IdentityNodeID, shortAWSARN(finding.PrincipalARN))
+	}
+	for _, finding := range sprawl.Findings {
+		add(finding.PrincipalARN, finding.IdentityNodeID, finding.RoleName)
+	}
+	for _, c := range cases.Cases {
+		add(c.IdentityARN, c.IdentityNodeID, c.IdentityName)
+	}
+	if scope.NodeID == "" && scope.PrincipalARN != "" {
+		scope.NodeID = awsIdentityNodeIDForAPI(scope.PrincipalARN)
+	}
+	if scope.NodeID == "" && scope.PrincipalARN == "" && scope.RoleName != "" {
+		scope.DownstreamIdentity = "aws:identity:unresolved:" + stableAWSBlastRadiusToken(scope.RoleName)
+		return scope
+	}
+	scope.DownstreamIdentity = firstNonEmptyAWSValue(scope.PrincipalARN, scope.NodeID, scope.RoleName)
+	return scope
+}
+
+func awsMachineIdentityDetailScopeAccepts(scope awsMachineIdentityDetailScope, principalARN, nodeID, roleName string) bool {
+	if scope.PrincipalARN != "" {
+		return awsMachineIdentityMatches(scope.PrincipalARN, principalARN, nodeID, roleName)
+	}
+	if scope.NodeID != "" {
+		return awsMachineIdentityMatches(scope.NodeID, principalARN, nodeID, roleName)
+	}
+	if scope.RoleName != "" {
+		return awsMachineIdentityRoleNameMatches(scope.RoleName, principalARN, nodeID, roleName)
+	}
+	return false
+}
+
+func awsMachineIdentityRoleNameMatches(roleName string, candidates ...string) bool {
+	roleName = strings.ToLower(strings.TrimSpace(roleName))
+	if roleName == "" {
+		return true
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		candidateLower := strings.ToLower(candidate)
+		switch {
+		case candidateLower == roleName:
+			return true
+		case strings.HasPrefix(candidateLower, "arn:") && strings.ToLower(shortAWSARN(candidate)) == roleName:
+			return true
+		case strings.HasPrefix(candidateLower, "aws:identity:arn:"):
+			arn := strings.TrimPrefix(candidate, "aws:identity:")
+			if strings.ToLower(shortAWSARN(arn)) == roleName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func awsMachineIdentityDetailAppliedFilters(request AWSMachineIdentityDetailRequest, identityNodeID string) map[string]string {
@@ -591,11 +729,11 @@ func awsMachineIdentityMatches(identity string, candidates ...string) bool {
 		if strings.HasPrefix(identityLower, "arn:") && strings.HasPrefix(candidateLower, "aws:identity:") && strings.TrimPrefix(candidateLower, "aws:identity:") == identityLower {
 			return true
 		}
+		if strings.HasPrefix(identityLower, "aws:identity:arn:") && strings.HasPrefix(candidateLower, "arn:") && strings.TrimPrefix(identityLower, "aws:identity:") == candidateLower {
+			return true
+		}
 	}
-	if strings.HasPrefix(identityLower, "arn:") || strings.HasPrefix(identityLower, "aws:identity:") {
-		return false
-	}
-	return awsRuntimeEventMatchesAny(identity, candidates...)
+	return false
 }
 
 func awsMachineIdentityPermissionSummaries(recommendations []AWSLeastPrivilegeRecommendation) []AWSMachineIdentityPermissionSummary {

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -260,7 +260,8 @@ func (s *Service) GetAWSMachineIdentityDetail(ctx context.Context, workspaceID s
 		return AWSMachineIdentityDetailResult{}, fmt.Errorf("machine identity detail eks inventory: %w", err)
 	}
 
-	bindings := awsMachineIdentityDetailBindings(identity, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks)
+	bindingScope := awsMachineIdentityDetailBindingScopeFor(request)
+	bindings := awsMachineIdentityDetailBindings(identity, bindingScope, ec2, ecs, lambda, codeBuild, codePipeline, stepFunctions, eventDriven, managedCompute, eks)
 	identityScope := awsMachineIdentityDetailScopeFor(identity, bindings)
 	loadDownstream := func(downstreamIdentity string) (AWSRuntimeEventResult, AWSLeastPrivilegeResult, AWSSecretPermissionEquivalenceResult, AWSBlastRadiusResult, AWSIdentitySprawlResult, AWSRemediationCaseResult, error) {
 		runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
@@ -475,6 +476,36 @@ type awsMachineIdentityDetailScope struct {
 	PrincipalARN       string
 	RoleName           string
 	DownstreamIdentity string
+}
+
+type awsMachineIdentityDetailBindingScope struct {
+	AccountID string
+	Region    string
+}
+
+func awsMachineIdentityDetailBindingScopeFor(request AWSMachineIdentityDetailRequest) awsMachineIdentityDetailBindingScope {
+	return awsMachineIdentityDetailBindingScope{
+		AccountID: awsMachineIdentityDetailOptionalScopeValue(request.AccountID),
+		Region:    awsMachineIdentityDetailOptionalScopeValue(request.Region),
+	}
+}
+
+func awsMachineIdentityDetailOptionalScopeValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "all") {
+		return ""
+	}
+	return value
+}
+
+func (scope awsMachineIdentityDetailBindingScope) accepts(accountID, region string) bool {
+	if scope.AccountID != "" && !strings.EqualFold(strings.TrimSpace(accountID), scope.AccountID) {
+		return false
+	}
+	if scope.Region != "" && !strings.EqualFold(strings.TrimSpace(region), scope.Region) {
+		return false
+	}
+	return true
 }
 
 func awsMachineIdentityDetailScopeFor(identity string, bindings []AWSMachineIdentityWorkloadBinding) awsMachineIdentityDetailScope {
@@ -858,6 +889,7 @@ func awsMachineIdentityDetailAppliedFilters(request AWSMachineIdentityDetailRequ
 
 func awsMachineIdentityDetailBindings(
 	identity string,
+	bindingScope awsMachineIdentityDetailBindingScope,
 	ec2 AWSEC2InstanceProfileInventoryResult,
 	ecs AWSECSTaskRoleInventoryResult,
 	lambda AWSLambdaExecutionRoleInventoryResult,
@@ -870,55 +902,55 @@ func awsMachineIdentityDetailBindings(
 ) []AWSMachineIdentityWorkloadBinding {
 	bindings := []AWSMachineIdentityWorkloadBinding{}
 	for _, record := range ec2.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.InstanceProfileARN, record.InstanceProfileName, record.WorkloadID, record.WorkloadName) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.InstanceProfileARN, record.InstanceProfileName, record.WorkloadID, record.WorkloadName) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("ec2", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.InstanceName, record.LaunchTemplateName, record.WorkloadName), record.RoleARN, record.RoleName, "instance_profile", "runs_as", record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range ecs.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TaskRoleARN, record.ExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.ServiceName, record.TaskDefinitionFamily) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TaskRoleARN, record.ExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.ServiceName, record.TaskDefinitionFamily) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("ecs", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.ServiceName, record.TaskDefinitionFamily, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range lambda.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.FunctionARN, record.FunctionName, record.WorkloadID, record.WorkloadName) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.FunctionARN, record.FunctionName, record.WorkloadID, record.WorkloadName) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("lambda", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.FunctionName, record.WorkloadName), record.RoleARN, record.RoleName, "execution_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range codeBuild.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.ProjectARN, record.ProjectName, record.WorkloadID, record.WorkloadName) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.ProjectARN, record.ProjectName, record.WorkloadID, record.WorkloadName) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("codebuild", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.ProjectName, record.WorkloadName), record.RoleARN, record.RoleName, "service_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range codePipeline.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.PipelineARN, record.PipelineName, record.WorkloadID, record.WorkloadName) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.PipelineARN, record.PipelineName, record.WorkloadID, record.WorkloadName) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("codepipeline", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.PipelineName, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range stepFunctions.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.StateMachineARN, record.StateMachineName, record.WorkloadID, record.WorkloadName) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.StateMachineARN, record.StateMachineName, record.WorkloadID, record.WorkloadName) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("stepfunctions", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.StateMachineName, record.WorkloadName), record.RoleARN, record.RoleName, "state_machine_role", record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range eventDriven.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.TargetARN) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.TargetARN) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding(record.Service, record.WorkloadID, record.WorkloadType, record.WorkloadName, record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range managedCompute.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.ResourceARN) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.WorkloadARN, record.WorkloadName, record.WorkloadID, record.ResourceARN) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding(record.Service, record.WorkloadID, record.WorkloadType, record.WorkloadName, record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))
 	}
 	for _, record := range eks.Records {
-		if !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TargetRoleARN, record.NodeRoleARN, record.PodExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.KubernetesSubject, record.ServiceAccount) {
+		if !bindingScope.accepts(record.AccountID, record.Region) || !awsMachineIdentityMatches(identity, record.RoleARN, record.RoleName, record.ToNodeID, record.TargetRoleARN, record.NodeRoleARN, record.PodExecutionRoleARN, record.WorkloadID, record.WorkloadName, record.KubernetesSubject, record.ServiceAccount) {
 			continue
 		}
 		bindings = append(bindings, awsMachineIdentityBinding("eks", record.WorkloadID, record.WorkloadType, firstNonEmptyAWSValue(record.KubernetesSubject, record.ServiceAccount, record.WorkloadName), record.RoleARN, record.RoleName, record.RoleKind, record.RelationshipType, record.FromNodeID, record.ToNodeID, record.EvidenceRef, record.Status, record.Confidence, record.CollectedAt))

--- a/internal/api/aws_machine_identity_detail.go
+++ b/internal/api/aws_machine_identity_detail.go
@@ -610,6 +610,7 @@ func awsMachineIdentityDetailFilterDownstreamEvidence(scope awsMachineIdentityDe
 }
 
 func awsMachineIdentityDetailFilterRuntimeEvents(scope awsMachineIdentityDetailScope, result AWSRuntimeEventResult) AWSRuntimeEventResult {
+	allRecords := result.Records
 	records := make([]AWSRuntimeEventRecord, 0, len(result.Records))
 	for _, record := range result.Records {
 		if !awsMachineIdentityDetailScopeMatches(scope,
@@ -629,6 +630,8 @@ func awsMachineIdentityDetailFilterRuntimeEvents(scope awsMachineIdentityDetailS
 	}
 	result.Records = records
 	result.Relationships = awsRuntimeEventRelationships(records)
+	result.Diagnostics = scopeAWSRuntimeEventDiagnostics(result.Diagnostics, allRecords, records)
+	result.Status, result.Confidence, result.FailureReasons, result.RemediationHints = summarizeAWSRuntimeEventStatus(result.FixtureState, result.Diagnostics, records)
 	result.Summary = summarizeAWSRuntimeEvents(records, len(records), len(result.Relationships))
 	return result
 }

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -122,6 +122,66 @@ func TestGetAWSMachineIdentityDetailNormalizesRoleNameForGovernance(t *testing.T
 	}
 }
 
+func TestAWSMachineIdentityDetailBindingsApplyAccountRegionBeforeScope(t *testing.T) {
+	targetAccount := "222222222222"
+	targetRegion := "eu-west-1"
+	targetARN := "arn:aws:iam::222222222222:role/app"
+	targetNodeID := awsIdentityNodeIDForAPI(targetARN)
+	otherAccount := "111111111111"
+	otherRegion := "us-east-1"
+	otherARN := "arn:aws:iam::111111111111:role/app"
+	otherNodeID := awsIdentityNodeIDForAPI(otherARN)
+	bindingScope := awsMachineIdentityDetailBindingScopeFor(AWSMachineIdentityDetailRequest{
+		AccountID: targetAccount,
+		Region:    targetRegion,
+	})
+
+	if !bindingScope.accepts(targetAccount, targetRegion) || bindingScope.accepts(otherAccount, targetRegion) || bindingScope.accepts(targetAccount, otherRegion) {
+		t.Fatalf("binding scope must enforce both requested account and region: %+v", bindingScope)
+	}
+	if allScope := awsMachineIdentityDetailBindingScopeFor(AWSMachineIdentityDetailRequest{AccountID: "all", Region: "all"}); !allScope.accepts(otherAccount, otherRegion) {
+		t.Fatalf("all scope should not filter bindings: %+v", allScope)
+	}
+
+	bindings := awsMachineIdentityDetailBindings("app", bindingScope,
+		AWSEC2InstanceProfileInventoryResult{Records: []AWSEC2InstanceProfileRecord{{
+			AccountID: otherAccount, Region: targetRegion, RoleARN: otherARN, RoleName: "app", WorkloadID: "ec2-other-account", WorkloadType: "ec2", WorkloadName: "ec2-other-account", FromNodeID: "aws:workload:ec2:other-account", ToNodeID: otherNodeID,
+		}}},
+		AWSECSTaskRoleInventoryResult{Records: []AWSECSTaskRoleRecord{{
+			AccountID: targetAccount, Region: otherRegion, RoleARN: otherARN, RoleName: "app", WorkloadID: "ecs-other-region", WorkloadType: "ecs", WorkloadName: "ecs-other-region", FromNodeID: "aws:workload:ecs:other-region", ToNodeID: otherNodeID,
+		}}},
+		AWSLambdaExecutionRoleInventoryResult{Records: []AWSLambdaExecutionRoleRecord{{
+			AccountID: targetAccount, Region: targetRegion, RoleARN: targetARN, RoleName: "app", FunctionName: "app", WorkloadID: "lambda-target", WorkloadType: "lambda", WorkloadName: "lambda-target", FromNodeID: "aws:workload:lambda:target", ToNodeID: targetNodeID,
+		}}},
+		AWSCodeBuildServiceRoleInventoryResult{Records: []AWSCodeBuildServiceRoleRecord{{
+			AccountID: otherAccount, Region: targetRegion, RoleARN: otherARN, RoleName: "app", ProjectName: "codebuild-other-account", WorkloadID: "codebuild-other-account", WorkloadType: "codebuild", WorkloadName: "codebuild-other-account", FromNodeID: "aws:workload:codebuild:other-account", ToNodeID: otherNodeID,
+		}}},
+		AWSCodePipelineDeploymentRoleInventoryResult{Records: []AWSCodePipelineDeploymentRoleRecord{{
+			AccountID: targetAccount, Region: otherRegion, RoleARN: otherARN, RoleName: "app", PipelineName: "pipeline-other-region", WorkloadID: "pipeline-other-region", WorkloadType: "codepipeline", WorkloadName: "pipeline-other-region", FromNodeID: "aws:workload:codepipeline:other-region", ToNodeID: otherNodeID,
+		}}},
+		AWSStepFunctionsStateMachineRoleInventoryResult{Records: []AWSStepFunctionsStateMachineRoleRecord{{
+			AccountID: otherAccount, Region: targetRegion, RoleARN: otherARN, RoleName: "app", StateMachineName: "state-machine-other-account", WorkloadID: "sfn-other-account", WorkloadType: "stepfunctions", WorkloadName: "sfn-other-account", FromNodeID: "aws:workload:sfn:other-account", ToNodeID: otherNodeID,
+		}}},
+		AWSEventDrivenRoleInventoryResult{Records: []AWSEventDrivenRoleRecord{{
+			AccountID: targetAccount, Region: otherRegion, RoleARN: otherARN, RoleName: "app", Service: "eventbridge", WorkloadID: "event-other-region", WorkloadType: "event_rule", WorkloadName: "event-other-region", FromNodeID: "aws:workload:event:other-region", ToNodeID: otherNodeID,
+		}}},
+		AWSManagedComputeRoleInventoryResult{Records: []AWSManagedComputeRoleRecord{{
+			AccountID: otherAccount, Region: targetRegion, RoleARN: otherARN, RoleName: "app", Service: "batch", WorkloadID: "batch-other-account", WorkloadType: "batch_job", WorkloadName: "batch-other-account", FromNodeID: "aws:workload:batch:other-account", ToNodeID: otherNodeID,
+		}}},
+		AWSEKSWorkloadIdentityInventoryResult{Records: []AWSEKSWorkloadIdentityRecord{{
+			AccountID: targetAccount, Region: otherRegion, RoleARN: otherARN, RoleName: "app", WorkloadID: "eks-other-region", WorkloadType: "service_account", WorkloadName: "eks-other-region", FromNodeID: "aws:workload:eks:other-region", ToNodeID: otherNodeID,
+		}}},
+	)
+
+	if len(bindings) != 1 || bindings[0].RoleARN != targetARN || bindings[0].ToNodeID != targetNodeID {
+		t.Fatalf("bindings must be scoped before identity canonicalization: %+v", bindings)
+	}
+	scope := awsMachineIdentityDetailScopeFor("app", bindings)
+	if scope.PrincipalARN != targetARN || scope.NodeID != targetNodeID || scope.DownstreamIdentity != targetARN {
+		t.Fatalf("identity scope must be seeded only from requested account/region bindings: %+v", scope)
+	}
+}
+
 func TestGetAWSMachineIdentityDetailKeepsUnresolvedRoleNameGovernanceScoped(t *testing.T) {
 	now := time.Date(2026, 7, 3, 13, 19, 0, 0, time.UTC)
 	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-unresolved-role", now)

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -88,6 +88,38 @@ func TestGetAWSMachineIdentityDetailComposesRuntimePermissionsSecretsAndFixes(t 
 	if category := result.Governance.AppliedFilters["category"]; category != "" {
 		t.Fatalf("detail tab selector must not be forwarded as governance category filter: applied=%+v", result.Governance.AppliedFilters)
 	}
+	if result.Runtime.AppliedFilters["identity"] != identity || result.Permissions.AppliedFilters["identity"] != identity || result.RemediationCases.AppliedFilters["identity"] != identity {
+		t.Fatalf("ARN detail requests must preserve exact ARN downstream scope: runtime=%+v permissions=%+v cases=%+v", result.Runtime.AppliedFilters, result.Permissions.AppliedFilters, result.RemediationCases.AppliedFilters)
+	}
+	if result.Governance.AppliedFilters["identity_id"] != awsIdentityNodeIDForAPI(identity) {
+		t.Fatalf("governance must use normalized identity node id: %+v", result.Governance.AppliedFilters)
+	}
+}
+
+func TestGetAWSMachineIdentityDetailNormalizesRoleNameForGovernance(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 18, 0, 0, time.UTC)
+	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-role-name", now)
+	roleName := "lambda-invoice-agent"
+	roleARN := "arn:aws:iam::123456789012:role/lambda-invoice-agent"
+	roleNodeID := awsIdentityNodeIDForAPI(roleARN)
+
+	result, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-role-name", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     roleName,
+	})
+	if err != nil {
+		t.Fatalf("get machine identity detail by role name: %v", err)
+	}
+	if result.Identity.IdentityNodeID != roleNodeID || result.Identity.PrincipalARN != roleARN {
+		t.Fatalf("role-name detail request did not normalize identity scope: %+v", result.Identity)
+	}
+	if result.Governance.AppliedFilters["identity_id"] != roleNodeID || result.Summary.GovernanceDecisionCount == 0 {
+		t.Fatalf("role-name detail request must retain matching governance records: summary=%+v filters=%+v", result.Summary, result.Governance.AppliedFilters)
+	}
+	if result.Runtime.AppliedFilters["identity"] != roleARN || result.Permissions.AppliedFilters["identity"] != roleARN {
+		t.Fatalf("role-name detail request must use exact ARN downstream scope: runtime=%+v permissions=%+v", result.Runtime.AppliedFilters, result.Permissions.AppliedFilters)
+	}
 }
 
 func TestGetAWSMachineIdentityDetailFailureStates(t *testing.T) {
@@ -155,5 +187,36 @@ func TestRouterAWSMachineIdentityDetail(t *testing.T) {
 	}
 	if body.Detail.Summary.RuntimeEventCount == 0 {
 		t.Fatalf("expected identity-scoped runtime events via route: %+v", body.Detail.Summary)
+	}
+}
+
+func TestAWSMachineIdentityDetailMatchesExactIdentityScope(t *testing.T) {
+	appARN := "arn:aws:iam::123456789012:role/app"
+	appNodeID := awsIdentityNodeIDForAPI(appARN)
+	appAdminARN := "arn:aws:iam::123456789012:role/app-admin"
+
+	if !awsMachineIdentityMatches(appARN, appARN, appNodeID, "app") {
+		t.Fatalf("exact ARN scope should match its ARN, node id, and role name")
+	}
+	if awsMachineIdentityMatches(appARN, appAdminARN, awsIdentityNodeIDForAPI(appAdminARN), "app-admin") {
+		t.Fatalf("exact ARN scope must not match sibling role names by substring")
+	}
+	if !awsMachineIdentityMatches("app", "app") {
+		t.Fatalf("role-name scope should match the exact role name")
+	}
+	if awsMachineIdentityMatches("app", "app-admin", appAdminARN, awsIdentityNodeIDForAPI(appAdminARN)) {
+		t.Fatalf("role-name scope must not match sibling role names by substring")
+	}
+	if !awsMachineIdentityMatches(appNodeID, appARN) {
+		t.Fatalf("identity node id scope should match its source ARN")
+	}
+
+	scope := awsMachineIdentityDetailScopeFor("app", nil)
+	scope = awsMachineIdentityDetailScopeWithEvidence(scope, AWSRuntimeEventResult{Records: []AWSRuntimeEventRecord{{
+		ActorPrincipalARN:   appAdminARN,
+		ActorIdentityNodeID: awsIdentityNodeIDForAPI(appAdminARN),
+	}}}, AWSLeastPrivilegeResult{}, AWSSecretPermissionEquivalenceResult{}, AWSBlastRadiusResult{}, AWSIdentitySprawlResult{}, AWSRemediationCaseResult{})
+	if scope.PrincipalARN != "" || scope.NodeID != "" || scope.DownstreamIdentity == "app" {
+		t.Fatalf("unresolved role-name scope must not absorb sibling-role evidence: %+v", scope)
 	}
 }

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -313,9 +313,13 @@ func TestAWSMachineIdentityDetailPostFiltersDownstreamEvidenceByExactScope(t *te
 	scope := awsMachineIdentityDetailScopeFor(appARN, nil)
 
 	runtime, permissions, secrets, blast, sprawl, cases := awsMachineIdentityDetailFilterDownstreamEvidence(scope,
-		AWSRuntimeEventResult{Records: []AWSRuntimeEventRecord{
+		AWSRuntimeEventResult{FixtureState: "success", Records: []AWSRuntimeEventRecord{
 			{EventID: "runtime-app", EventType: "api-call", ActorPrincipalARN: appARN, ActorIdentityNodeID: appNodeID, ResourceNodeID: "aws:resource:app", EvidenceRef: "evidence-runtime-app", Status: "allowed", Owner: "platform"},
 			{EventID: "runtime-app-admin", EventType: "api-call", ActorPrincipalARN: appAdminARN, ActorIdentityNodeID: appAdminNodeID, ResourceNodeID: "aws:resource:app-admin", EvidenceRef: "evidence-runtime-admin", Status: "allowed", Owner: "platform"},
+		}, Diagnostics: []AWSRuntimeEventDiagnostic{
+			{Collector: "cloudtrail", SourceID: "runtime-app", Code: "late_delivery", Message: "app event arrived late", Retryable: true},
+			{Collector: "cloudtrail", SourceID: "runtime-app-admin", Code: "late_delivery", Message: "admin event arrived late", Retryable: true},
+			{Collector: "cloudtrail", Code: "collector_backfill", Message: "collector-wide runtime backfill", Retryable: true},
 		}},
 		AWSLeastPrivilegeResult{Recommendations: []AWSLeastPrivilegeRecommendation{
 			{RecommendationID: "permission-app", PrincipalARN: appARN, IdentityNodeID: appNodeID, DisplayName: "app", ImpactedPath: []AWSLeastPrivilegePathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}, {NodeID: "aws:resource:app", NodeType: "resource", Label: "app bucket"}}},
@@ -344,6 +348,9 @@ func TestAWSMachineIdentityDetailPostFiltersDownstreamEvidenceByExactScope(t *te
 
 	if len(runtime.Records) != 1 || runtime.Records[0].EventID != "runtime-app" || runtime.Summary.TotalEvents != 1 || runtime.Summary.FilteredEvents != 1 {
 		t.Fatalf("runtime evidence should be exact-scoped: records=%+v summary=%+v", runtime.Records, runtime.Summary)
+	}
+	if len(runtime.Diagnostics) != 2 || runtime.Diagnostics[0].SourceID != "runtime-app" || runtime.Diagnostics[1].SourceID != "" {
+		t.Fatalf("runtime diagnostics should keep exact event diagnostics and collector-level diagnostics only: %+v", runtime.Diagnostics)
 	}
 	if len(permissions.Recommendations) != 1 || permissions.Recommendations[0].RecommendationID != "permission-app" || permissions.Summary.TotalRecommendations != 1 || len(permissions.Relationships) != 1 {
 		t.Fatalf("permission evidence should be exact-scoped: recommendations=%+v summary=%+v relationships=%+v", permissions.Recommendations, permissions.Summary, permissions.Relationships)

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -65,6 +65,7 @@ func TestGetAWSMachineIdentityDetailComposesRuntimePermissionsSecretsAndFixes(t 
 		ConnectorID:  "aws-prod",
 		FixtureState: "success",
 		Identity:     identity,
+		Tab:          "governance",
 	})
 	if err != nil {
 		t.Fatalf("get machine identity detail: %v", err)
@@ -80,6 +81,12 @@ func TestGetAWSMachineIdentityDetailComposesRuntimePermissionsSecretsAndFixes(t 
 	}
 	if result.Summary.RemediationCaseCount == 0 {
 		t.Fatalf("expected identity-scoped remediation cases: %+v", result.Summary)
+	}
+	if result.Summary.GovernanceDecisionCount == 0 || len(result.GovernanceDecisions) == 0 {
+		t.Fatalf("detail tab selector must not filter governance categories: summary=%+v governance=%+v", result.Summary, result.Governance.Summary)
+	}
+	if category := result.Governance.AppliedFilters["category"]; category != "" {
+		t.Fatalf("detail tab selector must not be forwarded as governance category filter: applied=%+v", result.Governance.AppliedFilters)
 	}
 }
 

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -244,3 +244,60 @@ func TestAWSMachineIdentityDetailMatchesExactIdentityScope(t *testing.T) {
 		t.Fatalf("unresolved role-name scope must not absorb sibling-role evidence: %+v", scope)
 	}
 }
+
+func TestAWSMachineIdentityDetailPostFiltersDownstreamEvidenceByExactScope(t *testing.T) {
+	appARN := "arn:aws:iam::123456789012:role/app"
+	appNodeID := awsIdentityNodeIDForAPI(appARN)
+	appAdminARN := "arn:aws:iam::123456789012:role/app-admin"
+	appAdminNodeID := awsIdentityNodeIDForAPI(appAdminARN)
+	scope := awsMachineIdentityDetailScopeFor(appARN, nil)
+
+	runtime, permissions, secrets, blast, sprawl, cases := awsMachineIdentityDetailFilterDownstreamEvidence(scope,
+		AWSRuntimeEventResult{Records: []AWSRuntimeEventRecord{
+			{EventID: "runtime-app", EventType: "api-call", ActorPrincipalARN: appARN, ActorIdentityNodeID: appNodeID, ResourceNodeID: "aws:resource:app", EvidenceRef: "evidence-runtime-app", Status: "allowed", Owner: "platform"},
+			{EventID: "runtime-app-admin", EventType: "api-call", ActorPrincipalARN: appAdminARN, ActorIdentityNodeID: appAdminNodeID, ResourceNodeID: "aws:resource:app-admin", EvidenceRef: "evidence-runtime-admin", Status: "allowed", Owner: "platform"},
+		}},
+		AWSLeastPrivilegeResult{Recommendations: []AWSLeastPrivilegeRecommendation{
+			{RecommendationID: "permission-app", PrincipalARN: appARN, IdentityNodeID: appNodeID, DisplayName: "app", ImpactedPath: []AWSLeastPrivilegePathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}, {NodeID: "aws:resource:app", NodeType: "resource", Label: "app bucket"}}},
+			{RecommendationID: "permission-app-admin", PrincipalARN: appAdminARN, IdentityNodeID: appAdminNodeID, DisplayName: "app-admin", ImpactedPath: []AWSLeastPrivilegePathStep{{NodeID: appAdminNodeID, NodeType: "identity", Label: "app-admin"}, {NodeID: "aws:resource:app-admin", NodeType: "resource", Label: "admin bucket"}}},
+		}},
+		AWSSecretPermissionEquivalenceResult{Findings: []AWSSecretPermissionEquivalenceFinding{
+			{FindingID: "secret-app", PrincipalARN: appARN, IdentityNodeID: appNodeID, SecretNodeID: "aws:secret:app", SecretLabel: "app secret", ImpactedPath: []AWSSecretPermissionEquivalencePathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}}},
+			{FindingID: "secret-app-admin", PrincipalARN: appAdminARN, IdentityNodeID: appAdminNodeID, SecretNodeID: "aws:secret:app-admin", SecretLabel: "admin secret", ImpactedPath: []AWSSecretPermissionEquivalencePathStep{{NodeID: appAdminNodeID, NodeType: "identity", Label: "app-admin"}}},
+		}},
+		AWSBlastRadiusResult{Findings: []AWSBlastRadiusFinding{
+			{FindingID: "blast-app", PrincipalARN: appARN, IdentityNodeID: appNodeID, DisplayName: "app", ImpactedPath: []AWSBlastRadiusPathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}, {NodeID: "aws:data:app", NodeType: "data", Label: "app data"}}},
+			{FindingID: "blast-app-admin", PrincipalARN: appAdminARN, IdentityNodeID: appAdminNodeID, DisplayName: "app-admin", ImpactedPath: []AWSBlastRadiusPathStep{{NodeID: appAdminNodeID, NodeType: "identity", Label: "app-admin"}, {NodeID: "aws:data:app-admin", NodeType: "data", Label: "admin data"}}},
+		}},
+		AWSIdentitySprawlResult{
+			Findings: []AWSIdentitySprawlFinding{
+				{FindingID: "sprawl-app", PrincipalARN: appARN, IdentityNodeID: appNodeID, RoleName: "app", DisplayName: "app", ClusterID: "cluster-app-family", WorkloadNodeIDs: []string{"aws:workload:app"}, WorkloadTypes: []string{"lambda"}, ImpactedPath: []AWSIdentitySprawlPathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}, {NodeID: "aws:workload:app", NodeType: "workload", Label: "app workload"}}},
+				{FindingID: "sprawl-app-admin", PrincipalARN: appAdminARN, IdentityNodeID: appAdminNodeID, RoleName: "app-admin", DisplayName: "app-admin", ClusterID: "cluster-app-family", WorkloadNodeIDs: []string{"aws:workload:app-admin"}, WorkloadTypes: []string{"lambda"}, ImpactedPath: []AWSIdentitySprawlPathStep{{NodeID: appAdminNodeID, NodeType: "identity", Label: "app-admin"}, {NodeID: "aws:workload:app-admin", NodeType: "workload", Label: "admin workload"}}},
+			},
+			Clusters: []AWSIdentitySprawlCluster{{ClusterID: "cluster-app-family", IdentityNodeIDs: []string{appNodeID, appAdminNodeID}, WorkloadTypes: []string{"lambda"}}},
+		},
+		AWSRemediationCaseResult{Cases: []AWSRemediationCase{
+			{CaseID: "case-app", IdentityARN: appARN, IdentityNodeID: appNodeID, IdentityName: "app", ImpactedNodes: []string{appNodeID, "aws:resource:app"}, ImpactedPath: []AWSRemediationCasePathStep{{NodeID: appNodeID, NodeType: "identity", Label: "app"}}},
+			{CaseID: "case-app-admin", IdentityARN: appAdminARN, IdentityNodeID: appAdminNodeID, IdentityName: "app-admin", ImpactedNodes: []string{appAdminNodeID, "aws:resource:app-admin"}, ImpactedPath: []AWSRemediationCasePathStep{{NodeID: appAdminNodeID, NodeType: "identity", Label: "app-admin"}}},
+		}},
+	)
+
+	if len(runtime.Records) != 1 || runtime.Records[0].EventID != "runtime-app" || runtime.Summary.TotalEvents != 1 || runtime.Summary.FilteredEvents != 1 {
+		t.Fatalf("runtime evidence should be exact-scoped: records=%+v summary=%+v", runtime.Records, runtime.Summary)
+	}
+	if len(permissions.Recommendations) != 1 || permissions.Recommendations[0].RecommendationID != "permission-app" || permissions.Summary.TotalRecommendations != 1 || len(permissions.Relationships) != 1 {
+		t.Fatalf("permission evidence should be exact-scoped: recommendations=%+v summary=%+v relationships=%+v", permissions.Recommendations, permissions.Summary, permissions.Relationships)
+	}
+	if len(secrets.Findings) != 1 || secrets.Findings[0].FindingID != "secret-app" || secrets.Summary.TotalFindings != 1 || len(secrets.Relationships) != 1 {
+		t.Fatalf("secret evidence should be exact-scoped: findings=%+v summary=%+v relationships=%+v", secrets.Findings, secrets.Summary, secrets.Relationships)
+	}
+	if len(blast.Findings) != 1 || blast.Findings[0].FindingID != "blast-app" || blast.Summary.TotalFindings != 1 || len(blast.Relationships) != 1 {
+		t.Fatalf("blast evidence should be exact-scoped: findings=%+v summary=%+v relationships=%+v", blast.Findings, blast.Summary, blast.Relationships)
+	}
+	if len(sprawl.Findings) != 1 || sprawl.Findings[0].FindingID != "sprawl-app" || sprawl.Summary.TotalFindings != 1 || len(sprawl.Clusters) != 1 || len(sprawl.Clusters[0].IdentityNodeIDs) != 1 || sprawl.Clusters[0].IdentityNodeIDs[0] != appNodeID {
+		t.Fatalf("sprawl evidence should be exact-scoped: findings=%+v clusters=%+v summary=%+v", sprawl.Findings, sprawl.Clusters, sprawl.Summary)
+	}
+	if len(cases.Cases) != 1 || cases.Cases[0].CaseID != "case-app" || cases.Summary.TotalCases != 1 || len(cases.Relationships) != 1 {
+		t.Fatalf("remediation cases should be exact-scoped: cases=%+v summary=%+v relationships=%+v", cases.Cases, cases.Summary, cases.Relationships)
+	}
+}

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newMachineIdentityDetailService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSMachineIdentityDetailBuildsScopedContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 10, 0, 0, time.UTC)
+	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail", now)
+	identity := "arn:aws:iam::123456789012:role/payments-lambda-execution"
+
+	result, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     identity,
+	})
+	if err != nil {
+		t.Fatalf("get machine identity detail: %v", err)
+	}
+	if result.CurrentIssueRef != "#1549" || result.Version != awsMachineIdentityDetailVersion || result.PolicyVersion != awsMachineIdentityDetailPolicyID {
+		t.Fatalf("unexpected detail metadata: %+v", result)
+	}
+	if result.Identity.IdentityNodeID != awsIdentityNodeIDForAPI(identity) || result.Identity.PrincipalARN != identity || result.Identity.EvidenceBoundary == "" {
+		t.Fatalf("identity summary did not preserve ARN/node/evidence boundary: %+v", result.Identity)
+	}
+	if result.Status == "blocked" || result.Status == "empty" || result.Summary.WorkloadBindingCount != 1 || len(result.WorkloadBindings) != 1 {
+		t.Fatalf("expected scoped detail with one workload binding: status=%s summary=%+v bindings=%+v", result.Status, result.Summary, result.WorkloadBindings)
+	}
+	if result.Summary.RelationshipCount != len(result.Relationships) || result.Summary.EvidenceLinkCount != len(result.EvidenceLinks) {
+		t.Fatalf("summary counts must match payload: summary=%+v relationships=%d evidence=%d", result.Summary, len(result.Relationships), len(result.EvidenceLinks))
+	}
+	if len(result.Tabs) != 6 || result.Tabs[0].ID != "graph" {
+		t.Fatalf("expected graph/runtime/permissions/secrets/fixes/governance tabs, got %+v", result.Tabs)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	for _, forbidden := range []string{"secret_access_key", "\"secret_value\"", "password=", "rendered_policy", "policy_document_body", "payload_body"} {
+		if strings.Contains(strings.ToLower(string(encoded)), forbidden) {
+			t.Fatalf("machine identity detail leaked forbidden payload marker %q in %s", forbidden, string(encoded))
+		}
+	}
+}
+
+func TestGetAWSMachineIdentityDetailComposesRuntimePermissionsSecretsAndFixes(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 15, 0, 0, time.UTC)
+	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-compose", now)
+	identity := "arn:aws:iam::123456789012:role/lambda-invoice-agent"
+
+	result, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-compose", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     identity,
+	})
+	if err != nil {
+		t.Fatalf("get machine identity detail: %v", err)
+	}
+	if result.Summary.RuntimeEventCount == 0 || len(result.ResourcesReached) == 0 {
+		t.Fatalf("expected runtime timeline and reached resources for %s: summary=%+v resources=%+v", identity, result.Summary, result.ResourcesReached)
+	}
+	if result.Summary.PermissionRecommendationCount == 0 || len(result.PermissionSummaries) == 0 {
+		t.Fatalf("expected permission summaries for %s: summary=%+v permissions=%+v", identity, result.Summary, result.PermissionSummaries)
+	}
+	if result.Summary.SecretFindingCount == 0 || result.Summary.FindingCount == 0 {
+		t.Fatalf("expected secret/finding summaries for %s: summary=%+v findings=%+v", identity, result.Summary, result.Findings)
+	}
+	if result.Summary.RemediationCaseCount == 0 {
+		t.Fatalf("expected identity-scoped remediation cases: %+v", result.Summary)
+	}
+}
+
+func TestGetAWSMachineIdentityDetailFailureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 20, 0, 0, time.UTC)
+	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-states", now)
+	identity := "arn:aws:iam::123456789012:role/payments-lambda-execution"
+
+	denied, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-states", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+		Identity:     identity,
+	})
+	if err != nil {
+		t.Fatalf("permission denied detail: %v", err)
+	}
+	if denied.Status != "blocked" || len(denied.Diagnostics) == 0 || len(denied.FailureReasons) == 0 {
+		t.Fatalf("permission denied detail must be explicit: %+v", denied)
+	}
+
+	empty, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-states", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "empty",
+		Identity:     identity,
+	})
+	if err != nil {
+		t.Fatalf("empty detail: %v", err)
+	}
+	if empty.Status != "empty" || empty.Summary.WorkloadBindingCount != 0 || len(empty.FailureReasons) == 0 {
+		t.Fatalf("empty detail should return an explicit empty payload: %+v", empty)
+	}
+
+	if _, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-states", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	}); err == nil {
+		t.Fatalf("missing identity should fail validation")
+	}
+	if _, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-states", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "garbage",
+		Identity:     identity,
+	}); err == nil {
+		t.Fatalf("invalid fixture state should fail validation")
+	}
+}
+
+func TestRouterAWSMachineIdentityDetail(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 25, 0, 0, time.UTC)
+	svc, _ := newMachineIdentityDetailService(t, "project-machine-identity-detail-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+	identity := "arn:aws:iam::123456789012:role/lambda-invoice-agent"
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-machine-identity-detail-route/aws/machine-identity-detail?connector_id=aws-prod&fixture_state=success&identity="+url.QueryEscape(identity)+"&tab=runtime", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Detail AWSMachineIdentityDetailResult `json:"detail"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode detail response: %v", err)
+	}
+	if body.Detail.CurrentIssueRef != "#1549" || body.Detail.AppliedFilters["tab"] != "runtime" {
+		t.Fatalf("unexpected route payload: %+v", body.Detail)
+	}
+	if body.Detail.Summary.RuntimeEventCount == 0 {
+		t.Fatalf("expected identity-scoped runtime events via route: %+v", body.Detail.Summary)
+	}
+}

--- a/internal/api/aws_machine_identity_detail_test.go
+++ b/internal/api/aws_machine_identity_detail_test.go
@@ -122,6 +122,30 @@ func TestGetAWSMachineIdentityDetailNormalizesRoleNameForGovernance(t *testing.T
 	}
 }
 
+func TestGetAWSMachineIdentityDetailKeepsUnresolvedRoleNameGovernanceScoped(t *testing.T) {
+	now := time.Date(2026, 7, 3, 13, 19, 0, 0, time.UTC)
+	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-unresolved-role", now)
+
+	result, err := svc.GetAWSMachineIdentityDetail(defaultScopeContext(), ws, "project-machine-identity-detail-unresolved-role", AWSMachineIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Identity:     "stale-role-name",
+	})
+	if err != nil {
+		t.Fatalf("get machine identity detail for unresolved role name: %v", err)
+	}
+	if result.Status != "empty" || result.Summary.GovernanceDecisionCount != 0 || len(result.GovernanceDecisions) != 0 || len(result.Governance.Records) != 0 {
+		t.Fatalf("unresolved role-name detail must stay empty and avoid connector-wide governance: status=%s summary=%+v governance=%+v", result.Status, result.Summary, result.Governance.Summary)
+	}
+	governanceIdentityID := result.Governance.AppliedFilters["identity_id"]
+	if !strings.HasPrefix(governanceIdentityID, "aws:identity:unresolved:") {
+		t.Fatalf("unresolved role-name governance must stay explicitly scoped: applied=%+v", result.Governance.AppliedFilters)
+	}
+	if result.Identity.IdentityNodeID != "" || result.Identity.PrincipalARN != "" {
+		t.Fatalf("unresolved role-name identity should not synthesize a real ARN or node id: %+v", result.Identity)
+	}
+}
+
 func TestGetAWSMachineIdentityDetailFailureStates(t *testing.T) {
 	now := time.Date(2026, 7, 3, 13, 20, 0, 0, time.UTC)
 	svc, ws := newMachineIdentityDetailService(t, "project-machine-identity-detail-states", now)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2832,6 +2832,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, record)
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/machine-identity-detail", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSMachineIdentityDetail(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSMachineIdentityDetailRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			Identity:     strings.TrimSpace(c.Query("identity")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Tab:          strings.TrimSpace(c.Query("tab")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws machine identity detail request"})
+			default:
+				logger.Error("get aws machine identity detail",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					zap.String("identity", c.Query("identity")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws machine identity detail"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"detail": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
   ProductAWSGraphPage,
   ProductAWSRemediationPage,
   ProductAWSRuntimePage,
+  ProductAWSMachineIdentityDetailPage,
   ProductDomainRoutePage,
   ProductAWSConnectPage,
   ProductAWSIdentitiesPage,
@@ -4819,6 +4820,7 @@ export function RoutedSite() {
             <Route path="aws/connect" element={<ProductAWSConnectPage />} />
             <Route path="aws/accounts" element={<ProductAWSAccountsPage />} />
             <Route path="aws/identities" element={<ProductAWSIdentitiesPage />} />
+            <Route path="aws/identities/detail" element={<ProductAWSMachineIdentityDetailPage />} />
             <Route path="aws/agents" element={<ProductAWSAgentsPage />} />
             <Route path="aws/resources" element={<ProductAWSResourcesPage />} />
             <Route path="aws/runtime" element={<ProductAWSRuntimePage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2105,6 +2105,196 @@ export type AWSAIAgentIdentityQuery = {
   minConfidence?: string;
 };
 
+export type AWSMachineIdentityDetailStatus = 'ready' | 'degraded' | 'blocked' | 'empty';
+export type AWSMachineIdentityDetailFixtureState =
+  | 'success'
+  | 'empty'
+  | 'degraded'
+  | 'partial_failure'
+  | 'permission_denied';
+
+export type AWSMachineIdentityDetailQuery = {
+  connectorID?: string;
+  fixtureState?: AWSMachineIdentityDetailFixtureState;
+  identity: string;
+  accountID?: string;
+  region?: string;
+  tab?: string;
+  service?: string;
+  resource?: string;
+  severity?: string;
+  status?: string;
+};
+
+export type AWSMachineIdentityDetailIdentity = {
+  identity: string;
+  identity_node_id: string;
+  principal_arn?: string;
+  role_name?: string;
+  display_name: string;
+  account_id?: string;
+  region?: string;
+  status: AWSMachineIdentityDetailStatus | string;
+  confidence: number;
+  evidence_boundary: string;
+};
+
+export type AWSMachineIdentityWorkloadBinding = {
+  binding_id: string;
+  service: string;
+  workload_id?: string;
+  workload_type?: string;
+  workload_name?: string;
+  role_arn?: string;
+  role_name?: string;
+  role_kind?: string;
+  relationship_type?: string;
+  from_node_id?: string;
+  to_node_id?: string;
+  evidence_ref?: string;
+  status: string;
+  confidence: number;
+  collected_at?: string;
+};
+
+export type AWSMachineIdentityPermissionSummary = {
+  recommendation_id: string;
+  decision: string;
+  severity: string;
+  status: string;
+  service: string;
+  resource_arn?: string;
+  display_name: string;
+  actions?: string[];
+  rationale: string;
+  next_action: string;
+  score: number;
+};
+
+export type AWSMachineIdentityResourceSummary = {
+  resource_id: string;
+  resource_arn?: string;
+  resource_type?: string;
+  label: string;
+  source: string;
+  evidence_ref?: string;
+  observed_at?: string;
+};
+
+export type AWSMachineIdentityFindingSummary = {
+  finding_id: string;
+  source: string;
+  finding_type: string;
+  severity: string;
+  status: string;
+  score: number;
+  title: string;
+  summary: string;
+  evidence_refs?: string[];
+  next_action: string;
+};
+
+export type AWSMachineIdentityGovernanceDecision = {
+  report_id: string;
+  category: string;
+  decision_type: string;
+  state: string;
+  title: string;
+  summary: string;
+  actor?: string;
+  approver?: string;
+  evidence_refs?: string[];
+  occurred_at?: string;
+};
+
+export type AWSMachineIdentityDetailRelationship = {
+  source: string;
+  type: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_ref?: string;
+};
+
+export type AWSMachineIdentityDetailTab = {
+  id: 'graph' | 'runtime' | 'permissions' | 'secrets' | 'fixes' | 'governance' | string;
+  label: string;
+  status: AWSMachineIdentityDetailStatus | string;
+  count: number;
+};
+
+export type AWSMachineIdentityDetailDiagnostic = {
+  collector: string;
+  source_id?: string;
+  code: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+};
+
+export type AWSMachineIdentityDetailCoverageGap = {
+  capability: string;
+  status: string;
+  reason: string;
+  remediation?: string;
+};
+
+export type AWSMachineIdentityDetailSummary = {
+  workload_binding_count: number;
+  runtime_event_count: number;
+  permission_recommendation_count: number;
+  secret_finding_count: number;
+  finding_count: number;
+  remediation_case_count: number;
+  governance_decision_count: number;
+  resource_reached_count: number;
+  relationship_count: number;
+  evidence_link_count: number;
+  diagnostic_count: number;
+  coverage_gap_count: number;
+};
+
+export type AWSMachineIdentityDetailResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSMachineIdentityDetailStatus;
+  fixture_state?: AWSMachineIdentityDetailFixtureState;
+  confidence: number;
+  policy_version: string;
+  applied_filters: Record<string, string>;
+  identity: AWSMachineIdentityDetailIdentity;
+  summary: AWSMachineIdentityDetailSummary;
+  tabs: AWSMachineIdentityDetailTab[];
+  workload_bindings: AWSMachineIdentityWorkloadBinding[];
+  permission_summaries: AWSMachineIdentityPermissionSummary[];
+  resources_reached: AWSMachineIdentityResourceSummary[];
+  findings: AWSMachineIdentityFindingSummary[];
+  governance_decisions: AWSMachineIdentityGovernanceDecision[];
+  relationships: AWSMachineIdentityDetailRelationship[];
+  runtime: AWSRuntimeEventResult;
+  permissions: AWSLeastPrivilegeResult;
+  secrets: AWSSecretPermissionEquivalenceResult;
+  blast_radius: AWSBlastRadiusResult;
+  identity_sprawl: AWSIdentitySprawlResult;
+  remediation_cases: AWSRemediationCaseResult;
+  governance: AWSGovernanceAuditReportingResult;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSMachineIdentityDetailCoverageGap[];
+  diagnostics: AWSMachineIdentityDetailDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSRuntimeEventStatus = 'ready' | 'degraded' | 'blocked';
 // AWSRuntimeEventFixtureStateRequest is the query-side enum: every
 // value here is one the backend accepts as `?fixture_state=...`. It
@@ -9712,6 +9902,28 @@ export const apiClient = {
         status: query?.status,
         risk: query?.risk,
         min_confidence: query?.minConfidence
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectMachineIdentityDetail(
+    workspaceID: string,
+    projectID: string,
+    query: AWSMachineIdentityDetailQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ detail: AWSMachineIdentityDetailResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/machine-identity-detail${buildQuery({
+        connector_id: query.connectorID,
+        fixture_state: query.fixtureState,
+        identity: query.identity,
+        account_id: query.accountID,
+        region: query.region,
+        tab: query.tab,
+        service: query.service,
+        resource: query.resource,
+        severity: query.severity,
+        status: query.status
       })}`,
       auth
     );

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -4,6 +4,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/connect',
   '/app/:tenantID/:workspaceID/aws/accounts',
   '/app/:tenantID/:workspaceID/aws/identities',
+  '/app/:tenantID/:workspaceID/aws/identities/detail',
   '/app/:tenantID/:workspaceID/aws/agents',
   '/app/:tenantID/:workspaceID/aws/resources',
   '/app/:tenantID/:workspaceID/aws/runtime',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -11,6 +11,7 @@ import type {
   AWSECSTaskRoleInventoryResult,
   AWSLambdaExecutionRoleInventoryResult,
   AWSLeastPrivilegeResult,
+  AWSMachineIdentityDetailResult,
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
@@ -2671,6 +2672,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/connect',
       '/app/:tenantID/:workspaceID/aws/accounts',
       '/app/:tenantID/:workspaceID/aws/identities',
+      '/app/:tenantID/:workspaceID/aws/identities/detail',
       '/app/:tenantID/:workspaceID/aws/agents',
       '/app/:tenantID/:workspaceID/aws/resources',
       '/app/:tenantID/:workspaceID/aws/runtime',
@@ -3078,6 +3080,10 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText('payments-ecs-task')).toBeInTheDocument();
     expect(screen.getByText('payments-ecs-execution')).toBeInTheDocument();
     expect(await screen.findByText('payments-lambda-execution')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'payments-lambda-execution' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/identities/detail?environment=production&identity=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fpayments-lambda-execution&tab=graph'
+    );
     expect(await screen.findByText('payments-codebuild-service')).toBeInTheDocument();
     expect(await screen.findByText('payments-irsa')).toBeInTheDocument();
     expect(screen.getByText('batch-pod-identity')).toBeInTheDocument();
@@ -3134,6 +3140,137 @@ describe('Domain-first app routes', () => {
     );
     expect(screen.getByText(/Risk score/i)).toBeInTheDocument();
     expect(screen.getByText(/Unscored until AWS findings land/i)).toBeInTheDocument();
+  });
+
+  it('renders AWS machine identity detail scoped to the selected identity and tab', async () => {
+    const api = await import('./api/client');
+    const identity = 'arn:aws:iam::123456789012:role/lambda-invoice-agent';
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const machineIdentityDetail = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      parent_issue_number: 1472,
+      parent_issue_ref: '#1472',
+      current_issue_number: 1549,
+      current_issue_ref: '#1549',
+      version: 'aws-machine-identity-detail-page-v1',
+      status: 'ready',
+      fixture_state: 'success',
+      confidence: 0.91,
+      policy_version: 'aws-machine-identity-detail-policy-v1',
+      applied_filters: { identity },
+      identity: {
+        identity,
+        identity_node_id: 'aws:identity:lambda-invoice-agent',
+        principal_arn: identity,
+        role_name: 'lambda-invoice-agent',
+        display_name: 'lambda-invoice-agent',
+        account_id: '123456789012',
+        region: 'us-east-1',
+        status: 'ready',
+        confidence: 0.91,
+        evidence_boundary: 'metadata_only_no_secret_values_no_policy_bodies_no_payloads'
+      },
+      summary: {
+        workload_binding_count: 1,
+        runtime_event_count: 1,
+        permission_recommendation_count: 1,
+        secret_finding_count: 0,
+        finding_count: 0,
+        remediation_case_count: 0,
+        governance_decision_count: 0,
+        resource_reached_count: 1,
+        relationship_count: 1,
+        evidence_link_count: 1,
+        diagnostic_count: 0,
+        coverage_gap_count: 0
+      },
+      tabs: [
+        { id: 'graph', label: 'Graph', status: 'ready', count: 1 },
+        { id: 'runtime', label: 'Runtime', status: 'ready', count: 1 },
+        { id: 'permissions', label: 'Permissions', status: 'ready', count: 1 },
+        { id: 'secrets', label: 'Secrets', status: 'empty', count: 0 },
+        { id: 'fixes', label: 'Fixes', status: 'empty', count: 0 },
+        { id: 'governance', label: 'Governance', status: 'empty', count: 0 }
+      ],
+      workload_bindings: [],
+      permission_summaries: [],
+      resources_reached: [],
+      findings: [],
+      governance_decisions: [],
+      relationships: [],
+      runtime: { ...readyAWSRuntimeEvents, records: [readyAWSRuntimeEvents.records[0]] },
+      permissions: readyAWSLeastPrivilege,
+      secrets: { findings: [] },
+      blast_radius: { findings: [] },
+      identity_sprawl: { findings: [] },
+      remediation_cases: { cases: [] },
+      governance: { records: [] },
+      failure_reasons: [],
+      remediation_hints: [],
+      evidence_links: ['/docs/aws-machine-identity-detail'],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-06-14T17:30:00Z',
+      updated_at: '2026-06-14T17:30:00Z'
+    } as unknown as AWSMachineIdentityDetailResult;
+    const getMachineIdentityDetail = vi
+      .spyOn(api.apiClient, 'getAWSProjectMachineIdentityDetail')
+      .mockResolvedValue({ detail: machineIdentityDetail });
+
+    const { ProductAWSMachineIdentityDetailPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          `/app/tenant-a/workspace-a/aws/identities/detail?environment=production&identity=${encodeURIComponent(identity)}&tab=runtime`
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/identities/detail"
+            element={<ProductAWSMachineIdentityDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'lambda-invoice-agent' })).toBeInTheDocument();
+    expect(screen.getByText('metadata_only_no_secret_values_no_policy_bodies_no_payloads')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Runtime\s+1/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('table', { name: 'Machine identity runtime events' })).toBeInTheDocument();
+    expect(screen.getByText('s3:GetObject')).toBeInTheDocument();
+    expect(getMachineIdentityDetail).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      {
+        connectorID: 'aws-connector-1',
+        identity,
+        tab: 'runtime'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      }
+    );
   });
 
   it('renders AWS agent identity inventory as an honest reserved surface', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -44,6 +44,7 @@ import {
   type AWSManagedComputeRoleRecord,
   type AWSAIAgentIdentityQuery,
   type AWSAIAgentIdentityInventoryResult,
+  type AWSMachineIdentityDetailResult,
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
@@ -3101,6 +3102,29 @@ function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, envi
   return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
 }
 
+function awsMachineIdentityDetailLink(
+  scope: ProductSession,
+  environmentID: string,
+  identity: string,
+  tab = 'graph'
+): string {
+  const params = new URLSearchParams();
+  const normalizedEnvironmentID = normalizeValue(environmentID);
+  const normalizedIdentity = normalizeValue(identity);
+  const normalizedTab = normalizeValue(tab);
+  if (normalizedEnvironmentID) {
+    params.set(ENVIRONMENT_QUERY_PARAM, normalizedEnvironmentID);
+  }
+  if (normalizedIdentity) {
+    params.set('identity', normalizedIdentity);
+  }
+  if (normalizedTab) {
+    params.set('tab', normalizedTab);
+  }
+  const search = params.toString();
+  return `${buildScopedPath(scope, 'aws/identities/detail')}${search ? `?${search}` : ''}`;
+}
+
 function AWSConnectionDiagnostics({
   connection,
   emptyLabel = 'No diagnostics reported for this environment.'
@@ -3697,6 +3721,7 @@ type AWSInventoryFilterable = {
 type AWSInventoryTableRow = AWSInventoryFilterable & {
   id: string;
   name: string;
+  detailIdentity?: string;
   category: string;
   scope: string;
   status: string;
@@ -5300,6 +5325,8 @@ function AWSPartialFailureReportList({ reports, label }: { reports: AWSPartialFa
 }
 
 function AWSMachineIdentitiesContent({
+  scope,
+  selectedEnvironmentID,
   connection,
   ec2State,
   ecsState,
@@ -5313,6 +5340,8 @@ function AWSMachineIdentitiesContent({
   filters,
   onFiltersChange
 }: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
   connection: AWSConnectionStatus | null;
   ec2State: AWSInventoryEC2State;
   ecsState: AWSInventoryECSState;
@@ -5350,6 +5379,7 @@ function AWSMachineIdentitiesContent({
           {
             id: 'current-role',
             name: connection.role_arn,
+            detailIdentity: connection.role_arn,
             category: 'IAM role',
             scope: awsAccountRegionLabel(connection),
             status: connection.connected ? 'wired now' : 'pending validation',
@@ -5655,7 +5685,13 @@ function AWSMachineIdentitiesContent({
               header: 'Identity',
               render: (row) => (
                 <div className="idt-aws-inventory-table-cell">
-                  <strong>{row.name}</strong>
+                  <strong>
+                    {row.detailIdentity ? (
+                      <Link to={awsMachineIdentityDetailLink(scope, selectedEnvironmentID, row.detailIdentity)}>{row.name}</Link>
+                    ) : (
+                      row.name
+                    )}
+                  </strong>
                   <p>{row.detail}</p>
                 </div>
               )
@@ -5828,6 +5864,7 @@ function awsEC2InstanceProfileRow(record: AWSEC2InstanceProfileRecord): AWSInven
   return {
     id: `instance-profile-${record.from_node_id}`,
     name: record.instance_profile_name || roleLabel,
+    detailIdentity: record.role_arn,
     category: isLaunchTemplate ? 'Launch template profile' : 'EC2 instance profile',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -5942,6 +5979,7 @@ function awsECSTaskRoleRow(record: AWSECSTaskRoleRecord): AWSInventoryTableRow {
   return {
     id: `ecs-task-role-${record.from_node_id}-${rowRoleID}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: isExecutionRole ? 'ECS execution role' : 'ECS task role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6057,6 +6095,7 @@ function awsLambdaExecutionRoleRow(record: AWSLambdaExecutionRoleRecord): AWSInv
   return {
     id: `lambda-execution-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.function_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: 'Lambda execution role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6173,6 +6212,7 @@ function awsCodeBuildServiceRoleRow(record: AWSCodeBuildServiceRoleRecord): AWSI
   return {
     id: `codebuild-service-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.project_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: 'CodeBuild service role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6303,6 +6343,7 @@ function awsCodePipelineDeploymentRoleRow(record: AWSCodePipelineDeploymentRoleR
   return {
     id: `codepipeline-deployment-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.pipeline_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: 'CodePipeline deployment role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6428,6 +6469,7 @@ function awsStepFunctionsStateMachineRoleRow(record: AWSStepFunctionsStateMachin
   return {
     id: `stepfunctions-state-machine-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.state_machine_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: 'Step Functions state-machine role',
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6537,6 +6579,7 @@ function awsEventDrivenRoleRow(record: AWSEventDrivenRoleRecord): AWSInventoryTa
   return {
     id: `event-driven-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.workload_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: formatTokenLabel(record.workload_type || 'event_driven_role'),
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6654,6 +6697,7 @@ function awsManagedComputeRoleRow(record: AWSManagedComputeRoleRecord): AWSInven
   return {
     id: `managed-compute-role-${record.from_node_id}-${record.to_node_id || record.role_arn || record.workload_arn}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category: formatTokenLabel(record.role_kind || record.workload_type || 'managed_compute_role'),
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -6794,6 +6838,7 @@ function awsEKSWorkloadIdentityRow(record: AWSEKSWorkloadIdentityRecord): AWSInv
   return {
     id: `eks-workload-identity-${record.from_node_id}-${record.to_node_id || record.role_arn || record.evidence_ref}`,
     name: roleLabel,
+    detailIdentity: record.role_arn,
     category,
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -9537,6 +9582,8 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       ) : null}
       {routeID === 'identities' ? (
         <AWSMachineIdentitiesContent
+          scope={scope}
+          selectedEnvironmentID={selectedEnvironmentID}
           connection={connection}
           ec2State={{
             inventory: ec2Inventory,
@@ -9668,6 +9715,499 @@ export function ProductAWSAccountsPage() {
 
 export function ProductAWSIdentitiesPage() {
   return <ProductAWSInventoryPage routeID="identities" />;
+}
+
+const AWS_MACHINE_IDENTITY_DETAIL_TAB_IDS = ['graph', 'runtime', 'permissions', 'secrets', 'fixes', 'governance'] as const;
+type AWSMachineIdentityDetailTabID = (typeof AWS_MACHINE_IDENTITY_DETAIL_TAB_IDS)[number];
+const AWS_MACHINE_IDENTITY_DETAIL_TAB_LABELS: Record<AWSMachineIdentityDetailTabID, string> = {
+  graph: 'Graph',
+  runtime: 'Runtime',
+  permissions: 'Permissions',
+  secrets: 'Secrets',
+  fixes: 'Fixes',
+  governance: 'Governance'
+};
+
+function normalizeAWSMachineIdentityDetailTab(value: string | null): AWSMachineIdentityDetailTabID {
+  const normalized = normalizeValue(value ?? '').toLowerCase();
+  return AWS_MACHINE_IDENTITY_DETAIL_TAB_IDS.includes(normalized as AWSMachineIdentityDetailTabID)
+    ? (normalized as AWSMachineIdentityDetailTabID)
+    : 'graph';
+}
+
+function awsMachineIdentityDetailStage(status: string): AWSCapabilityStage {
+  if (status === 'ready') {
+    return 'wired';
+  }
+  if (status === 'blocked') {
+    return 'not-available';
+  }
+  return 'coming';
+}
+
+function awsMachineIdentityDetailTone(status: string): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (status === 'ready') {
+    return 'success';
+  }
+  if (status === 'blocked') {
+    return 'danger';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function awsMachineIdentityDetailDescription(detail: AWSMachineIdentityDetailResult | null, identity: string): string {
+  if (detail?.identity.principal_arn) {
+    return detail.identity.principal_arn;
+  }
+  if (detail?.identity.identity_node_id) {
+    return detail.identity.identity_node_id;
+  }
+  return identity || 'Select a machine identity from the AWS identities inventory.';
+}
+
+function AWSMachineIdentityDetailTabs({
+  scope,
+  selectedEnvironmentID,
+  identity,
+  activeTab,
+  detail
+}: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
+  identity: string;
+  activeTab: AWSMachineIdentityDetailTabID;
+  detail: AWSMachineIdentityDetailResult | null;
+}) {
+  const tabCounts = new Map((detail?.tabs ?? []).map((tab) => [tab.id, tab.count]));
+  return (
+    <div className="idt-inline-actions" role="tablist" aria-label="Machine identity detail tabs">
+      {AWS_MACHINE_IDENTITY_DETAIL_TAB_IDS.map((tabID) => (
+        <Link
+          key={tabID}
+          role="tab"
+          aria-selected={activeTab === tabID}
+          aria-label={`${AWS_MACHINE_IDENTITY_DETAIL_TAB_LABELS[tabID]} ${tabCounts.get(tabID) ?? 0}`}
+          className={`idt-btn ${activeTab === tabID ? 'idt-btn-primary' : 'idt-btn-ghost'}`}
+          to={awsMachineIdentityDetailLink(scope, selectedEnvironmentID, identity, tabID)}
+        >
+          <span>{AWS_MACHINE_IDENTITY_DETAIL_TAB_LABELS[tabID]}</span>
+          <span>{tabCounts.get(tabID) ?? 0}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function AWSMachineIdentityDetailDiagnostics({ detail }: { detail: AWSMachineIdentityDetailResult }) {
+  return (
+    <>
+      {detail.failure_reasons.length || detail.remediation_hints.length ? (
+        <DomainStatusPanel
+          eyebrow="State"
+          title="Detail readiness"
+          status={formatTokenLabel(detail.status)}
+          tone={awsMachineIdentityDetailTone(detail.status)}
+        >
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Failures</dt>
+              <dd>{detail.failure_reasons.length ? detail.failure_reasons.join(', ') : 'None'}</dd>
+            </div>
+            <div>
+              <dt>Next actions</dt>
+              <dd>{detail.remediation_hints.length ? detail.remediation_hints.join(', ') : 'None'}</dd>
+            </div>
+          </dl>
+        </DomainStatusPanel>
+      ) : null}
+      {detail.diagnostics.length ? (
+        <DomainStatusPanel
+          eyebrow="Collectors"
+          title="Diagnostics"
+          status={`${detail.diagnostics.length} active`}
+          tone={detail.status === 'blocked' ? 'danger' : 'warning'}
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="Machine identity detail diagnostics">
+            {detail.diagnostics.map((diagnostic) => (
+              <article key={`${diagnostic.collector}-${diagnostic.source_id ?? diagnostic.code}-${diagnostic.message}`}>
+                <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                <p>{diagnostic.message}</p>
+                {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+      {detail.coverage_gaps.length ? (
+        <DomainStatusPanel
+          eyebrow="Coverage"
+          title="Evidence gaps"
+          status={`${detail.coverage_gaps.length} gaps`}
+          tone="warning"
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="Machine identity detail coverage gaps">
+            {detail.coverage_gaps.map((gap) => (
+              <article key={`${gap.capability}-${gap.status}-${gap.reason}`}>
+                <strong>{formatTokenLabel(gap.capability)}</strong>
+                <p>{gap.reason}</p>
+                {gap.remediation ? <small>{gap.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+    </>
+  );
+}
+
+function AWSMachineIdentityDetailTabContent({
+  detail,
+  activeTab
+}: {
+  detail: AWSMachineIdentityDetailResult;
+  activeTab: AWSMachineIdentityDetailTabID;
+}) {
+  if (activeTab === 'graph') {
+    return (
+      <>
+        <DomainDataTable
+          label="Machine identity workload bindings"
+          rows={detail.workload_bindings}
+          getRowKey={(row) => row.binding_id}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No workload bindings" body="No workload collector has reported a binding for this identity." />}
+          columns={[
+            { key: 'service', header: 'Service', render: (row) => formatTokenLabel(row.service) },
+            { key: 'workload', header: 'Workload', render: (row) => row.workload_name || row.workload_id || '-' },
+            { key: 'role', header: 'Role', render: (row) => row.role_name || row.role_arn || '-' },
+            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence_ref || '-' },
+            {
+              key: 'status',
+              header: 'Status',
+              render: (row) => <AWSInventoryPill stage={awsMachineIdentityDetailStage(row.status)} label={`${formatTokenLabel(row.status)} / ${formatConfidenceScore(row.confidence)}`} />
+            }
+          ]}
+        />
+        <DomainDataTable
+          label="Machine identity relationships"
+          rows={detail.relationships}
+          getRowKey={(row) => `${row.source}-${row.type}-${row.from_node_id}-${row.to_node_id}-${row.evidence_ref ?? ''}`}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No relationships" body="No graph relationships matched this identity yet." />}
+          columns={[
+            { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source) },
+            { key: 'type', header: 'Relationship', render: (row) => formatTokenLabel(row.type) },
+            { key: 'from', header: 'From', render: (row) => row.from_node_id },
+            { key: 'to', header: 'To', render: (row) => row.to_node_id },
+            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence_ref || '-' }
+          ]}
+        />
+      </>
+    );
+  }
+
+  if (activeTab === 'runtime') {
+    return (
+      <DomainDataTable
+        label="Machine identity runtime events"
+        rows={detail.runtime.records}
+        getRowKey={(row) => row.event_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No runtime events" body="No runtime event evidence matched this identity." />}
+        columns={[
+          { key: 'event', header: 'Event', render: (row) => <strong>{row.action || row.event_name}</strong> },
+          { key: 'source', header: 'Source', render: (row) => row.event_source },
+          { key: 'resource', header: 'Resource', render: (row) => row.target_resource_name || row.target_resource_arn || '-' },
+          { key: 'observed', header: 'Observed', render: (row) => formatDateLabel(row.observed_at) },
+          {
+            key: 'status',
+            header: 'Status',
+            render: (row) => <AWSInventoryPill stage={awsMachineIdentityDetailStage(row.status)} label={`${formatTokenLabel(row.status)} / ${formatConfidenceScore(row.confidence)}`} />
+          }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'permissions') {
+    return (
+      <DomainDataTable
+        label="Machine identity permission summaries"
+        rows={detail.permission_summaries}
+        getRowKey={(row) => row.recommendation_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No permission recommendations" body="No least-privilege recommendation matched this identity." />}
+        columns={[
+          { key: 'permission', header: 'Permission', render: (row) => <strong>{row.display_name}</strong> },
+          { key: 'service', header: 'Service', render: (row) => formatTokenLabel(row.service) },
+          { key: 'resource', header: 'Resource', render: (row) => row.resource_arn || '-' },
+          { key: 'decision', header: 'Decision', render: (row) => `${formatTokenLabel(row.decision)} / ${formatTokenLabel(row.status)}` },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'secrets') {
+    return (
+      <>
+        <DomainDataTable
+          label="Machine identity resources reached"
+          rows={detail.resources_reached}
+          getRowKey={(row) => row.resource_id}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No resources reached" body="No runtime or static resource reachability matched this identity." />}
+          columns={[
+            { key: 'resource', header: 'Resource', render: (row) => <strong>{row.label}</strong> },
+            { key: 'type', header: 'Type', render: (row) => row.resource_type ? formatTokenLabel(row.resource_type) : '-' },
+            { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source) },
+            { key: 'arn', header: 'ARN', render: (row) => row.resource_arn || '-' },
+            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence_ref || '-' }
+          ]}
+        />
+        <DomainDataTable
+          label="Machine identity security findings"
+          rows={detail.findings}
+          getRowKey={(row) => row.finding_id}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No secret or blast-radius findings" body="No secret equivalence, blast radius, or sprawl finding matched this identity." />}
+          columns={[
+            { key: 'finding', header: 'Finding', render: (row) => <strong>{row.title}</strong> },
+            { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source) },
+            { key: 'type', header: 'Type', render: (row) => formatTokenLabel(row.finding_type) },
+            { key: 'severity', header: 'Severity', render: (row) => `${formatTokenLabel(row.severity)} / ${formatTokenLabel(row.status)}` },
+            { key: 'next', header: 'Next action', render: (row) => row.next_action }
+          ]}
+        />
+      </>
+    );
+  }
+
+  if (activeTab === 'fixes') {
+    return (
+      <DomainDataTable
+        label="Machine identity remediation cases"
+        rows={detail.remediation_cases.cases}
+        getRowKey={(row) => row.case_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No remediation cases" body="No read-only remediation case matched this identity." />}
+        columns={[
+          { key: 'case', header: 'Case', render: (row) => <strong>{row.title}</strong> },
+          { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+          { key: 'owner', header: 'Owner', render: (row) => awsRemediationCaseOwnerLabel(row) },
+          { key: 'state', header: 'State', render: (row) => `${formatTokenLabel(row.lifecycle)} / ${formatTokenLabel(row.status)}` },
+          {
+            key: 'severity',
+            header: 'Severity',
+            render: (row) => <AWSInventoryPill stage={awsRemediationCaseStage(row)} label={`${formatTokenLabel(row.severity)} / ${row.score}`} />
+          }
+        ]}
+      />
+    );
+  }
+
+  return (
+    <DomainDataTable
+      label="Machine identity governance decisions"
+      rows={detail.governance_decisions}
+      getRowKey={(row) => `${row.report_id}-${row.decision_type}-${row.state}`}
+      emptyState={<DomainEmptyState eyebrow="Empty" title="No governance decisions" body="No advisory, approval, remediation, enforcement, or exception record matched this identity." />}
+      columns={[
+        { key: 'decision', header: 'Decision', render: (row) => <strong>{row.title}</strong> },
+        { key: 'category', header: 'Category', render: (row) => formatTokenLabel(row.category) },
+        { key: 'type', header: 'Type', render: (row) => formatTokenLabel(row.decision_type) },
+        { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+        { key: 'actor', header: 'Actor', render: (row) => row.actor || row.approver || '-' }
+      ]}
+    />
+  );
+}
+
+export function ProductAWSMachineIdentityDetailPage() {
+  const data = useAWSInventoryData();
+  const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
+  const location = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const identity = normalizeValue(searchParams.get('identity') ?? '');
+  const activeTab = normalizeAWSMachineIdentityDetailTab(searchParams.get('tab'));
+  const [detail, setDetail] = useState<AWSMachineIdentityDetailResult | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState('');
+  const detailRequestRef = useRef(0);
+
+  const loadDetail = useCallback(async () => {
+    const requestID = ++detailRequestRef.current;
+    setDetail(null);
+    setDetailError('');
+    if (!scope || !selectedEnvironmentID || !identity || !connection?.connector_id) {
+      setDetailLoading(false);
+      return;
+    }
+    setDetailLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectMachineIdentityDetail(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          identity,
+          tab: activeTab
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== detailRequestRef.current) {
+        return;
+      }
+      setDetail(response.detail);
+    } catch (error) {
+      if (requestID !== detailRequestRef.current) {
+        return;
+      }
+      setDetailError(formatAPIError(error, 'Unable to load AWS machine identity detail.'));
+    } finally {
+      if (requestID === detailRequestRef.current) {
+        setDetailLoading(false);
+      }
+    }
+  }, [
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    identity,
+    activeTab,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadDetail();
+    return () => {
+      detailRequestRef.current += 1;
+    };
+  }, [loadDetail]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Machine identity detail</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading AWS machine identity detail.</p>
+      </section>
+    );
+  }
+
+  const identitiesPath = awsRouteLink(scope, 'identities', selectedEnvironmentID);
+  const status = environmentScope.loading || connectionLoading || detailLoading
+    ? 'Loading detail'
+    : connectionError || detailError
+      ? 'Needs retry'
+      : detail
+        ? formatTokenLabel(detail.status)
+        : 'Select identity';
+  const statusTone = connectionError || detailError
+    ? 'danger'
+    : detail
+      ? awsMachineIdentityDetailTone(detail.status)
+      : awsDomainTone(connection, environmentScope.loading || connectionLoading);
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow={null}
+      hideLogo
+      title={detail?.identity.display_name || 'Machine identity detail'}
+      description={awsMachineIdentityDetailDescription(detail, identity)}
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
+      status={status}
+      statusTone={statusTone}
+      primaryAction={{ label: 'Back to identities', to: identitiesPath, variant: 'secondary' }}
+    >
+      <div className="idt-aws-risk-page">
+        {connectionError ? (
+          <DomainErrorState
+            title="Couldn't load AWS status"
+            body={connectionError}
+            retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
+          />
+        ) : null}
+        {!identity ? (
+          <DomainEmptyState
+            eyebrow="Identity required"
+            title="Select a machine identity"
+            body="Open an identity from the AWS identities inventory to inspect its workload, runtime, permission, secret, remediation, and governance evidence."
+            nextAction={{ label: 'Open identities', to: identitiesPath }}
+          />
+        ) : null}
+        {!connectionError && identity && !connectionLoading && !connection?.connector_id ? (
+          <DomainEmptyState
+            eyebrow="Connector required"
+            title="AWS connector detail is unavailable"
+            body="The selected environment does not have an AWS connector identifier to scope the detail request."
+          />
+        ) : null}
+        {detailError ? (
+          <DomainErrorState
+            title="Couldn't load machine identity detail"
+            body={detailError}
+            retryAction={{ label: 'Retry', onClick: loadDetail }}
+          />
+        ) : null}
+        {!detailError && detailLoading ? <DomainLoadingState label="Loading machine identity detail" /> : null}
+        {detail ? (
+          <>
+            <DomainKpiStrip
+              label="Machine identity detail metrics"
+              items={[
+                { label: 'Workloads', value: detail.summary.workload_binding_count, detail: 'bound to this identity' },
+                { label: 'Runtime', value: detail.summary.runtime_event_count, detail: 'events matched' },
+                { label: 'Permissions', value: detail.summary.permission_recommendation_count, detail: 'recommendations' },
+                { label: 'Findings', value: detail.summary.finding_count, detail: 'security signals' },
+                { label: 'Fixes', value: detail.summary.remediation_case_count, detail: 'read-only cases' },
+                { label: 'Governance', value: detail.summary.governance_decision_count, detail: 'decisions' }
+              ]}
+            />
+            <DomainStatusPanel
+              eyebrow="Evidence contract"
+              title="Scoped read-only identity view"
+              status={<AWSInventoryPill stage={awsMachineIdentityDetailStage(detail.status)} label={formatTokenLabel(detail.status)} />}
+              tone={awsMachineIdentityDetailTone(detail.status)}
+            >
+              <dl className="idt-domain-route-facts">
+                <div>
+                  <dt>Evidence boundary</dt>
+                  <dd>{detail.identity.evidence_boundary}</dd>
+                </div>
+                <div>
+                  <dt>Account</dt>
+                  <dd>{detail.account_id || detail.identity.account_id || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Region</dt>
+                  <dd>{detail.region || detail.identity.region || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{formatConfidenceScore(detail.confidence)}</dd>
+                </div>
+                <div>
+                  <dt>Policy</dt>
+                  <dd>{detail.policy_version}</dd>
+                </div>
+                <div>
+                  <dt>Issue</dt>
+                  <dd>{detail.current_issue_ref}</dd>
+                </div>
+              </dl>
+            </DomainStatusPanel>
+            <AWSMachineIdentityDetailDiagnostics detail={detail} />
+            <AWSMachineIdentityDetailTabs
+              scope={scope}
+              selectedEnvironmentID={selectedEnvironmentID}
+              identity={identity}
+              activeTab={activeTab}
+              detail={detail}
+            />
+            <AWSMachineIdentityDetailTabContent detail={detail} activeTab={activeTab} />
+          </>
+        ) : null}
+      </div>
+    </DomainPageShell>
+  );
 }
 
 export function ProductAWSAgentsPage() {


### PR DESCRIPTION
## Summary
- Add a scoped AWS machine identity detail API that composes workload bindings, runtime, permissions, secrets/resource reachability, remediation, governance, diagnostics, and coverage gaps.
- Add the app detail route from AWS identities with exact identity ARN links and tabbed graph/runtime/permissions/secrets/fixes/governance views.
- Document the contract, route authorization, OpenAPI path, and metadata-only evidence boundary.

## Validation
- go test ./internal/api -run 'TestGetAWSMachineIdentityDetail|TestRouterAWSMachineIdentityDetail'
- go test ./internal/api -run 'TestRoutePolicyRegistryCoversAllV1Routes|TestOpenAPIV1SpecCoversRegisteredV1Routes|TestOpenAPIV1SpecDocumentsRequestScopeHeaders|TestOpenAPIV1SpecCoversRegisteredV1RouteMethods|TestOpenAPIV1SpecPathParameterNamesMatchRegisteredRoutes|TestGetAWSMachineIdentityDetail|TestRouterAWSMachineIdentityDetail'
- go test ./internal/api
- npm test -- --run src/productShell.test.tsx
- npm run build
- git diff --check

Closes identrail/identrail#1549

AI disclosure: No