### PR TITLE
Gate repo secret findings on classifier confidence for precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 ## Unreleased
+- Add a **precision suppression gate** to the repository secret scanner so it
+  surfaces real, actionable secrets instead of a flood of low-value matches.
+  The classifier already recognized placeholders, sequential/repeated fillers,
+  low-entropy values, test/sample paths, and allowlisted fingerprints, but every
+  match was still emitted at the rule's static severity. The scanner now (1)
+  drops matches whose value is provably not a credential — placeholder markers,
+  sequential or repeated fillers, low entropy — as well as allowlisted
+  fingerprints; (2) caps a match's severity to its classifier confidence, so a
+  low-confidence hit can never present as high or critical; and (3) adds two
+  operator-configurable tuning directives, set in a repository's
+  `.identrailignore` alongside allowlisted fingerprints:
+  `drop-test-and-sample: true` (suppress real-looking values whose only weakness
+  is a test/sample/docs path) and `min-confidence-score: 0.85` (drop any
+  surviving match below a score floor). Placeholder-word suppression is scoped
+  to the secret value itself; a marker appearing only in surrounding line
+  context (a variable name or comment), or in a composite value's
+  non-credential component (a DSN host or database name), downranks confidence
+  but never suppresses, so a real credential next to the word "example" is still
+  reported. The `drop-test-and-sample` directive keys off the file path only, so
+  it never drops a real production secret that merely sits next to a placeholder
+  word. A real, high-entropy credential in a production path is always reported —
+  precision does not cost true positives.
 - Add a **WorkOS email-verification continuation flow** for hosted login.
   When WorkOS refuses an OAuth code exchange with
   `email_verification_required` (common for GitHub accounts whose email is

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -18,6 +18,13 @@ import (
 	awsprovider "github.com/identrail/identrail/internal/providers/aws"
 )
 
+// cliTestSecretValue is a synthetic high-entropy AWS secret used by the repo
+// scan CLI tests. It is realistic enough that the scanner's precision gate
+// treats it as a real credential; gitleaks:allow marks it as an intentional
+// test fixture. Both the fixture writer and the redaction assertion reference
+// this single constant so the redaction check always tracks the real value.
+const cliTestSecretValue = "wJ8kR2mNp7qXvB4cT1sYzH6dL9gF3aQ5eU0iPoM8" //gitleaks:allow
+
 func TestExecuteScanAndFindingsTable(t *testing.T) {
 	cfg := config.Config{ServiceName: "identrail-test", Provider: "aws"}
 	stateFile := filepath.Join(t.TempDir(), "state.json")
@@ -161,7 +168,7 @@ func TestExecuteRepoScan(t *testing.T) {
 	if !strings.Contains(body, "\"secret_exposure\"") {
 		t.Fatalf("expected secret finding output, got %q", body)
 	}
-	if strings.Contains(body, "ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234") {
+	if strings.Contains(body, cliTestSecretValue) {
 		t.Fatalf("expected redacted output, got %q", body)
 	}
 }
@@ -418,7 +425,7 @@ func initCLITestRepoWithSecret(t *testing.T) string {
 	repo := t.TempDir()
 	runCLITestGit(t, repo, "init", "-q")
 
-	if err := os.WriteFile(filepath.Join(repo, "app.env"), []byte("AWS_SECRET_ACCESS_KEY=ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(repo, "app.env"), []byte("AWS_SECRET_ACCESS_KEY="+cliTestSecretValue+"\n"), 0o600); err != nil {
 		t.Fatalf("write secret file: %v", err)
 	}
 	runCLITestGit(t, repo, "add", "app.env")

--- a/internal/repoexposure/ai_agent_analyzer_test.go
+++ b/internal/repoexposure/ai_agent_analyzer_test.go
@@ -18,7 +18,7 @@ func TestDetectAIAgentConfigFindingsDetectsSecretsEnvAndDangerousTools(t *testin
       "args": ["@modelcontextprotocol/server-filesystem", "/"],
       "env": {
         "GITHUB_TOKEN": "${GITHUB_TOKEN}",
-        "OPENAI_API_KEY": "sk-proj-` + strings.Repeat("a", 40) + `"
+        "OPENAI_API_KEY": "sk-proj-` + entropicFixture(fixtureCharsetAlnum, 40) + `"
       }
     },
     "deploy": {
@@ -177,7 +177,7 @@ func TestDetectAIAgentConfigFindingsHonorsSecretAllowlistPolicy(t *testing.T) {
     "filesystem": {
       "command": "npx",
       "env": {
-        "OPENAI_API_KEY": "sk-proj-` + strings.Repeat("a", 40) + `"
+        "OPENAI_API_KEY": "sk-proj-` + entropicFixture(fixtureCharsetAlnum, 40) + `"
       }
     }
   }
@@ -199,21 +199,12 @@ func TestDetectAIAgentConfigFindingsHonorsSecretAllowlistPolicy(t *testing.T) {
 	allowlisted := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, detectedAt,
 		withSecretFindingPolicy(secretFindingPolicy{AllowlistedFingerprints: map[string]struct{}{fingerprint: {}}}))
 
-	var secret domain.Finding
+	// An allowlisted fingerprint must be dropped on the AI-agent path too, not
+	// merely tagged, so the surfaced findings never include an opted-out secret.
 	for _, finding := range allowlisted {
 		if finding.Type == domain.FindingSecretExposure {
-			secret = finding
-			break
+			t.Fatalf("expected allowlisted secret to be suppressed on the AI-agent path, got %+v", finding)
 		}
-	}
-	if secret.ID == "" {
-		t.Fatalf("expected a secret finding when allowlist policy is applied, got %+v", allowlisted)
-	}
-	if got := secret.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
-		t.Fatalf("expected allowlisted classification on AI-agent secret path, got %v in %+v", got, secret.Evidence)
-	}
-	if got, _ := secret.Evidence["secret_allowlisted"].(bool); !got {
-		t.Fatalf("expected allowlisted evidence flag on AI-agent secret path, got %+v", secret.Evidence)
 	}
 }
 

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -41,6 +41,12 @@ type secretDetector struct {
 	Version     string
 	Examples    []string
 	Patterns    []secretDetectorPattern
+	// CompositeValue marks detectors whose captured material is more than the
+	// bare credential (for example a database DSN that also contains a host and
+	// database name). A placeholder word in such a value may sit in a
+	// non-credential component, so markers are never treated as proof the value
+	// is fake — they only downrank confidence, never hard-suppress.
+	CompositeValue bool
 }
 
 const (
@@ -55,6 +61,15 @@ const (
 
 type secretFindingPolicy struct {
 	AllowlistedFingerprints map[string]struct{}
+	// DropTestAndSampleFindings suppresses matches whose ONLY low-confidence
+	// signal is a test/sample/docs file path while the value itself still looks
+	// like a real secret. Off by default so a genuine credential committed to a
+	// test fixture is never silently hidden; enable for maximum precision.
+	DropTestAndSampleFindings bool
+	// MinConfidenceScore, when greater than zero, drops any surviving match
+	// whose classifier score is below it. Off by default (0.0); raise it to tune
+	// precision higher once real-world results are reviewed.
+	MinConfidenceScore float64
 }
 
 type secretFindingOptions struct {
@@ -344,15 +359,16 @@ var secretDetectorRegistry = []secretDetector{
 		},
 	},
 	{
-		ID:          "database_connection_url",
-		Version:     "2026.05",
-		Severity:    domain.SeverityMedium,
-		Confidence:  0.86,
-		Title:       "Potential database URL with embedded credentials",
-		Provider:    "General",
-		Category:    "configuration",
-		Summary:     "A line added in commit history appears to include a database URL with inline credentials.",
-		Remediation: "Move connection credentials to a secret store and use short-lived runtime env injection.",
+		ID:             "database_connection_url",
+		Version:        "2026.05",
+		Severity:       domain.SeverityMedium,
+		Confidence:     0.86,
+		Title:          "Potential database URL with embedded credentials",
+		Provider:       "General",
+		Category:       "configuration",
+		CompositeValue: true,
+		Summary:        "A line added in commit history appears to include a database URL with inline credentials.",
+		Remediation:    "Move connection credentials to a secret store and use short-lived runtime env injection.",
 		Patterns: []secretDetectorPattern{
 			{
 				Regexp:     regexp.MustCompile(`\b(?:postgres|postgresql|mysql|mysql2|mssql|redis|mongodb|mongodb\+srv|cockroach|oracle)://[^\s'\"<>]+:[^\s'\"<>]+@[^\s'\"<>]+`),
@@ -526,11 +542,18 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		}
 		fingerprint := hashSHA256(secretMaterial)
 		classification := classifySecretMatch(item.rule, path, item.match, secretMaterial, fingerprint, secretOptions.Policy)
+		// Precision gate: drop matches the classifier proves are not real
+		// credentials (placeholders, sequential/repeated fillers, low entropy,
+		// allowlisted) so the surfaced findings stay small and actionable.
+		if suppressed, _ := classification.suppressedBy(secretOptions.Policy); suppressed {
+			continue
+		}
+		severity := severityForClassification(item.rule.Severity, classification)
 		id := hashDeterministicID("repo-secret", repo, commit, path, strconv.Itoa(line), item.rule.ID, fingerprint)
 		findings = append(findings, domain.Finding{
 			ID:                  "finding:" + id,
 			Type:                domain.FindingSecretExposure,
-			Severity:            item.rule.Severity,
+			Severity:            severity,
 			ConfidenceScore:     classification.Score,
 			Title:               item.rule.Title,
 			HumanSummary:        item.rule.Summary,
@@ -581,6 +604,9 @@ func parseSecretFindingPolicy(content []byte) secretFindingPolicy {
 		if index := strings.Index(line, "#"); index >= 0 {
 			line = strings.TrimSpace(line[:index])
 		}
+		if applySecretPolicyDirective(&policy, line) {
+			continue
+		}
 		fingerprint := normalizeSecretFingerprint(line)
 		if fingerprint == "" {
 			continue
@@ -591,6 +617,48 @@ func parseSecretFindingPolicy(content []byte) secretFindingPolicy {
 		policy.AllowlistedFingerprints = nil
 	}
 	return policy
+}
+
+// applySecretPolicyDirective interprets a `.identrailignore` line as a tuning
+// directive and applies it to the policy. It reports whether the line was a
+// recognized directive so the caller can skip fingerprint parsing. Supported:
+//
+//	drop-test-and-sample: true      # suppress real-looking secrets in test/sample paths
+//	min-confidence-score: 0.85      # drop any surviving match below this score
+func applySecretPolicyDirective(policy *secretFindingPolicy, line string) bool {
+	key, value, ok := splitSecretPolicyDirective(line)
+	if !ok {
+		return false
+	}
+	switch key {
+	case "drop-test-and-sample", "drop_test_and_sample":
+		if enabled, err := strconv.ParseBool(value); err == nil {
+			policy.DropTestAndSampleFindings = enabled
+		}
+		return true
+	case "min-confidence-score", "min_confidence_score":
+		if score, err := strconv.ParseFloat(value, 64); err == nil && score >= 0 && score <= 1 {
+			policy.MinConfidenceScore = score
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func splitSecretPolicyDirective(line string) (key string, value string, ok bool) {
+	separator := strings.IndexAny(line, ":=")
+	if separator <= 0 {
+		return "", "", false
+	}
+	key = strings.ToLower(strings.TrimSpace(line[:separator]))
+	value = strings.TrimSpace(line[separator+1:])
+	switch key {
+	case "drop-test-and-sample", "drop_test_and_sample", "min-confidence-score", "min_confidence_score":
+		return key, value, true
+	default:
+		return "", "", false
+	}
 }
 
 func normalizeSecretFingerprint(value string) string {
@@ -639,7 +707,7 @@ func classifySecretMatch(rule secretDetector, filePath string, line string, secr
 		reasons = append(reasons, "path_context:sample_or_docs")
 	}
 
-	placeholderReasons := secretPlaceholderReasons(line, secretMaterial)
+	placeholderReasons := secretPlaceholderReasons(line, secretMaterial, rule.CompositeValue)
 	if len(placeholderReasons) > 0 {
 		if state == "" {
 			state = secretClassificationSamplePlaceholder
@@ -657,6 +725,110 @@ func classifySecretMatch(rule secretDetector, filePath string, line string, secr
 		}
 	}
 	return secretConfidenceClassification{State: state, Score: score, Reasons: reasons}
+}
+
+// suppressedBy reports whether a classified secret match should be dropped
+// rather than emitted as a finding, and why. The gate is precision-first: it
+// removes matches that are provably not real credentials so the surfaced set
+// stays small and every finding is actionable.
+//
+// A match is suppressed when:
+//   - it is allowlisted (the repository owner explicitly opted it out); or
+//   - the VALUE itself is proven fake — a known placeholder marker, a
+//     sequential or repeated dummy, or a low-entropy string. These are safe to
+//     drop regardless of file path, because a value that is provably fake is
+//     never a real exposure; or
+//   - the policy opts in to dropping test/sample/docs paths, and the match's
+//     only weakness is its path; or
+//   - the policy sets a minimum confidence score and this match falls below it.
+//
+// A real-looking, high-entropy value committed to a test or example file is
+// deliberately NOT suppressed by default: that is still a genuine leaked
+// secret, so it is kept (at reduced confidence) unless DropTestAndSampleFindings
+// is explicitly enabled.
+func (c secretConfidenceClassification) suppressedBy(policy secretFindingPolicy) (bool, string) {
+	if c.Allowlisted {
+		return true, "allowlisted"
+	}
+	if classificationValueProvenFake(c.Reasons) {
+		return true, "value_proven_placeholder_or_low_entropy"
+	}
+	if policy.DropTestAndSampleFindings && classificationFromTestOrSamplePath(c.Reasons) {
+		return true, "test_or_sample_path"
+	}
+	if policy.MinConfidenceScore > 0 && c.Score < policy.MinConfidenceScore {
+		return true, "below_min_confidence"
+	}
+	return false, ""
+}
+
+// classificationValueProvenFake reports whether any classifier reason indicates
+// the matched value itself is not a real credential (a placeholder marker, a
+// sequential or repeated dummy, or a low-entropy string). These directly cover
+// the noisy cases operators complain about: "EXAMPLE" tokens, consecutive or
+// repeated digits, and other obvious fillers.
+// classificationFromTestOrSamplePath reports whether the low-confidence signal
+// came from the file's PATH (a test fixture, sample, or docs location) rather
+// than from the value or its surrounding text. The opt-in
+// DropTestAndSampleFindings knob keys off this so it suppresses only path-based
+// matches — a real credential that merely sits next to a placeholder word in a
+// production file (a context_marker, which shares the sample_or_placeholder
+// state) is never dropped by it.
+func classificationFromTestOrSamplePath(reasons []string) bool {
+	for _, reason := range reasons {
+		if reason == "path_context:test_fixture" || reason == "path_context:sample_or_docs" {
+			return true
+		}
+	}
+	return false
+}
+
+func classificationValueProvenFake(reasons []string) bool {
+	for _, reason := range reasons {
+		if strings.HasPrefix(reason, "value_marker:") ||
+			reason == "value_shape:sequential" ||
+			reason == "value_shape:repeated_or_low_variety" ||
+			reason == "value_entropy:low" {
+			return true
+		}
+	}
+	return false
+}
+
+// severityForClassification maps a rule's static severity down to the caller's
+// confidence in the match. Only high-confidence matches keep the rule's full
+// severity; anything weaker is capped at medium so a low-confidence match can
+// never present as high or critical. This is what stops the scanner from
+// "treating everything as great."
+func severityForClassification(base domain.FindingSeverity, c secretConfidenceClassification) domain.FindingSeverity {
+	if c.State == secretClassificationHighConfidence {
+		return base
+	}
+	return capSecretSeverity(base, domain.SeverityMedium)
+}
+
+func capSecretSeverity(severity domain.FindingSeverity, ceiling domain.FindingSeverity) domain.FindingSeverity {
+	if secretSeverityRank(severity) > secretSeverityRank(ceiling) {
+		return ceiling
+	}
+	return severity
+}
+
+func secretSeverityRank(severity domain.FindingSeverity) int {
+	switch severity {
+	case domain.SeverityCritical:
+		return 5
+	case domain.SeverityHigh:
+		return 4
+	case domain.SeverityMedium:
+		return 3
+	case domain.SeverityLow:
+		return 2
+	case domain.SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func baseSecretDetectorConfidence(rule secretDetector) float64 {
@@ -746,26 +918,57 @@ func normalizeSecretPath(filePath string) string {
 	return strings.ToLower(normalized)
 }
 
-func secretPlaceholderReasons(line string, secretMaterial string) []string {
+var secretPlaceholderMarkers = []string{"example", "changeme", "change_me", "dummy", "fake", "sample", "placeholder", "notasecret", "not_a_secret", "replace_me", "your_", "todo", "testsecret", "test_secret", "test-secret", "sk_test_", "pk_test_"}
+
+func secretPlaceholderReasons(line string, secretMaterial string, compositeValue bool) []string {
 	lowerMaterial := strings.ToLower(strings.TrimSpace(secretMaterial))
 	lowerLine := strings.ToLower(strings.TrimSpace(line))
 	reasons := []string{}
-	for _, marker := range []string{"example", "changeme", "change_me", "dummy", "fake", "sample", "placeholder", "notasecret", "not_a_secret", "replace_me", "your_", "todo", "testsecret", "test_secret", "test-secret", "sk_test_", "pk_test_"} {
-		if strings.Contains(lowerMaterial, marker) || strings.Contains(lowerLine, marker) {
-			reasons = append(reasons, "value_marker:"+marker)
-			break
+	// A marker inside the secret VALUE proves the value is fake and is safe to
+	// suppress. A marker that appears only in the surrounding line context (a
+	// variable name, a comment, or an adjacent word like "example"/"todo") is a
+	// weaker signal: a genuine credential can sit next to such words, so it is
+	// recorded as a distinct context_marker that downranks confidence but never
+	// triggers hard suppression. This prevents false negatives on real secrets.
+	//
+	// For composite detectors the captured value is more than the bare
+	// credential (a DSN host/database name, for example), so a marker in the
+	// value is treated as context too — never as proof the credential is fake.
+	valueMarked := false
+	if !compositeValue {
+		for _, marker := range secretPlaceholderMarkers {
+			if strings.Contains(lowerMaterial, marker) {
+				reasons = append(reasons, "value_marker:"+marker)
+				valueMarked = true
+				break
+			}
+		}
+	}
+	if !valueMarked {
+		for _, marker := range secretPlaceholderMarkers {
+			if strings.Contains(lowerLine, marker) || (compositeValue && strings.Contains(lowerMaterial, marker)) {
+				reasons = append(reasons, "context_marker:"+marker)
+				break
+			}
 		}
 	}
 
-	compact := compactSecretValue(secretMaterial)
-	if len(compact) >= 12 && isRepeatedOrLowVarietySecret(compact) {
-		reasons = append(reasons, "value_shape:repeated_or_low_variety")
-	}
-	if len(compact) >= 16 && containsSequentialSecretPattern(compact) {
-		reasons = append(reasons, "value_shape:sequential")
-	}
-	if len(compact) >= 16 && entropy(secretMaterial) < 2.6 && !strings.Contains(lowerMaterial, "-----begin ") {
-		reasons = append(reasons, "value_entropy:low")
+	// Value-shape and entropy heuristics prove a bare credential is fake, but on
+	// a composite value they run over the whole DSN — a filler-looking host or
+	// database name (e.g. "db-0123456789abcdef") would otherwise suppress a real
+	// password. They are only computed for non-composite detectors, where the
+	// captured material is the credential itself.
+	if !compositeValue {
+		compact := compactSecretValue(secretMaterial)
+		if len(compact) >= 12 && isRepeatedOrLowVarietySecret(compact) {
+			reasons = append(reasons, "value_shape:repeated_or_low_variety")
+		}
+		if len(compact) >= 16 && containsSequentialSecretPattern(compact) {
+			reasons = append(reasons, "value_shape:sequential")
+		}
+		if len(compact) >= 16 && entropy(secretMaterial) < 2.6 && !strings.Contains(lowerMaterial, "-----begin ") {
+			reasons = append(reasons, "value_entropy:low")
+		}
 	}
 	return reasons
 }

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -16,10 +16,18 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 )
 
-const testSecretValue = "ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234"
+// testSecretValue is a realistic, high-entropy 40-character credential body
+// generated at runtime. It is deliberately not a string literal so repository
+// secret scanners (gitleaks) do not flag this synthetic test fixture, and it
+// has enough variety to pass the precision gate that these scanner tests need
+// to exercise a real detection.
+var testSecretValue = entropicFixture(fixtureCharsetAlnum, 40)
 
+// testGitHubToken returns a realistic GitHub token with a high-entropy body.
+// The body is generated (not a literal) so it exercises detection without
+// tripping repository secret scanners or the precision gate.
 func testGitHubToken() string {
-	return strings.Join([]string{"ghp", "_0123456789abcdef0123456789abcdef0123"}, "")
+	return "ghp_" + entropicFixture(fixtureCharsetAlnum, 36)
 }
 
 func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
@@ -173,24 +181,12 @@ func TestScanRepositoryClassifiesAllowlistedSecretFingerprint(t *testing.T) {
 		t.Fatalf("scan repository failed: %v", err)
 	}
 
-	var secretFinding domain.Finding
+	// The fixture secret's fingerprint is allowlisted via .identrailignore, so
+	// the scanner must drop it entirely rather than surface an opted-out secret.
 	for _, finding := range result.Findings {
 		if finding.Type == domain.FindingSecretExposure && finding.Detector == "aws_secret_access_key" {
-			secretFinding = finding
-			break
+			t.Fatalf("expected allowlisted secret to be suppressed, got %+v", finding)
 		}
-	}
-	if secretFinding.ID == "" {
-		t.Fatalf("expected allowlisted secret finding, got %+v", result.Findings)
-	}
-	if got := secretFinding.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
-		t.Fatalf("expected allowlisted confidence state, got %v in %+v", got, secretFinding.Evidence)
-	}
-	if got, _ := secretFinding.Evidence["secret_allowlisted"].(bool); !got {
-		t.Fatalf("expected secret_allowlisted evidence flag, got %+v", secretFinding.Evidence)
-	}
-	if secretFinding.ConfidenceScore != 0.05 {
-		t.Fatalf("expected allowlisted confidence score 0.05, got %.2f", secretFinding.ConfidenceScore)
 	}
 }
 

--- a/internal/repoexposure/secret_detector_test.go
+++ b/internal/repoexposure/secret_detector_test.go
@@ -18,32 +18,32 @@ func TestSecretDetectorFixtures(t *testing.T) {
 	fixtures := []secretDetectorFixture{
 		{
 			ID:        "aws_access_key_id",
-			Positives: []string{fixtureToken("AKIA", strings.Repeat("A", 16))},
+			Positives: []string{fixtureToken("AKIA", entropicFixture(fixtureCharsetUpperAlnum, 16))},
 			Negatives: []string{"AKIA12"},
 		},
 		{
 			ID:        "aws_secret_access_key",
-			Positives: []string{fixtureToken("aws_secret_access_key=", strings.Repeat("A", 40))},
+			Positives: []string{fixtureToken("aws_secret_access_key=", entropicFixture(fixtureCharsetAlnum, 40))},
 			Negatives: []string{"AWS_SECRET=ABCD1234ABCD1234"},
 		},
 		{
 			ID:        "github_token",
-			Positives: []string{fixtureToken("ghp_", strings.Repeat("a", 36))},
+			Positives: []string{fixtureToken("ghp_", entropicFixture(fixtureCharsetAlnum, 36))},
 			Negatives: []string{"ghp_short"},
 		},
 		{
 			ID:        "github_app_token",
-			Positives: []string{fixtureToken("ghs_", strings.Repeat("b", 40))},
+			Positives: []string{fixtureToken("ghs_", entropicFixture(fixtureCharsetAlnum, 40))},
 			Negatives: []string{"ghs_short"},
 		},
 		{
 			ID:        "slack_token",
-			Positives: []string{fixtureToken("xoxp-", strings.Repeat("c", 20), "-", strings.Repeat("d", 13))},
+			Positives: []string{fixtureToken("xoxp-", entropicFixture(fixtureCharsetAlnum, 20), "-", entropicFixture(fixtureCharsetAlnum, 13))},
 			Negatives: []string{"xox-short"},
 		},
 		{
 			ID:        "gitlab_token",
-			Positives: []string{fixtureToken("glpat-", strings.Repeat("e", 24))},
+			Positives: []string{fixtureToken("glpat-", entropicFixture(fixtureCharsetAlnum, 24))},
 			Negatives: []string{"gitlab: token"},
 		},
 		{
@@ -53,17 +53,17 @@ func TestSecretDetectorFixtures(t *testing.T) {
 		},
 		{
 			ID:        "gcp_api_key",
-			Positives: []string{fixtureToken("AIza", strings.Repeat("A", 35))},
+			Positives: []string{fixtureToken("AIza", entropicFixture(fixtureCharsetAlnum, 35))},
 			Negatives: []string{"AIzaShort"},
 		},
 		{
 			ID:        "stripe_api_key",
-			Positives: []string{fixtureToken("sk_", "live_", strings.Repeat("g", 24))},
+			Positives: []string{fixtureToken("sk_", "live_", entropicFixture(fixtureCharsetAlnum, 24))},
 			Negatives: []string{"sk_live_short"},
 		},
 		{
 			ID:        "openai_api_key",
-			Positives: []string{fixtureToken("sk-proj-", strings.Repeat("h", 40))},
+			Positives: []string{fixtureToken("sk-proj-", entropicFixture(fixtureCharsetAlnum, 40))},
 			Negatives: []string{"sk-1234"},
 		},
 		{
@@ -73,12 +73,12 @@ func TestSecretDetectorFixtures(t *testing.T) {
 		},
 		{
 			ID:        "vercel_token",
-			Positives: []string{fixtureToken("vercel_pat_", strings.Repeat("j", 24))},
+			Positives: []string{fixtureToken("vercel_pat_", entropicFixture(fixtureCharsetAlnum, 24))},
 			Negatives: []string{"VERCEL_TOKEN=foo"},
 		},
 		{
 			ID:        "npm_token",
-			Positives: []string{fixtureToken("NPM_TOKEN=", strings.Repeat("k", 16))},
+			Positives: []string{fixtureToken("NPM_TOKEN=", entropicFixture(fixtureCharsetAlnum, 16))},
 			Negatives: []string{"NPM_TOKEN="},
 		},
 		{
@@ -98,11 +98,14 @@ func TestSecretDetectorFixtures(t *testing.T) {
 		},
 		{
 			ID:        "jwt_token",
-			Positives: []string{fixtureToken("eyJ", strings.Repeat("m", 30), ".", strings.Repeat("n", 30), ".", strings.Repeat("o", 32))},
+			Positives: []string{fixtureToken("eyJ", entropicFixture(fixtureCharsetAlnum, 30), ".", entropicFixture(fixtureCharsetAlnum, 30), ".", entropicFixture(fixtureCharsetAlnum, 32))},
 			Negatives: []string{"eyJ.not-a-jwt"},
 		},
 		{
-			ID:        "database_connection_url",
+			ID: "database_connection_url",
+			// Host "example.com" and database "sample" carry placeholder words,
+			// but the credential is real. A composite detector must not treat
+			// those context words as proof the value is fake.
 			Positives: []string{"postgres://user:supersecret@db.example.com:5432/sample"},
 			Negatives: []string{"postgres://127.0.0.1"},
 		},
@@ -118,7 +121,7 @@ func TestSecretDetectorFixtures(t *testing.T) {
 		},
 		{
 			ID:        "ci_cd_token",
-			Positives: []string{fixtureToken("CI_JOB_TOKEN=", strings.Repeat("r", 20))},
+			Positives: []string{fixtureToken("CI_JOB_TOKEN=", entropicFixture(fixtureCharsetAlnum, 20))},
 			Negatives: []string{"CI_JOB_TOKEN="},
 		},
 	}
@@ -232,18 +235,13 @@ func TestSecretConfidenceClassifiesLikelyProductionSecret(t *testing.T) {
 	}
 }
 
-func TestSecretConfidenceClassifiesSamplePlaceholder(t *testing.T) {
-	finding := firstFindingForDetector(t,
+func TestSecretPlaceholderMarkerIsSuppressed(t *testing.T) {
+	// A value containing a known placeholder marker ("example") is not a real
+	// credential and must be dropped entirely rather than surfaced as a finding.
+	assertNoFindingForDetector(t,
 		detectSecretFindings("owner/repo", "HEAD", "README.md", 7, "client_secret=exampleclientsecretvalue123", time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
 		"oauth_client_secret",
 	)
-
-	if got := finding.Evidence["confidence_state"]; got != secretClassificationSamplePlaceholder {
-		t.Fatalf("expected sample placeholder classification, got %v in %+v", got, finding.Evidence)
-	}
-	if finding.ConfidenceScore > 0.40 {
-		t.Fatalf("expected downgraded sample score, got %.2f", finding.ConfidenceScore)
-	}
 }
 
 func TestSecretConfidenceUsesMatchedSecretContext(t *testing.T) {
@@ -276,18 +274,13 @@ func TestSecretConfidenceClassifiesRootSampleDirectory(t *testing.T) {
 	}
 }
 
-func TestSecretConfidenceClassifiesTestModeTokenValue(t *testing.T) {
-	finding := firstFindingForDetector(t,
+func TestSecretTestModeTokenValueIsSuppressed(t *testing.T) {
+	// A Stripe test-mode key (sk_test_) is a documented non-production value and
+	// must be suppressed rather than reported as a critical leak.
+	assertNoFindingForDetector(t,
 		detectSecretFindings("owner/repo", "HEAD", "app.env", 7, fixtureToken("STRIPE_SECRET_KEY=", "sk_test_", "aB3dE5fG7hJ9kLmN2pQrS4tUvW6x"), time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
 		"stripe_api_key",
 	)
-
-	if got := finding.Evidence["confidence_state"]; got != secretClassificationSamplePlaceholder {
-		t.Fatalf("expected test-mode token value classification, got %v in %+v", got, finding.Evidence)
-	}
-	if finding.ConfidenceScore > 0.25 {
-		t.Fatalf("expected downgraded test-mode token score, got %.2f", finding.ConfidenceScore)
-	}
 }
 
 func TestSecretConfidenceClassifiesTestFixturePath(t *testing.T) {
@@ -302,6 +295,156 @@ func TestSecretConfidenceClassifiesTestFixturePath(t *testing.T) {
 	}
 	if finding.ConfidenceScore > 0.35 {
 		t.Fatalf("expected downgraded test fixture score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretPrecisionGateDropsProvenFakeButKeepsReal(t *testing.T) {
+	at := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+
+	// The canonical AWS documentation example key must be suppressed.
+	assertNoFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, "aws_access_key_id=AKIAIOSFODNN7EXAMPLE", at),
+		"aws_access_key_id",
+	)
+
+	// A repeated / low-variety filler that merely satisfies the regex length is
+	// not a real credential and must be suppressed.
+	assertNoFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 2, fixtureToken("ghp_", strings.Repeat("a", 36)), at),
+		"github_token",
+	)
+
+	// A real, high-entropy key in a production path must still surface —
+	// precision must not cost a genuine true positive.
+	firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 3, fixtureToken("ghp_", entropicFixture(fixtureCharsetAlnum, 36)), at),
+		"github_token",
+	)
+}
+
+func TestSecretSeverityCappedByConfidence(t *testing.T) {
+	// A real-looking secret whose only weakness is a sample/example file path is
+	// kept (no false negative) but must not present at the rule's full severity.
+	at := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "examples/secrets.env", 7, fixtureToken("aws_secret_access_key=", entropicFixture(fixtureCharsetAlnum, 40)), at),
+		"aws_secret_access_key",
+	)
+	if finding.Severity != domain.SeverityMedium {
+		t.Fatalf("expected low-confidence match capped to medium severity, got %q", finding.Severity)
+	}
+}
+
+func TestSecretPrecisionPolicyKnobs(t *testing.T) {
+	at := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	realKey := fixtureToken("ghp_", entropicFixture(fixtureCharsetAlnum, 36))
+
+	// DropTestAndSampleFindings suppresses real-looking secrets whose only
+	// weakness is a test/sample path, for operators who want maximum precision.
+	assertNoFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "examples/secrets.env", 1, realKey, at,
+			withSecretFindingPolicy(secretFindingPolicy{DropTestAndSampleFindings: true})),
+		"github_token",
+	)
+
+	// A MinConfidenceScore floor above the detector's confidence drops even an
+	// otherwise high-confidence production match.
+	assertNoFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 2, realKey, at,
+			withSecretFindingPolicy(secretFindingPolicy{MinConfidenceScore: 0.999})),
+		"github_token",
+	)
+
+	// The same production match with no floor still surfaces.
+	firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 3, realKey, at),
+		"github_token",
+	)
+}
+
+func TestSecretContextMarkerDoesNotSuppressRealValue(t *testing.T) {
+	// A placeholder marker inside the secret value proves it is fake and is
+	// safe to suppress.
+	valueReasons := secretPlaceholderReasons("client_secret=exampletoken", "exampletoken", false)
+	if !classificationValueProvenFake(valueReasons) {
+		t.Fatalf("expected an in-value marker to be proven fake, got %v", valueReasons)
+	}
+
+	// The same marker appearing only in the surrounding context (a variable
+	// name or comment) next to a real, high-entropy secret must NOT trigger
+	// suppression — that would be a false negative on a genuine exposure.
+	realValue := entropicFixture(fixtureCharsetAlnum, 36)
+	contextReasons := secretPlaceholderReasons("example_api_key = "+realValue, realValue, false)
+	if classificationValueProvenFake(contextReasons) {
+		t.Fatalf("expected a context-only marker NOT to be proven fake, got %v", contextReasons)
+	}
+	foundContextMarker := false
+	for _, reason := range contextReasons {
+		if strings.HasPrefix(reason, "context_marker:") {
+			foundContextMarker = true
+		}
+	}
+	if !foundContextMarker {
+		t.Fatalf("expected a context_marker reason to still downrank confidence, got %v", contextReasons)
+	}
+
+	// A composite detector's value (e.g. a DSN) that carries a marker in its
+	// host/database component must NOT be proven fake — the marker is not part
+	// of the credential.
+	dsn := "postgres://svc:" + realValue + "@sample-db.internal/appdb"
+	compositeReasons := secretPlaceholderReasons(dsn, dsn, true)
+	if classificationValueProvenFake(compositeReasons) {
+		t.Fatalf("expected a composite value marker NOT to be proven fake, got %v", compositeReasons)
+	}
+
+	// The same protection must cover value-shape/entropy heuristics: a real
+	// password behind a filler-looking host (a sequential run in the host name)
+	// must not be suppressed as a composite value. The password is generated so
+	// it is a real high-entropy credential without tripping literal scanners.
+	shapeDSN := "postgres://svc:" + entropicFixture(fixtureCharsetAlnum, 18) + "@db-0123456789abcdef.internal/app"
+	shapeReasons := secretPlaceholderReasons(shapeDSN, shapeDSN, true)
+	if classificationValueProvenFake(shapeReasons) {
+		t.Fatalf("expected a composite value with a filler-looking host NOT to be proven fake, got %v", shapeReasons)
+	}
+	// A non-composite value with the same sequential run IS proven fake. The
+	// literal is an intentional sequential filler (gitleaks:allow), needed to
+	// exercise the shape detector directly.
+	nonComposite := secretPlaceholderReasons("token=0123456789abcdef0123", "0123456789abcdef0123", false) //gitleaks:allow
+	if !classificationValueProvenFake(nonComposite) {
+		t.Fatalf("expected a sequential non-composite value to be proven fake, got %v", nonComposite)
+	}
+}
+
+func TestSecretDropTestAndSampleOnlyAffectsPathMatches(t *testing.T) {
+	// A real, high-entropy secret in a PRODUCTION file that merely sits next to
+	// a placeholder word (context_marker -> sample_or_placeholder state) must
+	// survive even when the aggressive drop-test-and-sample knob is enabled: the
+	// signal was a context word, not a test/sample path.
+	realValue := entropicFixture(fixtureCharsetAlnum, 40)
+	classification := classifySecretMatch(
+		secretDetector{ID: "aws_secret_access_key", Severity: domain.SeverityCritical, Confidence: 0.96},
+		"config/secrets.env",
+		"example_secret = "+realValue,
+		realValue,
+		hashSHA256(realValue),
+		secretFindingPolicy{},
+	)
+	if suppressed, reason := classification.suppressedBy(secretFindingPolicy{DropTestAndSampleFindings: true}); suppressed {
+		t.Fatalf("expected production context-marker match to survive drop-test-and-sample, got suppressed (%s) with reasons %v", reason, classification.Reasons)
+	}
+
+	// The same knob still drops a match whose low confidence comes from a
+	// genuine test/sample path.
+	sampleClassification := classifySecretMatch(
+		secretDetector{ID: "aws_secret_access_key", Severity: domain.SeverityCritical, Confidence: 0.96},
+		"examples/secrets.env",
+		realValue,
+		realValue,
+		hashSHA256(realValue),
+		secretFindingPolicy{},
+	)
+	if suppressed, _ := sampleClassification.suppressedBy(secretFindingPolicy{DropTestAndSampleFindings: true}); !suppressed {
+		t.Fatalf("expected sample-path match to be dropped when drop-test-and-sample is enabled, reasons %v", sampleClassification.Reasons)
 	}
 }
 
@@ -321,10 +464,12 @@ func TestSecretConfidencePathClassifiersIncludeRepositoryRootDirectories(t *test
 	}
 }
 
-func TestSecretConfidenceClassifiesAllowlistedFingerprint(t *testing.T) {
+func TestSecretAllowlistedFingerprintIsSuppressed(t *testing.T) {
+	// An explicitly allowlisted fingerprint reflects the repository owner's
+	// intent to opt the value out; it must be dropped, not merely tagged.
 	secretValue := fixtureToken("A1b2C3d4E5f6G7h8I9j0K", "LmNoPqRsT")
 	fingerprint := hashSHA256(secretValue)
-	finding := firstFindingForDetector(t,
+	assertNoFindingForDetector(t,
 		detectSecretFindings(
 			"owner/repo",
 			"HEAD",
@@ -336,16 +481,6 @@ func TestSecretConfidenceClassifiesAllowlistedFingerprint(t *testing.T) {
 		),
 		"oauth_client_secret",
 	)
-
-	if got := finding.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
-		t.Fatalf("expected allowlisted classification, got %v in %+v", got, finding.Evidence)
-	}
-	if got, _ := finding.Evidence["secret_allowlisted"].(bool); !got {
-		t.Fatalf("expected allowlisted evidence flag, got %+v", finding.Evidence)
-	}
-	if finding.ConfidenceScore != 0.05 {
-		t.Fatalf("expected allowlisted confidence score 0.05, got %.2f", finding.ConfidenceScore)
-	}
 }
 
 func TestParseSecretFindingPolicyAcceptsFingerprintForms(t *testing.T) {
@@ -364,8 +499,68 @@ func TestParseSecretFindingPolicyAcceptsFingerprintForms(t *testing.T) {
 	}
 }
 
+func TestParseSecretFindingPolicyAcceptsTuningDirectives(t *testing.T) {
+	fingerprint := strings.Repeat("a", 64)
+	policy := parseSecretFindingPolicy([]byte(
+		"drop-test-and-sample: true\n" +
+			"min-confidence-score = 0.85\n" +
+			"secret-fingerprint: " + fingerprint + "\n",
+	))
+
+	if !policy.DropTestAndSampleFindings {
+		t.Fatalf("expected drop-test-and-sample directive to be applied, got %+v", policy)
+	}
+	if policy.MinConfidenceScore != 0.85 {
+		t.Fatalf("expected min-confidence-score 0.85, got %.2f", policy.MinConfidenceScore)
+	}
+	if _, ok := policy.AllowlistedFingerprints[fingerprint]; !ok {
+		t.Fatalf("expected fingerprints to still parse alongside directives, got %+v", policy.AllowlistedFingerprints)
+	}
+
+	// Out-of-range or malformed directive values are ignored rather than
+	// silently disabling detection.
+	ignored := parseSecretFindingPolicy([]byte("min-confidence-score: 5\ndrop-test-and-sample: maybe\n"))
+	if ignored.MinConfidenceScore != 0 || ignored.DropTestAndSampleFindings {
+		t.Fatalf("expected invalid directive values to be ignored, got %+v", ignored)
+	}
+}
+
 func fixtureToken(parts ...string) string {
 	return strings.Join(parts, "")
+}
+
+const (
+	fixtureCharsetAlnum      = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	fixtureCharsetUpperAlnum = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+// entropicFixture returns a deterministic, high-entropy token body of the given
+// length drawn from charset. Unlike strings.Repeat, its output has enough
+// character variety to pass the scanner's placeholder / low-variety / sequential
+// heuristics, so fixtures model realistic credentials instead of obvious fillers
+// that the precision gate (correctly) suppresses.
+func entropicFixture(charset string, length int) string {
+	if len(charset) == 0 || length <= 0 {
+		return ""
+	}
+	out := make([]byte, length)
+	state := uint64(1469598103934665603)
+	for i := 0; i < length; i++ {
+		state ^= uint64(i)*2654435761 + 40503
+		state *= 1099511628211
+		state ^= state >> 27
+		out[i] = charset[state%uint64(len(charset))]
+	}
+	return string(out)
+}
+
+func assertNoFindingForDetector(t *testing.T, findings []domain.Finding, id string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Detector == id {
+			t.Fatalf("expected detector %s to be suppressed, but it produced finding %+v", id, finding)
+		}
+	}
 }
 
 func findSecretDetector(id string) (secretDetector, bool) {


### PR DESCRIPTION
## Summary

Stage 1 of the repository-scanner precision program: wire the existing secret confidence classifier into a **suppression gate** so the scanner surfaces real, actionable secrets instead of a flood of low-value matches.

The classifier (`classifySecretMatch`) already recognized placeholder markers, sequential/repeated fillers, low-entropy values, test/sample/docs paths, and allowlisted fingerprints — but `detectSecretFindings` emitted **every** match at the rule's static severity and only recorded the verdict as metadata. This PR connects the brain to the output:

1. **Suppress provably-fake matches:** value-level placeholder markers, sequential or repeated fillers, low entropy, and allowlisted fingerprints are dropped rather than emitted. (Allowlisted values being emitted at all was a bug.)
2. **Severity follows confidence:** only high-confidence matches keep the rule's full severity; anything weaker is capped at medium, so a low-confidence hit can never present as high/critical.
3. **Opt-in tuning knobs** on `secretFindingPolicy`: `DropTestAndSampleFindings` (drop real-looking values whose only weakness is a test/sample/docs path) and `MinConfidenceScore` (drop any surviving match below a score floor).

Crucially, a real, high-entropy credential in a production path still surfaces — precision does not cost true positives. Path-only test/sample matches are kept by default (at reduced confidence) so a genuine secret leaked into a test file is never silently hidden.

## Why

The scanner generated many findings without discovering anything actionable: placeholders, `EXAMPLE` keys, consecutive/repeated fillers, and even explicitly allowlisted values all surfaced as High/Critical. That noise buries the findings that matter. See #1725.

## Scope

- [x] Focused change (secret finding emission gate + tests)
- [x] Backward compatibility considered — behavior change is intentional and precision-improving; the two knobs default off. No API/schema change.
- [x] Risk level assessed — the only false-negative surface is heuristic value-shape/entropy suppression, which applies length floors and near-never matches cryptographically-random real secrets.

## Validation

```bash
go test ./internal/repoexposure/                                  # pass
go test ./internal/findings/... ./internal/db/ ./internal/api/ ./internal/domain/   # pass
make fmt-check && go vet ./internal/repoexposure/                 # pass
```

Test corpus was also corrected: several fixtures used unrealistic filler values (`strings.Repeat("A", 16)`, `ABCD1234`×5, `0123456789abcdef…`) that the gate now (correctly) suppresses. They were replaced with realistic high-entropy values via a new `entropicFixture` helper, so the suite exercises genuine detections. New tests assert the AWS `EXAMPLE` key, repeated/consecutive values, `sk_test_` keys, and allowlisted fingerprints all produce zero findings, while a real key in a production path still surfaces, plus severity-capping and both policy knobs.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes (`CHANGELOG.md`)
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no

## Related Issues

Closes #1725

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate secret scanner findings on classifier confidence to cut noise and surface only actionable leaks. Drop provably fake values, cap severity by confidence, add `.identrailignore` tuning (supports ":" or "="), and treat placeholders in composite values (e.g., DSNs) as context only.

- **New Features**
  - Added a precision suppression gate: drop value-level placeholders, sequential/repeated fillers, low-entropy values, and allowlisted fingerprints. Context-only markers or markers inside composite values downrank confidence but never suppress; value-shape/entropy checks do not suppress composite captures. Test/sample/docs path-only matches are kept by default (enable `drop-test-and-sample` to hide).
  - Severity now follows confidence (only high-confidence keeps full severity; others cap at medium). Added `.identrailignore` directives `drop-test-and-sample` and `min-confidence-score` (also accepts `drop_test_and_sample`/`min_confidence_score`, with ":" or "=").

- **Bug Fixes**
  - Allowlisted secret fingerprints are fully suppressed and no longer emitted as findings.

<sup>Written for commit 132d5e56cc3f8302fe564aac5d6d53cf90642988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

