### PR TITLE
Honor agent tool filters in recommendations

### DIFF
--- a/docs/aws-least-privilege-engine.md
+++ b/docs/aws-least-privilege-engine.md
@@ -63,6 +63,7 @@ The endpoint supports:
 - `region`
 - `identity`
 - `resource`
+- `tool`
 - `service`
 - `severity`
 - `status`

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -7153,6 +7153,10 @@ paths:
           schema: { type: string }
           description: Optional impacted resource, ARN, display label, or graph-node search.
         - in: query
+          name: tool
+          schema: { type: string }
+          description: Optional AI-agent tool name, target reference, or agent-tool action search.
+        - in: query
           name: service
           schema: { type: string }
           description: Optional AWS service token, such as s3, secretsmanager, kms, lambda, or agent-runtime.

--- a/internal/api/aws_agent_identity_detail.go
+++ b/internal/api/aws_agent_identity_detail.go
@@ -335,6 +335,7 @@ func (s *Service) GetAWSAgentIdentityDetail(ctx context.Context, workspaceID str
 		Region:       request.Region,
 		Identity:     permissionsIdentity,
 		Resource:     request.Resource,
+		Tool:         request.Tool,
 		Severity:     request.Severity,
 		Status:       request.Status,
 	})

--- a/internal/api/aws_agent_identity_detail_test.go
+++ b/internal/api/aws_agent_identity_detail_test.go
@@ -111,6 +111,32 @@ func TestGetAWSAgentIdentityDetailForwardsResourceToRecommendations(t *testing.T
 	}
 }
 
