### PR TITLE
Add audited finding actions

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2428,11 +2428,11 @@ describe('App', () => {
     const findingDialog = await screen.findByRole('dialog', {
       name: /Potential AWS access key exposed in commit history/i
     });
-    const workflowControls = within(findingDialog).getByText(/Workflow controls/i).closest('.idt-repo-finding-triage-form');
+    const workflowControls = within(findingDialog).getByText(/Finding actions/i).closest('.idt-repo-finding-triage-form');
     expect(workflowControls).toBeInTheDocument();
 
     fireEvent.change(within(workflowControls as HTMLElement).getByLabelText(/Assignee/i), { target: { value: 'platform' } });
-    fireEvent.click(within(workflowControls as HTMLElement).getByRole('button', { name: /Apply workflow/i }));
+    fireEvent.click(within(workflowControls as HTMLElement).getByRole('button', { name: /Apply action/i }));
 
     await waitFor(() => {
       expect(

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2343,7 +2343,7 @@ describe('App', () => {
     expect(screen.queryByText(/Failed to load AI \/ Agentic Risk/i)).not.toBeInTheDocument();
   });
 
-  it('allows suppressed repository finding assignee edits without a new suppression reason', async () => {
+  it('requires a suppression reason before updating suppressed repository findings', async () => {
     const suppressionExpiresAt = '2027-01-01T00:00:00Z';
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString();
@@ -2434,6 +2434,17 @@ describe('App', () => {
     fireEvent.change(within(workflowControls as HTMLElement).getByLabelText(/Assignee/i), { target: { value: 'platform' } });
     fireEvent.click(within(workflowControls as HTMLElement).getByRole('button', { name: /Apply action/i }));
 
+    expect(await within(workflowControls as HTMLElement).findByText(/Suppression requires a reason/i)).toBeInTheDocument();
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/v1/findings/repo-f1/triage'))).toBe(false);
+
+    fireEvent.change(
+      within(workflowControls as HTMLElement).getByPlaceholderText(/Required: why this finding can leave the active queue/i),
+      {
+        target: { value: 'Extending the suppression while the owner validates the fixture.' }
+      }
+    );
+    fireEvent.click(within(workflowControls as HTMLElement).getByRole('button', { name: /Apply action/i }));
+
     await waitFor(() => {
       expect(
         fetchMock.mock.calls.some(([url]) => String(url).includes('/v1/findings/repo-f1/triage'))
@@ -2443,9 +2454,8 @@ describe('App', () => {
     const triageCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/v1/findings/repo-f1/triage'));
     const payload = JSON.parse(String((triageCall?.[1] as RequestInit | undefined)?.body));
     expect(payload.assignee).toBe('platform');
-    expect(payload.comment).toBeUndefined();
+    expect(payload.comment).toBe('Extending the suppression while the owner validates the fixture.');
     expect(payload.status).toBeUndefined();
-    expect(screen.queryByText(/Suppression requires a reason/i)).not.toBeInTheDocument();
   });
 
   it('renders real workspace settings from account, member, and auth config APIs', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7360,6 +7360,30 @@ async function renderFindings(options: { repoScans?: RepoScanRecord[]; repoFindi
       }
       return { items, summary: undefined };
     });
+  const triageFinding = vi.spyOn(api.apiClient, 'triageFinding').mockImplementation(async (findingID, payload, scanID) => {
+    const existing = options.repoFindings?.find((finding) => finding.id === findingID) ?? options.repoFindings?.[0];
+    return {
+      finding: {
+        ...(existing ?? {
+          id: findingID,
+          scan_id: scanID ?? 'repo-scan-default',
+          type: 'secret_exposure',
+          severity: 'high',
+          title: 'Default finding',
+          human_summary: 'Default finding summary.',
+          remediation: 'Rotate and remove the exposed secret.',
+          created_at: '2026-05-17T11:00:00Z'
+        }),
+        triage: {
+          status: payload.status ?? existing?.triage?.status ?? 'open',
+          assignee: payload.assignee ?? existing?.triage?.assignee,
+          suppression_expires_at: payload.suppression_expires_at ?? existing?.triage?.suppression_expires_at,
+          updated_at: '2026-05-17T11:12:00Z',
+          updated_by: 'test-operator'
+        }
+      }
+    };
+  });
   vi.spyOn(api.apiClient, 'getRepoFindingsTrends').mockResolvedValue({ items: [] });
   vi.spyOn(api.apiClient, 'getRepoRiskGraph').mockRejectedValue(new Error('no graph'));
 
@@ -7372,7 +7396,7 @@ async function renderFindings(options: { repoScans?: RepoScanRecord[]; repoFindi
     </MemoryRouter>
   );
 
-  return { listRepoScans, listRepoFindings };
+  return { listRepoScans, listRepoFindings, triageFinding };
 }
 
 describe('ProductFindingsPage states', () => {
@@ -7578,6 +7602,64 @@ describe('ProductFindingsPage states', () => {
     });
     await waitFor(() => {
       expect(document.activeElement).toBe(rowButton);
+    });
+  });
+
+  it('surfaces audited finding actions and requires a reason before suppressing', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-with-actionable-finding',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-action-1',
+      scan_id: scan.id,
+      type: 'secret_exposure',
+      severity: 'critical',
+      title: 'Potential token exposed in workflow history',
+      human_summary: 'A token-like value appears in a committed workflow.',
+      remediation: 'Rotate the credential and remove the committed value.',
+      source_url: 'https://github.com/identrail/identrail/blob/main/.github/workflows/deploy.yml#L12',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+
+    const { triageFinding } = await renderFindings({ repoScans: [scan], repoFindings: [finding] });
+
+    const rowButton = (await screen.findAllByRole('listitem')).find((node) =>
+      node.textContent?.includes('Potential token exposed in workflow history')
+    ) as HTMLButtonElement | undefined;
+    expect(rowButton).toBeDefined();
+    if (!rowButton) return;
+    fireEvent.click(rowButton);
+
+    const dialog = await screen.findByRole('dialog', { name: /Potential token exposed in workflow history/i });
+    expect(within(dialog).getByRole('heading', { name: 'Finding actions' })).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /Suppress/i }));
+    expect(within(dialog).getByLabelText('Status')).toHaveValue('suppressed');
+    fireEvent.click(within(dialog).getByRole('button', { name: /Apply action/i }));
+
+    expect(await within(dialog).findByText('Suppression requires a reason.')).toBeInTheDocument();
+    expect(triageFinding).not.toHaveBeenCalled();
+
+    fireEvent.change(within(dialog).getByLabelText('Comment'), {
+      target: { value: 'Suppressed while the repository owner validates this legacy test fixture.' }
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /Apply action/i }));
+
+    await waitFor(() => {
+      expect(triageFinding).toHaveBeenCalledWith(
+        finding.id,
+        expect.objectContaining({
+          status: 'suppressed',
+          comment: 'Suppressed while the repository owner validates this legacy test fixture.'
+        }),
+        scan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
     });
   });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -26983,7 +26983,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     const currentStatus = normalizeFindingStatus(selectedFinding.triage?.status);
     const currentAssignee = normalizeValue(selectedFinding.triage?.assignee ?? '');
     const trackingSuppression = nextStatus === 'suppressed';
-    const enteringSuppression = currentStatus !== 'suppressed' && trackingSuppression;
+    const updatingSuppression = trackingSuppression;
     const currentSuppression = normalizeValue(toLocalDateTimeInputValue(selectedFinding.triage?.suppression_expires_at ?? ''));
     const nextSuppression = normalizeValue(workflowSuppressionExpiresAt);
     const hasChanges =
@@ -27009,7 +27009,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         comment?: string;
       } = {};
       const trimmedComment = normalizeValue(workflowComment);
-      if (enteringSuppression && !trimmedComment) {
+      if (updatingSuppression && !trimmedComment) {
         setWorkflowError('Suppression requires a reason.');
         setWorkflowLoading(false);
         return;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7,11 +7,13 @@ import type {
 } from 'react';
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
+  Archive,
   BarChart3,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronUp,
+  CheckCircle2,
   ExternalLink,
   FolderKanban,
   HelpCircle,
@@ -21,8 +23,10 @@ import {
   Moon,
   Palette,
   Pencil,
+  RotateCcw,
   Search,
   Settings as SettingsIcon,
+  ShieldCheck,
   Sun
 } from 'lucide-react';
 import {
@@ -417,6 +421,32 @@ const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
 const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolved'] as const;
+const REPO_FINDING_WORKFLOW_ACTIONS: Array<{
+  status: FindingLifecycleStatus;
+  label: string;
+  description: string;
+}> = [
+  {
+    status: 'ack',
+    label: 'Acknowledge',
+    description: 'Keep the finding visible while showing an owner has accepted triage.'
+  },
+  {
+    status: 'suppressed',
+    label: 'Suppress',
+    description: 'Remove it from the active queue with a required audit reason and optional expiry.'
+  },
+  {
+    status: 'resolved',
+    label: 'Resolve',
+    description: 'Move it out of active review after validating the underlying risk is gone.'
+  },
+  {
+    status: 'open',
+    label: 'Reopen',
+    description: 'Return the finding to active review when the risk needs another look.'
+  }
+];
 const ENVIRONMENT_QUERY_PARAM = 'environment';
 const OVERVIEW_FINDING_LIMIT = 50;
 const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
@@ -1195,6 +1225,20 @@ function normalizeRepoFindingLifecycleStatus(value: string | undefined): RepoFin
 
 function repoFindingStatusClass(status: FindingLifecycleStatus | RepoFindingLifecycleStatus): string {
   return `idt-repo-finding-status is-${status}`;
+}
+
+function repoFindingWorkflowActionIcon(status: FindingLifecycleStatus): ReactNode {
+  switch (status) {
+    case 'ack':
+      return <ShieldCheck size={16} strokeWidth={2} aria-hidden="true" />;
+    case 'suppressed':
+      return <Archive size={16} strokeWidth={2} aria-hidden="true" />;
+    case 'resolved':
+      return <CheckCircle2 size={16} strokeWidth={2} aria-hidden="true" />;
+    case 'open':
+    default:
+      return <RotateCcw size={16} strokeWidth={2} aria-hidden="true" />;
+  }
 }
 
 function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
@@ -26968,6 +27012,22 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     }
   };
 
+  const primeWorkflowAction = (nextStatus: FindingLifecycleStatus) => {
+    if (workflowLoading || !hasTriageAccess) {
+      return;
+    }
+    setWorkflowStatus(nextStatus);
+    setWorkflowError('');
+    setWorkflowSuccess('');
+    if (nextStatus !== 'suppressed') {
+      setWorkflowSuppressionExpiresAt('');
+      return;
+    }
+    if (!workflowSuppressionExpiresAt && selectedFinding?.triage?.suppression_expires_at) {
+      setWorkflowSuppressionExpiresAt(toLocalDateTimeInputValue(selectedFinding.triage.suppression_expires_at));
+    }
+  };
+
   const handleLoadRemediationPreview = async () => {
     if (!scope || !selectedFinding || remediationPreviewLoading) {
       return;
@@ -27974,24 +28034,43 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               </section>
 
               <section className="idt-repo-finding-detail-section idt-repo-finding-triage-form">
-                <h4>Workflow controls</h4>
+                <div className="idt-repo-finding-action-head">
+                  <div>
+                    <h4>Finding actions</h4>
+                    <p>
+                      Remove findings from the active queue through lifecycle states while preserving evidence,
+                      history, and audit context.
+                    </p>
+                  </div>
+                  <span className={repoFindingStatusClass(normalizeFindingStatus(selectedFinding.triage?.status))}>
+                    {formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}
+                  </span>
+                </div>
                 {workflowError ? <div className="idt-app-alert idt-app-alert-error">{workflowError}</div> : null}
                 {workflowSuccess ? <div className="idt-app-alert idt-app-alert-success">{workflowSuccess}</div> : null}
+                <div className="idt-repo-finding-action-grid" role="group" aria-label="Finding lifecycle actions">
+                  {REPO_FINDING_WORKFLOW_ACTIONS.map((action) => (
+                    <button
+                      key={action.status}
+                      type="button"
+                      className={`idt-repo-finding-action-card${workflowStatus === action.status ? ' is-selected' : ''}`}
+                      onClick={() => primeWorkflowAction(action.status)}
+                      disabled={workflowLoading || !hasTriageAccess}
+                      aria-pressed={workflowStatus === action.status}
+                    >
+                      <span className="idt-repo-finding-action-icon">{repoFindingWorkflowActionIcon(action.status)}</span>
+                      <span className="idt-repo-finding-action-copy">
+                        <strong>{action.label}</strong>
+                        <span>{action.description}</span>
+                      </span>
+                    </button>
+                  ))}
+                </div>
                 <label>
                   Status
                   <select
                     value={workflowStatus}
-                    onChange={(event) => {
-                      const nextStatus = event.target.value as FindingLifecycleStatus;
-                      setWorkflowStatus(nextStatus);
-                      if (nextStatus !== 'suppressed') {
-                        setWorkflowSuppressionExpiresAt('');
-                      } else if (!workflowSuppressionExpiresAt && selectedFinding?.triage?.suppression_expires_at) {
-                        setWorkflowSuppressionExpiresAt(
-                          toLocalDateTimeInputValue(selectedFinding.triage.suppression_expires_at)
-                        );
-                      }
-                    }}
+                    onChange={(event) => primeWorkflowAction(event.target.value as FindingLifecycleStatus)}
                     disabled={workflowLoading || !hasTriageAccess}
                   >
                     {REPO_FINDING_STATUS_FILTERS.filter((status) => status !== 'all').map((status) => (
@@ -28012,7 +28091,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                     placeholder="YYYY-MM-DDThh:mm"
                   />
                   <span className="idt-app-field-hint">
-                    Required when setting status to <strong>suppressed</strong>, ignored otherwise.
+                    Optional expiry for temporary suppressions. A suppression reason is required in the comment.
                   </span>
                 </label>
                 <label>
@@ -28032,7 +28111,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                     value={workflowComment}
                     onChange={(event) => setWorkflowComment(event.target.value)}
                     disabled={workflowLoading || !hasTriageAccess}
-                    placeholder="Optional workflow comment"
+                    placeholder={
+                      workflowStatus === 'suppressed'
+                        ? 'Required: why this finding can leave the active queue'
+                        : 'Optional workflow comment'
+                    }
                     maxLength={500}
                   />
                 </label>
@@ -28042,7 +28125,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                   onClick={handleApplyWorkflow}
                   disabled={workflowLoading || !hasTriageAccess}
                 >
-                  {workflowLoading ? 'Saving...' : 'Apply workflow'}
+                  {workflowLoading ? 'Saving...' : 'Apply action'}
                 </button>
               </section>
             </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -25438,6 +25438,119 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-modal-close {
   flex-wrap: wrap;
 }
 
+.idt-app-console-layout .idt-repo-finding-action-head,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-head h4,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-head h4 {
+  margin: 0;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-head p,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-head p {
+  margin: 0.28rem 0 0;
+  max-width: 58rem;
+  color: var(--app-muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-grid,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-card,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card {
+  min-width: 0;
+  min-height: 7.35rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.6rem;
+  align-content: start;
+  align-items: flex-start;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.8rem;
+  background: #080809;
+  color: #ffffff;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-card:hover,
+.idt-app-console-layout .idt-repo-finding-action-card:focus-visible,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card:hover,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card:focus-visible {
+  border-color: rgba(255, 255, 255, 0.55);
+  background: #111113;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.idt-app-console-layout .idt-repo-finding-action-card.is-selected,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card.is-selected {
+  border-color: rgba(94, 234, 212, 0.72);
+  background: rgba(20, 83, 74, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.12);
+}
+
+.idt-app-console-layout .idt-repo-finding-action-card:disabled,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+  transform: none;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-icon,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-icon {
+  width: 2rem;
+  height: 2rem;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-card.is-selected .idt-repo-finding-action-icon,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card.is-selected .idt-repo-finding-action-icon {
+  border-color: rgba(94, 234, 212, 0.48);
+  color: #99f6e4;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-copy,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-copy strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-copy strong {
+  color: #ffffff;
+  font-size: 0.86rem;
+  line-height: 1.2;
+}
+
+.idt-app-console-layout .idt-repo-finding-action-copy span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-copy span {
+  color: var(--app-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
 .idt-app-console-layout {
   --repo-disclosure-column: 2rem;
   --repo-disclosure-size: 1.35rem;
@@ -26070,6 +26183,21 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-grou
   .idt-source-enterprise-fallback summary,
   .idt-source-policy-summary {
     display: grid;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-action-head,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-head {
+    display: grid;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-action-grid,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-action-card,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-action-card {
+    min-height: 0;
   }
 
   .idt-source-compact-stats div {


### PR DESCRIPTION
## Summary

- Adds a prominent Finding actions panel to the GitHub finding detail modal.
- Lets operators prepare acknowledge, suppress, resolve, and reopen lifecycle actions without deleting evidence.
- Styles the action cards to match the existing Identrail console and collapse cleanly on mobile.
- Adds regression coverage that suppression cannot be saved without an audit reason.

No issue: product UX follow-up requested directly in Codex.

## Validation

- `npm test -- --run src/productShell.test.tsx -t "ProductFindingsPage states"`
- `npm test -- --run src/productShell.test.tsx`
- `npm run build`

## Notes

- Browser screenshot verification reached the session validation screen locally because the dev app had no authenticated backend session available. The interaction path is covered in the focused React tests, and the production frontend build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Finding actions” panel in the GitHub finding modal so operators can acknowledge, suppress, resolve, or reopen findings with a clear audit trail. Suppression now always requires a reason, including when updating an existing suppression, and the UI adds an accessible action grid with status icons.

- **New Features**
  - Action cards set status and prefill suppression expiry when present; header shows a status chip and explainer.
  - Button label is “Apply action”; comment is required for suppressions (including updates); expiry is optional.
  - Adds icons and an ARIA-labeled action group; mobile collapses to one column; validation blocks API calls until a suppression reason is provided and triage includes the audit comment and auth context.

<sup>Written for commit e2607d564e381fa3eedbbce5a8873d2efa9ba577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

