### PR TITLE
Add AWS agent identity detail page

### DIFF
--- a/docs/aws-agent-identity-detail.md
+++ b/docs/aws-agent-identity-detail.md
@@ -52,7 +52,7 @@ The UI exposes eight tabs:
 - `findings`: AI-agent risk findings
 - `recommendations`: least-privilege recommendations for the agent or backing role
 - `remediation`: read-only remediation case projections
-- `governance`: advisory, approval, remediation, enforcement, and exception records
+- `governance`: advisory, approval, remediation, enforcement, and exception records for the agent or backing role; role-wide decisions stay visible, while agent-scoped decisions that belong to other agents sharing the backing role are excluded
 
 The page also links to the broader AWS runtime, graph, remediation, and
 governance surfaces so operators can move from the scoped agent view back to the

--- a/docs/aws-agent-identity-detail.md
+++ b/docs/aws-agent-identity-detail.md
@@ -1,0 +1,84 @@
+# AWS agent identity detail page
+
+Issue #1550 adds the read-only detail surface for a single AWS AI agent
+identity. It composes agent inventory, observed runtime tool calls, AI-agent
+risk findings, least-privilege recommendations, remediation cases, governance
+decisions, and graph relationships into one scoped response that backs the app
+route `/app/{tenant_id}/{workspace_id}/aws/agents/detail`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-identity-detail`
+
+Required query parameters:
+
+- `agent`: agent ID, agent ARN, agent node id, or agent name to inspect.
+
+Supported optional filters:
+
+- `connector_id`
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
+- `account_id`
+- `region`
+- `tab`: `overview`, `tools`, `runtime`, `secrets`, `findings`, `recommendations`, `remediation`, or `governance`
+- `tool`
+- `resource`
+- `severity`
+- `status`
+
+The response is returned as `{ "detail": ... }` and includes:
+
+- tenant, workspace, project, connector, account, region, issue, version, status, confidence, and applied filters
+- normalized agent metadata with provider, model, runtime role, gateway, account, region, confidence, and evidence boundary
+- explicit candidate and low-confidence flags for inferred or unresolved agents
+- tab counts for overview, tools, runtime, secrets, findings, recommendations, remediation, and governance
+- declared and observed tools, memory/browser/code-interpreter capability metadata, and secret reference metadata
+- runtime calls, risk findings, least-privilege recommendations, remediation cases, governance decisions, and graph relationships
+- diagnostics, coverage gaps, failure reasons, remediation hints, and evidence links
+
+## App behavior
+
+The AWS agents inventory links agent rows to the detail route with the selected
+environment and exact agent identifier. The detail page keeps the environment
+selector active and reloads when the environment, agent, connector, or tab
+changes.
+
+The UI exposes eight tabs:
+
+- `overview`: memory/browser/code-interpreter capabilities and graph relationships
+- `tools`: declared tools, observed tools, and undeclared runtime observations
+- `runtime`: observed agent/tool runtime calls
+- `secrets`: provider-key and credential reference metadata
+- `findings`: AI-agent risk findings
+- `recommendations`: least-privilege recommendations for the agent or backing role
+- `remediation`: read-only remediation case projections
+- `governance`: advisory, approval, remediation, enforcement, and exception records
+
+The page also links to the broader AWS runtime, graph, remediation, and
+governance surfaces so operators can move from the scoped agent view back to the
+cross-agent evidence flows.
+
+## Safety boundaries
+
+The contract is read-only and metadata-only. It must not read, expose, log, or
+persist secret values, prompt text, completions, tool payloads, browser pages,
+code-interpreter output, database rows, customer object contents, or workload
+data.
+
+The response evidence boundary is
+`metadata_only_no_secret_values_no_prompt_text_no_tool_payloads_no_workload_data_tenant_workspace_project_connector_account_region_scoped`.
+Downstream collectors may contribute ARNs, names, ids, hashes, timestamps,
+action names, capability flags, safe reference identifiers, and safe evidence
+references, but not sensitive values or document bodies.
+
+## Failure states
+
+- `empty`: the selected scope has no matching evidence after collectors run.
+- `degraded`: evidence exists, but one or more collectors returned partial or low-confidence data.
+- `partial_failure`: at least one downstream capability failed while retained evidence remains visible.
+- `permission_denied`: the selected connector lacks required read-only metadata permissions.
+- `unknown`: the requested agent was not found in the AI-agent inventory and is shown as a candidate, low-confidence agent.
+
+These states remain visible in the detail page through status panels,
+diagnostics, coverage gaps, and remediation hints rather than being collapsed
+into a successful view.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -549,6 +549,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-identity-detail
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents
     action: tenancy.read
     resource_type: project
@@ -4753,6 +4758,82 @@ paths:
                 $ref: "#/components/schemas/AWSMachineIdentityDetailResponse"
         "400":
           description: Invalid AWS machine identity detail request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-identity-detail:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS agent identity detail
+      operationId: getAWSProjectAgentIdentityDetail
+      description: Returns one scoped, metadata-only AWS AI agent identity detail view by composing the agent inventory record (provider/runtime, backing role, tools, memory/browser/code-interpreter capabilities, secret references), observed runtime tool calls, AI agent risk findings, least-privilege recommendations, remediation cases, governance decisions, and graph relationships. Candidate and low-confidence agents are flagged explicitly. The endpoint is read-only and never resolves or returns secret values, prompt text, completions, tool payloads, browser pages, code-interpreter output, or workload data.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: agent
+          required: true
+          schema: { type: string }
+          description: Agent ID, agent ARN, agent node id, or agent name to inspect.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: tab
+          schema:
+            type: string
+            enum: [overview, tools, runtime, secrets, findings, recommendations, remediation, governance]
+          description: Optional detail tab selector used by the app route.
+        - in: query
+          name: tool
+          schema: { type: string }
+        - in: query
+          name: resource
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema: { type: string }
+        - in: query
+          name: status
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS agent identity detail contract
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AWSAgentIdentityDetailResponse"
+        "400":
+          description: Invalid AWS agent identity detail request
           content:
             application/json:
               schema:
@@ -13696,6 +13777,253 @@ components:
           $ref: "#/components/schemas/AWSBlastRadiusResult"
         identity_sprawl:
           $ref: "#/components/schemas/AWSIdentitySprawlResult"
+        remediation_cases:
+          $ref: "#/components/schemas/AWSRemediationCaseResult"
+        governance:
+          $ref: "#/components/schemas/AWSGovernanceAuditReportingResult"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSAgentIdentityDetailResponse:
+      type: object
+      required: [detail]
+      properties:
+        detail:
+          $ref: "#/components/schemas/AWSAgentIdentityDetailResult"
+    AWSAgentIdentityDetailAgent:
+      type: object
+      properties:
+        agent: { type: string }
+        agent_id: { type: string }
+        agent_arn: { type: string }
+        agent_node_id: { type: string }
+        agent_name: { type: string }
+        agent_type: { type: string }
+        display_name: { type: string }
+        provider: { type: string }
+        model_id: { type: string }
+        service: { type: string }
+        runtime_version: { type: string }
+        runtime_role_arn: { type: string }
+        runtime_role_name: { type: string }
+        runtime_role_node_id: { type: string }
+        gateway_id: { type: string }
+        gateway_node_id: { type: string }
+        external_provider: { type: string }
+        auth_mode: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        status: { type: string }
+        resolved: { type: boolean }
+        candidate: { type: boolean }
+        low_confidence: { type: boolean }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        coverage_status: { type: string }
+        coverage_reason: { type: string }
+        evidence_ref: { type: string }
+        evidence_boundary: { type: string }
+    AWSAgentIdentityToolSummary:
+      type: object
+      properties:
+        tool_name: { type: string }
+        tool_target_ref: { type: string }
+        declared: { type: boolean }
+        observed: { type: boolean }
+        status: { type: string }
+        observed_count: { type: integer }
+        evidence_ref: { type: string }
+        last_observed:
+          type: string
+          format: date-time
+    AWSAgentIdentityCapabilitySummary:
+      type: object
+      properties:
+        capability:
+          type: string
+          enum: [memory, browser, code_interpreter]
+        enabled: { type: boolean }
+        reference_refs:
+          type: array
+          items: { type: string }
+        encryption_key_arn: { type: string }
+    AWSAgentIdentitySecretReference:
+      type: object
+      properties:
+        reference: { type: string }
+        reference_name: { type: string }
+        reference_kind: { type: string }
+        provider: { type: string }
+        sensitivity: { type: string }
+        resolved: { type: boolean }
+        target_node_id: { type: string }
+        evidence_ref: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSAgentIdentityRuntimeCall:
+      type: object
+      properties:
+        correlation_id: { type: string }
+        tool_name: { type: string }
+        tool_target_ref: { type: string }
+        status: { type: string }
+        observed_count: { type: integer }
+        outcomes:
+          type: array
+          items: { type: string }
+        target_arns:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        next_action: { type: string }
+        last_observed:
+          type: string
+          format: date-time
+    AWSAgentIdentityFindingSummary:
+      type: object
+      properties:
+        finding_id: { type: string }
+        risk_type: { type: string }
+        severity: { type: string }
+        status: { type: string }
+        score: { type: integer }
+        rationale: { type: string }
+        next_action: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+    AWSAgentIdentityRecommendationSummary:
+      type: object
+      properties:
+        recommendation_id: { type: string }
+        decision: { type: string }
+        severity: { type: string }
+        status: { type: string }
+        service: { type: string }
+        display_name: { type: string }
+        rationale: { type: string }
+        next_action: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    AWSAgentIdentityDetailSummary:
+      type: object
+      properties:
+        tool_count: { type: integer }
+        declared_tool_count: { type: integer }
+        observed_tool_count: { type: integer }
+        undeclared_tool_count: { type: integer }
+        capability_count: { type: integer }
+        secret_reference_count: { type: integer }
+        runtime_call_count: { type: integer }
+        finding_count: { type: integer }
+        recommendation_count: { type: integer }
+        remediation_case_count: { type: integer }
+        governance_decision_count: { type: integer }
+        relationship_count: { type: integer }
+        evidence_link_count: { type: integer }
+        diagnostic_count: { type: integer }
+        coverage_gap_count: { type: integer }
+    AWSAgentIdentityDetailResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied, unknown]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        policy_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        agent:
+          $ref: "#/components/schemas/AWSAgentIdentityDetailAgent"
+        summary:
+          $ref: "#/components/schemas/AWSAgentIdentityDetailSummary"
+        tabs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailTab"
+        tools:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentityToolSummary"
+        capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentityCapabilitySummary"
+        secret_references:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentitySecretReference"
+        runtime_calls:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentityRuntimeCall"
+        findings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentityFindingSummary"
+        recommendations:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSAgentIdentityRecommendationSummary"
+        governance_decisions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityGovernanceDecision"
+        relationships:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailRelationship"
+        runtime_access:
+          $ref: "#/components/schemas/AWSAgentRuntimeAccessResult"
+        risk:
+          $ref: "#/components/schemas/AWSAIAgentRiskResult"
+        permissions:
+          $ref: "#/components/schemas/AWSLeastPrivilegeResult"
         remediation_cases:
           $ref: "#/components/schemas/AWSRemediationCaseResult"
         governance:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -753,6 +753,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities/:agent_id", Action: policyActionTenancyRead, ResourceType: "ai_agent_identity", ResourceIDParam: "agent_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/machine-identity-detail", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-identity-detail", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -379,6 +379,26 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail governance: %w", err)
 	}
+	governanceIdentityFilters := []string{governanceIdentityID}
+	governanceAgentFilters := []string{governanceAgentID}
+	for _, alternate := range awsAgentIdentityDetailGovernanceAlternateFilters(record, resolved, governanceIdentityID, governanceAgentID) {
+		alternateGovernance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			IdentityID:   alternate.IdentityID,
+			AgentID:      alternate.AgentID,
+			State:        request.Status,
+		})
+		if err != nil {
+			return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail alternate governance: %w", err)
+		}
+		governanceIdentityFilters = append(governanceIdentityFilters, alternate.IdentityID)
+		governanceAgentFilters = append(governanceAgentFilters, alternate.AgentID)
+		governance = awsAgentIdentityDetailMergeGovernanceResults(governance, alternateGovernance, governanceIdentityFilters, governanceAgentFilters)
+	}
+	governance = awsAgentIdentityDetailScopeGovernance(governance, record)
 
 	tools := awsAgentIdentityDetailTools(record, runtimeAccess.Records, request.Tool)
 	capabilities := awsAgentIdentityDetailCapabilities(record)
@@ -813,6 +833,114 @@ func awsAgentIdentityDetailGovernanceFilters(record AWSAIAgentIdentityRecord, ag
 		return roleIdentity, ""
 	}
 	return "", agentFilter
+}
+
+// awsAgentIdentityDetailGovernanceFilter is one exact-scoped governance audit
+// query. The governance filter matches identity_id and agent_id exactly, so a
+// single primary query misses rows keyed by an alternate exact key (an
+// agent-scoped advisory row for a role-backed agent, or a role row keyed by
+// the raw role ARN instead of the identity node ID).
+type awsAgentIdentityDetailGovernanceFilter struct {
+	IdentityID string
+	AgentID    string
+}
+
+func awsAgentIdentityDetailGovernanceAlternateFilters(record AWSAIAgentIdentityRecord, resolved bool, primaryIdentityID, primaryAgentID string) []awsAgentIdentityDetailGovernanceFilter {
+	if !resolved {
+		return nil
+	}
+	alternates := []awsAgentIdentityDetailGovernanceFilter{}
+	for _, identity := range emptyStrings(dedupeStrings([]string{record.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(record.RuntimeRoleARN), record.RuntimeRoleARN})) {
+		if strings.EqualFold(identity, strings.TrimSpace(primaryIdentityID)) {
+			continue
+		}
+		alternates = append(alternates, awsAgentIdentityDetailGovernanceFilter{IdentityID: identity})
+	}
+	for _, agentKey := range emptyStrings(dedupeStrings([]string{record.AgentNodeID, record.AgentID})) {
+		if strings.EqualFold(agentKey, strings.TrimSpace(primaryAgentID)) {
+			continue
+		}
+		alternates = append(alternates, awsAgentIdentityDetailGovernanceFilter{AgentID: agentKey})
+	}
+	return alternates
+}
+
+func awsAgentIdentityDetailMergeGovernanceResults(primary, secondary AWSGovernanceAuditReportingResult, identityFilters, agentFilters []string) AWSGovernanceAuditReportingResult {
+	primaryRecordsLen := len(primary.Records)
+	secondaryRecordsLen := len(secondary.Records)
+	merged := make([]AWSGovernanceAuditReportRecord, 0, primaryRecordsLen+secondaryRecordsLen)
+	seen := map[string]struct{}{}
+	for _, record := range append(append([]AWSGovernanceAuditReportRecord{}, primary.Records...), secondary.Records...) {
+		key := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(
+			record.ReportID,
+			strings.Join([]string{record.Category, record.SourceType, record.SourceID, record.State}, "|"),
+		)))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, record)
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		if merged[i].OccurredAt.Equal(merged[j].OccurredAt) {
+			return merged[i].ReportID < merged[j].ReportID
+		}
+		return merged[i].OccurredAt.After(merged[j].OccurredAt)
+	})
+	primary.Records = merged
+	primary.Summary = summarizeAWSGovernanceAuditReportRecords(merged, merged)
+	if primaryRecordsLen == 0 && secondaryRecordsLen > 0 {
+		primary.Status = secondary.Status
+		primary.Confidence = secondary.Confidence
+	}
+	primary.FailureReasons = dedupeStrings(append(append([]string{}, primary.FailureReasons...), secondary.FailureReasons...))
+	primary.RemediationHints = dedupeStrings(append(append([]string{}, primary.RemediationHints...), secondary.RemediationHints...))
+	primary.EvidenceLinks = dedupeStrings(append(append([]string{}, primary.EvidenceLinks...), secondary.EvidenceLinks...))
+	primary.CoverageGaps = append(append([]AWSGovernanceAuditReportingCoverageGap{}, primary.CoverageGaps...), secondary.CoverageGaps...)
+	primary.Diagnostics = append(append([]AWSGovernanceAuditReportingDiagnostic{}, primary.Diagnostics...), secondary.Diagnostics...)
+	primary.AppliedFilters = awsAgentIdentityDetailMergeGovernanceAppliedFilters(primary.AppliedFilters, identityFilters, agentFilters)
+	return primary
+}
+
+func awsAgentIdentityDetailMergeGovernanceAppliedFilters(applied map[string]string, identityFilters, agentFilters []string) map[string]string {
+	filters := map[string]string{}
+	for key, value := range applied {
+		filters[key] = value
+	}
+	identities := emptyStrings(dedupeStrings(identityFilters))
+	if len(identities) > 0 {
+		filters["identity_id"] = identities[0]
+	}
+	if len(identities) > 1 {
+		filters["identity_id_alternates"] = strings.Join(identities[1:], ",")
+	}
+	agents := emptyStrings(dedupeStrings(agentFilters))
+	if len(agents) > 0 {
+		filters["agent_id"] = agents[0]
+	}
+	if len(agents) > 1 {
+		filters["agent_id_alternates"] = strings.Join(agents[1:], ",")
+	}
+	return filters
+}
+
+// awsAgentIdentityDetailScopeGovernance drops agent-scoped governance rows
+// that belong to a different agent — for example a sibling agent sharing the
+// selected agent's runtime role, whose advisory rows carry the shared
+// identity_id and therefore pass the identity-scoped query filter — while
+// keeping truly role-wide rows that carry no agent key.
+func awsAgentIdentityDetailScopeGovernance(result AWSGovernanceAuditReportingResult, record AWSAIAgentIdentityRecord) AWSGovernanceAuditReportingResult {
+	scoped := make([]AWSGovernanceAuditReportRecord, 0, len(result.Records))
+	for _, candidate := range result.Records {
+		agentScoped := strings.TrimSpace(candidate.AgentID) != "" || strings.TrimSpace(candidate.AgentNodeID) != ""
+		if agentScoped && !awsAgentIdentityDetailMatchesResolvedAgent(record, candidate.AgentNodeID, candidate.AgentID) {
+			continue
+		}
+		scoped = append(scoped, candidate)
+	}
+	result.Records = scoped
+	result.Summary = summarizeAWSGovernanceAuditReportRecords(scoped, scoped)
+	return result
 }
 
 func awsAgentIdentityDetailAgent(agent string, record AWSAIAgentIdentityRecord, resolved bool, accountID, region string) AWSAgentIdentityDetailAgent {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -308,6 +308,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail permissions: %w", err)
 	}
+	permissions = awsAgentIdentityDetailScopePermissions(permissions, record, permissionsIdentity)
 	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -320,6 +321,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail remediation cases: %w", err)
 	}
+	cases = awsAgentIdentityDetailScopeRemediationCases(cases, record, permissionsIdentity)
 	governanceIdentityID, governanceAgentID := awsAgentIdentityDetailGovernanceFilters(record, agentFilter)
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
@@ -517,6 +519,70 @@ func awsAgentIdentityDetailMatchesResolvedAgent(record AWSAIAgentIdentityRecord,
 		}
 		for _, value := range values {
 			if strings.EqualFold(strings.TrimSpace(value), expected) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func awsAgentIdentityDetailScopePermissions(result AWSLeastPrivilegeResult, record AWSAIAgentIdentityRecord, fallback string) AWSLeastPrivilegeResult {
+	targets := awsAgentIdentityDetailPermissionIdentityCandidates(record, fallback)
+	scoped := make([]AWSLeastPrivilegeRecommendation, 0, len(result.Recommendations))
+	for _, recommendation := range result.Recommendations {
+		if awsAgentIdentityDetailAnyExactMatch(targets, awsLeastPrivilegeIdentityMatchValues(recommendation)...) {
+			scoped = append(scoped, recommendation)
+		}
+	}
+	result.Recommendations = scoped
+	result.Relationships = awsLeastPrivilegeRelationships(scoped)
+	result.Summary = summarizeAWSLeastPrivilege(scoped, scoped, result.Relationships)
+	return result
+}
+
+func awsAgentIdentityDetailScopeRemediationCases(result AWSRemediationCaseResult, record AWSAIAgentIdentityRecord, fallback string) AWSRemediationCaseResult {
+	targets := awsAgentIdentityDetailPermissionIdentityCandidates(record, fallback)
+	scoped := make([]AWSRemediationCase, 0, len(result.Cases))
+	for _, c := range result.Cases {
+		if awsAgentIdentityDetailAnyExactMatch(targets, awsAgentIdentityDetailRemediationCaseIdentityValues(c)...) {
+			scoped = append(scoped, c)
+		}
+	}
+	result.Cases = scoped
+	result.Relationships = awsRemediationCaseRelationships(scoped)
+	result.Summary = summarizeAWSRemediationCases(scoped, scoped, result.Relationships)
+	return result
+}
+
+func awsAgentIdentityDetailPermissionIdentityCandidates(record AWSAIAgentIdentityRecord, fallback string) []string {
+	roleTargets := emptyStrings(dedupeStrings([]string{
+		record.RuntimeRoleNodeID,
+		awsIdentityNodeIDForAPI(record.RuntimeRoleARN),
+		record.RuntimeRoleARN,
+		record.RuntimeRoleName,
+	}))
+	if len(roleTargets) > 0 {
+		return roleTargets
+	}
+	return emptyStrings(dedupeStrings([]string{record.AgentNodeID, record.AgentID, fallback}))
+}
+
+func awsAgentIdentityDetailRemediationCaseIdentityValues(c AWSRemediationCase) []string {
+	values := []string{c.IdentityNodeID, c.IdentityARN, c.IdentityName}
+	if strings.EqualFold(c.SourceType, "aws_permission_boundary_scp") {
+		values = append(values, c.ResourceNodeIDs...)
+	}
+	return dedupeStrings(values)
+}
+
+func awsAgentIdentityDetailAnyExactMatch(targets []string, values ...string) bool {
+	for _, target := range targets {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+		for _, value := range values {
+			if strings.EqualFold(strings.TrimSpace(value), target) {
 				return true
 			}
 		}

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -302,6 +302,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		AccountID:    request.AccountID,
 		Region:       request.Region,
 		Identity:     permissionsIdentity,
+		Resource:     request.Resource,
 		Severity:     request.Severity,
 		Status:       request.Status,
 	})
@@ -309,7 +310,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail permissions: %w", err)
 	}
 	permissions = awsAgentIdentityDetailScopePermissions(permissions, record, permissionsIdentity)
-	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+	remediationRequest := AWSRemediationCaseRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
 		AccountID:    request.AccountID,
@@ -317,9 +318,20 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		Identity:     permissionsIdentity,
 		Severity:     request.Severity,
 		Status:       request.Status,
-	})
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, remediationRequest)
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail remediation cases: %w", err)
+	}
+	agentRemediationIdentity := awsAgentIdentityDetailRemediationAgentIdentity(record, agentFilter)
+	if agentRemediationIdentity != "" && !strings.EqualFold(strings.TrimSpace(agentRemediationIdentity), strings.TrimSpace(permissionsIdentity)) {
+		agentRemediationRequest := remediationRequest
+		agentRemediationRequest.Identity = agentRemediationIdentity
+		agentCases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, agentRemediationRequest)
+		if err != nil {
+			return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail agent remediation cases: %w", err)
+		}
+		cases = awsAgentIdentityDetailMergeRemediationCaseResults(cases, agentCases, permissionsIdentity, agentRemediationIdentity)
 	}
 	cases = awsAgentIdentityDetailScopeRemediationCases(cases, record, permissionsIdentity)
 	governanceIdentityID, governanceAgentID := awsAgentIdentityDetailGovernanceFilters(record, agentFilter)
@@ -542,7 +554,7 @@ func awsAgentIdentityDetailScopePermissions(result AWSLeastPrivilegeResult, reco
 }
 
 func awsAgentIdentityDetailScopeRemediationCases(result AWSRemediationCaseResult, record AWSAIAgentIdentityRecord, fallback string) AWSRemediationCaseResult {
-	targets := awsAgentIdentityDetailPermissionIdentityCandidates(record, fallback)
+	targets := awsAgentIdentityDetailRemediationCaseIdentityCandidates(record, fallback)
 	scoped := make([]AWSRemediationCase, 0, len(result.Cases))
 	for _, c := range result.Cases {
 		if awsAgentIdentityDetailAnyExactMatch(targets, awsAgentIdentityDetailRemediationCaseIdentityValues(c)...) &&
@@ -554,6 +566,30 @@ func awsAgentIdentityDetailScopeRemediationCases(result AWSRemediationCaseResult
 	result.Relationships = awsRemediationCaseRelationships(scoped)
 	result.Summary = summarizeAWSRemediationCases(scoped, scoped, result.Relationships)
 	return result
+}
+
+func awsAgentIdentityDetailMergeRemediationCaseResults(primary, secondary AWSRemediationCaseResult, identities ...string) AWSRemediationCaseResult {
+	mergedCases := awsRemediationCaseDedupe(append(append([]AWSRemediationCase{}, primary.Cases...), secondary.Cases...))
+	primary.Cases = mergedCases
+	primary.Relationships = awsRemediationCaseRelationships(mergedCases)
+	primary.Summary = summarizeAWSRemediationCases(mergedCases, mergedCases, primary.Relationships)
+	primary.FailureReasons = dedupeStrings(append(append([]string{}, primary.FailureReasons...), secondary.FailureReasons...))
+	primary.RemediationHints = dedupeStrings(append(append([]string{}, primary.RemediationHints...), secondary.RemediationHints...))
+	primary.EvidenceLinks = dedupeStrings(append(append([]string{}, primary.EvidenceLinks...), secondary.EvidenceLinks...))
+	primary.CoverageGaps = append(append([]AWSRemediationCaseCoverageGap{}, primary.CoverageGaps...), secondary.CoverageGaps...)
+	filters := map[string]string{}
+	for key, value := range primary.AppliedFilters {
+		filters[key] = value
+	}
+	identityFilters := emptyStrings(dedupeStrings(identities))
+	if len(identityFilters) > 0 {
+		filters["identity"] = identityFilters[0]
+	}
+	if len(identityFilters) > 1 {
+		filters["agent_identity"] = identityFilters[1]
+	}
+	primary.AppliedFilters = filters
+	return primary
 }
 
 func awsAgentIdentityDetailRecommendationMatchesAgentScope(record AWSAIAgentIdentityRecord, recommendation AWSLeastPrivilegeRecommendation) bool {
@@ -612,6 +648,21 @@ func awsAgentIdentityDetailPermissionIdentityCandidates(record AWSAIAgentIdentit
 	return emptyStrings(dedupeStrings([]string{record.AgentNodeID, record.AgentID, fallback}))
 }
 
+func awsAgentIdentityDetailRemediationCaseIdentityCandidates(record AWSAIAgentIdentityRecord, fallback string) []string {
+	roleTargets := emptyStrings(dedupeStrings([]string{
+		record.RuntimeRoleNodeID,
+		awsIdentityNodeIDForAPI(record.RuntimeRoleARN),
+		record.RuntimeRoleARN,
+		record.RuntimeRoleName,
+	}))
+	agentTargets := emptyStrings(dedupeStrings([]string{
+		record.AgentNodeID,
+		record.AgentID,
+		fallback,
+	}))
+	return emptyStrings(dedupeStrings(append(roleTargets, agentTargets...)))
+}
+
 func awsAgentIdentityDetailRemediationCaseIdentityValues(c AWSRemediationCase) []string {
 	values := []string{c.IdentityNodeID, c.IdentityARN, c.IdentityName}
 	if strings.EqualFold(c.SourceType, "aws_permission_boundary_scp") {
@@ -644,6 +695,10 @@ func awsAgentIdentityDetailPermissionIdentity(record AWSAIAgentIdentityRecord, f
 		record.AgentNodeID,
 		fallback,
 	)
+}
+
+func awsAgentIdentityDetailRemediationAgentIdentity(record AWSAIAgentIdentityRecord, fallback string) string {
+	return firstNonEmptyAWSValue(record.AgentNodeID, record.AgentID, fallback)
 }
 
 func awsAgentIdentityDetailGovernanceFilters(record AWSAIAgentIdentityRecord, agentFilter string) (string, string) {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -265,14 +265,9 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	}
 	record, resolved := awsAgentIdentityDetailResolve(agent, inventory.Records)
 
-	// Downstream sources filter on the resolved agent's canonical IDs so a
-	// display-name lookup still scopes evidence correctly. Unresolved agents
-	// fall back to the requested token, which keeps unknown agents explicit
-	// (empty evidence) instead of leaking other agents' records.
-	agentFilter := agent
-	if resolved {
-		agentFilter = firstNonEmptyAWSValue(record.AgentID, record.AgentNodeID, agent)
-	}
+	// Downstream evidence filters are broad substring matches in some source
+	// APIs, so only resolved inventory records may contribute real agent IDs.
+	agentFilter := awsAgentIdentityDetailEvidenceAgentFilter(agent, record, resolved)
 	runtimeAccess, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -435,6 +430,13 @@ func awsAgentIdentityDetailResolve(agent string, records []AWSAIAgentIdentityRec
 		}
 	}
 	return AWSAIAgentIdentityRecord{}, false
+}
+
+func awsAgentIdentityDetailEvidenceAgentFilter(agent string, record AWSAIAgentIdentityRecord, resolved bool) string {
+	if !resolved {
+		return "aws-agent-identity-detail-unresolved:" + stableAWSBlastRadiusToken(agent)
+	}
+	return firstNonEmptyAWSValue(record.AgentNodeID, record.AgentID, agent)
 }
 
 func awsAgentIdentityDetailPermissionIdentity(record AWSAIAgentIdentityRecord, fallback string) string {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -281,6 +281,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail runtime access: %w", err)
 	}
+	runtimeAccess = awsAgentIdentityDetailScopeRuntimeAccess(runtimeAccess, record)
 	risk, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -293,6 +294,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail risk: %w", err)
 	}
+	risk = awsAgentIdentityDetailScopeRisk(risk, record)
 	permissionsIdentity := awsAgentIdentityDetailPermissionIdentity(record, agentFilter)
 	permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
 		ConnectorID:  connectorID,
@@ -318,12 +320,14 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail remediation cases: %w", err)
 	}
+	governanceIdentityID, governanceAgentID := awsAgentIdentityDetailGovernanceFilters(record, agentFilter)
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
 		AccountID:    request.AccountID,
 		Region:       request.Region,
-		IdentityID:   permissionsIdentity,
+		IdentityID:   governanceIdentityID,
+		AgentID:      governanceAgentID,
 		State:        request.Status,
 	})
 	if err != nil {
@@ -439,6 +443,87 @@ func awsAgentIdentityDetailEvidenceAgentFilter(agent string, record AWSAIAgentId
 	return firstNonEmptyAWSValue(record.AgentNodeID, record.AgentID, agent)
 }
 
+func awsAgentIdentityDetailScopeRuntimeAccess(result AWSAgentRuntimeAccessResult, record AWSAIAgentIdentityRecord) AWSAgentRuntimeAccessResult {
+	scoped := make([]AWSAgentRuntimeAccessRecord, 0, len(result.Records))
+	for _, candidate := range result.Records {
+		if awsAgentIdentityDetailMatchesResolvedAgent(record, candidate.AgentNodeID, candidate.AgentID) {
+			scoped = append(scoped, candidate)
+		}
+	}
+	result.Records = scoped
+	result.Relationships = awsAgentRuntimeAccessRelationships(scoped)
+	result.Summary = awsAgentIdentityDetailRuntimeAccessSummary(scoped, result.Relationships)
+	return result
+}
+
+func awsAgentIdentityDetailRuntimeAccessSummary(records []AWSAgentRuntimeAccessRecord, relationships []AWSAgentRuntimeAccessRelationship) AWSAgentRuntimeAccessSummary {
+	summary := AWSAgentRuntimeAccessSummary{
+		TotalCorrelations:    len(records),
+		FilteredCorrelations: len(records),
+		StatusCounts:         map[string]int{},
+		RelationshipCount:    len(relationships),
+	}
+	agentIDs := map[string]struct{}{}
+	toolNames := map[string]struct{}{}
+	for _, record := range records {
+		summary.StatusCounts[record.Status]++
+		switch record.Status {
+		case "confirmed":
+			summary.ConfirmedCount++
+		case "observed_without_declaration":
+			summary.ObservedWithoutDeclCount++
+		case "declared_unused":
+			summary.DeclaredUnusedCount++
+		}
+		if !record.DeclaredInInventory && record.ObservedCount > 0 {
+			summary.UndeclaredToolCount++
+		}
+		if record.DeclaredInInventory {
+			summary.DeclaredToolCount++
+		}
+		summary.ObservedToolCallCount += record.ObservedCount
+		if strings.TrimSpace(record.AgentNodeID) != "" {
+			agentIDs[strings.ToLower(strings.TrimSpace(record.AgentNodeID))] = struct{}{}
+		} else if strings.TrimSpace(record.AgentID) != "" {
+			agentIDs[strings.ToLower(strings.TrimSpace(record.AgentID))] = struct{}{}
+		}
+		if strings.TrimSpace(record.ToolName) != "" {
+			toolNames[strings.ToLower(strings.TrimSpace(record.ToolName))] = struct{}{}
+		}
+	}
+	summary.AgentCount = len(agentIDs)
+	summary.ToolCount = len(toolNames)
+	return summary
+}
+
+func awsAgentIdentityDetailScopeRisk(result AWSAIAgentRiskResult, record AWSAIAgentIdentityRecord) AWSAIAgentRiskResult {
+	scoped := make([]AWSAIAgentRiskFinding, 0, len(result.Findings))
+	for _, finding := range result.Findings {
+		if awsAgentIdentityDetailMatchesResolvedAgent(record, finding.AgentNodeID, finding.AgentID) {
+			scoped = append(scoped, finding)
+		}
+	}
+	result.Findings = scoped
+	result.Relationships = awsAIAgentRiskRelationships(scoped)
+	result.Summary = summarizeAWSAIAgentRisk(scoped, scoped, result.Relationships)
+	return result
+}
+
+func awsAgentIdentityDetailMatchesResolvedAgent(record AWSAIAgentIdentityRecord, values ...string) bool {
+	for _, expected := range []string{record.AgentNodeID, record.AgentID} {
+		expected = strings.TrimSpace(expected)
+		if expected == "" {
+			continue
+		}
+		for _, value := range values {
+			if strings.EqualFold(strings.TrimSpace(value), expected) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func awsAgentIdentityDetailPermissionIdentity(record AWSAIAgentIdentityRecord, fallback string) string {
 	return firstNonEmptyAWSValue(
 		record.RuntimeRoleNodeID,
@@ -448,6 +533,14 @@ func awsAgentIdentityDetailPermissionIdentity(record AWSAIAgentIdentityRecord, f
 		record.AgentNodeID,
 		fallback,
 	)
+}
+
+func awsAgentIdentityDetailGovernanceFilters(record AWSAIAgentIdentityRecord, agentFilter string) (string, string) {
+	roleIdentity := firstNonEmptyAWSValue(record.RuntimeRoleNodeID, awsIdentityNodeIDForAPI(record.RuntimeRoleARN))
+	if roleIdentity != "" {
+		return roleIdentity, ""
+	}
+	return "", agentFilter
 }
 
 func awsAgentIdentityDetailAgent(agent string, record AWSAIAgentIdentityRecord, resolved bool, accountID, region string) AWSAgentIdentityDetailAgent {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -530,7 +530,8 @@ func awsAgentIdentityDetailScopePermissions(result AWSLeastPrivilegeResult, reco
 	targets := awsAgentIdentityDetailPermissionIdentityCandidates(record, fallback)
 	scoped := make([]AWSLeastPrivilegeRecommendation, 0, len(result.Recommendations))
 	for _, recommendation := range result.Recommendations {
-		if awsAgentIdentityDetailAnyExactMatch(targets, awsLeastPrivilegeIdentityMatchValues(recommendation)...) {
+		if awsAgentIdentityDetailAnyExactMatch(targets, awsLeastPrivilegeIdentityMatchValues(recommendation)...) &&
+			awsAgentIdentityDetailRecommendationMatchesAgentScope(record, recommendation) {
 			scoped = append(scoped, recommendation)
 		}
 	}
@@ -544,7 +545,8 @@ func awsAgentIdentityDetailScopeRemediationCases(result AWSRemediationCaseResult
 	targets := awsAgentIdentityDetailPermissionIdentityCandidates(record, fallback)
 	scoped := make([]AWSRemediationCase, 0, len(result.Cases))
 	for _, c := range result.Cases {
-		if awsAgentIdentityDetailAnyExactMatch(targets, awsAgentIdentityDetailRemediationCaseIdentityValues(c)...) {
+		if awsAgentIdentityDetailAnyExactMatch(targets, awsAgentIdentityDetailRemediationCaseIdentityValues(c)...) &&
+			awsAgentIdentityDetailRemediationCaseMatchesAgentScope(record, c) {
 			scoped = append(scoped, c)
 		}
 	}
@@ -552,6 +554,49 @@ func awsAgentIdentityDetailScopeRemediationCases(result AWSRemediationCaseResult
 	result.Relationships = awsRemediationCaseRelationships(scoped)
 	result.Summary = summarizeAWSRemediationCases(scoped, scoped, result.Relationships)
 	return result
+}
+
+func awsAgentIdentityDetailRecommendationMatchesAgentScope(record AWSAIAgentIdentityRecord, recommendation AWSLeastPrivilegeRecommendation) bool {
+	values := []string{}
+	agentScoped := strings.EqualFold(normalizeAWSRuntimeEventFilterToken(recommendation.Service), "agent-runtime") ||
+		strings.Contains(normalizeAWSRuntimeEventFilterToken(recommendation.RecommendationType), "agent")
+	for _, evidence := range recommendation.Evidence {
+		if strings.EqualFold(normalizeAWSRuntimeEventFilterToken(evidence.Source), "agent-runtime-access") {
+			agentScoped = true
+		}
+	}
+	values = append(values, recommendation.ImpactedNodes...)
+	for _, step := range recommendation.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "ai_agent") {
+			agentScoped = true
+		}
+		values = append(values, step.NodeID, step.Label)
+	}
+	if !agentScoped {
+		return true
+	}
+	return awsAgentIdentityDetailMatchesResolvedAgent(record, values...)
+}
+
+func awsAgentIdentityDetailRemediationCaseMatchesAgentScope(record AWSAIAgentIdentityRecord, c AWSRemediationCase) bool {
+	values := append([]string{}, c.ImpactedNodes...)
+	agentScoped := false
+	for _, value := range values {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "aws:agent:") {
+			agentScoped = true
+			break
+		}
+	}
+	for _, step := range c.ImpactedPath {
+		if strings.EqualFold(strings.TrimSpace(step.NodeType), "ai_agent") {
+			agentScoped = true
+		}
+		values = append(values, step.NodeID, step.Label)
+	}
+	if !agentScoped {
+		return true
+	}
+	return awsAgentIdentityDetailMatchesResolvedAgent(record, values...)
 }
 
 func awsAgentIdentityDetailPermissionIdentityCandidates(record AWSAIAgentIdentityRecord, fallback string) []string {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -267,7 +267,8 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 
 	// Downstream evidence filters are broad substring matches in some source
 	// APIs, so only resolved inventory records may contribute real agent IDs.
-	agentFilter := awsAgentIdentityDetailEvidenceAgentFilter(agent, record, resolved)
+	agentFilters := awsAgentIdentityDetailEvidenceAgentFilters(agent, record, resolved)
+	agentFilter := firstString(agentFilters)
 	runtimeAccess, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -281,6 +282,22 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail runtime access: %w", err)
 	}
+	for _, alternateAgentFilter := range agentFilters[1:] {
+		alternateRuntimeAccess, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			AgentID:      alternateAgentFilter,
+			Tool:         request.Tool,
+			Resource:     request.Resource,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail alternate runtime access: %w", err)
+		}
+		runtimeAccess = awsAgentIdentityDetailMergeRuntimeAccessResults(runtimeAccess, alternateRuntimeAccess, agentFilters...)
+	}
 	runtimeAccess = awsAgentIdentityDetailScopeRuntimeAccess(runtimeAccess, record)
 	risk, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{
 		ConnectorID:  connectorID,
@@ -293,6 +310,21 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	})
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail risk: %w", err)
+	}
+	for _, alternateAgentFilter := range agentFilters[1:] {
+		alternateRisk, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{
+			ConnectorID:  connectorID,
+			FixtureState: sourceFixtureState,
+			AccountID:    request.AccountID,
+			Region:       request.Region,
+			AgentID:      alternateAgentFilter,
+			Severity:     request.Severity,
+			Status:       request.Status,
+		})
+		if err != nil {
+			return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail alternate risk: %w", err)
+		}
+		risk = awsAgentIdentityDetailMergeRiskResults(risk, alternateRisk, agentFilters...)
 	}
 	risk = awsAgentIdentityDetailScopeRisk(risk, record)
 	permissionsIdentity := awsAgentIdentityDetailPermissionIdentity(record, agentFilter)
@@ -348,7 +380,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail governance: %w", err)
 	}
 
-	tools := awsAgentIdentityDetailTools(record, runtimeAccess.Records)
+	tools := awsAgentIdentityDetailTools(record, runtimeAccess.Records, request.Tool)
 	capabilities := awsAgentIdentityDetailCapabilities(record)
 	secretReferences := awsAgentIdentityDetailSecretReferences(record)
 	runtimeCalls := awsAgentIdentityDetailRuntimeCalls(runtimeAccess.Records)
@@ -450,11 +482,85 @@ func awsAgentIdentityDetailResolve(agent string, records []AWSAIAgentIdentityRec
 	return AWSAIAgentIdentityRecord{}, false
 }
 
-func awsAgentIdentityDetailEvidenceAgentFilter(agent string, record AWSAIAgentIdentityRecord, resolved bool) string {
+func awsAgentIdentityDetailEvidenceAgentFilters(agent string, record AWSAIAgentIdentityRecord, resolved bool) []string {
 	if !resolved {
-		return "aws-agent-identity-detail-unresolved:" + stableAWSBlastRadiusToken(agent)
+		return []string{"aws-agent-identity-detail-unresolved:" + stableAWSBlastRadiusToken(agent)}
 	}
-	return firstNonEmptyAWSValue(record.AgentNodeID, record.AgentID, agent)
+	return emptyStrings(dedupeStrings([]string{record.AgentNodeID, record.AgentID, agent}))
+}
+
+func awsAgentIdentityDetailMergeRuntimeAccessResults(primary, secondary AWSAgentRuntimeAccessResult, agentFilters ...string) AWSAgentRuntimeAccessResult {
+	primaryRecordsLen := len(primary.Records)
+	secondaryRecordsLen := len(secondary.Records)
+	primary.Records = awsAgentIdentityDetailDedupeRuntimeAccessRecords(append(append([]AWSAgentRuntimeAccessRecord{}, primary.Records...), secondary.Records...))
+	primary.Relationships = awsAgentRuntimeAccessRelationships(primary.Records)
+	primary.Summary = awsAgentIdentityDetailRuntimeAccessSummary(primary.Records, primary.Relationships)
+	if primaryRecordsLen == 0 && secondaryRecordsLen > 0 {
+		primary.Status = secondary.Status
+		primary.Confidence = secondary.Confidence
+	}
+	primary.FailureReasons = dedupeStrings(append(append([]string{}, primary.FailureReasons...), secondary.FailureReasons...))
+	primary.RemediationHints = dedupeStrings(append(append([]string{}, primary.RemediationHints...), secondary.RemediationHints...))
+	primary.EvidenceLinks = dedupeStrings(append(append([]string{}, primary.EvidenceLinks...), secondary.EvidenceLinks...))
+	primary.CoverageGaps = append(append([]AWSAgentRuntimeAccessCoverageGap{}, primary.CoverageGaps...), secondary.CoverageGaps...)
+	primary.Diagnostics = append(append([]AWSAgentRuntimeAccessDiagnostic{}, primary.Diagnostics...), secondary.Diagnostics...)
+	primary.AppliedFilters = awsAgentIdentityDetailMergeAgentAppliedFilters(primary.AppliedFilters, agentFilters...)
+	return primary
+}
+
+func awsAgentIdentityDetailDedupeRuntimeAccessRecords(records []AWSAgentRuntimeAccessRecord) []AWSAgentRuntimeAccessRecord {
+	out := make([]AWSAgentRuntimeAccessRecord, 0, len(records))
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		key := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(
+			record.CorrelationID,
+			record.EvidenceRef,
+			strings.Join([]string{record.AgentNodeID, record.AgentID, record.ToolName, record.ToolTargetRef}, "|"),
+		)))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, record)
+	}
+	return out
+}
+
+func awsAgentIdentityDetailMergeRiskResults(primary, secondary AWSAIAgentRiskResult, agentFilters ...string) AWSAIAgentRiskResult {
+	primaryFindingsLen := len(primary.Findings)
+	secondaryFindingsLen := len(secondary.Findings)
+	primary.Findings = awsAIAgentRiskDedupeFindings(append(append([]AWSAIAgentRiskFinding{}, primary.Findings...), secondary.Findings...))
+	primary.Relationships = awsAIAgentRiskRelationships(primary.Findings)
+	primary.Summary = summarizeAWSAIAgentRisk(primary.Findings, primary.Findings, primary.Relationships)
+	if primaryFindingsLen == 0 && secondaryFindingsLen > 0 {
+		primary.Status = secondary.Status
+		primary.Confidence = secondary.Confidence
+	}
+	primary.FailureReasons = dedupeStrings(append(append([]string{}, primary.FailureReasons...), secondary.FailureReasons...))
+	primary.RemediationHints = dedupeStrings(append(append([]string{}, primary.RemediationHints...), secondary.RemediationHints...))
+	primary.EvidenceLinks = dedupeStrings(append(append([]string{}, primary.EvidenceLinks...), secondary.EvidenceLinks...))
+	primary.CoverageGaps = append(append([]AWSAIAgentRiskCoverageGap{}, primary.CoverageGaps...), secondary.CoverageGaps...)
+	primary.Diagnostics = append(append([]AWSAIAgentRiskDiagnostic{}, primary.Diagnostics...), secondary.Diagnostics...)
+	primary.AppliedFilters = awsAgentIdentityDetailMergeAgentAppliedFilters(primary.AppliedFilters, agentFilters...)
+	return primary
+}
+
+func awsAgentIdentityDetailMergeAgentAppliedFilters(applied map[string]string, agentFilters ...string) map[string]string {
+	filters := map[string]string{}
+	for key, value := range applied {
+		filters[key] = value
+	}
+	keys := emptyStrings(dedupeStrings(agentFilters))
+	if len(keys) > 0 {
+		filters["agent_id"] = keys[0]
+	}
+	if len(keys) > 1 {
+		filters["agent_id_alternates"] = strings.Join(keys[1:], ",")
+	}
+	return filters
 }
 
 func awsAgentIdentityDetailScopeRuntimeAccess(result AWSAgentRuntimeAccessResult, record AWSAIAgentIdentityRecord) AWSAgentRuntimeAccessResult {
@@ -761,10 +867,14 @@ func awsAgentIdentityDetailAgent(agent string, record AWSAIAgentIdentityRecord, 
 // awsAgentIdentityDetailTools merges declared inventory tools with observed
 // runtime correlations so declared-unused and observed-undeclared tools are
 // explicit rows.
-func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSAgentRuntimeAccessRecord) []AWSAgentIdentityToolSummary {
+func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSAgentRuntimeAccessRecord, toolFilters ...string) []AWSAgentIdentityToolSummary {
 	byName := map[string]*AWSAgentIdentityToolSummary{}
 	order := []string{}
 	targetRefs := map[string]string{}
+	toolFilter := ""
+	if len(toolFilters) > 0 {
+		toolFilter = strings.TrimSpace(toolFilters[0])
+	}
 	for i, name := range record.ToolNames {
 		trimmed := strings.TrimSpace(name)
 		if trimmed == "" {
@@ -772,6 +882,9 @@ func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSA
 		}
 		if i < len(record.ToolTargetRefs) {
 			targetRefs[strings.ToLower(trimmed)] = record.ToolTargetRefs[i]
+		}
+		if toolFilter != "" && !awsRuntimeEventMatchesAny(toolFilter, trimmed, targetRefs[strings.ToLower(trimmed)]) {
+			continue
 		}
 		key := strings.ToLower(trimmed)
 		if _, ok := byName[key]; ok {
@@ -789,6 +902,9 @@ func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSA
 	for _, correlation := range runtime {
 		name := strings.TrimSpace(correlation.ToolName)
 		if name == "" {
+			continue
+		}
+		if toolFilter != "" && !awsRuntimeEventMatchesAny(toolFilter, name, correlation.ToolTargetRef) {
 			continue
 		}
 		key := strings.ToLower(name)

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -298,7 +298,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 	if err != nil {
 		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail risk: %w", err)
 	}
-	permissionsIdentity := firstNonEmptyAWSValue(record.AgentNodeID, record.RuntimeRoleARN, agentFilter)
+	permissionsIdentity := awsAgentIdentityDetailPermissionIdentity(record, agentFilter)
 	permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -437,6 +437,17 @@ func awsAgentIdentityDetailResolve(agent string, records []AWSAIAgentIdentityRec
 	return AWSAIAgentIdentityRecord{}, false
 }
 
+func awsAgentIdentityDetailPermissionIdentity(record AWSAIAgentIdentityRecord, fallback string) string {
+	return firstNonEmptyAWSValue(
+		record.RuntimeRoleNodeID,
+		awsIdentityNodeIDForAPI(record.RuntimeRoleARN),
+		record.RuntimeRoleARN,
+		record.RuntimeRoleName,
+		record.AgentNodeID,
+		fallback,
+	)
+}
+
 func awsAgentIdentityDetailAgent(agent string, record AWSAIAgentIdentityRecord, resolved bool, accountID, region string) AWSAgentIdentityDetailAgent {
 	if !resolved {
 		return AWSAgentIdentityDetailAgent{
@@ -530,8 +541,10 @@ func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSA
 			byName[key] = tool
 			order = append(order, key)
 		}
-		tool.Observed = true
-		tool.ObservedCount += correlation.ObservedCount
+		if awsAgentIdentityDetailRuntimeToolObserved(correlation) {
+			tool.Observed = true
+			tool.ObservedCount += correlation.ObservedCount
+		}
 		if tool.Declared {
 			tool.Status = firstNonEmptyAWSValue(correlation.Status, "confirmed")
 		} else {
@@ -552,6 +565,13 @@ func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSA
 		out = append(out, *byName[key])
 	}
 	return out
+}
+
+func awsAgentIdentityDetailRuntimeToolObserved(correlation AWSAgentRuntimeAccessRecord) bool {
+	if strings.EqualFold(strings.TrimSpace(correlation.Status), "declared_unused") {
+		return false
+	}
+	return correlation.ObservedCount > 0
 }
 
 func awsAgentIdentityDetailCountTools(tools []AWSAgentIdentityToolSummary, match func(AWSAgentIdentityToolSummary) bool) int {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -323,7 +323,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		FixtureState: sourceFixtureState,
 		AccountID:    request.AccountID,
 		Region:       request.Region,
-		AgentID:      agentFilter,
+		IdentityID:   permissionsIdentity,
 		State:        request.Status,
 	})
 	if err != nil {

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -1,0 +1,895 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+)
+
+const (
+	awsAgentIdentityDetailCurrentIssue = 1550
+	awsAgentIdentityDetailVersion      = "aws-agent-identity-detail-page-v1"
+	awsAgentIdentityDetailPolicyID     = "aws-agent-identity-detail-policy-v1"
+
+	// awsAgentIdentityDetailLowConfidenceFloor marks agents whose inventory
+	// confidence sits below the floor as low-confidence so the page can
+	// surface candidate/uncertain agents explicitly instead of presenting
+	// them like confirmed identities.
+	awsAgentIdentityDetailLowConfidenceFloor = 0.7
+)
+
+// AWSAgentIdentityDetailRequest scopes the read-only agent identity detail
+// page to one agent plus the operator filters shared by downstream surfaces.
+type AWSAgentIdentityDetailRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	Agent        string `json:"agent,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Tab          string `json:"tab,omitempty"`
+	Tool         string `json:"tool,omitempty"`
+	Resource     string `json:"resource,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// Reuse the machine-identity detail shapes for the sections both pages share
+// so the two Wave 10 detail contracts stay consistent.
+type AWSAgentIdentityDetailDiagnostic = AWSMachineIdentityDetailDiagnostic
+type AWSAgentIdentityDetailCoverageGap = AWSMachineIdentityDetailCoverageGap
+type AWSAgentIdentityDetailTab = AWSMachineIdentityDetailTab
+type AWSAgentIdentityDetailRelationship = AWSMachineIdentityDetailRelationship
+type AWSAgentIdentityGovernanceDecision = AWSMachineIdentityGovernanceDecision
+
+// AWSAgentIdentityDetailAgent is the page-level agent header. Candidate and
+// low-confidence agents are flagged explicitly so operators never mistake an
+// inferred agent for a confirmed one.
+type AWSAgentIdentityDetailAgent struct {
+	Agent             string  `json:"agent"`
+	AgentID           string  `json:"agent_id,omitempty"`
+	AgentARN          string  `json:"agent_arn,omitempty"`
+	AgentNodeID       string  `json:"agent_node_id,omitempty"`
+	AgentName         string  `json:"agent_name,omitempty"`
+	AgentType         string  `json:"agent_type,omitempty"`
+	DisplayName       string  `json:"display_name"`
+	Provider          string  `json:"provider,omitempty"`
+	ModelID           string  `json:"model_id,omitempty"`
+	Service           string  `json:"service,omitempty"`
+	RuntimeVersion    string  `json:"runtime_version,omitempty"`
+	RuntimeRoleARN    string  `json:"runtime_role_arn,omitempty"`
+	RuntimeRoleName   string  `json:"runtime_role_name,omitempty"`
+	RuntimeRoleNodeID string  `json:"runtime_role_node_id,omitempty"`
+	GatewayID         string  `json:"gateway_id,omitempty"`
+	GatewayNodeID     string  `json:"gateway_node_id,omitempty"`
+	ExternalProvider  string  `json:"external_provider,omitempty"`
+	AuthMode          string  `json:"auth_mode,omitempty"`
+	AccountID         string  `json:"account_id,omitempty"`
+	Region            string  `json:"region,omitempty"`
+	Status            string  `json:"status"`
+	Resolved          bool    `json:"resolved"`
+	Candidate         bool    `json:"candidate"`
+	LowConfidence     bool    `json:"low_confidence"`
+	Confidence        float64 `json:"confidence"`
+	CoverageStatus    string  `json:"coverage_status,omitempty"`
+	CoverageReason    string  `json:"coverage_reason,omitempty"`
+	EvidenceRef       string  `json:"evidence_ref,omitempty"`
+	EvidenceBoundary  string  `json:"evidence_boundary"`
+}
+
+// AWSAgentIdentityToolSummary joins one declared or observed tool with its
+// runtime evidence so the page can show declared-unused and
+// observed-undeclared tools explicitly.
+type AWSAgentIdentityToolSummary struct {
+	ToolName      string    `json:"tool_name"`
+	ToolTargetRef string    `json:"tool_target_ref,omitempty"`
+	Declared      bool      `json:"declared"`
+	Observed      bool      `json:"observed"`
+	Status        string    `json:"status"`
+	ObservedCount int       `json:"observed_count"`
+	EvidenceRef   string    `json:"evidence_ref,omitempty"`
+	LastObserved  time.Time `json:"last_observed,omitzero"`
+}
+
+// AWSAgentIdentityCapabilitySummary is one AgentCore capability
+// (memory/browser/code-interpreter) with its metadata references only.
+type AWSAgentIdentityCapabilitySummary struct {
+	Capability       string   `json:"capability"`
+	Enabled          bool     `json:"enabled"`
+	ReferenceRefs    []string `json:"reference_refs,omitempty"`
+	EncryptionKeyARN string   `json:"encryption_key_arn,omitempty"`
+}
+
+// AWSAgentIdentitySecretReference is one credential/provider-key reference
+// the agent carries. Values are never resolved or inlined; the record is the
+// reference metadata plus sensitivity classification.
+type AWSAgentIdentitySecretReference struct {
+	Reference     string  `json:"reference"`
+	ReferenceName string  `json:"reference_name,omitempty"`
+	ReferenceKind string  `json:"reference_kind"`
+	Provider      string  `json:"provider,omitempty"`
+	Sensitivity   string  `json:"sensitivity,omitempty"`
+	Resolved      bool    `json:"resolved"`
+	TargetNodeID  string  `json:"target_node_id,omitempty"`
+	EvidenceRef   string  `json:"evidence_ref,omitempty"`
+	Confidence    float64 `json:"confidence"`
+}
+
+// AWSAgentIdentityRuntimeCall is one observed (agent, tool) runtime
+// correlation summary.
+type AWSAgentIdentityRuntimeCall struct {
+	CorrelationID string    `json:"correlation_id"`
+	ToolName      string    `json:"tool_name,omitempty"`
+	ToolTargetRef string    `json:"tool_target_ref,omitempty"`
+	Status        string    `json:"status"`
+	ObservedCount int       `json:"observed_count"`
+	Outcomes      []string  `json:"outcomes,omitempty"`
+	TargetARNs    []string  `json:"target_arns,omitempty"`
+	EvidenceRef   string    `json:"evidence_ref,omitempty"`
+	NextAction    string    `json:"next_action,omitempty"`
+	LastObserved  time.Time `json:"last_observed,omitzero"`
+}
+
+// AWSAgentIdentityFindingSummary is one AI-agent risk finding scoped to the
+// agent.
+type AWSAgentIdentityFindingSummary struct {
+	FindingID    string   `json:"finding_id"`
+	RiskType     string   `json:"risk_type"`
+	Severity     string   `json:"severity"`
+	Status       string   `json:"status"`
+	Score        int      `json:"score"`
+	Rationale    string   `json:"rationale"`
+	NextAction   string   `json:"next_action"`
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+}
+
+// AWSAgentIdentityRecommendationSummary is one least-privilege
+// recommendation scoped to the agent or its backing role.
+type AWSAgentIdentityRecommendationSummary struct {
+	RecommendationID string  `json:"recommendation_id"`
+	Decision         string  `json:"decision"`
+	Severity         string  `json:"severity"`
+	Status           string  `json:"status"`
+	Service          string  `json:"service"`
+	DisplayName      string  `json:"display_name"`
+	Rationale        string  `json:"rationale"`
+	NextAction       string  `json:"next_action"`
+	Score            int     `json:"score"`
+	Confidence       float64 `json:"confidence"`
+}
+
+type AWSAgentIdentityDetailSummary struct {
+	ToolCount               int `json:"tool_count"`
+	DeclaredToolCount       int `json:"declared_tool_count"`
+	ObservedToolCount       int `json:"observed_tool_count"`
+	UndeclaredToolCount     int `json:"undeclared_tool_count"`
+	CapabilityCount         int `json:"capability_count"`
+	SecretReferenceCount    int `json:"secret_reference_count"`
+	RuntimeCallCount        int `json:"runtime_call_count"`
+	FindingCount            int `json:"finding_count"`
+	RecommendationCount     int `json:"recommendation_count"`
+	RemediationCaseCount    int `json:"remediation_case_count"`
+	GovernanceDecisionCount int `json:"governance_decision_count"`
+	RelationshipCount       int `json:"relationship_count"`
+	EvidenceLinkCount       int `json:"evidence_link_count"`
+	DiagnosticCount         int `json:"diagnostic_count"`
+	CoverageGapCount        int `json:"coverage_gap_count"`
+}
+
+type AWSAgentIdentityDetailResult struct {
+	TenantID            string                                  `json:"tenant_id"`
+	WorkspaceID         string                                  `json:"workspace_id"`
+	ProjectID           string                                  `json:"project_id"`
+	ConnectorID         string                                  `json:"connector_id,omitempty"`
+	AccountID           string                                  `json:"account_id,omitempty"`
+	Region              string                                  `json:"region,omitempty"`
+	ParentIssueNumber   int                                     `json:"parent_issue_number"`
+	ParentIssueRef      string                                  `json:"parent_issue_ref"`
+	CurrentIssueNumber  int                                     `json:"current_issue_number"`
+	CurrentIssueRef     string                                  `json:"current_issue_ref"`
+	Version             string                                  `json:"version"`
+	Status              string                                  `json:"status"`
+	FixtureState        string                                  `json:"fixture_state,omitempty"`
+	Confidence          float64                                 `json:"confidence"`
+	PolicyVersion       string                                  `json:"policy_version"`
+	AppliedFilters      map[string]string                       `json:"applied_filters"`
+	Agent               AWSAgentIdentityDetailAgent             `json:"agent"`
+	Summary             AWSAgentIdentityDetailSummary           `json:"summary"`
+	Tabs                []AWSAgentIdentityDetailTab             `json:"tabs"`
+	Tools               []AWSAgentIdentityToolSummary           `json:"tools"`
+	Capabilities        []AWSAgentIdentityCapabilitySummary     `json:"capabilities"`
+	SecretReferences    []AWSAgentIdentitySecretReference       `json:"secret_references"`
+	RuntimeCalls        []AWSAgentIdentityRuntimeCall           `json:"runtime_calls"`
+	Findings            []AWSAgentIdentityFindingSummary        `json:"findings"`
+	Recommendations     []AWSAgentIdentityRecommendationSummary `json:"recommendations"`
+	GovernanceDecisions []AWSAgentIdentityGovernanceDecision    `json:"governance_decisions"`
+	Relationships       []AWSAgentIdentityDetailRelationship    `json:"relationships"`
+	RuntimeAccess       AWSAgentRuntimeAccessResult             `json:"runtime_access"`
+	Risk                AWSAIAgentRiskResult                    `json:"risk"`
+	Permissions         AWSLeastPrivilegeResult                 `json:"permissions"`
+	RemediationCases    AWSRemediationCaseResult                `json:"remediation_cases"`
+	Governance          AWSGovernanceAuditReportingResult       `json:"governance"`
+	FailureReasons      []string                                `json:"failure_reasons"`
+	RemediationHints    []string                                `json:"remediation_hints"`
+	EvidenceLinks       []string                                `json:"evidence_links"`
+	CoverageGaps        []AWSAgentIdentityDetailCoverageGap     `json:"coverage_gaps"`
+	Diagnostics         []AWSAgentIdentityDetailDiagnostic      `json:"diagnostics"`
+	GeneratedAt         time.Time                               `json:"generated_at"`
+	UpdatedAt           time.Time                               `json:"updated_at"`
+}
+
+// GetAWSAgentIdentityDetail aggregates the read-only agent identity detail
+// page: the AI-agent inventory record (provider/runtime, backing role,
+// tools, memory/browser/code-interpreter capabilities, secret references),
+// observed runtime tool calls, AI-agent risk findings, least-privilege
+// recommendations, remediation cases, and governance decisions for one
+// agent. The endpoint is metadata-only; secret values, prompt text, tool
+// payloads, and workload data are never resolved or inlined.
+func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID string, projectID string, request AWSAgentIdentityDetailRequest) (AWSAgentIdentityDetailResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, err
+	}
+	agent := strings.TrimSpace(request.Agent)
+	if agent == "" {
+		return AWSAgentIdentityDetailResult{}, ErrInvalidAWSConnectionRequest
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSAgentIdentityDetailFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSAgentIdentityDetailResult{}, ErrInvalidAWSConnectionRequest
+	}
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	inventory, err := s.GetAWSAIAgentIdentityInventory(ctx, workspaceID, projectID, AWSAIAgentIdentityInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail inventory: %w", err)
+	}
+	record, resolved := awsAgentIdentityDetailResolve(agent, inventory.Records)
+
+	// Downstream sources filter on the resolved agent's canonical IDs so a
+	// display-name lookup still scopes evidence correctly. Unresolved agents
+	// fall back to the requested token, which keeps unknown agents explicit
+	// (empty evidence) instead of leaking other agents' records.
+	agentFilter := agent
+	if resolved {
+		agentFilter = firstNonEmptyAWSValue(record.AgentID, record.AgentNodeID, agent)
+	}
+	runtimeAccess, err := s.GetAWSAgentRuntimeAccess(ctx, workspaceID, projectID, AWSAgentRuntimeAccessRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		AgentID:      agentFilter,
+		Tool:         request.Tool,
+		Resource:     request.Resource,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail runtime access: %w", err)
+	}
+	risk, err := s.GetAWSAIAgentRisk(ctx, workspaceID, projectID, AWSAIAgentRiskRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		AgentID:      agentFilter,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail risk: %w", err)
+	}
+	permissionsIdentity := firstNonEmptyAWSValue(record.AgentNodeID, record.RuntimeRoleARN, agentFilter)
+	permissions, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     permissionsIdentity,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail permissions: %w", err)
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Identity:     permissionsIdentity,
+		Severity:     request.Severity,
+		Status:       request.Status,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail remediation cases: %w", err)
+	}
+	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		AgentID:      agentFilter,
+		State:        request.Status,
+	})
+	if err != nil {
+		return AWSAgentIdentityDetailResult{}, fmt.Errorf("agent identity detail governance: %w", err)
+	}
+
+	tools := awsAgentIdentityDetailTools(record, runtimeAccess.Records)
+	capabilities := awsAgentIdentityDetailCapabilities(record)
+	secretReferences := awsAgentIdentityDetailSecretReferences(record)
+	runtimeCalls := awsAgentIdentityDetailRuntimeCalls(runtimeAccess.Records)
+	findings := awsAgentIdentityDetailFindings(risk.Findings)
+	recommendations := awsAgentIdentityDetailRecommendations(permissions.Recommendations)
+	governanceDecisions := awsMachineIdentityGovernanceDecisions(governance.Records)
+	relationships := awsAgentIdentityDetailRelationships(record, inventory, runtimeAccess)
+	diagnostics := awsAgentIdentityDetailDiagnostics(inventory, runtimeAccess, risk, permissions, cases, governance)
+	coverageGaps := awsAgentIdentityDetailCoverageGaps(resolved, agent, inventory, runtimeAccess, risk, permissions, cases, governance)
+	evidenceLinks := awsAgentIdentityDetailEvidenceLinks(scope, project, record, inventory, runtimeAccess, risk, governance)
+	status, confidence, failures, hints := summarizeAWSAgentIdentityDetail(fixtureState, resolved, record, diagnostics)
+	agentSummary := awsAgentIdentityDetailAgent(agent, record, resolved, accountID, region)
+	summary := AWSAgentIdentityDetailSummary{
+		ToolCount:               len(tools),
+		DeclaredToolCount:       awsAgentIdentityDetailCountTools(tools, func(tool AWSAgentIdentityToolSummary) bool { return tool.Declared }),
+		ObservedToolCount:       awsAgentIdentityDetailCountTools(tools, func(tool AWSAgentIdentityToolSummary) bool { return tool.Observed }),
+		UndeclaredToolCount:     awsAgentIdentityDetailCountTools(tools, func(tool AWSAgentIdentityToolSummary) bool { return tool.Observed && !tool.Declared }),
+		CapabilityCount:         awsAgentIdentityDetailEnabledCapabilityCount(capabilities),
+		SecretReferenceCount:    len(secretReferences),
+		RuntimeCallCount:        len(runtimeCalls),
+		FindingCount:            len(findings),
+		RecommendationCount:     len(recommendations),
+		RemediationCaseCount:    len(cases.Cases),
+		GovernanceDecisionCount: len(governanceDecisions),
+		RelationshipCount:       len(relationships),
+		EvidenceLinkCount:       len(evidenceLinks),
+		DiagnosticCount:         len(diagnostics),
+		CoverageGapCount:        len(coverageGaps),
+	}
+
+	return AWSAgentIdentityDetailResult{
+		TenantID:            scope.TenantID,
+		WorkspaceID:         project.WorkspaceID,
+		ProjectID:           project.ProjectID,
+		ConnectorID:         connectorID,
+		AccountID:           accountID,
+		Region:              region,
+		ParentIssueNumber:   awsPlatformDependencyParentIssue,
+		ParentIssueRef:      awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber:  awsAgentIdentityDetailCurrentIssue,
+		CurrentIssueRef:     awsIssueRef(awsAgentIdentityDetailCurrentIssue),
+		Version:             awsAgentIdentityDetailVersion,
+		Status:              status,
+		FixtureState:        fixtureState,
+		Confidence:          confidence,
+		PolicyVersion:       awsAgentIdentityDetailPolicyID,
+		AppliedFilters:      awsAgentIdentityDetailAppliedFilters(request, agentSummary.AgentNodeID),
+		Agent:               agentSummary,
+		Summary:             summary,
+		Tabs:                awsAgentIdentityDetailTabs(summary, status),
+		Tools:               tools,
+		Capabilities:        capabilities,
+		SecretReferences:    secretReferences,
+		RuntimeCalls:        runtimeCalls,
+		Findings:            findings,
+		Recommendations:     recommendations,
+		GovernanceDecisions: governanceDecisions,
+		Relationships:       relationships,
+		RuntimeAccess:       runtimeAccess,
+		Risk:                risk,
+		Permissions:         permissions,
+		RemediationCases:    cases,
+		Governance:          governance,
+		FailureReasons:      dedupeStrings(append(failures, awsAgentIdentityDetailFailureReasons(inventory, runtimeAccess, risk, permissions, cases, governance)...)),
+		RemediationHints:    dedupeStrings(append(hints, awsAgentIdentityDetailRemediationHints(inventory, runtimeAccess, risk, permissions, cases, governance)...)),
+		EvidenceLinks:       evidenceLinks,
+		CoverageGaps:        coverageGaps,
+		Diagnostics:         diagnostics,
+		GeneratedAt:         now,
+		UpdatedAt:           now,
+	}, nil
+}
+
+func normalizeAWSAgentIdentityDetailFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// awsAgentIdentityDetailResolve finds the inventory record matching the
+// requested agent token by ID, ARN, node ID, or name.
+func awsAgentIdentityDetailResolve(agent string, records []AWSAIAgentIdentityRecord) (AWSAIAgentIdentityRecord, bool) {
+	needle := strings.ToLower(strings.TrimSpace(agent))
+	for _, record := range records {
+		for _, candidate := range []string{record.AgentID, record.AgentARN, record.AgentNodeID, record.AgentName} {
+			if candidate != "" && strings.ToLower(strings.TrimSpace(candidate)) == needle {
+				return record, true
+			}
+		}
+	}
+	return AWSAIAgentIdentityRecord{}, false
+}
+
+func awsAgentIdentityDetailAgent(agent string, record AWSAIAgentIdentityRecord, resolved bool, accountID, region string) AWSAgentIdentityDetailAgent {
+	if !resolved {
+		return AWSAgentIdentityDetailAgent{
+			Agent:            agent,
+			DisplayName:      agent,
+			AccountID:        accountID,
+			Region:           region,
+			Status:           "unknown",
+			Resolved:         false,
+			Candidate:        true,
+			LowConfidence:    true,
+			EvidenceBoundary: awsAgentIdentityDetailEvidenceBoundary(),
+		}
+	}
+	status := firstNonEmptyAWSValue(record.Status, "active")
+	candidate := strings.EqualFold(status, "candidate") || strings.EqualFold(record.CoverageStatus, "degraded")
+	return AWSAgentIdentityDetailAgent{
+		Agent:             agent,
+		AgentID:           record.AgentID,
+		AgentARN:          record.AgentARN,
+		AgentNodeID:       record.AgentNodeID,
+		AgentName:         record.AgentName,
+		AgentType:         record.AgentType,
+		DisplayName:       firstNonEmptyAWSValue(record.AgentName, record.AgentID, agent),
+		Provider:          record.Provider,
+		ModelID:           record.ModelID,
+		Service:           record.Service,
+		RuntimeVersion:    record.RuntimeVersion,
+		RuntimeRoleARN:    record.RuntimeRoleARN,
+		RuntimeRoleName:   record.RuntimeRoleName,
+		RuntimeRoleNodeID: record.RuntimeRoleNodeID,
+		GatewayID:         record.GatewayID,
+		GatewayNodeID:     record.GatewayNodeID,
+		ExternalProvider:  record.ExternalProvider,
+		AuthMode:          record.AuthMode,
+		AccountID:         firstNonEmptyAWSValue(record.AccountID, accountID),
+		Region:            firstNonEmptyAWSValue(record.Region, region),
+		Status:            status,
+		Resolved:          true,
+		Candidate:         candidate,
+		LowConfidence:     record.Confidence < awsAgentIdentityDetailLowConfidenceFloor,
+		Confidence:        record.Confidence,
+		CoverageStatus:    record.CoverageStatus,
+		CoverageReason:    record.CoverageReason,
+		EvidenceRef:       record.EvidenceRef,
+		EvidenceBoundary:  awsAgentIdentityDetailEvidenceBoundary(),
+	}
+}
+
+// awsAgentIdentityDetailTools merges declared inventory tools with observed
+// runtime correlations so declared-unused and observed-undeclared tools are
+// explicit rows.
+func awsAgentIdentityDetailTools(record AWSAIAgentIdentityRecord, runtime []AWSAgentRuntimeAccessRecord) []AWSAgentIdentityToolSummary {
+	byName := map[string]*AWSAgentIdentityToolSummary{}
+	order := []string{}
+	targetRefs := map[string]string{}
+	for i, name := range record.ToolNames {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		if i < len(record.ToolTargetRefs) {
+			targetRefs[strings.ToLower(trimmed)] = record.ToolTargetRefs[i]
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := byName[key]; ok {
+			continue
+		}
+		byName[key] = &AWSAgentIdentityToolSummary{
+			ToolName:      trimmed,
+			ToolTargetRef: targetRefs[key],
+			Declared:      true,
+			Status:        "declared_unused",
+			EvidenceRef:   record.EvidenceRef,
+		}
+		order = append(order, key)
+	}
+	for _, correlation := range runtime {
+		name := strings.TrimSpace(correlation.ToolName)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		tool, ok := byName[key]
+		if !ok {
+			tool = &AWSAgentIdentityToolSummary{
+				ToolName:      name,
+				ToolTargetRef: correlation.ToolTargetRef,
+				Status:        "observed_undeclared",
+			}
+			byName[key] = tool
+			order = append(order, key)
+		}
+		tool.Observed = true
+		tool.ObservedCount += correlation.ObservedCount
+		if tool.Declared {
+			tool.Status = firstNonEmptyAWSValue(correlation.Status, "confirmed")
+		} else {
+			tool.Status = firstNonEmptyAWSValue(correlation.Status, "observed_undeclared")
+		}
+		if tool.ToolTargetRef == "" {
+			tool.ToolTargetRef = correlation.ToolTargetRef
+		}
+		if tool.EvidenceRef == "" {
+			tool.EvidenceRef = correlation.EvidenceRef
+		}
+		if correlation.LastObservedAt.After(tool.LastObserved) {
+			tool.LastObserved = correlation.LastObservedAt
+		}
+	}
+	out := make([]AWSAgentIdentityToolSummary, 0, len(order))
+	for _, key := range order {
+		out = append(out, *byName[key])
+	}
+	return out
+}
+
+func awsAgentIdentityDetailCountTools(tools []AWSAgentIdentityToolSummary, match func(AWSAgentIdentityToolSummary) bool) int {
+	count := 0
+	for _, tool := range tools {
+		if match(tool) {
+			count++
+		}
+	}
+	return count
+}
+
+func awsAgentIdentityDetailCapabilities(record AWSAIAgentIdentityRecord) []AWSAgentIdentityCapabilitySummary {
+	return []AWSAgentIdentityCapabilitySummary{
+		{
+			Capability:       "memory",
+			Enabled:          record.MemoryEnabled || len(record.MemoryStoreRefs) > 0,
+			ReferenceRefs:    emptyStrings(dedupeStrings(record.MemoryStoreRefs)),
+			EncryptionKeyARN: record.EncryptionKeyARN,
+		},
+		{
+			Capability:    "browser",
+			Enabled:       record.BrowserEnabled,
+			ReferenceRefs: awsAgentIdentityDetailCapabilityRefs(record, "browser"),
+		},
+		{
+			Capability:    "code_interpreter",
+			Enabled:       record.CodeInterpreterEnabled,
+			ReferenceRefs: awsAgentIdentityDetailCapabilityRefs(record, "code_interpreter"),
+		},
+	}
+}
+
+// awsAgentIdentityDetailCapabilityRefs attributes storage references to the
+// browser/code-interpreter capability record they belong to; the inventory
+// carries capability-scoped records with a CapabilityKind marker.
+func awsAgentIdentityDetailCapabilityRefs(record AWSAIAgentIdentityRecord, kind string) []string {
+	if !strings.EqualFold(record.CapabilityKind, kind) {
+		return nil
+	}
+	return emptyStrings(dedupeStrings(record.StorageReferenceRefs))
+}
+
+func awsAgentIdentityDetailEnabledCapabilityCount(capabilities []AWSAgentIdentityCapabilitySummary) int {
+	count := 0
+	for _, capability := range capabilities {
+		if capability.Enabled {
+			count++
+		}
+	}
+	return count
+}
+
+func awsAgentIdentityDetailSecretReferences(record AWSAIAgentIdentityRecord) []AWSAgentIdentitySecretReference {
+	out := []AWSAgentIdentitySecretReference{}
+	seen := map[string]struct{}{}
+	for _, reference := range record.ProviderKeyReferences {
+		key := strings.ToLower(strings.TrimSpace(reference.Reference))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, AWSAgentIdentitySecretReference{
+			Reference:     reference.Reference,
+			ReferenceName: reference.ReferenceName,
+			ReferenceKind: reference.ReferenceKind,
+			Provider:      reference.Provider,
+			Sensitivity:   reference.Sensitivity,
+			Resolved:      reference.Resolved,
+			TargetNodeID:  reference.TargetNodeID,
+			EvidenceRef:   reference.EvidenceRef,
+			Confidence:    reference.Confidence,
+		})
+	}
+	for _, reference := range record.CredentialReferenceRefs {
+		key := strings.ToLower(strings.TrimSpace(reference))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, AWSAgentIdentitySecretReference{
+			Reference:     reference,
+			ReferenceKind: "credential_reference",
+			EvidenceRef:   record.EvidenceRef,
+			Confidence:    record.Confidence,
+		})
+	}
+	return out
+}
+
+func awsAgentIdentityDetailRuntimeCalls(records []AWSAgentRuntimeAccessRecord) []AWSAgentIdentityRuntimeCall {
+	out := make([]AWSAgentIdentityRuntimeCall, 0, len(records))
+	for _, record := range records {
+		out = append(out, AWSAgentIdentityRuntimeCall{
+			CorrelationID: record.CorrelationID,
+			ToolName:      record.ToolName,
+			ToolTargetRef: record.ToolTargetRef,
+			Status:        record.Status,
+			ObservedCount: record.ObservedCount,
+			Outcomes:      emptyStrings(dedupeStrings(record.Outcomes)),
+			TargetARNs:    emptyStrings(dedupeStrings(record.TargetResourceARNs)),
+			EvidenceRef:   record.EvidenceRef,
+			NextAction:    record.NextAction,
+			LastObserved:  record.LastObservedAt,
+		})
+	}
+	return out
+}
+
+func awsAgentIdentityDetailFindings(findings []AWSAIAgentRiskFinding) []AWSAgentIdentityFindingSummary {
+	out := make([]AWSAgentIdentityFindingSummary, 0, len(findings))
+	for _, finding := range findings {
+		out = append(out, AWSAgentIdentityFindingSummary{
+			FindingID:    finding.FindingID,
+			RiskType:     finding.RiskType,
+			Severity:     finding.Severity,
+			Status:       finding.Status,
+			Score:        finding.Score,
+			Rationale:    finding.Rationale,
+			NextAction:   finding.NextAction,
+			EvidenceRefs: awsLeastPrivilegeEvidenceRefs(finding.Evidence),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].FindingID < out[j].FindingID
+		}
+		return out[i].Score > out[j].Score
+	})
+	return out
+}
+
+func awsAgentIdentityDetailRecommendations(recommendations []AWSLeastPrivilegeRecommendation) []AWSAgentIdentityRecommendationSummary {
+	out := make([]AWSAgentIdentityRecommendationSummary, 0, len(recommendations))
+	for _, recommendation := range recommendations {
+		out = append(out, AWSAgentIdentityRecommendationSummary{
+			RecommendationID: recommendation.RecommendationID,
+			Decision:         recommendation.Decision,
+			Severity:         recommendation.Severity,
+			Status:           recommendation.Status,
+			Service:          recommendation.Service,
+			DisplayName:      recommendation.DisplayName,
+			Rationale:        recommendation.Rationale,
+			NextAction:       recommendation.NextAction,
+			Score:            recommendation.Score,
+			Confidence:       recommendation.Confidence,
+		})
+	}
+	return out
+}
+
+func awsAgentIdentityDetailRelationships(record AWSAIAgentIdentityRecord, inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult) []AWSAgentIdentityDetailRelationship {
+	out := []AWSAgentIdentityDetailRelationship{}
+	agentNode := strings.ToLower(strings.TrimSpace(record.AgentNodeID))
+	if agentNode != "" {
+		for _, relation := range inventory.Relationships {
+			if strings.ToLower(strings.TrimSpace(relation.FromNodeID)) != agentNode && strings.ToLower(strings.TrimSpace(relation.ToNodeID)) != agentNode {
+				continue
+			}
+			out = append(out, AWSAgentIdentityDetailRelationship{
+				Source:      "ai_agent_identities",
+				Type:        relation.Type,
+				FromNodeID:  relation.FromNodeID,
+				ToNodeID:    relation.ToNodeID,
+				EvidenceRef: relation.EvidenceRef,
+			})
+		}
+	}
+	for _, relation := range runtime.Relationships {
+		out = append(out, AWSAgentIdentityDetailRelationship{
+			Source:      "agent_runtime_access",
+			Type:        relation.Type,
+			FromNodeID:  relation.FromNodeID,
+			ToNodeID:    relation.ToNodeID,
+			EvidenceRef: relation.EvidenceRef,
+		})
+	}
+	return awsMachineIdentityDedupeRelationships(out)
+}
+
+func awsAgentIdentityDetailAppliedFilters(request AWSAgentIdentityDetailRequest, agentNodeID string) map[string]string {
+	filters := map[string]string{}
+	set := func(key, value string) {
+		value = strings.TrimSpace(value)
+		if value != "" && !strings.EqualFold(value, "all") {
+			filters[key] = value
+		}
+	}
+	set("agent", request.Agent)
+	set("agent_node_id", agentNodeID)
+	set("account_id", request.AccountID)
+	set("region", request.Region)
+	set("tab", request.Tab)
+	set("tool", request.Tool)
+	set("resource", request.Resource)
+	set("severity", request.Severity)
+	set("status", request.Status)
+	return filters
+}
+
+func awsAgentIdentityDetailTabs(summary AWSAgentIdentityDetailSummary, status string) []AWSAgentIdentityDetailTab {
+	tabStatus := status
+	if tabStatus == "" {
+		tabStatus = "success"
+	}
+	return []AWSAgentIdentityDetailTab{
+		{ID: "overview", Label: "Overview", Status: tabStatus, Count: summary.ToolCount + summary.CapabilityCount},
+		{ID: "tools", Label: "Tools", Status: tabStatus, Count: summary.ToolCount},
+		{ID: "runtime", Label: "Runtime", Status: tabStatus, Count: summary.RuntimeCallCount},
+		{ID: "secrets", Label: "Secrets", Status: tabStatus, Count: summary.SecretReferenceCount},
+		{ID: "findings", Label: "Findings", Status: tabStatus, Count: summary.FindingCount},
+		{ID: "recommendations", Label: "Recommendations", Status: tabStatus, Count: summary.RecommendationCount},
+		{ID: "remediation", Label: "Remediation", Status: tabStatus, Count: summary.RemediationCaseCount},
+		{ID: "governance", Label: "Governance", Status: tabStatus, Count: summary.GovernanceDecisionCount},
+	}
+}
+
+func summarizeAWSAgentIdentityDetail(fixtureState string, resolved bool, record AWSAIAgentIdentityRecord, diagnostics []AWSAgentIdentityDetailDiagnostic) (string, float64, []string, []string) {
+	failures := []string{}
+	hints := []string{}
+	switch fixtureState {
+	case "permission_denied":
+		return "permission_denied", 0.2, []string{"AWS connection is not authorized for this environment."}, []string{"Reconnect the AWS connector with read-only agent inventory permissions."}
+	case "empty":
+		return "empty", 0.5, failures, []string{"No agent identity evidence matched the selected account, region, and agent filters."}
+	case "degraded", "partial_failure":
+		failures = append(failures, "One or more agent evidence sources are degraded for this environment.")
+		hints = append(hints, "Retry the degraded collectors before treating missing evidence as absence of risk.")
+	}
+	if !resolved {
+		failures = append(failures, "The requested agent was not found in the AI agent inventory for this environment.")
+		hints = append(hints, "Open the agent from the AWS agents inventory so the detail request carries a known agent ID, ARN, or node ID.")
+		return "unknown", 0.3, failures, hints
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return "degraded", 0.7, failures, hints
+		}
+	}
+	if fixtureState == "degraded" || fixtureState == "partial_failure" {
+		return "degraded", 0.7, failures, hints
+	}
+	confidence := record.Confidence
+	if confidence == 0 {
+		confidence = 0.75
+	}
+	if record.Confidence > 0 && record.Confidence < awsAgentIdentityDetailLowConfidenceFloor {
+		hints = append(hints, "Agent confidence is below the detail-page floor; refresh runtime evidence before acting on inferred bindings.")
+	}
+	return "success", confidence, failures, hints
+}
+
+func awsAgentIdentityDetailFailureReasons(inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult, risk AWSAIAgentRiskResult, permissions AWSLeastPrivilegeResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult) []string {
+	out := []string{}
+	out = append(out, inventory.FailureReasons...)
+	out = append(out, runtime.FailureReasons...)
+	out = append(out, risk.FailureReasons...)
+	out = append(out, permissions.FailureReasons...)
+	out = append(out, cases.FailureReasons...)
+	out = append(out, governance.FailureReasons...)
+	return dedupeStrings(out)
+}
+
+func awsAgentIdentityDetailRemediationHints(inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult, risk AWSAIAgentRiskResult, permissions AWSLeastPrivilegeResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult) []string {
+	out := []string{}
+	out = append(out, inventory.RemediationHints...)
+	out = append(out, runtime.RemediationHints...)
+	out = append(out, risk.RemediationHints...)
+	out = append(out, permissions.RemediationHints...)
+	out = append(out, cases.RemediationHints...)
+	out = append(out, governance.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsAgentIdentityDetailDiagnostics(inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult, risk AWSAIAgentRiskResult, permissions AWSLeastPrivilegeResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult) []AWSAgentIdentityDetailDiagnostic {
+	out := []AWSAgentIdentityDetailDiagnostic{}
+	for _, diagnostic := range inventory.Diagnostics {
+		out = append(out, AWSAgentIdentityDetailDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range runtime.Diagnostics {
+		out = append(out, AWSAgentIdentityDetailDiagnostic(diagnostic))
+	}
+	for _, diagnostic := range risk.Diagnostics {
+		out = append(out, AWSAgentIdentityDetailDiagnostic(diagnostic))
+	}
+	out = append(out, awsMachineIdentityDetailDiagnostics(permissions, cases, governance)...)
+	return awsMachineIdentityDedupeDiagnostics(out)
+}
+
+func awsAgentIdentityDetailCoverageGaps(resolved bool, agent string, inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult, risk AWSAIAgentRiskResult, permissions AWSLeastPrivilegeResult, cases AWSRemediationCaseResult, governance AWSGovernanceAuditReportingResult) []AWSAgentIdentityDetailCoverageGap {
+	out := []AWSAgentIdentityDetailCoverageGap{}
+	if !resolved {
+		out = append(out, AWSAgentIdentityDetailCoverageGap{
+			Capability:  "agent_inventory_resolution",
+			Status:      "unknown",
+			Reason:      fmt.Sprintf("Agent %q was not found in the AI agent inventory for this environment.", agent),
+			Remediation: "Open the agent from the AWS agents inventory or verify the agent ID, ARN, or node ID.",
+		})
+	}
+	for _, gap := range inventory.CoverageGaps {
+		out = append(out, AWSAgentIdentityDetailCoverageGap(gap))
+	}
+	for _, gap := range runtime.CoverageGaps {
+		out = append(out, AWSAgentIdentityDetailCoverageGap(gap))
+	}
+	for _, gap := range risk.CoverageGaps {
+		out = append(out, AWSAgentIdentityDetailCoverageGap(gap))
+	}
+	out = append(out, awsMachineIdentityDetailCoverageGaps(permissions, cases, governance)...)
+	return out
+}
+
+func awsAgentIdentityDetailEvidenceLinks(scope db.Scope, project db.TenancyProject, record AWSAIAgentIdentityRecord, inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult, risk AWSAIAgentRiskResult, governance AWSGovernanceAuditReportingResult) []string {
+	links := []string{
+		awsIssueURL(awsPlatformDependencyParentIssue),
+		awsIssueURL(awsAgentIdentityDetailCurrentIssue),
+		"/docs/aws-agent-identity-detail",
+		"/docs/aws-ai-agent-identities",
+		"/docs/aws-agent-runtime-access",
+		"/docs/aws-ai-agent-risk",
+		awsBaselineProjectEvidenceURL(scope, project),
+	}
+	if strings.TrimSpace(record.EvidenceRef) != "" {
+		links = append(links, record.EvidenceRef)
+	}
+	links = append(links, inventory.EvidenceLinks...)
+	links = append(links, runtime.EvidenceLinks...)
+	links = append(links, risk.EvidenceLinks...)
+	links = append(links, governance.EvidenceLinks...)
+	return dedupeStrings(links)
+}
+
+func awsAgentIdentityDetailEvidenceBoundary() string {
+	return "metadata_only_no_secret_values_no_prompt_text_no_tool_payloads_no_workload_data_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -992,20 +992,14 @@ func awsAgentIdentityDetailRecommendations(recommendations []AWSLeastPrivilegeRe
 
 func awsAgentIdentityDetailRelationships(record AWSAIAgentIdentityRecord, inventory AWSAIAgentIdentityInventoryResult, runtime AWSAgentRuntimeAccessResult) []AWSAgentIdentityDetailRelationship {
 	out := []AWSAgentIdentityDetailRelationship{}
-	agentNode := strings.ToLower(strings.TrimSpace(record.AgentNodeID))
-	if agentNode != "" {
-		for _, relation := range inventory.Relationships {
-			if strings.ToLower(strings.TrimSpace(relation.FromNodeID)) != agentNode && strings.ToLower(strings.TrimSpace(relation.ToNodeID)) != agentNode {
-				continue
-			}
-			out = append(out, AWSAgentIdentityDetailRelationship{
-				Source:      "ai_agent_identities",
-				Type:        relation.Type,
-				FromNodeID:  relation.FromNodeID,
-				ToNodeID:    relation.ToNodeID,
-				EvidenceRef: relation.EvidenceRef,
-			})
-		}
+	for _, relation := range awsAIAgentIdentityRelationshipsForRecord(record, inventory.Relationships) {
+		out = append(out, AWSAgentIdentityDetailRelationship{
+			Source:      "ai_agent_identities",
+			Type:        relation.Type,
+			FromNodeID:  relation.FromNodeID,
+			ToNodeID:    relation.ToNodeID,
+			EvidenceRef: relation.EvidenceRef,
+		})
 	}
 	for _, relation := range runtime.Relationships {
 		out = append(out, AWSAgentIdentityDetailRelationship{

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -37,6 +37,12 @@ func TestGetAWSAgentIdentityDetailBuildsContract(t *testing.T) {
 	if result.Agent.Provider == "" || result.Agent.RuntimeRoleARN == "" {
 		t.Fatalf("agent header must carry provider and backing role: %+v", result.Agent)
 	}
+	if result.Permissions.AppliedFilters["identity"] != result.Agent.RuntimeRoleNodeID {
+		t.Fatalf("permission recommendations must be scoped by backing role identity, got filters=%+v agent=%+v", result.Permissions.AppliedFilters, result.Agent)
+	}
+	if result.RemediationCases.AppliedFilters["identity"] != result.Agent.RuntimeRoleNodeID {
+		t.Fatalf("remediation cases must be scoped by backing role identity, got filters=%+v agent=%+v", result.RemediationCases.AppliedFilters, result.Agent)
+	}
 	if result.Agent.EvidenceBoundary != awsAgentIdentityDetailEvidenceBoundary() {
 		t.Fatalf("agent header crossed evidence boundary: %+v", result.Agent)
 	}
@@ -147,6 +153,12 @@ func TestAWSAgentIdentityDetailToolsMergeDeclaredAndObserved(t *testing.T) {
 			ObservedCount: 1,
 			EvidenceRef:   "evidence://runtime/corr-2",
 		},
+		{
+			CorrelationID: "corr-3",
+			ToolName:      "close-ticket",
+			Status:        "declared_unused",
+			EvidenceRef:   "evidence://runtime/corr-3",
+		},
 	}
 
 	tools := awsAgentIdentityDetailTools(record, runtime)
@@ -168,6 +180,25 @@ func TestAWSAgentIdentityDetailToolsMergeDeclaredAndObserved(t *testing.T) {
 	undeclared := byName["delete-database"]
 	if undeclared.Declared || !undeclared.Observed || undeclared.Status != "observed_without_declaration" {
 		t.Fatalf("observed-only tool must carry the runtime status: %+v", undeclared)
+	}
+}
+
+func TestAWSAgentIdentityDetailPermissionIdentityPrefersBackingRole(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
+	record := AWSAIAgentIdentityRecord{
+		AgentID:           "agent-1",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:bedrock_agent/agent-1",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: awsIdentityNodeIDForAPI(roleARN),
+	}
+
+	if got, want := awsAgentIdentityDetailPermissionIdentity(record, record.AgentID), record.RuntimeRoleNodeID; got != want {
+		t.Fatalf("expected backing role node identity %q, got %q", want, got)
+	}
+
+	record.RuntimeRoleNodeID = ""
+	if got, want := awsAgentIdentityDetailPermissionIdentity(record, record.AgentID), awsIdentityNodeIDForAPI(roleARN); got != want {
+		t.Fatalf("expected role ARN-derived identity %q, got %q", want, got)
 	}
 }
 

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -285,6 +285,114 @@ func TestAWSAgentIdentityDetailScopesResolvedRuntimeAndRiskExactly(t *testing.T)
 	}
 }
 
+func TestAWSAgentIdentityDetailScopesPermissionsAndCasesExactly(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/agent"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	leakedRoleARN := "arn:aws:iam::123456789012:role/agent-v2"
+	leakedRoleNode := awsIdentityNodeIDForAPI(leakedRoleARN)
+	record := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+		RuntimeRoleName:   "agent",
+	}
+	permissions := AWSLeastPrivilegeResult{
+		Recommendations: []AWSLeastPrivilegeRecommendation{
+			{
+				RecommendationID: "lp-agent",
+				Decision:         "remove",
+				Severity:         "high",
+				Status:           "open",
+				Service:          "s3",
+				IdentityNodeID:   roleNode,
+				PrincipalARN:     roleARN,
+				DisplayName:      "agent",
+				Score:            90,
+				Confidence:       0.9,
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "agent"},
+					{NodeID: "aws:s3:bucket/tickets", NodeType: "resource", Label: "tickets"},
+				},
+			},
+			{
+				RecommendationID: "lp-agent-v2",
+				Decision:         "remove",
+				Severity:         "high",
+				Status:           "open",
+				Service:          "s3",
+				IdentityNodeID:   leakedRoleNode,
+				PrincipalARN:     leakedRoleARN,
+				DisplayName:      "agent-v2",
+				Score:            80,
+				Confidence:       0.8,
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: leakedRoleNode, NodeType: "identity", Label: "agent-v2"},
+					{NodeID: "aws:s3:bucket/archive", NodeType: "resource", Label: "archive"},
+				},
+			},
+		},
+	}
+	cases := AWSRemediationCaseResult{
+		Cases: []AWSRemediationCase{
+			{
+				CaseID:         "case-agent",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "high",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: roleNode,
+				IdentityARN:    roleARN,
+				IdentityName:   "agent",
+				Score:          90,
+				Confidence:     0.9,
+				ImpactedNodes:  []string{roleNode, "aws:s3:bucket/tickets"},
+			},
+			{
+				CaseID:         "case-agent-v2",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "high",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: leakedRoleNode,
+				IdentityARN:    leakedRoleARN,
+				IdentityName:   "agent-v2",
+				Score:          80,
+				Confidence:     0.8,
+				ImpactedNodes:  []string{leakedRoleNode, "aws:s3:bucket/archive"},
+			},
+		},
+	}
+
+	scopedPermissions := awsAgentIdentityDetailScopePermissions(permissions, record, roleNode)
+	if len(scopedPermissions.Recommendations) != 1 || scopedPermissions.Recommendations[0].IdentityNodeID != roleNode {
+		t.Fatalf("permissions must exact-scope to the selected runtime role: %+v", scopedPermissions.Recommendations)
+	}
+	if scopedPermissions.Summary.FilteredRecommendations != 1 || scopedPermissions.Summary.RelationshipCount != len(scopedPermissions.Relationships) {
+		t.Fatalf("permission summary must match exact-scoped recommendations: summary=%+v relationships=%+v", scopedPermissions.Summary, scopedPermissions.Relationships)
+	}
+	for _, relation := range scopedPermissions.Relationships {
+		if relation.FromNodeID == leakedRoleNode || relation.ToNodeID == leakedRoleNode {
+			t.Fatalf("permission relationships must not retain prefix-matched leaked role: %+v", scopedPermissions.Relationships)
+		}
+	}
+
+	scopedCases := awsAgentIdentityDetailScopeRemediationCases(cases, record, roleNode)
+	if len(scopedCases.Cases) != 1 || scopedCases.Cases[0].IdentityNodeID != roleNode {
+		t.Fatalf("remediation cases must exact-scope to the selected runtime role: %+v", scopedCases.Cases)
+	}
+	if scopedCases.Summary.FilteredCases != 1 || scopedCases.Summary.RelationshipCount != len(scopedCases.Relationships) {
+		t.Fatalf("remediation summary must match exact-scoped cases: summary=%+v relationships=%+v", scopedCases.Summary, scopedCases.Relationships)
+	}
+	for _, relation := range scopedCases.Relationships {
+		if relation.FromNodeID == leakedRoleNode || relation.ToNodeID == leakedRoleNode {
+			t.Fatalf("remediation relationships must not retain prefix-matched leaked role: %+v", scopedCases.Relationships)
+		}
+	}
+}
+
 func TestAWSAgentIdentityDetailGovernanceFiltersPreferRoleThenAgent(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
 	roleRecord := AWSAIAgentIdentityRecord{

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newAgentIdentityDetailService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSAgentIdentityDetailBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 3, 20, 0, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail", now)
+
+	result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail", AWSAgentIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Agent:        "AGENTPAY1",
+	})
+	if err != nil {
+		t.Fatalf("get agent identity detail: %v", err)
+	}
+	if result.CurrentIssueRef != "#1550" || result.Version != awsAgentIdentityDetailVersion || result.PolicyVersion != awsAgentIdentityDetailPolicyID {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if !result.Agent.Resolved || result.Agent.AgentID != "AGENTPAY1" {
+		t.Fatalf("expected fixture agent to resolve from inventory: %+v", result.Agent)
+	}
+	if result.Agent.Provider == "" || result.Agent.RuntimeRoleARN == "" {
+		t.Fatalf("agent header must carry provider and backing role: %+v", result.Agent)
+	}
+	if result.Agent.EvidenceBoundary != awsAgentIdentityDetailEvidenceBoundary() {
+		t.Fatalf("agent header crossed evidence boundary: %+v", result.Agent)
+	}
+	if len(result.Tools) == 0 {
+		t.Fatalf("expected declared tools from the inventory record: %+v", result.Summary)
+	}
+	if len(result.Capabilities) != 3 {
+		t.Fatalf("expected memory/browser/code-interpreter capability rows: %+v", result.Capabilities)
+	}
+	if len(result.Tabs) == 0 {
+		t.Fatalf("expected detail tabs: %+v", result)
+	}
+	if result.Summary.ToolCount != len(result.Tools) || result.Summary.RuntimeCallCount != len(result.RuntimeCalls) {
+		t.Fatalf("summary counts must match sections: %+v", result.Summary)
+	}
+	if result.Summary.FindingCount != len(result.Findings) || result.Summary.RecommendationCount != len(result.Recommendations) {
+		t.Fatalf("summary finding/recommendation counts must match: %+v", result.Summary)
+	}
+	if len(result.EvidenceLinks) == 0 {
+		t.Fatalf("expected evidence links: %+v", result)
+	}
+	for _, tool := range result.Tools {
+		if tool.ToolName == "" || tool.Status == "" {
+			t.Fatalf("tool row missing name/status: %+v", tool)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_value\"", "\"prompt\"", "\"completion\"", "\"tool_payload\"", "\"secret_access_key\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("agent identity detail serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestGetAWSAgentIdentityDetailUnknownAgentIsExplicit(t *testing.T) {
+	now := time.Date(2026, 7, 3, 20, 15, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-unknown", now)
+
+	result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-unknown", AWSAgentIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Agent:        "agent-that-does-not-exist",
+	})
+	if err != nil {
+		t.Fatalf("unknown agent must be an explicit state, not an error: %v", err)
+	}
+	if result.Status != "unknown" {
+		t.Fatalf("unknown agent must surface status=unknown: %q", result.Status)
+	}
+	if result.Agent.Resolved || !result.Agent.Candidate || !result.Agent.LowConfidence {
+		t.Fatalf("unknown agent header must be flagged candidate/low-confidence: %+v", result.Agent)
+	}
+	foundGap := false
+	for _, gap := range result.CoverageGaps {
+		if gap.Capability == "agent_inventory_resolution" {
+			foundGap = true
+			break
+		}
+	}
+	if !foundGap {
+		t.Fatalf("unknown agent must carry an explicit coverage gap: %+v", result.CoverageGaps)
+	}
+	if len(result.Relationships) != 0 {
+		t.Fatalf("unknown agent must not inherit unrelated graph relationships: %+v", result.Relationships)
+	}
+	if len(result.FailureReasons) == 0 {
+		t.Fatalf("unknown agent must carry a failure reason: %+v", result.FailureReasons)
+	}
+}
+
+func TestGetAWSAgentIdentityDetailRequiresAgent(t *testing.T) {
+	now := time.Date(2026, 7, 3, 20, 30, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-required", now)
+
+	if _, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-required", AWSAgentIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	}); err == nil {
+		t.Fatalf("missing agent parameter must be rejected")
+	}
+}
+
+func TestAWSAgentIdentityDetailToolsMergeDeclaredAndObserved(t *testing.T) {
+	record := AWSAIAgentIdentityRecord{
+		AgentID:        "agent-1",
+		ToolNames:      []string{"search-tickets", "close-ticket"},
+		ToolTargetRefs: []string{"api://tickets/search", "api://tickets/close"},
+		EvidenceRef:    "evidence://inventory/agent-1",
+	}
+	runtime := []AWSAgentRuntimeAccessRecord{
+		{
+			CorrelationID:  "corr-1",
+			ToolName:       "search-tickets",
+			Status:         "confirmed",
+			ObservedCount:  4,
+			EvidenceRef:    "evidence://runtime/corr-1",
+			LastObservedAt: time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			CorrelationID: "corr-2",
+			ToolName:      "delete-database",
+			Status:        "observed_without_declaration",
+			ObservedCount: 1,
+			EvidenceRef:   "evidence://runtime/corr-2",
+		},
+	}
+
+	tools := awsAgentIdentityDetailTools(record, runtime)
+	if len(tools) != 3 {
+		t.Fatalf("expected declared + observed union, got %+v", tools)
+	}
+	byName := map[string]AWSAgentIdentityToolSummary{}
+	for _, tool := range tools {
+		byName[tool.ToolName] = tool
+	}
+	confirmed := byName["search-tickets"]
+	if !confirmed.Declared || !confirmed.Observed || confirmed.Status != "confirmed" || confirmed.ObservedCount != 4 {
+		t.Fatalf("declared+observed tool must be confirmed with counts: %+v", confirmed)
+	}
+	unused := byName["close-ticket"]
+	if !unused.Declared || unused.Observed || unused.Status != "declared_unused" {
+		t.Fatalf("declared-only tool must stay declared_unused: %+v", unused)
+	}
+	undeclared := byName["delete-database"]
+	if undeclared.Declared || !undeclared.Observed || undeclared.Status != "observed_without_declaration" {
+		t.Fatalf("observed-only tool must carry the runtime status: %+v", undeclared)
+	}
+}
+
+func TestAWSAgentIdentityDetailSecretReferencesAreMetadataOnly(t *testing.T) {
+	record := AWSAIAgentIdentityRecord{
+		AgentID: "agent-1",
+		ProviderKeyReferences: []AWSAIAgentProviderKeyReference{
+			{Reference: "arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key", ReferenceKind: "secretsmanager_secret", Provider: "openai", Sensitivity: "external_provider_key", Resolved: true, EvidenceRef: "evidence://keys/openai", Confidence: 0.9},
+		},
+		CredentialReferenceRefs: []string{"ssm://params/agent-1/token", "arn:aws:secretsmanager:us-east-1:111111111111:secret:openai/api-key"},
+		EvidenceRef:             "evidence://inventory/agent-1",
+		Confidence:              0.8,
+	}
+	references := awsAgentIdentityDetailSecretReferences(record)
+	if len(references) != 2 {
+		t.Fatalf("duplicate references must be deduped: %+v", references)
+	}
+	for _, reference := range references {
+		if reference.Reference == "" || reference.ReferenceKind == "" {
+			t.Fatalf("secret reference missing metadata: %+v", reference)
+		}
+	}
+}
+
+func TestAWSAgentIdentityDetailResolveMatchesAllTokens(t *testing.T) {
+	records := []AWSAIAgentIdentityRecord{
+		{AgentID: "AGENT1", AgentARN: "arn:aws:bedrock:us-east-1:1:agent/AGENT1", AgentNodeID: "aws:agent:1:us-east-1:bedrock_agent/AGENT1", AgentName: "payments-agent"},
+	}
+	for _, token := range []string{"AGENT1", "arn:aws:bedrock:us-east-1:1:agent/AGENT1", "aws:agent:1:us-east-1:bedrock_agent/AGENT1", "payments-agent", "agent1"} {
+		if _, ok := awsAgentIdentityDetailResolve(token, records); !ok {
+			t.Fatalf("token %q must resolve the agent record", token)
+		}
+	}
+	if _, ok := awsAgentIdentityDetailResolve("other-agent", records); ok {
+		t.Fatalf("unrelated token must not resolve")
+	}
+}
+
+func TestGetAWSAgentIdentityDetailFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 3, 21, 0, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-fixture", AWSAgentIdentityDetailRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+			Agent:        "AGENTPAY1",
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+		if state == "empty" && result.Status != "empty" {
+			t.Fatalf("empty fixture must surface as explicit status, got %q", result.Status)
+		}
+		if state == "permission_denied" && result.Status != "permission_denied" {
+			t.Fatalf("permission denied must surface as explicit status, got %q", result.Status)
+		}
+	}
+}
+
+func TestRouterAWSAgentIdentityDetail(t *testing.T) {
+	now := time.Date(2026, 7, 3, 21, 30, 0, 0, time.UTC)
+	svc, _ := newAgentIdentityDetailService(t, "project-agent-identity-detail-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-agent-identity-detail-route/aws/agent-identity-detail?connector_id=aws-prod&fixture_state=success&agent=AGENTPAY1", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Detail AWSAgentIdentityDetailResult `json:"detail"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Detail.CurrentIssueRef != "#1550" || !body.Detail.Agent.Resolved {
+		t.Fatalf("unexpected route payload: %+v", body.Detail.Agent)
+	}
+
+	missingAgent := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-agent-identity-detail-route/aws/agent-identity-detail?connector_id=aws-prod&fixture_state=success", "")
+	if missingAgent.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 without agent, got %d body=%s", missingAgent.Code, missingAgent.Body.String())
+	}
+}

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -681,6 +681,64 @@ func TestAWSAgentIdentityDetailMergesAgentScopedRemediationCases(t *testing.T) {
 	}
 }
 
