### PR TITLE
Add WorkOS email verification continuation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Add a **WorkOS email-verification continuation flow** for hosted login.
+  When WorkOS refuses an OAuth code exchange with
+  `email_verification_required` (common for GitHub accounts whose email is
+  unverified), the API now seals the pending authentication state into an
+  encrypted, short-lived cookie and redirects the browser to a new
+  `/auth/email-verification` page where the user enters the one-time code
+  WorkOS emailed them. New endpoints
+  `GET /auth/email-verification/pending` and
+  `POST /auth/email-verification/verify` mirror the existing MFA pending
+  flow, including hand-off to the MFA challenge when WorkOS chains both
+  requirements. Previously these sign-ins dead-ended on a generic
+  "Sign-in did not complete" error that retrying could never fix.
 - Make app-side social-login MFA enforcement opt-in via
   `IDENTRAIL_AUTH_REQUIRE_SOCIAL_MFA` (default `false`). Previously the API
   unconditionally rejected Google/GitHub OAuth logins whose WorkOS MFA

--- a/internal/api/auth/mfa_pending.go
+++ b/internal/api/auth/mfa_pending.go
@@ -100,41 +100,20 @@ func (m *MFAPendingStateManager) Seal(state WorkOSMFAPendingState) (string, erro
 	if err != nil {
 		return "", err
 	}
-	gcm, err := m.cipher()
+	sealed, err := sealPendingPayload(m.secret, mfaPendingStateVersion, mfaPendingStateAAD, payload)
 	if err != nil {
-		return "", err
+		return "", ErrMFAPendingStateInvalid
 	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", err
-	}
-	ciphertext := gcm.Seal(nil, nonce, payload, []byte(mfaPendingStateAAD))
-	return strings.Join([]string{
-		mfaPendingStateVersion,
-		base64.RawURLEncoding.EncodeToString(nonce),
-		base64.RawURLEncoding.EncodeToString(ciphertext),
-	}, "."), nil
+	return sealed, nil
 }
 
 func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error) {
 	if m == nil || len(m.secret) == 0 {
 		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
 	}
-	parts := strings.Split(strings.TrimSpace(raw), ".")
-	if len(parts) != 3 || parts[0] != mfaPendingStateVersion {
-		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
-	}
-	nonce, err := base64.RawURLEncoding.DecodeString(parts[1])
+	payload, err := openPendingPayload(m.secret, m.previous, mfaPendingStateVersion, mfaPendingStateAAD, raw)
 	if err != nil {
 		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
-	}
-	ciphertext, err := base64.RawURLEncoding.DecodeString(parts[2])
-	if err != nil {
-		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
-	}
-	payload, err := m.decrypt(nonce, ciphertext)
-	if err != nil {
-		return WorkOSMFAPendingState{}, err
 	}
 	var state WorkOSMFAPendingState
 	if err := json.Unmarshal(payload, &state); err != nil {
@@ -146,31 +125,59 @@ func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error)
 	return state, nil
 }
 
