### PR TITLE
Polish GitHub post-install return flow

### DIFF
--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -578,11 +578,10 @@ func (s *Service) CompleteGitHubConnector(ctx context.Context, request GitHubCon
 	delete(s.githubConnectStates, normalizedState)
 	s.githubConnectMu.Unlock()
 	status := s.toGitHubConnectionStatus(connection)
-	// Land on the dedicated GitHub section after install rather than the legacy
-	// per-project source-connections page. Carry the project as the environment
-	// query so the section shows the environment that was just connected instead
-	// of falling back to the workspace default.
-	redirectPath := "/app/" + url.PathEscape(connection.TenantID) + "/" + url.PathEscape(connection.WorkspaceID) + "/github/repositories?environment=" + url.QueryEscape(connection.ProjectID)
+	// Land on the quiet connection surface after install. The repositories
+	// page can collect live posture data, so keep that as an intentional next
+	// step instead of making the post-install return feel like a scan result.
+	redirectPath := "/app/" + url.PathEscape(connection.TenantID) + "/" + url.PathEscape(connection.WorkspaceID) + "/github/connect?environment=" + url.QueryEscape(connection.ProjectID)
 	return GitHubConnectorCompleteResponse{
 		Connection:   status,
 		TenantID:     connection.TenantID,

--- a/internal/api/github_connector_v2_test.go
+++ b/internal/api/github_connector_v2_test.go
@@ -235,7 +235,7 @@ func TestRouterGitHubConnectorV2CompletesAppInstall(t *testing.T) {
 	if !completeBody.Connection.Connected || completeBody.Connection.InstallationID != 12345 {
 		t.Fatalf("expected active github app connector, got %+v", completeBody.Connection)
 	}
-	if completeBody.RedirectPath != "/app/tenant-a/workspace-a/github/repositories?environment=project-1" {
+	if completeBody.RedirectPath != "/app/tenant-a/workspace-a/github/connect?environment=project-1" {
 		t.Fatalf("unexpected redirect path %q", completeBody.RedirectPath)
 	}
 	if len(completeBody.Connection.SelectedRepositories) != 2 || completeBody.Connection.SelectedRepositories[0] != "identrail/api" {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1223,7 +1223,7 @@ describe('App', () => {
       window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
     });
 
-    expect(await screen.findByText(/Validating session/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Preparing workspace/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 2, name: 'AWS' })).not.toBeInTheDocument();
 
     await act(async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8018,6 +8018,58 @@ describe('GitHub domain pages (#1382)', () => {
     };
   }
 
+  it('GitHub callback shows a polished handoff and redirects to the clean connection page', async () => {
+    const api = await import('./api/client');
+    const completion = deferred<Awaited<ReturnType<typeof api.apiClient.completeGitHubConnector>>>();
+    const completeGitHubConnector = vi
+      .spyOn(api.apiClient, 'completeGitHubConnector')
+      .mockImplementation(() => completion.promise);
+
+    const productShell = await import('./productShell');
+    function LocationCapture() {
+      const location = useLocation();
+      return <p data-testid="location">{location.pathname + location.search}</p>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/github/callback?state=github-state&installation_id=12345&code=oauth-code&setup_action=install']}>
+        <Routes>
+          <Route path="/app/github/callback" element={<productShell.ProductGitHubCallbackPage />} />
+          <Route path="*" element={<LocationCapture />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Finishing GitHub connection/i)).toBeInTheDocument();
+    expect(screen.getByText(/saved appearance settings/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(completeGitHubConnector).toHaveBeenCalledWith({
+        state: 'github-state',
+        installation_id: 12345,
+        code: 'oauth-code',
+        setup_action: 'install'
+      })
+    );
+
+    await act(async () => {
+      completion.resolve({
+        connection: connectedGitHub,
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'production-platform',
+        redirect_path: '/app/tenant-a/workspace-a/github/connect?environment=production-platform'
+      });
+      await completion.promise;
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/app/tenant-a/workspace-a/github/connect?environment=production-platform'
+      )
+    );
+  });
+
   it('Control Center loads the GitHub connection and surfaces connection status', async () => {
     const mocks = await renderGitHubPage('control-center', { scans: [succeededRepoScan] });
 
@@ -8702,9 +8754,15 @@ describe('GitHub domain pages (#1382)', () => {
 
     await screen.findByRole('heading', { level: 2, name: 'Repositories' });
     const posturePanel = await screen.findByRole('region', { name: 'Repository posture' });
+    expect(within(posturePanel).getByText('No repository posture collected yet')).toBeInTheDocument();
+    expect(mocks.getGitHubConnectorRepositoryPosture).not.toHaveBeenCalled();
+
+    fireEvent.click(within(posturePanel).getByRole('button', { name: /Review posture/i }));
+
     expect(await within(posturePanel).findByText('Default branch is missing required pull request reviews.')).toBeInTheDocument();
     expect(within(posturePanel).getByLabelText('GitHub posture summary')).toHaveTextContent('Secure1');
     expect(within(posturePanel).getByText('Organization posture')).toBeInTheDocument();
+    expect(within(posturePanel).getByText('Review 1 check').closest('details')).not.toHaveAttribute('open');
     await waitFor(() =>
       expect(mocks.getGitHubConnectorRepositoryPosture).toHaveBeenCalledWith(
         'github-app',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8757,7 +8757,9 @@ describe('GitHub domain pages (#1382)', () => {
     expect(within(posturePanel).getByText('No repository posture collected yet')).toBeInTheDocument();
     expect(mocks.getGitHubConnectorRepositoryPosture).not.toHaveBeenCalled();
 
-    fireEvent.click(within(posturePanel).getByRole('button', { name: /Review posture/i }));
+    const reviewButton = within(posturePanel).getByRole('button', { name: /Review posture/i });
+    await waitFor(() => expect(reviewButton).not.toBeDisabled());
+    fireEvent.click(reviewButton);
 
     expect(await within(posturePanel).findByText('Default branch is missing required pull request reviews.')).toBeInTheDocument();
     expect(within(posturePanel).getByLabelText('GitHub posture summary')).toHaveTextContent('Secure1');
@@ -8772,6 +8774,57 @@ describe('GitHub domain pages (#1382)', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('Repositories page keeps posture review opt-in after switching repositories', async () => {
+    const mocks = await renderGitHubPage('repositories', {
+      githubConnection: {
+        ...connectedGitHub,
+        selected_repositories: ['identrail/identrail', 'identrail/docs']
+      },
+      scans: [succeededRepoScan]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
+    const posturePanel = await screen.findByRole('region', { name: 'Repository posture' });
+    const repositorySelect = within(posturePanel).getByLabelText('Repository');
+    const reviewButton = within(posturePanel).getByRole('button', { name: /Review posture/i });
+
+    await waitFor(() => expect(reviewButton).not.toBeDisabled());
+    fireEvent.click(reviewButton);
+
+    expect(await within(posturePanel).findByText('Default branch is missing required pull request reviews.')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getGitHubConnectorRepositoryPosture).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(repositorySelect, { target: { value: 'identrail/docs' } });
+
+    await waitFor(() => expect(repositorySelect).toHaveValue('identrail/docs'));
+    expect(within(posturePanel).getByText('No repository posture collected yet')).toBeInTheDocument();
+    expect(mocks.getGitHubConnectorRepositoryPosture).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(repositorySelect, { target: { value: 'identrail/identrail' } });
+
+    await waitFor(() => expect(repositorySelect).toHaveValue('identrail/identrail'));
+    expect(within(posturePanel).getByText('No repository posture collected yet')).toBeInTheDocument();
+    expect(mocks.getGitHubConnectorRepositoryPosture).toHaveBeenCalledTimes(1);
+  });
+
+  it('Repositories page disables repository posture review for PAT connections', async () => {
+    const mocks = await renderGitHubPage('repositories', {
+      githubConnection: connectedGitHubPAT,
+      scans: [succeededRepoScan]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'Repositories' });
+    const posturePanel = await screen.findByRole('region', { name: 'Repository posture' });
+    const reviewButton = within(posturePanel).getByRole('button', { name: /GitHub App required/i });
+
+    expect(reviewButton).toBeDisabled();
+    expect(
+      within(posturePanel).getByText('Repository posture checks are available after connecting this environment with the GitHub App.')
+    ).toBeInTheDocument();
+    fireEvent.click(reviewButton);
+    expect(mocks.getGitHubConnectorRepositoryPosture).not.toHaveBeenCalled();
   });
 
   it('Repositories page bypasses in-flight refreshes after queueing a scan', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1926,13 +1926,21 @@ class ProductErrorBoundaryInner extends Component<
   }
 }
 
-function AppShellLoading({ message }: { message: string }) {
+function AppShellLoading({
+  message,
+  kicker = 'Loading',
+  body = 'Preparing workspace context.'
+}: {
+  message: string;
+  kicker?: string;
+  body?: string;
+}) {
   return (
     <section className="idt-app-shell-screen" aria-live="polite">
-      <article className="idt-app-panel">
-        <p className="idt-app-kicker">Loading</p>
+      <article className="idt-app-panel idt-app-loading-panel">
+        <p className="idt-app-kicker">{kicker}</p>
         <h1>{message}</h1>
-        <p>Preparing route context and tenancy scope.</p>
+        <p>{body}</p>
       </article>
     </section>
   );
@@ -2227,7 +2235,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
   }, [routeHasExplicitScope, routeTenantID, routeWorkspaceID, routeScopeKey, routeLocationKey]);
 
   if (status === 'checking' || (status === 'authenticated' && validatedScopeKey !== routeScopeKey)) {
-    return <AppShellLoading message="Validating session" />;
+    return <AppShellLoading message="Preparing workspace" body="Opening your app with the saved account and appearance settings." />;
   }
 
   if (status === 'error') {
@@ -2346,7 +2354,13 @@ export function ProductGitHubCallbackPage() {
     );
   }
 
-  return <AppShellLoading message="Completing GitHub installation" />;
+  return (
+    <AppShellLoading
+      kicker="GitHub"
+      message="Finishing GitHub connection"
+      body="Returning you to Identrail with your saved appearance settings."
+    />
+  );
 }
 
 export function ProductLogoutPage() {
@@ -21275,7 +21289,9 @@ export function ProductGitHubRepositoriesPage() {
   const [githubOrganizationPosture, setGitHubOrganizationPosture] = useState<GitHubOrganizationPosture | null>(null);
   const [githubPostureLoading, setGitHubPostureLoading] = useState(false);
   const [githubPostureError, setGitHubPostureError] = useState('');
+  const [postureRequest, setPostureRequest] = useState({ key: '', nonce: 0 });
   const hasActiveRepositoryScan = data.scans.some((scan) => isActiveScanStatus(scan.status));
+  const postureScopeKey = scope ? `${scope.tenantID}|${scope.workspaceID}|${selectedEnvironmentID}|${postureRepository}` : '';
 
   useEffect(() => {
     const nextRepository = selectedRepositories.includes(postureRepository)
@@ -21297,6 +21313,14 @@ export function ProductGitHubRepositoriesPage() {
   }, [oneOffScanScopeKey, selectedEnvironmentID]);
 
   useEffect(() => {
+    postureRequestRef.current += 1;
+    setGitHubPosture(null);
+    setGitHubOrganizationPosture(null);
+    setGitHubPostureLoading(false);
+    setGitHubPostureError('');
+  }, [postureScopeKey]);
+
+  useEffect(() => {
     const connection = data.connection;
     const repository = canonicalGitHubRepositoryDisplay(postureRepository);
     const requestID = postureRequestRef.current + 1;
@@ -21308,12 +21332,11 @@ export function ProductGitHubRepositoriesPage() {
       !connection?.connected ||
       connection.provider !== 'github_app' ||
       !connection.connector_id ||
-      !repository
+      !repository ||
+      postureRequest.key !== postureScopeKey ||
+      postureRequest.nonce <= 0
     ) {
-      setGitHubPosture(null);
-      setGitHubOrganizationPosture(null);
       setGitHubPostureLoading(false);
-      setGitHubPostureError('');
       return undefined;
     }
 
@@ -21360,6 +21383,9 @@ export function ProductGitHubRepositoriesPage() {
     data.connection?.connector_id,
     data.connection?.provider,
     postureRepository,
+    postureRequest.key,
+    postureRequest.nonce,
+    postureScopeKey,
     scope?.tenantID,
     scope?.workspaceID,
     selectedEnvironmentID
@@ -21486,6 +21512,13 @@ export function ProductGitHubRepositoriesPage() {
     } finally {
       setSubmittingRepository((current) => (current === repository ? '' : current));
     }
+  };
+
+  const reviewRepositoryPosture = () => {
+    setPostureRequest((current) => ({
+      key: postureScopeKey,
+      nonce: current.nonce + 1
+    }));
   };
 
   const launchOneOffScan = async (event: FormEvent<HTMLFormElement>) => {
@@ -21773,18 +21806,28 @@ export function ProductGitHubRepositoriesPage() {
               <h3>Repository posture</h3>
               <p>Branch protection, Actions permissions, security settings, and organization posture for a selected repository.</p>
             </div>
-            {selectedRepositories.length > 1 ? (
-              <label>
-                Repository
-                <select value={postureRepository} onChange={(event) => setPostureRepository(event.target.value)}>
-                  {selectedRepositories.map((repository) => (
-                    <option key={repository} value={repository}>
-                      {repository}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
+            <div className="idt-github-posture-controls">
+              {selectedRepositories.length > 1 ? (
+                <label>
+                  Repository
+                  <select value={postureRepository} onChange={(event) => setPostureRepository(event.target.value)}>
+                    {selectedRepositories.map((repository) => (
+                      <option key={repository} value={repository}>
+                        {repository}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              <button
+                type="button"
+                className="idt-btn idt-btn-ghost"
+                onClick={reviewRepositoryPosture}
+                disabled={githubPostureLoading || !postureRepository}
+              >
+                {githubPostureLoading ? 'Loading posture...' : githubPosture || githubPostureError ? 'Refresh posture' : 'Review posture'}
+              </button>
+            </div>
           </header>
           {githubPostureLoading ? (
             <DomainLoadingState label="Loading repository posture" />
@@ -21823,7 +21866,7 @@ export function ProductGitHubRepositoriesPage() {
                   </div>
                 </dl>
               </article>
-              <details className="idt-source-advanced idt-github-posture-details" open={githubPostureNeedsAttentionCount > 0}>
+              <details className="idt-source-advanced idt-github-posture-details">
                 <summary>
                   <span>
                     <strong>
@@ -21893,7 +21936,7 @@ export function ProductGitHubRepositoriesPage() {
           ) : (
             <DomainEmptyState
               title="No repository posture collected yet"
-              body="Posture checks appear here after Identrail can read the selected repository through the GitHub App."
+              body="Posture checks stay quiet until you review the selected repository."
             />
           )}
         </section>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -21280,6 +21280,7 @@ export function ProductGitHubRepositoriesPage() {
   const selectedOneOffScanEnvironmentRef = useRef(selectedEnvironmentID);
   const selectedOneOffScanScopeRef = useRef(oneOffScanScopeKey);
   const postureRequestRef = useRef(0);
+  const postureResetKeyRef = useRef('');
   selectedOneOffScanEnvironmentRef.current = selectedEnvironmentID;
   selectedOneOffScanScopeRef.current = oneOffScanScopeKey;
   const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
@@ -21292,6 +21293,11 @@ export function ProductGitHubRepositoriesPage() {
   const [postureRequest, setPostureRequest] = useState({ key: '', nonce: 0 });
   const hasActiveRepositoryScan = data.scans.some((scan) => isActiveScanStatus(scan.status));
   const postureScopeKey = scope ? `${scope.tenantID}|${scope.workspaceID}|${selectedEnvironmentID}|${postureRepository}` : '';
+  const githubPostureSupported = Boolean(
+    data.connection?.connected && data.connection.provider === 'github_app' && data.connection.connector_id
+  );
+  const postureResetKey = `${postureScopeKey}|${data.connection?.connected ? 'connected' : 'disconnected'}|${data.connection?.provider ?? ''}|${data.connection?.connector_id ?? ''}`;
+  const githubPostureSelectionReady = postureResetKeyRef.current === postureResetKey;
 
   useEffect(() => {
     const nextRepository = selectedRepositories.includes(postureRepository)
@@ -21313,16 +21319,18 @@ export function ProductGitHubRepositoriesPage() {
   }, [oneOffScanScopeKey, selectedEnvironmentID]);
 
   useEffect(() => {
-    postureRequestRef.current += 1;
-    setGitHubPosture(null);
-    setGitHubOrganizationPosture(null);
-    setGitHubPostureLoading(false);
-    setGitHubPostureError('');
-  }, [postureScopeKey]);
-
-  useEffect(() => {
     const connection = data.connection;
     const repository = canonicalGitHubRepositoryDisplay(postureRepository);
+    if (postureResetKeyRef.current !== postureResetKey) {
+      postureResetKeyRef.current = postureResetKey;
+      postureRequestRef.current += 1;
+      setPostureRequest({ key: '', nonce: 0 });
+      setGitHubPosture(null);
+      setGitHubOrganizationPosture(null);
+      setGitHubPostureLoading(false);
+      setGitHubPostureError('');
+      return undefined;
+    }
     const requestID = postureRequestRef.current + 1;
     postureRequestRef.current = requestID;
 
@@ -21385,6 +21393,7 @@ export function ProductGitHubRepositoriesPage() {
     postureRepository,
     postureRequest.key,
     postureRequest.nonce,
+    postureResetKey,
     postureScopeKey,
     scope?.tenantID,
     scope?.workspaceID,
@@ -21515,6 +21524,9 @@ export function ProductGitHubRepositoriesPage() {
   };
 
   const reviewRepositoryPosture = () => {
+    if (!githubPostureSupported || !postureRepository || !githubPostureSelectionReady) {
+      return;
+    }
     setPostureRequest((current) => ({
       key: postureScopeKey,
       nonce: current.nonce + 1
@@ -21823,9 +21835,15 @@ export function ProductGitHubRepositoriesPage() {
                 type="button"
                 className="idt-btn idt-btn-ghost"
                 onClick={reviewRepositoryPosture}
-                disabled={githubPostureLoading || !postureRepository}
+                disabled={githubPostureLoading || !postureRepository || !githubPostureSupported || !githubPostureSelectionReady}
               >
-                {githubPostureLoading ? 'Loading posture...' : githubPosture || githubPostureError ? 'Refresh posture' : 'Review posture'}
+                {githubPostureLoading
+                  ? 'Loading posture...'
+                  : !githubPostureSupported
+                    ? 'GitHub App required'
+                    : githubPosture || githubPostureError
+                      ? 'Refresh posture'
+                      : 'Review posture'}
               </button>
             </div>
           </header>
@@ -21936,7 +21954,11 @@ export function ProductGitHubRepositoriesPage() {
           ) : (
             <DomainEmptyState
               title="No repository posture collected yet"
-              body="Posture checks stay quiet until you review the selected repository."
+              body={
+                githubPostureSupported
+                  ? 'Posture checks stay quiet until you review the selected repository.'
+                  : 'Repository posture checks are available after connecting this environment with the GitHub App.'
+              }
             />
           )}
         </section>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23025,7 +23025,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
   border: 1px solid var(--app-border);
   border-radius: 8px;
   padding: 0.7rem 0.95rem;
-  background: #050505;
+  background: var(--idt-console-surface-deep, var(--app-panel));
 }
 
 .idt-github-repository-row-main {
@@ -23035,7 +23035,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
 }
 
 .idt-github-repository-row-main strong {
-  color: #ffffff;
+  color: var(--app-text);
   font-family: var(--idt-display);
   font-size: 0.98rem;
   line-height: 1.2;
@@ -23054,6 +23054,18 @@ html[data-theme='light'] .idt-app-shell-screen select {
   display: flex;
   gap: 0.45rem;
   justify-content: flex-end;
+}
+
+.idt-github-posture-controls {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-end;
+}
+
+.idt-github-posture-controls label {
+  min-width: min(22rem, 100%);
 }
 
 @media (max-width: 760px) {
@@ -29036,6 +29048,25 @@ html[data-theme='light'] .idt-executive-report-shell {
   letter-spacing: 0;
 }
 
+html[data-theme='light']:not([data-appearance-ready='true']) #main-content:has(.idt-app-shell-screen) {
+  background: #f7f8fa;
+}
+
+html[data-theme='light']:not([data-appearance-ready='true']) .idt-app-shell-screen {
+  --app-bg: #f7f8fa;
+  --app-panel: #ffffff;
+  --app-panel-strong: #f1f3f5;
+  --app-border: #d9dde3;
+  --app-border-soft: #e8ebef;
+  --app-text: #20242a;
+  --app-muted: #5f6975;
+  --app-dim: #7d8792;
+  --idt-console-focus: #6758ff;
+  color-scheme: light;
+  background: #f7f8fa;
+  color: var(--app-text);
+}
+
 .idt-app-shell-screen .idt-app-panel h1,
 html[data-theme='light'] .idt-app-shell-screen .idt-app-panel h1 {
   color: var(--app-text);
@@ -29049,6 +29080,45 @@ html[data-theme='light'] .idt-app-shell-screen .idt-app-panel h1 {
 .idt-app-shell-screen .idt-app-panel p,
 html[data-theme='light'] .idt-app-shell-screen .idt-app-panel p {
   color: var(--app-muted);
+}
+
+.idt-app-shell-screen .idt-app-loading-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.idt-app-shell-screen .idt-app-loading-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--idt-console-focus, #7c6dff),
+    color-mix(in srgb, var(--app-text) 45%, var(--idt-console-focus, #7c6dff)),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: idtShellLoadingBar 1.4s ease-in-out infinite;
+}
+
+@keyframes idtShellLoadingBar {
+  0% {
+    transform: translateX(-100%);
+  }
+  55%,
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idt-app-shell-screen .idt-app-loading-panel::before {
+    transform: none;
+    animation: none;
+  }
 }
 
 .idt-app-shell-screen .idt-app-panel .idt-app-kicker,


### PR DESCRIPTION
## Summary
- redirect successful GitHub App installs back to the quiet GitHub Connect surface instead of the repositories/posture page
- replace the transient session validation copy with a polished GitHub handoff that inherits saved appearance settings
- make repository posture collection opt-in and keep the posture details collapsed until the user reviews it
- use theme-aware repository row colors so light and dark appearances stay clean

## Validation
- `go test ./internal/api -run 'TestRouterGitHubConnectorV2'`
- `cd web && npm test -- --run src/productShell.test.tsx`
- `cd web && npm test -- --run src/App.test.tsx -t "clears stale scoped auth after a session-only validation"`
- `cd web && npm run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the GitHub post-install flow so installs return to a quiet GitHub Connect page, and posture checks are opt-in with clearer controls.

- **New Features**
  - Redirect post-install to /github/connect and keep the selected environment.
  - Callback screen shows “Finishing GitHub connection” and uses saved appearance.
  - Repository posture is opt-in via a “Review posture” button; no API calls until clicked. Switching repositories doesn’t auto-fetch, and details start collapsed.
  - For PAT connections, show a disabled “GitHub App required” button with guidance.

- **Refactors**
  - Added a flexible AppShellLoading with kicker/body and an animated loading bar; session copy is now “Preparing workspace.”
  - Theme-aware repository rows and loading panel, with a better light-mode fallback before appearance is ready.

<sup>Written for commit 64f47013084853814587a61b0098e4db48d37215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