+func TestAWSAgentIdentityDetailRelationshipsIncludeInventorySourceNodes(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	selected := AWSAIAgentIdentityRecord{
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+		AgentType:         "custom_agent",
+		AgentID:           "agent",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+		GatewayNodeID:     "aws:agent-gateway:123456789012:us-east-1:gateway/agent-gateway",
+		ToolNames:         []string{"search-tickets"},
+		EvidenceRef:       "evidence://inventory/agent",
+	}
+	other := AWSAIAgentIdentityRecord{
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+		AgentType:         "custom_agent",
+		AgentID:           "agent-v2",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent-v2",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+		GatewayNodeID:     "aws:agent-gateway:123456789012:us-east-1:gateway/agent-v2-gateway",
+		ToolNames:         []string{"archive-tickets"},
+		EvidenceRef:       "evidence://inventory/agent-v2",
+	}
+	inventory := AWSAIAgentIdentityInventoryResult{
+		Relationships: awsAIAgentIdentityRelationships([]AWSAIAgentIdentityRecord{selected, other}),
+	}
+
+	relationships := awsAgentIdentityDetailRelationships(selected, inventory, AWSAgentRuntimeAccessResult{})
+	if len(relationships) == 0 {
+		t.Fatal("expected selected inventory relationships")
+	}
+	workloadNode := awsAIAgentWorkloadNodeID(selected)
+	toolNode := awsAIAgentToolNodeID(selected.GatewayNodeID, "search-tickets")
+	foundRunsAs := false
+	foundCallsTool := false
+	for _, relationship := range relationships {
+		if relationship.Type == "runs_as" && relationship.FromNodeID == workloadNode && relationship.ToNodeID == roleNode {
+			foundRunsAs = true
+		}
+		if relationship.Type == "calls_tool" && relationship.FromNodeID == selected.GatewayNodeID && relationship.ToNodeID == toolNode {
+			foundCallsTool = true
+		}
+		if relationship.FromNodeID == other.AgentNodeID || relationship.FromNodeID == other.GatewayNodeID || relationship.FromNodeID == awsAIAgentWorkloadNodeID(other) {
+			t.Fatalf("detail relationships must not include sibling agent source edges: %+v", relationships)
+		}
+	}
+	if !foundRunsAs {
+		t.Fatalf("expected workload-sourced runs_as relationship, got %+v", relationships)
+	}
+	if !foundCallsTool {
+		t.Fatalf("expected gateway-sourced calls_tool relationship, got %+v", relationships)
+	}
+}
+
 func TestAWSAgentIdentityDetailGovernanceFiltersPreferRoleThenAgent(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
 	roleRecord := AWSAIAgentIdentityRecord{

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -37,14 +37,17 @@ func TestGetAWSAgentIdentityDetailBuildsContract(t *testing.T) {
 	if result.Agent.Provider == "" || result.Agent.RuntimeRoleARN == "" {
 		t.Fatalf("agent header must carry provider and backing role: %+v", result.Agent)
 	}
-	if result.RuntimeAccess.AppliedFilters["agent_id"] != result.Agent.AgentNodeID || result.Risk.AppliedFilters["agent_id"] != result.Agent.AgentNodeID || result.Governance.AppliedFilters["agent_id"] != result.Agent.AgentNodeID {
-		t.Fatalf("runtime/risk/governance evidence must be scoped by unique agent node id: runtime=%+v risk=%+v governance=%+v agent=%+v", result.RuntimeAccess.AppliedFilters, result.Risk.AppliedFilters, result.Governance.AppliedFilters, result.Agent)
+	if result.RuntimeAccess.AppliedFilters["agent_id"] != result.Agent.AgentNodeID || result.Risk.AppliedFilters["agent_id"] != result.Agent.AgentNodeID {
+		t.Fatalf("runtime/risk evidence must be scoped by unique agent node id: runtime=%+v risk=%+v agent=%+v", result.RuntimeAccess.AppliedFilters, result.Risk.AppliedFilters, result.Agent)
 	}
 	if result.Permissions.AppliedFilters["identity"] != result.Agent.RuntimeRoleNodeID {
 		t.Fatalf("permission recommendations must be scoped by backing role identity, got filters=%+v agent=%+v", result.Permissions.AppliedFilters, result.Agent)
 	}
 	if result.RemediationCases.AppliedFilters["identity"] != result.Agent.RuntimeRoleNodeID {
 		t.Fatalf("remediation cases must be scoped by backing role identity, got filters=%+v agent=%+v", result.RemediationCases.AppliedFilters, result.Agent)
+	}
+	if result.Governance.AppliedFilters["identity_id"] != result.Agent.RuntimeRoleNodeID || result.Summary.GovernanceDecisionCount == 0 {
+		t.Fatalf("governance decisions must be scoped by backing role identity, got summary=%+v filters=%+v agent=%+v", result.Summary, result.Governance.AppliedFilters, result.Agent)
 	}
 	if result.Agent.EvidenceBoundary != awsAgentIdentityDetailEvidenceBoundary() {
 		t.Fatalf("agent header crossed evidence boundary: %+v", result.Agent)

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -220,6 +220,94 @@ func TestAWSAgentIdentityDetailPermissionIdentityPrefersBackingRole(t *testing.T
 	}
 }
 
+func TestAWSAgentIdentityDetailScopesResolvedRuntimeAndRiskExactly(t *testing.T) {
+	record := AWSAIAgentIdentityRecord{
+		AgentID:     "agent",
+		AgentNodeID: "aws:agent:123456789012:us-east-1:custom_agent/agent",
+	}
+	leakedAgentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v2"
+	runtime := AWSAgentRuntimeAccessResult{
+		Records: []AWSAgentRuntimeAccessRecord{
+			{
+				CorrelationID:         "corr-agent",
+				AgentID:               record.AgentID,
+				AgentNodeID:           record.AgentNodeID,
+				ToolName:              "search",
+				Status:                "confirmed",
+				ObservedCount:         2,
+				DeclaredInInventory:   true,
+				BackingRoleNodeIDs:    []string{"aws:identity:role/agent"},
+				TargetResourceNodeIDs: []string{"aws:s3:bucket/tickets"},
+			},
+			{
+				CorrelationID:         "corr-agent-v2",
+				AgentID:               "agent-v2",
+				AgentNodeID:           leakedAgentNode,
+				ToolName:              "delete",
+				Status:                "confirmed",
+				ObservedCount:         1,
+				BackingRoleNodeIDs:    []string{"aws:identity:role/agent-v2"},
+				TargetResourceNodeIDs: []string{"aws:s3:bucket/archive"},
+			},
+		},
+	}
+	risk := AWSAIAgentRiskResult{
+		Findings: []AWSAIAgentRiskFinding{
+			{FindingID: "risk-agent", AgentID: record.AgentID, AgentNodeID: record.AgentNodeID, RiskType: "broad_tool_access", Severity: "high", Status: "open", Score: 90, ImpactedNodes: []string{record.AgentNodeID, "aws:identity:role/agent"}},
+			{FindingID: "risk-agent-v2", AgentID: "agent-v2", AgentNodeID: leakedAgentNode, RiskType: "ownerless_agent", Severity: "medium", Status: "open", Score: 70, ImpactedNodes: []string{leakedAgentNode, "aws:identity:role/agent-v2"}},
+		},
+	}
+
+	scopedRuntime := awsAgentIdentityDetailScopeRuntimeAccess(runtime, record)
+	if len(scopedRuntime.Records) != 1 || scopedRuntime.Records[0].AgentNodeID != record.AgentNodeID {
+		t.Fatalf("runtime evidence must be exact-scoped to the resolved agent: %+v", scopedRuntime.Records)
+	}
+	if scopedRuntime.Summary.FilteredCorrelations != 1 || scopedRuntime.Summary.ConfirmedCount != 1 || scopedRuntime.Summary.RelationshipCount != len(scopedRuntime.Relationships) {
+		t.Fatalf("runtime summary must match exact-scoped records: summary=%+v relationships=%+v", scopedRuntime.Summary, scopedRuntime.Relationships)
+	}
+	for _, relation := range scopedRuntime.Relationships {
+		if relation.FromNodeID == leakedAgentNode || relation.ToNodeID == leakedAgentNode {
+			t.Fatalf("runtime relationships must not retain prefix-matched leaked agent: %+v", scopedRuntime.Relationships)
+		}
+	}
+
+	scopedRisk := awsAgentIdentityDetailScopeRisk(risk, record)
+	if len(scopedRisk.Findings) != 1 || scopedRisk.Findings[0].AgentNodeID != record.AgentNodeID {
+		t.Fatalf("risk evidence must be exact-scoped to the resolved agent: %+v", scopedRisk.Findings)
+	}
+	if scopedRisk.Summary.FilteredFindings != 1 || scopedRisk.Summary.RelationshipCount != len(scopedRisk.Relationships) {
+		t.Fatalf("risk summary must match exact-scoped findings: summary=%+v relationships=%+v", scopedRisk.Summary, scopedRisk.Relationships)
+	}
+	for _, relation := range scopedRisk.Relationships {
+		if relation.FromNodeID == leakedAgentNode || relation.ToNodeID == leakedAgentNode {
+			t.Fatalf("risk relationships must not retain prefix-matched leaked agent: %+v", scopedRisk.Relationships)
+		}
+	}
+}
+
+func TestAWSAgentIdentityDetailGovernanceFiltersPreferRoleThenAgent(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
+	roleRecord := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: awsIdentityNodeIDForAPI(roleARN),
+	}
+	identityID, agentID := awsAgentIdentityDetailGovernanceFilters(roleRecord, roleRecord.AgentNodeID)
+	if identityID != roleRecord.RuntimeRoleNodeID || agentID != "" {
+		t.Fatalf("role-backed governance must use identity_id only, got identity=%q agent=%q", identityID, agentID)
+	}
+
+	rolelessRecord := AWSAIAgentIdentityRecord{
+		AgentID:     "custom-agent",
+		AgentNodeID: "aws:agent:123456789012:us-east-1:custom_agent/custom-agent",
+	}
+	identityID, agentID = awsAgentIdentityDetailGovernanceFilters(rolelessRecord, rolelessRecord.AgentNodeID)
+	if identityID != "" || agentID != rolelessRecord.AgentNodeID {
+		t.Fatalf("roleless governance must use agent_id, got identity=%q agent=%q", identityID, agentID)
+	}
+}
+
 func TestAWSAgentIdentityDetailSecretReferencesAreMetadataOnly(t *testing.T) {
 	record := AWSAIAgentIdentityRecord{
 		AgentID: "agent-1",

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -224,6 +224,40 @@ func TestAWSAgentIdentityDetailToolsMergeDeclaredAndObserved(t *testing.T) {
 	}
 }
 
+func TestAWSAgentIdentityDetailToolsApplyToolFilterToDeclaredRows(t *testing.T) {
+	record := AWSAIAgentIdentityRecord{
+		AgentID:        "agent-1",
+		ToolNames:      []string{"search-tickets", "close-ticket"},
+		ToolTargetRefs: []string{"api://tickets/search", "api://tickets/close"},
+		EvidenceRef:    "evidence://inventory/agent-1",
+	}
+	runtime := []AWSAgentRuntimeAccessRecord{
+		{
+			CorrelationID: "corr-search",
+			ToolName:      "search-tickets",
+			ToolTargetRef: "api://tickets/search",
+			Status:        "confirmed",
+			ObservedCount: 2,
+			EvidenceRef:   "evidence://runtime/search",
+		},
+		{
+			CorrelationID: "corr-close",
+			ToolName:      "close-ticket",
+			ToolTargetRef: "api://tickets/close",
+			Status:        "declared_unused",
+			EvidenceRef:   "evidence://runtime/close",
+		},
+	}
+
+	tools := awsAgentIdentityDetailTools(record, runtime, "api://tickets/search")
+	if len(tools) != 1 {
+		t.Fatalf("tool-filtered detail must only include matching declared/runtime tools, got %+v", tools)
+	}
+	if tools[0].ToolName != "search-tickets" || !tools[0].Declared || !tools[0].Observed {
+		t.Fatalf("tool-filtered row must preserve the matching declared+observed tool: %+v", tools[0])
+	}
+}
+
 func TestAWSAgentIdentityDetailPermissionIdentityPrefersBackingRole(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
 	record := AWSAIAgentIdentityRecord{
@@ -240,6 +274,66 @@ func TestAWSAgentIdentityDetailPermissionIdentityPrefersBackingRole(t *testing.T
 	record.RuntimeRoleNodeID = ""
 	if got, want := awsAgentIdentityDetailPermissionIdentity(record, record.AgentID), awsIdentityNodeIDForAPI(roleARN); got != want {
 		t.Fatalf("expected role ARN-derived identity %q, got %q", want, got)
+	}
+}
+
+func TestAWSAgentIdentityDetailMergesRuntimeAndRiskAgentKeys(t *testing.T) {
+	record := AWSAIAgentIdentityRecord{
+		AgentID:     "agent",
+		AgentNodeID: "aws:agent:123456789012:us-east-1:custom_agent/agent-v1",
+	}
+	versionedNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v2"
+	otherNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v20"
+	runtimeByNode := AWSAgentRuntimeAccessResult{
+		AppliedFilters: map[string]string{"agent_id": record.AgentNodeID},
+	}
+	runtimeByID := AWSAgentRuntimeAccessResult{
+		AppliedFilters: map[string]string{"agent_id": record.AgentID},
+		Records: []AWSAgentRuntimeAccessRecord{
+			{
+				CorrelationID: "corr-agent-id",
+				AgentID:       record.AgentID,
+				AgentNodeID:   versionedNode,
+				ToolName:      "search",
+				Status:        "confirmed",
+				ObservedCount: 1,
+			},
+			{
+				CorrelationID: "corr-sibling",
+				AgentID:       "agent-v2",
+				AgentNodeID:   otherNode,
+				ToolName:      "archive",
+				Status:        "confirmed",
+				ObservedCount: 1,
+			},
+		},
+	}
+	mergedRuntime := awsAgentIdentityDetailMergeRuntimeAccessResults(runtimeByNode, runtimeByID, record.AgentNodeID, record.AgentID)
+	scopedRuntime := awsAgentIdentityDetailScopeRuntimeAccess(mergedRuntime, record)
+	if len(scopedRuntime.Records) != 1 || scopedRuntime.Records[0].CorrelationID != "corr-agent-id" {
+		t.Fatalf("runtime evidence must merge alternate exact agent keys and still exact-filter siblings: %+v", scopedRuntime.Records)
+	}
+	if scopedRuntime.AppliedFilters["agent_id"] != record.AgentNodeID || scopedRuntime.AppliedFilters["agent_id_alternates"] != record.AgentID {
+		t.Fatalf("merged runtime filters must expose primary and alternate agent keys: %+v", scopedRuntime.AppliedFilters)
+	}
+
+	riskByNode := AWSAIAgentRiskResult{
+		AppliedFilters: map[string]string{"agent_id": record.AgentNodeID},
+	}
+	riskByID := AWSAIAgentRiskResult{
+		AppliedFilters: map[string]string{"agent_id": record.AgentID},
+		Findings: []AWSAIAgentRiskFinding{
+			{FindingID: "risk-agent-id", AgentID: record.AgentID, AgentNodeID: versionedNode, RiskType: "broad_tool_access", Severity: "medium", Status: "open", Score: 70},
+			{FindingID: "risk-sibling", AgentID: "agent-v2", AgentNodeID: otherNode, RiskType: "ownerless_agent", Severity: "medium", Status: "open", Score: 65},
+		},
+	}
+	mergedRisk := awsAgentIdentityDetailMergeRiskResults(riskByNode, riskByID, record.AgentNodeID, record.AgentID)
+	scopedRisk := awsAgentIdentityDetailScopeRisk(mergedRisk, record)
+	if len(scopedRisk.Findings) != 1 || scopedRisk.Findings[0].FindingID != "risk-agent-id" {
+		t.Fatalf("risk evidence must merge alternate exact agent keys and still exact-filter siblings: %+v", scopedRisk.Findings)
+	}
+	if scopedRisk.AppliedFilters["agent_id"] != record.AgentNodeID || scopedRisk.AppliedFilters["agent_id_alternates"] != record.AgentID {
+		t.Fatalf("merged risk filters must expose primary and alternate agent keys: %+v", scopedRisk.AppliedFilters)
 	}
 }
 

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -37,6 +37,9 @@ func TestGetAWSAgentIdentityDetailBuildsContract(t *testing.T) {
 	if result.Agent.Provider == "" || result.Agent.RuntimeRoleARN == "" {
 		t.Fatalf("agent header must carry provider and backing role: %+v", result.Agent)
 	}
+	if result.RuntimeAccess.AppliedFilters["agent_id"] != result.Agent.AgentNodeID || result.Risk.AppliedFilters["agent_id"] != result.Agent.AgentNodeID || result.Governance.AppliedFilters["agent_id"] != result.Agent.AgentNodeID {
+		t.Fatalf("runtime/risk/governance evidence must be scoped by unique agent node id: runtime=%+v risk=%+v governance=%+v agent=%+v", result.RuntimeAccess.AppliedFilters, result.Risk.AppliedFilters, result.Governance.AppliedFilters, result.Agent)
+	}
 	if result.Permissions.AppliedFilters["identity"] != result.Agent.RuntimeRoleNodeID {
 		t.Fatalf("permission recommendations must be scoped by backing role identity, got filters=%+v agent=%+v", result.Permissions.AppliedFilters, result.Agent)
 	}
@@ -89,7 +92,7 @@ func TestGetAWSAgentIdentityDetailUnknownAgentIsExplicit(t *testing.T) {
 	result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-unknown", AWSAgentIdentityDetailRequest{
 		ConnectorID:  "aws-prod",
 		FixtureState: "success",
-		Agent:        "agent-that-does-not-exist",
+		Agent:        "agent",
 	})
 	if err != nil {
 		t.Fatalf("unknown agent must be an explicit state, not an error: %v", err)
@@ -112,6 +115,18 @@ func TestGetAWSAgentIdentityDetailUnknownAgentIsExplicit(t *testing.T) {
 	}
 	if len(result.Relationships) != 0 {
 		t.Fatalf("unknown agent must not inherit unrelated graph relationships: %+v", result.Relationships)
+	}
+	if len(result.Tools) != 0 || len(result.RuntimeCalls) != 0 || len(result.RuntimeAccess.Records) != 0 {
+		t.Fatalf("unknown agent must not inherit runtime evidence: tools=%+v calls=%+v runtime=%+v", result.Tools, result.RuntimeCalls, result.RuntimeAccess.Records)
+	}
+	if len(result.Findings) != 0 || len(result.Risk.Findings) != 0 {
+		t.Fatalf("unknown agent must not inherit risk findings: findings=%+v risk=%+v", result.Findings, result.Risk.Findings)
+	}
+	if len(result.Recommendations) != 0 || len(result.Permissions.Recommendations) != 0 {
+		t.Fatalf("unknown agent must not inherit permission recommendations: recommendations=%+v permissions=%+v", result.Recommendations, result.Permissions.Recommendations)
+	}
+	if len(result.RemediationCases.Cases) != 0 || len(result.GovernanceDecisions) != 0 || len(result.Governance.Records) != 0 {
+		t.Fatalf("unknown agent must not inherit remediation/governance evidence: cases=%+v decisions=%+v governance=%+v", result.RemediationCases.Cases, result.GovernanceDecisions, result.Governance.Records)
 	}
 	if len(result.FailureReasons) == 0 {
 		t.Fatalf("unknown agent must carry a failure reason: %+v", result.FailureReasons)

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -393,6 +393,172 @@ func TestAWSAgentIdentityDetailScopesPermissionsAndCasesExactly(t *testing.T) {
 	}
 }
 
+func TestAWSAgentIdentityDetailKeepsRoleWideButFiltersOtherAgentToolRecommendations(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	agentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent"
+	otherAgentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v2"
+	record := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       agentNode,
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+	}
+	permissions := AWSLeastPrivilegeResult{
+		Recommendations: []AWSLeastPrivilegeRecommendation{
+			{
+				RecommendationID:   "lp-selected-agent-tool",
+				RecommendationType: "remove-unused-agent-tool",
+				Decision:           "remove",
+				Severity:           "medium",
+				Status:             "open",
+				Service:            "agent-runtime",
+				IdentityNodeID:     roleNode,
+				PrincipalARN:       roleARN,
+				DisplayName:        "agent",
+				Score:              70,
+				Confidence:         0.8,
+				ImpactedNodes:      []string{roleNode, agentNode, "aws:s3:bucket/tickets"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: agentNode, NodeType: "ai_agent", Label: "agent"},
+					{NodeID: "aws:s3:bucket/tickets", NodeType: "target_resource", Label: "tickets"},
+				},
+				Evidence: []AWSLeastPrivilegeEvidence{{Source: "agent_runtime_access", EvidenceRef: "evidence://runtime/agent"}},
+			},
+			{
+				RecommendationID:   "lp-other-agent-tool",
+				RecommendationType: "remove-unused-agent-tool",
+				Decision:           "remove",
+				Severity:           "medium",
+				Status:             "open",
+				Service:            "agent-runtime",
+				IdentityNodeID:     roleNode,
+				PrincipalARN:       roleARN,
+				DisplayName:        "agent-v2",
+				Score:              68,
+				Confidence:         0.8,
+				ImpactedNodes:      []string{roleNode, otherAgentNode, "aws:s3:bucket/archive"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: otherAgentNode, NodeType: "ai_agent", Label: "agent-v2"},
+					{NodeID: "aws:s3:bucket/archive", NodeType: "target_resource", Label: "archive"},
+				},
+				Evidence: []AWSLeastPrivilegeEvidence{{Source: "agent_runtime_access", EvidenceRef: "evidence://runtime/agent-v2"}},
+			},
+			{
+				RecommendationID:   "lp-role-wide",
+				RecommendationType: "remove-unused-iam-action",
+				Decision:           "remove",
+				Severity:           "high",
+				Status:             "open",
+				Service:            "s3",
+				IdentityNodeID:     roleNode,
+				PrincipalARN:       roleARN,
+				DisplayName:        "shared-agent-runtime",
+				Score:              80,
+				Confidence:         0.85,
+				ImpactedNodes:      []string{roleNode, "aws:s3:bucket/shared"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: "aws:s3:bucket/shared", NodeType: "resource", Label: "shared"},
+				},
+				Evidence: []AWSLeastPrivilegeEvidence{{Source: "iam_last_used", EvidenceRef: "evidence://iam-last-used/shared-agent-runtime"}},
+			},
+		},
+	}
+	cases := AWSRemediationCaseResult{
+		Cases: []AWSRemediationCase{
+			{
+				CaseID:         "case-selected-agent-tool",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "medium",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: roleNode,
+				IdentityARN:    roleARN,
+				IdentityName:   "agent",
+				Score:          70,
+				Confidence:     0.8,
+				ImpactedNodes:  []string{roleNode, agentNode, "aws:s3:bucket/tickets"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: agentNode, NodeType: "ai_agent", Label: "agent"},
+					{NodeID: "aws:s3:bucket/tickets", NodeType: "target_resource", Label: "tickets"},
+				},
+			},
+			{
+				CaseID:         "case-other-agent-tool",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "medium",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: roleNode,
+				IdentityARN:    roleARN,
+				IdentityName:   "agent-v2",
+				Score:          68,
+				Confidence:     0.8,
+				ImpactedNodes:  []string{roleNode, otherAgentNode, "aws:s3:bucket/archive"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: otherAgentNode, NodeType: "ai_agent", Label: "agent-v2"},
+					{NodeID: "aws:s3:bucket/archive", NodeType: "target_resource", Label: "archive"},
+				},
+			},
+			{
+				CaseID:         "case-role-wide",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "high",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: roleNode,
+				IdentityARN:    roleARN,
+				IdentityName:   "shared-agent-runtime",
+				Score:          80,
+				Confidence:     0.85,
+				ImpactedNodes:  []string{roleNode, "aws:s3:bucket/shared"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: "aws:s3:bucket/shared", NodeType: "resource", Label: "shared"},
+				},
+			},
+		},
+	}
+
+	scopedPermissions := awsAgentIdentityDetailScopePermissions(permissions, record, roleNode)
+	gotRecommendations := map[string]struct{}{}
+	for _, recommendation := range scopedPermissions.Recommendations {
+		gotRecommendations[recommendation.RecommendationID] = struct{}{}
+	}
+	if _, ok := gotRecommendations["lp-selected-agent-tool"]; !ok {
+		t.Fatalf("selected agent tool recommendation must be retained: %+v", scopedPermissions.Recommendations)
+	}
+	if _, ok := gotRecommendations["lp-role-wide"]; !ok {
+		t.Fatalf("role-wide IAM recommendation must be retained: %+v", scopedPermissions.Recommendations)
+	}
+	if _, ok := gotRecommendations["lp-other-agent-tool"]; ok {
+		t.Fatalf("other agent tool recommendation must be filtered out: %+v", scopedPermissions.Recommendations)
+	}
+
+	scopedCases := awsAgentIdentityDetailScopeRemediationCases(cases, record, roleNode)
+	gotCases := map[string]struct{}{}
+	for _, c := range scopedCases.Cases {
+		gotCases[c.CaseID] = struct{}{}
+	}
+	if _, ok := gotCases["case-selected-agent-tool"]; !ok {
+		t.Fatalf("selected agent tool case must be retained: %+v", scopedCases.Cases)
+	}
+	if _, ok := gotCases["case-role-wide"]; !ok {
+		t.Fatalf("role-wide IAM case must be retained: %+v", scopedCases.Cases)
+	}
+	if _, ok := gotCases["case-other-agent-tool"]; ok {
+		t.Fatalf("other agent tool case must be filtered out: %+v", scopedCases.Cases)
+	}
+}
+
 func TestAWSAgentIdentityDetailGovernanceFiltersPreferRoleThenAgent(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/agent-runtime"
 	roleRecord := AWSAIAgentIdentityRecord{

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -88,6 +88,29 @@ func TestGetAWSAgentIdentityDetailBuildsContract(t *testing.T) {
 	}
 }
 
+func TestGetAWSAgentIdentityDetailForwardsResourceToRecommendations(t *testing.T) {
+	now := time.Date(2026, 7, 4, 11, 30, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-resource", now)
+
+	result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-resource", AWSAgentIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Agent:        "AGENTPAY1",
+		Resource:     "prod/ai/openai-key",
+	})
+	if err != nil {
+		t.Fatalf("get resource-filtered agent identity detail: %v", err)
+	}
+	if result.Permissions.AppliedFilters["resource"] != "prod/ai/openai-key" {
+		t.Fatalf("permissions must receive the detail resource filter, got %+v", result.Permissions.AppliedFilters)
+	}
+	for _, recommendation := range result.Permissions.Recommendations {
+		if !awsRuntimeEventMatchesAny("prod/ai/openai-key", awsLeastPrivilegeResourceMatchValues(recommendation)...) {
+			t.Fatalf("resource-filtered permissions leaked unrelated recommendation: %+v", recommendation)
+		}
+	}
+}
+
 func TestGetAWSAgentIdentityDetailUnknownAgentIsExplicit(t *testing.T) {
 	now := time.Date(2026, 7, 3, 20, 15, 0, 0, time.UTC)
 	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-unknown", now)
@@ -556,6 +579,105 @@ func TestAWSAgentIdentityDetailKeepsRoleWideButFiltersOtherAgentToolRecommendati
 	}
 	if _, ok := gotCases["case-other-agent-tool"]; ok {
 		t.Fatalf("other agent tool case must be filtered out: %+v", scopedCases.Cases)
+	}
+}
+
+func TestAWSAgentIdentityDetailMergesAgentScopedRemediationCases(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	agentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent"
+	otherAgentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v2"
+	record := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       agentNode,
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+	}
+	roleCases := AWSRemediationCaseResult{
+		AppliedFilters: map[string]string{"identity": roleNode},
+		Cases: []AWSRemediationCase{
+			{
+				CaseID:         "case-role-wide",
+				SourceType:     "least_privilege",
+				Lifecycle:      "proposed",
+				Severity:       "high",
+				Status:         "open",
+				ApprovalState:  "pending",
+				IdentityNodeID: roleNode,
+				IdentityARN:    roleARN,
+				IdentityName:   "shared-agent-runtime",
+				Score:          80,
+				Confidence:     0.85,
+				ImpactedNodes:  []string{roleNode, "aws:s3:bucket/shared"},
+			},
+		},
+	}
+	agentCases := AWSRemediationCaseResult{
+		AppliedFilters: map[string]string{"identity": agentNode},
+		Cases: []AWSRemediationCase{
+			{
+				CaseID:          "case-selected-agent-risk",
+				SourceType:      "ai_agent_risk",
+				SourceFindingID: "risk-selected",
+				Lifecycle:       "proposed",
+				Severity:        "medium",
+				Status:          "open",
+				ApprovalState:   "pending",
+				IdentityNodeID:  agentNode,
+				IdentityName:    "agent",
+				IdentityType:    "ai_agent",
+				Score:           70,
+				Confidence:      0.8,
+				ImpactedNodes:   []string{agentNode, roleNode, "aws:s3:bucket/tickets"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: agentNode, NodeType: "ai_agent", Label: "agent"},
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: "aws:s3:bucket/tickets", NodeType: "target_resource", Label: "tickets"},
+				},
+			},
+			{
+				CaseID:          "case-other-agent-risk",
+				SourceType:      "ai_agent_risk",
+				SourceFindingID: "risk-other",
+				Lifecycle:       "proposed",
+				Severity:        "medium",
+				Status:          "open",
+				ApprovalState:   "pending",
+				IdentityNodeID:  otherAgentNode,
+				IdentityName:    "agent-v2",
+				IdentityType:    "ai_agent",
+				Score:           68,
+				Confidence:      0.8,
+				ImpactedNodes:   []string{otherAgentNode, roleNode, "aws:s3:bucket/archive"},
+				ImpactedPath: []AWSLeastPrivilegePathStep{
+					{NodeID: otherAgentNode, NodeType: "ai_agent", Label: "agent-v2"},
+					{NodeID: roleNode, NodeType: "identity", Label: "shared-agent-runtime"},
+					{NodeID: "aws:s3:bucket/archive", NodeType: "target_resource", Label: "archive"},
+				},
+			},
+		},
+	}
+
+	merged := awsAgentIdentityDetailMergeRemediationCaseResults(roleCases, agentCases, roleNode, agentNode)
+	scoped := awsAgentIdentityDetailScopeRemediationCases(merged, record, roleNode)
+	got := map[string]struct{}{}
+	for _, c := range scoped.Cases {
+		got[c.CaseID] = struct{}{}
+	}
+	if _, ok := got["case-role-wide"]; !ok {
+		t.Fatalf("role-wide remediation case must be retained: %+v", scoped.Cases)
+	}
+	if _, ok := got["case-selected-agent-risk"]; !ok {
+		t.Fatalf("selected agent-scoped remediation case must be retained: %+v", scoped.Cases)
+	}
+	if _, ok := got["case-other-agent-risk"]; ok {
+		t.Fatalf("other agent remediation case must be filtered out: %+v", scoped.Cases)
+	}
+	if scoped.AppliedFilters["identity"] != roleNode || scoped.AppliedFilters["agent_identity"] != agentNode {
+		t.Fatalf("merged remediation filters must expose role and agent identities, got %+v", scoped.AppliedFilters)
+	}
+	if scoped.Summary.FilteredCases != len(scoped.Cases) || scoped.Summary.RelationshipCount != len(scoped.Relationships) {
+		t.Fatalf("merged remediation summary must match scoped cases: summary=%+v relationships=%+v", scoped.Summary, scoped.Relationships)
 	}
 }
 

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -856,6 +856,126 @@ func TestAWSAgentIdentityDetailGovernanceFiltersPreferRoleThenAgent(t *testing.T
 	}
 }
 