-// decrypt opens the sealed payload with the active key, falling back to the
-// previous key when one is configured (key-rotation window). State is only
-// ever sealed with the active key, so the previous key is open-only.
-func (m *MFAPendingStateManager) decrypt(nonce, ciphertext []byte) ([]byte, error) {
-	secrets := [][]byte{m.secret}
-	if len(m.previous) > 0 {
-		secrets = append(secrets, m.previous)
+var errPendingPayloadInvalid = errors.New("pending payload invalid")
+
+func sealPendingPayload(secret []byte, version, aad string, payload []byte) (string, error) {
+	gcm, err := cipherFor(secret)
+	if err != nil {
+		return "", err
 	}
-	for _, secret := range secrets {
-		gcm, err := cipherFor(secret)
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nil, nonce, payload, []byte(aad))
+	return strings.Join([]string{
+		version,
+		base64.RawURLEncoding.EncodeToString(nonce),
+		base64.RawURLEncoding.EncodeToString(ciphertext),
+	}, "."), nil
+}
+
+// openPendingPayload opens the sealed payload with the active key, falling
+// back to the previous key when one is configured (key-rotation window).
+// Payloads are only ever sealed with the active key, so the previous key is
+// open-only.
+func openPendingPayload(secret, previous []byte, version, aad, raw string) ([]byte, error) {
+	parts := strings.Split(strings.TrimSpace(raw), ".")
+	if len(parts) != 3 || parts[0] != version {
+		return nil, errPendingPayloadInvalid
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, errPendingPayloadInvalid
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, errPendingPayloadInvalid
+	}
+	secrets := [][]byte{secret}
+	if len(previous) > 0 {
+		secrets = append(secrets, previous)
+	}
+	for _, candidate := range secrets {
+		gcm, err := cipherFor(candidate)
 		if err != nil {
 			return nil, err
 		}
 		if len(nonce) != gcm.NonceSize() {
-			return nil, ErrMFAPendingStateInvalid
+			return nil, errPendingPayloadInvalid
 		}
-		if payload, err := gcm.Open(nil, nonce, ciphertext, []byte(mfaPendingStateAAD)); err == nil {
+		if payload, err := gcm.Open(nil, nonce, ciphertext, []byte(aad)); err == nil {
 			return payload, nil
 		}
 	}
-	return nil, ErrMFAPendingStateInvalid
-}
-
-func (m *MFAPendingStateManager) cipher() (cipher.AEAD, error) {
-	return cipherFor(m.secret)
+	return nil, errPendingPayloadInvalid
 }
 
 func cipherFor(secret []byte) (cipher.AEAD, error) {

--- a/internal/api/auth/workos.go
+++ b/internal/api/auth/workos.go
@@ -53,6 +53,7 @@ type WorkOSClient interface {
 	EnrollAuthFactor(ctx context.Context, input WorkOSMFAEnrollRequest) (WorkOSMFAEnrollResponse, error)
 	ChallengeAuthFactor(ctx context.Context, input WorkOSMFAChallengeRequest) (WorkOSMFAChallengeResponse, error)
 	AuthenticateWithTOTP(ctx context.Context, input WorkOSMFAVerifyRequest) (WorkOSAuthentication, error)
+	AuthenticateWithEmailVerificationCode(ctx context.Context, input WorkOSEmailVerificationVerifyRequest) (WorkOSAuthentication, error)
 }
 
 type WorkOSSDKClient struct {
@@ -170,6 +171,23 @@ func (c *WorkOSSDKClient) AuthenticateWithTOTP(ctx context.Context, input WorkOS
 	return authenticated, nil
 }
 
+func (c *WorkOSSDKClient) AuthenticateWithEmailVerificationCode(ctx context.Context, input WorkOSEmailVerificationVerifyRequest) (WorkOSAuthentication, error) {
+	if c == nil || c.client == nil || c.clientID == "" {
+		return WorkOSAuthentication{}, ErrWorkOSUnavailable
+	}
+	response, err := c.client.AuthenticateWithEmailVerificationCode(ctx, usermanagement.AuthenticateWithEmailVerificationCodeOpts{
+		ClientID:                   c.clientID,
+		Code:                       strings.TrimSpace(input.Code),
+		PendingAuthenticationToken: strings.TrimSpace(input.PendingAuthenticationToken),
+		IPAddress:                  strings.TrimSpace(input.IPAddress),
+		UserAgent:                  strings.TrimSpace(input.UserAgent),
+	})
+	if err != nil {
+		return WorkOSAuthentication{}, normalizeWorkOSAuthenticationError(err)
+	}
+	return workOSAuthenticationFromResponse(response), nil
+}
+
 func normalizeWorkOSAuthenticationError(err error) error {
 	if err == nil {
 		return nil
@@ -182,6 +200,9 @@ func normalizeWorkOSAuthenticationError(err error) error {
 		return ErrWorkOSUnavailable
 	}
 	if required, ok := AsWorkOSMFARequired(err); ok {
+		return required
+	}
+	if required, ok := AsWorkOSEmailVerificationRequired(err); ok {
 		return required
 	}
 	return err

--- a/internal/api/auth/workos_email_verification.go
+++ b/internal/api/auth/workos_email_verification.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/workos/workos-go/v6/pkg/workos_errors"
+)
+
+const (
+	PendingEmailVerificationCookieName = "identrail_email_verification_pending"
+	DefaultEmailVerificationPendingTTL = 10 * time.Minute
+
+	emailVerificationPendingStateVersion = "v1"
+	emailVerificationPendingStateAAD     = "identrail.workos.email.verification.pending.v1"
+)
+
+var (
+	ErrEmailVerificationPendingStateInvalid = errors.New("email verification pending state invalid")
+	ErrEmailVerificationPendingStateExpired = errors.New("email verification pending state expired")
+)
+
+// WorkOSEmailVerificationRequired is returned when WorkOS refuses a code
+// exchange because the user's email address has not been verified. WorkOS
+// has already emailed the user a one-time code; the pending token and
+// verification id let the app finish the handshake once the user enters it.
+type WorkOSEmailVerificationRequired struct {
+	Email                      string
+	PendingAuthenticationToken string
+	EmailVerificationID        string
+}
+
+func (e *WorkOSEmailVerificationRequired) Error() string {
+	return "workos email verification required"
+}
+
+func AsWorkOSEmailVerificationRequired(err error) (*WorkOSEmailVerificationRequired, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var required *WorkOSEmailVerificationRequired
+	if errors.As(err, &required) && required != nil {
+		return required, true
+	}
+	var verificationErr *workos_errors.EmailVerificationRequiredError
+	if errors.As(err, &verificationErr) && verificationErr != nil {
+		return &WorkOSEmailVerificationRequired{
+			Email:                      verificationErr.Email,
+			PendingAuthenticationToken: verificationErr.PendingAuthenticationToken,
+			EmailVerificationID:        verificationErr.EmailVerificationID,
+		}, true
+	}
+	var httpErr workos_errors.HTTPError
+	if errors.As(err, &httpErr) && httpErr.ErrorCode == workos_errors.EmailVerificationRequiredCode {
+		return &WorkOSEmailVerificationRequired{
+			PendingAuthenticationToken: httpErr.PendingAuthenticationToken,
+			EmailVerificationID:        httpErr.EmailVerificationID,
+		}, true
+	}
+	return nil, false
+}
+
+type WorkOSEmailVerificationPendingState struct {
+	Intent                     string `json:"intent,omitempty"`
+	ReturnTo                   string `json:"return_to,omitempty"`
+	Email                      string `json:"email,omitempty"`
+	PendingAuthenticationToken string `json:"pending_authentication_token"`
+	EmailVerificationID        string `json:"email_verification_id,omitempty"`
+	ExpiresAt                  int64  `json:"expires_at"`
+}
+
+type WorkOSEmailVerificationVerifyRequest struct {
+	PendingAuthenticationToken string
+	Code                       string
+	IPAddress                  string
+	UserAgent                  string
+}
+
+type EmailVerificationPendingStateManager struct {
+	secret   []byte
+	previous []byte
+	ttl      time.Duration
+	now      func() time.Time
+}
+
+func NewEmailVerificationPendingStateManager(secret string, now func() time.Time) *EmailVerificationPendingStateManager {
+	if now == nil {
+		now = time.Now
+	}
+	return &EmailVerificationPendingStateManager{
+		secret: []byte(strings.TrimSpace(secret)),
+		ttl:    DefaultEmailVerificationPendingTTL,
+		now:    now,
+	}
+}
+
+// WithPreviousSecret registers a previous sealing key accepted for opening
+// (decryption) only during a key-rotation window. State is always sealed
+// with the active secret; the previous secret is never used to seal. An
+// empty previous secret clears any prior value. Returns the manager so it
+// can be chained off the constructor.
+func (m *EmailVerificationPendingStateManager) WithPreviousSecret(previous string) *EmailVerificationPendingStateManager {
+	if m == nil {
+		return m
+	}
+	if trimmed := strings.TrimSpace(previous); trimmed != "" {
+		m.previous = []byte(trimmed)
+	} else {
+		m.previous = nil
+	}
+	return m
+}
+
+func (m *EmailVerificationPendingStateManager) TTL() time.Duration {
+	if m == nil || m.ttl <= 0 {
+		return DefaultEmailVerificationPendingTTL
+	}
+	return m.ttl
+}
+
+func (m *EmailVerificationPendingStateManager) Seal(state WorkOSEmailVerificationPendingState) (string, error) {
+	if m == nil || len(m.secret) == 0 {
+		return "", ErrEmailVerificationPendingStateInvalid
+	}
+	now := m.now().UTC()
+	if state.ExpiresAt <= 0 {
+		state.ExpiresAt = now.Add(m.TTL()).Unix()
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	sealed, err := sealPendingPayload(m.secret, emailVerificationPendingStateVersion, emailVerificationPendingStateAAD, payload)
+	if err != nil {
+		return "", ErrEmailVerificationPendingStateInvalid
+	}
+	return sealed, nil
+}
+
+func (m *EmailVerificationPendingStateManager) Open(raw string) (WorkOSEmailVerificationPendingState, error) {
+	if m == nil || len(m.secret) == 0 {
+		return WorkOSEmailVerificationPendingState{}, ErrEmailVerificationPendingStateInvalid
+	}
+	payload, err := openPendingPayload(m.secret, m.previous, emailVerificationPendingStateVersion, emailVerificationPendingStateAAD, raw)
+	if err != nil {
+		return WorkOSEmailVerificationPendingState{}, ErrEmailVerificationPendingStateInvalid
+	}
+	var state WorkOSEmailVerificationPendingState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return WorkOSEmailVerificationPendingState{}, ErrEmailVerificationPendingStateInvalid
+	}
+	if state.ExpiresAt <= 0 || !time.Unix(state.ExpiresAt, 0).After(m.now().UTC()) {
+		return WorkOSEmailVerificationPendingState{}, ErrEmailVerificationPendingStateExpired
+	}
+	return state, nil
+}

--- a/internal/api/auth/workos_email_verification_test.go
+++ b/internal/api/auth/workos_email_verification_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/workos/workos-go/v6/pkg/workos_errors"
+)
+
+func TestEmailVerificationPendingStateManagerSealsEncryptedState(t *testing.T) {
+	now := time.Date(2026, 7, 4, 18, 45, 0, 0, time.UTC)
+	manager := NewEmailVerificationPendingStateManager(strings.Repeat("a", 64), func() time.Time { return now })
+	raw, err := manager.Seal(WorkOSEmailVerificationPendingState{
+		Email:                      "user@example.com",
+		PendingAuthenticationToken: "pending-token",
+		EmailVerificationID:        "email_verification_1",
+		ReturnTo:                   "https://app.identrail.test/app",
+	})
+	if err != nil {
+		t.Fatalf("seal pending email verification state: %v", err)
+	}
+	if strings.Contains(raw, "pending-token") || strings.Contains(raw, "user@example.com") {
+		t.Fatalf("sealed state must not expose sensitive values: %q", raw)
+	}
+	opened, err := manager.Open(raw)
+	if err != nil {
+		t.Fatalf("open pending email verification state: %v", err)
+	}
+	if opened.PendingAuthenticationToken != "pending-token" || opened.Email != "user@example.com" || opened.EmailVerificationID != "email_verification_1" {
+		t.Fatalf("unexpected pending email verification state: %+v", opened)
+	}
+}
+
+func TestEmailVerificationPendingStateManagerRejectsExpiredAndInvalidState(t *testing.T) {
+	now := time.Date(2026, 7, 4, 18, 45, 0, 0, time.UTC)
+	managerNow := now
+	manager := NewEmailVerificationPendingStateManager(strings.Repeat("a", 64), func() time.Time { return managerNow })
+	raw, err := manager.Seal(WorkOSEmailVerificationPendingState{
+		PendingAuthenticationToken: "pending-token",
+	})
+	if err != nil {
+		t.Fatalf("seal pending email verification state: %v", err)
+	}
+	managerNow = now.Add(DefaultEmailVerificationPendingTTL + time.Second)
+	if _, err := manager.Open(raw); !errors.Is(err, ErrEmailVerificationPendingStateExpired) {
+		t.Fatalf("expected expired pending state, got %v", err)
+	}
+	managerNow = now
+	if _, err := manager.Open(raw + "tampered"); !errors.Is(err, ErrEmailVerificationPendingStateInvalid) {
+		t.Fatalf("expected tampered state to fail, got %v", err)
+	}
+	if _, err := (*EmailVerificationPendingStateManager)(nil).Seal(WorkOSEmailVerificationPendingState{}); !errors.Is(err, ErrEmailVerificationPendingStateInvalid) {
+		t.Fatalf("expected nil manager seal to fail, got %v", err)
+	}
+}
+
+func TestEmailVerificationPendingStateManagerAADSeparationFromMFA(t *testing.T) {
+	// An MFA pending blob must never open as email-verification state (and
+	// vice versa) even under the same session key: the two flows carry
+	// different privileges and use distinct AADs to prevent cross-replay.
+	key := strings.Repeat("a", 64)
+	mfaSealed, err := NewMFAPendingStateManager(key, nil).Seal(WorkOSMFAPendingState{
+		Mode:                       WorkOSMFAModeChallenge,
+		PendingAuthenticationToken: "pending-token",
+	})
+	if err != nil {
+		t.Fatalf("seal mfa state: %v", err)
+	}
+	if _, err := NewEmailVerificationPendingStateManager(key, nil).Open(mfaSealed); !errors.Is(err, ErrEmailVerificationPendingStateInvalid) {
+		t.Fatalf("mfa pending blob must not open as email verification state, got %v", err)
+	}
+	emailSealed, err := NewEmailVerificationPendingStateManager(key, nil).Seal(WorkOSEmailVerificationPendingState{
+		PendingAuthenticationToken: "pending-token",
+	})
+	if err != nil {
+		t.Fatalf("seal email verification state: %v", err)
+	}
+	if _, err := NewMFAPendingStateManager(key, nil).Open(emailSealed); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("email verification blob must not open as mfa state, got %v", err)
+	}
+}
+
+func TestEmailVerificationPendingStateManagerPreviousKeyRotation(t *testing.T) {
+	oldKey, newKey := strings.Repeat("o", 64), strings.Repeat("n", 64)
+	pending := WorkOSEmailVerificationPendingState{PendingAuthenticationToken: "pending-token"}
+
+	sealed, err := NewEmailVerificationPendingStateManager(oldKey, nil).Seal(pending)
+	if err != nil {
+		t.Fatalf("seal with old key: %v", err)
+	}
+	if _, err := NewEmailVerificationPendingStateManager(newKey, nil).Open(sealed); !errors.Is(err, ErrEmailVerificationPendingStateInvalid) {
+		t.Fatalf("expected old-key state rejected without previous key, got %v", err)
+	}
+	rotating := NewEmailVerificationPendingStateManager(newKey, nil).WithPreviousSecret(oldKey)
+	opened, err := rotating.Open(sealed)
+	if err != nil || opened.PendingAuthenticationToken != "pending-token" {
+		t.Fatalf("expected previous-key Open to succeed, got %+v err=%v", opened, err)
+	}
+}
+
+func TestAsWorkOSEmailVerificationRequired(t *testing.T) {
+	if _, ok := AsWorkOSEmailVerificationRequired(nil); ok {
+		t.Fatal("nil error must not report email verification required")
+	}
+	if _, ok := AsWorkOSEmailVerificationRequired(errors.New("boom")); ok {
+		t.Fatal("unrelated error must not report email verification required")
+	}
+	direct := &WorkOSEmailVerificationRequired{PendingAuthenticationToken: "token"}
+	if required, ok := AsWorkOSEmailVerificationRequired(direct); !ok || required.PendingAuthenticationToken != "token" {
+		t.Fatalf("expected direct error to round-trip, got %+v ok=%v", required, ok)
+	}
+	typed := &workos_errors.EmailVerificationRequiredError{
+		Email:                      "user@example.com",
+		EmailVerificationID:        "email_verification_1",
+		PendingAuthenticationToken: "token",
+	}
+	required, ok := AsWorkOSEmailVerificationRequired(typed)
+	if !ok || required.Email != "user@example.com" || required.PendingAuthenticationToken != "token" || required.EmailVerificationID != "email_verification_1" {
+		t.Fatalf("expected typed sdk error to convert, got %+v ok=%v", required, ok)
+	}
+	httpErr := workos_errors.HTTPError{
+		ErrorCode:                  workos_errors.EmailVerificationRequiredCode,
+		PendingAuthenticationToken: "token",
+		EmailVerificationID:        "email_verification_1",
+	}
+	required, ok = AsWorkOSEmailVerificationRequired(httpErr)
+	if !ok || required.PendingAuthenticationToken != "token" || required.EmailVerificationID != "email_verification_1" {
+		t.Fatalf("expected http error code to convert, got %+v ok=%v", required, ok)
+	}
+}

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -33,6 +33,7 @@ type authSessionRouteOptions struct {
 	StateManager          *sessionauth.OAuthStateManager
 	TransactionStore      *sessionauth.OAuthTransactionStore
 	PendingMFAManager     *sessionauth.MFAPendingStateManager
+	PendingEmailManager   *sessionauth.EmailVerificationPendingStateManager
 	PublicBaseURL         string
 	ReturnToOrigins       []string
 }
@@ -50,6 +51,8 @@ func registerAuthSessionRoutes(r *gin.Engine, logger *zap.Logger, svc *Service, 
 		authGroup.POST("/mfa/enroll", rateLimitMiddleware(20, 20), workOSMFAEnrollHandler(logger, opts))
 		authGroup.POST("/mfa/challenge", rateLimitMiddleware(20, 20), workOSMFAChallengeHandler(logger, opts))
 		authGroup.POST("/mfa/verify", rateLimitMiddleware(30, 30), workOSMFAVerifyHandler(logger, svc, manager, opts))
+		authGroup.GET("/email-verification/pending", rateLimitMiddleware(30, 30), workOSEmailVerificationPendingHandler(opts))
+		authGroup.POST("/email-verification/verify", rateLimitMiddleware(30, 30), workOSEmailVerificationVerifyHandler(logger, svc, manager, opts))
 		authGroup.POST("/webhooks/workos", rateLimitMiddleware(60, 60), workOSWebhookHandler(logger, svc, opts))
 	}
 	if opts.ManualMode {
@@ -297,6 +300,10 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 				handleWorkOSMFARequired(c, logger, opts, state, required)
 				return
 			}
+			if required, ok := sessionauth.AsWorkOSEmailVerificationRequired(err); ok {
+				handleWorkOSEmailVerificationRequired(c, logger, opts, state, required)
+				return
+			}
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
 			if logger != nil {
 				logger.Warn("authenticate workos callback", telemetry.ZapError(err))
@@ -322,6 +329,7 @@ const (
 	authFailureReasonAccountNotFound     = "account_not_found"
 	authFailureReasonCallbackError       = "callback_error"
 	authFailureReasonIdentityConflict    = "identity_conflict"
+	authFailureReasonEmailUnverified     = "email_verification_required"
 	authFailureReasonMFARequired         = "mfa_required"
 	authFailureReasonProviderUnavailable = "provider_unavailable"
 	authFailureReasonReactivationNeeded  = "account_reactivation_required"
@@ -414,17 +422,29 @@ func workOSAuthFailureReturnToParam(opts authSessionRouteOptions, frontendOrigin
 }
 
 func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, state sessionauth.OAuthState, required *sessionauth.WorkOSMFARequired) {
+	redirectTo, ok := sealWorkOSMFAPending(c, logger, opts, state.Intent, state.ReturnTo, required)
+	if !ok {
+		return
+	}
+	c.Redirect(http.StatusFound, redirectTo)
+}
+
+// sealWorkOSMFAPending seals the MFA pending state WorkOS returned, sets the
+// pending cookie, and reports the MFA page URL the browser should continue
+// on. Callers decide how to deliver that URL: the OAuth callback issues a
+// top-level redirect, while fetch-style endpoints return it as JSON.
+func sealWorkOSMFAPending(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, intent string, returnTo string, required *sessionauth.WorkOSMFARequired) (string, bool) {
 	if required == nil || opts.PendingMFAManager == nil || strings.TrimSpace(required.PendingAuthenticationToken) == "" {
 		if logger != nil {
 			logger.Warn("workos mfa required without resumable pending token")
 		}
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "mfa required"})
-		return
+		return "", false
 	}
 	pending := sessionauth.WorkOSMFAPendingState{
 		Mode:                       required.Mode,
-		Intent:                     state.Intent,
-		ReturnTo:                   sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins),
+		Intent:                     intent,
+		ReturnTo:                   sanitizeAuthReturnTo(returnTo, opts.ReturnToOrigins),
 		PendingAuthenticationToken: required.PendingAuthenticationToken,
 		User:                       required.User,
 		AuthenticationFactors:      required.AuthenticationFactors,
@@ -438,13 +458,13 @@ func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessio
 			logger.Error("seal workos mfa pending state", telemetry.ZapError(err))
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to continue login"})
-		return
+		return "", false
 	}
 	if logger != nil {
 		logger.Info("workos mfa required", zap.String("mode", pending.Mode))
 	}
 	http.SetCookie(c.Writer, workOSMFAPendingCookie(opts.PublicBaseURL, sealed, opts.PendingMFAManager.TTL()))
-	c.Redirect(http.StatusFound, workOSMFARedirectURL(pending.ReturnTo, opts.PublicBaseURL, opts.ReturnToOrigins))
+	return workOSMFARedirectURL(pending.ReturnTo, opts.PublicBaseURL, opts.ReturnToOrigins), true
 }
 
 func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions, authenticated sessionauth.WorkOSAuthentication, state sessionauth.OAuthState, failureMode workOSLoginFailureMode) (string, bool) {
@@ -852,6 +872,188 @@ func workOSMFAClearCookie(publicBaseURL string) *http.Cookie {
 		Secure:   sessionauthCookieSecure(publicBaseURL),
 		SameSite: http.SameSiteLaxMode,
 	}
+}
+
+func handleWorkOSEmailVerificationRequired(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, state sessionauth.OAuthState, required *sessionauth.WorkOSEmailVerificationRequired) {
+	if required == nil || opts.PendingEmailManager == nil || strings.TrimSpace(required.PendingAuthenticationToken) == "" {
+		if logger != nil {
+			logger.Warn("workos email verification required without resumable pending token")
+		}
+		redirectWorkOSCallbackFailure(c, opts, state.ReturnTo, authFailureReasonEmailUnverified)
+		return
+	}
+	pending := sessionauth.WorkOSEmailVerificationPendingState{
+		Intent:                     state.Intent,
+		ReturnTo:                   sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins),
+		Email:                      required.Email,
+		PendingAuthenticationToken: required.PendingAuthenticationToken,
+		EmailVerificationID:        required.EmailVerificationID,
+	}
+	sealed, err := opts.PendingEmailManager.Seal(pending)
+	if err != nil {
+		if logger != nil {
+			logger.Error("seal workos email verification pending state", telemetry.ZapError(err))
+		}
+		redirectWorkOSCallbackFailure(c, opts, state.ReturnTo, authFailureReasonEmailUnverified)
+		return
+	}
+	if logger != nil {
+		logger.Info("workos email verification required")
+	}
+	http.SetCookie(c.Writer, workOSEmailVerificationPendingCookie(opts.PublicBaseURL, sealed, opts.PendingEmailManager.TTL()))
+	c.Redirect(http.StatusFound, workOSEmailVerificationRedirectURL(pending.ReturnTo, opts.PublicBaseURL, opts.ReturnToOrigins))
+}
+
+type workOSEmailVerificationVerifyRequest struct {
+	Code string `json:"code"`
+}
+
+func workOSEmailVerificationPendingHandler(opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, ok := readWorkOSEmailVerificationPendingState(c, opts)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"email": state.Email})
+	}
+}
+
+func workOSEmailVerificationVerifyHandler(logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if svc == nil || svc.Store == nil || opts.WorkOSClient == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
+			return
+		}
+		state, ok := readWorkOSEmailVerificationPendingState(c, opts)
+		if !ok {
+			return
+		}
+		var req workOSEmailVerificationVerifyRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid verification request"})
+			return
+		}
+		code := strings.TrimSpace(req.Code)
+		if code == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "verification code is required"})
+			return
+		}
+		authenticated, err := opts.WorkOSClient.AuthenticateWithEmailVerificationCode(c.Request.Context(), sessionauth.WorkOSEmailVerificationVerifyRequest{
+			PendingAuthenticationToken: state.PendingAuthenticationToken,
+			Code:                       code,
+			IPAddress:                  c.ClientIP(),
+			UserAgent:                  c.Request.UserAgent(),
+		})
+		if err != nil {
+			// WorkOS can chain a second pending step after the email is
+			// verified: when MFA enforcement is enabled it answers the
+			// verification exchange with an MFA challenge/enrollment error
+			// instead of a session. Hand the browser to the existing MFA
+			// flow rather than reporting a bad code.
+			if required, ok := sessionauth.AsWorkOSMFARequired(err); ok {
+				redirectTo, handed := sealWorkOSMFAPending(c, logger, opts, state.Intent, state.ReturnTo, required)
+				if !handed {
+					return
+				}
+				http.SetCookie(c.Writer, workOSEmailVerificationClearCookie(opts.PublicBaseURL))
+				c.JSON(http.StatusOK, gin.H{"ok": true, "redirect_to": redirectTo})
+				return
+			}
+			writeWorkOSEmailVerificationVerifyError(c, logger, err)
+			return
+		}
+		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, sessionauth.OAuthState{
+			Intent:   state.Intent,
+			ReturnTo: state.ReturnTo,
+		}, workOSLoginFailureRedirectJSON)
+		if !ok {
+			return
+		}
+		http.SetCookie(c.Writer, workOSEmailVerificationClearCookie(opts.PublicBaseURL))
+		c.JSON(http.StatusOK, gin.H{
+			"ok":          true,
+			"redirect_to": redirectTo,
+		})
+	}
+}
+
+func readWorkOSEmailVerificationPendingState(c *gin.Context, opts authSessionRouteOptions) (sessionauth.WorkOSEmailVerificationPendingState, bool) {
+	if opts.PendingEmailManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
+		return sessionauth.WorkOSEmailVerificationPendingState{}, false
+	}
+	cookie, err := c.Request.Cookie(sessionauth.PendingEmailVerificationCookieName)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "email verification session expired"})
+		return sessionauth.WorkOSEmailVerificationPendingState{}, false
+	}
+	state, err := opts.PendingEmailManager.Open(cookie.Value)
+	if err != nil {
+		http.SetCookie(c.Writer, workOSEmailVerificationClearCookie(opts.PublicBaseURL))
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "email verification session expired"})
+		return sessionauth.WorkOSEmailVerificationPendingState{}, false
+	}
+	return state, true
+}
+
+func writeWorkOSEmailVerificationVerifyError(c *gin.Context, logger *zap.Logger, err error) {
+	if logger != nil {
+		logger.Warn("verify workos email verification code", zap.String("error", "workos email verification failed"))
+	}
+	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
+		c.Header("Retry-After", "30")
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth provider unavailable"})
+		return
+	}
+	c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid verification code"})
+}
+
+func workOSEmailVerificationPendingCookie(publicBaseURL string, value string, ttl time.Duration) *http.Cookie {
+	if ttl <= 0 {
+		ttl = sessionauth.DefaultEmailVerificationPendingTTL
+	}
+	return &http.Cookie{
+		Name:     sessionauth.PendingEmailVerificationCookieName,
+		Value:    value,
+		Path:     "/auth/email-verification",
+		MaxAge:   int(ttl.Seconds()),
+		HttpOnly: true,
+		Secure:   sessionauthCookieSecure(publicBaseURL),
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func workOSEmailVerificationClearCookie(publicBaseURL string) *http.Cookie {
+	return &http.Cookie{
+		Name:     sessionauth.PendingEmailVerificationCookieName,
+		Value:    "",
+		Path:     "/auth/email-verification",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   sessionauthCookieSecure(publicBaseURL),
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func workOSEmailVerificationRedirectURL(returnTo string, publicBaseURL string, allowedOrigins []string) string {
+	sanitizedReturnTo := sanitizeAuthReturnTo(returnTo, allowedOrigins)
+	if sanitizedReturnTo == "" {
+		sanitizedReturnTo = "/app"
+	}
+	targetOrigin := ""
+	if parsed, err := url.Parse(sanitizedReturnTo); err == nil && parsed.IsAbs() {
+		targetOrigin = strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+	}
+	if targetOrigin == "" {
+		targetOrigin = preferredAuthFrontendOrigin(publicBaseURL, allowedOrigins)
+	}
+	query := url.Values{}
+	query.Set("return_to", sanitizedReturnTo)
+	targetPath := "/auth/email-verification?" + query.Encode()
+	if targetOrigin == "" {
+		return targetPath
+	}
+	return strings.TrimRight(targetOrigin, "/") + targetPath
 }
 
 func oauthTransactionCookie(publicBaseURL string, nonce string, value string, ttl time.Duration) *http.Cookie {

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -825,7 +825,7 @@ func workOSMFAFactorAllowed(factors []sessionauth.WorkOSMFAFactor, factorID stri
 
 func writeWorkOSMFAProviderError(c *gin.Context, logger *zap.Logger, err error, message string) {
 	if logger != nil {
-		logger.Warn(message, zap.String("error", "workos mfa provider returned an error"))
+		logger.Warn(message, telemetry.ZapError(err))
 	}
 	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
 		c.Header("Retry-After", "30")
@@ -837,7 +837,7 @@ func writeWorkOSMFAProviderError(c *gin.Context, logger *zap.Logger, err error, 
 
 func writeWorkOSMFAVerifyError(c *gin.Context, logger *zap.Logger, err error) {
 	if logger != nil {
-		logger.Warn("verify workos mfa challenge", zap.String("error", "workos mfa verification failed"))
+		logger.Warn("verify workos mfa challenge", telemetry.ZapError(err))
 	}
 	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
 		c.Header("Retry-After", "30")
@@ -998,7 +998,7 @@ func readWorkOSEmailVerificationPendingState(c *gin.Context, opts authSessionRou
 
 func writeWorkOSEmailVerificationVerifyError(c *gin.Context, logger *zap.Logger, err error) {
 	if logger != nil {
-		logger.Warn("verify workos email verification code", zap.String("error", "workos email verification failed"))
+		logger.Warn("verify workos email verification code", telemetry.ZapError(err))
 	}
 	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
 		c.Header("Retry-After", "30")
@@ -1036,24 +1036,7 @@ func workOSEmailVerificationClearCookie(publicBaseURL string) *http.Cookie {
 }
 
 func workOSEmailVerificationRedirectURL(returnTo string, publicBaseURL string, allowedOrigins []string) string {
-	sanitizedReturnTo := sanitizeAuthReturnTo(returnTo, allowedOrigins)
-	if sanitizedReturnTo == "" {
-		sanitizedReturnTo = "/app"
-	}
-	targetOrigin := ""
-	if parsed, err := url.Parse(sanitizedReturnTo); err == nil && parsed.IsAbs() {
-		targetOrigin = strings.ToLower(parsed.Scheme + "://" + parsed.Host)
-	}
-	if targetOrigin == "" {
-		targetOrigin = preferredAuthFrontendOrigin(publicBaseURL, allowedOrigins)
-	}
-	query := url.Values{}
-	query.Set("return_to", sanitizedReturnTo)
-	targetPath := "/auth/email-verification?" + query.Encode()
-	if targetOrigin == "" {
-		return targetPath
-	}
-	return strings.TrimRight(targetOrigin, "/") + targetPath
+	return workOSAuthContinuationRedirectURL("/auth/email-verification", returnTo, publicBaseURL, allowedOrigins)
 }
 
 func oauthTransactionCookie(publicBaseURL string, nonce string, value string, ttl time.Duration) *http.Cookie {
@@ -1092,6 +1075,16 @@ func sessionauthCookieSecure(publicBaseURL string) bool {
 }
 
 func workOSMFARedirectURL(returnTo string, publicBaseURL string, allowedOrigins []string) string {
+	return workOSAuthContinuationRedirectURL("/auth/mfa", returnTo, publicBaseURL, allowedOrigins)
+}
+
+// workOSAuthContinuationRedirectURL builds the absolute (or path-only, when no
+// frontend origin can be resolved) URL that hands the browser to a WorkOS
+// login-continuation page such as /auth/mfa or /auth/email-verification. It
+// sanitizes the return target, prefers its origin when it is an allowed
+// absolute URL, and otherwise falls back to the configured frontend origin so
+// both continuation flows share one place to fix redirect/sanitization logic.
+func workOSAuthContinuationRedirectURL(targetPagePath string, returnTo string, publicBaseURL string, allowedOrigins []string) string {
 	sanitizedReturnTo := sanitizeAuthReturnTo(returnTo, allowedOrigins)
 	if sanitizedReturnTo == "" {
 		sanitizedReturnTo = "/app"
@@ -1105,7 +1098,7 @@ func workOSMFARedirectURL(returnTo string, publicBaseURL string, allowedOrigins 
 	}
 	query := url.Values{}
 	query.Set("return_to", sanitizedReturnTo)
-	targetPath := "/auth/mfa?" + query.Encode()
+	targetPath := targetPagePath + "?" + query.Encode()
 	if targetOrigin == "" {
 		return targetPath
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -344,6 +344,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			StateManager:          stateManager,
 			TransactionStore:      oauthTransactionStore,
 			PendingMFAManager:     sessionauth.NewMFAPendingStateManager(opts.SessionKey, nil).WithPreviousSecret(opts.SessionKeyPrevious),
+			PendingEmailManager:   sessionauth.NewEmailVerificationPendingStateManager(opts.SessionKey, nil).WithPreviousSecret(opts.SessionKeyPrevious),
 			PublicBaseURL:         opts.PublicBaseURL,
 			ReturnToOrigins:       authReturnToOrigins(opts.PublicBaseURL, opts.CORSAllowedOrigins),
 		})

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -26,6 +26,7 @@ import (
 type fakeWorkOSClient struct {
 	authorizationInput sessionauth.WorkOSAuthorizationRequest
 	verifyInput        sessionauth.WorkOSMFAVerifyRequest
+	emailVerifyInput   sessionauth.WorkOSEmailVerificationVerifyRequest
 	authentication     sessionauth.WorkOSAuthentication
 	enrollResponse     sessionauth.WorkOSMFAEnrollResponse
 	challengeResponse  sessionauth.WorkOSMFAChallengeResponse
@@ -34,6 +35,7 @@ type fakeWorkOSClient struct {
 	enrollErr          error
 	challengeErr       error
 	verifyErr          error
+	emailVerifyErr     error
 }
 
 type fakeEmailSender struct {
@@ -112,6 +114,14 @@ func (f *fakeWorkOSClient) AuthenticateWithTOTP(ctx context.Context, input sessi
 	authenticated := f.authentication
 	authenticated.MFACompleted = true
 	return authenticated, nil
+}
+
+func (f *fakeWorkOSClient) AuthenticateWithEmailVerificationCode(ctx context.Context, input sessionauth.WorkOSEmailVerificationVerifyRequest) (sessionauth.WorkOSAuthentication, error) {
+	f.emailVerifyInput = input
+	if f.emailVerifyErr != nil {
+		return sessionauth.WorkOSAuthentication{}, f.emailVerifyErr
+	}
+	return f.authentication, nil
 }
 
 func TestWorkOSHostedLoginCreatesSessionAndIdentity(t *testing.T) {
@@ -1042,6 +1052,210 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 		if event.Action == "auth.login.failure" {
 			t.Fatalf("mfa continuation must not write denied login failure audit event: %+v", event)
 		}
+	}
+}
+
+func TestWorkOSCallbackContinuesEmailVerification(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 7, 4, 18, 45, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	sink := &recordingAuditSink{}
+	secret := strings.Repeat("a", 64)
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSEmailVerificationRequired{
+			Email:                      "unverified@example.com",
+			PendingAuthenticationToken: "pending-email-token",
+			EmailVerificationID:        "email_verification_1",
+		},
+		authentication: sessionauth.WorkOSAuthentication{
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_email_verify",
+				Email:         "unverified@example.com",
+				EmailVerified: true,
+			},
+			AuthenticationMethod: "GitHubOAuth",
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		AuditSink:          sink,
+		SessionKey:         secret,
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	if startResp.Code != http.StatusFound {
+		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected email verification redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); !strings.HasPrefix(got, "https://app.identrail.test/auth/email-verification?") || !strings.Contains(got, "return_to=https%3A%2F%2Fapp.identrail.test%2Fapp") {
+		t.Fatalf("unexpected email verification redirect: %q", got)
+	}
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingEmailVerificationCookieName)
+	if pendingCookie == nil || pendingCookie.Value == "" {
+		t.Fatalf("expected pending email verification cookie, got %+v", callbackResp.Result().Cookies())
+	}
+	if strings.Contains(pendingCookie.Value, "pending-email-token") {
+		t.Fatalf("pending cookie must not expose the raw workos token: %q", pendingCookie.Value)
+	}
+
+	pendingReq := httptest.NewRequest(http.MethodGet, "/auth/email-verification/pending", nil)
+	pendingReq.AddCookie(pendingCookie)
+	pendingResp := httptest.NewRecorder()
+	router.ServeHTTP(pendingResp, pendingReq)
+	if pendingResp.Code != http.StatusOK || !strings.Contains(pendingResp.Body.String(), `"email":"unverified@example.com"`) {
+		t.Fatalf("unexpected pending response: code=%d body=%s", pendingResp.Code, pendingResp.Body.String())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/email-verification/verify", strings.NewReader(`{"code":"123456"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(pendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusOK || !strings.Contains(verifyResp.Body.String(), `"redirect_to":"https://app.identrail.test/app"`) {
+		t.Fatalf("unexpected verify response: code=%d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	if workOS.emailVerifyInput.PendingAuthenticationToken != "pending-email-token" || workOS.emailVerifyInput.Code != "123456" {
+		t.Fatalf("unexpected verify input: %+v", workOS.emailVerifyInput)
+	}
+	if findTestCookie(verifyResp.Result().Cookies(), sessionauth.CookieName) == nil {
+		t.Fatalf("expected session cookie after email verification, got %+v", verifyResp.Result().Cookies())
+	}
+	clearedPending := findTestCookie(verifyResp.Result().Cookies(), sessionauth.PendingEmailVerificationCookieName)
+	if clearedPending == nil || clearedPending.MaxAge >= 0 {
+		t.Fatalf("expected pending email verification cookie to be cleared, got %+v", verifyResp.Result().Cookies())
+	}
+	if _, err := store.GetUserIdentity(context.Background(), sessionauth.WorkOSProvider, "user_workos_email_verify"); err != nil {
+		t.Fatalf("expected workos identity after email verification: %v", err)
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	for _, event := range sink.events {
+		if event.Action == "auth.login.failure" {
+			t.Fatalf("email verification continuation must not write denied login failure audit event: %+v", event)
+		}
+	}
+}
+
+func TestWorkOSEmailVerificationVerifyRejectsInvalidCode(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	secret := strings.Repeat("a", 64)
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSEmailVerificationRequired{
+			Email:                      "unverified@example.com",
+			PendingAuthenticationToken: "pending-email-token",
+		},
+		emailVerifyErr: errors.New("workos rejected the code"),
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         secret,
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingEmailVerificationCookieName)
+	if pendingCookie == nil {
+		t.Fatalf("expected pending email verification cookie, got %+v", callbackResp.Result().Cookies())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/email-verification/verify", strings.NewReader(`{"code":"000000"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(pendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusUnauthorized || !strings.Contains(verifyResp.Body.String(), "invalid verification code") {
+		t.Fatalf("expected invalid code rejection, got %d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	if findTestCookie(verifyResp.Result().Cookies(), sessionauth.CookieName) != nil {
+		t.Fatalf("failed verification must not create a session cookie, got %+v", verifyResp.Result().Cookies())
+	}
+}
+
+func TestWorkOSEmailVerificationVerifyContinuesMFAChallenge(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	secret := strings.Repeat("a", 64)
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSEmailVerificationRequired{
+			Email:                      "unverified@example.com",
+			PendingAuthenticationToken: "pending-email-token",
+		},
+		emailVerifyErr: &sessionauth.WorkOSMFARequired{
+			Mode:                       sessionauth.WorkOSMFAModeChallenge,
+			PendingAuthenticationToken: "pending-mfa-token",
+			AuthenticationFactors:      []sessionauth.WorkOSMFAFactor{{ID: "auth_factor_1", Type: "totp"}},
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         secret,
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingEmailVerificationCookieName)
+	if pendingCookie == nil {
+		t.Fatalf("expected pending email verification cookie, got %+v", callbackResp.Result().Cookies())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/email-verification/verify", strings.NewReader(`{"code":"123456"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(pendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusOK || !strings.Contains(verifyResp.Body.String(), "https://app.identrail.test/auth/mfa?") {
+		t.Fatalf("expected mfa continuation response, got %d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	mfaPending := findTestCookie(verifyResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if mfaPending == nil || mfaPending.Value == "" {
+		t.Fatalf("expected pending mfa cookie after chained requirement, got %+v", verifyResp.Result().Cookies())
+	}
+	openedPending, err := sessionauth.NewMFAPendingStateManager(secret, nil).Open(mfaPending.Value)
+	if err != nil {
+		t.Fatalf("open chained mfa pending cookie: %v", err)
+	}
+	if openedPending.PendingAuthenticationToken != "pending-mfa-token" || openedPending.Mode != sessionauth.WorkOSMFAModeChallenge {
+		t.Fatalf("unexpected chained mfa pending state: %+v", openedPending)
+	}
+	clearedEmailPending := findTestCookie(verifyResp.Result().Cookies(), sessionauth.PendingEmailVerificationCookieName)
+	if clearedEmailPending == nil || clearedEmailPending.MaxAge >= 0 {
+		t.Fatalf("expected email verification cookie to be cleared on mfa handoff, got %+v", verifyResp.Result().Cookies())
+	}
+	if findTestCookie(verifyResp.Result().Cookies(), sessionauth.CookieName) != nil {
+		t.Fatalf("mfa handoff must not create a session cookie, got %+v", verifyResp.Result().Cookies())
 	}
 }
 

--- a/web/prerender-routes.ts
+++ b/web/prerender-routes.ts
@@ -18,6 +18,7 @@ export const PRERENDER_ROUTES = [
   '/signin',
   '/signup',
   '/auth/mfa',
+  '/auth/email-verification',
   '/why-no-passwords',
   '/docs',
   '/faq',

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -19,6 +19,7 @@
   <url><loc>https://www.identrail.com/signin</loc></url>
   <url><loc>https://www.identrail.com/signup</loc></url>
   <url><loc>https://www.identrail.com/auth/mfa</loc></url>
+  <url><loc>https://www.identrail.com/auth/email-verification</loc></url>
   <url><loc>https://www.identrail.com/why-no-passwords</loc></url>
   <url><loc>https://www.identrail.com/docs</loc></url>
   <url><loc>https://www.identrail.com/faq</loc></url>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { SignInPage } from './pages/SignInPage';
 import { SignUpPage } from './pages/SignUpPage';
 import { WorkOSMFAPage } from './pages/WorkOSMFAPage';
+import { WorkOSEmailVerificationPage } from './pages/WorkOSEmailVerificationPage';
 import { WhyNoPasswordsPage } from './pages/WhyNoPasswordsPage';
 import { siteEmails } from './siteConfig';
 import { ConnectPage } from './pages/onboarding/ConnectPage';
@@ -4689,7 +4690,11 @@ export function RoutedSite() {
   const isProductShellRoute = location.pathname.startsWith('/app') || location.pathname.startsWith('/reports');
   const isOnboardingRoute = location.pathname.startsWith('/onboarding');
   const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
-  const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup' || normalizedPath === '/auth/mfa';
+  const isAuthChoiceRoute =
+    normalizedPath === '/signin' ||
+    normalizedPath === '/signup' ||
+    normalizedPath === '/auth/mfa' ||
+    normalizedPath === '/auth/email-verification';
   const isAuthShellRoute = isAuthChoiceRoute || normalizedPath === '/auth/callback';
   useEffect(() => {
     if (isProductShellRoute || isOnboardingRoute || isAuthShellRoute) {
@@ -4716,6 +4721,7 @@ export function RoutedSite() {
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
           <Route path="/auth/mfa" element={<WorkOSMFAPage />} />
+          <Route path="/auth/email-verification" element={<WorkOSEmailVerificationPage />} />
           <Route path="/why-no-passwords" element={<WhyNoPasswordsPage />} />
           <Route path="/app/login" element={<ProductLoginPage />} />
           <Route path="/app/callback" element={<ProductAuthCallbackRedirectPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -611,6 +611,15 @@ export type WorkOSMFAVerifyResponse = {
   redirect_to: string;
 };
 
+export type WorkOSEmailVerificationPendingResponse = {
+  email?: string;
+};
+
+export type WorkOSEmailVerificationVerifyResponse = {
+  ok: boolean;
+  redirect_to: string;
+};
+
 export type ProjectRecord = {
   tenant_id: string;
   workspace_id: string;
@@ -9486,6 +9495,18 @@ export const apiClient = {
   },
   verifyWorkOSMFA(code: string) {
     return request<WorkOSMFAVerifyResponse>('/auth/mfa/verify', undefined, {
+      method: 'POST',
+      body: JSON.stringify({ code }),
+      redirectOnUnauthorized: false
+    });
+  },
+  getWorkOSEmailVerificationPending() {
+    return request<WorkOSEmailVerificationPendingResponse>('/auth/email-verification/pending', undefined, {
+      redirectOnUnauthorized: false
+    });
+  },
+  verifyWorkOSEmailVerification(code: string) {
+    return request<WorkOSEmailVerificationVerifyResponse>('/auth/email-verification/verify', undefined, {
       method: 'POST',
       body: JSON.stringify({ code }),
       redirectOnUnauthorized: false

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -156,6 +156,11 @@ function authReasonDetails(reason: string, returnTo: string, hardDeleteAfter: st
       };
     case 'mfa_required':
       return { message: 'Additional verification is required before Identrail can create a session. Start sign-in again to continue.' };
+    case 'email_verification_required':
+      return {
+        message:
+          'Your email address must be verified before Identrail can create a session. Start sign-in again to receive a new verification code.'
+      };
     case 'provider_unavailable':
       return { message: 'The sign-in provider is temporarily unavailable. Please retry in a moment.' };
     default:

--- a/web/src/pages/WorkOSEmailVerificationPage.test.ts
+++ b/web/src/pages/WorkOSEmailVerificationPage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../api/client';
+import { emailVerificationErrorMessage } from './WorkOSEmailVerificationPage';
+
+describe('WorkOSEmailVerificationPage helpers', () => {
+  it('preserves API verification errors instead of rewriting every unauthorized response', () => {
+    expect(emailVerificationErrorMessage(new ApiError('invalid verification code', 401))).toBe(
+      'invalid verification code'
+    );
+    expect(emailVerificationErrorMessage(new ApiError('email verification session expired', 401))).toBe(
+      'This verification session expired. Start sign-in again to receive a new code.'
+    );
+  });
+
+  it('falls back to a generic message for unknown failures', () => {
+    expect(emailVerificationErrorMessage('boom')).toBe('Unable to continue verification.');
+    expect(emailVerificationErrorMessage(new Error('network down'))).toBe('network down');
+  });
+});

--- a/web/src/pages/WorkOSEmailVerificationPage.tsx
+++ b/web/src/pages/WorkOSEmailVerificationPage.tsx
@@ -1,0 +1,188 @@
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { OTPInput, REGEXP_ONLY_DIGITS } from 'input-otp';
+import { ApiError, apiClient, type WorkOSEmailVerificationPendingResponse } from '../api/client';
+import { normalizeCompletedSessionRedirect, normalizeReturnTo } from './WorkOSMFAPage';
+
+export function emailVerificationErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    if (error.message && error.message !== `Request failed (${error.status})`) {
+      if (error.message === 'email verification session expired') {
+        return 'This verification session expired. Start sign-in again to receive a new code.';
+      }
+      return error.message;
+    }
+    return 'This verification session expired. Start sign-in again to receive a new code.';
+  }
+  return error instanceof Error ? error.message : 'Unable to continue verification.';
+}
+
+export function WorkOSEmailVerificationPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const returnTo = normalizeReturnTo(query.get('return_to'));
+  const [pending, setPending] = useState<WorkOSEmailVerificationPendingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [code, setCode] = useState('');
+  const lastAutoSubmittedCodeRef = useRef('');
+
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const response = await apiClient.getWorkOSEmailVerificationPending();
+        if (mounted) {
+          setPending(response);
+        }
+      } catch (loadError) {
+        if (mounted) {
+          setError(emailVerificationErrorMessage(loadError));
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+    void run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const verifyCode = useCallback(async (nextCode: string) => {
+    const verificationCode = nextCode.trim();
+    if (busy || verificationCode.length < 6) {
+      return;
+    }
+    lastAutoSubmittedCodeRef.current = verificationCode;
+    setBusy(true);
+    setError('');
+    try {
+      const response = await apiClient.verifyWorkOSEmailVerification(verificationCode);
+      navigate(normalizeCompletedSessionRedirect(response.redirect_to || returnTo), { replace: true });
+    } catch (verifyError) {
+      lastAutoSubmittedCodeRef.current = '';
+      setError(emailVerificationErrorMessage(verifyError));
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, navigate, returnTo]);
+
+  const submitCode = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void verifyCode(code);
+  };
+
+  useEffect(() => {
+    const verificationCode = code.trim();
+    if (verificationCode.length < 6) {
+      lastAutoSubmittedCodeRef.current = '';
+      return;
+    }
+    if (loading || !pending || busy || error) {
+      return;
+    }
+    if (lastAutoSubmittedCodeRef.current === verificationCode) {
+      return;
+    }
+    lastAutoSubmittedCodeRef.current = verificationCode;
+    void verifyCode(verificationCode);
+  }, [busy, code, error, loading, pending, verifyCode]);
+
+  const retryVerification = () => {
+    lastAutoSubmittedCodeRef.current = '';
+    void verifyCode(code);
+  };
+
+  const updateCode = (nextCode: string) => {
+    setCode(nextCode);
+    if (error && pending) {
+      setError('');
+    }
+    if (nextCode.trim().length < 6) {
+      lastAutoSubmittedCodeRef.current = '';
+    }
+  };
+
+  const canRetryVerification = Boolean(error && pending && code.trim().length === 6 && !busy);
+
+  return (
+    <section className="idt-auth-page idt-auth-page-login">
+      <div className="idt-auth-topbar">
+        <Link to="/" className="idt-auth-logo is-mark-only" aria-label="Identrail homepage">
+          <img src="/identrail-logo.png" alt="" />
+          <span>Identrail</span>
+        </Link>
+        <Link className="idt-auth-topbar-action" to="/signin">
+          Sign In
+        </Link>
+      </div>
+
+      <article className="idt-auth-panel idt-auth-panel-login idt-auth-mfa-panel">
+        <h1>Verify your email address</h1>
+        {pending?.email ? <p className="idt-auth-mfa-subtitle">{pending.email}</p> : null}
+        {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
+        {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
+
+        {!loading && pending ? (
+          <p className="idt-auth-mfa-subtitle">
+            Enter the code we emailed you to finish signing in.
+          </p>
+        ) : null}
+
+        {!loading && pending ? (
+          <form className="idt-auth-manual-form idt-auth-mfa-form" onSubmit={submitCode} aria-busy={busy}>
+            <OTPInput
+              aria-label="Email verification code"
+              autoComplete="one-time-code"
+              autoFocus
+              containerClassName="idt-auth-otp"
+              disabled={busy}
+              inputMode="numeric"
+              maxLength={6}
+              onChange={updateCode}
+              pattern={REGEXP_ONLY_DIGITS}
+              pushPasswordManagerStrategy="none"
+              value={code}
+              render={({ slots }) => (
+                <div className="idt-auth-otp-group">
+                  {slots.map((slot, index) => (
+                    <div
+                      aria-hidden="true"
+                      className={[
+                        'idt-auth-otp-slot',
+                        slot.isActive ? 'is-active' : '',
+                        slot.char ? 'is-filled' : ''
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                      key={index}
+                    >
+                      {slot.char ?? ''}
+                      {slot.hasFakeCaret ? <span className="idt-auth-otp-caret" /> : null}
+                    </div>
+                  ))}
+                </div>
+              )}
+            />
+            <p className="idt-visually-hidden" role="status" aria-live="polite">
+              {busy ? 'Verifying code.' : ''}
+            </p>
+          </form>
+        ) : null}
+
+        {canRetryVerification ? (
+          <button className="idt-btn idt-btn-secondary idt-auth-mfa-full" type="button" onClick={retryVerification}>
+            Try again
+          </button>
+        ) : null}
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the email-verification continuation flow for WorkOS hosted login, mirroring the existing MFA pending flow:

- **Error extraction** (`internal/api/auth/workos_email_verification.go`): `AsWorkOSEmailVerificationRequired` converts the WorkOS SDK's typed `EmailVerificationRequiredError` (and the `email_verification_required` HTTP error-code fallback) into an app-level error carrying the pending authentication token, verification id, and email. `normalizeWorkOSAuthenticationError` preserves it across the client boundary.
- **Sealed pending state**: a new `EmailVerificationPendingStateManager` seals `{intent, return_to, email, pending token}` into an encrypted, 10-minute cookie scoped to `/auth/email-verification`. The AES-GCM seal/open logic is factored out of the MFA manager into shared helpers; each flow keeps a distinct AAD so an MFA pending blob can never be replayed as email-verification state (covered by a dedicated test).
- **Endpoints**: the OAuth callback now catches the error, seals the state, and redirects to the frontend page; `GET /auth/email-verification/pending` reports the masked pending context; `POST /auth/email-verification/verify` exchanges the emailed code via WorkOS `AuthenticateWithEmailVerificationCode` and completes login through the existing `completeWorkOSLogin` path. When WorkOS chains an MFA requirement after email verification, the verify endpoint hands off to the existing MFA pending flow (shared `sealWorkOSMFAPending` helper, deduplicated from `handleWorkOSMFARequired`).
- **Frontend**: new `/auth/email-verification` page with the same OTP input and auto-submit behavior as the MFA page, plus a `email_verification_required` failure message on the sign-in page for the no-pending-token fallback.

## Why

WorkOS refuses the OAuth code exchange with `email_verification_required` when the account's email is unverified — common for GitHub OAuth, which frequently reports private/secondary emails as unverified. The callback had no handler for this error, so it fell through to the generic `callback_error` branch and users dead-ended on "Sign-in did not complete. Please retry from this page." with no path forward, discarding the pending token and the verification code WorkOS had already emailed. Production logs confirmed repeated occurrences.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered — no config changes; existing MFA pending flow untouched apart from extracting shared helpers (wire format unchanged, verified by existing MFA tests); logins that don't hit the WorkOS error are unaffected.
- [x] Risk level assessed — low-medium; new endpoints mirror the rate limits, cookie scoping, and sealed-state pattern of the audited MFA flow.

## Validation

```bash
make fmt-check                      # pass
make vet                            # pass
go test ./internal/api/auth ./internal/api ./internal/server ./internal/config   # pass
npm run test:ci --prefix web        # 465 tests pass
npm run build --prefix web          # production build + 39 routes prerendered
```

End-to-end handler tests cover: callback → pending cookie → verify → session; invalid code rejection; chained MFA hand-off; AAD cross-replay rejection; key-rotation open-only fallback. The new page was also rendered in a local dev server to confirm route registration and layout.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes (no env vars or operator behavior added; CHANGELOG covers the user-facing change)
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Fixes #1720

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a continuation flow for WorkOS `email_verification_required` so users can finish hosted login. The OAuth callback now redirects to `/auth/email-verification`, verifies the emailed code, and continues to MFA when needed.

- **New Features**
  - Normalize and surface email verification errors via `AsWorkOSEmailVerificationRequired`, and add `AuthenticateWithEmailVerificationCode` to the WorkOS client.
  - New sealed pending state and cookie for email verification (10‑minute TTL, scoped to `/auth/email-verification`).
  - Endpoints: callback captures the error and sets the pending cookie; `GET /auth/email-verification/pending`; `POST /auth/email-verification/verify` completes login or hands off to MFA.
  - Frontend: new `/auth/email-verification` page with OTP input and auto-submit; prerendered and added to sitemap; sign-in page shows `email_verification_required` message; client methods `getWorkOSEmailVerificationPending` and `verifyWorkOSEmailVerification`.

- **Refactors**
  - Extract shared AES‑GCM seal/open helpers; distinct AAD prevents cross‑replay with MFA pending blobs; supports previous-key open-only.
  - Deduplicate MFA pending sealing into a helper used by the callback and the email-verification→MFA handoff; share one auth continuation URL builder across MFA and email verification; verify handlers log the real WorkOS errors.

<sup>Written for commit e21e8448c4ce836c170aee8d7fca511b9ef91bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

