### PR TITLE
Promote GitHub posture gaps into repo findings

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -2161,6 +2161,28 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 			}
 		}
 	}
+	if s.GitHubRepositoryPostureCollector != nil {
+		posture, err := s.GitHubRepositoryPostureCollector.CollectRepositoryPosture(ctx, source.InstallationID, record.Repository)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			recordSourceErr("github_repository_posture", "posture_collect_error", err)
+		} else {
+			findings = append(findings, githubconnector.RepositoryPostureFindings(posture, detectedAt)...)
+		}
+		if owner, _, ok := strings.Cut(record.Repository, "/"); ok && strings.TrimSpace(owner) != "" {
+			orgPosture, orgErr := s.GitHubRepositoryPostureCollector.CollectOrganizationPosture(ctx, source.InstallationID, owner, record.Repository)
+			if orgErr != nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
+				recordSourceErr("github_organization_posture", "posture_collect_error", orgErr)
+			} else if githubOrganizationPostureAvailable(orgPosture) {
+				findings = append(findings, githubconnector.OrganizationPostureFindings(orgPosture, record.Repository, detectedAt)...)
+			}
+		}
+	}
 	return findings, sourceErrors, nil
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1874,9 +1874,11 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		return RunRepoScanResult{}, safeErr
 	}
 	result = applyRepoScanContextToResult(result, target, scanContext)
