### PR TITLE
Expose repo scan source health

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -24773,6 +24773,25 @@ components:
         files_scanned: { type: integer }
         finding_count: { type: integer }
         truncated: { type: boolean }
+        source_health:
+          type: string
+          enum: [complete, partial, permission_limited, rate_limited, unavailable, unknown]
+          description: Overall collection health across native and GitHub-native repository scan sources.
+        source_health_details:
+          type: array
+          description: Per-source collection health. Complete scans with zero findings still report complete source health.
+          items:
+            type: object
+            properties:
+              source:
+                type: string
+                description: Source collector id, such as identrail_repo_scanner or github_secret_scanning.
+              status:
+                type: string
+                enum: [complete, partial, permission_limited, rate_limited, unavailable, unknown]
+              code: { type: string }
+              message: { type: string }
+              retryable: { type: boolean }
         scan_mode:
           type: string
           enum: [quick, delta, deep]

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1973,6 +1973,8 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	record.FilesScanned = result.FilesScanned
 	record.FindingCount = len(result.Findings)
 	record.Truncated = result.Truncated
+	record.SourceHealth = sourceHealth
+	record.SourceHealthDetails = sourceHealthDetails
 	record.ScanMode = result.ScanMode
 	record.BaseRevision = result.BaseRevision
 	record.HeadRevision = result.HeadRevision

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1874,11 +1874,11 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		return RunRepoScanResult{}, safeErr
 	}
 	result = applyRepoScanContextToResult(result, target, scanContext)