+func TestAWSAgentIdentityDetailGovernanceAlternateFiltersCoverExactKeys(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	roleRecord := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+	}
+	alternates := awsAgentIdentityDetailGovernanceAlternateFilters(roleRecord, true, roleNode, "")
+	gotIdentities := map[string]struct{}{}
+	gotAgents := map[string]struct{}{}
+	for _, alternate := range alternates {
+		if alternate.IdentityID != "" {
+			gotIdentities[alternate.IdentityID] = struct{}{}
+		}
+		if alternate.AgentID != "" {
+			gotAgents[alternate.AgentID] = struct{}{}
+		}
+	}
+	if _, ok := gotIdentities[roleNode]; ok {
+		t.Fatalf("primary identity filter must not repeat as an alternate: %+v", alternates)
+	}
+	if _, ok := gotIdentities[roleARN]; !ok {
+		t.Fatalf("raw role ARN identity must be queried as an alternate: %+v", alternates)
+	}
+	if _, ok := gotAgents[roleRecord.AgentNodeID]; !ok {
+		t.Fatalf("agent node key must be queried as an alternate for role-backed agents: %+v", alternates)
+	}
+	if _, ok := gotAgents[roleRecord.AgentID]; !ok {
+		t.Fatalf("agent id key must be queried as an alternate for role-backed agents: %+v", alternates)
+	}
+
+	rolelessRecord := AWSAIAgentIdentityRecord{
+		AgentID:     "custom-agent",
+		AgentNodeID: "aws:agent:123456789012:us-east-1:custom_agent/custom-agent",
+	}
+	rolelessAlternates := awsAgentIdentityDetailGovernanceAlternateFilters(rolelessRecord, true, "", rolelessRecord.AgentNodeID)
+	if len(rolelessAlternates) != 1 || rolelessAlternates[0].AgentID != rolelessRecord.AgentID || rolelessAlternates[0].IdentityID != "" {
+		t.Fatalf("roleless agents must query the alternate exact agent id only: %+v", rolelessAlternates)
+	}
+
+	if alternates := awsAgentIdentityDetailGovernanceAlternateFilters(AWSAIAgentIdentityRecord{}, false, "", "unresolved-sentinel"); len(alternates) != 0 {
+		t.Fatalf("unresolved agents must not fan out governance queries: %+v", alternates)
+	}
+}
+
+func TestAWSAgentIdentityDetailScopesGovernanceToSelectedAgent(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	record := AWSAIAgentIdentityRecord{
+		AgentID:           "agent",
+		AgentNodeID:       "aws:agent:123456789012:us-east-1:custom_agent/agent",
+		RuntimeRoleARN:    roleARN,
+		RuntimeRoleNodeID: roleNode,
+	}
+	otherAgentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent-v2"
+	occurred := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	governance := AWSGovernanceAuditReportingResult{
+		Records: []AWSGovernanceAuditReportRecord{
+			{ReportID: "report-role-wide", Category: "approval", SourceType: "least_privilege", DecisionType: "remediation_approval", State: "pending", IdentityNodeID: roleNode, OccurredAt: occurred},
+			{ReportID: "report-selected-agent", Category: "decision", SourceType: "agentcore_gateway_policy_advisory", DecisionType: "agentcore_gateway_policy_advisory", State: "advisory", IdentityNodeID: roleNode, AgentID: record.AgentID, AgentNodeID: record.AgentNodeID, OccurredAt: occurred},
+			{ReportID: "report-sibling-agent", Category: "decision", SourceType: "agentcore_gateway_policy_advisory", DecisionType: "agentcore_gateway_policy_advisory", State: "advisory", IdentityNodeID: roleNode, AgentID: "agent-v2", AgentNodeID: otherAgentNode, OccurredAt: occurred},
+		},
+	}
+
+	scoped := awsAgentIdentityDetailScopeGovernance(governance, record)
+	got := map[string]struct{}{}
+	for _, candidate := range scoped.Records {
+		got[candidate.ReportID] = struct{}{}
+	}
+	if _, ok := got["report-role-wide"]; !ok {
+		t.Fatalf("role-wide governance rows must be retained: %+v", scoped.Records)
+	}
+	if _, ok := got["report-selected-agent"]; !ok {
+		t.Fatalf("selected-agent governance rows must be retained: %+v", scoped.Records)
+	}
+	if _, ok := got["report-sibling-agent"]; ok {
+		t.Fatalf("sibling-agent governance rows sharing the runtime role must be filtered out: %+v", scoped.Records)
+	}
+	if scoped.Summary.FilteredRecords != len(scoped.Records) || scoped.Summary.TotalRecords != len(scoped.Records) {
+		t.Fatalf("governance summary must be recomputed from scoped records: %+v", scoped.Summary)
+	}
+}
+
+func TestAWSAgentIdentityDetailMergesGovernanceResults(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/shared-agent-runtime"
+	roleNode := awsIdentityNodeIDForAPI(roleARN)
+	agentNode := "aws:agent:123456789012:us-east-1:custom_agent/agent"
+	occurred := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	roleGovernance := AWSGovernanceAuditReportingResult{
+		AppliedFilters: map[string]string{"identity_id": roleNode},
+		Records: []AWSGovernanceAuditReportRecord{
+			{ReportID: "report-role-wide", Category: "approval", SourceType: "least_privilege", DecisionType: "remediation_approval", State: "pending", IdentityNodeID: roleNode, OccurredAt: occurred},
+			{ReportID: "report-shared", Category: "decision", SourceType: "agentcore_gateway_policy_advisory", DecisionType: "agentcore_gateway_policy_advisory", State: "advisory", IdentityNodeID: roleNode, AgentNodeID: agentNode, OccurredAt: occurred},
+		},
+	}
+	agentGovernance := AWSGovernanceAuditReportingResult{
+		AppliedFilters: map[string]string{"agent_id": agentNode},
+		Records: []AWSGovernanceAuditReportRecord{
+			{ReportID: "report-shared", Category: "decision", SourceType: "agentcore_gateway_policy_advisory", DecisionType: "agentcore_gateway_policy_advisory", State: "advisory", IdentityNodeID: roleNode, AgentNodeID: agentNode, OccurredAt: occurred},
+			{ReportID: "report-agent-only", Category: "decision", SourceType: "agentcore_gateway_policy_advisory", DecisionType: "agentcore_gateway_policy_advisory", State: "advisory", AgentNodeID: agentNode, OccurredAt: occurred.Add(time.Hour)},
+		},
+	}
+
+	merged := awsAgentIdentityDetailMergeGovernanceResults(roleGovernance, agentGovernance, []string{roleNode}, []string{"", agentNode})
+	if len(merged.Records) != 3 {
+		t.Fatalf("merged governance must dedupe shared report rows, got %+v", merged.Records)
+	}
+	if merged.Records[0].ReportID != "report-agent-only" {
+		t.Fatalf("merged governance must stay sorted by occurred_at desc: %+v", merged.Records)
+	}
+	if merged.Summary.FilteredRecords != 3 || merged.Summary.TotalRecords != 3 {
+		t.Fatalf("merged governance summary must be recomputed: %+v", merged.Summary)
+	}
+	if merged.AppliedFilters["identity_id"] != roleNode || merged.AppliedFilters["agent_id"] != agentNode {
+		t.Fatalf("merged governance filters must expose the role identity and agent keys: %+v", merged.AppliedFilters)
+	}
+}
+
 func TestAWSAgentIdentityDetailSecretReferencesAreMetadataOnly(t *testing.T) {
 	record := AWSAIAgentIdentityRecord{
 		AgentID: "agent-1",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2869,6 +2869,43 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"detail": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/agent-identity-detail", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSAgentIdentityDetail(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSAgentIdentityDetailRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			Agent:        strings.TrimSpace(c.Query("agent")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Tab:          strings.TrimSpace(c.Query("tab")),
+			Tool:         strings.TrimSpace(c.Query("tool")),
+			Resource:     strings.TrimSpace(c.Query("resource")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Status:       strings.TrimSpace(c.Query("status")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws agent identity detail request"})
+			default:
+				logger.Error("get aws agent identity detail",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					zap.String("agent", c.Query("agent")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws agent identity detail"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"detail": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
   ProductAWSGraphPage,
   ProductAWSRemediationPage,
   ProductAWSRuntimePage,
+  ProductAWSAgentIdentityDetailPage,
   ProductAWSMachineIdentityDetailPage,
   ProductDomainRoutePage,
   ProductAWSConnectPage,
@@ -4822,6 +4823,7 @@ export function RoutedSite() {
             <Route path="aws/identities" element={<ProductAWSIdentitiesPage />} />
             <Route path="aws/identities/detail" element={<ProductAWSMachineIdentityDetailPage />} />
             <Route path="aws/agents" element={<ProductAWSAgentsPage />} />
+            <Route path="aws/agents/detail" element={<ProductAWSAgentIdentityDetailPage />} />
             <Route path="aws/resources" element={<ProductAWSResourcesPage />} />
             <Route path="aws/runtime" element={<ProductAWSRuntimePage />} />
             <Route path="aws/graph" element={<ProductAWSGraphPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2295,6 +2295,180 @@ export type AWSMachineIdentityDetailResult = {
   updated_at: string;
 };
 
+export type AWSAgentIdentityDetailStatus = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied' | 'unknown' | string;
+
+export type AWSAgentIdentityDetailQuery = {
+  connectorID?: string;
+  fixtureState?: AWSMachineIdentityDetailFixtureState;
+  agent: string;
+  accountID?: string;
+  region?: string;
+  tab?: string;
+  tool?: string;
+  resource?: string;
+  severity?: string;
+  status?: string;
+};
+
+export type AWSAgentIdentityDetailAgent = {
+  agent: string;
+  agent_id?: string;
+  agent_arn?: string;
+  agent_node_id?: string;
+  agent_name?: string;
+  agent_type?: string;
+  display_name: string;
+  provider?: string;
+  model_id?: string;
+  service?: string;
+  runtime_version?: string;
+  runtime_role_arn?: string;
+  runtime_role_name?: string;
+  runtime_role_node_id?: string;
+  gateway_id?: string;
+  gateway_node_id?: string;
+  external_provider?: string;
+  auth_mode?: string;
+  account_id?: string;
+  region?: string;
+  status: string;
+  resolved: boolean;
+  candidate: boolean;
+  low_confidence: boolean;
+  confidence: number;
+  coverage_status?: string;
+  coverage_reason?: string;
+  evidence_ref?: string;
+  evidence_boundary: string;
+};
+
+export type AWSAgentIdentityToolSummary = {
+  tool_name: string;
+  tool_target_ref?: string;
+  declared: boolean;
+  observed: boolean;
+  status: string;
+  observed_count: number;
+  evidence_ref?: string;
+  last_observed?: string;
+};
+
+export type AWSAgentIdentityCapabilitySummary = {
+  capability: 'memory' | 'browser' | 'code_interpreter' | string;
+  enabled: boolean;
+  reference_refs?: string[];
+  encryption_key_arn?: string;
+};
+
+export type AWSAgentIdentitySecretReference = {
+  reference: string;
+  reference_name?: string;
+  reference_kind: string;
+  provider?: string;
+  sensitivity?: string;
+  resolved: boolean;
+  target_node_id?: string;
+  evidence_ref?: string;
+  confidence: number;
+};
+
+export type AWSAgentIdentityRuntimeCall = {
+  correlation_id: string;
+  tool_name?: string;
+  tool_target_ref?: string;
+  status: string;
+  observed_count: number;
+  outcomes?: string[];
+  target_arns?: string[];
+  evidence_ref?: string;
+  next_action?: string;
+  last_observed?: string;
+};
+
+export type AWSAgentIdentityFindingSummary = {
+  finding_id: string;
+  risk_type: string;
+  severity: string;
+  status: string;
+  score: number;
+  rationale: string;
+  next_action: string;
+  evidence_refs?: string[];
+};
+
+export type AWSAgentIdentityRecommendationSummary = {
+  recommendation_id: string;
+  decision: string;
+  severity: string;
+  status: string;
+  service: string;
+  display_name: string;
+  rationale: string;
+  next_action: string;
+  score: number;
+  confidence: number;
+};
+
+export type AWSAgentIdentityDetailSummary = {
+  tool_count: number;
+  declared_tool_count: number;
+  observed_tool_count: number;
+  undeclared_tool_count: number;
+  capability_count: number;
+  secret_reference_count: number;
+  runtime_call_count: number;
+  finding_count: number;
+  recommendation_count: number;
+  remediation_case_count: number;
+  governance_decision_count: number;
+  relationship_count: number;
+  evidence_link_count: number;
+  diagnostic_count: number;
+  coverage_gap_count: number;
+};
+
+export type AWSAgentIdentityDetailResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSAgentIdentityDetailStatus;
+  fixture_state?: AWSMachineIdentityDetailFixtureState;
+  confidence: number;
+  policy_version: string;
+  applied_filters: Record<string, string>;
+  agent: AWSAgentIdentityDetailAgent;
+  summary: AWSAgentIdentityDetailSummary;
+  tabs: AWSMachineIdentityDetailTab[];
+  tools: AWSAgentIdentityToolSummary[];
+  capabilities: AWSAgentIdentityCapabilitySummary[];
+  secret_references: AWSAgentIdentitySecretReference[];
+  runtime_calls: AWSAgentIdentityRuntimeCall[];
+  findings: AWSAgentIdentityFindingSummary[];
+  recommendations: AWSAgentIdentityRecommendationSummary[];
+  governance_decisions: AWSMachineIdentityGovernanceDecision[];
+  relationships: AWSMachineIdentityDetailRelationship[];
+  runtime_access: AWSAgentRuntimeAccessResult;
+  risk: AWSAIAgentRiskResult;
+  permissions: AWSLeastPrivilegeResult;
+  remediation_cases: AWSRemediationCaseResult;
+  governance: AWSGovernanceAuditReportingResult;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSMachineIdentityDetailCoverageGap[];
+  diagnostics: AWSMachineIdentityDetailDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSRuntimeEventStatus = 'ready' | 'degraded' | 'blocked';
 // AWSRuntimeEventFixtureStateRequest is the query-side enum: every
 // value here is one the backend accepts as `?fixture_state=...`. It
@@ -9921,6 +10095,28 @@ export const apiClient = {
         region: query.region,
         tab: query.tab,
         service: query.service,
+        resource: query.resource,
+        severity: query.severity,
+        status: query.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectAgentIdentityDetail(
+    workspaceID: string,
+    projectID: string,
+    query: AWSAgentIdentityDetailQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ detail: AWSAgentIdentityDetailResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/agent-identity-detail${buildQuery({
+        connector_id: query.connectorID,
+        fixture_state: query.fixtureState,
+        agent: query.agent,
+        account_id: query.accountID,
+        region: query.region,
+        tab: query.tab,
+        tool: query.tool,
         resource: query.resource,
         severity: query.severity,
         status: query.status

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -6,6 +6,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/identities',
   '/app/:tenantID/:workspaceID/aws/identities/detail',
   '/app/:tenantID/:workspaceID/aws/agents',
+  '/app/:tenantID/:workspaceID/aws/agents/detail',
   '/app/:tenantID/:workspaceID/aws/resources',
   '/app/:tenantID/:workspaceID/aws/runtime',
   '/app/:tenantID/:workspaceID/aws/graph',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -6,6 +6,8 @@ import type {
   AWSConnectorStartResponse,
   AWSCodeBuildServiceRoleInventoryResult,
   AWSConnectionStatus,
+  AWSAIAgentIdentityInventoryResult,
+  AWSBedrockAgentsInventoryResult,
   AWSEC2InstanceProfileInventoryResult,
   AWSEKSWorkloadIdentityInventoryResult,
   AWSECSTaskRoleInventoryResult,
@@ -3514,6 +3516,160 @@ describe('Domain-first app routes', () => {
     expect(screen.getAllByText(/Bedrock agents/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/AgentCore runtime and gateway identity/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Secret metadata only, no value reads/i)).toBeInTheDocument();
+  });
+
+  it('links AWS agent identity rows with the unique agent node id', async () => {
+    const api = await import('./api/client');
+    const agentNodeID = 'aws:agent:123456789012:us-east-1:agentcore_runtime/shared-agent/2026-07';
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    vi.spyOn(api.apiClient, 'getAWSProjectAIAgentIdentities').mockResolvedValue({
+      inventory: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        account_id: '123456789012',
+        region: 'us-east-1',
+        parent_issue_number: 1472,
+        parent_issue_ref: '#1472',
+        current_issue_number: 1512,
+        current_issue_ref: '#1512',
+        version: 'aws-ai-agent-identities-v1',
+        status: 'ready',
+        fixture_state: 'success',
+        confidence: 0.92,
+        applied_filters: {},
+        record_count: 1,
+        total_record_count: 1,
+        filtered_record_count: 1,
+        bedrock_agent_count: 0,
+        agentcore_runtime_count: 1,
+        custom_agent_count: 0,
+        external_agent_count: 0,
+        gateway_count: 0,
+        capability_agent_count: 0,
+        memory_store_count: 0,
+        browser_count: 0,
+        code_interpreter_count: 0,
+        runtime_role_count: 1,
+        provider_count: 1,
+        model_count: 1,
+        tool_count: 1,
+        capability_count: 1,
+        credential_reference_count: 0,
+        external_provider_key_count: 0,
+        ai_provider_key_count: 0,
+        provider_key_breakdown: {},
+        relationship_count: 1,
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: ['/docs/aws-ai-agent-identities'],
+        coverage_gaps: [],
+        diagnostics: [],
+        relationships: [],
+        records: [
+          {
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'agentcore',
+            agent_id: 'shared-agent',
+            agent_name: 'Shared Agent Runtime',
+            agent_type: 'agentcore_runtime',
+            runtime_version: '2026-07',
+            provider: 'amazon-bedrock-agentcore',
+            model_id: 'amazon.nova-pro',
+            runtime_role_arn: 'arn:aws:iam::123456789012:role/shared-agent-runtime',
+            runtime_role_name: 'shared-agent-runtime',
+            tool_names: ['case-router'],
+            allowed_actions: ['invoke_tool'],
+            memory_enabled: false,
+            browser_enabled: false,
+            code_interpreter_enabled: false,
+            capability_names: ['tool_use'],
+            sensitive_boundary: 'metadata_only',
+            coverage_status: 'covered',
+            source: 'ai_agent_metadata',
+            evidence_ref: 'evidence://agent/shared-agent',
+            agent_node_id: agentNodeID,
+            runtime_role_node_id: 'aws:identity:arn:aws:iam::123456789012:role/shared-agent-runtime',
+            relationship_types: ['runs_as'],
+            confidence: 0.92,
+            collected_at: '2026-07-03T19:00:00Z',
+            status: 'ready'
+          }
+        ],
+        generated_at: '2026-07-03T19:00:00Z',
+        updated_at: '2026-07-03T19:00:00Z'
+      } satisfies AWSAIAgentIdentityInventoryResult
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectBedrockAgents').mockResolvedValue({
+      inventory: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production',
+        connector_id: 'aws-connector-1',
+        account_id: '123456789012',
+        region: 'us-east-1',
+        parent_issue_number: 1472,
+        parent_issue_ref: '#1472',
+        current_issue_number: 1512,
+        current_issue_ref: '#1512',
+        version: 'aws-bedrock-agents-v1',
+        status: 'ready',
+        fixture_state: 'success',
+        confidence: 0.9,
+        agent_count: 0,
+        filtered_agent_count: 0,
+        guardrail_count: 0,
+        knowledge_base_count: 0,
+        tool_count: 0,
+        credential_reference_count: 0,
+        runtime_role_count: 0,
+        model_count: 0,
+        provider_breakdown: {},
+        status_breakdown: {},
+        relationship_count: 0,
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: ['/docs/aws-bedrock-agents'],
+        coverage_gaps: [],
+        records: [],
+        relationships: [],
+        diagnostics: [],
+        generated_at: '2026-07-03T19:00:00Z',
+        updated_at: '2026-07-03T19:00:00Z'
+      } satisfies AWSBedrockAgentsInventoryResult
+    });
+
+    const { ProductAWSAgentsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/agents?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/agents" element={<ProductAWSAgentsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const link = await screen.findByRole('link', { name: 'Shared Agent Runtime' });
+    expect(link).toHaveAttribute(
+      'href',
+      `/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=${encodeURIComponent(agentNodeID)}&tab=overview`
+    );
   });
 
   it('translates AWS runtime filter aliases before querying runtime events', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -11,6 +11,7 @@ import type {
   AWSECSTaskRoleInventoryResult,
   AWSLambdaExecutionRoleInventoryResult,
   AWSLeastPrivilegeResult,
+  AWSAgentIdentityDetailResult,
   AWSMachineIdentityDetailResult,
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
@@ -2674,6 +2675,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/identities',
       '/app/:tenantID/:workspaceID/aws/identities/detail',
       '/app/:tenantID/:workspaceID/aws/agents',
+      '/app/:tenantID/:workspaceID/aws/agents/detail',
       '/app/:tenantID/:workspaceID/aws/resources',
       '/app/:tenantID/:workspaceID/aws/runtime',
       '/app/:tenantID/:workspaceID/aws/graph',
@@ -3264,6 +3266,212 @@ describe('Domain-first app routes', () => {
       {
         connectorID: 'aws-connector-1',
         identity,
+        tab: 'runtime'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      }
+    );
+  });
+
+  it('renders AWS agent identity detail scoped to the selected agent and tab', async () => {
+    const api = await import('./api/client');
+    const agent = 'AGENTSUPPORT1';
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const agentIdentityDetail = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      parent_issue_number: 1472,
+      parent_issue_ref: '#1472',
+      current_issue_number: 1550,
+      current_issue_ref: '#1550',
+      version: 'aws-agent-identity-detail-page-v1',
+      status: 'success',
+      fixture_state: 'success',
+      confidence: 0.88,
+      policy_version: 'aws-agent-identity-detail-policy-v1',
+      applied_filters: { agent },
+      agent: {
+        agent,
+        agent_id: agent,
+        agent_node_id: 'aws:agent:bedrock:AGENTSUPPORT1',
+        agent_name: 'support-assistant',
+        agent_type: 'bedrock_agent',
+        display_name: 'support-assistant',
+        provider: 'bedrock',
+        model_id: 'anthropic.claude-3-sonnet',
+        service: 'bedrock',
+        runtime_version: '2026-07',
+        runtime_role_arn: 'arn:aws:iam::123456789012:role/bedrock-support-agent',
+        runtime_role_name: 'bedrock-support-agent',
+        account_id: '123456789012',
+        region: 'us-east-1',
+        status: 'active',
+        resolved: true,
+        candidate: false,
+        low_confidence: false,
+        confidence: 0.88,
+        evidence_boundary: 'metadata_only_no_secret_values_no_prompt_text_no_tool_payloads_no_workload_data_tenant_workspace_project_connector_account_region_scoped'
+      },
+      summary: {
+        tool_count: 1,
+        declared_tool_count: 1,
+        observed_tool_count: 1,
+        undeclared_tool_count: 0,
+        capability_count: 1,
+        secret_reference_count: 1,
+        runtime_call_count: 1,
+        finding_count: 1,
+        recommendation_count: 1,
+        remediation_case_count: 0,
+        governance_decision_count: 0,
+        relationship_count: 0,
+        evidence_link_count: 1,
+        diagnostic_count: 0,
+        coverage_gap_count: 0
+      },
+      tabs: [
+        { id: 'overview', label: 'Overview', status: 'success', count: 2 },
+        { id: 'tools', label: 'Tools', status: 'success', count: 1 },
+        { id: 'runtime', label: 'Runtime', status: 'success', count: 1 },
+        { id: 'secrets', label: 'Secrets', status: 'success', count: 1 },
+        { id: 'findings', label: 'Findings', status: 'success', count: 1 },
+        { id: 'recommendations', label: 'Recommendations', status: 'success', count: 1 },
+        { id: 'remediation', label: 'Remediation', status: 'empty', count: 0 },
+        { id: 'governance', label: 'Governance', status: 'empty', count: 0 }
+      ],
+      tools: [
+        {
+          tool_name: 'invoke-knowledge-base',
+          tool_target_ref: 'bedrock://knowledge-base/support',
+          declared: true,
+          observed: true,
+          status: 'confirmed',
+          observed_count: 3,
+          evidence_ref: 'evidence://agent/tools/support'
+        }
+      ],
+      capabilities: [
+        { capability: 'memory', enabled: true, reference_refs: ['memory://support-session'], encryption_key_arn: 'arn:aws:kms:us-east-1:123456789012:key/support' },
+        { capability: 'browser', enabled: false },
+        { capability: 'code_interpreter', enabled: false }
+      ],
+      secret_references: [
+        {
+          reference: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:support/provider-key',
+          reference_name: 'support-provider-key',
+          reference_kind: 'secretsmanager_secret',
+          provider: 'anthropic',
+          sensitivity: 'external_provider_key',
+          resolved: true,
+          confidence: 0.9
+        }
+      ],
+      runtime_calls: [
+        {
+          correlation_id: 'agent-runtime-call-1',
+          tool_name: 'invoke-knowledge-base',
+          tool_target_ref: 'bedrock://knowledge-base/support',
+          status: 'confirmed',
+          observed_count: 3,
+          outcomes: ['allowed'],
+          target_arns: ['arn:aws:bedrock:us-east-1:123456789012:knowledge-base/support'],
+          evidence_ref: 'evidence://agent/runtime/support',
+          next_action: 'Review knowledge-base access.',
+          last_observed: '2026-07-03T19:00:00Z'
+        }
+      ],
+      findings: [
+        {
+          finding_id: 'aws-ai-agent-risk:support-provider-key',
+          risk_type: 'external_credential_exposure',
+          severity: 'high',
+          status: 'review',
+          score: 86,
+          rationale: 'Agent references an external provider key.',
+          next_action: 'Rotate provider key and scope runtime role.'
+        }
+      ],
+      recommendations: [
+        {
+          recommendation_id: 'aws-least-privilege:agent-runtime-role',
+          decision: 'review',
+          severity: 'medium',
+          status: 'review',
+          service: 'bedrock',
+          display_name: 'Scope support agent runtime role',
+          rationale: 'Runtime role has broader Bedrock access than observed calls need.',
+          next_action: 'Approve a scoped policy update.',
+          score: 73,
+          confidence: 0.86
+        }
+      ],
+      governance_decisions: [],
+      relationships: [],
+      runtime_access: { records: [] },
+      risk: { findings: [] },
+      permissions: readyAWSLeastPrivilege,
+      remediation_cases: { cases: [] },
+      governance: { records: [] },
+      failure_reasons: [],
+      remediation_hints: [],
+      evidence_links: ['/docs/aws-agent-identity-detail'],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-07-03T19:05:00Z',
+      updated_at: '2026-07-03T19:05:00Z'
+    } as unknown as AWSAgentIdentityDetailResult;
+    const getAgentIdentityDetail = vi
+      .spyOn(api.apiClient, 'getAWSProjectAgentIdentityDetail')
+      .mockResolvedValue({ detail: agentIdentityDetail });
+
+    const { ProductAWSAgentIdentityDetailPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          `/app/tenant-a/workspace-a/aws/agents/detail?environment=production&agent=${encodeURIComponent(agent)}&tab=runtime`
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/agents/detail"
+            element={<ProductAWSAgentIdentityDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'support-assistant' })).toBeInTheDocument();
+    expect(screen.getByText('metadata_only_no_secret_values_no_prompt_text_no_tool_payloads_no_workload_data_tenant_workspace_project_connector_account_region_scoped')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Runtime\s+1/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('table', { name: 'Agent identity runtime calls' })).toBeInTheDocument();
+    expect(screen.getByText('invoke-knowledge-base')).toBeInTheDocument();
+    expect(getAgentIdentityDetail).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      {
+        connectorID: 'aws-connector-1',
+        agent,
         tab: 'runtime'
       },
       {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -45,6 +45,7 @@ import {
   type AWSAIAgentIdentityQuery,
   type AWSAIAgentIdentityInventoryResult,
   type AWSMachineIdentityDetailResult,
+  type AWSAgentIdentityDetailResult,
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
@@ -3125,6 +3126,29 @@ function awsMachineIdentityDetailLink(
   return `${buildScopedPath(scope, 'aws/identities/detail')}${search ? `?${search}` : ''}`;
 }
 
+function awsAgentIdentityDetailLink(
+  scope: ProductSession,
+  environmentID: string,
+  agent: string,
+  tab = 'overview'
+): string {
+  const params = new URLSearchParams();
+  const normalizedEnvironmentID = normalizeValue(environmentID);
+  const normalizedAgent = normalizeValue(agent);
+  const normalizedTab = normalizeValue(tab);
+  if (normalizedEnvironmentID) {
+    params.set(ENVIRONMENT_QUERY_PARAM, normalizedEnvironmentID);
+  }
+  if (normalizedAgent) {
+    params.set('agent', normalizedAgent);
+  }
+  if (normalizedTab) {
+    params.set('tab', normalizedTab);
+  }
+  const search = params.toString();
+  return `${buildScopedPath(scope, 'aws/agents/detail')}${search ? `?${search}` : ''}`;
+}
+
 function AWSConnectionDiagnostics({
   connection,
   emptyLabel = 'No diagnostics reported for this environment.'
@@ -3722,6 +3746,7 @@ type AWSInventoryTableRow = AWSInventoryFilterable & {
   id: string;
   name: string;
   detailIdentity?: string;
+  detailAgent?: string;
   category: string;
   scope: string;
   status: string;
@@ -5686,7 +5711,9 @@ function AWSMachineIdentitiesContent({
               render: (row) => (
                 <div className="idt-aws-inventory-table-cell">
                   <strong>
-                    {row.detailIdentity ? (
+                    {row.detailAgent ? (
+                      <Link to={awsAgentIdentityDetailLink(scope, selectedEnvironmentID, row.detailAgent)}>{row.name}</Link>
+                    ) : row.detailIdentity ? (
                       <Link to={awsMachineIdentityDetailLink(scope, selectedEnvironmentID, row.detailIdentity)}>{row.name}</Link>
                     ) : (
                       row.name
@@ -7426,6 +7453,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   return {
     id: `ai-agent-identity-${record.agent_node_id || record.agent_id}`,
     name: record.agent_name || record.agent_id,
+    detailAgent: record.agent_id || record.agent_node_id,
     category,
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -10203,6 +10231,530 @@ export function ProductAWSMachineIdentityDetailPage() {
               detail={detail}
             />
             <AWSMachineIdentityDetailTabContent detail={detail} activeTab={activeTab} />
+          </>
+        ) : null}
+      </div>
+    </DomainPageShell>
+  );
+}
+
+const AWS_AGENT_IDENTITY_DETAIL_TAB_IDS = ['overview', 'tools', 'runtime', 'secrets', 'findings', 'recommendations', 'remediation', 'governance'] as const;
+type AWSAgentIdentityDetailTabID = (typeof AWS_AGENT_IDENTITY_DETAIL_TAB_IDS)[number];
+const AWS_AGENT_IDENTITY_DETAIL_TAB_LABELS: Record<AWSAgentIdentityDetailTabID, string> = {
+  overview: 'Overview',
+  tools: 'Tools',
+  runtime: 'Runtime',
+  secrets: 'Secrets',
+  findings: 'Findings',
+  recommendations: 'Recommendations',
+  remediation: 'Remediation',
+  governance: 'Governance'
+};
+
+function normalizeAWSAgentIdentityDetailTab(value: string | null): AWSAgentIdentityDetailTabID {
+  const normalized = normalizeValue(value ?? '').toLowerCase();
+  return AWS_AGENT_IDENTITY_DETAIL_TAB_IDS.includes(normalized as AWSAgentIdentityDetailTabID)
+    ? (normalized as AWSAgentIdentityDetailTabID)
+    : 'overview';
+}
+
+function awsAgentIdentityDetailStage(status: string): AWSCapabilityStage {
+  if (status === 'success') {
+    return 'wired';
+  }
+  if (status === 'permission_denied' || status === 'unknown') {
+    return 'not-available';
+  }
+  return 'coming';
+}
+
+function awsAgentIdentityDetailTone(status: string): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (status === 'success') {
+    return 'success';
+  }
+  if (status === 'permission_denied') {
+    return 'danger';
+  }
+  if (status === 'degraded' || status === 'partial_failure') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function awsAgentIdentityDetailDescription(detail: AWSAgentIdentityDetailResult | null, agent: string): string {
+  if (detail?.agent.runtime_role_arn) {
+    return detail.agent.runtime_role_arn;
+  }
+  if (detail?.agent.agent_node_id) {
+    return detail.agent.agent_node_id;
+  }
+  return agent || 'Select an AI agent from the AWS agents inventory.';
+}
+
+function AWSAgentIdentityDetailTabs({
+  scope,
+  selectedEnvironmentID,
+  agent,
+  activeTab,
+  detail
+}: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
+  agent: string;
+  activeTab: AWSAgentIdentityDetailTabID;
+  detail: AWSAgentIdentityDetailResult | null;
+}) {
+  const tabCounts = new Map((detail?.tabs ?? []).map((tab) => [tab.id, tab.count]));
+  return (
+    <div className="idt-inline-actions" role="tablist" aria-label="Agent identity detail tabs">
+      {AWS_AGENT_IDENTITY_DETAIL_TAB_IDS.map((tabID) => (
+        <Link
+          key={tabID}
+          role="tab"
+          aria-selected={activeTab === tabID}
+          aria-label={`${AWS_AGENT_IDENTITY_DETAIL_TAB_LABELS[tabID]} ${tabCounts.get(tabID) ?? 0}`}
+          className={`idt-btn ${activeTab === tabID ? 'idt-btn-primary' : 'idt-btn-ghost'}`}
+          to={awsAgentIdentityDetailLink(scope, selectedEnvironmentID, agent, tabID)}
+        >
+          <span>{AWS_AGENT_IDENTITY_DETAIL_TAB_LABELS[tabID]}</span>
+          <span>{tabCounts.get(tabID) ?? 0}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function AWSAgentIdentityDetailDiagnostics({ detail }: { detail: AWSAgentIdentityDetailResult }) {
+  return (
+    <>
+      {detail.failure_reasons.length || detail.remediation_hints.length ? (
+        <DomainStatusPanel
+          eyebrow="State"
+          title="Detail readiness"
+          status={formatTokenLabel(detail.status)}
+          tone={awsAgentIdentityDetailTone(detail.status)}
+        >
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Failures</dt>
+              <dd>{detail.failure_reasons.length ? detail.failure_reasons.join(', ') : 'None'}</dd>
+            </div>
+            <div>
+              <dt>Next actions</dt>
+              <dd>{detail.remediation_hints.length ? detail.remediation_hints.join(', ') : 'None'}</dd>
+            </div>
+          </dl>
+        </DomainStatusPanel>
+      ) : null}
+      {detail.diagnostics.length ? (
+        <DomainStatusPanel
+          eyebrow="Collectors"
+          title="Diagnostics"
+          status={`${detail.diagnostics.length} active`}
+          tone={detail.status === 'permission_denied' ? 'danger' : 'warning'}
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="Agent identity detail diagnostics">
+            {detail.diagnostics.map((diagnostic) => (
+              <article key={`${diagnostic.collector}-${diagnostic.source_id ?? diagnostic.code}-${diagnostic.message}`}>
+                <strong>{formatTokenLabel(diagnostic.code)}</strong>
+                <p>{diagnostic.message}</p>
+                {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+      {detail.coverage_gaps.length ? (
+        <DomainStatusPanel
+          eyebrow="Coverage"
+          title="Evidence gaps"
+          status={`${detail.coverage_gaps.length} gaps`}
+          tone="warning"
+        >
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="Agent identity detail coverage gaps">
+            {detail.coverage_gaps.map((gap) => (
+              <article key={`${gap.capability}-${gap.status}-${gap.reason}`}>
+                <strong>{formatTokenLabel(gap.capability)}</strong>
+                <p>{gap.reason}</p>
+                {gap.remediation ? <small>{gap.remediation}</small> : null}
+              </article>
+            ))}
+          </div>
+        </DomainStatusPanel>
+      ) : null}
+    </>
+  );
+}
+
+function AWSAgentIdentityDetailTabContent({
+  detail,
+  activeTab
+}: {
+  detail: AWSAgentIdentityDetailResult;
+  activeTab: AWSAgentIdentityDetailTabID;
+}) {
+  if (activeTab === 'overview') {
+    return (
+      <>
+        <DomainDataTable
+          label="Agent identity capabilities"
+          rows={detail.capabilities}
+          getRowKey={(row) => row.capability}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No capabilities" body="No memory, browser, or code-interpreter capability metadata matched this agent." />}
+          columns={[
+            { key: 'capability', header: 'Capability', render: (row) => <strong>{formatTokenLabel(row.capability)}</strong> },
+            { key: 'state', header: 'State', render: (row) => (row.enabled ? 'Enabled' : 'Not enabled') },
+            { key: 'references', header: 'References', render: (row) => row.reference_refs?.join(', ') || row.encryption_key_arn || '-' }
+          ]}
+        />
+        <DomainDataTable
+          label="Agent identity relationships"
+          rows={detail.relationships}
+          getRowKey={(row) => `${row.source}-${row.type}-${row.from_node_id}-${row.to_node_id}-${row.evidence_ref ?? ''}`}
+          emptyState={<DomainEmptyState eyebrow="Empty" title="No relationships" body="No graph relationships matched this agent yet." />}
+          columns={[
+            { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source) },
+            { key: 'type', header: 'Relationship', render: (row) => formatTokenLabel(row.type) },
+            { key: 'from', header: 'From', render: (row) => row.from_node_id },
+            { key: 'to', header: 'To', render: (row) => row.to_node_id },
+            { key: 'evidence', header: 'Evidence', render: (row) => row.evidence_ref || '-' }
+          ]}
+        />
+      </>
+    );
+  }
+
+  if (activeTab === 'tools') {
+    return (
+      <DomainDataTable
+        label="Agent identity tools"
+        rows={detail.tools}
+        getRowKey={(row) => `${row.tool_name}-${row.tool_target_ref ?? ''}-${row.status}`}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No tools" body="No declared or observed tools matched this agent." />}
+        columns={[
+          { key: 'tool', header: 'Tool', render: (row) => <strong>{row.tool_name}</strong> },
+          { key: 'target', header: 'Target', render: (row) => row.tool_target_ref || '-' },
+          { key: 'declared', header: 'Declared', render: (row) => (row.declared ? 'Yes' : 'No') },
+          { key: 'observed', header: 'Observed', render: (row) => `${row.observed ? 'Yes' : 'No'} / ${row.observed_count}` },
+          { key: 'status', header: 'Status', render: (row) => formatTokenLabel(row.status) }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'runtime') {
+    return (
+      <DomainDataTable
+        label="Agent identity runtime calls"
+        rows={detail.runtime_calls}
+        getRowKey={(row) => row.correlation_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No runtime calls" body="No runtime call evidence matched this agent." />}
+        columns={[
+          { key: 'call', header: 'Correlation', render: (row) => <strong>{row.correlation_id}</strong> },
+          { key: 'tool', header: 'Tool', render: (row) => row.tool_name || '-' },
+          { key: 'target', header: 'Target', render: (row) => row.tool_target_ref || row.target_arns?.[0] || '-' },
+          { key: 'observed', header: 'Observed', render: (row) => `${row.observed_count} / ${row.last_observed ? formatDateLabel(row.last_observed) : 'not dated'}` },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action || formatTokenLabel(row.status) }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'secrets') {
+    return (
+      <DomainDataTable
+        label="Agent identity secret references"
+        rows={detail.secret_references}
+        getRowKey={(row) => `${row.reference_kind}-${row.reference}-${row.target_node_id ?? ''}`}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No secret references" body="No provider-key, credential, or secret reference metadata matched this agent." />}
+        columns={[
+          { key: 'reference', header: 'Reference', render: (row) => <strong>{row.reference_name || row.reference}</strong> },
+          { key: 'kind', header: 'Kind', render: (row) => formatTokenLabel(row.reference_kind) },
+          { key: 'provider', header: 'Provider', render: (row) => row.provider ? formatTokenLabel(row.provider) : '-' },
+          { key: 'sensitivity', header: 'Sensitivity', render: (row) => row.sensitivity ? formatTokenLabel(row.sensitivity) : '-' },
+          { key: 'resolved', header: 'Resolved', render: (row) => `${row.resolved ? 'Yes' : 'No'} / ${formatConfidenceScore(row.confidence)}` }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'findings') {
+    return (
+      <DomainDataTable
+        label="Agent identity findings"
+        rows={detail.findings}
+        getRowKey={(row) => row.finding_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No findings" body="No AI-agent risk finding matched this agent." />}
+        columns={[
+          { key: 'finding', header: 'Finding', render: (row) => <strong>{formatTokenLabel(row.risk_type)}</strong> },
+          { key: 'severity', header: 'Severity', render: (row) => `${formatTokenLabel(row.severity)} / ${row.score}` },
+          { key: 'status', header: 'Status', render: (row) => formatTokenLabel(row.status) },
+          { key: 'rationale', header: 'Rationale', render: (row) => row.rationale },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'recommendations') {
+    return (
+      <DomainDataTable
+        label="Agent identity recommendations"
+        rows={detail.recommendations}
+        getRowKey={(row) => row.recommendation_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No recommendations" body="No least-privilege recommendation matched this agent or backing role." />}
+        columns={[
+          { key: 'recommendation', header: 'Recommendation', render: (row) => <strong>{row.display_name}</strong> },
+          { key: 'service', header: 'Service', render: (row) => formatTokenLabel(row.service) },
+          { key: 'decision', header: 'Decision', render: (row) => `${formatTokenLabel(row.decision)} / ${formatTokenLabel(row.status)}` },
+          { key: 'severity', header: 'Severity', render: (row) => `${formatTokenLabel(row.severity)} / ${row.score}` },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action }
+        ]}
+      />
+    );
+  }
+
+  if (activeTab === 'remediation') {
+    return (
+      <DomainDataTable
+        label="Agent identity remediation cases"
+        rows={detail.remediation_cases.cases}
+        getRowKey={(row) => row.case_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No remediation cases" body="No read-only remediation case matched this agent or backing role." />}
+        columns={[
+          { key: 'case', header: 'Case', render: (row) => <strong>{row.title}</strong> },
+          { key: 'source', header: 'Source', render: (row) => formatTokenLabel(row.source_type) },
+          { key: 'owner', header: 'Owner', render: (row) => awsRemediationCaseOwnerLabel(row) },
+          { key: 'state', header: 'State', render: (row) => `${formatTokenLabel(row.lifecycle)} / ${formatTokenLabel(row.status)}` },
+          {
+            key: 'severity',
+            header: 'Severity',
+            render: (row) => <AWSInventoryPill stage={awsRemediationCaseStage(row)} label={`${formatTokenLabel(row.severity)} / ${row.score}`} />
+          }
+        ]}
+      />
+    );
+  }
+
+  return (
+    <DomainDataTable
+      label="Agent identity governance decisions"
+      rows={detail.governance_decisions}
+      getRowKey={(row) => `${row.report_id}-${row.decision_type}-${row.state}`}
+      emptyState={<DomainEmptyState eyebrow="Empty" title="No governance decisions" body="No advisory, approval, remediation, enforcement, or exception record matched this agent." />}
+      columns={[
+        { key: 'decision', header: 'Decision', render: (row) => <strong>{row.title}</strong> },
+        { key: 'category', header: 'Category', render: (row) => formatTokenLabel(row.category) },
+        { key: 'type', header: 'Type', render: (row) => formatTokenLabel(row.decision_type) },
+        { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+        { key: 'actor', header: 'Actor', render: (row) => row.actor || row.approver || '-' }
+      ]}
+    />
+  );
+}
+
+export function ProductAWSAgentIdentityDetailPage() {
+  const data = useAWSInventoryData();
+  const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
+  const location = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const agent = normalizeValue(searchParams.get('agent') ?? '');
+  const activeTab = normalizeAWSAgentIdentityDetailTab(searchParams.get('tab'));
+  const [detail, setDetail] = useState<AWSAgentIdentityDetailResult | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState('');
+  const detailRequestRef = useRef(0);
+
+  const loadDetail = useCallback(async () => {
+    const requestID = ++detailRequestRef.current;
+    setDetail(null);
+    setDetailError('');
+    if (!scope || !selectedEnvironmentID || !agent || !connection?.connector_id) {
+      setDetailLoading(false);
+      return;
+    }
+    setDetailLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectAgentIdentityDetail(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          agent,
+          tab: activeTab
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== detailRequestRef.current) {
+        return;
+      }
+      setDetail(response.detail);
+    } catch (error) {
+      if (requestID !== detailRequestRef.current) {
+        return;
+      }
+      setDetailError(formatAPIError(error, 'Unable to load AWS agent identity detail.'));
+    } finally {
+      if (requestID === detailRequestRef.current) {
+        setDetailLoading(false);
+      }
+    }
+  }, [
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    agent,
+    activeTab,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadDetail();
+    return () => {
+      detailRequestRef.current += 1;
+    };
+  }, [loadDetail]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Agent identity detail</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading AWS agent identity detail.</p>
+      </section>
+    );
+  }
+
+  const agentsPath = awsRouteLink(scope, 'agents', selectedEnvironmentID);
+  const runtimePath = awsRouteLink(scope, 'runtime', selectedEnvironmentID);
+  const graphPath = awsRouteLink(scope, 'graph', selectedEnvironmentID);
+  const remediationPath = awsRouteLink(scope, 'remediation', selectedEnvironmentID);
+  const governancePath = awsRouteLink(scope, 'governance', selectedEnvironmentID);
+  const status = environmentScope.loading || connectionLoading || detailLoading
+    ? 'Loading detail'
+    : connectionError || detailError
+      ? 'Needs retry'
+      : detail
+        ? formatTokenLabel(detail.status)
+        : 'Select agent';
+  const statusTone = connectionError || detailError
+    ? 'danger'
+    : detail
+      ? awsAgentIdentityDetailTone(detail.status)
+      : awsDomainTone(connection, environmentScope.loading || connectionLoading);
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow={null}
+      hideLogo
+      title={detail?.agent.display_name || 'Agent identity detail'}
+      description={awsAgentIdentityDetailDescription(detail, agent)}
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
+      status={status}
+      statusTone={statusTone}
+      primaryAction={{ label: 'Back to agents', to: agentsPath, variant: 'secondary' }}
+    >
+      <div className="idt-aws-risk-page">
+        {connectionError ? (
+          <DomainErrorState
+            title="Couldn't load AWS status"
+            body={connectionError}
+            retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
+          />
+        ) : null}
+        {!agent ? (
+          <DomainEmptyState
+            eyebrow="Agent required"
+            title="Select an agent identity"
+            body="Open an agent from the AWS agents inventory to inspect its provider, runtime, tool, secret-reference, risk, remediation, and governance evidence."
+            nextAction={{ label: 'Open agents', to: agentsPath }}
+          />
+        ) : null}
+        {!connectionError && agent && !connectionLoading && !connection?.connector_id ? (
+          <DomainEmptyState
+            eyebrow="Connector required"
+            title="AWS connector detail is unavailable"
+            body="The selected environment does not have an AWS connector identifier to scope the detail request."
+          />
+        ) : null}
+        {detailError ? (
+          <DomainErrorState
+            title="Couldn't load agent identity detail"
+            body={detailError}
+            retryAction={{ label: 'Retry', onClick: loadDetail }}
+          />
+        ) : null}
+        {!detailError && detailLoading ? <DomainLoadingState label="Loading agent identity detail" /> : null}
+        {detail ? (
+          <>
+            <DomainKpiStrip
+              label="Agent identity detail metrics"
+              items={[
+                { label: 'Tools', value: detail.summary.tool_count, detail: `${detail.summary.observed_tool_count} observed` },
+                { label: 'Capabilities', value: detail.summary.capability_count, detail: 'memory, browser, code' },
+                { label: 'Secrets', value: detail.summary.secret_reference_count, detail: 'metadata references' },
+                { label: 'Runtime', value: detail.summary.runtime_call_count, detail: 'calls matched' },
+                { label: 'Findings', value: detail.summary.finding_count, detail: 'risk signals' },
+                { label: 'Recommendations', value: detail.summary.recommendation_count, detail: 'least privilege' }
+              ]}
+            />
+            <DomainStatusPanel
+              eyebrow="Evidence contract"
+              title="Scoped read-only agent view"
+              status={<AWSInventoryPill stage={awsAgentIdentityDetailStage(detail.status)} label={formatTokenLabel(detail.status)} />}
+              tone={awsAgentIdentityDetailTone(detail.status)}
+              actions={[
+                { label: 'Runtime', to: runtimePath, variant: 'secondary' },
+                { label: 'Graph', to: graphPath, variant: 'secondary' },
+                { label: 'Remediation', to: remediationPath, variant: 'secondary' },
+                { label: 'Governance', to: governancePath, variant: 'secondary' }
+              ]}
+            >
+              <dl className="idt-domain-route-facts">
+                <div>
+                  <dt>Evidence boundary</dt>
+                  <dd>{detail.agent.evidence_boundary}</dd>
+                </div>
+                <div>
+                  <dt>Provider</dt>
+                  <dd>{detail.agent.provider || detail.agent.external_provider || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Runtime role</dt>
+                  <dd>{detail.agent.runtime_role_name || detail.agent.runtime_role_arn || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Account</dt>
+                  <dd>{detail.account_id || detail.agent.account_id || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Region</dt>
+                  <dd>{detail.region || detail.agent.region || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{formatConfidenceScore(detail.confidence)}</dd>
+                </div>
+                <div>
+                  <dt>Candidate</dt>
+                  <dd>{detail.agent.candidate || detail.agent.low_confidence ? 'Candidate or low confidence' : 'Resolved'}</dd>
+                </div>
+                <div>
+                  <dt>Issue</dt>
+                  <dd>{detail.current_issue_ref}</dd>
+                </div>
+              </dl>
+            </DomainStatusPanel>
+            <AWSAgentIdentityDetailDiagnostics detail={detail} />
+            <AWSAgentIdentityDetailTabs
+              scope={scope}
+              selectedEnvironmentID={selectedEnvironmentID}
+              agent={agent}
+              activeTab={activeTab}
+              detail={detail}
+            />
+            <AWSAgentIdentityDetailTabContent detail={detail} activeTab={activeTab} />
           </>
         ) : null}
       </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6920,12 +6920,16 @@ function awsEC2IMDSLabel(inventory: AWSEC2InstanceProfileInventoryResult | null)
 }
 
 function AWSAgentIdentitiesContent({
+  scope,
+  selectedEnvironmentID,
   connection,
   aiAgentState,
   bedrockAgentsState,
   filters,
   onFiltersChange
 }: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
   connection: AWSConnectionStatus | null;
   aiAgentState: AWSInventoryAIAgentState;
   bedrockAgentsState: AWSInventoryBedrockAgentsState;
@@ -7037,7 +7041,19 @@ function AWSAgentIdentitiesContent({
         rows={displayedRows}
         getRowKey={(row) => row.id}
         columns={[
-          { key: 'name', header: 'Agent surface', render: (row) => <strong>{row.name}</strong> },
+          {
+            key: 'name',
+            header: 'Agent surface',
+            render: (row) => (
+              <strong>
+                {row.detailAgent ? (
+                  <Link to={awsAgentIdentityDetailLink(scope, selectedEnvironmentID, row.detailAgent)}>{row.name}</Link>
+                ) : (
+                  row.name
+                )}
+              </strong>
+            )
+          },
           { key: 'category', header: 'Category', render: (row) => row.category },
           { key: 'scope', header: 'Scope', render: (row) => row.scope },
           { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> },
@@ -7453,7 +7469,7 @@ function awsAIAgentIdentityRow(record: AWSAIAgentIdentityRecord): AWSInventoryTa
   return {
     id: `ai-agent-identity-${record.agent_node_id || record.agent_id}`,
     name: record.agent_name || record.agent_id,
-    detailAgent: record.agent_id || record.agent_node_id,
+    detailAgent: record.agent_node_id || record.agent_id,
     category,
     scope: awsAccountRegionInventoryLabel(record.account_id, record.region),
     status,
@@ -9673,6 +9689,8 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
       ) : null}
       {routeID === 'agents' ? (
         <AWSAgentIdentitiesContent
+          scope={scope}
+          selectedEnvironmentID={selectedEnvironmentID}
           connection={connection}
           aiAgentState={{
             inventory: aiAgentInventory,


### PR DESCRIPTION
## Summary

- Add a metadata-only AWS agent identity detail API that composes agent inventory, runtime calls, risk findings, least-privilege recommendations, remediation cases, governance decisions, relationships, diagnostics, and coverage gaps for one agent.
- Add the AWS agents detail app route, tabbed UI, inventory links, client types, route manifest entry, OpenAPI contract, and operator documentation.
- Add backend and frontend regression coverage for the contract, unknown-agent handling, route wiring, and scoped client calls.

## Why

Issue #1550 needs a scoped agent identity detail page that can show provider/runtime metadata, backing role, tools, memory/browser/code-interpreter capability metadata, secret references, runtime calls, findings, recommendations, and related AWS surfaces without exposing sensitive values or payloads.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api -run 'TestGetAWSAgentIdentityDetail|TestAWSAgentIdentityDetail|TestRouterAWSAgentIdentityDetail'
go test ./internal/api
npm test -- productShell.test.tsx -t "AWS agent identity detail|full route manifest"
npm test -- productShell.test.tsx
npm run build
```

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: Local tests and production web build listed above.

## Related Issues

Closes #1550

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS agent identity detail page and metadata-only API so operators can inspect one agent’s metadata and related signals without exposing sensitive values. Addresses #1550 with a single, scoped view across inventory, runtime calls, findings, recommendations, remediation, governance, relationships, diagnostics, and coverage.

- New Features
  - API: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/agent-identity-detail` (required: `agent`; optional: `connector_id`, `fixture_state`, `account_id`, `region`, `tab`, `tool`, `resource`, `severity`, `status`) returning metadata-only detail with status flags (`success`, `empty`, `degraded`, `partial_failure`, `permission_denied`, `unknown`)
  - OpenAPI and auth: route + schemas added; route authorized in the policy bundle
  - Frontend: new route `/app/:tenantID/:workspaceID/aws/agents/detail`, `ProductAWSAgentIdentityDetailPage` with tabs (`overview`, `tools`, `runtime`, `secrets`, `findings`, `recommendations`, `remediation`, `governance`), deep-link helper, and inventory links; client types added
  - Tests/docs: backend contract and router tests, frontend route/manifest tests, unknown-agent handling, scoped client calls, and operator guide

- Bug Fixes
  - Scoped all evidence and governance to the selected agent and its backing runtime role; filtered shared-role recommendations to the agent; exact-scoped role evidence
  - Fixed unknown-agent filtering; normalized and trimmed query params; refined client types and status handling
  - Kept inventory source edges in the detail graph; merged detail evidence keys to dedupe and stabilize payload fields
  - Included agent-scoped remediation cases

<sup>Written for commit f222a66e0d7f4a658c4842c9a5603a4e55f9d506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