+	partialSourceRun := false
 	if !result.Truncated {
 		externalFindings, sourceErrors, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
 		if len(sourceErrors) > 0 {
+			partialSourceRun = true
 			s.appendScanEvent(ctx, record.ID, db.ScanEventLevelWarn, "repo scan completed with partial source errors", map[string]any{
 				"source_error_count": len(sourceErrors),
 				"source_errors":      truncateSourceErrors(sourceErrors, maxSourceErrorsInEvent),
@@ -1911,10 +1913,11 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	}
 	cursorAfter := firstNonEmptyString(result.HeadRevision, record.HeadRevision)
 	completionContext := db.RepoScanContext{
-		ScanMode:     result.ScanMode,
-		BaseRevision: result.BaseRevision,
-		HeadRevision: result.HeadRevision,
-		ChangedPaths: append([]string(nil), result.ChangedPaths...),
+		ScanMode:         result.ScanMode,
+		BaseRevision:     result.BaseRevision,
+		HeadRevision:     result.HeadRevision,
+		ChangedPaths:     append([]string(nil), result.ChangedPaths...),
+		PartialSourceRun: partialSourceRun,
 	}
 	if !result.Truncated {
 		completionContext.CursorAfter = cursorAfter

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4860,6 +4860,102 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsPostureFindings(t *testing.
 	}
 }
 
+func TestServiceProcessQueuedGitHubAppRepoScanPreservesPostureFindingsWhenPostureSourceFails(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+
+	previousScan, err := store.CreateRepoScan(ctx, "owner/private", db.RepoScanSource{}, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, now)
+	if err != nil {
+		t.Fatalf("create previous repo scan: %v", err)
+	}
+	previousFindings := githubconnector.RepositoryPostureFindings(githubconnector.RepositoryPosture{
+		Repository:     "owner/private",
+		InstallationID: 101,
+		CollectedAt:    now,
+		Checks: []githubconnector.RepositoryPostureCheck{
+			{
+				ID:       "default_branch_protection",
+				Category: "branch_protection",
+				State:    githubconnector.RepositoryPostureStateInsecure,
+				Reason:   "weak_protection",
+				Summary:  "Default branch protection is weak.",
+			},
+		},
+	}, now)
+	if len(previousFindings) != 1 {
+		t.Fatalf("expected one previous posture finding, got %+v", previousFindings)
+	}
+	if err := store.UpsertRepoFindings(ctx, previousScan.ID, previousFindings); err != nil {
+		t.Fatalf("upsert previous posture finding: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, previousScan.ID, "succeeded", now.Add(time.Minute), 1, 1, len(previousFindings), false, db.RepoScanContext{ScanMode: db.RepoScanModeDeep}, ""); err != nil {
+		t.Fatalf("complete previous repo scan: %v", err)
+	}
+
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: now.Add(time.Hour)},
+	}
+	svc.GitHubRepositoryPostureCollector = &fakeGitHubRepositoryPostureCollector{
+		err: errors.New("github posture source unavailable"),
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	currentScan, err := svc.GetRepoScan(ctx, record.ID)
+	if err != nil {
+		t.Fatalf("get current repo scan: %v", err)
+	}
+	if currentScan.Status != "succeeded" || currentScan.FindingCount != 0 {
+		t.Fatalf("expected partial source scan to succeed without imported posture findings, got %+v", currentScan)
+	}
+
+	openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleOpen),
+	})
+	if err != nil {
+		t.Fatalf("list open repo findings: %v", err)
+	}
+	if len(openFindings) != 1 || openFindings[0].LifecycleKey != previousFindings[0].LifecycleKey {
+		t.Fatalf("expected previous posture finding to remain open after source failure, got %+v", openFindings)
+	}
+	fixedFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Repository: "owner/private",
+		Status:     string(domain.RepoFindingLifecycleFixed),
+	})
+	if err != nil {
+		t.Fatalf("list fixed repo findings: %v", err)
+	}
+	if len(fixedFindings) != 0 {
+		t.Fatalf("expected posture source failure not to mark findings fixed, got %+v", fixedFindings)
+	}
+}
+
 func repoFindingByDetector(findings []domain.Finding, detector string) *domain.Finding {
 	for i := range findings {
 		if findings[i].Detector == detector {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4757,6 +4757,118 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsSecretAndDependabotAlerts(t
 	}
 }
 
+func TestServiceProcessQueuedGitHubAppRepoScanImportsPostureFindings(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	collectedAt := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	svc.GitHubRepositoryPostureCollector = &fakeGitHubRepositoryPostureCollector{
+		posture: githubconnector.RepositoryPosture{
+			Repository:     "owner/private",
+			InstallationID: 101,
+			CollectedAt:    collectedAt,
+			Checks: []githubconnector.RepositoryPostureCheck{
+				{
+					ID:       "default_branch_protection",
+					Category: "branch_protection",
+					State:    githubconnector.RepositoryPostureStateInsecure,
+					Reason:   "weak_protection",
+					Summary:  "Default branch protection is weak.",
+				},
+				{
+					ID:       "deploy_keys",
+					Category: "access",
+					State:    githubconnector.RepositoryPostureStateSecure,
+					Reason:   "no_writable_deploy_keys",
+					Summary:  "No writable deploy keys were returned.",
+				},
+			},
+		},
+		organizationPosture: githubconnector.OrganizationPosture{
+			Organization:   "owner",
+			InstallationID: 101,
+			CollectedAt:    collectedAt,
+			Checks: []githubconnector.RepositoryPostureCheck{
+				{
+					ID:       "org_workflow_permissions",
+					Category: "actions",
+					State:    githubconnector.RepositoryPostureStateInsecure,
+					Reason:   "write_token_or_pr_approval",
+					Summary:  "Organization grants write-scoped default workflow tokens.",
+				},
+			},
+		},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	collector := svc.GitHubRepositoryPostureCollector.(*fakeGitHubRepositoryPostureCollector)
+	if collector.seenInstallationID != 101 || collector.seenRepository != "owner/private" || collector.seenOrganization != "owner" || collector.seenOrganizationRepo != "owner/private" {
+		t.Fatalf("unexpected posture collector calls: %+v", collector)
+	}
+	stored, err := svc.GetRepoScan(ctx, record.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.FindingCount != 2 {
+		t.Fatalf("expected two imported posture findings, got %+v", stored)
+	}
+	findings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{RepoScanID: record.ID})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	branchFinding := repoFindingByDetector(findings, "github_default_branch_unprotected")
+	if branchFinding == nil {
+		t.Fatalf("expected branch posture finding, got %+v", findings)
+	}
+	if branchFinding.Repository != "owner/private" || branchFinding.LifecycleKey == "" || branchFinding.Evidence["github_posture_check_id"] != "default_branch_protection" {
+		t.Fatalf("unexpected branch posture finding: %+v", branchFinding)
+	}
+	orgFinding := repoFindingByDetector(findings, "github_workflow_permissions_write_default")
+	if orgFinding == nil {
+		t.Fatalf("expected org workflow posture finding, got %+v", findings)
+	}
+	if orgFinding.AdapterSource != "github_org_posture" || orgFinding.Evidence["organization"] != "owner" || orgFinding.Evidence["raw_secret_stored"] != false {
+		t.Fatalf("unexpected org posture finding: %+v", orgFinding)
+	}
+}
+
+func repoFindingByDetector(findings []domain.Finding, detector string) *domain.Finding {
+	for i := range findings {
+		if findings[i].Detector == detector {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
 func TestServiceProcessQueuedGitHubAppRepoScanRedactsInstallationTokenErrors(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/connectors/github/posture_findings.go
+++ b/internal/connectors/github/posture_findings.go
@@ -1,0 +1,328 @@
+package github
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	githubPostureFindingVersion      = "2026.07"
+	githubPostureAdapterSource       = "github_posture"
+	githubOrgPostureAdapterSource    = "github_org_posture"
+	githubPosturePermissionDetector  = "github_posture_permission_limited"
+	githubPostureUnavailableDetector = "github_posture_unavailable"
+	githubPostureUnknownDetector     = "github_posture_unknown"
+)
+
+// RepositoryPostureFindings converts non-secure repository posture checks into
+// durable repository findings. Secure checks and unsupported plan/account
+// surfaces are intentionally skipped.
+func RepositoryPostureFindings(posture RepositoryPosture, detectedAt time.Time) []domain.Finding {
+	return postureChecksToFindings(posture.Repository, "", posture.InstallationID, posture.CollectedAt, posture.Checks, githubPostureAdapterSource, "repository", detectedAt)
+}
+
+// OrganizationPostureFindings converts non-secure organization posture checks
+// into durable repository findings scoped to the repository that inherited the
+// organization policy.
+func OrganizationPostureFindings(posture OrganizationPosture, repository string, detectedAt time.Time) []domain.Finding {
+	return postureChecksToFindings(repository, posture.Organization, posture.InstallationID, posture.CollectedAt, posture.Checks, githubOrgPostureAdapterSource, "organization", detectedAt)
+}
+
+func postureChecksToFindings(repository string, organization string, installationID int64, collectedAt time.Time, checks []RepositoryPostureCheck, adapterSource string, scope string, detectedAt time.Time) []domain.Finding {
+	repository = strings.ToLower(strings.TrimSpace(repository))
+	organization = strings.ToLower(strings.TrimSpace(organization))
+	if repository == "" || len(checks) == 0 {
+		return nil
+	}
+	if detectedAt.IsZero() {
+		detectedAt = time.Now().UTC()
+	}
+	if collectedAt.IsZero() {
+		collectedAt = detectedAt
+	}
+	findings := make([]domain.Finding, 0, len(checks))
+	seen := map[string]struct{}{}
+	for _, check := range checks {
+		finding, ok := postureCheckToFinding(repository, organization, installationID, collectedAt.UTC(), check, adapterSource, scope, detectedAt.UTC())
+		if !ok {
+			continue
+		}
+		if _, exists := seen[finding.LifecycleKey]; exists {
+			continue
+		}
+		seen[finding.LifecycleKey] = struct{}{}
+		findings = append(findings, finding)
+	}
+	return findings
+}
+
+func postureCheckToFinding(repository string, organization string, installationID int64, collectedAt time.Time, check RepositoryPostureCheck, adapterSource string, scope string, detectedAt time.Time) (domain.Finding, bool) {
+	check.ID = strings.TrimSpace(check.ID)
+	check.Category = strings.TrimSpace(check.Category)
+	check.Reason = strings.TrimSpace(check.Reason)
+	check.Summary = strings.TrimSpace(check.Summary)
+	if check.ID == "" || check.State == RepositoryPostureStateSecure || check.State == RepositoryPostureStateUnsupported {
+		return domain.Finding{}, false
+	}
+	detector := postureFindingDetector(check)
+	if detector == "" {
+		return domain.Finding{}, false
+	}
+	severity := postureFindingSeverity(check, detector)
+	confidence := postureFindingConfidence(check.State)
+	lifecycleKey := strings.Join([]string{
+		"repo_finding",
+		repository,
+		string(domain.FindingRepoMisconfig),
+		detector,
+		adapterSource,
+		scope,
+		check.ID,
+	}, "\x1f")
+	evidence := postureFindingEvidence(repository, organization, installationID, collectedAt, check, adapterSource, scope, detector, confidence)
+	finding := domain.Finding{
+		ID:                  postureFindingID(lifecycleKey),
+		Type:                domain.FindingRepoMisconfig,
+		Severity:            severity,
+		ConfidenceScore:     confidence,
+		Title:               postureFindingTitle(check),
+		HumanSummary:        postureFindingSummary(check),
+		Repository:          repository,
+		Detector:            detector,
+		LifecycleKey:        lifecycleKey,
+		LifecycleStatus:     domain.RepoFindingLifecycleOpen,
+		RuleVersion:         githubPostureFindingVersion,
+		DetectorVersion:     githubPostureFindingVersion,
+		AdapterSource:       adapterSource,
+		ConfidenceState:     postureFindingConfidenceState(check.State),
+		VerificationStatus:  string(check.State),
+		EvidenceVersion:     githubPostureFindingVersion,
+		Evidence:            evidence,
+		Remediation:         postureFindingRemediation(check, detector),
+		CreatedAt:           detectedAt,
+		LineSnippetRedacted: boolPointer(false),
+	}
+	domain.NormalizeRepoFindingMetadata(&finding)
+	return finding, true
+}
+
+func postureFindingDetector(check RepositoryPostureCheck) string {
+	switch check.State {
+	case RepositoryPostureStatePermissionLimited:
+		return githubPosturePermissionDetector
+	case RepositoryPostureStateUnavailable:
+		return githubPostureUnavailableDetector
+	case RepositoryPostureStateUnknown:
+		return githubPostureUnknownDetector
+	case RepositoryPostureStateInsecure:
+	default:
+		return ""
+	}
+	switch check.ID {
+	case "repository_metadata":
+		return "github_repository_metadata_weak"
+	case "default_branch_protection":
+		return "github_default_branch_unprotected"
+	case "repository_rulesets":
+		return "github_rulesets_weak"
+	case "actions_permissions", "org_actions_policy":
+		return "github_actions_policy_broad"
+	case "org_workflow_permissions":
+		return "github_workflow_permissions_write_default"
+	case "dependabot_security":
+		return "github_dependabot_disabled"
+	case "code_scanning":
+		return "github_code_scanning_disabled"
+	case "secret_scanning", "org_secret_scanning_policy":
+		return "github_secret_scanning_disabled"
+	case "deploy_keys":
+		return "github_write_deploy_key"
+	case "webhooks":
+		return "github_webhook_unhealthy"
+	case "deployment_environments":
+		return "github_environment_unprotected"
+	case "self_hosted_runners":
+		return "github_self_hosted_runner_unrestricted"
+	case "org_reusable_workflow_policy":
+		return "github_reusable_workflow_policy_broad"
+	case "org_code_security_configuration":
+		return "github_code_security_configuration_weak"
+	default:
+		return "github_posture_" + sanitizePostureID(check.ID)
+	}
+}
+
+func postureFindingSeverity(check RepositoryPostureCheck, detector string) domain.FindingSeverity {
+	switch check.State {
+	case RepositoryPostureStatePermissionLimited:
+		return domain.SeverityMedium
+	case RepositoryPostureStateUnavailable, RepositoryPostureStateUnknown:
+		return domain.SeverityLow
+	}
+	switch detector {
+	case "github_default_branch_unprotected",
+		"github_secret_scanning_disabled",
+		"github_write_deploy_key",
+		"github_self_hosted_runner_unrestricted",
+		"github_workflow_permissions_write_default":
+		return domain.SeverityHigh
+	case "github_repository_metadata_weak", "github_webhook_unhealthy":
+		return domain.SeverityLow
+	default:
+		return domain.SeverityMedium
+	}
+}
+
+func postureFindingConfidence(state RepositoryPostureState) float64 {
+	switch state {
+	case RepositoryPostureStateInsecure:
+		return 0.88
+	case RepositoryPostureStatePermissionLimited:
+		return 0.72
+	case RepositoryPostureStateUnavailable:
+		return 0.60
+	case RepositoryPostureStateUnknown:
+		return 0.55
+	default:
+		return 0.50
+	}
+}
+
+func postureFindingConfidenceState(state RepositoryPostureState) string {
+	switch state {
+	case RepositoryPostureStateInsecure:
+		return "high_confidence"
+	case RepositoryPostureStatePermissionLimited:
+		return "permission_limited"
+	case RepositoryPostureStateUnavailable:
+		return "unavailable"
+	case RepositoryPostureStateUnknown:
+		return "unknown"
+	default:
+		return strings.TrimSpace(string(state))
+	}
+}
+
+func postureFindingEvidence(repository string, organization string, installationID int64, collectedAt time.Time, check RepositoryPostureCheck, adapterSource string, scope string, detector string, confidence float64) map[string]any {
+	evidence := map[string]any{}
+	if len(check.Evidence) > 0 {
+		evidence = maps.Clone(check.Evidence)
+	}
+	evidence["repository"] = repository
+	if organization != "" {
+		evidence["organization"] = organization
+	}
+	if installationID > 0 {
+		evidence["installation_id"] = installationID
+	}
+	evidence["detector"] = detector
+	evidence["adapter_source"] = adapterSource
+	evidence["adapter_source_type"] = adapterSource
+	evidence["github_posture_scope"] = scope
+	evidence["github_posture_check_id"] = check.ID
+	evidence["github_posture_category"] = check.Category
+	evidence["github_posture_state"] = string(check.State)
+	evidence["github_posture_reason"] = check.Reason
+	evidence["github_posture_summary"] = check.Summary
+	evidence["github_posture_collected_at"] = collectedAt.UTC().Format(time.RFC3339)
+	evidence["confidence_score"] = confidence
+	evidence["confidence_state"] = postureFindingConfidenceState(check.State)
+	evidence["rule_version"] = githubPostureFindingVersion
+	evidence["detector_version"] = githubPostureFindingVersion
+	evidence["evidence_version"] = githubPostureFindingVersion
+	evidence["raw_secret_stored"] = false
+	evidence["raw_adapter_result_stored"] = false
+	return evidence
+}
+
+func postureFindingTitle(check RepositoryPostureCheck) string {
+	name := strings.ReplaceAll(strings.TrimSpace(check.ID), "_", " ")
+	if name == "" {
+		name = "GitHub posture"
+	}
+	switch check.State {
+	case RepositoryPostureStatePermissionLimited:
+		return "GitHub posture check permission-limited: " + name
+	case RepositoryPostureStateUnavailable:
+		return "GitHub posture check unavailable: " + name
+	case RepositoryPostureStateUnknown:
+		return "GitHub posture check unknown: " + name
+	default:
+		return "GitHub posture gap: " + name
+	}
+}
+
+func postureFindingSummary(check RepositoryPostureCheck) string {
+	if check.Summary != "" {
+		return check.Summary
+	}
+	return fmt.Sprintf("GitHub posture check %q reported state %q.", check.ID, check.State)
+}
+
+func postureFindingRemediation(check RepositoryPostureCheck, detector string) string {
+	switch detector {
+	case githubPosturePermissionDetector:
+		return "Grant the GitHub App the read permission needed for this posture source, then rerun repository intelligence."
+	case githubPostureUnavailableDetector:
+		return "Retry posture collection and verify the GitHub API, installation, and account plan expose this posture source."
+	case githubPostureUnknownDetector:
+		return "Review the GitHub control manually and update the posture collector classification if this state is expected."
+	case "github_default_branch_unprotected":
+		return "Require pull-request reviews, required status checks, admin enforcement, and destructive-change protection on the default branch."
+	case "github_rulesets_weak":
+		return "Add an active branch ruleset that enforces review, status-check, and destructive-change protections."
+	case "github_secret_scanning_disabled":
+		return "Enable GitHub secret scanning and push protection, preferably through an enforced organization code security configuration."
+	case "github_code_scanning_disabled":
+		return "Enable code scanning for the repository or attach it to an organization security configuration that enables code scanning."
+	case "github_dependabot_disabled":
+		return "Enable Dependabot alerts and security updates for the repository."
+	case "github_actions_policy_broad":
+		return "Restrict GitHub Actions sources and default workflow permissions to least privilege."
+	case "github_workflow_permissions_write_default":
+		return "Set default workflow token permissions to read-only and grant write scopes only to jobs that require them."
+	case "github_reusable_workflow_policy_broad":
+		return "Restrict reusable workflows and third-party actions to an explicit pinned allowlist."
+	case "github_write_deploy_key":
+		return "Remove writable deploy keys or replace them with scoped, auditable GitHub App access."
+	case "github_webhook_unhealthy":
+		return "Disable insecure webhook SSL settings and repair or remove failing webhook deliveries."
+	case "github_environment_unprotected":
+		return "Add required reviewers or deployment protection rules to sensitive GitHub environments."
+	case "github_self_hosted_runner_unrestricted":
+		return "Isolate self-hosted runners with restricted runner groups and avoid routing untrusted workflows to persistent infrastructure."
+	default:
+		return "Review the GitHub posture check and harden the affected repository or organization control."
+	}
+}
+
+func postureFindingID(lifecycleKey string) string {
+	sum := sha256.Sum256([]byte(lifecycleKey))
+	return "finding:" + hex.EncodeToString(sum[:16])
+}
+
+func sanitizePostureID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		default:
+			builder.WriteByte('_')
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/internal/connectors/github/posture_findings.go
+++ b/internal/connectors/github/posture_findings.go
@@ -80,7 +80,6 @@ func postureCheckToFinding(repository string, organization string, installationI
 		"repo_finding",
 		repository,
 		string(domain.FindingRepoMisconfig),
-		detector,
 		adapterSource,
 		scope,
 		check.ID,
@@ -289,6 +288,8 @@ func postureFindingRemediation(check RepositoryPostureCheck, detector string) st
 		return "Set default workflow token permissions to read-only and grant write scopes only to jobs that require them."
 	case "github_reusable_workflow_policy_broad":
 		return "Restrict reusable workflows and third-party actions to an explicit pinned allowlist."
+	case "github_code_security_configuration_weak":
+		return "Enable an enforced organization-level code security configuration that covers secret scanning, code scanning, and Dependabot settings."
 	case "github_write_deploy_key":
 		return "Remove writable deploy keys or replace them with scoped, auditable GitHub App access."
 	case "github_webhook_unhealthy":

--- a/internal/connectors/github/posture_findings_test.go
+++ b/internal/connectors/github/posture_findings_test.go
@@ -105,19 +105,37 @@ func TestOrganizationPostureFindingsScopeToRepository(t *testing.T) {
 				Summary:  "Organization grants write-scoped default workflow tokens.",
 				Evidence: map[string]any{"default_workflow_permissions": "write"},
 			},
+			{
+				ID:       "org_code_security_configuration",
+				Category: "code_security",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "not_enforced",
+				Summary:  "Organization code security configuration is not enforced.",
+			},
 		},
 	}
 
 	findings := OrganizationPostureFindings(posture, "acme/repo", now)
-	if len(findings) != 1 {
-		t.Fatalf("expected one org posture finding, got %+v", findings)
+	if len(findings) != 2 {
+		t.Fatalf("expected two org posture findings, got %+v", findings)
 	}
-	finding := findings[0]
+	finding := findingByDetector(findings, "github_workflow_permissions_write_default")
+	if finding == nil {
+		t.Fatalf("expected workflow permissions finding, got %+v", findings)
+	}
 	if finding.Repository != "acme/repo" || finding.Detector != "github_workflow_permissions_write_default" {
 		t.Fatalf("unexpected organization posture finding: %+v", finding)
 	}
 	if finding.AdapterSource != githubOrgPostureAdapterSource || finding.Evidence["organization"] != "acme" || finding.Evidence["github_posture_scope"] != "organization" {
 		t.Fatalf("expected organization posture evidence, got %+v", finding.Evidence)
+	}
+
+	codeSecurity := findingByDetector(findings, "github_code_security_configuration_weak")
+	if codeSecurity == nil {
+		t.Fatalf("expected code security configuration finding, got %+v", findings)
+	}
+	if codeSecurity.Remediation != "Enable an enforced organization-level code security configuration that covers secret scanning, code scanning, and Dependabot settings." {
+		t.Fatalf("expected code security remediation guidance, got %q", codeSecurity.Remediation)
 	}
 }
 
@@ -130,6 +148,7 @@ func TestPostureFindingsHaveStableLifecycleAcrossRepeatedScans(t *testing.T) {
 		},
 	}
 	second := first
+	second.Checks = append([]RepositoryPostureCheck(nil), first.Checks...)
 	second.CollectedAt = first.CollectedAt.Add(time.Hour)
 	second.Checks[0].Summary = "Secret scanning remains unhealthy."
 
@@ -143,6 +162,39 @@ func TestPostureFindingsHaveStableLifecycleAcrossRepeatedScans(t *testing.T) {
 	}
 	if firstFindings[0].ID != secondFindings[0].ID {
 		t.Fatalf("expected stable finding id, got %q and %q", firstFindings[0].ID, secondFindings[0].ID)
+	}
+	if firstFindings[0].HumanSummary != "Open secret scanning alerts are present." || secondFindings[0].HumanSummary != "Secret scanning remains unhealthy." {
+		t.Fatalf("expected scan summaries to remain independent, got first=%q second=%q", firstFindings[0].HumanSummary, secondFindings[0].HumanSummary)
+	}
+}
+
+func TestPostureFindingsKeepLifecycleWhenCheckStateDegrades(t *testing.T) {
+	first := RepositoryPosture{
+		Repository:  "owner/repo",
+		CollectedAt: time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC),
+		Checks: []RepositoryPostureCheck{
+			{ID: "default_branch_protection", Category: "branch_protection", State: RepositoryPostureStateInsecure, Reason: "weak_protection", Summary: "Default branch protection is weak."},
+		},
+	}
+	second := first
+	second.Checks = []RepositoryPostureCheck{
+		{ID: "default_branch_protection", Category: "branch_protection", State: RepositoryPostureStatePermissionLimited, Reason: "permission_limited", Summary: "Default branch protection could not be collected."},
+	}
+	second.CollectedAt = first.CollectedAt.Add(time.Hour)
+
+	firstFindings := RepositoryPostureFindings(first, first.CollectedAt)
+	secondFindings := RepositoryPostureFindings(second, second.CollectedAt)
+	if len(firstFindings) != 1 || len(secondFindings) != 1 {
+		t.Fatalf("expected one finding in each scan, got first=%+v second=%+v", firstFindings, secondFindings)
+	}
+	if firstFindings[0].Detector != "github_default_branch_unprotected" || secondFindings[0].Detector != githubPosturePermissionDetector {
+		t.Fatalf("expected detector to reflect current check state, got first=%q second=%q", firstFindings[0].Detector, secondFindings[0].Detector)
+	}
+	if firstFindings[0].LifecycleKey != secondFindings[0].LifecycleKey {
+		t.Fatalf("expected degraded posture state to keep lifecycle key, got %q and %q", firstFindings[0].LifecycleKey, secondFindings[0].LifecycleKey)
+	}
+	if firstFindings[0].ID != secondFindings[0].ID {
+		t.Fatalf("expected degraded posture state to keep finding id, got %q and %q", firstFindings[0].ID, secondFindings[0].ID)
 	}
 }
 

--- a/internal/connectors/github/posture_findings_test.go
+++ b/internal/connectors/github/posture_findings_test.go
@@ -1,0 +1,156 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestRepositoryPostureFindingsPromotesInsecureAndLimitedChecks(t *testing.T) {
+	collectedAt := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	detectedAt := collectedAt.Add(time.Minute)
+	posture := RepositoryPosture{
+		Repository:     "owner/repo",
+		InstallationID: 101,
+		CollectedAt:    collectedAt,
+		Checks: []RepositoryPostureCheck{
+			{
+				ID:       "default_branch_protection",
+				Category: "branch_protection",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "weak_protection",
+				Summary:  "Default branch protection is weak.",
+				Evidence: map[string]any{"default_branch": "main"},
+			},
+			{
+				ID:       "deploy_keys",
+				Category: "access",
+				State:    RepositoryPostureStateSecure,
+				Reason:   "no_writable_deploy_keys",
+				Summary:  "No writable deploy keys were returned.",
+			},
+			{
+				ID:       "self_hosted_runners",
+				Category: "runners",
+				State:    RepositoryPostureStatePermissionLimited,
+				Reason:   "permission_limited",
+				Summary:  "Self-hosted runner posture could not be collected.",
+			},
+			{
+				ID:       "actions_permissions",
+				Category: "actions",
+				State:    RepositoryPostureStateUnavailable,
+				Reason:   "api_unavailable",
+				Summary:  "GitHub Actions permissions could not be collected.",
+			},
+			{
+				ID:       "org_code_security_configuration",
+				Category: "code_security",
+				State:    RepositoryPostureStateUnsupported,
+				Reason:   "plan_unavailable",
+				Summary:  "Plan does not expose this endpoint.",
+			},
+		},
+	}
+
+	findings := RepositoryPostureFindings(posture, detectedAt)
+	if len(findings) != 3 {
+		t.Fatalf("expected three posture findings, got %+v", findings)
+	}
+
+	branch := findingByDetector(findings, "github_default_branch_unprotected")
+	if branch == nil {
+		t.Fatalf("expected default branch posture finding, got %+v", findings)
+	}
+	if branch.Type != domain.FindingRepoMisconfig || branch.Severity != domain.SeverityHigh || branch.Repository != "owner/repo" {
+		t.Fatalf("unexpected branch finding: %+v", branch)
+	}
+	if branch.LifecycleKey == "" || branch.Evidence["github_posture_check_id"] != "default_branch_protection" {
+		t.Fatalf("expected stable posture metadata, got key=%q evidence=%+v", branch.LifecycleKey, branch.Evidence)
+	}
+	if branch.Evidence["raw_secret_stored"] != false || branch.AdapterSource != githubPostureAdapterSource {
+		t.Fatalf("expected non-secret github posture source evidence, got %+v", branch)
+	}
+
+	limited := findingByDetector(findings, githubPosturePermissionDetector)
+	if limited == nil {
+		t.Fatalf("expected permission-limited posture finding, got %+v", findings)
+	}
+	if limited.Severity != domain.SeverityMedium || limited.ConfidenceState != "permission_limited" || limited.VerificationStatus != string(RepositoryPostureStatePermissionLimited) {
+		t.Fatalf("unexpected permission-limited finding: %+v", limited)
+	}
+
+	unavailable := findingByDetector(findings, githubPostureUnavailableDetector)
+	if unavailable == nil {
+		t.Fatalf("expected unavailable posture finding, got %+v", findings)
+	}
+	if unavailable.Severity != domain.SeverityLow || unavailable.ConfidenceState != "unavailable" || unavailable.VerificationStatus != string(RepositoryPostureStateUnavailable) {
+		t.Fatalf("unexpected unavailable finding: %+v", unavailable)
+	}
+}
+
+func TestOrganizationPostureFindingsScopeToRepository(t *testing.T) {
+	now := time.Date(2026, 7, 4, 11, 0, 0, 0, time.UTC)
+	posture := OrganizationPosture{
+		Organization:   "acme",
+		InstallationID: 202,
+		CollectedAt:    now,
+		Checks: []RepositoryPostureCheck{
+			{
+				ID:       "org_workflow_permissions",
+				Category: "actions",
+				State:    RepositoryPostureStateInsecure,
+				Reason:   "write_token_or_pr_approval",
+				Summary:  "Organization grants write-scoped default workflow tokens.",
+				Evidence: map[string]any{"default_workflow_permissions": "write"},
+			},
+		},
+	}
+
+	findings := OrganizationPostureFindings(posture, "acme/repo", now)
+	if len(findings) != 1 {
+		t.Fatalf("expected one org posture finding, got %+v", findings)
+	}
+	finding := findings[0]
+	if finding.Repository != "acme/repo" || finding.Detector != "github_workflow_permissions_write_default" {
+		t.Fatalf("unexpected organization posture finding: %+v", finding)
+	}
+	if finding.AdapterSource != githubOrgPostureAdapterSource || finding.Evidence["organization"] != "acme" || finding.Evidence["github_posture_scope"] != "organization" {
+		t.Fatalf("expected organization posture evidence, got %+v", finding.Evidence)
+	}
+}
+
+func TestPostureFindingsHaveStableLifecycleAcrossRepeatedScans(t *testing.T) {
+	first := RepositoryPosture{
+		Repository:  "owner/repo",
+		CollectedAt: time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC),
+		Checks: []RepositoryPostureCheck{
+			{ID: "secret_scanning", Category: "secret_scanning", State: RepositoryPostureStateInsecure, Reason: "open_alerts_present", Summary: "Open secret scanning alerts are present."},
+		},
+	}
+	second := first
+	second.CollectedAt = first.CollectedAt.Add(time.Hour)
+	second.Checks[0].Summary = "Secret scanning remains unhealthy."
+
+	firstFindings := RepositoryPostureFindings(first, first.CollectedAt)
+	secondFindings := RepositoryPostureFindings(second, second.CollectedAt)
+	if len(firstFindings) != 1 || len(secondFindings) != 1 {
+		t.Fatalf("expected one finding in each scan, got first=%+v second=%+v", firstFindings, secondFindings)
+	}
+	if firstFindings[0].LifecycleKey != secondFindings[0].LifecycleKey {
+		t.Fatalf("expected stable lifecycle key, got %q and %q", firstFindings[0].LifecycleKey, secondFindings[0].LifecycleKey)
+	}
+	if firstFindings[0].ID != secondFindings[0].ID {
+		t.Fatalf("expected stable finding id, got %q and %q", firstFindings[0].ID, secondFindings[0].ID)
+	}
+}
+
+func findingByDetector(findings []domain.Finding, detector string) *domain.Finding {
+	for i := range findings {
+		if findings[i].Detector == detector {
+			return &findings[i]
+		}
+	}
+	return nil
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -362,12 +362,13 @@ type RepoScanRecord struct {
 
 // RepoScanContext captures incremental execution metadata for one scan.
 type RepoScanContext struct {
-	ScanMode     string
-	BaseRevision string
-	HeadRevision string
-	CursorBefore string
-	CursorAfter  string
-	ChangedPaths []string
+	ScanMode         string
+	BaseRevision     string
+	HeadRevision     string
+	CursorBefore     string
+	CursorAfter      string
+	ChangedPaths     []string
+	PartialSourceRun bool
 }
 
 // NormalizeRepoScanContext returns stable scan-mode and revision metadata.
@@ -377,12 +378,13 @@ func NormalizeRepoScanContext(scanContext RepoScanContext) RepoScanContext {
 		mode = RepoScanModeDeep
 	}
 	normalized := RepoScanContext{
-		ScanMode:     mode,
-		BaseRevision: strings.TrimSpace(scanContext.BaseRevision),
-		HeadRevision: strings.TrimSpace(scanContext.HeadRevision),
-		CursorBefore: strings.TrimSpace(scanContext.CursorBefore),
-		CursorAfter:  strings.TrimSpace(scanContext.CursorAfter),
-		ChangedPaths: normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
+		ScanMode:         mode,
+		BaseRevision:     strings.TrimSpace(scanContext.BaseRevision),
+		HeadRevision:     strings.TrimSpace(scanContext.HeadRevision),
+		CursorBefore:     strings.TrimSpace(scanContext.CursorBefore),
+		CursorAfter:      strings.TrimSpace(scanContext.CursorAfter),
+		ChangedPaths:     normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
+		PartialSourceRun: scanContext.PartialSourceRun,
 	}
 	return normalized
 }
@@ -2767,6 +2769,9 @@ func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext R
 		return false
 	}
 	normalizedContext := NormalizeRepoScanContext(scanContext)
+	if normalizedContext.PartialSourceRun {
+		return false
+	}
 	return normalizedContext.ScanMode == "deep" && len(normalizedContext.ChangedPaths) == 0
 }
 