-	partialSourceRun := false
+	sourceErrors := []providers.SourceError{}
 	if !result.Truncated {
-		externalFindings, sourceErrors, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		externalFindings, externalSourceErrors, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		sourceErrors = append(sourceErrors, externalSourceErrors...)
 		if len(sourceErrors) > 0 {
-			partialSourceRun = true
 			s.appendScanEvent(ctx, record.ID, db.ScanEventLevelWarn, "repo scan completed with partial source errors", map[string]any{
 				"source_error_count": len(sourceErrors),
 				"source_errors":      truncateSourceErrors(sourceErrors, maxSourceErrorsInEvent),
@@ -1898,6 +1898,9 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 			result.Truncated = result.Truncated || externalTruncated
 		}
 	}
+	sourceHealthDetails := s.repoScanSourceHealthDetails(record, result.Truncated, sourceErrors)
+	sourceHealth, _ := db.NormalizeRepoScanSourceHealth("", sourceHealthDetails)
+	partialSourceRun := sourceHealth != db.RepoScanSourceHealthComplete
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		if errors.Is(err, db.ErrConflict) {
@@ -1918,6 +1921,8 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		HeadRevision:     result.HeadRevision,
 		ChangedPaths:     append([]string(nil), result.ChangedPaths...),
 		PartialSourceRun: partialSourceRun,
+		SourceHealth:     sourceHealth,
+		SourceDetails:    sourceHealthDetails,
 	}
 	if !result.Truncated && !partialSourceRun {
 		completionContext.CursorAfter = cursorAfter
@@ -2187,6 +2192,157 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		}
 	}
 	return findings, sourceErrors, nil
+}
+
+func (s *Service) repoScanSourceHealthDetails(record db.RepoScanRecord, truncated bool, sourceErrors []providers.SourceError) []db.RepoScanSourceHealth {
+	details := []db.RepoScanSourceHealth{{
+		Source: "identrail_repo_scanner",
+		Status: db.RepoScanSourceHealthComplete,
+	}}
+	skipCode := ""
+	skipMessage := ""
+	if truncated {
+		details[0].Status = db.RepoScanSourceHealthPartial
+		details[0].Code = "repo_scan_truncated"
+		details[0].Message = "repository scan reached the configured finding limit"
+		skipCode = "scan_truncated"
+		skipMessage = "source collection skipped because repository scan was truncated"
+	}
+
+	source := record.Source.Normalize()
+	if source.Provider != "github_app" || source.InstallationID <= 0 {
+		return details
+	}
+
+	errorsByCollector := map[string][]providers.SourceError{}
+	for _, sourceError := range sourceErrors {
+		collector := strings.ToLower(strings.TrimSpace(sourceError.Collector))
+		if collector == "" {
+			collector = "unknown"
+		}
+		errorsByCollector[collector] = append(errorsByCollector[collector], sourceError)
+	}
+
+	githubSources := []struct {
+		name      string
+		available bool
+		code      string
+		message   string
+	}{
+		{name: "github_code_scanning", available: s.GitHubCodeScanningAlertCollector != nil, code: "collector_unavailable", message: "GitHub code scanning collector is unavailable"},
+		{name: "github_secret_scanning", available: s.GitHubSecretScanningAlertCollector != nil, code: "collector_unavailable", message: "GitHub secret scanning collector is unavailable"},
+		{name: "github_dependabot", available: s.GitHubDependabotAlertCollector != nil, code: "collector_unavailable", message: "GitHub Dependabot collector is unavailable"},
+		{name: "github_repository_posture", available: s.GitHubRepositoryPostureCollector != nil, code: "collector_unavailable", message: "GitHub repository posture collector is unavailable"},
+		{name: "github_organization_posture", available: s.GitHubRepositoryPostureCollector != nil && repoScanRepositoryOwner(record.Repository) != "", code: "collector_unavailable", message: "GitHub organization posture collector is unavailable"},
+	}
+	for _, githubSource := range githubSources {
+		if sourceErrors, exists := errorsByCollector[githubSource.name]; exists {
+			for _, sourceError := range sourceErrors {
+				details = append(details, repoScanSourceHealthFromSourceError(githubSource.name, sourceError))
+			}
+			continue
+		}
+		if truncated {
+			details = append(details, db.RepoScanSourceHealth{
+				Source:  githubSource.name,
+				Status:  db.RepoScanSourceHealthPartial,
+				Code:    skipCode,
+				Message: skipMessage,
+			})
+			continue
+		}
+		if !githubSource.available {
+			if githubSource.name == "github_organization_posture" && s.GitHubRepositoryPostureCollector != nil {
+				githubSource.code = "invalid_repository"
+				githubSource.message = "repository target does not include an owner for organization posture collection"
+			}
+			details = append(details, db.RepoScanSourceHealth{
+				Source:  githubSource.name,
+				Status:  db.RepoScanSourceHealthUnavailable,
+				Code:    githubSource.code,
+				Message: githubSource.message,
+			})
+			continue
+		}
+		details = append(details, db.RepoScanSourceHealth{
+			Source: githubSource.name,
+			Status: db.RepoScanSourceHealthComplete,
+		})
+	}
+	for collector, collectorErrors := range errorsByCollector {
+		if repoScanKnownGitHubCollector(collector) {
+			continue
+		}
+		for _, sourceError := range collectorErrors {
+			details = append(details, repoScanSourceHealthFromSourceError(collector, sourceError))
+		}
+	}
+	return details
+}
+
+func repoScanSourceHealthFromSourceError(source string, sourceError providers.SourceError) db.RepoScanSourceHealth {
+	status := classifyRepoScanSourceHealth(sourceError.Code, sourceError.Message)
+	return db.RepoScanSourceHealth{
+		Source:    source,
+		Status:    status,
+		Code:      sourceError.Code,
+		Message:   sourceError.Message,
+		Retryable: sourceError.Retryable || status == db.RepoScanSourceHealthRateLimited || status == db.RepoScanSourceHealthUnavailable,
+	}
+}
+
+func classifyRepoScanSourceHealth(code string, message string) string {
+	needle := strings.ToLower(strings.TrimSpace(code + " " + message))
+	switch {
+	case strings.Contains(needle, "rate limit") ||
+		strings.Contains(needle, "secondary rate") ||
+		strings.Contains(needle, "abuse detection") ||
+		strings.Contains(needle, "throttl") ||
+		strings.Contains(needle, "429") ||
+		(strings.Contains(needle, "403") && strings.Contains(needle, "rate")):
+		return db.RepoScanSourceHealthRateLimited
+	case strings.Contains(needle, "permission") ||
+		strings.Contains(needle, "forbidden") ||
+		strings.Contains(needle, "unauthor") ||
+		strings.Contains(needle, "access denied") ||
+		strings.Contains(needle, "accessdenied") ||
+		strings.Contains(needle, "requires authentication") ||
+		strings.Contains(needle, "bad credentials") ||
+		strings.Contains(needle, "403"):
+		return db.RepoScanSourceHealthPermissionLimited
+	case strings.Contains(needle, "timeout") ||
+		strings.Contains(needle, "timed out") ||
+		strings.Contains(needle, "unavailable") ||
+		strings.Contains(needle, "temporarily") ||
+		strings.Contains(needle, "network") ||
+		strings.Contains(needle, "connection") ||
+		strings.Contains(needle, "502") ||
+		strings.Contains(needle, "503") ||
+		strings.Contains(needle, "504"):
+		return db.RepoScanSourceHealthUnavailable
+	case strings.Contains(needle, "partial") ||
+		strings.Contains(needle, "normalize"):
+		return db.RepoScanSourceHealthPartial
+	default:
+		return db.RepoScanSourceHealthUnknown
+	}
+}
+
+func repoScanRepositoryOwner(repository string) string {
+	owner, _, ok := strings.Cut(strings.TrimSpace(repository), "/")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(owner)
+}
+
+func repoScanKnownGitHubCollector(collector string) bool {
+	switch strings.ToLower(strings.TrimSpace(collector)) {
+	case "github_code_scanning", "github_secret_scanning", "github_dependabot", "github_repository_posture", "github_organization_posture":
+		return true
+	default:
+		return false
+	}
 }
 
 func githubCodeScanningAlertsToRepoExposure(alerts []githubconnector.CodeScanningAlert) []repoexposure.GitHubCodeScanningAlert {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -5003,6 +5003,13 @@ func TestServiceProcessQueuedGitHubAppRepoScanPreservesPostureFindingsWhenPostur
 	if currentScan.Status != "succeeded" || currentScan.FindingCount != 0 {
 		t.Fatalf("expected partial source scan to succeed without imported posture findings, got %+v", currentScan)
 	}
+	if currentScan.SourceHealth != db.RepoScanSourceHealthPartial {
+		t.Fatalf("expected partial source health, got %+v", currentScan)
+	}
+	postureHealth := repoScanSourceHealthBySource(currentScan.SourceHealthDetails, "github_repository_posture")
+	if postureHealth == nil || postureHealth.Status != db.RepoScanSourceHealthUnavailable {
+		t.Fatalf("expected unavailable repository posture health, got %+v", currentScan.SourceHealthDetails)
+	}
 
 	openFindings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
 		Repository: "owner/private",
@@ -5024,6 +5031,108 @@ func TestServiceProcessQueuedGitHubAppRepoScanPreservesPostureFindingsWhenPostur
 	if len(fixedFindings) != 0 {
 		t.Fatalf("expected posture source failure not to mark findings fixed, got %+v", fixedFindings)
 	}
+}
+
+func TestRepoScanSourceHealthClassification(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    string
+		message string
+		want    string
+	}{
+		{name: "permission limited", code: "alert_list_error", message: "403 resource not accessible by integration", want: db.RepoScanSourceHealthPermissionLimited},
+		{name: "rate limited", code: "alert_list_error", message: "secondary rate limit exceeded", want: db.RepoScanSourceHealthRateLimited},
+		{name: "rate limited with 403", code: "alert_list_error", message: "HTTP 403: Secondary rate limit hit", want: db.RepoScanSourceHealthRateLimited},
+		{name: "unavailable", code: "posture_collect_error", message: "GitHub API unavailable: 503", want: db.RepoScanSourceHealthUnavailable},
+		{name: "partial normalization", code: "normalize_error", message: "could not normalize one alert", want: db.RepoScanSourceHealthPartial},
+		{name: "unknown", code: "alert_list_error", message: "unexpected response", want: db.RepoScanSourceHealthUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyRepoScanSourceHealth(tt.code, tt.message); got != tt.want {
+				t.Fatalf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRepoScanSourceHealthDetailsMixedGitHubSources(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.GitHubCodeScanningAlertCollector = &fakeGitHubCodeScanningAlertCollector{}
+	svc.GitHubSecretScanningAlertCollector = &fakeGitHubSecretScanningAlertCollector{}
+	svc.GitHubDependabotAlertCollector = &fakeGitHubDependabotAlertCollector{}
+	svc.GitHubRepositoryPostureCollector = &fakeGitHubRepositoryPostureCollector{}
+	details := svc.repoScanSourceHealthDetails(db.RepoScanRecord{
+		Repository: "owner/repo",
+		Source: db.RepoScanSource{
+			Provider:       "github_app",
+			InstallationID: 101,
+		},
+	}, false, []providers.SourceError{
+		{Collector: "github_secret_scanning", Code: "alert_list_error", Message: "403 resource not accessible by integration"},
+		{Collector: "github_dependabot", Code: "alert_list_error", Message: "secondary rate limit exceeded"},
+	})
+	overall, normalized := db.NormalizeRepoScanSourceHealth("", details)
+	if overall != db.RepoScanSourceHealthPartial {
+		t.Fatalf("expected mixed source health to be partial, got %s with %+v", overall, normalized)
+	}
+	if health := repoScanSourceHealthBySource(normalized, "github_code_scanning"); health == nil || health.Status != db.RepoScanSourceHealthComplete {
+		t.Fatalf("expected complete code scanning source, got %+v", normalized)
+	}
+	if health := repoScanSourceHealthBySource(normalized, "github_secret_scanning"); health == nil || health.Status != db.RepoScanSourceHealthPermissionLimited {
+		t.Fatalf("expected permission-limited secret scanning source, got %+v", normalized)
+	}
+	if health := repoScanSourceHealthBySource(normalized, "github_dependabot"); health == nil || health.Status != db.RepoScanSourceHealthRateLimited {
+		t.Fatalf("expected rate-limited dependabot source, got %+v", normalized)
+	}
+}
+
+func TestRepoScanSourceHealthDetailsMarksGitHubSourcesSkippedWhenTruncated(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.GitHubCodeScanningAlertCollector = &fakeGitHubCodeScanningAlertCollector{}
+	svc.GitHubSecretScanningAlertCollector = &fakeGitHubSecretScanningAlertCollector{}
+	svc.GitHubDependabotAlertCollector = &fakeGitHubDependabotAlertCollector{}
+	svc.GitHubRepositoryPostureCollector = &fakeGitHubRepositoryPostureCollector{}
+
+	details := svc.repoScanSourceHealthDetails(db.RepoScanRecord{
+		Repository: "owner/private",
+		Source: db.RepoScanSource{
+			Provider:       "github_app",
+			InstallationID: 101,
+		},
+	}, true, nil)
+	overall, normalized := db.NormalizeRepoScanSourceHealth("", details)
+	if overall != db.RepoScanSourceHealthPartial {
+		t.Fatalf("expected truncated source collection to be partial, got %s with %+v", overall, normalized)
+	}
+	truncatedSources := []string{
+		"github_code_scanning",
+		"github_secret_scanning",
+		"github_dependabot",
+		"github_repository_posture",
+		"github_organization_posture",
+	}
+	for _, source := range truncatedSources {
+		health := repoScanSourceHealthBySource(normalized, source)
+		if health == nil || health.Status != db.RepoScanSourceHealthPartial {
+			t.Fatalf("expected truncated source %s to be partial, got %+v", source, normalized)
+		}
+		if health.Code != "scan_truncated" {
+			t.Fatalf("expected truncated source %s to have scan_truncated code, got %+v", source, health)
+		}
+		if !strings.Contains(strings.ToLower(health.Message), "truncated") {
+			t.Fatalf("expected truncated source %s to include truncated message, got %+v", source, health)
+		}
+	}
+}
+
+func repoScanSourceHealthBySource(details []db.RepoScanSourceHealth, source string) *db.RepoScanSourceHealth {
+	for i := range details {
+		if details[i].Source == source {
+			return &details[i]
+		}
+	}
+	return nil
 }
 
 func repoFindingByDetector(findings []domain.Finding, detector string) *domain.Finding {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2847,6 +2847,13 @@ func TestServiceRunRepoScanPersistedDoesNotAdvanceCursorAfterPartialSourceRun(t 
 	if run.RepoScan.CursorAfter != "" {
 		t.Fatalf("partial source run must not advance cursor_after, got %+v", run.RepoScan)
 	}
+	if run.RepoScan.SourceHealth != db.RepoScanSourceHealthPartial {
+		t.Fatalf("expected returned repo scan source health to be partial, got %+v", run.RepoScan)
+	}
+	postureHealth := repoScanSourceHealthBySource(run.RepoScan.SourceHealthDetails, "github_repository_posture")
+	if postureHealth == nil || postureHealth.Status != db.RepoScanSourceHealthUnavailable {
+		t.Fatalf("expected posture source to be unavailable from returned source health details, got %+v", run.RepoScan.SourceHealthDetails)
+	}
 
 	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/private", db.RepoScanSource{})
 	if err != nil {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2142,6 +2142,8 @@ func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) er
 	record.StartedAt = time.Now().UTC()
 	record.FinishedAt = nil
 	record.ErrorMessage = ""
+	record.SourceHealth = RepoScanSourceHealthUnknown
+	record.SourceHealthDetails = nil
 	m.repoScans[repoScanID] = record
 	return nil
 }
@@ -2174,6 +2176,13 @@ func (m *MemoryStore) FailStaleRepoScansAnyScope(_ context.Context, staleBefore 
 		record.Status = "failed"
 		record.FinishedAt = &finishedAt
 		record.ErrorMessage = strings.TrimSpace(errorMessage)
+		record.SourceHealth = RepoScanSourceHealthUnavailable
+		record.SourceHealthDetails = []RepoScanSourceHealth{{
+			Source:  "identrail_repo_scanner",
+			Status:  RepoScanSourceHealthUnavailable,
+			Code:    "stale_running_scan",
+			Message: firstNonEmptyRepoScanSourceHealth(strings.TrimSpace(errorMessage), "repository scan exceeded its processing window"),
+		}}
 		m.repoScans[record.ID] = record
 	}
 	return len(candidates), nil
@@ -2195,6 +2204,7 @@ func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, sourc
 		CursorBefore: normalizedContext.CursorBefore,
 		CursorAfter:  normalizedContext.CursorAfter,
 		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
+		SourceHealth: RepoScanSourceHealthUnknown,
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       source.Normalize(),
@@ -2240,6 +2250,13 @@ func (m *MemoryStore) CancelRepoScan(ctx context.Context, repoScanID string, fin
 	record.Status = "failed"
 	record.FinishedAt = &finished
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
+	record.SourceHealth = RepoScanSourceHealthUnavailable
+	record.SourceHealthDetails = []RepoScanSourceHealth{{
+		Source:  "identrail_repo_scanner",
+		Status:  RepoScanSourceHealthUnavailable,
+		Code:    "scan_canceled",
+		Message: strings.TrimSpace(errorMessage),
+	}}
 	m.repoScans[repoScanID] = record
 	return record, nil
 }
@@ -2268,6 +2285,7 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	record.FilesScanned = filesScanned
 	record.FindingCount = findingCount
 	record.Truncated = truncated
+	record.SourceHealth, record.SourceHealthDetails = repoScanCompletionSourceHealth(record.Status, normalizedContext)
 	record.CursorAfter = normalizedContext.CursorAfter
 	if normalizedContext.BaseRevision != "" {
 		record.BaseRevision = normalizedContext.BaseRevision

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -1616,6 +1616,32 @@ func TestMemoryStoreFailStaleRepoScansAnyScope(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreFailStaleRepoScansAnyScopeUsesFallbackErrorMessage(t *testing.T) {
+	store := NewMemoryStore()
+	staleAt := time.Date(2026, 5, 18, 20, 0, 0, 0, time.UTC)
+	cutoff := staleAt.Add(35 * time.Minute)
+
+	scan, err := store.CreateRepoScan(defaultScopeContext(), "owner/stale-fallback", RepoScanSource{}, RepoScanContext{}, staleAt)
+	if err != nil {
+		t.Fatalf("create stale repo scan: %v", err)
+	}
+
+	failed, err := store.FailStaleRepoScansAnyScope(context.Background(), cutoff, 1, "")
+	if err != nil {
+		t.Fatalf("fail stale repo scans: %v", err)
+	}
+	if failed != 1 {
+		t.Fatalf("expected one stale repo scan failed, got %d", failed)
+	}
+	stored, err := store.GetRepoScan(defaultScopeContext(), scan.ID)
+	if err != nil {
+		t.Fatalf("get stale repo scan: %v", err)
+	}
+	if stored.SourceHealth != "unavailable" || len(stored.SourceHealthDetails) != 1 || stored.SourceHealthDetails[0].Message != "repository scan exceeded its processing window" {
+		t.Fatalf("expected fallback source-health message, got status %s details %+v", stored.SourceHealth, stored.SourceHealthDetails)
+	}
+}
+
 func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2823,6 +2823,7 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 		CursorBefore: normalizedContext.CursorBefore,
 		CursorAfter:  normalizedContext.CursorAfter,
 		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
+		SourceHealth: RepoScanSourceHealthUnknown,
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       normalizedSource,
@@ -2830,14 +2831,15 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, source_health, source_health_details, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+			 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, '[]'::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19, NULLIF($20, ''), NULLIF($21, ''))`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
+		record.SourceHealth,
 		record.ScanMode,
 		record.BaseRevision,
 		record.HeadRevision,
@@ -2885,10 +2887,12 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			LIMIT 1
 		)
 		UPDATE repo_scans AS r
-		SET status = 'running',
-		    started_at = NOW(),
-		    finished_at = NULL,
-		    error_message = NULL
+			SET status = 'running',
+			    started_at = NOW(),
+			    finished_at = NULL,
+			    error_message = NULL,
+			    source_health = 'unknown',
+			    source_health_details = '[]'::jsonb
 		FROM next_repo_scan
 		WHERE r.id = next_repo_scan.id
 		RETURNING
@@ -2901,9 +2905,11 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.finished_at,
 			r.commits_scanned,
 			r.files_scanned,
-			r.finding_count,
-			r.truncated,
-			COALESCE(r.scan_mode, 'deep'),
+				r.finding_count,
+				r.truncated,
+				COALESCE(r.source_health, 'unknown'),
+				COALESCE(r.source_health_details, '[]'::jsonb),
+				COALESCE(r.scan_mode, 'deep'),
 			COALESCE(r.base_revision, ''),
 			COALESCE(r.head_revision, ''),
 			COALESCE(r.cursor_before, ''),
@@ -2931,10 +2937,12 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			LIMIT 1
 		)
 		UPDATE repo_scans AS r
-		SET status = 'running',
-		    started_at = NOW(),
-		    finished_at = NULL,
-		    error_message = NULL
+			SET status = 'running',
+			    started_at = NOW(),
+			    finished_at = NULL,
+			    error_message = NULL,
+			    source_health = 'unknown',
+			    source_health_details = '[]'::jsonb
 		FROM next_repo_scan
 		WHERE r.id = next_repo_scan.id
 		RETURNING
@@ -2947,9 +2955,11 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.finished_at,
 			r.commits_scanned,
 			r.files_scanned,
-			r.finding_count,
-			r.truncated,
-			COALESCE(r.scan_mode, 'deep'),
+				r.finding_count,
+				r.truncated,
+				COALESCE(r.source_health, 'unknown'),
+				COALESCE(r.source_health_details, '[]'::jsonb),
+				COALESCE(r.scan_mode, 'deep'),
 			COALESCE(r.base_revision, ''),
 			COALESCE(r.head_revision, ''),
 			COALESCE(r.cursor_before, ''),
@@ -3054,7 +3064,9 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 		 SET status = 'queued',
 		     started_at = NOW(),
 		     finished_at = NULL,
-		     error_message = NULL
+		     error_message = NULL,
+		     source_health = 'unknown',
+		     source_health_details = '[]'::jsonb
 		 WHERE id = $1
 		   AND tenant_id = $2
 		   AND workspace_id = $3
@@ -3095,7 +3107,14 @@ func (p *PostgresStore) FailStaleRepoScansAnyScope(ctx context.Context, staleBef
 		UPDATE repo_scans AS r
 		SET status = 'failed',
 		    finished_at = NOW(),
-		    error_message = NULLIF($3, '')
+		    error_message = NULLIF($3, ''),
+		    source_health = 'unavailable',
+		    source_health_details = jsonb_build_array(jsonb_build_object(
+		        'source', 'identrail_repo_scanner',
+		        'status', 'unavailable',
+		        'code', 'stale_running_scan',
+		        'message', COALESCE(NULLIF($3, ''), 'repository scan exceeded its processing window')
+		    ))
 		FROM stale_repo_scans
 		WHERE r.id = stale_repo_scans.id`,
 		staleBefore.UTC(),
@@ -3136,20 +3155,22 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		CursorBefore: normalizedContext.CursorBefore,
 		CursorAfter:  normalizedContext.CursorAfter,
 		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
+		SourceHealth: RepoScanSourceHealthUnknown,
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       normalizedSource,
 	}
 	_, err = p.execContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, source_health, source_health_details, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, '[]'::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19)`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
+		record.SourceHealth,
 		record.ScanMode,
 		record.BaseRevision,
 		record.HeadRevision,
@@ -3177,8 +3198,8 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	}
 	row := p.queryRowContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
-		 FROM repo_scans
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+			 FROM repo_scans
 		 WHERE id = $1
 		   AND tenant_id = $2
 		   AND workspace_id = $3`,
@@ -3207,12 +3228,19 @@ func (p *PostgresStore) CancelRepoScan(ctx context.Context, repoScanID string, f
 		`UPDATE repo_scans
 		 SET status = 'failed',
 		     finished_at = $2,
-		     error_message = NULLIF($3, '')
+		     error_message = NULLIF($3, ''),
+		     source_health = 'unavailable',
+		     source_health_details = jsonb_build_array(jsonb_build_object(
+		         'source', 'identrail_repo_scanner',
+		         'status', 'unavailable',
+		         'code', 'scan_canceled',
+		         'message', COALESCE(NULLIF($3, ''), 'repository scan canceled')
+		     ))
 		 WHERE id = $1
 		   AND tenant_id = $4
 		   AND workspace_id = $5
 		   AND status IN ('queued', 'running')
-		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`,
+		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`,
 		repoScanID,
 		finishedAt.UTC(),
 		strings.TrimSpace(errorMessage),
@@ -3242,6 +3270,14 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		return err
 	}
 	normalizedContext := NormalizeRepoScanContext(scanContext)
+	sourceHealth, sourceHealthDetails := repoScanCompletionSourceHealth(status, normalizedContext)
+	if len(sourceHealthDetails) == 0 {
+		sourceHealthDetails = []RepoScanSourceHealth{}
+	}
+	sourceHealthDetailsJSON, err := json.Marshal(sourceHealthDetails)
+	if err != nil {
+		return fmt.Errorf("marshal repo scan source health details: %w", err)
+	}
 	changedPaths := normalizedContext.ChangedPaths
 	if len(changedPaths) == 0 {
 		changedPaths = []string{}
@@ -3269,10 +3305,12 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
 		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
 		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
-		     error_message = $12
+		     source_health = $12,
+		     source_health_details = $13::jsonb,
+		     error_message = $14
 		 WHERE id = $1
-		   AND tenant_id = $13
-		   AND workspace_id = $14
+		   AND tenant_id = $15
+		   AND workspace_id = $16
 		   AND status IN ('queued', 'running')`,
 		repoScanID,
 		strings.TrimSpace(status),
@@ -3285,6 +3323,8 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		normalizedContext.BaseRevision,
 		normalizedContext.HeadRevision,
 		string(changedPathsJSON),
+		sourceHealth,
+		string(sourceHealthDetailsJSON),
 		nullableString(errorMessage),
 		scope.TenantID,
 		scope.WorkspaceID,
@@ -3714,8 +3754,8 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	}
 	rows, err := p.queryContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
-		 FROM repo_scans
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+			 FROM repo_scans
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		 ORDER BY started_at DESC
@@ -4744,6 +4784,7 @@ type scanner interface {
 func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	var record RepoScanRecord
 	var finishedAt sql.NullTime
+	var sourceHealthDetails []byte
 	var changedPaths []byte
 	if err := scanner.Scan(
 		&record.ID,
@@ -4757,6 +4798,8 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.FilesScanned,
 		&record.FindingCount,
 		&record.Truncated,
+		&record.SourceHealth,
+		&sourceHealthDetails,
 		&record.ScanMode,
 		&record.BaseRevision,
 		&record.HeadRevision,
@@ -4776,6 +4819,7 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	record.StartedAt = record.StartedAt.UTC()
 	record.ScanMode = NormalizeRepoScanContext(RepoScanContext{ScanMode: record.ScanMode}).ScanMode
 	record.ChangedPaths = decodeRepoScanChangedPaths(changedPaths)
+	record.SourceHealth, record.SourceHealthDetails = NormalizeRepoScanSourceHealth(record.SourceHealth, decodeRepoScanSourceHealthDetails(sourceHealthDetails))
 	record.Source = record.Source.Normalize()
 	if finishedAt.Valid {
 		converted := finishedAt.Time.UTC()
@@ -4787,6 +4831,7 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	var record RepoScanRecord
 	var finishedAt sql.NullTime
+	var sourceHealthDetails []byte
 	var changedPaths []byte
 	if err := scanner.Scan(
 		&record.ID,
@@ -4800,6 +4845,8 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.FilesScanned,
 		&record.FindingCount,
 		&record.Truncated,
+		&record.SourceHealth,
+		&sourceHealthDetails,
 		&record.ScanMode,
 		&record.BaseRevision,
 		&record.HeadRevision,
@@ -4821,6 +4868,7 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	record.StartedAt = record.StartedAt.UTC()
 	record.ScanMode = NormalizeRepoScanContext(RepoScanContext{ScanMode: record.ScanMode}).ScanMode
 	record.ChangedPaths = decodeRepoScanChangedPaths(changedPaths)
+	record.SourceHealth, record.SourceHealthDetails = NormalizeRepoScanSourceHealth(record.SourceHealth, decodeRepoScanSourceHealthDetails(sourceHealthDetails))
 	record.Source = record.Source.Normalize()
 	record.TraceParent = strings.TrimSpace(record.TraceParent)
 	record.TraceState = strings.TrimSpace(record.TraceState)
@@ -4871,6 +4919,17 @@ func decodeRepoScanChangedPaths(raw []byte) []string {
 		return nil
 	}
 	return normalizeRepoScanChangedPaths(paths)
+}
+
+func decodeRepoScanSourceHealthDetails(raw []byte) []RepoScanSourceHealth {
+	if len(raw) == 0 {
+		return nil
+	}
+	var details []RepoScanSourceHealth
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return nil
+	}
+	return details
 }
 
 func repoScanChangedPathsForJSON(paths []string) []string {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -691,8 +691,8 @@ func TestNewPostgresStoreWithDB(t *testing.T) {
 }
 
 func repoScanRows(recordID string, status string, startedAt time.Time, finishedAt any) *sqlmock.Rows {
-	return sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
-		AddRow(recordID, "default", "default", "owner/repo", status, startedAt, finishedAt, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
+	return sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "source_health", "source_health_details", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(recordID, "default", "default", "owner/repo", status, startedAt, finishedAt, 12, 8, 1, false, "complete", []byte("[]"), "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
 }
 
 func repoFindingLifecycleColumns() []string {
@@ -749,9 +749,9 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 0, 0, "", "", "", int64(0)).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, source_health, source_health_details, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, '[]'::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), "unknown", "deep", "", "", "", "", "[]", 0, 0, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
@@ -796,12 +796,14 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
 		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
 		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
-		     error_message = $12
+		     source_health = $12,
+		     source_health_details = $13::jsonb,
+		     error_message = $14
 		 WHERE id = $1
-		   AND tenant_id = $13
-		   AND workspace_id = $14
+		   AND tenant_id = $15
+		   AND workspace_id = $16
 		   AND status IN ('queued', 'running')`)).
-		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", nil, "default", "default").
+		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", "complete", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE repo_findings rf").
 		WithArgs(sqlmock.AnyArg(), "default", "default", record.ID).
@@ -1717,9 +1719,9 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0)).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, source_health, source_health_details, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, '[]'::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), "unknown", "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now)
@@ -1780,6 +1782,8 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"files_scanned",
 		"finding_count",
 		"truncated",
+		"source_health",
+		"source_health_details",
 		"scan_mode",
 		"base_revision",
 		"head_revision",
@@ -1795,7 +1799,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"source_installation_id",
 		"trace_parent",
 		"trace_state",
-	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "", 50, 80, "", "", "", int64(0), "", "")
+	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "unknown", []byte("[]"), "deep", "", "", "", "", []byte("[]"), "", 50, 80, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").WithArgs("default", "default").WillReturnRows(claimRows)
 
 	claimed, err := store.ClaimNextQueuedRepoScan(defaultScopeContext())
@@ -1810,7 +1814,9 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		 SET status = 'queued',
 		     started_at = NOW(),
 		     finished_at = NULL,
-		     error_message = NULL
+			     error_message = NULL,
+			     source_health = 'unknown',
+			     source_health_details = '[]'::jsonb
 		 WHERE id = $1
 		   AND tenant_id = $2
 		   AND workspace_id = $3
@@ -1936,12 +1942,14 @@ func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.
 		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
 		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
 		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
-		     error_message = $12
+		     source_health = $12,
+		     source_health_details = $13::jsonb,
+		     error_message = $14
 		 WHERE id = $1
-		   AND tenant_id = $13
-		   AND workspace_id = $14
+		   AND tenant_id = $15
+		   AND workspace_id = $16
 		   AND status IN ('queued', 'running')`)).
-		WithArgs(scanID, "completed", now, 4, 2, 1, false, "", "", "", "[]", nil, "default", "default").
+		WithArgs(scanID, "completed", now, 4, 2, 1, false, "", "", "", "[]", "complete", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectRollback()
 
@@ -1957,6 +1965,8 @@ func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.
 		"files_scanned",
 		"finding_count",
 		"truncated",
+		"source_health",
+		"source_health_details",
 		"scan_mode",
 		"base_revision",
 		"head_revision",
@@ -1970,8 +1980,8 @@ func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.
 		"source_project_id",
 		"source_connector_id",
 		"source_installation_id",
-	}).AddRow(scanID, "default", "default", "owner/repo", "failed", now, now.Add(time.Minute), 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "repository scan canceled by user", 50, 80, "github_app", "project-1", "github", int64(77))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+	}).AddRow(scanID, "default", "default", "owner/repo", "failed", now, now.Add(time.Minute), 0, 0, 0, false, "unavailable", []byte(`[{"source":"identrail_repo_scanner","status":"unavailable"}]`), "deep", "", "", "", "", []byte("[]"), "repository scan canceled by user", 50, 80, "github_app", "project-1", "github", int64(77))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
 		 FROM repo_scans
 		 WHERE id = $1
 		   AND tenant_id = $2
@@ -2012,6 +2022,8 @@ func TestPostgresStoreCancelRepoScan(t *testing.T) {
 		"files_scanned",
 		"finding_count",
 		"truncated",
+		"source_health",
+		"source_health_details",
 		"scan_mode",
 		"base_revision",
 		"head_revision",
@@ -2025,17 +2037,24 @@ func TestPostgresStoreCancelRepoScan(t *testing.T) {
 		"source_project_id",
 		"source_connector_id",
 		"source_installation_id",
-	}).AddRow(scanID, "default", "default", "owner/repo", "failed", startedAt, finishedAt, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), cancelMessage, 50, 80, "github_app", "project-1", "github", int64(77))
+	}).AddRow(scanID, "default", "default", "owner/repo", "failed", startedAt, finishedAt, 0, 0, 0, false, "unavailable", []byte(`[{"source":"identrail_repo_scanner","status":"unavailable","code":"scan_canceled"}]`), "deep", "", "", "", "", []byte("[]"), cancelMessage, 50, 80, "github_app", "project-1", "github", int64(77))
 
 	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE repo_scans
 		 SET status = 'failed',
 		     finished_at = $2,