+func TestGetAWSAgentIdentityDetailForwardsToolToRecommendations(t *testing.T) {
+	now := time.Date(2026, 7, 4, 16, 0, 0, 0, time.UTC)
+	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-tool", now)
+
+	result, err := svc.GetAWSAgentIdentityDetail(defaultScopeContext(), ws, "project-agent-identity-detail-tool", AWSAgentIdentityDetailRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Agent:        "AGENTPAY1",
+		Tool:         "case-router",
+	})
+	if err != nil {
+		t.Fatalf("get tool-filtered agent identity detail: %v", err)
+	}
+	if result.Permissions.AppliedFilters["tool"] != "case-router" {
+		t.Fatalf("permissions must receive the detail tool filter, got %+v", result.Permissions.AppliedFilters)
+	}
+	if result.Summary.RecommendationCount != len(result.Recommendations) || len(result.Recommendations) != len(result.Permissions.Recommendations) {
+		t.Fatalf("tool-filtered recommendation counts must match summary=%+v recommendations=%+v permissions=%+v", result.Summary, result.Recommendations, result.Permissions.Recommendations)
+	}
+	for _, recommendation := range result.Permissions.Recommendations {
+		if !awsRuntimeEventMatchesAny("case-router", awsLeastPrivilegeToolMatchValues(recommendation)...) {
+			t.Fatalf("tool-filtered detail leaked unrelated recommendation: %+v", recommendation)
+		}
+	}
+}
+
 func TestGetAWSAgentIdentityDetailUnknownAgentIsExplicit(t *testing.T) {
 	now := time.Date(2026, 7, 3, 20, 15, 0, 0, time.UTC)
 	svc, ws := newAgentIdentityDetailService(t, "project-agent-identity-detail-unknown", now)

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -24,6 +24,7 @@ type AWSLeastPrivilegeRequest struct {
 	Region       string `json:"region,omitempty"`
 	Identity     string `json:"identity,omitempty"`
 	Resource     string `json:"resource,omitempty"`
+	Tool         string `json:"tool,omitempty"`
 	Service      string `json:"service,omitempty"`
 	Severity     string `json:"severity,omitempty"`
 	Status       string `json:"status,omitempty"`
@@ -858,6 +859,7 @@ func filterAWSLeastPrivilegeRecommendations(recommendations []AWSLeastPrivilegeR
 		"region":     strings.TrimSpace(request.Region),
 		"identity":   strings.TrimSpace(request.Identity),
 		"resource":   strings.TrimSpace(request.Resource),
+		"tool":       strings.TrimSpace(request.Tool),
 		"service":    normalizeAWSRuntimeEventFilterToken(request.Service),
 		"severity":   normalizeAWSRuntimeEventFilterToken(request.Severity),
 		"status":     normalizeAWSRuntimeEventFilterToken(request.Status),
@@ -899,6 +901,9 @@ func filterAWSLeastPrivilegeRecommendations(recommendations []AWSLeastPrivilegeR
 		if filters["resource"] != "" && !awsRuntimeEventMatchesAny(filters["resource"], awsLeastPrivilegeResourceMatchValues(recommendation)...) {
 			continue
 		}
+		if filters["tool"] != "" && !awsRuntimeEventMatchesAny(filters["tool"], awsLeastPrivilegeToolMatchValues(recommendation)...) {
+			continue
+		}
 		filtered = append(filtered, recommendation)
 	}
 	return filtered, applied
@@ -919,6 +924,17 @@ func awsLeastPrivilegeResourceMatchValues(recommendation AWSLeastPrivilegeRecomm
 	candidates = append(candidates, recommendation.ImpactedNodes...)
 	for _, step := range recommendation.ImpactedPath {
 		candidates = append(candidates, step.NodeID, step.Label)
+	}
+	return dedupeStrings(candidates)
+}
+
+func awsLeastPrivilegeToolMatchValues(recommendation AWSLeastPrivilegeRecommendation) []string {
+	candidates := append(append(append([]string{}, recommendation.KeepActions...), recommendation.RemoveActions...), recommendation.ObservedActions...)
+	candidates = append(candidates, recommendation.GrantedActions...)
+	for _, action := range append([]string{}, candidates...) {
+		if tool, ok := strings.CutPrefix(strings.TrimSpace(action), "agent-tool:"); ok {
+			candidates = append(candidates, tool)
+		}
 	}
 	return dedupeStrings(candidates)
 }

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -521,9 +521,13 @@ func awsLeastPrivilegeAgentToolActions(record AWSAgentRuntimeAccessRecord) []str
 	candidates := dedupeStrings([]string{
 		awsLeastPrivilegeAgentToolAction(record.ToolName),
 		awsLeastPrivilegeAgentToolAction(record.ToolTargetRef),
-		awsLeastPrivilegeAgentToolAction(record.AgentID),
-		awsLeastPrivilegeAgentToolAction(record.AgentNodeID),
 	})
+	if len(candidates) == 0 {
+		candidates = dedupeStrings([]string{
+			awsLeastPrivilegeAgentToolAction(record.AgentID),
+			awsLeastPrivilegeAgentToolAction(record.AgentNodeID),
+		})
+	}
 	return candidates
 }
 

--- a/internal/api/aws_least_privilege.go
+++ b/internal/api/aws_least_privilege.go
@@ -473,13 +473,13 @@ func awsLeastPrivilegeRecommendationFromAgent(record AWSAgentRuntimeAccessRecord
 	roleARN := firstNonEmptyAWSValue(firstString(record.BackingRoleARNs), record.DeclaredBackingRole)
 	decision, status, recommendationType, severity, score := awsLeastPrivilegeDecisionForAgentStatus(record.Status)
 	breakage := awsLeastPrivilegeBreakagePrediction(decision, record.Status, record.Confidence, record.ObservedCount, record.Caveats)
-	toolAction := "agent-tool:" + firstNonEmptyAWSValue(record.ToolName, record.ToolTargetRef, record.AgentID, record.AgentNodeID)
+	toolActions := awsLeastPrivilegeAgentToolActions(record)
 	removeActions := []string{}
 	keepActions := []string{}
 	if decision == "remove" {
-		removeActions = []string{toolAction}
+		removeActions = dedupeStrings(append([]string{}, toolActions...))
 	} else {
-		keepActions = []string{toolAction}
+		keepActions = dedupeStrings(append([]string{}, toolActions...))
 	}
 	evidenceRef := firstNonEmptyAWSValue(record.EvidenceRef, firstString(record.EvidenceRefs), fmt.Sprintf("agent-runtime-access://%s", record.CorrelationID))
 	targetSteps := awsLeastPrivilegeAgentTargetSteps(record.TargetResourceNodeIDs, record.TargetResourceARNs, record.AccountID, record.Region)
@@ -505,8 +505,8 @@ func awsLeastPrivilegeRecommendationFromAgent(record AWSAgentRuntimeAccessRecord
 		BreakageRationale:  awsLeastPrivilegeBreakageRationale(decision, breakage, record.ObservedCount, record.Caveats),
 		KeepActions:        keepActions,
 		RemoveActions:      removeActions,
-		ObservedActions:    awsLeastPrivilegeObservedActions(record.ObservedCount, []string{toolAction}),
-		GrantedActions:     []string{toolAction},
+		ObservedActions:    awsLeastPrivilegeObservedActions(record.ObservedCount, append([]string{}, toolActions...)),
+		GrantedActions:     dedupeStrings(append([]string{}, toolActions...)),
 		ImpactedNodes:      dedupeStrings(append(append([]string{roleNode, record.AgentNodeID}, record.TargetResourceNodeIDs...), record.TargetResourceARNs...)),
 		ImpactedPath:       awsLeastPrivilegeAgentPath(roleNode, roleARN, record.AgentNodeID, record.AgentName, record.AgentID, targetSteps, record.AccountID, record.Region),
 		Evidence:           []AWSLeastPrivilegeEvidence{{Source: "agent_runtime_access", EvidenceRef: evidenceRef, Label: "Agent runtime / tool path", Confidence: record.Confidence, ObservedAt: record.LastObservedAt, Relationship: record.Status}},
@@ -515,6 +515,24 @@ func awsLeastPrivilegeRecommendationFromAgent(record AWSAgentRuntimeAccessRecord
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}
+}
+
+func awsLeastPrivilegeAgentToolActions(record AWSAgentRuntimeAccessRecord) []string {
+	candidates := dedupeStrings([]string{
+		awsLeastPrivilegeAgentToolAction(record.ToolName),
+		awsLeastPrivilegeAgentToolAction(record.ToolTargetRef),
+		awsLeastPrivilegeAgentToolAction(record.AgentID),
+		awsLeastPrivilegeAgentToolAction(record.AgentNodeID),
+	})
+	return candidates
+}
+
+func awsLeastPrivilegeAgentToolAction(tool string) string {
+	tool = strings.TrimSpace(tool)
+	if tool == "" {
+		return ""
+	}
+	return "agent-tool:" + tool
 }
 
 func awsLeastPrivilegeRecommendationFromRuntimeSignal(record AWSRuntimeEventRecord, now time.Time) (AWSLeastPrivilegeRecommendation, bool) {
@@ -932,11 +950,20 @@ func awsLeastPrivilegeToolMatchValues(recommendation AWSLeastPrivilegeRecommenda
 	candidates := append(append(append([]string{}, recommendation.KeepActions...), recommendation.RemoveActions...), recommendation.ObservedActions...)
 	candidates = append(candidates, recommendation.GrantedActions...)
 	for _, action := range append([]string{}, candidates...) {
-		if tool, ok := strings.CutPrefix(strings.TrimSpace(action), "agent-tool:"); ok {
-			candidates = append(candidates, tool)
+		parts := strings.SplitN(strings.TrimSpace(action), ":", 2)
+		if len(parts) != 2 || parts[0] != "agent-tool" {
+			continue
+		}
+		candidates = append(candidates, parts[1])
+	}
+	filtered := make([]string, 0, len(candidates))
+	for _, action := range candidates {
+		action = strings.TrimSpace(action)
+		if strings.HasPrefix(action, "agent-tool:") {
+			filtered = append(filtered, action)
 		}
 	}
-	return dedupeStrings(candidates)
+	return dedupeStrings(filtered)
 }
 
 func awsLeastPrivilegeRelationships(recommendations []AWSLeastPrivilegeRecommendation) []AWSLeastPrivilegeRelationship {

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -216,6 +216,60 @@ func TestAWSLeastPrivilegeRecommendationFromAgentRecordsIncludeToolTargetRefAndN
 	}
 }
 
+func TestAWSLeastPrivilegeRecommendationFromAgentRecordsDoNotLeakAgentIdentifiersInToolFilterWhenToolAvailable(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 35, 0, 0, time.UTC)
+	recommendation := awsLeastPrivilegeRecommendationFromAgent(AWSAgentRuntimeAccessRecord{
+		CorrelationID:      "agent-runtime-filter-no-leak",
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		AgentNodeID:        "agent-runtime-node",
+		AgentID:            "agent-runtime-id",
+		ToolName:           "case-router",
+		ToolTargetRef:      "api://tickets/search",
+		Status:             "declared-unused",
+		ObservedCount:      2,
+		Confidence:         0.94,
+		ObservedEventIDs:   []string{"agent-runtime-filter-no-leak-1"},
+		EvidenceRef:        "agent-runtime-access://agent-runtime-filter-no-leak",
+		BackingRoleARNs:    []string{"arn:aws:iam::123456789012:role/agent-runtime"},
+		BackingRoleNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/agent-runtime"},
+		LastObservedAt:     now,
+	}, now)
+	matches := awsLeastPrivilegeToolMatchValues(recommendation)
+	if awsRuntimeEventMatchesAny("agent-runtime-id", matches...) {
+		t.Fatalf("tool matching should not leak agent identifier when tool is present: %+v", matches)
+	}
+	if awsRuntimeEventMatchesAny("agent-runtime-node", matches...) {
+		t.Fatalf("tool matching should not leak agent node identifier when tool is present: %+v", matches)
+	}
+}
+
+func TestAWSLeastPrivilegeRecommendationFromAgentRecordsFallbackToAgentIdentifiersWhenNoToolIsPresent(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 40, 0, 0, time.UTC)
+	recommendation := awsLeastPrivilegeRecommendationFromAgent(AWSAgentRuntimeAccessRecord{
+		CorrelationID:      "agent-runtime-filter-fallback",
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		AgentNodeID:        "agent-runtime-node",
+		AgentID:            "agent-runtime-id",
+		Status:             "declared-unused",
+		ObservedCount:      0,
+		Confidence:         0.94,
+		ObservedEventIDs:   []string{"agent-runtime-filter-fallback-1"},
+		EvidenceRef:        "agent-runtime-access://agent-runtime-filter-fallback",
+		BackingRoleARNs:    []string{"arn:aws:iam::123456789012:role/agent-runtime"},
+		BackingRoleNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/agent-runtime"},
+		LastObservedAt:     now,
+	}, now)
+	matches := awsLeastPrivilegeToolMatchValues(recommendation)
+	if !awsRuntimeEventMatchesAny("agent-runtime-id", matches...) {
+		t.Fatalf("expected fallback agent identifier in tool candidates: %+v", matches)
+	}
+	if !awsRuntimeEventMatchesAny("agent-runtime-node", matches...) {
+		t.Fatalf("expected fallback agent node identifier in tool candidates: %+v", matches)
+	}
+}
+
 func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalKeepsAccessAnalyzerInReview(t *testing.T) {
 	now := time.Date(2026, 6, 20, 8, 20, 0, 0, time.UTC)
 	record := AWSRuntimeEventRecord{

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -166,6 +166,56 @@ func TestGetAWSLeastPrivilegeFiltersByDecisionServiceAndResource(t *testing.T) {
 	}
 }
 
+func TestAWSLeastPrivilegeToolMatchValuesUsesOnlyAgentToolCandidates(t *testing.T) {
+	matches := awsLeastPrivilegeToolMatchValues(AWSLeastPrivilegeRecommendation{
+		KeepActions:     []string{"agent-tool:case-router", "s3:GetObject"},
+		RemoveActions:   []string{"agent-tool:api://tickets/search", "kms:Decrypt"},
+		ObservedActions: []string{"agent-tool:case-router"},
+		GrantedActions:  []string{"iam:DeleteRole"},
+	})
+
+	if !awsRuntimeEventMatchesAny("case-router", matches...) {
+		t.Fatalf("expected tool name to match tool candidates: %v", matches)
+	}
+	if !awsRuntimeEventMatchesAny("api://tickets/search", matches...) {
+		t.Fatalf("expected tool target ref to match tool candidates: %v", matches)
+	}
+	if awsRuntimeEventMatchesAny("s3:GetObject", matches...) {
+		t.Fatalf("agent least-privilege tool filter should not match IAM actions: %v", matches)
+	}
+	if awsRuntimeEventMatchesAny("kms:Decrypt", matches...) {
+		t.Fatalf("agent least-privilege tool filter should not match IAM actions: %v", matches)
+	}
+}
+
+func TestAWSLeastPrivilegeRecommendationFromAgentRecordsIncludeToolTargetRefAndName(t *testing.T) {
+	now := time.Date(2026, 6, 20, 8, 30, 0, 0, time.UTC)
+	recommendation := awsLeastPrivilegeRecommendationFromAgent(AWSAgentRuntimeAccessRecord{
+		CorrelationID:      "agent-runtime-filter-target-ref",
+		AccountID:          "123456789012",
+		Region:             "us-east-1",
+		AgentNodeID:        "agent-runtime-node",
+		AgentID:            "agent-runtime-id",
+		ToolName:           "case-router",
+		ToolTargetRef:      "api://tickets/search",
+		Status:             "declared-unused",
+		ObservedCount:      2,
+		Confidence:         0.94,
+		ObservedEventIDs:   []string{"agent-runtime-filter-target-ref-1"},
+		EvidenceRef:        "agent-runtime-access://agent-runtime-filter-target-ref",
+		BackingRoleARNs:    []string{"arn:aws:iam::123456789012:role/agent-runtime"},
+		BackingRoleNodeIDs: []string{"aws:identity:arn:aws:iam::123456789012:role/agent-runtime"},
+		LastObservedAt:     now,
+	}, now)
+	matches := awsLeastPrivilegeToolMatchValues(recommendation)
+	if !awsRuntimeEventMatchesAny("case-router", matches...) {
+		t.Fatalf("expected recommendation tool candidates to include tool name: %+v", matches)
+	}
+	if !awsRuntimeEventMatchesAny("api://tickets/search", matches...) {
+		t.Fatalf("expected recommendation tool candidates to include tool target ref: %+v", matches)
+	}
+}
+
 func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalKeepsAccessAnalyzerInReview(t *testing.T) {
 	now := time.Date(2026, 6, 20, 8, 20, 0, 0, time.UTC)
 	record := AWSRuntimeEventRecord{

--- a/internal/api/aws_least_privilege_test.go
+++ b/internal/api/aws_least_privilege_test.go
@@ -144,6 +144,26 @@ func TestGetAWSLeastPrivilegeFiltersByDecisionServiceAndResource(t *testing.T) {
 			t.Fatalf("resource filter leaked %+v", recommendation)
 		}
 	}
+
+	tool, err := svc.GetAWSLeastPrivilegeRecommendations(defaultScopeContext(), ws, "project-least-privilege-filters", AWSLeastPrivilegeRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Tool:         "case-router",
+	})
+	if err != nil {
+		t.Fatalf("tool filter: %v", err)
+	}
+	if len(tool.Recommendations) == 0 {
+		t.Fatalf("expected agent-runtime tool recommendations")
+	}
+	if tool.AppliedFilters["tool"] != "case-router" {
+		t.Fatalf("expected applied tool filter, got %+v", tool.AppliedFilters)
+	}
+	for _, recommendation := range tool.Recommendations {
+		if !awsRuntimeEventMatchesAny("case-router", awsLeastPrivilegeToolMatchValues(recommendation)...) {
+			t.Fatalf("tool filter leaked %+v", recommendation)
+		}
+	}
 }
 
 func TestAWSLeastPrivilegeRecommendationFromRuntimeSignalKeepsAccessAnalyzerInReview(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3938,6 +3938,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			Region:       strings.TrimSpace(c.Query("region")),
 			Identity:     strings.TrimSpace(c.Query("identity")),
 			Resource:     strings.TrimSpace(c.Query("resource")),
+			Tool:         strings.TrimSpace(c.Query("tool")),
 			Service:      strings.TrimSpace(c.Query("service")),
 			Severity:     strings.TrimSpace(c.Query("severity")),
 			Status:       strings.TrimSpace(c.Query("status")),

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1250,6 +1250,7 @@ describe('apiClient', () => {
         region: 'us-east-1',
         identity: 'lambda-invoice-agent',
         resource: 'prod/ai/openai-key',
+        tool: 'case-router',
         service: 'secretsmanager',
         severity: 'high',
         status: 'review',
@@ -1264,7 +1265,7 @@ describe('apiClient', () => {
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain(
-      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/least-privilege?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=lambda-invoice-agent&resource=prod%2Fai%2Fopenai-key&service=secretsmanager&severity=high&status=review&decision=remove'
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/least-privilege?connector_id=aws-prod&fixture_state=success&account_id=123456789012&region=us-east-1&identity=lambda-invoice-agent&resource=prod%2Fai%2Fopenai-key&tool=case-router&service=secretsmanager&severity=high&status=review&decision=remove'
     );
     expect(options.method ?? 'GET').toBe('GET');
     const headers = new Headers(options.headers);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6395,6 +6395,7 @@ export type AWSLeastPrivilegeQuery = {
   region?: string;
   identity?: string;
   resource?: string;
+  tool?: string;
   service?: string;
   severity?: string;
   status?: string;
@@ -10772,6 +10773,7 @@ export const apiClient = {
         region: query?.region,
         identity: query?.identity,
         resource: query?.resource,
+        tool: query?.tool,
         service: query?.service,
         severity: query?.severity,
         status: query?.status,


### PR DESCRIPTION
Follow-up for the unresolved review on #1706.

## Summary
- Add `tool` to the AWS least-privilege request/filter contract and route it through the API.
- Forward the agent detail `?tool=...` filter into least-privilege recommendations so the Recommendations tab stays aligned with filtered Tools/Runtime evidence.
- Document the least-privilege `tool` query filter in docs and OpenAPI.

## Validation
- `go test ./internal/api -run 'Test(GetAWSLeastPrivilegeFiltersByDecisionServiceAndResource|GetAWSAgentIdentityDetailForwardsToolToRecommendations|GetAWSAgentIdentityDetailForwardsResourceToRecommendations)'`\n- `go test ./internal/api -run 'Test(GetAWSLeastPrivilege|AWSLeastPrivilege|GetAWSAgentIdentityDetail|AWSAgentIdentityDetail)'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tool` filter to AWS least-privilege recommendations and wires it through agent identity detail and the web client. Tool filtering matches agent-tool activity only and stays aligned with the selected tool and runtime evidence.

- **New Features**
  - Added `?tool=` to least-privilege endpoints; forwarded from agent identity detail, router, docs, OpenAPI, and `web/src/api` client/tests.
  - Recommendations emit `agent-tool:` tokens for tool name and target ref, with fallback to agent id/node when no tool; tests cover forwarding, strict matching, and counts.

- **Bug Fixes**
  - Tightened matching to ignore IAM actions and prevent leaking agent identifiers when a tool is present.

<sup>Written for commit 0bd0c5ce9428abdda479ed20bc3b1b5681143f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