### PR DESCRIPTION
## Summary

Promotes GitHub repository and organization posture gaps into durable repository findings.

## Why

Issue #1707 calls out that posture checks were collected separately from the repo findings workflow. This meant insecure, permission-limited, unavailable, and unknown GitHub posture states could miss lifecycle, triage, trends, clusters, risk graph scoring, and remediation queues.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/connectors/github ./internal/api
```

## Checklist

- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Closes #1707

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes GitHub repo and org posture gaps into durable repo findings during scans, so they participate in lifecycle, triage, trends, clustering, and risk scoring. Also marks scans as partial when posture sources fail and keeps existing posture findings open.

- New Features
  - Imports repo and org posture into findings during repo scans when `GitHubRepositoryPostureCollector` is available; scopes org checks to the affected repo.
  - Converts non-secure states to detectors (e.g., `github_default_branch_unprotected`, `github_workflow_permissions_write_default`; generic: `github_posture_permission_limited`, `github_posture_unavailable`, `github_posture_unknown`; fallback: `github_posture_<id>`).
  - Adds stable lifecycle keys and deterministic finding IDs; adapter sources `github_posture` and `github_org_posture`; rule/detector/evidence version `2026.07`.
  - Sets severity, confidence, and confidence state by posture state and detector; adds targeted remediation.
  - Stores rich evidence (repository, organization, installation_id, posture metadata) with `raw_secret_stored: false`.
  - Includes unit tests for conversion logic and service-level import during a repo scan.

- Bug Fixes
  - Corrects detector mapping and evidence so posture findings display, dedupe, and keep lifecycle across state changes.
  - Preserves posture findings when posture collection fails by marking the scan `PartialSourceRun` and skipping close-on-missing for that scan.

<sup>Written for commit fa47debe0a6d0612e87ec03e293df411543afaa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