-		     error_message = NULLIF($3, '')
+		     error_message = NULLIF($3, ''),
+		     source_health = 'unavailable',
+		     source_health_details = jsonb_build_array(jsonb_build_object(
+		         'source', 'identrail_repo_scanner',
+		         'status', 'unavailable',
+		         'code', 'scan_canceled',
+		         'message', COALESCE(NULLIF($3, ''), 'repository scan canceled')
+		     ))
 		 WHERE id = $1
 		   AND tenant_id = $4
 		   AND workspace_id = $5
 		   AND status IN ('queued', 'running')
-		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`)).
+		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`)).
 		WithArgs(scanID, finishedAt, cancelMessage, "default", "default").
 		WillReturnRows(cancelRows)
 
@@ -2100,7 +2119,14 @@ func TestPostgresStoreFailStaleRepoScansAnyScope(t *testing.T) {
 		UPDATE repo_scans AS r
 		SET status = 'failed',
 		    finished_at = NOW(),
-		    error_message = NULLIF($3, '')
+		    error_message = NULLIF($3, ''),
+		    source_health = 'unavailable',
+		    source_health_details = jsonb_build_array(jsonb_build_object(
+		        'source', 'identrail_repo_scanner',
+		        'status', 'unavailable',
+		        'code', 'stale_running_scan',
+		        'message', COALESCE(NULLIF($3, ''), 'repository scan exceeded its processing window')
+		    ))
 		FROM stale_repo_scans
 		WHERE r.id = stale_repo_scans.id`)).
 		WithArgs(staleBefore, 25, "worker timed out").
@@ -2151,9 +2177,9 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		   AND status = 'queued'`)).
 		WithArgs("default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0), "", "").
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, source_health, source_health_details, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, '[]'::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19, NULLIF($20, ''), NULLIF($21, ''))`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, "unknown", "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0), "", "").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -3334,10 +3360,11 @@ func TestPostgresStoreClaimNextQueuedRepoScanAnyScopeBypassesScopeInjection(t *t
 	rows := sqlmock.NewRows([]string{
 		"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at",
 		"commits_scanned", "files_scanned", "finding_count", "truncated",
+		"source_health", "source_health_details",
 		"scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths",
 		"coalesce", "history_limit", "max_findings_limit",
 		"source_provider", "source_project_id", "source_connector_id", "source_installation_id", "trace_parent", "trace_state",
-	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "", 500, 200, "", "", "", int64(0), "", "")
+	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "unknown", []byte("[]"), "deep", "", "", "", "", []byte("[]"), "", 500, 200, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").
 		WillReturnRows(rows)
 

--- a/internal/db/sqlcdb/queries.go
+++ b/internal/db/sqlcdb/queries.go
@@ -65,6 +65,8 @@ type RepoScanRow struct {
 	FilesScanned   int
 	FindingCount   int
 	Truncated      bool
+	SourceHealth   string
+	SourceDetails  []byte
 	ErrorMessage   string
 }
 
@@ -194,7 +196,7 @@ func (q *Queries) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanR
 	var row RepoScanRow
 	err := q.db.QueryRowContext(
 		ctx,
-		`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '')
+		`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(error_message, '')
 		 FROM repo_scans
 		 WHERE id = $1`,
 		repoScanID,
