### PR TITLE
Follow-up for #1713: avoid cursor advance on partial source runs

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1919,7 +1919,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		ChangedPaths:     append([]string(nil), result.ChangedPaths...),
 		PartialSourceRun: partialSourceRun,
 	}
-	if !result.Truncated {
+	if !result.Truncated && !partialSourceRun {
 		completionContext.CursorAfter = cursorAfter
 	}
 	if err := s.completeRepoScanTerminal(
@@ -1944,7 +1944,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
 		return RunRepoScanResult{}, fmt.Errorf("complete repo scan: %w", err)
 	}
-	if cursorAfter != "" && !result.Truncated {
+	if cursorAfter != "" && !result.Truncated && !partialSourceRun {
 		completedAt := s.Now().UTC()
 		record.CursorAfter = cursorAfter
 		record.HeadRevision = firstNonEmptyString(record.HeadRevision, result.HeadRevision)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2787,6 +2787,76 @@ func TestServiceRunRepoScanPersistedDoesNotAdvanceCursorAfterTruncatedScan(t *te
 	}
 }
 
+func TestServiceRunRepoScanPersistedDoesNotAdvanceCursorAfterPartialSourceRun(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/private"}
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+
+	oldHead := "1111111111111111111111111111111111111111"
+	newHead := "2222222222222222222222222222222222222222"
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), db.RepoScanCursor{
+		Repository:          "owner/private",
+		LastScannedRevision: oldHead,
+		LastScanID:          "old-scan-id",
+		LastScanMode:        db.RepoScanModeDelta,
+		LastScanCompletedAt: now.Add(-time.Hour),
+		UpdatedAt:           now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed existing cursor: %v", err)
+	}
+
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_token", ExpiresAt: now.Add(time.Hour)},
+	}
+	collector := &fakeGitHubRepositoryPostureCollector{
+		err: errors.New("github posture source unavailable"),
+	}
+	svc.GitHubRepositoryPostureCollector = collector
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   2,
+				ScanMode:       db.RepoScanModeDelta,
+				BaseRevision:   oldHead,
+				HeadRevision:   newHead,
+			},
+		}
+	}
+
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{
+		Repository:   "owner/private",
+		ProjectID:    "project-1",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: oldHead,
+		HeadRevision: newHead,
+	})
+	if err != nil {
+		t.Fatalf("run persisted delta repo scan: %v", err)
+	}
+	if collector.seenRepository != "owner/private" {
+		t.Fatalf("expected repository posture collector to run for owner/private, got %+v", collector.seenRepository)
+	}
+	if run.RepoScan.CursorAfter != "" {
+		t.Fatalf("partial source run must not advance cursor_after, got %+v", run.RepoScan)
+	}
+
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/private", db.RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	if cursor.LastScannedRevision != oldHead || cursor.LastScanID != "old-scan-id" || cursor.LastScanMode != db.RepoScanModeDelta {
+		t.Fatalf("partial source run must not overwrite existing cursor, got %+v", cursor)
+	}
+}
+
 func TestServiceRunRepoScanPersistedDoesNotFailAfterSuccessfulCursorUpdateMiss(t *testing.T) {
 	store := &failingRepoScanCursorStore{MemoryStore: db.NewMemoryStore()}
 	svc := NewService(store, fakeScanner{}, "aws")


### PR DESCRIPTION
This follow-up PR addresses the open review thread on #1713 (PRRT_kwDORog7ms6OWe1p).\n\nChanges:\n- Do not set `CursorAfter` in `completionContext` when `partialSourceRun` is true.\n- Do not persist repo scan cursor updates when `partialSourceRun` is true.\n- Add regression test `TestServiceRunRepoScanPersistedDoesNotAdvanceCursorAfterPartialSourceRun`.\n\nThis treats partial source runs the same as truncated scans for cursor advancement, preventing transient source-collector failures from skipping retry opportunities.