### PR TITLE
Make app-side social-login MFA enforcement opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+- Make app-side social-login MFA enforcement opt-in via
+  `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` (default `false`). Previously the API
+  unconditionally rejected Google/GitHub OAuth logins whose WorkOS MFA
+  handshake had not completed, so disabling MFA enforcement in the WorkOS
+  dashboard bricked social sign-in with an unrecoverable `mfa_required`
+  loop. With the flag off, WorkOS is the single source of truth for whether
+  MFA runs; setting it to `true` restores the app-side assertion as
+  defense-in-depth for deployments that also enforce MFA in WorkOS. The
+  flag requires `IDENTRAIL_FEATURE_WORKOS_LOGIN=true` at startup.
 - Add **AWS governance audit reporting** (#1548). Adds a metadata-only
   reporting projection over advisory authorization, AgentCore gateway policy
   advisory, remediation approval, post-remediation verification, and limited

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -48,7 +48,7 @@ in [`production-api-readiness.md`](./production-api-readiness.md).
 | `IDENTRAIL_WORKOS_ENVIRONMENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Picks the WorkOS environment (test, staging, production). | WorkOS login |
 | `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` | `false` | Boolean. Defense-in-depth assertion that refuses to create a session for a Google/GitHub OAuth login unless the WorkOS MFA handshake completed. Only set this to `true` when MFA enforcement is **also** enabled in the WorkOS dashboard — the app cannot initiate MFA on its own, so enabling this while WorkOS enforcement is off rejects every social login with `mfa_required`. When `false` (default), WorkOS is the single source of truth for whether MFA runs. Requires `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`; refuses to start otherwise. | WorkOS login |
 
-Self-hosted operators leave all four WorkOS variables in this section empty.
+Self-hosted operators leave every variable in this section unset.
 They still set the two required core variables in the previous section
 (`IDENTRAIL_PUBLIC_BASE_URL` and `IDENTRAIL_SESSION_KEY`), set the two optional
 ones if they need them (`IDENTRAIL_SESSION_KEY_PREVIOUS` during a key rotation,

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -46,6 +46,7 @@ in [`production-api-readiness.md`](./production-api-readiness.md).
 | `IDENTRAIL_WORKOS_API_KEY` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Treated as a secret. | WorkOS login |
 | `IDENTRAIL_WORKOS_WEBHOOK_SECRET` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Used to verify webhook HMAC. | WorkOS login |
 | `IDENTRAIL_WORKOS_ENVIRONMENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Picks the WorkOS environment (test, staging, production). | WorkOS login |
+| `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` | `false` | Boolean. Defense-in-depth assertion that refuses to create a session for a Google/GitHub OAuth login unless the WorkOS MFA handshake completed. Only set this to `true` when MFA enforcement is **also** enabled in the WorkOS dashboard — the app cannot initiate MFA on its own, so enabling this while WorkOS enforcement is off rejects every social login with `mfa_required`. When `false` (default), WorkOS is the single source of truth for whether MFA runs. Requires `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`; refuses to start otherwise. | WorkOS login |
 
 Self-hosted operators leave all four WorkOS variables in this section empty.
 They still set the two required core variables in the previous section

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -25,6 +25,7 @@ type authSessionRouteOptions struct {
 	AuditFingerprinter    *audit.Fingerprinter
 	ManualMode            bool
 	ManualModeAllowUnsafe bool
+	RequireSocialMFA      bool
 	WorkOSEnabled         bool
 	WorkOSClientID        string
 	WorkOSClient          sessionauth.WorkOSClient
@@ -451,10 +452,14 @@ func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manag
 	if strings.TrimSpace(profile.OrganizationID) == "" {
 		profile.OrganizationID = authenticated.OrganizationID
 	}
-	if workOSSocialLoginRequiresMFA(authenticated) {
+	if opts.RequireSocialMFA && workOSSocialLoginRequiresMFA(authenticated) {
 		auditAuthAction(c.Request.Context(), "auth.login.failure", profile.ID, "denied")
 		if logger != nil {
-			logger.Warn("workos social login completed without mfa", zap.String("auth_method", authenticated.AuthenticationMethod))
+			// This assertion fires when IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA=true
+			// but WorkOS never initiated the MFA handshake — usually because
+			// MFA enforcement is disabled in the WorkOS dashboard. The two
+			// settings must match; the app cannot start MFA on its own.
+			logger.Warn("workos social login completed without mfa; IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA=true requires MFA to also be enforced in WorkOS", zap.String("auth_method", authenticated.AuthenticationMethod))
 		}
 		writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonMFARequired, http.StatusForbidden, "mfa required")
 		return "", false

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -88,6 +88,7 @@ type RouterOptions struct {
 	SessionKeyPrevious        string
 	AuthManualMode            bool
 	AuthManualModeAllowUnsafe bool
+	AuthRequireSocialMFA      bool
 	WorkOSClientID            string
 	WorkOSAPIKey              string
 	WorkOSWebhookSecret       string
@@ -335,6 +336,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			AuditFingerprinter:    opts.AuditFingerprinter,
 			ManualMode:            opts.AuthManualMode,
 			ManualModeAllowUnsafe: opts.AuthManualModeAllowUnsafe,
+			RequireSocialMFA:      opts.AuthRequireSocialMFA,
 			WorkOSEnabled:         opts.FeatureWorkOSLogin,
 			WorkOSClientID:        opts.WorkOSClientID,
 			WorkOSClient:          workOSClient,

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -314,7 +314,7 @@ func TestWorkOSSignupEmailFailureDoesNotBlockSession(t *testing.T) {
 	}
 }
 
-func TestWorkOSSocialLoginWithoutMFADoesNotCreateSession(t *testing.T) {
+func TestWorkOSSocialLoginWithoutMFADoesNotCreateSessionWhenRequired(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 	workOS := &fakeWorkOSClient{
@@ -328,15 +328,16 @@ func TestWorkOSSocialLoginWithoutMFADoesNotCreateSession(t *testing.T) {
 		},
 	}
 	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
-		FeatureNewAuth:      true,
-		FeatureWorkOSLogin:  true,
-		PublicBaseURL:       "https://app.identrail.test",
-		SessionKey:          strings.Repeat("a", 64),
-		WorkOSClientID:      "client_123",
-		WorkOSWebhookSecret: "whsec_123",
-		WorkOSAuthClient:    workOS,
-		RateLimitRPM:        1000,
-		RateLimitBurst:      1000,
+		FeatureNewAuth:       true,
+		FeatureWorkOSLogin:   true,
+		AuthRequireSocialMFA: true,
+		PublicBaseURL:        "https://app.identrail.test",
+		SessionKey:           strings.Repeat("a", 64),
+		WorkOSClientID:       "client_123",
+		WorkOSWebhookSecret:  "whsec_123",
+		WorkOSAuthClient:     workOS,
+		RateLimitRPM:         1000,
+		RateLimitBurst:       1000,
 	})
 
 	startResp := httptest.NewRecorder()
@@ -358,6 +359,53 @@ func TestWorkOSSocialLoginWithoutMFADoesNotCreateSession(t *testing.T) {
 	}
 	if _, err := store.GetUserIdentity(context.Background(), sessionauth.WorkOSProvider, "user_social_no_mfa"); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("social login without mfa must not create identity, got %v", err)
+	}
+}
+
+func TestWorkOSSocialLoginWithoutMFACreatesSessionByDefault(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{
+		authentication: sessionauth.WorkOSAuthentication{
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_social_workos_mfa_off",
+				Email:         "social-workos-mfa-off@example.com",
+				EmailVerified: true,
+			},
+			AuthenticationMethod: "GitHubOAuth",
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:      true,
+		FeatureWorkOSLogin:  true,
+		PublicBaseURL:       "https://app.identrail.test",
+		SessionKey:          strings.Repeat("a", 64),
+		WorkOSClientID:      "client_123",
+		WorkOSWebhookSecret: "whsec_123",
+		WorkOSAuthClient:    workOS,
+		RateLimitRPM:        1000,
+		RateLimitBurst:      1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=/app/welcome", nil))
+	if startResp.Code != http.StatusFound {
+		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected callback redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); got != "/app/welcome" {
+		t.Fatalf("expected post-login redirect without app-side mfa enforcement, got %q", got)
+	}
+	if findTestCookie(callbackResp.Result().Cookies(), sessionauth.CookieName) == nil {
+		t.Fatalf("expected session cookie when IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA is off, got %+v", callbackResp.Result().Cookies())
+	}
+	if _, err := store.GetUserIdentity(context.Background(), sessionauth.WorkOSProvider, "user_social_workos_mfa_off"); err != nil {
+		t.Fatalf("expected identity to be created, got %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ const (
 	defaultFeatureNativeSSO              = false
 	defaultAuthManualMode                = false
 	defaultAuthManualModeAllowUnsafe     = false
+	defaultAuthRequireSocialMFA          = false
 	defaultEmailTimeout                  = 3 * time.Second
 	defaultAppModeEnabled                = false
 	defaultAppModeConnectorsEnabled      = false
@@ -204,6 +205,7 @@ type Config struct {
 	SessionKeyPrevious            string
 	AuthManualMode                bool
 	AuthManualModeAllowUnsafe     bool
+	AuthRequireSocialMFA          bool
 	WorkOSClientID                string
 	WorkOSAPIKey                  string
 	WorkOSWebhookSecret           string
@@ -396,6 +398,7 @@ func Load() Config {
 		SessionKeyPrevious:            getEnv("IDENTRAIL_SESSION_KEY_PREVIOUS", ""),
 		AuthManualMode:                boolEnv("IDENTRAIL_AUTH_MANUAL_MODE", defaultAuthManualMode),
 		AuthManualModeAllowUnsafe:     boolEnv("IDENTRAIL_AUTH_MANUAL_MODE_ALLOW_UNSAFE", defaultAuthManualModeAllowUnsafe),
+		AuthRequireSocialMFA:          boolEnv("IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA", defaultAuthRequireSocialMFA),
 		WorkOSClientID:                getEnv("IDENTRAIL_WORKOS_CLIENT_ID", ""),
 		WorkOSAPIKey:                  getEnv("IDENTRAIL_WORKOS_API_KEY", ""),
 		WorkOSWebhookSecret:           getEnv("IDENTRAIL_WORKOS_WEBHOOK_SECRET", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,6 +94,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_SESSION_KEY", "")
 	t.Setenv("IDENTRAIL_SESSION_KEY_PREVIOUS", "")
 	t.Setenv("IDENTRAIL_AUTH_MANUAL_MODE", "")
+	t.Setenv("IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA", "")
 	t.Setenv("IDENTRAIL_WORKOS_CLIENT_ID", "")
 	t.Setenv("IDENTRAIL_OIDC_TENANT_CLAIM", "")
 	t.Setenv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", "")
@@ -347,6 +348,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.AuthManualMode {
 		t.Fatal("expected manual auth mode disabled by default")
 	}
+	if cfg.AuthRequireSocialMFA {
+		t.Fatal("expected social mfa requirement disabled by default")
+	}
 	if cfg.WorkOSClientID != "" {
 		t.Fatalf("expected empty WorkOS client id by default, got %q", cfg.WorkOSClientID)
 	}
@@ -470,6 +474,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_SESSION_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	t.Setenv("IDENTRAIL_SESSION_KEY_PREVIOUS", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	t.Setenv("IDENTRAIL_AUTH_MANUAL_MODE", "true")
+	t.Setenv("IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA", "true")
 	t.Setenv("IDENTRAIL_WORKOS_CLIENT_ID", "client_123")
 	t.Setenv("IDENTRAIL_WORKOS_API_KEY", "sk_test_123")
 	t.Setenv("IDENTRAIL_WORKOS_WEBHOOK_SECRET", "whsec_123")
@@ -731,6 +736,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if !cfg.AuthManualMode {
 		t.Fatal("expected manual auth mode enabled from env")
+	}
+	if !cfg.AuthRequireSocialMFA {
+		t.Fatal("expected social mfa requirement enabled from env")
 	}
 	if cfg.WorkOSClientID != "client_123" {
 		t.Fatalf("unexpected WorkOS client id: %q", cfg.WorkOSClientID)

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -240,6 +240,9 @@ func ValidateSecurity(cfg Config) error {
 	if cfg.FeatureWorkOSLogin && !cfg.FeatureNewAuth {
 		return fmt.Errorf("IDENTRAIL_FEATURE_WORKOS_LOGIN=true requires IDENTRAIL_FEATURE_NEW_AUTH=true")
 	}
+	if cfg.AuthRequireSocialMFA && !cfg.FeatureWorkOSLogin {
+		return fmt.Errorf("IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA=true requires IDENTRAIL_FEATURE_WORKOS_LOGIN=true: the assertion only checks the MFA handshake that WorkOS hosted login initiates")
+	}
 	if err := validateEmailRuntimeConfig(cfg); err != nil {
 		return err
 	}

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -1194,6 +1194,16 @@ func TestValidateSecurityOnboardingRequiresNewAuth(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRequireSocialMFARequiresWorkOSLogin(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:         map[string][]string{"reader-key-12345678901234567890": {"read"}},
+		AuthRequireSocialMFA: true,
+	}
+	if err := ValidateSecurity(cfg); err == nil || !strings.Contains(err.Error(), "IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA=true requires IDENTRAIL_FEATURE_WORKOS_LOGIN=true") {
+		t.Fatalf("expected social mfa workos login dependency error, got %v", err)
+	}
+}
+
 func TestValidateSecurityGitHubV2AllowsPATOnlyConfig(t *testing.T) {
 	cfg := Config{
 		APIKeyScopes:             map[string][]string{"reader-key-12345678901234567890": {"read"}},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,6 +153,7 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 		SessionKeyPrevious:        cfg.SessionKeyPrevious,
 		AuthManualMode:            cfg.AuthManualMode,
 		AuthManualModeAllowUnsafe: cfg.AuthManualModeAllowUnsafe,
+		AuthRequireSocialMFA:      cfg.AuthRequireSocialMFA,
 		WorkOSClientID:            cfg.WorkOSClientID,
 		WorkOSAPIKey:              cfg.WorkOSAPIKey,
 		WorkOSWebhookSecret:       cfg.WorkOSWebhookSecret,


### PR DESCRIPTION
## Summary

Adds `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` (default `false`) and gates the app-side social-login MFA assertion in `completeWorkOSLogin` behind it. With the flag off, WorkOS is the single source of truth for whether MFA runs during Google/GitHub OAuth sign-in. Setting it to `true` restores the previous behavior as an explicit defense-in-depth assertion for deployments that also enforce MFA in the WorkOS dashboard. Startup validation rejects the flag without `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`, and the enforcement-failure log now names the env var and the WorkOS-side requirement.

## Why

`workOSSocialLoginRequiresMFA` unconditionally rejected Google/GitHub OAuth logins whose WorkOS MFA handshake had not completed. The app cannot initiate that handshake itself — `MFACompleted` is only set after the `/auth/mfa/*` TOTP flow, which is reachable only when WorkOS returns an MFA-required error with a pending authentication token. So disabling MFA enforcement in the WorkOS dashboard bricked all social sign-in: every attempt (new and existing users) failed with an unrecoverable `mfa_required` loop ("Additional verification is required before Identrail can create a session").

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered — the default changes behavior deliberately: it un-bricks the WorkOS-MFA-off configuration. Deployments that enforce MFA in WorkOS are unaffected (the handshake still runs); deployments that want the app-side assertion back set the flag.
- [x] Risk level assessed — low; single boolean threaded through existing config plumbing, validated at startup.

## Validation

```bash
make fmt-check   # pass
make vet         # pass
make test        # pass (full unit suite with coverage)
go test ./internal/api -run TestWorkOSSocialLogin -v   # both enforcement-on and default-off paths pass
```

## Checklist

- [x] Tests added/updated for behavior changes (`TestWorkOSSocialLoginWithoutMFADoesNotCreateSessionWhenRequired`, `TestWorkOSSocialLoginWithoutMFACreatesSessionByDefault`, config default/env/validation tests)
- [x] Docs updated for user/operator-facing changes (`docs/auth/env-vars-reference.md`)
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Fixes #1714

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make app-side social-login MFA enforcement opt-in via `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` (default `false`) so WorkOS decides if MFA runs for Google/GitHub OAuth; fixes broken social sign-in when WorkOS MFA is disabled. Set it to `true` to restore the previous defense-in-depth assertion.

- **Migration**
  - Leave the flag unset unless MFA is enforced in WorkOS; turning it on without WorkOS MFA will block all social logins with `mfa_required`.
  - Requires `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`; startup validation enforces this.

<sup>Written for commit be9a8f510c3aad385148b231550ba4db156c8684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