@@ -208,6 +210,8 @@ func (q *Queries) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanR
 		&row.FilesScanned,
 		&row.FindingCount,
 		&row.Truncated,
+		&row.SourceHealth,
+		&row.SourceDetails,
 		&row.ErrorMessage,
 	)
 	if err != nil {
@@ -219,7 +223,7 @@ func (q *Queries) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanR
 func (q *Queries) ListRepoScans(ctx context.Context, limit int) ([]RepoScanRow, error) {
 	rows, err := q.db.QueryContext(
 		ctx,
-		`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '')
+		`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(error_message, '')
 		 FROM repo_scans
 		 ORDER BY started_at DESC
 		 LIMIT $1`,
@@ -243,6 +247,8 @@ func (q *Queries) ListRepoScans(ctx context.Context, limit int) ([]RepoScanRow, 
 			&row.FilesScanned,
 			&row.FindingCount,
 			&row.Truncated,
+			&row.SourceHealth,
+			&row.SourceDetails,
 			&row.ErrorMessage,
 		); err != nil {
 			return nil, err

--- a/internal/db/sqlcdb/queries_test.go
+++ b/internal/db/sqlcdb/queries_test.go
@@ -97,9 +97,9 @@ func TestQueriesListRepoScans(t *testing.T) {
 
 	q := New(db)
 	now := time.Now().UTC()
-	rows := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "coalesce"}).
-		AddRow("repo-scan-1", "owner/repo", "completed", now, now, 10, 5, 2, false, "")
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '')
+	rows := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "source_health", "source_health_details", "coalesce"}).
+		AddRow("repo-scan-1", "owner/repo", "completed", now, now, 10, 5, 2, false, "partial", []byte(`[{"source":"github_secret_scanning","status":"permission_limited"}]`), "")
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(error_message, '')
 		 FROM repo_scans
 		 ORDER BY started_at DESC
 		 LIMIT $1`)).WithArgs(20).WillReturnRows(rows)
@@ -110,6 +110,9 @@ func TestQueriesListRepoScans(t *testing.T) {
 	}
 	if len(result) != 1 || result[0].ID != "repo-scan-1" {
 		t.Fatalf("unexpected results: %+v", result)
+	}
+	if result[0].SourceHealth != "partial" || string(result[0].SourceDetails) == "" {
+		t.Fatalf("expected source health details, got %+v", result[0])
 	}
 }
 
@@ -173,9 +176,9 @@ func TestQueriesGetRepoScan(t *testing.T) {
 
 	q := New(db)
 	now := time.Now().UTC()
-	rows := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "coalesce"}).
-		AddRow("repo-scan-1", "owner/repo", "completed", now, now, 20, 10, 2, false, "")
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '')
+	rows := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "source_health", "source_health_details", "coalesce"}).
+		AddRow("repo-scan-1", "owner/repo", "completed", now, now, 20, 10, 2, false, "complete", []byte(`[]`), "")
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown'), COALESCE(source_health_details, '[]'::jsonb), COALESCE(error_message, '')
 		 FROM repo_scans
 		 WHERE id = $1`)).WithArgs("repo-scan-1").WillReturnRows(rows)
 
@@ -185,6 +188,9 @@ func TestQueriesGetRepoScan(t *testing.T) {
 	}
 	if result.ID != "repo-scan-1" {
 		t.Fatalf("unexpected repo scan: %+v", result)
+	}
+	if result.SourceHealth != "complete" {
+		t.Fatalf("expected complete source health, got %+v", result)
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -335,29 +335,49 @@ func (s ScanSource) Empty() bool {
 
 // RepoScanRecord tracks persisted repository exposure scan metadata.
 type RepoScanRecord struct {
-	ID             string         `json:"id"`
-	TenantID       string         `json:"-"`
-	WorkspaceID    string         `json:"-"`
-	Repository     string         `json:"repository"`
-	Status         string         `json:"status"`
-	StartedAt      time.Time      `json:"started_at"`
-	FinishedAt     *time.Time     `json:"finished_at,omitempty"`
-	CommitsScanned int            `json:"commits_scanned"`
-	FilesScanned   int            `json:"files_scanned"`
-	FindingCount   int            `json:"finding_count"`
-	Truncated      bool           `json:"truncated"`
-	ScanMode       string         `json:"scan_mode"`
-	BaseRevision   string         `json:"base_revision,omitempty"`
-	HeadRevision   string         `json:"head_revision,omitempty"`
-	CursorBefore   string         `json:"cursor_before,omitempty"`
-	CursorAfter    string         `json:"cursor_after,omitempty"`
-	ChangedPaths   []string       `json:"changed_paths,omitempty"`
-	ErrorMessage   string         `json:"error_message,omitempty"`
-	HistoryLimit   int            `json:"-"`
-	MaxFindings    int            `json:"-"`
-	Source         RepoScanSource `json:"-"`
-	TraceParent    string         `json:"-"`
-	TraceState     string         `json:"-"`
+	ID                  string                 `json:"id"`
+	TenantID            string                 `json:"-"`
+	WorkspaceID         string                 `json:"-"`
+	Repository          string                 `json:"repository"`
+	Status              string                 `json:"status"`
+	StartedAt           time.Time              `json:"started_at"`
+	FinishedAt          *time.Time             `json:"finished_at,omitempty"`
+	CommitsScanned      int                    `json:"commits_scanned"`
+	FilesScanned        int                    `json:"files_scanned"`
+	FindingCount        int                    `json:"finding_count"`
+	Truncated           bool                   `json:"truncated"`
+	SourceHealth        string                 `json:"source_health"`
+	SourceHealthDetails []RepoScanSourceHealth `json:"source_health_details,omitempty"`
+	ScanMode            string                 `json:"scan_mode"`
+	BaseRevision        string                 `json:"base_revision,omitempty"`
+	HeadRevision        string                 `json:"head_revision,omitempty"`
+	CursorBefore        string                 `json:"cursor_before,omitempty"`
+	CursorAfter         string                 `json:"cursor_after,omitempty"`
+	ChangedPaths        []string               `json:"changed_paths,omitempty"`
+	ErrorMessage        string                 `json:"error_message,omitempty"`
+	HistoryLimit        int                    `json:"-"`
+	MaxFindings         int                    `json:"-"`
+	Source              RepoScanSource         `json:"-"`
+	TraceParent         string                 `json:"-"`
+	TraceState          string                 `json:"-"`
+}
+
+const (
+	RepoScanSourceHealthComplete          = "complete"
+	RepoScanSourceHealthPartial           = "partial"
+	RepoScanSourceHealthPermissionLimited = "permission_limited"
+	RepoScanSourceHealthRateLimited       = "rate_limited"
+	RepoScanSourceHealthUnavailable       = "unavailable"
+	RepoScanSourceHealthUnknown           = "unknown"
+)
+
+// RepoScanSourceHealth captures collection completeness for one repo scan source.
+type RepoScanSourceHealth struct {
+	Source    string `json:"source"`
+	Status    string `json:"status"`
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Retryable bool   `json:"retryable,omitempty"`
 }
 
 // RepoScanContext captures incremental execution metadata for one scan.
@@ -369,6 +389,8 @@ type RepoScanContext struct {
 	CursorAfter      string
 	ChangedPaths     []string
 	PartialSourceRun bool
+	SourceHealth     string
+	SourceDetails    []RepoScanSourceHealth
 }
 
 // NormalizeRepoScanContext returns stable scan-mode and revision metadata.
@@ -386,7 +408,130 @@ func NormalizeRepoScanContext(scanContext RepoScanContext) RepoScanContext {
 		ChangedPaths:     normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
 		PartialSourceRun: scanContext.PartialSourceRun,
 	}
+	normalized.SourceHealth, normalized.SourceDetails = NormalizeRepoScanSourceHealth(scanContext.SourceHealth, scanContext.SourceDetails)
 	return normalized
+}
+
+func NormalizeRepoScanSourceHealth(status string, details []RepoScanSourceHealth) (string, []RepoScanSourceHealth) {
+	normalizedDetails := normalizeRepoScanSourceHealthDetails(details)
+	normalizedStatus := normalizeRepoScanSourceHealthStatus(status)
+	if normalizedStatus != "" {
+		return normalizedStatus, normalizedDetails
+	}
+	return deriveRepoScanSourceHealth(normalizedDetails), normalizedDetails
+}
+
+func normalizeRepoScanSourceHealthDetails(details []RepoScanSourceHealth) []RepoScanSourceHealth {
+	if len(details) == 0 {
+		return nil
+	}
+	normalized := make([]RepoScanSourceHealth, 0, len(details))
+	seen := map[string]int{}
+	for _, detail := range details {
+		item := RepoScanSourceHealth{
+			Source:    strings.ToLower(strings.TrimSpace(detail.Source)),
+			Status:    normalizeRepoScanSourceHealthStatus(detail.Status),
+			Code:      strings.ToLower(strings.TrimSpace(detail.Code)),
+			Message:   strings.TrimSpace(detail.Message),
+			Retryable: detail.Retryable,
+		}
+		if item.Source == "" {
+			item.Source = "unknown"
+		}
+		if item.Status == "" {
+			item.Status = RepoScanSourceHealthUnknown
+		}
+		if existing, ok := seen[item.Source]; ok {
+			normalized[existing] = mergeRepoScanSourceHealth(normalized[existing], item)
+			continue
+		}
+		seen[item.Source] = len(normalized)
+		normalized = append(normalized, item)
+	}
+	return normalized
+}
+
+func mergeRepoScanSourceHealth(existing RepoScanSourceHealth, incoming RepoScanSourceHealth) RepoScanSourceHealth {
+	if repoScanSourceHealthRank(incoming.Status) > repoScanSourceHealthRank(existing.Status) {
+		existing.Status = incoming.Status
+	}
+	if existing.Code == "" {
+		existing.Code = incoming.Code
+	}
+	if existing.Message == "" {
+		existing.Message = incoming.Message
+	}
+	existing.Retryable = existing.Retryable || incoming.Retryable
+	return existing
+}
+
+func deriveRepoScanSourceHealth(details []RepoScanSourceHealth) string {
+	if len(details) == 0 {
+		return RepoScanSourceHealthComplete
+	}
+	worst := RepoScanSourceHealthComplete
+	hasComplete := false
+	distinctDegraded := map[string]struct{}{}
+	for _, detail := range details {
+		status := normalizeRepoScanSourceHealthStatus(detail.Status)
+		if status == "" {
+			status = RepoScanSourceHealthUnknown
+		}
+		if status == RepoScanSourceHealthComplete {
+			hasComplete = true
+		} else {
+			distinctDegraded[status] = struct{}{}
+		}
+		if repoScanSourceHealthRank(status) > repoScanSourceHealthRank(worst) {
+			worst = status
+		}
+	}
+	if len(distinctDegraded) == 0 {
+		return RepoScanSourceHealthComplete
+	}
+	if hasComplete {
+		return RepoScanSourceHealthPartial
+	}
+	if len(distinctDegraded) > 1 {
+		return RepoScanSourceHealthPartial
+	}
+	return worst
+}
+
+func normalizeRepoScanSourceHealthStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case RepoScanSourceHealthComplete:
+		return RepoScanSourceHealthComplete
+	case RepoScanSourceHealthPartial:
+		return RepoScanSourceHealthPartial
+	case RepoScanSourceHealthPermissionLimited:
+		return RepoScanSourceHealthPermissionLimited
+	case RepoScanSourceHealthRateLimited:
+		return RepoScanSourceHealthRateLimited
+	case RepoScanSourceHealthUnavailable:
+		return RepoScanSourceHealthUnavailable
+	case RepoScanSourceHealthUnknown:
+		return RepoScanSourceHealthUnknown
+	default:
+		return ""
+	}
+}
+
+func repoScanSourceHealthRank(status string) int {
+	switch normalizeRepoScanSourceHealthStatus(status) {
+	case RepoScanSourceHealthPartial:
+		return 5
+	case RepoScanSourceHealthPermissionLimited:
+		return 4
+	case RepoScanSourceHealthRateLimited:
+		return 3
+	case RepoScanSourceHealthUnavailable:
+		return 2
+	case RepoScanSourceHealthUnknown:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // RepoScanCursor stores the latest scanned revision for one scoped repository source.
@@ -2773,6 +2918,30 @@ func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext R
 		return false
 	}
 	return normalizedContext.ScanMode == "deep" && len(normalizedContext.ChangedPaths) == 0
+}
+
+func repoScanCompletionSourceHealth(status string, scanContext RepoScanContext) (string, []RepoScanSourceHealth) {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if normalizedStatus != "succeeded" && normalizedStatus != "completed" {
+		return NormalizeRepoScanSourceHealth(RepoScanSourceHealthUnavailable, scanContext.SourceDetails)
+	}
+	if scanContext.PartialSourceRun {
+		health := strings.TrimSpace(scanContext.SourceHealth)
+		if health == "" {
+			health = RepoScanSourceHealthPartial
+		}
+		return NormalizeRepoScanSourceHealth(health, scanContext.SourceDetails)
+	}
+	return NormalizeRepoScanSourceHealth(firstNonEmptyRepoScanSourceHealth(scanContext.SourceHealth, RepoScanSourceHealthComplete), scanContext.SourceDetails)
+}
+
+func firstNonEmptyRepoScanSourceHealth(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // NormalizeFindingTriage returns a stable, API-shaped finding triage state.

--- a/migrations/000038_repo_scan_source_health.down.sql
+++ b/migrations/000038_repo_scan_source_health.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_repo_scans_source_health;
+
+ALTER TABLE repo_scans
+    DROP CONSTRAINT IF EXISTS repo_scans_source_health_valid;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS source_health_details,
+    DROP COLUMN IF EXISTS source_health;

--- a/migrations/000038_repo_scan_source_health.up.sql
+++ b/migrations/000038_repo_scan_source_health.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE repo_scans
+    ADD COLUMN source_health TEXT NOT NULL DEFAULT 'unknown',
+    ADD COLUMN source_health_details JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE repo_scans
+    ADD CONSTRAINT repo_scans_source_health_valid
+    CHECK (source_health IN ('complete', 'partial', 'permission_limited', 'rate_limited', 'unavailable', 'unknown'));
+
+ALTER TABLE repo_scans
+    ADD CONSTRAINT repo_scans_source_health_details_is_array
+    CHECK (jsonb_typeof(source_health_details) = 'array');
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_source_health
+    ON repo_scans (tenant_id, workspace_id, source_health, started_at DESC);

--- a/sqlc/queries/repo.sql
+++ b/sqlc/queries/repo.sql
@@ -1,10 +1,10 @@
 -- name: GetRepoScan :one
-SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '') AS error_message
+SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown') AS source_health, COALESCE(source_health_details, '[]'::jsonb) AS source_health_details, COALESCE(error_message, '') AS error_message
 FROM repo_scans
 WHERE id = $1;
 
 -- name: ListRepoScans :many
-SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, '') AS error_message
+SELECT id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(source_health, 'unknown') AS source_health, COALESCE(source_health_details, '[]'::jsonb) AS source_health_details, COALESCE(error_message, '') AS error_message
 FROM repo_scans
 ORDER BY started_at DESC
 LIMIT $1;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -65,6 +65,22 @@ export type RepoFindingsSummary = {
   by_severity: Record<string, number>;
 };
 
+export type RepoScanSourceHealthStatus =
+  | 'complete'
+  | 'partial'
+  | 'permission_limited'
+  | 'rate_limited'
+  | 'unavailable'
+  | 'unknown';
+
+export type RepoScanSourceHealth = {
+  source: string;
+  status: RepoScanSourceHealthStatus;
+  code?: string;
+  message?: string;
+  retryable?: boolean;
+};
+
 export type RepoScanRecord = {
   id: string;
   repository: string;
@@ -75,6 +91,8 @@ export type RepoScanRecord = {
   files_scanned: number;
   finding_count: number;
   truncated: boolean;
+  source_health?: RepoScanSourceHealthStatus;
+  source_health_details?: RepoScanSourceHealth[];
   scan_mode?: 'quick' | 'delta' | 'deep';
   base_revision?: string;
   head_revision?: string;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8043,6 +8043,28 @@ describe('GitHub domain pages (#1382)', () => {
     );
   });
 
+  it('Control Center distinguishes partial repository source collection', async () => {
+    const partialScan: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-partial',
+      finding_count: 0,
+      source_health: 'partial',
+      source_health_details: [
+        {
+          source: 'github_secret_scanning',
+          status: 'permission_limited',
+          code: 'alert_list_error',
+          message: 'resource not accessible by integration'
+        }
+      ]
+    };
+
+    await renderGitHubPage('control-center', { scans: [partialScan] });
+
+    expect(await screen.findByText(/Partial source collection/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 findings/i)).toBeInTheDocument();
+  });
+
   it('Control Center clears cached dashboard data when the auth session resets', async () => {
     const firstRender = await renderGitHubPage('control-center', { scans: [succeededRepoScan] });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1456,6 +1456,40 @@ function repoScanStatusTone(status: string): 'success' | 'warning' | 'error' | '
   return 'neutral';
 }
 
+function repoScanSourceHealth(scan: RepoScanRecord): string {
+  return normalizeValue(scan.source_health || 'complete').toLowerCase();
+}
+
+function repoScanHasDegradedSourceHealth(scan: RepoScanRecord): boolean {
+  const health = repoScanSourceHealth(scan);
+  return health !== '' && health !== 'complete';
+}
+
+function repoScanTone(scan: RepoScanRecord): 'success' | 'warning' | 'error' | 'neutral' {
+  const tone = repoScanStatusTone(scan.status);
+  if (tone === 'success' && repoScanHasDegradedSourceHealth(scan)) {
+    return 'warning';
+  }
+  return tone;
+}
+
+function summarizeRepoScanSourceHealth(scan: RepoScanRecord): string {
+  switch (repoScanSourceHealth(scan)) {
+    case 'partial':
+      return 'Partial source collection';
+    case 'permission_limited':
+      return 'Permission-limited source collection';
+    case 'rate_limited':
+      return 'Rate-limited source collection';
+    case 'unavailable':
+      return 'Unavailable source collection';
+    case 'unknown':
+      return 'Unknown source collection';
+    default:
+      return '';
+  }
+}
+
 function githubPostureStateTone(state: GitHubRepositoryPostureCheck['state']): 'success' | 'warning' | 'error' | 'neutral' {
   if (state === 'secure') {
     return 'success';
@@ -19941,7 +19975,7 @@ function gitHubRecentScans(scans: RepoScanRecord[], selectedRepositories: string
 function gitHubRecentScansTimeline(scans: RepoScanRecord[]): DomainTimelineEntry[] {
   return scans.map((scan) => {
     const repo = canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository;
-    const tone = repoScanStatusTone(scan.status);
+    const tone = repoScanTone(scan);
     const statusLabel = formatTokenLabel(scan.status);
     const detail = isCompletedScanStatus(scan.status)
       ? scan.error_message
@@ -23808,6 +23842,10 @@ function summarizeSuccessfulRepoScan(scan: RepoScanRecord): string {
   const parts = [formatCountLabel(scan.finding_count ?? 0, 'finding')];
   if (Number.isFinite(scan.files_scanned)) {
     parts.push(formatCountLabel(scan.files_scanned, 'file'));
+  }
+  const sourceHealth = summarizeRepoScanSourceHealth(scan);
+  if (sourceHealth) {
+    parts.unshift(sourceHealth);
   }
   return parts.join(' · ');
 }


### PR DESCRIPTION
## Summary
- add durable overall and per-source repo scan health for native scanner and GitHub-native sources
- classify source errors as partial, permission-limited, rate-limited, unavailable, or unknown and keep partial scans from looking like complete no-finding runs
- expose source health in OpenAPI, TypeScript client types, and GitHub recent scan summaries

## Validation
- go test ./internal/db ./internal/db/sqlcdb ./internal/api
- npm test -- productShell.test.tsx --run
- npm run build

Closes #1708

AI disclosure: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose repository scan source health and per‑source details so partial or limited collections don’t look like clean “no findings.” Adds classification, storage, API/types, and UI signals to mark degraded sources. Closes #1708.

- **New Features**
  - Classify source health: complete, partial, permission_limited, rate_limited, unavailable, unknown.
  - Persist per‑source details (code/message/retryable) and derive overall health for native (`identrail_repo_scanner`) and GitHub sources: code scanning, secret scanning, Dependabot, repo posture, org posture (supports unknown collectors).
  - Truncated scans: native marked partial (`repo_scan_truncated`); GitHub collectors skipped → partial (`scan_truncated`). Canceled/stale scans → unavailable with details (`scan_canceled`/`stale_running_scan`). Requeued scans reset to `unknown`.
  - Normalize/merge per‑source details and compute overall health; completion now returns `source_health` and `source_health_details` and gates cursor advancement on degraded health.
  - Classify rate limits (incl. 403 variants) as `rate_limited`; flag invalid org‑posture targets; set `retryable` when appropriate.
  - API/DB/UI: OpenAPI schema updated; Postgres/Memory stores set defaults on create/claim/requeue and populate details on cancel/stale; `sqlc`/`sqlcdb` queries include health fields; web client types extended; Control Center shows a source‑health label and uses a warning tone for degraded health (e.g., “Partial source collection”).

- **Migration**
  - Run migration `000038` to add `source_health` and `source_health_details` (defaults `unknown`/`[]`), validation checks (status enum and JSON array), and an index on `(tenant_id, workspace_id, source_health, started_at DESC)`. No config changes or backfill needed.

<sup>Written for commit 4d84946c0639948a809602371f4edd7853a38d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

