### PR TITLE
Add AWS Remediation Center unified experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@
   confidence, identity type, action type, status, and stage; and per-case
   tradeoffs and safety gates surfaced before any action. The most
   safety-critical verification state is retained per case so kill-switch,
-  failed, and rollback states are never masked by a later verified record. The
-  contract is metadata-only and never exposes rendered policy bodies, secret
-  values, or workload payloads.
+  failed, and rollback states are never masked by a later verified record. When
+  a filter narrows the case set, the embedded approval, dry-run, live-action,
+  verification, and audit payloads are reconciled to the filtered cases so a tab
+  never renders rows outside the current filter, and the audit tab draws from a
+  consolidated audit trail spanning every lifecycle stage (not just
+  verification) so its rows always match its count. The contract is
+  metadata-only and never exposes rendered policy bodies, secret values, or
+  workload payloads.
 - Add a **precision suppression gate** to the repository secret scanner so it
   surfaces real, actionable secrets instead of a flood of low-value matches.
   The classifier already recognized placeholders, sequential/repeated fillers,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ## Unreleased
+- Add the **AWS Remediation Center unified experience** (read-only). A new
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center`
+  endpoint stitches remediation cases, the approval queue, dry-run projections,
+  low-risk live actions, and post-remediation verification and rollback into
+  case-keyed lifecycle rollups, backing the app route
+  `/app/{tenant_id}/{workspace_id}/aws/remediation/center`. Operators get one
+  scoped surface with overview, cases, approvals, dry-runs, live actions,
+  verification, and audit tabs; filters for account, region, severity,
+  confidence, identity type, action type, status, and stage; and per-case
+  tradeoffs and safety gates surfaced before any action. The most
+  safety-critical verification state is retained per case so kill-switch,
+  failed, and rollback states are never masked by a later verified record. The
+  contract is metadata-only and never exposes rendered policy bodies, secret
+  values, or workload payloads.
 - Add a **precision suppression gate** to the repository secret scanner so it
   surfaces real, actionable secrets instead of a flood of low-value matches.
   The classifier already recognized placeholders, sequential/repeated fillers,

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS advisory authorization decision API: `aws-advisory-authorization.md`
 - AWS limited enforcement framework: `aws-limited-enforcement.md`
 - AWS high-confidence limited enforcement pilot: `aws-limited-enforcement-pilot.md`
+- AWS Remediation Center unified experience: `aws-remediation-center.md`
 - AWS governance audit reporting: `aws-governance-audit-reporting.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`

--- a/docs/aws-remediation-center.md
+++ b/docs/aws-remediation-center.md
@@ -54,7 +54,7 @@ The UI exposes seven tabs:
 - `dry_runs`: dry-run projections with outcome, apply readiness, and severity
 - `live_actions`: low-risk live actions with state and next action
 - `verification`: post-remediation verification and rollback state
-- `audit`: the immutable audit trail flattened from verification records
+- `audit`: the consolidated immutable audit trail across every lifecycle stage (case, approval, dry-run, live action, and verification), tagged with the owning case and stage
 
 Key metrics, safety-gate status, ready-for-apply, kill-switch, and rollback
 counts surface above the tabs, and the page links back to the broader AWS
@@ -63,7 +63,11 @@ remediation and governance surfaces.
 Filters are driven by URL query parameters (`account_id`, `region`, `severity`,
 `confidence`, `identity_type`, `action_type`, `status`, `stage`, `case_id`, and
 `search`). They are forwarded to the API and preserved across tab navigation, so
-deep links with filters fetch and keep the expected subset.
+deep links with filters fetch and keep the expected subset. When filters narrow
+the case set, the embedded approval, dry-run, live-action, verification, and
+audit payloads are reconciled to the filtered cases so a tab never renders rows
+from cases outside the current filter. The consolidated `audit_trail` is scoped
+the same way, so its entries always match the audit tab count.
 
 ## Safety boundaries
 

--- a/docs/aws-remediation-center.md
+++ b/docs/aws-remediation-center.md
@@ -1,0 +1,84 @@
+# AWS Remediation Center unified experience
+
+Issue #1552 adds the read-only operator center that unifies the AWS remediation
+lifecycle into one scoped surface. It stitches remediation cases, the approval
+queue, dry-run projections, low-risk live actions, and post-remediation
+verification and rollback into case-keyed rollups that back the app route
+`/app/{tenant_id}/{workspace_id}/aws/remediation/center`.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center`
+
+Supported optional filters:
+
+- `connector_id`
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or `permission_denied`
+- `account_id`
+- `region`
+- `severity`
+- `confidence`: `high`, `medium`, `low`, or a `0..1` floor value
+- `identity_type`
+- `action_type`
+- `status`
+- `stage`: `case`, `approval`, `dry_run`, `live_action`, `verification`, or `rollback`
+- `case_id`
+- `tab`: `overview`, `cases`, `approvals`, `dry_runs`, `live_actions`, `verification`, or `audit`
+- `search`
+
+The response is returned as `{ "remediation_center": ... }` and includes:
+
+- tenant, workspace, project, connector, account, region, parent/current issue, version, status, confidence, policy version, and applied filters
+- a summary with total and filtered case counts, per-stage/severity/status/action-type/identity-type counts, and lifecycle rollups (pending approvals, dry-runs, live actions, verification, rollbacks, ready-for-apply, kill-switch, and blocked safety-gate counts)
+- tab counts for overview, cases, approvals, dry-runs, live actions, verification, and audit
+- case rollups that carry the case spine id, lifecycle stage, severity, confidence, owner, approval/dry-run/execution/verification/rollback linkage, tradeoffs, safety gates, and the next action
+- the underlying remediation case, approval queue, dry-run, live-action, and verification/rollback source results
+- diagnostics, coverage gaps, failure reasons, remediation hints, and evidence links
+
+Each case is keyed by its remediation `case_id`, which is the spine that joins the
+approval, dry-run, live-action, and verification stages. The most safety-critical
+verification state is retained per case so kill-switch, failed, and rollback
+states are never masked by a later `verified` record.
+
+## App behavior
+
+The AWS remediation surface links operators into the center with the selected
+environment. The page keeps the environment selector active and reloads when the
+environment, connector, or tab changes.
+
+The UI exposes seven tabs:
+
+- `overview`: case lifecycle table with stage, safety gates, next action, and severity/confidence
+- `cases`: the same case lifecycle rollup
+- `approvals`: approval-queue entries with state, readiness, and severity
+- `dry_runs`: dry-run projections with outcome, apply readiness, and severity
+- `live_actions`: low-risk live actions with state and next action
+- `verification`: post-remediation verification and rollback state
+- `audit`: the immutable audit trail flattened from verification records
+
+Key metrics, safety-gate status, ready-for-apply, kill-switch, and rollback
+counts surface above the tabs, and the page links back to the broader AWS
+remediation and governance surfaces.
+
+## Safety boundaries
+
+The contract is read-only and metadata-only. It must not read, expose, log, or
+persist rendered policy bodies, secret values, workload payloads, prompt text,
+completions, database rows, or customer object contents.
+
+The response evidence boundary is
+`metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped`.
+Downstream sources may contribute ARNs, names, ids, hashes, timestamps, action
+names, safety-gate status, and safe reference identifiers, but not sensitive
+values or document bodies.
+
+## Failure states
+
+- `empty`: the selected scope has no matching remediation evidence after sources run.
+- `degraded`: evidence exists, but one or more sources returned partial or low-confidence data.
+- `partial_failure`: at least one downstream source failed while retained evidence remains visible.
+- `permission_denied`: the selected connector lacks required read-only metadata permissions.
+
+These states remain visible in the center through status panels, diagnostics,
+coverage gaps, and remediation hints rather than being collapsed into a
+successful view.

--- a/docs/aws-remediation-center.md
+++ b/docs/aws-remediation-center.md
@@ -48,8 +48,8 @@ environment, connector, or tab changes.
 
 The UI exposes seven tabs:
 
-- `overview`: case lifecycle table with stage, safety gates, next action, and severity/confidence
-- `cases`: the same case lifecycle rollup
+- `overview`: pre-action safety review — per-case tradeoffs, safety-gate status, apply readiness, kill-switch state, and severity/confidence
+- `cases`: case lifecycle rollup with stage, safety gates, next action, and severity/confidence
 - `approvals`: approval-queue entries with state, readiness, and severity
 - `dry_runs`: dry-run projections with outcome, apply readiness, and severity
 - `live_actions`: low-risk live actions with state and next action
@@ -59,6 +59,11 @@ The UI exposes seven tabs:
 Key metrics, safety-gate status, ready-for-apply, kill-switch, and rollback
 counts surface above the tabs, and the page links back to the broader AWS
 remediation and governance surfaces.
+
+Filters are driven by URL query parameters (`account_id`, `region`, `severity`,
+`confidence`, `identity_type`, `action_type`, `status`, `stage`, `case_id`, and
+`search`). They are forwarded to the API and preserved across tab navigation, so
+deep links with filters fetch and keep the expected subset.
 
 ## Safety boundaries
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -14350,10 +14350,29 @@ components:
           type: array
           items: { type: string }
         evidence_boundary: { type: string }
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCenterAuditEntry"
         audit_entry_count: { type: integer }
         updated_at:
           type: string
           format: date-time
+    AWSRemediationCenterAuditEntry:
+      type: object
+      properties:
+        case_id: { type: string }
+        stage:
+          type: string
+          enum: [case, approval, dry_run, live_action, verification, rollback]
+        event_id: { type: string }
+        event_type: { type: string }
+        actor: { type: string }
+        occurred_at:
+          type: string
+          format: date-time
+        evidence_ref: { type: string }
+        notes: { type: string }
     AWSRemediationCenterSummary:
       type: object
       properties:
@@ -14433,6 +14452,10 @@ components:
           $ref: "#/components/schemas/AWSLowRiskRemediationResult"
         verification:
           $ref: "#/components/schemas/AWSPostRemediationVerificationResult"
+        audit_trail:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCenterAuditEntry"
         failure_reasons:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -564,6 +564,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/bedrock-agents
     action: tenancy.read
     resource_type: project
@@ -4844,6 +4849,95 @@ paths:
                 $ref: "#/components/schemas/AWSAgentIdentityDetailResponse"
         "400":
           description: Invalid AWS agent identity detail request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS Remediation Center
+      operationId: getAWSProjectRemediationCenter
+      description: Returns the unified, metadata-only AWS Remediation Center by joining remediation cases, the approval queue, dry-run projections, low-risk live actions, and post-remediation verification/rollback into one case-keyed lifecycle view. Each case rollup surfaces its lifecycle stage, tradeoffs, and the consolidated safety gates that must clear before action. The endpoint is read-only and never mutates AWS or returns secret values, rendered policy bodies, payload bodies, prompts, completions, browser pages, code-interpreter output, or database rows.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+          description: Optional AWS connector ID used to scope account, region, and read-only evidence.
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+          description: Optional deterministic fixture state for UI validation and contract tests.
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema: { type: string }
+        - in: query
+          name: confidence
+          schema: { type: string }
+          description: Minimum confidence floor as a 0..1 threshold or a high/medium/low bucket.
+        - in: query
+          name: identity_type
+          schema: { type: string }
+        - in: query
+          name: action_type
+          schema: { type: string }
+          description: Remediation action type (case diff kind or source type).
+        - in: query
+          name: status
+          schema: { type: string }
+          description: Lifecycle status token matched against case lifecycle, approval, execution, verification, or stage.
+        - in: query
+          name: stage
+          schema:
+            type: string
+            enum: [case, approval, dry_run, live_action, verification, rollback]
+          description: Optional lifecycle-stage focus.
+        - in: query
+          name: case_id
+          schema: { type: string }
+        - in: query
+          name: tab
+          schema:
+            type: string
+            enum: [overview, cases, approvals, dry_runs, live_actions, verification, audit]
+          description: Optional detail tab selector used by the app route.
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS Remediation Center contract
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AWSRemediationCenterResponse"
+        "400":
+          description: Invalid AWS remediation center request
           content:
             application/json:
               schema:
@@ -14166,6 +14260,179 @@ components:
           $ref: "#/components/schemas/AWSRemediationCaseResult"
         governance:
           $ref: "#/components/schemas/AWSGovernanceAuditReportingResult"
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationCenterResponse:
+      type: object
+      required: [remediation_center]
+      properties:
+        remediation_center:
+          $ref: "#/components/schemas/AWSRemediationCenterResult"
+    AWSRemediationCenterSafetyGate:
+      type: object
+      properties:
+        source: { type: string }
+        name: { type: string }
+        status: { type: string }
+        rationale: { type: string }
+    AWSRemediationCenterCase:
+      type: object
+      properties:
+        case_id: { type: string }
+        title: { type: string }
+        summary: { type: string }
+        source_type: { type: string }
+        action_type: { type: string }
+        lifecycle: { type: string }
+        stage:
+          type: string
+          enum: [case, approval, dry_run, live_action, verification, rollback]
+        severity: { type: string }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        target_account_ids:
+          type: array
+          items: { type: string }
+        region: { type: string }
+        identity_node_id: { type: string }
+        identity_name: { type: string }
+        identity_type: { type: string }
+        owner: { type: string }
+        owner_assigned: { type: boolean }
+        approval_required: { type: boolean }
+        approval_state: { type: string }
+        approval_id: { type: string }
+        dry_run_id: { type: string }
+        dry_run_outcome: { type: string }
+        execution_id: { type: string }
+        execution_state: { type: string }
+        verification_id: { type: string }
+        verification_state: { type: string }
+        rollback_state: { type: string }
+        rollback_strategy: { type: string }
+        ready_for_apply: { type: boolean }
+        kill_switch_engaged: { type: boolean }
+        tradeoffs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationTradeoff"
+        safety_gates:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCenterSafetyGate"
+        next_action: { type: string }
+        evidence_refs:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        audit_entry_count: { type: integer }
+        updated_at:
+          type: string
+          format: date-time
+    AWSRemediationCenterSummary:
+      type: object
+      properties:
+        total_cases: { type: integer }
+        filtered_cases: { type: integer }
+        stage_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        action_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        identity_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        approval_pending_count: { type: integer }
+        dry_run_count: { type: integer }
+        live_action_count: { type: integer }
+        verification_count: { type: integer }
+        rollback_count: { type: integer }
+        ready_for_apply_count: { type: integer }
+        kill_switch_engaged_count: { type: integer }
+        blocked_safety_gate_count: { type: integer }
+        audit_entry_count: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSRemediationCenterResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked, permission_denied]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        policy_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSRemediationCenterSummary"
+        tabs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSMachineIdentityDetailTab"
+        cases:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSRemediationCenterCase"
+        remediation_cases:
+          $ref: "#/components/schemas/AWSRemediationCaseResult"
+        approval_queue:
+          $ref: "#/components/schemas/AWSRemediationApprovalResult"
+        dry_runs:
+          $ref: "#/components/schemas/AWSRemediationDryRunResult"
+        live_actions:
+          $ref: "#/components/schemas/AWSLowRiskRemediationResult"
+        verification:
+          $ref: "#/components/schemas/AWSPostRemediationVerificationResult"
         failure_reasons:
           type: array
           items: { type: string }

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -14333,6 +14333,10 @@ components:
         execution_state: { type: string }
         verification_id: { type: string }
         verification_state: { type: string }
+        verification_entry_count: { type: integer }
+        verification_states:
+          type: array
+          items: { type: string }
         rollback_state: { type: string }
         rollback_strategy: { type: string }
         ready_for_apply: { type: boolean }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -756,6 +756,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ai-agent-identities/:agent_id", Action: policyActionTenancyRead, ResourceType: "ai_agent_identity", ResourceIDParam: "agent_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/machine-identity-detail", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agent-identity-detail", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/remediation-center", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/runtime-events", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/secrets-kms-runtime-access", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -279,7 +279,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
 	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, request.Status)
-	filtered = awsRemediationCenterCasesWithVerificationEntryCounts(filtered, verification.Entries)
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
@@ -764,18 +764,46 @@ func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVe
 	return out
 }
 
-func awsRemediationCenterCasesWithVerificationEntryCounts(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry) []AWSRemediationCenterCase {
+func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry) []AWSRemediationCenterCase {
 	counts := map[string]int{}
+	verificationAuditEvents := map[string]map[string]struct{}{}
 	for _, entry := range entries {
-		if key := strings.TrimSpace(entry.CaseID); key != "" {
-			counts[key]++
+		key := strings.TrimSpace(entry.CaseID)
+		if key == "" {
+			continue
+		}
+		counts[key]++
+		if _, ok := verificationAuditEvents[key]; !ok {
+			verificationAuditEvents[key] = map[string]struct{}{}
+		}
+		for _, audit := range entry.AuditTrail {
+			if eventID := strings.TrimSpace(audit.EventID); eventID != "" {
+				verificationAuditEvents[key][eventID] = struct{}{}
+			}
 		}
 	}
 	out := append([]AWSRemediationCenterCase{}, cases...)
 	for i := range out {
-		if out[i].VerificationID != "" {
-			out[i].VerificationEntryCount = counts[strings.TrimSpace(out[i].CaseID)]
+		if out[i].VerificationID == "" {
+			continue
 		}
+		caseID := strings.TrimSpace(out[i].CaseID)
+		out[i].VerificationEntryCount = counts[caseID]
+		out[i].AuditTrail = awsRemediationCenterAuditTrailWithScopedVerificationEvents(out[i].AuditTrail, verificationAuditEvents[caseID])
+		out[i].AuditEntryCount = len(out[i].AuditTrail)
+	}
+	return out
+}
+
+func awsRemediationCenterAuditTrailWithScopedVerificationEvents(entries []AWSRemediationCenterAuditEntry, verificationEvents map[string]struct{}) []AWSRemediationCenterAuditEntry {
+	out := make([]AWSRemediationCenterAuditEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Stage == awsRemediationCenterStageVerification {
+			if _, ok := verificationEvents[strings.TrimSpace(entry.EventID)]; !ok {
+				continue
+			}
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -105,8 +105,25 @@ type AWSRemediationCenterCase struct {
 	NextAction        string                           `json:"next_action"`
 	EvidenceRefs      []string                         `json:"evidence_refs,omitempty"`
 	EvidenceBoundary  string                           `json:"evidence_boundary"`
+	AuditTrail        []AWSRemediationCenterAuditEntry `json:"audit_trail"`
 	AuditEntryCount   int                              `json:"audit_entry_count"`
 	UpdatedAt         time.Time                        `json:"updated_at,omitzero"`
+}
+
+// AWSRemediationCenterAuditEntry is one immutable audit record projected from a
+// lifecycle stage (case, approval, dry-run, live action, or verification) and
+// tagged with the case it belongs to plus the stage that produced it, so the
+// audit tab consolidates the whole lifecycle rather than only verification. It
+// is metadata-only.
+type AWSRemediationCenterAuditEntry struct {
+	CaseID      string    `json:"case_id"`
+	Stage       string    `json:"stage"`
+	EventID     string    `json:"event_id"`
+	EventType   string    `json:"event_type"`
+	Actor       string    `json:"actor"`
+	OccurredAt  time.Time `json:"occurred_at"`
+	EvidenceRef string    `json:"evidence_ref,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
 }
 
 // AWSRemediationCenterSummary aggregates the unfiltered and filtered case set
@@ -160,6 +177,7 @@ type AWSRemediationCenterResult struct {
 	DryRuns            AWSRemediationDryRunResult           `json:"dry_runs"`
 	LiveActions        AWSLowRiskRemediationResult          `json:"live_actions"`
 	Verification       AWSPostRemediationVerificationResult `json:"verification"`
+	AuditTrail         []AWSRemediationCenterAuditEntry     `json:"audit_trail"`
 	FailureReasons     []string                             `json:"failure_reasons"`
 	RemediationHints   []string                             `json:"remediation_hints"`
 	EvidenceLinks      []string                             `json:"evidence_links"`
@@ -262,6 +280,18 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	evidenceLinks := awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification)
 	status, confidence := summarizeAWSRemediationCenterStatus(fixtureState, cases, approvals, dryRuns, liveActions, verification, diagnostics)
 
+	// Scope the embedded lifecycle payloads (rendered directly by the app tabs)
+	// and the consolidated audit trail to the filtered case set, so a filtered
+	// deep link never surfaces rows from cases that fell outside the filter.
+	// Diagnostics, status, and evidence links stay on the full source results
+	// because they report collector health across the whole connector scope.
+	scopedCaseIDs := awsRemediationCenterCaseIDSet(filtered)
+	approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
+	dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
+	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
+	verification.Entries = awsRemediationCenterScopeEntries(verification.Entries, scopedCaseIDs, func(e AWSPostRemediationVerificationEntry) string { return e.CaseID })
+	auditTrail := awsRemediationCenterAuditTrail(filtered)
+
 	return AWSRemediationCenterResult{
 		TenantID:           scope.TenantID,
 		WorkspaceID:        project.WorkspaceID,
@@ -287,6 +317,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 		DryRuns:            dryRuns,
 		LiveActions:        liveActions,
 		Verification:       verification,
+		AuditTrail:         auditTrail,
 		FailureReasons:     awsRemediationCenterFailureReasons(cases, approvals, dryRuns, liveActions, verification),
 		RemediationHints:   awsRemediationCenterRemediationHints(cases, approvals, dryRuns, liveActions, verification),
 		EvidenceLinks:      evidenceLinks,
@@ -389,7 +420,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 	killSwitch := false
 	tradeoffs := append([]AWSRemediationTradeoff{}, c.Tradeoffs...)
 	gates := []AWSRemediationCenterSafetyGate{}
-	auditCount := len(c.AuditTrail)
+	audit := awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageCase, c.AuditTrail)
 	entry := AWSRemediationCenterCase{
 		CaseID:           c.CaseID,
 		Title:            c.Title,
@@ -420,7 +451,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.ApprovalID = approval.ApprovalID
 		entry.ApprovalState = firstNonEmptyAWSValue(approval.State, entry.ApprovalState)
 		killSwitch = killSwitch || approval.KillSwitchEngaged
-		auditCount += len(approval.AuditTrail)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageApproval, approval.AuditTrail)...)
 		tradeoffs = append(tradeoffs, approval.Tradeoffs...)
 		for _, gate := range approval.RBACGates {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "approval_rbac", Name: gate.Name, Status: gate.Status, Rationale: gate.Rationale})
@@ -434,7 +465,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.DryRunID = dryRun.DryRunID
 		entry.DryRunOutcome = dryRun.Outcome
 		killSwitch = killSwitch || dryRun.KillSwitchEngaged
-		auditCount += len(dryRun.AuditTrail)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageDryRun, dryRun.AuditTrail)...)
 		for _, prereq := range dryRun.SatisfiedPrereqs {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "dry_run_prerequisite", Name: prereq.Name, Status: firstNonEmptyAWSValue(prereq.Status, "passed"), Rationale: prereq.Rationale})
 		}
@@ -448,7 +479,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.ExecutionID = live.ExecutionID
 		entry.ExecutionState = live.State
 		killSwitch = killSwitch || live.KillSwitchEngaged
-		auditCount += len(live.AuditTrail)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageLiveAction, live.AuditTrail)...)
 		for _, preflight := range live.Preflights {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "live_action_preflight", Name: preflight.Name, Status: preflight.Status, Rationale: preflight.Rationale})
 		}
@@ -461,7 +492,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.RollbackState = verify.Rollback.State
 		entry.RollbackStrategy = verify.Rollback.Strategy
 		killSwitch = killSwitch || verify.KillSwitchEngaged
-		auditCount += len(verify.AuditTrail)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verify.AuditTrail)...)
 		if verify.State == awsPostRemediationVerificationStateRollback || verify.State == awsPostRemediationVerificationStateFailed {
 			stage = awsRemediationCenterStageRollback
 		}
@@ -478,8 +509,64 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 	entry.Tradeoffs = awsRemediationCenterDedupeTradeoffs(tradeoffs)
 	entry.SafetyGates = gates
 	entry.EvidenceRefs = evidenceRefs
-	entry.AuditEntryCount = auditCount
+	entry.AuditTrail = audit
+	entry.AuditEntryCount = len(audit)
 	return entry
+}
+
+// awsRemediationCenterCaseIDSet collects the case IDs of the given rollups so
+// the embedded lifecycle payloads can be reconciled against the filtered set.
+func awsRemediationCenterCaseIDSet(cases []AWSRemediationCenterCase) map[string]struct{} {
+	set := make(map[string]struct{}, len(cases))
+	for _, c := range cases {
+		if key := strings.TrimSpace(c.CaseID); key != "" {
+			set[key] = struct{}{}
+		}
+	}
+	return set
+}
+
+// awsRemediationCenterScopeEntries keeps only the entries whose case ID is in the
+// allowed set, preserving order.
+func awsRemediationCenterScopeEntries[T any](entries []T, allow map[string]struct{}, caseID func(T) string) []T {
+	out := make([]T, 0, len(entries))
+	for _, entry := range entries {
+		if _, ok := allow[strings.TrimSpace(caseID(entry))]; ok {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// awsRemediationCenterAuditTrail flattens the per-case audit records into one
+// consolidated, filter-scoped list so the audit tab renders the same entries its
+// count reflects, across every lifecycle stage rather than verification alone.
+func awsRemediationCenterAuditTrail(cases []AWSRemediationCenterCase) []AWSRemediationCenterAuditEntry {
+	out := []AWSRemediationCenterAuditEntry{}
+	for _, c := range cases {
+		out = append(out, c.AuditTrail...)
+	}
+	return out
+}
+
+// awsRemediationCenterAuditEntries projects a stage's audit trail into the
+// center's consolidated audit record, tagging each with the owning case and the
+// stage that produced it.
+func awsRemediationCenterAuditEntries(caseID, stage string, trail []AWSRemediationAuditEntry) []AWSRemediationCenterAuditEntry {
+	out := make([]AWSRemediationCenterAuditEntry, 0, len(trail))
+	for _, a := range trail {
+		out = append(out, AWSRemediationCenterAuditEntry{
+			CaseID:      caseID,
+			Stage:       stage,
+			EventID:     a.EventID,
+			EventType:   a.EventType,
+			Actor:       a.Actor,
+			OccurredAt:  a.OccurredAt,
+			EvidenceRef: a.EvidenceRef,
+			Notes:       a.Notes,
+		})
+	}
+	return out
 }
 
 func awsRemediationCenterActionType(c AWSRemediationCase) string {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -420,7 +420,8 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 	killSwitch := false
 	tradeoffs := append([]AWSRemediationTradeoff{}, c.Tradeoffs...)
 	gates := []AWSRemediationCenterSafetyGate{}
-	audit := awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageCase, c.AuditTrail)
+	seenAuditEvents := map[string]struct{}{}
+	audit := awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageCase, c.AuditTrail, seenAuditEvents)
 	entry := AWSRemediationCenterCase{
 		CaseID:           c.CaseID,
 		Title:            c.Title,
@@ -451,7 +452,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.ApprovalID = approval.ApprovalID
 		entry.ApprovalState = firstNonEmptyAWSValue(approval.State, entry.ApprovalState)
 		killSwitch = killSwitch || approval.KillSwitchEngaged
-		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageApproval, approval.AuditTrail)...)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageApproval, approval.AuditTrail, seenAuditEvents)...)
 		tradeoffs = append(tradeoffs, approval.Tradeoffs...)
 		for _, gate := range approval.RBACGates {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "approval_rbac", Name: gate.Name, Status: gate.Status, Rationale: gate.Rationale})
@@ -465,7 +466,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.DryRunID = dryRun.DryRunID
 		entry.DryRunOutcome = dryRun.Outcome
 		killSwitch = killSwitch || dryRun.KillSwitchEngaged
-		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageDryRun, dryRun.AuditTrail)...)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageDryRun, dryRun.AuditTrail, seenAuditEvents)...)
 		for _, prereq := range dryRun.SatisfiedPrereqs {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "dry_run_prerequisite", Name: prereq.Name, Status: firstNonEmptyAWSValue(prereq.Status, "passed"), Rationale: prereq.Rationale})
 		}
@@ -479,7 +480,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.ExecutionID = live.ExecutionID
 		entry.ExecutionState = live.State
 		killSwitch = killSwitch || live.KillSwitchEngaged
-		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageLiveAction, live.AuditTrail)...)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageLiveAction, live.AuditTrail, seenAuditEvents)...)
 		for _, preflight := range live.Preflights {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "live_action_preflight", Name: preflight.Name, Status: preflight.Status, Rationale: preflight.Rationale})
 		}
@@ -491,7 +492,7 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		entry.RollbackState = verify.Rollback.State
 		entry.RollbackStrategy = verify.Rollback.Strategy
 		killSwitch = killSwitch || verify.KillSwitchEngaged
-		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verify.AuditTrail)...)
+		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verify.AuditTrail, seenAuditEvents)...)
 		if verify.State == awsPostRemediationVerificationStateRollback || verify.State == awsPostRemediationVerificationStateFailed {
 			stage = awsRemediationCenterStageRollback
 		}
@@ -548,16 +549,23 @@ func awsRemediationCenterAuditTrail(cases []AWSRemediationCenterCase) []AWSRemed
 	return out
 }
 
-// awsRemediationCenterAuditEntries projects a stage's audit trail into the
-// center's consolidated audit record, tagging each with the owning case and the
-// stage that produced it.
-func awsRemediationCenterAuditEntries(caseID, stage string, trail []AWSRemediationAuditEntry) []AWSRemediationCenterAuditEntry {
+// awsRemediationCenterAuditEntries projects only the first occurrence of each
+// event ID into the center trail. Downstream stage trails are cumulative, so the
+// first lifecycle stage that emits an event is the stage that owns it.
+func awsRemediationCenterAuditEntries(caseID, stage string, trail []AWSRemediationAuditEntry, seen map[string]struct{}) []AWSRemediationCenterAuditEntry {
 	out := make([]AWSRemediationCenterAuditEntry, 0, len(trail))
 	for _, a := range trail {
+		eventID := strings.TrimSpace(a.EventID)
+		if eventID != "" {
+			if _, ok := seen[eventID]; ok {
+				continue
+			}
+			seen[eventID] = struct{}{}
+		}
 		out = append(out, AWSRemediationCenterAuditEntry{
 			CaseID:      caseID,
 			Stage:       stage,
-			EventID:     a.EventID,
+			EventID:     eventID,
 			EventType:   a.EventType,
 			Actor:       a.Actor,
 			OccurredAt:  a.OccurredAt,

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -285,7 +285,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
 	liveActions.Relationships = awsRemediationCenterScopeEntries(liveActions.Relationships, awsRemediationCenterStringSet(liveActions.Entries, func(e AWSLowRiskRemediationEntry) string { return e.ExecutionID }), func(r AWSLowRiskRemediationRelationship) string { return r.ExecutionID })
 	liveActions.Summary = summarizeAWSLowRiskRemediationEntries(allLiveActionEntries, liveActions.Entries, liveActions.Relationships)
-	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, request.Status)
+	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, request.Status, request.AccountID)
 	verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
 	verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries)
@@ -767,13 +767,17 @@ func awsRemediationCenterScopeEntries[T any](entries []T, allow map[string]struc
 // with the filtered case set. If a case matched status through a verification
 // row state, the tab renders only matching rows; lifecycle/approval/stage status
 // matches keep all verification rows for that case.
-func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVerificationEntry, allow map[string]struct{}, cases []AWSRemediationCenterCase, status string) []AWSPostRemediationVerificationEntry {
+func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVerificationEntry, allow map[string]struct{}, cases []AWSRemediationCenterCase, status, accountID string) []AWSPostRemediationVerificationEntry {
 	status = normalizeAWSRuntimeEventFilterToken(status)
+	accountID = strings.TrimSpace(accountID)
 	statusCaseIDs := awsRemediationCenterVerificationStatusCaseIDSet(cases, status)
 	out := make([]AWSPostRemediationVerificationEntry, 0, len(entries))
 	for _, entry := range entries {
 		caseID := strings.TrimSpace(entry.CaseID)
 		if _, ok := allow[caseID]; !ok {
+			continue
+		}
+		if accountID != "" && !awsRemediationCenterVerificationAccountMatch(entry, accountID) {
 			continue
 		}
 		if _, ok := statusCaseIDs[caseID]; ok && status != normalizeAWSRuntimeEventFilterToken(entry.State) {
@@ -782,6 +786,18 @@ func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVe
 		out = append(out, entry)
 	}
 	return out
+}
+
+func awsRemediationCenterVerificationAccountMatch(entry AWSPostRemediationVerificationEntry, accountID string) bool {
+	if strings.EqualFold(strings.TrimSpace(entry.AccountID), accountID) {
+		return true
+	}
+	for _, target := range entry.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), accountID) {
+			return true
+		}
+	}
+	return false
 }
 
 func awsRemediationCenterVerificationStatusCaseIDSet(cases []AWSRemediationCenterCase, status string) map[string]struct{} {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -264,7 +264,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 		return centerCases[i].Score > centerCases[j].Score
 	})
 	filtered, applied := filterAWSRemediationCenterCases(centerCases, request)
-	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	diagnostics := awsRemediationCenterDiagnostics(cases, approvals, dryRuns, liveActions, verification)
 	coverageGaps := awsRemediationCenterCoverageGaps(cases, verification)
 	evidenceLinks := awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification)
@@ -279,7 +278,9 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
 	dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
-	verification.Entries = awsRemediationCenterScopeEntries(verification.Entries, scopedCaseIDs, func(e AWSPostRemediationVerificationEntry) string { return e.CaseID })
+	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, request.Status)
+	filtered = awsRemediationCenterCasesWithVerificationEntryCounts(filtered, verification.Entries)
+	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
 	return AWSRemediationCenterResult{
@@ -743,6 +744,42 @@ func awsRemediationCenterScopeEntries[T any](entries []T, allow map[string]struc
 	return out
 }
 
+// awsRemediationCenterScopeVerificationEntries keeps verification rows in sync
+// with both the filtered case set and an active status filter. The case rollup
+// may match a status through any verification row; the tab renders individual
+// rows, so row state must be checked before returning/counting them.
+func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVerificationEntry, allow map[string]struct{}, status string) []AWSPostRemediationVerificationEntry {
+	status = normalizeAWSRuntimeEventFilterToken(status)
+	statusFilter := status != "" && !strings.EqualFold(status, "all")
+	out := make([]AWSPostRemediationVerificationEntry, 0, len(entries))
+	for _, entry := range entries {
+		if _, ok := allow[strings.TrimSpace(entry.CaseID)]; !ok {
+			continue
+		}
+		if statusFilter && status != normalizeAWSRuntimeEventFilterToken(entry.State) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func awsRemediationCenterCasesWithVerificationEntryCounts(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry) []AWSRemediationCenterCase {
+	counts := map[string]int{}
+	for _, entry := range entries {
+		if key := strings.TrimSpace(entry.CaseID); key != "" {
+			counts[key]++
+		}
+	}
+	out := append([]AWSRemediationCenterCase{}, cases...)
+	for i := range out {
+		if out[i].VerificationID != "" {
+			out[i].VerificationEntryCount = counts[strings.TrimSpace(out[i].CaseID)]
+		}
+	}
+	return out
+}
+
 // awsRemediationCenterAuditTrail flattens the per-case audit records into one
 // consolidated, filter-scoped list so the audit tab renders the same entries its
 // count reflects, across every lifecycle stage rather than verification alone.
@@ -1027,7 +1064,7 @@ func summarizeAWSRemediationCenterCases(all, filtered []AWSRemediationCenterCase
 		}
 		if entry.VerificationID != "" {
 			verificationCount := entry.VerificationEntryCount
-			if verificationCount == 0 {
+			if verificationCount == 0 && len(entry.VerificationStates) == 0 {
 				verificationCount = 1
 			}
 			summary.VerificationCount += verificationCount

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -278,7 +278,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
 	dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
-	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, request.Status)
+	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, request.Status)
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
@@ -745,21 +745,40 @@ func awsRemediationCenterScopeEntries[T any](entries []T, allow map[string]struc
 }
 
 // awsRemediationCenterScopeVerificationEntries keeps verification rows in sync
-// with both the filtered case set and an active status filter. The case rollup
-// may match a status through any verification row; the tab renders individual
-// rows, so row state must be checked before returning/counting them.
-func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVerificationEntry, allow map[string]struct{}, status string) []AWSPostRemediationVerificationEntry {
+// with the filtered case set. If a case matched status through a verification
+// row state, the tab renders only matching rows; lifecycle/approval/stage status
+// matches keep all verification rows for that case.
+func awsRemediationCenterScopeVerificationEntries(entries []AWSPostRemediationVerificationEntry, allow map[string]struct{}, cases []AWSRemediationCenterCase, status string) []AWSPostRemediationVerificationEntry {
 	status = normalizeAWSRuntimeEventFilterToken(status)
-	statusFilter := status != "" && !strings.EqualFold(status, "all")
+	statusCaseIDs := awsRemediationCenterVerificationStatusCaseIDSet(cases, status)
 	out := make([]AWSPostRemediationVerificationEntry, 0, len(entries))
 	for _, entry := range entries {
-		if _, ok := allow[strings.TrimSpace(entry.CaseID)]; !ok {
+		caseID := strings.TrimSpace(entry.CaseID)
+		if _, ok := allow[caseID]; !ok {
 			continue
 		}
-		if statusFilter && status != normalizeAWSRuntimeEventFilterToken(entry.State) {
+		if _, ok := statusCaseIDs[caseID]; ok && status != normalizeAWSRuntimeEventFilterToken(entry.State) {
 			continue
 		}
 		out = append(out, entry)
+	}
+	return out
+}
+
+func awsRemediationCenterVerificationStatusCaseIDSet(cases []AWSRemediationCenterCase, status string) map[string]struct{} {
+	out := map[string]struct{}{}
+	if status == "" || strings.EqualFold(status, "all") {
+		return out
+	}
+	for _, entry := range cases {
+		for _, state := range entry.VerificationStates {
+			if status == normalizeAWSRuntimeEventFilterToken(state) {
+				if caseID := strings.TrimSpace(entry.CaseID); caseID != "" {
+					out[caseID] = struct{}{}
+				}
+				break
+			}
+		}
 	}
 	return out
 }

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -285,10 +285,10 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
 	liveActions.Relationships = awsRemediationCenterScopeEntries(liveActions.Relationships, awsRemediationCenterStringSet(liveActions.Entries, func(e AWSLowRiskRemediationEntry) string { return e.ExecutionID }), func(r AWSLowRiskRemediationRelationship) string { return r.ExecutionID })
 	liveActions.Summary = summarizeAWSLowRiskRemediationEntries(allLiveActionEntries, liveActions.Entries, liveActions.Relationships)
-	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, request.Status, request.AccountID)
+	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, applied["status"], applied["account_id"])
 	verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
 	verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
-	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries)
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries, applied["status"])
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
@@ -818,8 +818,9 @@ func awsRemediationCenterVerificationStatusCaseIDSet(cases []AWSRemediationCente
 	return out
 }
 
-func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry) []AWSRemediationCenterCase {
+func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry, status string) []AWSRemediationCenterCase {
 	counts := map[string]int{}
+	entriesByCase := map[string][]AWSPostRemediationVerificationEntry{}
 	verificationAuditEvents := map[string]map[string]struct{}{}
 	for _, entry := range entries {
 		key := strings.TrimSpace(entry.CaseID)
@@ -827,6 +828,7 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 			continue
 		}
 		counts[key]++
+		entriesByCase[key] = append(entriesByCase[key], entry)
 		if _, ok := verificationAuditEvents[key]; !ok {
 			verificationAuditEvents[key] = map[string]struct{}{}
 		}
@@ -836,15 +838,34 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 			}
 		}
 	}
-	out := append([]AWSRemediationCenterCase{}, cases...)
-	for i := range out {
-		if out[i].VerificationID == "" {
+	statusCaseIDs := awsRemediationCenterVerificationStatusCaseIDSet(cases, normalizeAWSRuntimeEventFilterToken(status))
+	out := make([]AWSRemediationCenterCase, 0, len(cases))
+	for _, entry := range cases {
+		caseID := strings.TrimSpace(entry.CaseID)
+		if entry.VerificationID == "" {
+			out = append(out, entry)
 			continue
 		}
-		caseID := strings.TrimSpace(out[i].CaseID)
-		out[i].VerificationEntryCount = counts[caseID]
-		out[i].AuditTrail = awsRemediationCenterAuditTrailWithScopedVerificationEvents(out[i].AuditTrail, verificationAuditEvents[caseID])
-		out[i].AuditEntryCount = len(out[i].AuditTrail)
+		scopedRows := entriesByCase[caseID]
+		if _, ok := statusCaseIDs[caseID]; ok && len(scopedRows) == 0 {
+			continue
+		}
+		entry.VerificationEntryCount = counts[caseID]
+		if selected, ok := awsRemediationCenterSelectedVerification(scopedRows); ok {
+			entry.VerificationID = selected.VerificationID
+			entry.VerificationState = selected.State
+			entry.VerificationStates = awsRemediationCenterVerificationStates(scopedRows)
+			entry.RollbackState = selected.Rollback.State
+			entry.RollbackStrategy = selected.Rollback.Strategy
+			entry.Stage = awsRemediationCenterStageVerification
+			if selected.State == awsPostRemediationVerificationStateRollback || selected.State == awsPostRemediationVerificationStateFailed {
+				entry.Stage = awsRemediationCenterStageRollback
+			}
+			entry.NextAction = selected.NextAction
+		}
+		entry.AuditTrail = awsRemediationCenterAuditTrailWithScopedVerificationEvents(entry.AuditTrail, verificationAuditEvents[caseID])
+		entry.AuditEntryCount = len(entry.AuditTrail)
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -1141,13 +1141,13 @@ func awsRemediationCenterShouldDeferStatusFilter(filters map[string]string) bool
 
 func awsRemediationCenterFilterTokenIsVerificationState(status string) bool {
 	switch normalizeAWSRuntimeEventFilterToken(status) {
-	case awsPostRemediationVerificationStatePending,
-		awsPostRemediationVerificationStateVerified,
-		awsPostRemediationVerificationStateFailed,
-		awsPostRemediationVerificationStateRollback,
-		awsPostRemediationVerificationStateSkipped,
-		awsPostRemediationVerificationStateBlocked,
-		awsPostRemediationVerificationStateNotReady:
+	case normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStatePending),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateVerified),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateFailed),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateRollback),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateSkipped),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateBlocked),
+		normalizeAWSRuntimeEventFilterToken(awsPostRemediationVerificationStateNotReady):
 		return true
 	default:
 		return false

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -267,6 +267,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 		return centerCases[i].Score > centerCases[j].Score
 	})
 	filtered, applied := filterAWSRemediationCenterCases(centerCases, request)
+	stageDeferred := awsRemediationCenterShouldDeferStageFilter(applied)
 	diagnostics := awsRemediationCenterDiagnostics(cases, approvals, dryRuns, liveActions, verification)
 	coverageGaps := awsRemediationCenterCoverageGaps(cases, verification)
 	evidenceLinks := awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification)
@@ -291,7 +292,22 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, applied["status"], applied["account_id"])
 	verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
 	verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
-	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries, applied["status"])
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries, applied["status"], applied["stage"])
+	if stageDeferred {
+		scopedCaseIDs = awsRemediationCenterCaseIDSet(filtered)
+		approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
+		approvals.Relationships = awsRemediationCenterScopeEntries(approvals.Relationships, awsRemediationCenterStringSet(approvals.Entries, func(e AWSRemediationApprovalEntry) string { return e.ApprovalID }), func(r AWSRemediationApprovalRelationship) string { return r.ApprovalID })
+		approvals.Summary = summarizeAWSRemediationApprovalEntries(allApprovalEntries, approvals.Entries, approvals.Relationships)
+		dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
+		dryRuns.Relationships = awsRemediationCenterScopeEntries(dryRuns.Relationships, awsRemediationCenterStringSet(dryRuns.Entries, func(e AWSRemediationDryRunEntry) string { return e.DryRunID }), func(r AWSRemediationDryRunRelationship) string { return r.DryRunID })
+		dryRuns.Summary = summarizeAWSRemediationDryRunEntries(allDryRunEntries, dryRuns.Entries, dryRuns.Relationships)
+		liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
+		liveActions.Relationships = awsRemediationCenterScopeEntries(liveActions.Relationships, awsRemediationCenterStringSet(liveActions.Entries, func(e AWSLowRiskRemediationEntry) string { return e.ExecutionID }), func(r AWSLowRiskRemediationRelationship) string { return r.ExecutionID })
+		liveActions.Summary = summarizeAWSLowRiskRemediationEntries(allLiveActionEntries, liveActions.Entries, liveActions.Relationships)
+		verification.Entries = awsRemediationCenterScopeEntries(verification.Entries, scopedCaseIDs, func(e AWSPostRemediationVerificationEntry) string { return e.CaseID })
+		verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
+		verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
+	}
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
@@ -829,7 +845,7 @@ func awsRemediationCenterVerificationStatusCaseIDSet(cases []AWSRemediationCente
 	return out
 }
 
-func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry, status string) []AWSRemediationCenterCase {
+func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationCenterCase, entries []AWSPostRemediationVerificationEntry, status, stage string) []AWSRemediationCenterCase {
 	counts := map[string]int{}
 	entriesByCase := map[string][]AWSPostRemediationVerificationEntry{}
 	verificationAuditEvents := map[string]map[string]struct{}{}
@@ -850,10 +866,14 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 		}
 	}
 	statusCaseIDs := awsRemediationCenterVerificationStatusCaseIDSet(cases, normalizeAWSRuntimeEventFilterToken(status))
+	stage = normalizeAWSRuntimeEventFilterToken(stage)
 	out := make([]AWSRemediationCenterCase, 0, len(cases))
 	for _, entry := range cases {
 		caseID := strings.TrimSpace(entry.CaseID)
 		if entry.VerificationID == "" {
+			if stage != "" && stage != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
+				continue
+			}
 			out = append(out, entry)
 			continue
 		}
@@ -880,6 +900,9 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 		entry.KillSwitchEngaged = entry.nonVerificationKillSwitchEngaged || scopedVerificationKillSwitch || (entry.KillSwitchEngaged && !entry.verificationKillSwitchEngaged)
 		entry.verificationKillSwitchEngaged = scopedVerificationKillSwitch
 		entry.AuditEntryCount = len(entry.AuditTrail)
+		if stage != "" && stage != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
+			continue
+		}
 		out = append(out, entry)
 	}
 	return out
@@ -1054,6 +1077,7 @@ func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, req
 		}
 	}
 	minConfidence, hasMinConfidence := awsRemediationCenterConfidenceFloor(filters["confidence"])
+	deferStageFilter := awsRemediationCenterShouldDeferStageFilter(filters)
 	applied := map[string]string{}
 	for key, value := range filters {
 		applied[key] = value
@@ -1078,7 +1102,7 @@ func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, req
 		if filters["status"] != "" && !awsRemediationCenterStatusMatch(entry, filters["status"]) {
 			continue
 		}
-		if filters["stage"] != "" && filters["stage"] != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
+		if filters["stage"] != "" && !deferStageFilter && filters["stage"] != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
 			continue
 		}
 		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
@@ -1093,6 +1117,28 @@ func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, req
 		filtered = append(filtered, entry)
 	}
 	return filtered, applied
+}
+
+func awsRemediationCenterShouldDeferStageFilter(filters map[string]string) bool {
+	if filters["stage"] == "" {
+		return false
+	}
+	return filters["account_id"] != "" || awsRemediationCenterFilterTokenIsVerificationState(filters["status"])
+}
+
+func awsRemediationCenterFilterTokenIsVerificationState(status string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(status) {
+	case awsPostRemediationVerificationStatePending,
+		awsPostRemediationVerificationStateVerified,
+		awsPostRemediationVerificationStateFailed,
+		awsPostRemediationVerificationStateRollback,
+		awsPostRemediationVerificationStateSkipped,
+		awsPostRemediationVerificationStateBlocked,
+		awsPostRemediationVerificationStateNotReady:
+		return true
+	default:
+		return false
+	}
 }
 
 // awsRemediationCenterConfidenceFloor parses the confidence filter as either a

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -222,9 +222,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Severity:     request.Severity,
 	})
 	if err != nil {
 		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center cases: %w", err)
@@ -232,9 +229,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	approvals, err := s.GetAWSRemediationApprovalQueue(ctx, workspaceID, projectID, AWSRemediationApprovalRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Severity:     request.Severity,
 	})
 	if err != nil {
 		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center approvals: %w", err)
@@ -242,9 +236,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	dryRuns, err := s.GetAWSRemediationDryRun(ctx, workspaceID, projectID, AWSRemediationDryRunRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Severity:     request.Severity,
 	})
 	if err != nil {
 		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center dry runs: %w", err)
@@ -252,9 +243,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	liveActions, err := s.GetAWSLowRiskRemediation(ctx, workspaceID, projectID, AWSLowRiskRemediationRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Severity:     request.Severity,
 	})
 	if err != nil {
 		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center live actions: %w", err)
@@ -262,9 +250,6 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
-		Severity:     request.Severity,
 	})
 	if err != nil {
 		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center verification: %w", err)

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -1,0 +1,861 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+)
+
+const (
+	awsRemediationCenterCurrentIssue = 1552
+	awsRemediationCenterVersion      = "aws-remediation-center-v1"
+	awsRemediationCenterPolicyID     = "aws-remediation-center-policy-v1"
+
+	// Lifecycle stages a case can reach, ordered from earliest to latest.
+	awsRemediationCenterStageCase         = "case"
+	awsRemediationCenterStageApproval     = "approval"
+	awsRemediationCenterStageDryRun       = "dry_run"
+	awsRemediationCenterStageLiveAction   = "live_action"
+	awsRemediationCenterStageVerification = "verification"
+	awsRemediationCenterStageRollback     = "rollback"
+)
+
+// AWSRemediationCenterRequest scopes the unified remediation center to one AWS
+// connector plus the operator drill-down filters shared across the remediation
+// lifecycle (severity, confidence, account, identity type, action type, status).
+type AWSRemediationCenterRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Confidence   string `json:"confidence,omitempty"`
+	IdentityType string `json:"identity_type,omitempty"`
+	ActionType   string `json:"action_type,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	CaseID       string `json:"case_id,omitempty"`
+	Tab          string `json:"tab,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+// Reuse the shared detail-page shapes so the remediation center's tabs,
+// diagnostics, and coverage-gap contracts stay consistent with the rest of
+// the Wave 10 app surface.
+type AWSRemediationCenterTab = AWSMachineIdentityDetailTab
+type AWSRemediationCenterDiagnostic = AWSMachineIdentityDetailDiagnostic
+type AWSRemediationCenterCoverageGap = AWSMachineIdentityDetailCoverageGap
+
+// AWSRemediationCenterSafetyGate is one consolidated safety gate an operator
+// must clear before a case advances. Gates are gathered across the approval
+// (RBAC + feature flags), dry-run (prerequisites), and verification
+// (preconditions) stages so the "safety gates before action" summary is a
+// single list.
+type AWSRemediationCenterSafetyGate struct {
+	Source    string `json:"source"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// AWSRemediationCenterCase is one case-keyed rollup across the remediation
+// lifecycle. It stitches the case, its approval-queue entry, dry-run, live
+// action, and verification/rollback record into a single row so operators can
+// see where each fix is without reading every stage table. It is
+// metadata-only and never carries rendered policy bodies or secret values.
+type AWSRemediationCenterCase struct {
+	CaseID            string                           `json:"case_id"`
+	Title             string                           `json:"title"`
+	Summary           string                           `json:"summary"`
+	SourceType        string                           `json:"source_type"`
+	ActionType        string                           `json:"action_type"`
+	Lifecycle         string                           `json:"lifecycle"`
+	Stage             string                           `json:"stage"`
+	Severity          string                           `json:"severity"`
+	Score             int                              `json:"score"`
+	Confidence        float64                          `json:"confidence"`
+	AccountID         string                           `json:"account_id,omitempty"`
+	TargetAccountIDs  []string                         `json:"target_account_ids,omitempty"`
+	Region            string                           `json:"region,omitempty"`
+	IdentityNodeID    string                           `json:"identity_node_id,omitempty"`
+	IdentityName      string                           `json:"identity_name,omitempty"`
+	IdentityType      string                           `json:"identity_type,omitempty"`
+	Owner             string                           `json:"owner,omitempty"`
+	OwnerAssigned     bool                             `json:"owner_assigned"`
+	ApprovalRequired  bool                             `json:"approval_required"`
+	ApprovalState     string                           `json:"approval_state,omitempty"`
+	ApprovalID        string                           `json:"approval_id,omitempty"`
+	DryRunID          string                           `json:"dry_run_id,omitempty"`
+	DryRunOutcome     string                           `json:"dry_run_outcome,omitempty"`
+	ExecutionID       string                           `json:"execution_id,omitempty"`
+	ExecutionState    string                           `json:"execution_state,omitempty"`
+	VerificationID    string                           `json:"verification_id,omitempty"`
+	VerificationState string                           `json:"verification_state,omitempty"`
+	RollbackState     string                           `json:"rollback_state,omitempty"`
+	RollbackStrategy  string                           `json:"rollback_strategy,omitempty"`
+	ReadyForApply     bool                             `json:"ready_for_apply"`
+	KillSwitchEngaged bool                             `json:"kill_switch_engaged"`
+	Tradeoffs         []AWSRemediationTradeoff         `json:"tradeoffs"`
+	SafetyGates       []AWSRemediationCenterSafetyGate `json:"safety_gates"`
+	NextAction        string                           `json:"next_action"`
+	EvidenceRefs      []string                         `json:"evidence_refs,omitempty"`
+	EvidenceBoundary  string                           `json:"evidence_boundary"`
+	AuditEntryCount   int                              `json:"audit_entry_count"`
+	UpdatedAt         time.Time                        `json:"updated_at,omitzero"`
+}
+
+// AWSRemediationCenterSummary aggregates the unfiltered and filtered case set
+// plus lifecycle-stage and safety rollups.
+type AWSRemediationCenterSummary struct {
+	TotalCases           int            `json:"total_cases"`
+	FilteredCases        int            `json:"filtered_cases"`
+	StageCounts          map[string]int `json:"stage_counts"`
+	SeverityCounts       map[string]int `json:"severity_counts"`
+	StatusCounts         map[string]int `json:"status_counts"`
+	ActionTypeCounts     map[string]int `json:"action_type_counts"`
+	IdentityTypeCounts   map[string]int `json:"identity_type_counts"`
+	ApprovalPendingCount int            `json:"approval_pending_count"`
+	DryRunCount          int            `json:"dry_run_count"`
+	LiveActionCount      int            `json:"live_action_count"`
+	VerificationCount    int            `json:"verification_count"`
+	RollbackCount        int            `json:"rollback_count"`
+	ReadyForApplyCount   int            `json:"ready_for_apply_count"`
+	KillSwitchCount      int            `json:"kill_switch_engaged_count"`
+	BlockedGateCount     int            `json:"blocked_safety_gate_count"`
+	AuditEntryCount      int            `json:"audit_entry_count"`
+	HighestScore         int            `json:"highest_score"`
+	AverageConfidencePct int            `json:"average_confidence_pct"`
+}
+
+// AWSRemediationCenterResult is the deterministic unified-center envelope. It
+// embeds the underlying stage results so the app tabs can render full stage
+// tables, mirroring the Wave 10 detail-page pattern.
+type AWSRemediationCenterResult struct {
+	TenantID           string                               `json:"tenant_id"`
+	WorkspaceID        string                               `json:"workspace_id"`
+	ProjectID          string                               `json:"project_id"`
+	ConnectorID        string                               `json:"connector_id,omitempty"`
+	AccountID          string                               `json:"account_id,omitempty"`
+	Region             string                               `json:"region,omitempty"`
+	ParentIssueNumber  int                                  `json:"parent_issue_number"`
+	ParentIssueRef     string                               `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                  `json:"current_issue_number"`
+	CurrentIssueRef    string                               `json:"current_issue_ref"`
+	Version            string                               `json:"version"`
+	Status             string                               `json:"status"`
+	FixtureState       string                               `json:"fixture_state,omitempty"`
+	Confidence         float64                              `json:"confidence"`
+	PolicyVersion      string                               `json:"policy_version"`
+	AppliedFilters     map[string]string                    `json:"applied_filters"`
+	Summary            AWSRemediationCenterSummary          `json:"summary"`
+	Tabs               []AWSRemediationCenterTab            `json:"tabs"`
+	Cases              []AWSRemediationCenterCase           `json:"cases"`
+	RemediationCases   AWSRemediationCaseResult             `json:"remediation_cases"`
+	ApprovalQueue      AWSRemediationApprovalResult         `json:"approval_queue"`
+	DryRuns            AWSRemediationDryRunResult           `json:"dry_runs"`
+	LiveActions        AWSLowRiskRemediationResult          `json:"live_actions"`
+	Verification       AWSPostRemediationVerificationResult `json:"verification"`
+	FailureReasons     []string                             `json:"failure_reasons"`
+	RemediationHints   []string                             `json:"remediation_hints"`
+	EvidenceLinks      []string                             `json:"evidence_links"`
+	CoverageGaps       []AWSRemediationCenterCoverageGap    `json:"coverage_gaps"`
+	Diagnostics        []AWSRemediationCenterDiagnostic     `json:"diagnostics"`
+	GeneratedAt        time.Time                            `json:"generated_at"`
+	UpdatedAt          time.Time                            `json:"updated_at"`
+}
+
+// GetAWSRemediationCenter composes the unified operator remediation center by
+// joining the remediation case engine (#1529), approval queue (#1536), dry-run
+// executor (#1537), low-risk live remediation (#1538), and post-remediation
+// verification/rollback (#1542) into one case-keyed lifecycle view. It is
+// read-only: it never mutates AWS, never reads secret values or workload
+// payloads, and surfaces unknown/permission-denied/degraded states explicitly.
+func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID string, projectID string, request AWSRemediationCenterRequest) (AWSRemediationCenterResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSRemediationCenterResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSRemediationCenterResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSRemediationCenterFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSRemediationCenterResult{}, ErrInvalidAWSConnectionRequest
+	}
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center cases: %w", err)
+	}
+	approvals, err := s.GetAWSRemediationApprovalQueue(ctx, workspaceID, projectID, AWSRemediationApprovalRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center approvals: %w", err)
+	}
+	dryRuns, err := s.GetAWSRemediationDryRun(ctx, workspaceID, projectID, AWSRemediationDryRunRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center dry runs: %w", err)
+	}
+	liveActions, err := s.GetAWSLowRiskRemediation(ctx, workspaceID, projectID, AWSLowRiskRemediationRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center live actions: %w", err)
+	}
+	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSRemediationCenterResult{}, fmt.Errorf("remediation center verification: %w", err)
+	}
+
+	centerCases := awsRemediationCenterCases(cases, approvals, dryRuns, liveActions, verification)
+	sort.SliceStable(centerCases, func(i, j int) bool {
+		if centerCases[i].Score == centerCases[j].Score {
+			return centerCases[i].CaseID < centerCases[j].CaseID
+		}
+		return centerCases[i].Score > centerCases[j].Score
+	})
+	filtered, applied := filterAWSRemediationCenterCases(centerCases, request)
+	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
+	diagnostics := awsRemediationCenterDiagnostics(cases, approvals, dryRuns, liveActions, verification)
+	coverageGaps := awsRemediationCenterCoverageGaps(cases, verification)
+	evidenceLinks := awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification)
+	status, confidence := summarizeAWSRemediationCenterStatus(fixtureState, cases, approvals, dryRuns, liveActions, verification, diagnostics)
+
+	return AWSRemediationCenterResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationCenterCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationCenterCurrentIssue),
+		Version:            awsRemediationCenterVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		PolicyVersion:      awsRemediationCenterPolicyID,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Tabs:               awsRemediationCenterTabs(summary, status),
+		Cases:              filtered,
+		RemediationCases:   cases,
+		ApprovalQueue:      approvals,
+		DryRuns:            dryRuns,
+		LiveActions:        liveActions,
+		Verification:       verification,
+		FailureReasons:     awsRemediationCenterFailureReasons(cases, approvals, dryRuns, liveActions, verification),
+		RemediationHints:   awsRemediationCenterRemediationHints(cases, approvals, dryRuns, liveActions, verification),
+		EvidenceLinks:      evidenceLinks,
+		CoverageGaps:       coverageGaps,
+		Diagnostics:        diagnostics,
+		GeneratedAt:        now,
+		UpdatedAt:          now,
+	}, nil
+}
+
+func normalizeAWSRemediationCenterFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "":
+		if hasConnection && !connection.Connected {
+			return "permission_denied"
+		}
+		return "success"
+	case "success", "empty", "degraded", "partial_failure", "permission_denied":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
+}
+
+// awsRemediationCenterCases builds the case-keyed lifecycle rollups by joining
+// every stage back to its originating case.
+func awsRemediationCenterCases(cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult) []AWSRemediationCenterCase {
+	approvalByCase := map[string]AWSRemediationApprovalEntry{}
+	for _, entry := range approvals.Entries {
+		if key := strings.TrimSpace(entry.CaseID); key != "" {
+			if _, ok := approvalByCase[key]; !ok {
+				approvalByCase[key] = entry
+			}
+		}
+	}
+	dryRunByCase := map[string]AWSRemediationDryRunEntry{}
+	for _, entry := range dryRuns.Entries {
+		if key := strings.TrimSpace(entry.CaseID); key != "" {
+			if _, ok := dryRunByCase[key]; !ok {
+				dryRunByCase[key] = entry
+			}
+		}
+	}
+	liveByCase := map[string]AWSLowRiskRemediationEntry{}
+	for _, entry := range liveActions.Entries {
+		if key := strings.TrimSpace(entry.CaseID); key != "" {
+			if _, ok := liveByCase[key]; !ok {
+				liveByCase[key] = entry
+			}
+		}
+	}
+	// Keep the most safety-critical verification per case so a failed or
+	// kill-switched verification on any target still drives the rollup.
+	verificationByCase := map[string]AWSPostRemediationVerificationEntry{}
+	for _, entry := range verification.Entries {
+		key := strings.TrimSpace(entry.CaseID)
+		if key == "" {
+			continue
+		}
+		existing, ok := verificationByCase[key]
+		if !ok || awsRemediationCenterVerificationRank(entry) > awsRemediationCenterVerificationRank(existing) {
+			verificationByCase[key] = entry
+		}
+	}
+
+	out := make([]AWSRemediationCenterCase, 0, len(cases.Cases))
+	for _, c := range cases.Cases {
+		approval, hasApproval := approvalByCase[c.CaseID]
+		dryRun, hasDryRun := dryRunByCase[c.CaseID]
+		live, hasLive := liveByCase[c.CaseID]
+		verify, hasVerify := verificationByCase[c.CaseID]
+		out = append(out, awsRemediationCenterCaseFromLifecycle(c, approval, hasApproval, dryRun, hasDryRun, live, hasLive, verify, hasVerify))
+	}
+	return out
+}
+
+func awsRemediationCenterVerificationRank(entry AWSPostRemediationVerificationEntry) int {
+	if entry.KillSwitchEngaged {
+		return 100
+	}
+	switch entry.State {
+	case awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateRollback:
+		return 90
+	case awsPostRemediationVerificationStateBlocked:
+		return 80
+	case awsPostRemediationVerificationStateNotReady:
+		return 40
+	case awsPostRemediationVerificationStatePending:
+		return 30
+	case awsPostRemediationVerificationStateSkipped:
+		return 20
+	case awsPostRemediationVerificationStateVerified:
+		return 10
+	}
+	return 0
+}
+
+func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRemediationApprovalEntry, hasApproval bool, dryRun AWSRemediationDryRunEntry, hasDryRun bool, live AWSLowRiskRemediationEntry, hasLive bool, verify AWSPostRemediationVerificationEntry, hasVerify bool) AWSRemediationCenterCase {
+	stage := awsRemediationCenterStageCase
+	killSwitch := false
+	tradeoffs := append([]AWSRemediationTradeoff{}, c.Tradeoffs...)
+	gates := []AWSRemediationCenterSafetyGate{}
+	auditCount := len(c.AuditTrail)
+	entry := AWSRemediationCenterCase{
+		CaseID:           c.CaseID,
+		Title:            c.Title,
+		Summary:          c.Summary,
+		SourceType:       c.SourceType,
+		ActionType:       awsRemediationCenterActionType(c),
+		Lifecycle:        c.Lifecycle,
+		Severity:         c.Severity,
+		Score:            c.Score,
+		Confidence:       c.Confidence,
+		AccountID:        firstNonEmptyAWSValue(c.AccountID, firstString(c.TargetAccountIDs)),
+		TargetAccountIDs: emptyStrings(dedupeStrings(c.TargetAccountIDs)),
+		Region:           c.Region,
+		IdentityNodeID:   c.IdentityNodeID,
+		IdentityName:     firstNonEmptyAWSValue(c.IdentityName, c.IdentityARN),
+		IdentityType:     c.IdentityType,
+		Owner:            c.Owner,
+		OwnerAssigned:    c.OwnerAssigned,
+		ApprovalRequired: c.ApprovalRequired,
+		ApprovalState:    c.ApprovalState,
+		EvidenceBoundary: awsRemediationCenterEvidenceBoundary(),
+		UpdatedAt:        c.UpdatedAt,
+	}
+	evidenceRefs := awsRemediationCenterCaseEvidenceRefs(c)
+
+	if hasApproval {
+		stage = awsRemediationCenterStageApproval
+		entry.ApprovalID = approval.ApprovalID
+		entry.ApprovalState = firstNonEmptyAWSValue(approval.State, entry.ApprovalState)
+		killSwitch = killSwitch || approval.KillSwitchEngaged
+		auditCount += len(approval.AuditTrail)
+		tradeoffs = append(tradeoffs, approval.Tradeoffs...)
+		for _, gate := range approval.RBACGates {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "approval_rbac", Name: gate.Name, Status: gate.Status, Rationale: gate.Rationale})
+		}
+		for _, flag := range approval.FeatureFlags {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "approval_feature_flag", Name: flag.Name, Status: awsRemediationCenterFlagStatus(flag.Enabled), Rationale: flag.Rationale})
+		}
+	}
+	if hasDryRun {
+		stage = awsRemediationCenterStageDryRun
+		entry.DryRunID = dryRun.DryRunID
+		entry.DryRunOutcome = dryRun.Outcome
+		killSwitch = killSwitch || dryRun.KillSwitchEngaged
+		auditCount += len(dryRun.AuditTrail)
+		for _, prereq := range dryRun.SatisfiedPrereqs {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "dry_run_prerequisite", Name: prereq.Name, Status: firstNonEmptyAWSValue(prereq.Status, "passed"), Rationale: prereq.Rationale})
+		}
+		for _, prereq := range dryRun.FailedPrereqs {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "dry_run_prerequisite", Name: prereq.Name, Status: firstNonEmptyAWSValue(prereq.Status, "blocked"), Rationale: prereq.Rationale})
+		}
+		entry.ReadyForApply = dryRun.ReadyForApply
+	}
+	if hasLive {
+		stage = awsRemediationCenterStageLiveAction
+		entry.ExecutionID = live.ExecutionID
+		entry.ExecutionState = live.State
+		killSwitch = killSwitch || live.KillSwitchEngaged
+		auditCount += len(live.AuditTrail)
+		for _, preflight := range live.Preflights {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "live_action_preflight", Name: preflight.Name, Status: preflight.Status, Rationale: preflight.Rationale})
+		}
+	}
+	if hasVerify {
+		stage = awsRemediationCenterStageVerification
+		entry.VerificationID = verify.VerificationID
+		entry.VerificationState = verify.State
+		entry.ExecutionID = firstNonEmptyAWSValue(entry.ExecutionID, verify.SourceExecutionID)
+		entry.RollbackState = verify.Rollback.State
+		entry.RollbackStrategy = verify.Rollback.Strategy
+		killSwitch = killSwitch || verify.KillSwitchEngaged
+		auditCount += len(verify.AuditTrail)
+		if verify.State == awsPostRemediationVerificationStateRollback || verify.State == awsPostRemediationVerificationStateFailed {
+			stage = awsRemediationCenterStageRollback
+		}
+		for _, precondition := range verify.Preconditions {
+			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "verification_precondition", Name: precondition.Name, Status: precondition.Status, Rationale: precondition.Rationale})
+		}
+		entry.NextAction = verify.NextAction
+	}
+	if entry.NextAction == "" {
+		entry.NextAction = firstNonEmptyAWSValue(firstString(c.NextActions), awsRemediationCenterStageNextAction(stage))
+	}
+	entry.Stage = stage
+	entry.KillSwitchEngaged = killSwitch
+	entry.Tradeoffs = awsRemediationCenterDedupeTradeoffs(tradeoffs)
+	entry.SafetyGates = gates
+	entry.EvidenceRefs = evidenceRefs
+	entry.AuditEntryCount = auditCount
+	return entry
+}
+
+func awsRemediationCenterActionType(c AWSRemediationCase) string {
+	if kind := strings.TrimSpace(c.DiffIntent.Kind); kind != "" {
+		return kind
+	}
+	return c.SourceType
+}
+
+func awsRemediationCenterFlagStatus(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func awsRemediationCenterStageNextAction(stage string) string {
+	switch stage {
+	case awsRemediationCenterStageCase:
+		return "Assign an owner and advance the case to the approval queue."
+	case awsRemediationCenterStageApproval:
+		return "Advance the approval workflow so the case can reach a dry-run."
+	case awsRemediationCenterStageDryRun:
+		return "Review the dry-run projection and its prerequisites before scheduling a live action."
+	case awsRemediationCenterStageLiveAction:
+		return "Confirm live-action preflights and let the wave-8 apply runtime record verification."
+	case awsRemediationCenterStageVerification:
+		return "Confirm verification checks pass; the change is recorded once verified."
+	case awsRemediationCenterStageRollback:
+		return "Verification failed or rolled back; follow the rollback plan and refresh upstream evidence."
+	}
+	return "Inspect the case for its next action."
+}
+
+func awsRemediationCenterCaseEvidenceRefs(c AWSRemediationCase) []string {
+	refs := []string{}
+	if ref := strings.TrimSpace(c.DiffIntent.BeforeRef); ref != "" {
+		refs = append(refs, ref)
+	}
+	for _, evidence := range c.Evidence {
+		if ref := strings.TrimSpace(evidence.EvidenceRef); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return dedupeStrings(refs)
+}
+
+func awsRemediationCenterDedupeTradeoffs(items []AWSRemediationTradeoff) []AWSRemediationTradeoff {
+	seen := map[string]struct{}{}
+	out := []AWSRemediationTradeoff{}
+	for _, item := range items {
+		key := strings.ToLower(strings.Join([]string{item.Dimension, item.Direction, item.Description, item.Severity}, "\x00"))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, request AWSRemediationCenterRequest) ([]AWSRemediationCenterCase, map[string]string) {
+	filters := map[string]string{
+		"account_id":    strings.TrimSpace(request.AccountID),
+		"region":        strings.TrimSpace(request.Region),
+		"severity":      normalizeAWSRuntimeEventFilterToken(request.Severity),
+		"identity_type": normalizeAWSRuntimeEventFilterToken(request.IdentityType),
+		"action_type":   normalizeAWSRuntimeEventFilterToken(request.ActionType),
+		"status":        normalizeAWSRuntimeEventFilterToken(request.Status),
+		"stage":         normalizeAWSRuntimeEventFilterToken(request.Stage),
+		"case_id":       strings.TrimSpace(request.CaseID),
+		"confidence":    strings.TrimSpace(request.Confidence),
+		"search":        strings.TrimSpace(request.Search),
+	}
+	for key, value := range filters {
+		if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
+			delete(filters, key)
+		}
+	}
+	minConfidence, hasMinConfidence := awsRemediationCenterConfidenceFloor(filters["confidence"])
+	applied := map[string]string{}
+	for key, value := range filters {
+		applied[key] = value
+	}
+	filtered := make([]AWSRemediationCenterCase, 0, len(centerCases))
+	for _, entry := range centerCases {
+		if filters["account_id"] != "" && !awsRemediationCenterAccountMatch(entry, filters["account_id"]) {
+			continue
+		}
+		if filters["region"] != "" && strings.TrimSpace(entry.Region) != "" && !strings.EqualFold(filters["region"], strings.TrimSpace(entry.Region)) {
+			continue
+		}
+		if filters["severity"] != "" && filters["severity"] != normalizeAWSRuntimeEventFilterToken(entry.Severity) {
+			continue
+		}
+		if filters["identity_type"] != "" && filters["identity_type"] != normalizeAWSRuntimeEventFilterToken(entry.IdentityType) {
+			continue
+		}
+		if filters["action_type"] != "" && filters["action_type"] != normalizeAWSRuntimeEventFilterToken(entry.ActionType) && filters["action_type"] != normalizeAWSRuntimeEventFilterToken(entry.SourceType) {
+			continue
+		}
+		if filters["status"] != "" && !awsRemediationCenterStatusMatch(entry, filters["status"]) {
+			continue
+		}
+		if filters["stage"] != "" && filters["stage"] != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
+			continue
+		}
+		if filters["case_id"] != "" && !strings.EqualFold(filters["case_id"], entry.CaseID) {
+			continue
+		}
+		if hasMinConfidence && entry.Confidence < minConfidence {
+			continue
+		}
+		if filters["search"] != "" && !awsRemediationCenterSearchMatch(entry, filters["search"]) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, applied
+}
+
+// awsRemediationCenterConfidenceFloor parses the confidence filter as either a
+// 0..1 float threshold or a high/medium/low bucket floor.
+func awsRemediationCenterConfidenceFloor(value string) (float64, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return 0, false
+	}
+	switch value {
+	case "high":
+		return 0.85, true
+	case "medium", "med":
+		return 0.6, true
+	case "low":
+		return 0, true
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || parsed < 0 || parsed > 1 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func awsRemediationCenterAccountMatch(entry AWSRemediationCenterCase, accountID string) bool {
+	if strings.EqualFold(strings.TrimSpace(entry.AccountID), accountID) {
+		return true
+	}
+	for _, target := range entry.TargetAccountIDs {
+		if strings.EqualFold(strings.TrimSpace(target), accountID) {
+			return true
+		}
+	}
+	return false
+}
+
+// awsRemediationCenterStatusMatch matches the status filter against the
+// case lifecycle, approval state, or the furthest execution/verification
+// state so operators can filter by any lifecycle status token.
+func awsRemediationCenterStatusMatch(entry AWSRemediationCenterCase, status string) bool {
+	for _, value := range []string{entry.Lifecycle, entry.ApprovalState, entry.ExecutionState, entry.VerificationState, entry.Stage} {
+		if status == normalizeAWSRuntimeEventFilterToken(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func awsRemediationCenterSearchMatch(entry AWSRemediationCenterCase, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return true
+	}
+	values := []string{
+		entry.CaseID, entry.Title, entry.Summary, entry.SourceType, entry.ActionType,
+		entry.Lifecycle, entry.Stage, entry.Severity, entry.IdentityNodeID, entry.IdentityName,
+		entry.IdentityType, entry.Owner, entry.ApprovalState, entry.ApprovalID, entry.DryRunID,
+		entry.DryRunOutcome, entry.ExecutionID, entry.ExecutionState, entry.VerificationID,
+		entry.VerificationState, entry.RollbackState, entry.RollbackStrategy, entry.NextAction,
+	}
+	values = append(values, entry.TargetAccountIDs...)
+	values = append(values, entry.EvidenceRefs...)
+	for _, gate := range entry.SafetyGates {
+		values = append(values, gate.Name, gate.Status, gate.Rationale)
+	}
+	for _, tradeoff := range entry.Tradeoffs {
+		values = append(values, tradeoff.Dimension, tradeoff.Description)
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeAWSRemediationCenterCases(all, filtered []AWSRemediationCenterCase) AWSRemediationCenterSummary {
+	summary := AWSRemediationCenterSummary{
+		TotalCases:         len(all),
+		FilteredCases:      len(filtered),
+		StageCounts:        map[string]int{},
+		SeverityCounts:     map[string]int{},
+		StatusCounts:       map[string]int{},
+		ActionTypeCounts:   map[string]int{},
+		IdentityTypeCounts: map[string]int{},
+	}
+	confidenceTotal := 0.0
+	for _, entry := range filtered {
+		if entry.Stage != "" {
+			summary.StageCounts[entry.Stage]++
+		}
+		if entry.Severity != "" {
+			summary.SeverityCounts[entry.Severity]++
+		}
+		if entry.Lifecycle != "" {
+			summary.StatusCounts[entry.Lifecycle]++
+		}
+		if entry.ActionType != "" {
+			summary.ActionTypeCounts[entry.ActionType]++
+		}
+		if entry.IdentityType != "" {
+			summary.IdentityTypeCounts[entry.IdentityType]++
+		}
+		if entry.ApprovalID != "" && !strings.EqualFold(entry.ApprovalState, "approved") {
+			summary.ApprovalPendingCount++
+		}
+		if entry.DryRunID != "" {
+			summary.DryRunCount++
+		}
+		if entry.ExecutionID != "" {
+			summary.LiveActionCount++
+		}
+		if entry.VerificationID != "" {
+			summary.VerificationCount++
+		}
+		if entry.Stage == awsRemediationCenterStageRollback {
+			summary.RollbackCount++
+		}
+		if entry.ReadyForApply {
+			summary.ReadyForApplyCount++
+		}
+		if entry.KillSwitchEngaged {
+			summary.KillSwitchCount++
+		}
+		for _, gate := range entry.SafetyGates {
+			if gate.Status == "blocked" || gate.Status == "failed" {
+				summary.BlockedGateCount++
+			}
+		}
+		summary.AuditEntryCount += entry.AuditEntryCount
+		if entry.Score > summary.HighestScore {
+			summary.HighestScore = entry.Score
+		}
+		confidenceTotal += entry.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func awsRemediationCenterTabs(summary AWSRemediationCenterSummary, status string) []AWSRemediationCenterTab {
+	tabStatus := status
+	if tabStatus == "" {
+		tabStatus = "success"
+	}
+	return []AWSRemediationCenterTab{
+		{ID: "overview", Label: "Overview", Status: tabStatus, Count: summary.FilteredCases},
+		{ID: "cases", Label: "Cases", Status: tabStatus, Count: summary.FilteredCases},
+		{ID: "approvals", Label: "Approvals", Status: tabStatus, Count: summary.ApprovalPendingCount},
+		{ID: "dry_runs", Label: "Dry-runs", Status: tabStatus, Count: summary.DryRunCount},
+		{ID: "live_actions", Label: "Live actions", Status: tabStatus, Count: summary.LiveActionCount},
+		{ID: "verification", Label: "Verification", Status: tabStatus, Count: summary.VerificationCount},
+		{ID: "audit", Label: "Audit", Status: tabStatus, Count: summary.AuditEntryCount},
+	}
+}
+
+func summarizeAWSRemediationCenterStatus(fixtureState string, cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult, diagnostics []AWSRemediationCenterDiagnostic) (string, float64) {
+	if fixtureState == "permission_denied" {
+		return "permission_denied", 0.2
+	}
+	statuses := []string{cases.Status, approvals.Status, dryRuns.Status, liveActions.Status, verification.Status}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusBlocked, 0.35
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Retryable {
+			return awsPlatformDependencyStatusDegraded, 0.72
+		}
+	}
+	for _, status := range statuses {
+		if status == awsPlatformDependencyStatusDegraded {
+			return awsPlatformDependencyStatusDegraded, 0.74
+		}
+	}
+	if fixtureState == "degraded" || fixtureState == "partial_failure" {
+		return awsPlatformDependencyStatusDegraded, 0.74
+	}
+	if len(cases.Cases) == 0 {
+		return awsPlatformDependencyStatusReady, 0.82
+	}
+	return awsPlatformDependencyStatusReady, 0.9
+}
+
+func awsRemediationCenterFailureReasons(cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult) []string {
+	out := []string{}
+	out = append(out, cases.FailureReasons...)
+	out = append(out, approvals.FailureReasons...)
+	out = append(out, dryRuns.FailureReasons...)
+	out = append(out, liveActions.FailureReasons...)
+	out = append(out, verification.FailureReasons...)
+	return dedupeStrings(out)
+}
+
+func awsRemediationCenterRemediationHints(cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult) []string {
+	out := []string{}
+	out = append(out, cases.RemediationHints...)
+	out = append(out, approvals.RemediationHints...)
+	out = append(out, dryRuns.RemediationHints...)
+	out = append(out, liveActions.RemediationHints...)
+	out = append(out, verification.RemediationHints...)
+	return dedupeStrings(out)
+}
+
+func awsRemediationCenterDiagnostics(cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult) []AWSRemediationCenterDiagnostic {
+	out := []AWSRemediationCenterDiagnostic{}
+	for _, d := range cases.Diagnostics {
+		out = append(out, AWSRemediationCenterDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range approvals.Diagnostics {
+		out = append(out, AWSRemediationCenterDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range dryRuns.Diagnostics {
+		out = append(out, AWSRemediationCenterDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range liveActions.Diagnostics {
+		out = append(out, AWSRemediationCenterDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	for _, d := range verification.Diagnostics {
+		out = append(out, AWSRemediationCenterDiagnostic{Collector: d.Collector, SourceID: d.SourceID, Code: d.Code, Message: d.Message, Remediation: d.Remediation, Retryable: d.Retryable})
+	}
+	return awsMachineIdentityDedupeDiagnostics(out)
+}
+
+func awsRemediationCenterCoverageGaps(cases AWSRemediationCaseResult, verification AWSPostRemediationVerificationResult) []AWSRemediationCenterCoverageGap {
+	out := []AWSRemediationCenterCoverageGap{}
+	for _, gap := range cases.CoverageGaps {
+		out = append(out, AWSRemediationCenterCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	for _, gap := range verification.CoverageGaps {
+		out = append(out, AWSRemediationCenterCoverageGap{Capability: gap.Capability, Status: gap.Status, Reason: gap.Reason, Remediation: gap.Remediation})
+	}
+	return out
+}
+
+func awsRemediationCenterEvidenceLinks(scope db.Scope, project db.TenancyProject, cases AWSRemediationCaseResult, approvals AWSRemediationApprovalResult, dryRuns AWSRemediationDryRunResult, liveActions AWSLowRiskRemediationResult, verification AWSPostRemediationVerificationResult) []string {
+	links := []string{
+		awsIssueURL(awsPlatformDependencyParentIssue),
+		awsIssueURL(awsRemediationCenterCurrentIssue),
+		awsIssueURL(awsRemediationCaseCurrentIssue),
+		awsIssueURL(awsRemediationApprovalCurrentIssue),
+		awsIssueURL(awsRemediationDryRunCurrentIssue),
+		awsIssueURL(awsLowRiskRemediationCurrentIssue),
+		awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+		"/docs/aws-remediation-center",
+		awsBaselineProjectEvidenceURL(scope, project),
+	}
+	links = append(links, cases.EvidenceLinks...)
+	links = append(links, approvals.EvidenceLinks...)
+	links = append(links, dryRuns.EvidenceLinks...)
+	links = append(links, liveActions.EvidenceLinks...)
+	links = append(links, verification.EvidenceLinks...)
+	return dedupeStrings(links)
+}
+
+func awsRemediationCenterEvidenceBoundary() string {
+	return "metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped"
+}

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -310,7 +310,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 		PolicyVersion:      awsRemediationCenterPolicyID,
 		AppliedFilters:     applied,
 		Summary:            summary,
-		Tabs:               awsRemediationCenterTabs(summary, status),
+		Tabs:               awsRemediationCenterTabs(summary, status, len(approvals.Entries)),
 		Cases:              filtered,
 		RemediationCases:   cases,
 		ApprovalQueue:      approvals,
@@ -508,7 +508,7 @@ func awsRemediationCenterNoConnectorResult(scope db.Scope, project db.TenancyPro
 		PolicyVersion:      awsRemediationCenterPolicyID,
 		AppliedFilters:     applied,
 		Summary:            summary,
-		Tabs:               awsRemediationCenterTabs(summary, status),
+		Tabs:               awsRemediationCenterTabs(summary, status, 0),
 		Cases:              filtered,
 		RemediationCases:   cases,
 		ApprovalQueue:      approvals,
@@ -1171,7 +1171,7 @@ func awsRemediationCenterApprovalIsPending(state string) bool {
 	return false
 }
 
-func awsRemediationCenterTabs(summary AWSRemediationCenterSummary, status string) []AWSRemediationCenterTab {
+func awsRemediationCenterTabs(summary AWSRemediationCenterSummary, status string, approvalEntryCount int) []AWSRemediationCenterTab {
 	tabStatus := status
 	if tabStatus == "" {
 		tabStatus = "success"
@@ -1179,7 +1179,7 @@ func awsRemediationCenterTabs(summary AWSRemediationCenterSummary, status string
 	return []AWSRemediationCenterTab{
 		{ID: "overview", Label: "Overview", Status: tabStatus, Count: summary.FilteredCases},
 		{ID: "cases", Label: "Cases", Status: tabStatus, Count: summary.FilteredCases},
-		{ID: "approvals", Label: "Approvals", Status: tabStatus, Count: summary.ApprovalPendingCount},
+		{ID: "approvals", Label: "Approvals", Status: tabStatus, Count: approvalEntryCount},
 		{ID: "dry_runs", Label: "Dry-runs", Status: tabStatus, Count: summary.DryRunCount},
 		{ID: "live_actions", Label: "Live actions", Status: tabStatus, Count: summary.LiveActionCount},
 		{ID: "verification", Label: "Verification", Status: tabStatus, Count: summary.VerificationCount},

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -213,7 +213,10 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	}
 	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
 	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
-	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID), "aws-fixture")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	if !hasConnection && sourceFixtureState == "permission_denied" {
+		return awsRemediationCenterNoConnectorResult(scope, project, request, connectorID, accountID, region, sourceFixtureState, now), nil
+	}
 
 	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
 		ConnectorID:  connectorID,
@@ -328,10 +331,205 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	}, nil
 }
 
+func awsRemediationCenterNoConnectorResult(scope db.Scope, project db.TenancyProject, request AWSRemediationCenterRequest, connectorID, accountID, region, fixtureState string, now time.Time) AWSRemediationCenterResult {
+	status := "permission_denied"
+	confidence := 0.2
+	filtered, applied := filterAWSRemediationCenterCases(nil, request)
+	summary := summarizeAWSRemediationCenterCases(nil, filtered)
+	failureReasons := []string{"AWS access is unavailable because this project has no AWS connector."}
+	remediationHints := []string{"Connect an AWS connector before viewing remediation lifecycle evidence."}
+	cases := AWSRemediationCaseResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationCaseCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationCaseCurrentIssue),
+		Version:            awsRemediationCaseVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationCaseVersion,
+		AppliedFilters:     map[string]string{},
+		Summary:            summarizeAWSRemediationCases(nil, nil, nil),
+		Caveats:            awsRemediationCaseCaveats(),
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-remediation-case-model",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		GeneratedAt: now,
+		UpdatedAt:   now,
+	}
+	approvals := AWSRemediationApprovalResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationApprovalCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationApprovalCurrentIssue),
+		Version:            awsRemediationApprovalVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationApprovalVersion,
+		AppliedFilters:     map[string]string{},
+		Summary:            summarizeAWSRemediationApprovalEntries(nil, nil, nil),
+		Caveats:            awsRemediationApprovalCaveats(),
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationApprovalCurrentIssue),
+			awsIssueURL(awsRemediationCaseCurrentIssue),
+			"/docs/aws-remediation-approval-rbac",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		GeneratedAt: now,
+		UpdatedAt:   now,
+	}
+	dryRuns := AWSRemediationDryRunResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationDryRunCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationDryRunCurrentIssue),
+		Version:            awsRemediationDryRunVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsRemediationDryRunVersion,
+		AppliedFilters:     map[string]string{},
+		Summary:            summarizeAWSRemediationDryRunEntries(nil, nil, nil),
+		Caveats:            awsRemediationDryRunCaveats(),
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			awsIssueURL(awsRemediationApprovalCurrentIssue),
+			"/docs/aws-remediation-dry-run-executor",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		GeneratedAt: now,
+		UpdatedAt:   now,
+	}
+	liveActions := AWSLowRiskRemediationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsLowRiskRemediationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsLowRiskRemediationCurrentIssue),
+		Version:            awsLowRiskRemediationVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsLowRiskRemediationVersion,
+		AppliedFilters:     map[string]string{},
+		Allowlist:          awsLowRiskRemediationAllowlist(),
+		Summary:            summarizeAWSLowRiskRemediationEntries(nil, nil, nil),
+		Caveats:            awsLowRiskRemediationCaveats(),
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsLowRiskRemediationCurrentIssue),
+			awsIssueURL(awsRemediationDryRunCurrentIssue),
+			"/docs/aws-low-risk-live-remediation",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		GeneratedAt: now,
+		UpdatedAt:   now,
+	}
+	verification := AWSPostRemediationVerificationResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPostRemediationVerificationCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPostRemediationVerificationCurrentIssue),
+		Version:            awsPostRemediationVerificationVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPostRemediationVerificationVersion,
+		AppliedFilters:     map[string]string{},
+		Summary:            summarizeAWSPostRemediationVerificationEntries(nil, nil, nil),
+		Caveats:            awsPostRemediationVerificationCaveats(),
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+			awsIssueURL(awsLowRiskRemediationCurrentIssue),
+			"/docs/aws-post-remediation-verification",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		GeneratedAt: now,
+		UpdatedAt:   now,
+	}
+	return AWSRemediationCenterResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsRemediationCenterCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsRemediationCenterCurrentIssue),
+		Version:            awsRemediationCenterVersion,
+		Status:             status,
+		FixtureState:       fixtureState,
+		Confidence:         confidence,
+		PolicyVersion:      awsRemediationCenterPolicyID,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Tabs:               awsRemediationCenterTabs(summary, status),
+		Cases:              filtered,
+		RemediationCases:   cases,
+		ApprovalQueue:      approvals,
+		DryRuns:            dryRuns,
+		LiveActions:        liveActions,
+		Verification:       verification,
+		FailureReasons:     failureReasons,
+		RemediationHints:   remediationHints,
+		EvidenceLinks:      awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification),
+		GeneratedAt:        now,
+		UpdatedAt:          now,
+	}
+}
+
 func normalizeAWSRemediationCenterFixtureState(requested string, connection AWSConnectionStatus, hasConnection bool) string {
 	switch strings.ToLower(strings.TrimSpace(requested)) {
 	case "":
-		if hasConnection && !connection.Connected {
+		if !hasConnection || !connection.Connected {
 			return "permission_denied"
 		}
 		return "success"

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -268,6 +268,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	})
 	filtered, applied := filterAWSRemediationCenterCases(centerCases, request)
 	stageDeferred := awsRemediationCenterShouldDeferStageFilter(applied)
+	statusDeferred := awsRemediationCenterShouldDeferStatusFilter(applied)
 	diagnostics := awsRemediationCenterDiagnostics(cases, approvals, dryRuns, liveActions, verification)
 	coverageGaps := awsRemediationCenterCoverageGaps(cases, verification)
 	evidenceLinks := awsRemediationCenterEvidenceLinks(scope, project, cases, approvals, dryRuns, liveActions, verification)
@@ -293,7 +294,7 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
 	verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries, applied["status"], applied["stage"])
-	if stageDeferred {
+	if stageDeferred || statusDeferred {
 		scopedCaseIDs = awsRemediationCenterCaseIDSet(filtered)
 		approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
 		approvals.Relationships = awsRemediationCenterScopeEntries(approvals.Relationships, awsRemediationCenterStringSet(approvals.Entries, func(e AWSRemediationApprovalEntry) string { return e.ApprovalID }), func(r AWSRemediationApprovalRelationship) string { return r.ApprovalID })
@@ -866,11 +867,15 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 		}
 	}
 	statusCaseIDs := awsRemediationCenterVerificationStatusCaseIDSet(cases, normalizeAWSRuntimeEventFilterToken(status))
+	status = normalizeAWSRuntimeEventFilterToken(status)
 	stage = normalizeAWSRuntimeEventFilterToken(stage)
 	out := make([]AWSRemediationCenterCase, 0, len(cases))
 	for _, entry := range cases {
 		caseID := strings.TrimSpace(entry.CaseID)
 		if entry.VerificationID == "" {
+			if status != "" && !awsRemediationCenterStatusMatch(entry, status) {
+				continue
+			}
 			if stage != "" && stage != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
 				continue
 			}
@@ -900,6 +905,9 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 		entry.KillSwitchEngaged = entry.nonVerificationKillSwitchEngaged || scopedVerificationKillSwitch || (entry.KillSwitchEngaged && !entry.verificationKillSwitchEngaged)
 		entry.verificationKillSwitchEngaged = scopedVerificationKillSwitch
 		entry.AuditEntryCount = len(entry.AuditTrail)
+		if status != "" && !awsRemediationCenterStatusMatch(entry, status) {
+			continue
+		}
 		if stage != "" && stage != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
 			continue
 		}
@@ -1078,6 +1086,7 @@ func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, req
 	}
 	minConfidence, hasMinConfidence := awsRemediationCenterConfidenceFloor(filters["confidence"])
 	deferStageFilter := awsRemediationCenterShouldDeferStageFilter(filters)
+	deferStatusFilter := awsRemediationCenterShouldDeferStatusFilter(filters)
 	applied := map[string]string{}
 	for key, value := range filters {
 		applied[key] = value
@@ -1099,7 +1108,7 @@ func filterAWSRemediationCenterCases(centerCases []AWSRemediationCenterCase, req
 		if filters["action_type"] != "" && filters["action_type"] != normalizeAWSRuntimeEventFilterToken(entry.ActionType) && filters["action_type"] != normalizeAWSRuntimeEventFilterToken(entry.SourceType) {
 			continue
 		}
-		if filters["status"] != "" && !awsRemediationCenterStatusMatch(entry, filters["status"]) {
+		if filters["status"] != "" && !deferStatusFilter && !awsRemediationCenterStatusMatch(entry, filters["status"]) {
 			continue
 		}
 		if filters["stage"] != "" && !deferStageFilter && filters["stage"] != normalizeAWSRuntimeEventFilterToken(entry.Stage) {
@@ -1124,6 +1133,10 @@ func awsRemediationCenterShouldDeferStageFilter(filters map[string]string) bool 
 		return false
 	}
 	return filters["account_id"] != "" || awsRemediationCenterFilterTokenIsVerificationState(filters["status"])
+}
+
+func awsRemediationCenterShouldDeferStatusFilter(filters map[string]string) bool {
+	return filters["status"] != "" && filters["account_id"] != ""
 }
 
 func awsRemediationCenterFilterTokenIsVerificationState(status string) bool {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -69,45 +69,46 @@ type AWSRemediationCenterSafetyGate struct {
 // see where each fix is without reading every stage table. It is
 // metadata-only and never carries rendered policy bodies or secret values.
 type AWSRemediationCenterCase struct {
-	CaseID            string                           `json:"case_id"`
-	Title             string                           `json:"title"`
-	Summary           string                           `json:"summary"`
-	SourceType        string                           `json:"source_type"`
-	ActionType        string                           `json:"action_type"`
-	Lifecycle         string                           `json:"lifecycle"`
-	Stage             string                           `json:"stage"`
-	Severity          string                           `json:"severity"`
-	Score             int                              `json:"score"`
-	Confidence        float64                          `json:"confidence"`
-	AccountID         string                           `json:"account_id,omitempty"`
-	TargetAccountIDs  []string                         `json:"target_account_ids,omitempty"`
-	Region            string                           `json:"region,omitempty"`
-	IdentityNodeID    string                           `json:"identity_node_id,omitempty"`
-	IdentityName      string                           `json:"identity_name,omitempty"`
-	IdentityType      string                           `json:"identity_type,omitempty"`
-	Owner             string                           `json:"owner,omitempty"`
-	OwnerAssigned     bool                             `json:"owner_assigned"`
-	ApprovalRequired  bool                             `json:"approval_required"`
-	ApprovalState     string                           `json:"approval_state,omitempty"`
-	ApprovalID        string                           `json:"approval_id,omitempty"`
-	DryRunID          string                           `json:"dry_run_id,omitempty"`
-	DryRunOutcome     string                           `json:"dry_run_outcome,omitempty"`
-	ExecutionID       string                           `json:"execution_id,omitempty"`
-	ExecutionState    string                           `json:"execution_state,omitempty"`
-	VerificationID    string                           `json:"verification_id,omitempty"`
-	VerificationState string                           `json:"verification_state,omitempty"`
-	RollbackState     string                           `json:"rollback_state,omitempty"`
-	RollbackStrategy  string                           `json:"rollback_strategy,omitempty"`
-	ReadyForApply     bool                             `json:"ready_for_apply"`
-	KillSwitchEngaged bool                             `json:"kill_switch_engaged"`
-	Tradeoffs         []AWSRemediationTradeoff         `json:"tradeoffs"`
-	SafetyGates       []AWSRemediationCenterSafetyGate `json:"safety_gates"`
-	NextAction        string                           `json:"next_action"`
-	EvidenceRefs      []string                         `json:"evidence_refs,omitempty"`
-	EvidenceBoundary  string                           `json:"evidence_boundary"`
-	AuditTrail        []AWSRemediationCenterAuditEntry `json:"audit_trail"`
-	AuditEntryCount   int                              `json:"audit_entry_count"`
-	UpdatedAt         time.Time                        `json:"updated_at,omitzero"`
+	CaseID                 string                           `json:"case_id"`
+	Title                  string                           `json:"title"`
+	Summary                string                           `json:"summary"`
+	SourceType             string                           `json:"source_type"`
+	ActionType             string                           `json:"action_type"`
+	Lifecycle              string                           `json:"lifecycle"`
+	Stage                  string                           `json:"stage"`
+	Severity               string                           `json:"severity"`
+	Score                  int                              `json:"score"`
+	Confidence             float64                          `json:"confidence"`
+	AccountID              string                           `json:"account_id,omitempty"`
+	TargetAccountIDs       []string                         `json:"target_account_ids,omitempty"`
+	Region                 string                           `json:"region,omitempty"`
+	IdentityNodeID         string                           `json:"identity_node_id,omitempty"`
+	IdentityName           string                           `json:"identity_name,omitempty"`
+	IdentityType           string                           `json:"identity_type,omitempty"`
+	Owner                  string                           `json:"owner,omitempty"`
+	OwnerAssigned          bool                             `json:"owner_assigned"`
+	ApprovalRequired       bool                             `json:"approval_required"`
+	ApprovalState          string                           `json:"approval_state,omitempty"`
+	ApprovalID             string                           `json:"approval_id,omitempty"`
+	DryRunID               string                           `json:"dry_run_id,omitempty"`
+	DryRunOutcome          string                           `json:"dry_run_outcome,omitempty"`
+	ExecutionID            string                           `json:"execution_id,omitempty"`
+	ExecutionState         string                           `json:"execution_state,omitempty"`
+	VerificationID         string                           `json:"verification_id,omitempty"`
+	VerificationState      string                           `json:"verification_state,omitempty"`
+	VerificationEntryCount int                              `json:"verification_entry_count,omitempty"`
+	RollbackState          string                           `json:"rollback_state,omitempty"`
+	RollbackStrategy       string                           `json:"rollback_strategy,omitempty"`
+	ReadyForApply          bool                             `json:"ready_for_apply"`
+	KillSwitchEngaged      bool                             `json:"kill_switch_engaged"`
+	Tradeoffs              []AWSRemediationTradeoff         `json:"tradeoffs"`
+	SafetyGates            []AWSRemediationCenterSafetyGate `json:"safety_gates"`
+	NextAction             string                           `json:"next_action"`
+	EvidenceRefs           []string                         `json:"evidence_refs,omitempty"`
+	EvidenceBoundary       string                           `json:"evidence_boundary"`
+	AuditTrail             []AWSRemediationCenterAuditEntry `json:"audit_trail"`
+	AuditEntryCount        int                              `json:"audit_entry_count"`
+	UpdatedAt              time.Time                        `json:"updated_at,omitzero"`
 }
 
 // AWSRemediationCenterAuditEntry is one immutable audit record projected from a
@@ -567,18 +568,13 @@ func awsRemediationCenterCases(cases AWSRemediationCaseResult, approvals AWSReme
 			}
 		}
 	}
-	// Keep the most safety-critical verification per case so a failed or
-	// kill-switched verification on any target still drives the rollup.
-	verificationByCase := map[string]AWSPostRemediationVerificationEntry{}
+	verificationByCase := map[string][]AWSPostRemediationVerificationEntry{}
 	for _, entry := range verification.Entries {
 		key := strings.TrimSpace(entry.CaseID)
 		if key == "" {
 			continue
 		}
-		existing, ok := verificationByCase[key]
-		if !ok || awsRemediationCenterVerificationRank(entry) > awsRemediationCenterVerificationRank(existing) {
-			verificationByCase[key] = entry
-		}
+		verificationByCase[key] = append(verificationByCase[key], entry)
 	}
 
 	out := make([]AWSRemediationCenterCase, 0, len(cases.Cases))
@@ -586,10 +582,23 @@ func awsRemediationCenterCases(cases AWSRemediationCaseResult, approvals AWSReme
 		approval, hasApproval := approvalByCase[c.CaseID]
 		dryRun, hasDryRun := dryRunByCase[c.CaseID]
 		live, hasLive := liveByCase[c.CaseID]
-		verify, hasVerify := verificationByCase[c.CaseID]
-		out = append(out, awsRemediationCenterCaseFromLifecycle(c, approval, hasApproval, dryRun, hasDryRun, live, hasLive, verify, hasVerify))
+		verifications := verificationByCase[c.CaseID]
+		verify, hasVerify := awsRemediationCenterSelectedVerification(verifications)
+		out = append(out, awsRemediationCenterCaseFromLifecycleWithVerifications(c, approval, hasApproval, dryRun, hasDryRun, live, hasLive, verify, hasVerify, verifications))
 	}
 	return out
+}
+
+func awsRemediationCenterSelectedVerification(entries []AWSPostRemediationVerificationEntry) (AWSPostRemediationVerificationEntry, bool) {
+	var selected AWSPostRemediationVerificationEntry
+	hasSelected := false
+	for _, entry := range entries {
+		if !hasSelected || awsRemediationCenterVerificationRank(entry) > awsRemediationCenterVerificationRank(selected) {
+			selected = entry
+			hasSelected = true
+		}
+	}
+	return selected, hasSelected
 }
 
 func awsRemediationCenterVerificationRank(entry AWSPostRemediationVerificationEntry) int {
@@ -614,6 +623,10 @@ func awsRemediationCenterVerificationRank(entry AWSPostRemediationVerificationEn
 }
 
 func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRemediationApprovalEntry, hasApproval bool, dryRun AWSRemediationDryRunEntry, hasDryRun bool, live AWSLowRiskRemediationEntry, hasLive bool, verify AWSPostRemediationVerificationEntry, hasVerify bool) AWSRemediationCenterCase {
+	return awsRemediationCenterCaseFromLifecycleWithVerifications(c, approval, hasApproval, dryRun, hasDryRun, live, hasLive, verify, hasVerify, nil)
+}
+
+func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase, approval AWSRemediationApprovalEntry, hasApproval bool, dryRun AWSRemediationDryRunEntry, hasDryRun bool, live AWSLowRiskRemediationEntry, hasLive bool, verify AWSPostRemediationVerificationEntry, hasVerify bool, verifications []AWSPostRemediationVerificationEntry) AWSRemediationCenterCase {
 	stage := awsRemediationCenterStageCase
 	killSwitch := false
 	tradeoffs := append([]AWSRemediationTradeoff{}, c.Tradeoffs...)
@@ -687,15 +700,22 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		stage = awsRemediationCenterStageVerification
 		entry.VerificationID = verify.VerificationID
 		entry.VerificationState = verify.State
+		entry.VerificationEntryCount = len(verifications)
+		if entry.VerificationEntryCount == 0 {
+			entry.VerificationEntryCount = 1
+			verifications = []AWSPostRemediationVerificationEntry{verify}
+		}
 		entry.RollbackState = verify.Rollback.State
 		entry.RollbackStrategy = verify.Rollback.Strategy
-		killSwitch = killSwitch || verify.KillSwitchEngaged
-		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verify.AuditTrail, seenAuditEvents)...)
 		if verify.State == awsPostRemediationVerificationStateRollback || verify.State == awsPostRemediationVerificationStateFailed {
 			stage = awsRemediationCenterStageRollback
 		}
-		for _, precondition := range verify.Preconditions {
-			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "verification_precondition", Name: precondition.Name, Status: precondition.Status, Rationale: precondition.Rationale})
+		for _, verification := range verifications {
+			killSwitch = killSwitch || verification.KillSwitchEngaged
+			audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verification.AuditTrail, seenAuditEvents)...)
+			for _, precondition := range verification.Preconditions {
+				gates = append(gates, AWSRemediationCenterSafetyGate{Source: "verification_precondition", Name: precondition.Name, Status: precondition.Status, Rationale: precondition.Rationale})
+			}
 		}
 		entry.NextAction = verify.NextAction
 	}
@@ -1004,7 +1024,11 @@ func summarizeAWSRemediationCenterCases(all, filtered []AWSRemediationCenterCase
 			summary.LiveActionCount++
 		}
 		if entry.VerificationID != "" {
-			summary.VerificationCount++
+			verificationCount := entry.VerificationEntryCount
+			if verificationCount == 0 {
+				verificationCount = 1
+			}
+			summary.VerificationCount += verificationCount
 		}
 		if entry.Stage == awsRemediationCenterStageRollback {
 			summary.RollbackCount++

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -110,6 +110,9 @@ type AWSRemediationCenterCase struct {
 	AuditTrail             []AWSRemediationCenterAuditEntry `json:"audit_trail"`
 	AuditEntryCount        int                              `json:"audit_entry_count"`
 	UpdatedAt              time.Time                        `json:"updated_at,omitzero"`
+
+	nonVerificationKillSwitchEngaged bool
+	verificationKillSwitchEngaged    bool
 }
 
 // AWSRemediationCenterAuditEntry is one immutable audit record projected from a
@@ -625,6 +628,8 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase, approval AWSRemediationApprovalEntry, hasApproval bool, dryRun AWSRemediationDryRunEntry, hasDryRun bool, live AWSLowRiskRemediationEntry, hasLive bool, verify AWSPostRemediationVerificationEntry, hasVerify bool, verifications []AWSPostRemediationVerificationEntry) AWSRemediationCenterCase {
 	stage := awsRemediationCenterStageCase
 	killSwitch := false
+	nonVerificationKillSwitch := false
+	verificationKillSwitch := false
 	tradeoffs := append([]AWSRemediationTradeoff{}, c.Tradeoffs...)
 	gates := []AWSRemediationCenterSafetyGate{}
 	seenAuditEvents := map[string]struct{}{}
@@ -659,6 +664,7 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 		entry.ApprovalID = approval.ApprovalID
 		entry.ApprovalState = firstNonEmptyAWSValue(approval.State, entry.ApprovalState)
 		killSwitch = killSwitch || approval.KillSwitchEngaged
+		nonVerificationKillSwitch = nonVerificationKillSwitch || approval.KillSwitchEngaged
 		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageApproval, approval.AuditTrail, seenAuditEvents)...)
 		tradeoffs = append(tradeoffs, approval.Tradeoffs...)
 		for _, gate := range approval.RBACGates {
@@ -673,6 +679,7 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 		entry.DryRunID = dryRun.DryRunID
 		entry.DryRunOutcome = dryRun.Outcome
 		killSwitch = killSwitch || dryRun.KillSwitchEngaged
+		nonVerificationKillSwitch = nonVerificationKillSwitch || dryRun.KillSwitchEngaged
 		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageDryRun, dryRun.AuditTrail, seenAuditEvents)...)
 		for _, prereq := range dryRun.SatisfiedPrereqs {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "dry_run_prerequisite", Name: prereq.Name, Status: firstNonEmptyAWSValue(prereq.Status, "passed"), Rationale: prereq.Rationale})
@@ -687,6 +694,7 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 		entry.ExecutionID = live.ExecutionID
 		entry.ExecutionState = live.State
 		killSwitch = killSwitch || live.KillSwitchEngaged
+		nonVerificationKillSwitch = nonVerificationKillSwitch || live.KillSwitchEngaged
 		audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageLiveAction, live.AuditTrail, seenAuditEvents)...)
 		for _, preflight := range live.Preflights {
 			gates = append(gates, AWSRemediationCenterSafetyGate{Source: "live_action_preflight", Name: preflight.Name, Status: preflight.Status, Rationale: preflight.Rationale})
@@ -709,6 +717,7 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 		}
 		for _, verification := range verifications {
 			killSwitch = killSwitch || verification.KillSwitchEngaged
+			verificationKillSwitch = verificationKillSwitch || verification.KillSwitchEngaged
 			audit = append(audit, awsRemediationCenterAuditEntries(c.CaseID, awsRemediationCenterStageVerification, verification.AuditTrail, seenAuditEvents)...)
 			for _, precondition := range verification.Preconditions {
 				gates = append(gates, AWSRemediationCenterSafetyGate{Source: "verification_precondition", Name: precondition.Name, Status: precondition.Status, Rationale: precondition.Rationale})
@@ -721,6 +730,8 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 	}
 	entry.Stage = stage
 	entry.KillSwitchEngaged = killSwitch
+	entry.nonVerificationKillSwitchEngaged = nonVerificationKillSwitch
+	entry.verificationKillSwitchEngaged = verificationKillSwitch
 	entry.Tradeoffs = awsRemediationCenterDedupeTradeoffs(tradeoffs)
 	entry.SafetyGates = gates
 	entry.EvidenceRefs = evidenceRefs
@@ -864,10 +875,44 @@ func awsRemediationCenterCasesWithScopedVerificationRows(cases []AWSRemediationC
 			entry.NextAction = selected.NextAction
 		}
 		entry.AuditTrail = awsRemediationCenterAuditTrailWithScopedVerificationEvents(entry.AuditTrail, verificationAuditEvents[caseID])
+		entry.SafetyGates = awsRemediationCenterSafetyGatesWithScopedVerificationRows(entry.SafetyGates, scopedRows)
+		scopedVerificationKillSwitch := awsRemediationCenterVerificationKillSwitch(scopedRows)
+		entry.KillSwitchEngaged = entry.nonVerificationKillSwitchEngaged || scopedVerificationKillSwitch || (entry.KillSwitchEngaged && !entry.verificationKillSwitchEngaged)
+		entry.verificationKillSwitchEngaged = scopedVerificationKillSwitch
 		entry.AuditEntryCount = len(entry.AuditTrail)
 		out = append(out, entry)
 	}
 	return out
+}
+
+func awsRemediationCenterSafetyGatesWithScopedVerificationRows(gates []AWSRemediationCenterSafetyGate, rows []AWSPostRemediationVerificationEntry) []AWSRemediationCenterSafetyGate {
+	out := make([]AWSRemediationCenterSafetyGate, 0, len(gates))
+	for _, gate := range gates {
+		if gate.Source == "verification_precondition" {
+			continue
+		}
+		out = append(out, gate)
+	}
+	for _, row := range rows {
+		for _, precondition := range row.Preconditions {
+			out = append(out, AWSRemediationCenterSafetyGate{
+				Source:    "verification_precondition",
+				Name:      precondition.Name,
+				Status:    precondition.Status,
+				Rationale: precondition.Rationale,
+			})
+		}
+	}
+	return out
+}
+
+func awsRemediationCenterVerificationKillSwitch(rows []AWSPostRemediationVerificationEntry) bool {
+	for _, row := range rows {
+		if row.KillSwitchEngaged {
+			return true
+		}
+	}
+	return false
 }
 
 func awsRemediationCenterAuditTrailWithScopedVerificationEvents(entries []AWSRemediationCenterAuditEntry, verificationEvents map[string]struct{}) []AWSRemediationCenterAuditEntry {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -488,7 +488,6 @@ func awsRemediationCenterCaseFromLifecycle(c AWSRemediationCase, approval AWSRem
 		stage = awsRemediationCenterStageVerification
 		entry.VerificationID = verify.VerificationID
 		entry.VerificationState = verify.State
-		entry.ExecutionID = firstNonEmptyAWSValue(entry.ExecutionID, verify.SourceExecutionID)
 		entry.RollbackState = verify.Rollback.State
 		entry.RollbackStrategy = verify.Rollback.Strategy
 		killSwitch = killSwitch || verify.KillSwitchEngaged
@@ -789,7 +788,7 @@ func summarizeAWSRemediationCenterCases(all, filtered []AWSRemediationCenterCase
 		if entry.IdentityType != "" {
 			summary.IdentityTypeCounts[entry.IdentityType]++
 		}
-		if entry.ApprovalID != "" && !strings.EqualFold(entry.ApprovalState, "approved") {
+		if entry.ApprovalID != "" && awsRemediationCenterApprovalIsPending(entry.ApprovalState) {
 			summary.ApprovalPendingCount++
 		}
 		if entry.DryRunID != "" {
@@ -825,6 +824,16 @@ func summarizeAWSRemediationCenterCases(all, filtered []AWSRemediationCenterCase
 		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
 	}
 	return summary
+}
+
+func awsRemediationCenterApprovalIsPending(state string) bool {
+	switch normalizeAWSRuntimeEventFilterToken(state) {
+	case normalizeAWSRuntimeEventFilterToken(awsRemediationApprovalStateRequested),
+		normalizeAWSRuntimeEventFilterToken(awsRemediationApprovalStateReview),
+		"pending", "pending-approver", "in-review", "review":
+		return true
+	}
+	return false
 }
 
 func awsRemediationCenterTabs(summary AWSRemediationCenterSummary, status string) []AWSRemediationCenterTab {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -1018,7 +1018,7 @@ func awsRemediationCenterFlagStatus(enabled bool) string {
 	if enabled {
 		return "enabled"
 	}
-	return "disabled"
+	return "blocked"
 }
 
 func awsRemediationCenterStageNextAction(stage string) string {

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -97,6 +97,7 @@ type AWSRemediationCenterCase struct {
 	VerificationID         string                           `json:"verification_id,omitempty"`
 	VerificationState      string                           `json:"verification_state,omitempty"`
 	VerificationEntryCount int                              `json:"verification_entry_count,omitempty"`
+	VerificationStates     []string                         `json:"verification_states,omitempty"`
 	RollbackState          string                           `json:"rollback_state,omitempty"`
 	RollbackStrategy       string                           `json:"rollback_strategy,omitempty"`
 	ReadyForApply          bool                             `json:"ready_for_apply"`
@@ -690,6 +691,7 @@ func awsRemediationCenterCaseFromLifecycleWithVerifications(c AWSRemediationCase
 			entry.VerificationEntryCount = 1
 			verifications = []AWSPostRemediationVerificationEntry{verify}
 		}
+		entry.VerificationStates = awsRemediationCenterVerificationStates(verifications)
 		entry.RollbackState = verify.Rollback.State
 		entry.RollbackStrategy = verify.Rollback.Strategy
 		if verify.State == awsPostRemediationVerificationStateRollback || verify.State == awsPostRemediationVerificationStateFailed {
@@ -777,6 +779,16 @@ func awsRemediationCenterAuditEntries(caseID, stage string, trail []AWSRemediati
 		})
 	}
 	return out
+}
+
+func awsRemediationCenterVerificationStates(entries []AWSPostRemediationVerificationEntry) []string {
+	states := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if state := strings.TrimSpace(entry.State); state != "" {
+			states = append(states, state)
+		}
+	}
+	return dedupeStrings(states)
 }
 
 func awsRemediationCenterActionType(c AWSRemediationCase) string {
@@ -937,6 +949,11 @@ func awsRemediationCenterAccountMatch(entry AWSRemediationCenterCase, accountID 
 // state so operators can filter by any lifecycle status token.
 func awsRemediationCenterStatusMatch(entry AWSRemediationCenterCase, status string) bool {
 	for _, value := range []string{entry.Lifecycle, entry.ApprovalState, entry.ExecutionState, entry.VerificationState, entry.Stage} {
+		if status == normalizeAWSRuntimeEventFilterToken(value) {
+			return true
+		}
+	}
+	for _, value := range entry.VerificationStates {
 		if status == normalizeAWSRuntimeEventFilterToken(value) {
 			return true
 		}

--- a/internal/api/aws_remediation_center.go
+++ b/internal/api/aws_remediation_center.go
@@ -275,10 +275,19 @@ func (s *Service) GetAWSRemediationCenter(ctx context.Context, workspaceID strin
 	// Diagnostics, status, and evidence links stay on the full source results
 	// because they report collector health across the whole connector scope.
 	scopedCaseIDs := awsRemediationCenterCaseIDSet(filtered)
+	allApprovalEntries, allDryRunEntries, allLiveActionEntries, allVerificationEntries := approvals.Entries, dryRuns.Entries, liveActions.Entries, verification.Entries
 	approvals.Entries = awsRemediationCenterScopeEntries(approvals.Entries, scopedCaseIDs, func(e AWSRemediationApprovalEntry) string { return e.CaseID })
+	approvals.Relationships = awsRemediationCenterScopeEntries(approvals.Relationships, awsRemediationCenterStringSet(approvals.Entries, func(e AWSRemediationApprovalEntry) string { return e.ApprovalID }), func(r AWSRemediationApprovalRelationship) string { return r.ApprovalID })
+	approvals.Summary = summarizeAWSRemediationApprovalEntries(allApprovalEntries, approvals.Entries, approvals.Relationships)
 	dryRuns.Entries = awsRemediationCenterScopeEntries(dryRuns.Entries, scopedCaseIDs, func(e AWSRemediationDryRunEntry) string { return e.CaseID })
+	dryRuns.Relationships = awsRemediationCenterScopeEntries(dryRuns.Relationships, awsRemediationCenterStringSet(dryRuns.Entries, func(e AWSRemediationDryRunEntry) string { return e.DryRunID }), func(r AWSRemediationDryRunRelationship) string { return r.DryRunID })
+	dryRuns.Summary = summarizeAWSRemediationDryRunEntries(allDryRunEntries, dryRuns.Entries, dryRuns.Relationships)
 	liveActions.Entries = awsRemediationCenterScopeEntries(liveActions.Entries, scopedCaseIDs, func(e AWSLowRiskRemediationEntry) string { return e.CaseID })
+	liveActions.Relationships = awsRemediationCenterScopeEntries(liveActions.Relationships, awsRemediationCenterStringSet(liveActions.Entries, func(e AWSLowRiskRemediationEntry) string { return e.ExecutionID }), func(r AWSLowRiskRemediationRelationship) string { return r.ExecutionID })
+	liveActions.Summary = summarizeAWSLowRiskRemediationEntries(allLiveActionEntries, liveActions.Entries, liveActions.Relationships)
 	verification.Entries = awsRemediationCenterScopeVerificationEntries(verification.Entries, scopedCaseIDs, filtered, request.Status)
+	verification.Relationships = awsRemediationCenterScopeEntries(verification.Relationships, awsRemediationCenterStringSet(verification.Entries, func(e AWSPostRemediationVerificationEntry) string { return e.VerificationID }), func(r AWSPostRemediationVerificationRelationship) string { return r.VerificationID })
+	verification.Summary = summarizeAWSPostRemediationVerificationEntries(allVerificationEntries, verification.Entries, verification.Relationships)
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, verification.Entries)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
@@ -727,6 +736,16 @@ func awsRemediationCenterCaseIDSet(cases []AWSRemediationCenterCase) map[string]
 	for _, c := range cases {
 		if key := strings.TrimSpace(c.CaseID); key != "" {
 			set[key] = struct{}{}
+		}
+	}
+	return set
+}
+
+func awsRemediationCenterStringSet[T any](items []T, key func(T) string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if value := strings.TrimSpace(key(item)); value != "" {
+			set[value] = struct{}{}
 		}
 	}
 	return set

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -411,12 +411,18 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 			VerificationEntryCount: 2,
 			VerificationStates:     []string{awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateVerified},
 			ApprovalState:          awsRemediationApprovalStateApproved,
+			KillSwitchEngaged:      true,
+			SafetyGates: []AWSRemediationCenterSafetyGate{
+				{Source: "verification_precondition", Name: "failed-target-ready", Status: "blocked"},
+				{Source: "verification_precondition", Name: "verified-target-ready", Status: "passed"},
+			},
 			AuditTrail: []AWSRemediationCenterAuditEntry{
 				{CaseID: "case-mixed", Stage: awsRemediationCenterStageCase, EventID: "case-mixed-created"},
 				{CaseID: "case-mixed", Stage: awsRemediationCenterStageVerification, EventID: "case-mixed-failed"},
 				{CaseID: "case-mixed", Stage: awsRemediationCenterStageVerification, EventID: "case-mixed-verified"},
 			},
-			AuditEntryCount: 3,
+			AuditEntryCount:               3,
+			verificationKillSwitchEngaged: true,
 		},
 		{
 			CaseID:                 "case-verified",
@@ -433,8 +439,24 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 		},
 	}
 	verificationRows := []AWSPostRemediationVerificationEntry{
-		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed, AccountID: "111111111111", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-failed"}}},
-		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified, AccountID: "222222222222", TargetAccountIDs: []string{"222222222222"}, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-verified"}}},
+		{
+			CaseID:            "case-mixed",
+			VerificationID:    "verify-failed",
+			State:             awsPostRemediationVerificationStateFailed,
+			AccountID:         "111111111111",
+			KillSwitchEngaged: true,
+			Preconditions:     []AWSPostRemediationVerificationGate{{Name: "failed-target-ready", Status: "blocked"}},
+			AuditTrail:        []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-failed"}},
+		},
+		{
+			CaseID:           "case-mixed",
+			VerificationID:   "verify-verified",
+			State:            awsPostRemediationVerificationStateVerified,
+			AccountID:        "222222222222",
+			TargetAccountIDs: []string{"222222222222"},
+			Preconditions:    []AWSPostRemediationVerificationGate{{Name: "verified-target-ready", Status: "passed"}},
+			AuditTrail:       []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-verified"}},
+		},
 		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified, AccountID: "333333333333", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-verified-verified"}}},
 		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified, AccountID: "222222222222", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-unfiltered-verified"}}},
 	}
@@ -521,6 +543,15 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	if accountSummary.VerificationCount != len(accountRows) {
 		t.Fatalf("account-scoped verification_count must match rendered rows: count=%d rows=%d", accountSummary.VerificationCount, len(accountRows))
 	}
+	if accountCases[0].KillSwitchEngaged || accountSummary.KillSwitchCount != 0 {
+		t.Fatalf("account-scoped rollup must drop kill switches from filtered-out verification rows: case=%+v summary=%+v", accountCases[0], accountSummary)
+	}
+	if got, want := len(accountCases[0].SafetyGates), 1; got != want || accountCases[0].SafetyGates[0].Name != "verified-target-ready" {
+		t.Fatalf("account-scoped safety gates must be rebuilt from rendered verification rows: %+v", accountCases[0].SafetyGates)
+	}
+	if accountSummary.BlockedGateCount != 0 {
+		t.Fatalf("account-scoped blocked gate count must ignore filtered-out verification rows: %+v", accountSummary)
+	}
 	for _, audit := range accountAudit {
 		if audit.EventID == "case-mixed-failed" || audit.EventID == "case-unfiltered-verified" {
 			t.Errorf("audit event %s leaked outside account-scoped verification rows", audit.EventID)
@@ -553,6 +584,24 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if len(mismatchedStatusAudit) != 0 || mismatchedStatusSummary.AuditEntryCount != 0 {
 		t.Fatalf("account+status audit must stay empty when no scoped verification row matched: summary=%+v audit=%+v", mismatchedStatusSummary, mismatchedStatusAudit)
+	}
+
+	matchedStatusCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsPostRemediationVerificationStateVerified})
+	matchedStatusRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(matchedStatusCases), matchedStatusCases, applied["status"], applied["account_id"])
+	matchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(matchedStatusCases, matchedStatusRows, applied["status"])
+	matchedStatusSummary := summarizeAWSRemediationCenterCases(centerCases, matchedStatusCases)
+
+	if len(matchedStatusCases) != 1 || matchedStatusCases[0].CaseID != "case-mixed" {
+		t.Fatalf("account+verification status filter should keep the matching row's case, got %+v", matchedStatusCases)
+	}
+	if matchedStatusCases[0].KillSwitchEngaged || matchedStatusSummary.KillSwitchCount != 0 {
+		t.Fatalf("account+verification status rollup must drop sibling-row kill switches: case=%+v summary=%+v", matchedStatusCases[0], matchedStatusSummary)
+	}
+	if got, want := len(matchedStatusCases[0].SafetyGates), 1; got != want || matchedStatusCases[0].SafetyGates[0].Name != "verified-target-ready" {
+		t.Fatalf("account+verification status safety gates must come from scoped rows only: %+v", matchedStatusCases[0].SafetyGates)
+	}
+	if matchedStatusSummary.BlockedGateCount != 0 {
+		t.Fatalf("account+verification status blocked gates must not count filtered sibling rows: %+v", matchedStatusSummary)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -441,7 +441,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
 	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), filtered, awsPostRemediationVerificationStateVerified, "")
-	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows)
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows, awsPostRemediationVerificationStateVerified)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
@@ -482,7 +482,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	approvedCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsRemediationApprovalStateApproved})
 	approvedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(approvedCases), approvedCases, awsRemediationApprovalStateApproved, "")
-	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows)
+	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows, awsRemediationApprovalStateApproved)
 	approvedSummary := summarizeAWSRemediationCenterCases(centerCases, approvedCases)
 	approvedAudit := awsRemediationCenterAuditTrail(approvedCases)
 
@@ -505,7 +505,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	accountCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222"})
 	accountRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(accountCases), accountCases, "", "222222222222")
-	accountCases = awsRemediationCenterCasesWithScopedVerificationRows(accountCases, accountRows)
+	accountCases = awsRemediationCenterCasesWithScopedVerificationRows(accountCases, accountRows, "")
 	accountSummary := summarizeAWSRemediationCenterCases(centerCases, accountCases)
 	accountAudit := awsRemediationCenterAuditTrail(accountCases)
 
@@ -514,6 +514,9 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if len(accountRows) != 1 || accountRows[0].VerificationID != "verify-verified" {
 		t.Fatalf("account-scoped verification rows should keep only matching target rows, got %+v", accountRows)
+	}
+	if accountCases[0].VerificationID != "verify-verified" || accountCases[0].VerificationState != awsPostRemediationVerificationStateVerified {
+		t.Fatalf("account-scoped case rollup must use the remaining verification row, got %+v", accountCases[0])
 	}
 	if accountSummary.VerificationCount != len(accountRows) {
 		t.Fatalf("account-scoped verification_count must match rendered rows: count=%d rows=%d", accountSummary.VerificationCount, len(accountRows))
@@ -525,6 +528,31 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if got, want := accountSummary.AuditEntryCount, len(accountAudit); got != want {
 		t.Fatalf("account-scoped audit_entry_count must match audit rows: got=%d want=%d trail=%+v", got, want, accountAudit)
+	}
+
+	allAccountCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "all"})
+	allAccountRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(allAccountCases), allAccountCases, "", applied["account_id"])
+	if _, ok := applied["account_id"]; ok {
+		t.Fatalf("account_id=all must be treated as an unset account filter, applied=%+v", applied)
+	}
+	if len(allAccountRows) != 3 {
+		t.Fatalf("account_id=all must not row-filter verification entries, got %+v", allAccountRows)
+	}
+
+	mismatchedStatusCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsPostRemediationVerificationStateFailed})
+	mismatchedStatusRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(mismatchedStatusCases), mismatchedStatusCases, applied["status"], applied["account_id"])
+	mismatchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(mismatchedStatusCases, mismatchedStatusRows, applied["status"])
+	mismatchedStatusSummary := summarizeAWSRemediationCenterCases(centerCases, mismatchedStatusCases)
+	mismatchedStatusAudit := awsRemediationCenterAuditTrail(mismatchedStatusCases)
+
+	if len(mismatchedStatusRows) != 0 {
+		t.Fatalf("account+status filter must not keep verification rows from a different account, got %+v", mismatchedStatusRows)
+	}
+	if len(mismatchedStatusCases) != 0 || mismatchedStatusSummary.VerificationCount != 0 || mismatchedStatusSummary.FilteredCases != 0 {
+		t.Fatalf("case set must drop verification-status matches that do not survive account row scoping: cases=%+v summary=%+v", mismatchedStatusCases, mismatchedStatusSummary)
+	}
+	if len(mismatchedStatusAudit) != 0 || mismatchedStatusSummary.AuditEntryCount != 0 {
+		t.Fatalf("account+status audit must stay empty when no scoped verification row matched: summary=%+v audit=%+v", mismatchedStatusSummary, mismatchedStatusAudit)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -375,6 +375,63 @@ func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
+	centerCases := []AWSRemediationCenterCase{
+		{
+			CaseID:                 "case-mixed",
+			VerificationID:         "verify-failed",
+			VerificationState:      awsPostRemediationVerificationStateFailed,
+			VerificationEntryCount: 2,
+			VerificationStates:     []string{awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateVerified},
+		},
+		{
+			CaseID:                 "case-verified",
+			VerificationID:         "verify-verified",
+			VerificationState:      awsPostRemediationVerificationStateVerified,
+			VerificationEntryCount: 1,
+			VerificationStates:     []string{awsPostRemediationVerificationStateVerified},
+		},
+	}
+	verificationRows := []AWSPostRemediationVerificationEntry{
+		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed},
+		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified},
+		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified},
+		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified},
+	}
+
+	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
+	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), awsPostRemediationVerificationStateVerified)
+	filtered = awsRemediationCenterCasesWithVerificationEntryCounts(filtered, scopedRows)
+	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
+
+	if len(filtered) != 2 {
+		t.Fatalf("case-level status filter should keep both verified cases, got %+v", filtered)
+	}
+	if len(scopedRows) != 2 {
+		t.Fatalf("status-scoped verification rows should keep only matching rows from filtered cases, got %+v", scopedRows)
+	}
+	for _, row := range scopedRows {
+		if row.State != awsPostRemediationVerificationStateVerified {
+			t.Errorf("verification row %s leaked state %s", row.VerificationID, row.State)
+		}
+		if row.CaseID == "case-unfiltered" {
+			t.Errorf("verification row %s leaked outside filtered case set", row.VerificationID)
+		}
+	}
+	countsByCase := map[string]int{}
+	for _, row := range scopedRows {
+		countsByCase[row.CaseID]++
+	}
+	for _, entry := range filtered {
+		if entry.VerificationEntryCount != countsByCase[entry.CaseID] {
+			t.Errorf("case %s verification_entry_count=%d want rendered rows=%d", entry.CaseID, entry.VerificationEntryCount, countsByCase[entry.CaseID])
+		}
+	}
+	if summary.VerificationCount != len(scopedRows) {
+		t.Fatalf("verification_count must match rendered status-scoped rows: count=%d rows=%d", summary.VerificationCount, len(scopedRows))
+	}
+}
+
 func TestGetAWSRemediationCenterPreservesUnfilteredTotals(t *testing.T) {
 	now := time.Date(2026, 7, 4, 10, 40, 0, 0, time.UTC)
 	svc, ws := newRemediationCenterService(t, "project-remediation-center-unfiltered-totals", now)

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -621,6 +621,22 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	if len(stageRollbackCases) != 0 {
 		t.Fatalf("stage=rollback must not keep a case rewritten to verification after account scoping, got %+v", stageRollbackCases)
 	}
+
+	statusVerificationCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsRemediationCenterStageVerification})
+	statusVerificationRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(statusVerificationCases), statusVerificationCases, applied["status"], applied["account_id"])
+	statusVerificationCases = awsRemediationCenterCasesWithScopedVerificationRows(statusVerificationCases, statusVerificationRows, applied["status"], applied["stage"])
+
+	if len(statusVerificationCases) != 1 || statusVerificationCases[0].CaseID != "case-mixed" || statusVerificationCases[0].Stage != awsRemediationCenterStageVerification {
+		t.Fatalf("status=verification must be applied after account-scoped verification row rewrite, got %+v", statusVerificationCases)
+	}
+
+	statusRollbackCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsRemediationCenterStageRollback})
+	statusRollbackRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(statusRollbackCases), statusRollbackCases, applied["status"], applied["account_id"])
+	statusRollbackCases = awsRemediationCenterCasesWithScopedVerificationRows(statusRollbackCases, statusRollbackRows, applied["status"], applied["stage"])
+
+	if len(statusRollbackCases) != 0 {
+		t.Fatalf("status=rollback must not keep a case rewritten to verification after account scoping, got %+v", statusRollbackCases)
+	}
 }
 
 func TestGetAWSRemediationCenterPreservesUnfilteredTotals(t *testing.T) {

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -193,6 +193,60 @@ func TestAWSRemediationCenterSummaryCountsOnlyActionablePendingApprovals(t *test
 	}
 }
 
+func TestAWSRemediationCenterAuditTrailDeduplicatesInheritedEvents(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 50, 0, 0, time.UTC)
+	caseAudit := AWSRemediationAuditEntry{EventID: "case-created", EventType: "case_projected", Actor: "case-engine", OccurredAt: now}
+	approvalAudit := AWSRemediationAuditEntry{EventID: "approval-requested", EventType: "approval_requested", Actor: "approval-engine", OccurredAt: now}
+	dryRunAudit := AWSRemediationAuditEntry{EventID: "dry-run-simulated", EventType: "dry_run_simulated", Actor: "dry-run-engine", OccurredAt: now}
+	liveAudit := AWSRemediationAuditEntry{EventID: "live-projected", EventType: "low_risk_execution_projected", Actor: "live-engine", OccurredAt: now}
+	verifyAudit := AWSRemediationAuditEntry{EventID: "verification-projected", EventType: "post_remediation_verification_projected", Actor: "verification-engine", OccurredAt: now}
+
+	entry := awsRemediationCenterCaseFromLifecycle(
+		AWSRemediationCase{CaseID: "case-audit", Title: "Audit lifecycle", AuditTrail: []AWSRemediationAuditEntry{caseAudit}},
+		AWSRemediationApprovalEntry{
+			ApprovalID: "approval-audit",
+			State:      awsRemediationApprovalStateApproved,
+			AuditTrail: []AWSRemediationApprovalAuditEntry{caseAudit, approvalAudit},
+		}, true,
+		AWSRemediationDryRunEntry{
+			DryRunID:   "dry-run-audit",
+			Outcome:    "would_succeed",
+			AuditTrail: []AWSRemediationApprovalAuditEntry{caseAudit, approvalAudit, dryRunAudit},
+		}, true,
+		AWSLowRiskRemediationEntry{
+			ExecutionID: "exec-audit",
+			State:       "projected",
+			AuditTrail:  []AWSLowRiskRemediationAuditEntry{caseAudit, approvalAudit, dryRunAudit, liveAudit},
+		}, true,
+		AWSPostRemediationVerificationEntry{
+			VerificationID: "verify-audit",
+			State:          awsPostRemediationVerificationStateVerified,
+			AuditTrail:     []AWSPostRemediationVerificationAuditEntry{caseAudit, approvalAudit, dryRunAudit, liveAudit, verifyAudit},
+		}, true,
+	)
+
+	wantStages := map[string]string{
+		"case-created":           awsRemediationCenterStageCase,
+		"approval-requested":     awsRemediationCenterStageApproval,
+		"dry-run-simulated":      awsRemediationCenterStageDryRun,
+		"live-projected":         awsRemediationCenterStageLiveAction,
+		"verification-projected": awsRemediationCenterStageVerification,
+	}
+	if len(entry.AuditTrail) != len(wantStages) || entry.AuditEntryCount != len(wantStages) {
+		t.Fatalf("audit trail must keep only unique lifecycle events: count=%d trail=%+v", entry.AuditEntryCount, entry.AuditTrail)
+	}
+	seen := map[string]struct{}{}
+	for _, audit := range entry.AuditTrail {
+		if _, ok := seen[audit.EventID]; ok {
+			t.Fatalf("audit event %s was duplicated: %+v", audit.EventID, entry.AuditTrail)
+		}
+		seen[audit.EventID] = struct{}{}
+		if wantStages[audit.EventID] != audit.Stage {
+			t.Fatalf("audit event %s stage=%s want=%s trail=%+v", audit.EventID, audit.Stage, wantStages[audit.EventID], entry.AuditTrail)
+		}
+	}
+}
+
 func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	now := time.Date(2026, 7, 4, 10, 30, 0, 0, time.UTC)
 	svc, ws := newRemediationCenterService(t, "project-remediation-center-scope", now)

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -211,6 +211,45 @@ func TestAWSRemediationCenterSummaryCountsOnlyActionablePendingApprovals(t *test
 	}
 }
 
+func TestAWSRemediationCenterCountsDisabledApprovalFeatureFlagsAsBlocked(t *testing.T) {
+	entry := awsRemediationCenterCaseFromLifecycle(
+		AWSRemediationCase{
+			CaseID:        "case-feature-flag",
+			Title:         "Feature flag gate",
+			SourceType:    "permission_boundary_diff",
+			Lifecycle:     "approved",
+			ApprovalState: awsRemediationApprovalStateApproved,
+		},
+		AWSRemediationApprovalEntry{
+			ApprovalID: "approval-feature-flag",
+			State:      awsRemediationApprovalStateApproved,
+			FeatureFlags: []AWSRemediationApprovalFeatureFlag{
+				{Name: "live_aws_mutation", Enabled: false, Scope: "tenant", Rationale: "Live mutation is disabled."},
+			},
+		}, true,
+		AWSRemediationDryRunEntry{}, false,
+		AWSLowRiskRemediationEntry{}, false,
+		AWSPostRemediationVerificationEntry{}, false,
+	)
+
+	foundFlagGate := false
+	for _, gate := range entry.SafetyGates {
+		if gate.Source == "approval_feature_flag" && gate.Name == "live_aws_mutation" {
+			foundFlagGate = true
+			if gate.Status != "blocked" {
+				t.Fatalf("disabled approval feature flag must become a blocked safety gate, got %+v", gate)
+			}
+		}
+	}
+	if !foundFlagGate {
+		t.Fatalf("case rollup must include approval feature flag gate: %+v", entry.SafetyGates)
+	}
+	summary := summarizeAWSRemediationCenterCases([]AWSRemediationCenterCase{entry}, []AWSRemediationCenterCase{entry})
+	if summary.BlockedGateCount != 1 {
+		t.Fatalf("summary must count disabled approval feature flags as blocked gates: %+v", summary)
+	}
+}
+
 func TestAWSRemediationCenterAuditTrailDeduplicatesInheritedEvents(t *testing.T) {
 	now := time.Date(2026, 7, 4, 10, 50, 0, 0, time.UTC)
 	caseAudit := AWSRemediationAuditEntry{EventID: "case-created", EventType: "case_projected", Actor: "case-engine", OccurredAt: now}

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -373,6 +373,24 @@ func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 			t.Errorf("audit trail leaked case %s under case_id=%s", e.CaseID, target)
 		}
 	}
+	if scoped.ApprovalQueue.Summary.FilteredEntries != len(scoped.ApprovalQueue.Entries) || scoped.ApprovalQueue.Summary.RelationshipCount != len(scoped.ApprovalQueue.Relationships) {
+		t.Fatalf("approval summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.ApprovalQueue.Summary, len(scoped.ApprovalQueue.Entries), len(scoped.ApprovalQueue.Relationships))
+	}
+	if scoped.DryRuns.Summary.FilteredEntries != len(scoped.DryRuns.Entries) || scoped.DryRuns.Summary.RelationshipCount != len(scoped.DryRuns.Relationships) {
+		t.Fatalf("dry-run summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.DryRuns.Summary, len(scoped.DryRuns.Entries), len(scoped.DryRuns.Relationships))
+	}
+	if scoped.LiveActions.Summary.FilteredEntries != len(scoped.LiveActions.Entries) || scoped.LiveActions.Summary.RelationshipCount != len(scoped.LiveActions.Relationships) {
+		t.Fatalf("live-action summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.LiveActions.Summary, len(scoped.LiveActions.Entries), len(scoped.LiveActions.Relationships))
+	}
+	if scoped.Verification.Summary.FilteredEntries != len(scoped.Verification.Entries) || scoped.Verification.Summary.RelationshipCount != len(scoped.Verification.Relationships) {
+		t.Fatalf("verification summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.Verification.Summary, len(scoped.Verification.Entries), len(scoped.Verification.Relationships))
+	}
+	if scoped.ApprovalQueue.Summary.TotalEntries < scoped.ApprovalQueue.Summary.FilteredEntries ||
+		scoped.DryRuns.Summary.TotalEntries < scoped.DryRuns.Summary.FilteredEntries ||
+		scoped.LiveActions.Summary.TotalEntries < scoped.LiveActions.Summary.FilteredEntries ||
+		scoped.Verification.Summary.TotalEntries < scoped.Verification.Summary.FilteredEntries {
+		t.Fatalf("scoped lifecycle summaries must preserve source totals while narrowing filtered counts: approvals=%+v dryRuns=%+v live=%+v verification=%+v", scoped.ApprovalQueue.Summary, scoped.DryRuns.Summary, scoped.LiveActions.Summary, scoped.Verification.Summary)
+	}
 }
 
 func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
 )
@@ -396,6 +397,27 @@ func TestGetAWSRemediationCenterFixtureStates(t *testing.T) {
 		if state == "permission_denied" && result.Status != "permission_denied" {
 			t.Fatalf("permission denied must surface as explicit status, got %q", result.Status)
 		}
+	}
+}
+
+func TestGetAWSRemediationCenterMissingConnectorIsPermissionDenied(t *testing.T) {
+	now := time.Date(2026, 7, 4, 11, 30, 0, 0, time.UTC)
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	projectID := "project-remediation-center-no-connector"
+	seedDefaultProject(t, store, ctx, projectID)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	result, err := svc.GetAWSRemediationCenter(ctx, "default", projectID, AWSRemediationCenterRequest{})
+	if err != nil {
+		t.Fatalf("missing connector must return explicit remediation center payload: %v", err)
+	}
+	if result.FixtureState != "permission_denied" || result.Status != "permission_denied" {
+		t.Fatalf("missing connector must surface permission_denied, got fixture=%q status=%q", result.FixtureState, result.Status)
+	}
+	if len(result.Cases) != 0 || len(result.ApprovalQueue.Entries) != 0 || len(result.DryRuns.Entries) != 0 || len(result.LiveActions.Entries) != 0 || len(result.Verification.Entries) != 0 {
+		t.Fatalf("missing connector must not fabricate remediation lifecycle rows: %+v", result)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -406,6 +406,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 			CaseID:                 "case-mixed",
 			AccountID:              "111111111111",
 			TargetAccountIDs:       []string{"111111111111", "222222222222"},
+			Stage:                  awsRemediationCenterStageRollback,
 			VerificationID:         "verify-failed",
 			VerificationState:      awsPostRemediationVerificationStateFailed,
 			VerificationEntryCount: 2,
@@ -427,6 +428,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 		{
 			CaseID:                 "case-verified",
 			AccountID:              "333333333333",
+			Stage:                  awsRemediationCenterStageVerification,
 			VerificationID:         "verify-verified",
 			VerificationState:      awsPostRemediationVerificationStateVerified,
 			VerificationEntryCount: 1,
@@ -463,7 +465,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
 	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), filtered, awsPostRemediationVerificationStateVerified, "")
-	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows, awsPostRemediationVerificationStateVerified)
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows, awsPostRemediationVerificationStateVerified, "")
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
@@ -504,7 +506,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	approvedCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsRemediationApprovalStateApproved})
 	approvedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(approvedCases), approvedCases, awsRemediationApprovalStateApproved, "")
-	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows, awsRemediationApprovalStateApproved)
+	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows, awsRemediationApprovalStateApproved, "")
 	approvedSummary := summarizeAWSRemediationCenterCases(centerCases, approvedCases)
 	approvedAudit := awsRemediationCenterAuditTrail(approvedCases)
 
@@ -527,7 +529,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	accountCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222"})
 	accountRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(accountCases), accountCases, "", "222222222222")
-	accountCases = awsRemediationCenterCasesWithScopedVerificationRows(accountCases, accountRows, "")
+	accountCases = awsRemediationCenterCasesWithScopedVerificationRows(accountCases, accountRows, "", "")
 	accountSummary := summarizeAWSRemediationCenterCases(centerCases, accountCases)
 	accountAudit := awsRemediationCenterAuditTrail(accountCases)
 
@@ -572,7 +574,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	mismatchedStatusCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsPostRemediationVerificationStateFailed})
 	mismatchedStatusRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(mismatchedStatusCases), mismatchedStatusCases, applied["status"], applied["account_id"])
-	mismatchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(mismatchedStatusCases, mismatchedStatusRows, applied["status"])
+	mismatchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(mismatchedStatusCases, mismatchedStatusRows, applied["status"], "")
 	mismatchedStatusSummary := summarizeAWSRemediationCenterCases(centerCases, mismatchedStatusCases)
 	mismatchedStatusAudit := awsRemediationCenterAuditTrail(mismatchedStatusCases)
 
@@ -588,7 +590,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 
 	matchedStatusCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Status: awsPostRemediationVerificationStateVerified})
 	matchedStatusRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(matchedStatusCases), matchedStatusCases, applied["status"], applied["account_id"])
-	matchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(matchedStatusCases, matchedStatusRows, applied["status"])
+	matchedStatusCases = awsRemediationCenterCasesWithScopedVerificationRows(matchedStatusCases, matchedStatusRows, applied["status"], "")
 	matchedStatusSummary := summarizeAWSRemediationCenterCases(centerCases, matchedStatusCases)
 
 	if len(matchedStatusCases) != 1 || matchedStatusCases[0].CaseID != "case-mixed" {
@@ -602,6 +604,22 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if matchedStatusSummary.BlockedGateCount != 0 {
 		t.Fatalf("account+verification status blocked gates must not count filtered sibling rows: %+v", matchedStatusSummary)
+	}
+
+	stageVerificationCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Stage: awsRemediationCenterStageVerification})
+	stageVerificationRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(stageVerificationCases), stageVerificationCases, applied["status"], applied["account_id"])
+	stageVerificationCases = awsRemediationCenterCasesWithScopedVerificationRows(stageVerificationCases, stageVerificationRows, applied["status"], applied["stage"])
+
+	if len(stageVerificationCases) != 1 || stageVerificationCases[0].CaseID != "case-mixed" || stageVerificationCases[0].Stage != awsRemediationCenterStageVerification {
+		t.Fatalf("stage=verification must be applied after account-scoped verification row rewrite, got %+v", stageVerificationCases)
+	}
+
+	stageRollbackCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Stage: awsRemediationCenterStageRollback})
+	stageRollbackRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(stageRollbackCases), stageRollbackCases, applied["status"], applied["account_id"])
+	stageRollbackCases = awsRemediationCenterCasesWithScopedVerificationRows(stageRollbackCases, stageRollbackRows, applied["status"], applied["stage"])
+
+	if len(stageRollbackCases) != 0 {
+		t.Fatalf("stage=rollback must not keep a case rewritten to verification after account scoping, got %+v", stageRollbackCases)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -383,6 +383,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 			VerificationState:      awsPostRemediationVerificationStateFailed,
 			VerificationEntryCount: 2,
 			VerificationStates:     []string{awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateVerified},
+			ApprovalState:          awsRemediationApprovalStateApproved,
 			AuditTrail: []AWSRemediationCenterAuditEntry{
 				{CaseID: "case-mixed", Stage: awsRemediationCenterStageCase, EventID: "case-mixed-created"},
 				{CaseID: "case-mixed", Stage: awsRemediationCenterStageVerification, EventID: "case-mixed-failed"},
@@ -411,7 +412,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 
 	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
-	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), awsPostRemediationVerificationStateVerified)
+	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), filtered, awsPostRemediationVerificationStateVerified)
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
@@ -449,6 +450,29 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if got, want := summary.AuditEntryCount, len(auditTrail); got != want {
 		t.Fatalf("audit_entry_count must match status-scoped audit rows: got=%d want=%d trail=%+v", got, want, auditTrail)
+	}
+
+	approvedCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsRemediationApprovalStateApproved})
+	approvedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(approvedCases), approvedCases, awsRemediationApprovalStateApproved)
+	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows)
+	approvedSummary := summarizeAWSRemediationCenterCases(centerCases, approvedCases)
+	approvedAudit := awsRemediationCenterAuditTrail(approvedCases)
+
+	if len(approvedCases) != 1 || approvedCases[0].CaseID != "case-mixed" {
+		t.Fatalf("approval status filter should keep the approved case, got %+v", approvedCases)
+	}
+	if len(approvedRows) != 2 {
+		t.Fatalf("approval status must not row-filter verification entries, got %+v", approvedRows)
+	}
+	if approvedSummary.VerificationCount != len(approvedRows) {
+		t.Fatalf("approval status verification_count must keep all rendered rows: count=%d rows=%d", approvedSummary.VerificationCount, len(approvedRows))
+	}
+	approvedAuditEvents := map[string]bool{}
+	for _, audit := range approvedAudit {
+		approvedAuditEvents[audit.EventID] = true
+	}
+	if !approvedAuditEvents["case-mixed-failed"] || !approvedAuditEvents["case-mixed-verified"] {
+		t.Fatalf("approval status must keep all verification audit events, got %+v", approvedAudit)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newRemediationCenterService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSRemediationCenterBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationCenterService(t, "project-remediation-center", now)
+
+	result, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation center: %v", err)
+	}
+	if result.CurrentIssueRef != "#1552" || result.Version != awsRemediationCenterVersion || result.PolicyVersion != awsRemediationCenterPolicyID {
+		t.Fatalf("unexpected contract metadata: %+v", result)
+	}
+	if len(result.Cases) == 0 {
+		t.Fatalf("expected case-keyed lifecycle rollups: %+v", result.Summary)
+	}
+	if result.Summary.TotalCases != len(result.RemediationCases.Cases) {
+		t.Fatalf("summary total must match source case count: summary=%d cases=%d", result.Summary.TotalCases, len(result.RemediationCases.Cases))
+	}
+	if len(result.Tabs) == 0 {
+		t.Fatalf("expected center tabs: %+v", result)
+	}
+	if len(result.EvidenceLinks) == 0 {
+		t.Fatalf("expected evidence links: %+v", result)
+	}
+	validStages := map[string]bool{
+		awsRemediationCenterStageCase: true, awsRemediationCenterStageApproval: true,
+		awsRemediationCenterStageDryRun: true, awsRemediationCenterStageLiveAction: true,
+		awsRemediationCenterStageVerification: true, awsRemediationCenterStageRollback: true,
+	}
+	for _, entry := range result.Cases {
+		if entry.CaseID == "" || entry.Title == "" {
+			t.Fatalf("case rollup missing identity fields: %+v", entry)
+		}
+		if !validStages[entry.Stage] {
+			t.Fatalf("case rollup has unknown stage: %+v", entry)
+		}
+		if entry.EvidenceBoundary != awsRemediationCenterEvidenceBoundary() {
+			t.Fatalf("case rollup crossed evidence boundary: %+v", entry)
+		}
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_value\"", "\"policy_document_body\"", "\"rendered_policy\"", "\"secret_access_key\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("remediation center serialized forbidden sensitive payload marker %q", forbidden)
+		}
+	}
+}
+
+func TestGetAWSRemediationCenterStitchesLifecycle(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 30, 0, 0, time.UTC)
+	svc, ws := newRemediationCenterService(t, "project-remediation-center-lifecycle", now)
+
+	result, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-lifecycle", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation center: %v", err)
+	}
+	advanced := 0
+	sawVerification := false
+	for _, entry := range result.Cases {
+		if entry.Stage == awsRemediationCenterStageCase {
+			continue
+		}
+		advanced++
+		// A case that advanced past `case` must carry the stage evidence
+		// that drove it there.
+		if entry.ApprovalID == "" {
+			t.Fatalf("advanced case must carry its approval ID: %+v", entry)
+		}
+		if entry.Stage == awsRemediationCenterStageVerification || entry.Stage == awsRemediationCenterStageRollback {
+			sawVerification = true
+			if entry.VerificationID == "" || entry.DryRunID == "" {
+				t.Fatalf("verification-stage case must carry verification and dry-run IDs: %+v", entry)
+			}
+		}
+		if len(entry.SafetyGates) == 0 {
+			t.Fatalf("advanced case must consolidate safety gates: %+v", entry)
+		}
+	}
+	if advanced == 0 || !sawVerification {
+		t.Fatalf("expected fixture cases to advance through the lifecycle incl. verification, got advanced=%d verification=%v", advanced, sawVerification)
+	}
+	if result.Summary.DryRunCount == 0 || result.Summary.VerificationCount == 0 {
+		t.Fatalf("summary must count dry-run and verification stages: %+v", result.Summary)
+	}
+}
+
+func TestFilterAWSRemediationCenterCases(t *testing.T) {
+	entries := []AWSRemediationCenterCase{
+		{CaseID: "c-1", Severity: "critical", Confidence: 0.95, IdentityType: "iam_role", ActionType: "iam_policy_diff", SourceType: "least_privilege", Lifecycle: "proposed", Stage: "dry_run", AccountID: "111111111111", Region: "us-east-1"},
+		{CaseID: "c-2", Severity: "high", Confidence: 0.6, IdentityType: "iam_identity", ActionType: "secret_rotation", SourceType: "aws_secret_key_rotation", Lifecycle: "in_review", Stage: "verification", AccountID: "222222222222", Region: "us-west-2", VerificationState: "verification_verified"},
+	}
+
+	filtered, applied := filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Severity: "critical"})
+	if applied["severity"] != normalizeAWSRuntimeEventFilterToken("critical") || len(filtered) != 1 || filtered[0].CaseID != "c-1" {
+		t.Fatalf("severity filter did not scope: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Stage: "verification"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
+		t.Fatalf("stage filter did not scope: %+v", filtered)
+	}
+
+	filtered, applied = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Confidence: "0.9"})
+	if applied["confidence"] != "0.9" || len(filtered) != 1 || filtered[0].CaseID != "c-1" {
+		t.Fatalf("numeric confidence floor did not scope: applied=%+v filtered=%+v", applied, filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Confidence: "high"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-1" {
+		t.Fatalf("bucket confidence floor did not scope: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{IdentityType: "iam_role"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-1" {
+		t.Fatalf("identity_type filter did not scope: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{ActionType: "secret_rotation"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
+		t.Fatalf("action_type filter did not scope: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{AccountID: "222222222222"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
+		t.Fatalf("account_id filter did not scope: %+v", filtered)
+	}
+
+	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Status: "verification_verified"})
+	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
+		t.Fatalf("status filter must match execution/verification state: %+v", filtered)
+	}
+}
+
+func TestAWSRemediationCenterConfidenceFloor(t *testing.T) {
+	cases := []struct {
+		value string
+		want  float64
+		ok    bool
+	}{
+		{"", 0, false},
+		{"high", 0.85, true},
+		{"medium", 0.6, true},
+		{"low", 0, true},
+		{"0.75", 0.75, true},
+		{"1", 1, true},
+		{"0", 0, true},
+		{"1.5", 0, false},
+		{"-0.1", 0, false},
+		{"bogus", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := awsRemediationCenterConfidenceFloor(tc.value)
+		if ok != tc.ok || (ok && got != tc.want) {
+			t.Fatalf("value=%q got (%v,%v) want (%v,%v)", tc.value, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestGetAWSRemediationCenterFixtureStates(t *testing.T) {
+	now := time.Date(2026, 7, 4, 11, 0, 0, 0, time.UTC)
+	svc, ws := newRemediationCenterService(t, "project-remediation-center-fixture", now)
+
+	for _, state := range []string{"success", "empty", "degraded", "partial_failure", "permission_denied"} {
+		result, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-fixture", AWSRemediationCenterRequest{
+			ConnectorID:  "aws-prod",
+			FixtureState: state,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", state, err)
+		}
+		if result.FixtureState != state {
+			t.Fatalf("%s: expected fixture_state echoed, got %q", state, result.FixtureState)
+		}
+		if result.Status == "" {
+			t.Fatalf("%s: missing status", state)
+		}
+		if state == "permission_denied" && result.Status != "permission_denied" {
+			t.Fatalf("permission denied must surface as explicit status, got %q", result.Status)
+		}
+	}
+}
+
+func TestRouterAWSRemediationCenter(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	svc, _ := newRemediationCenterService(t, "project-remediation-center-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-remediation-center-route/aws/remediation-center?connector_id=aws-prod&fixture_state=success&stage=verification", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Center AWSRemediationCenterResult `json:"remediation_center"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Center.CurrentIssueRef != "#1552" || body.Center.AppliedFilters["stage"] != "verification" {
+		t.Fatalf("unexpected route payload: %+v", body.Center)
+	}
+	for _, entry := range body.Center.Cases {
+		if entry.Stage != awsRemediationCenterStageVerification {
+			t.Fatalf("stage=verification route returned wrong stage: %+v", entry)
+		}
+	}
+
+	badFixture := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-remediation-center-route/aws/remediation-center?connector_id=aws-prod&fixture_state=bogus", "")
+	if badFixture.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid fixture state, got %d body=%s", badFixture.Code, badFixture.Body.String())
+	}
+}

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -135,6 +135,64 @@ func TestGetAWSRemediationCenterStitchesLifecycle(t *testing.T) {
 	}
 }
 
+func TestAWSRemediationCenterCaseDoesNotPromoteVerificationSourceExecution(t *testing.T) {
+	source := AWSRemediationCase{
+		CaseID:           "case-boundary",
+		Title:            "Permission boundary verification",
+		SourceType:       "permission_boundary_diff",
+		Lifecycle:        "approved",
+		Severity:         "high",
+		Confidence:       0.91,
+		ApprovalRequired: true,
+		ApprovalState:    awsRemediationApprovalStateApproved,
+		UpdatedAt:        time.Date(2026, 7, 4, 10, 45, 0, 0, time.UTC),
+	}
+	verify := AWSPostRemediationVerificationEntry{
+		VerificationID:    "verify-boundary",
+		SourceExecutionID: "exec-boundary-only",
+		State:             awsPostRemediationVerificationStateVerified,
+	}
+
+	entry := awsRemediationCenterCaseFromLifecycle(
+		source,
+		AWSRemediationApprovalEntry{}, false,
+		AWSRemediationDryRunEntry{}, false,
+		AWSLowRiskRemediationEntry{}, false,
+		verify, true,
+	)
+	if entry.ExecutionID != "" {
+		t.Fatalf("verification source execution must not be counted as a live action execution: %+v", entry)
+	}
+	if entry.VerificationID != verify.VerificationID || entry.Stage != awsRemediationCenterStageVerification {
+		t.Fatalf("verification evidence must still be retained on the case rollup: %+v", entry)
+	}
+	summary := summarizeAWSRemediationCenterCases([]AWSRemediationCenterCase{entry}, []AWSRemediationCenterCase{entry})
+	if summary.LiveActionCount != 0 || summary.VerificationCount != 1 {
+		t.Fatalf("verification-only case must not inflate live action count: %+v", summary)
+	}
+}
+
+func TestAWSRemediationCenterSummaryCountsOnlyActionablePendingApprovals(t *testing.T) {
+	entries := []AWSRemediationCenterCase{
+		{CaseID: "requested", ApprovalID: "approval-requested", ApprovalState: awsRemediationApprovalStateRequested},
+		{CaseID: "review", ApprovalID: "approval-review", ApprovalState: awsRemediationApprovalStateReview},
+		{CaseID: "approved", ApprovalID: "approval-approved", ApprovalState: awsRemediationApprovalStateApproved},
+		{CaseID: "denied", ApprovalID: "approval-denied", ApprovalState: awsRemediationApprovalStateDenied},
+		{CaseID: "expired", ApprovalID: "approval-expired", ApprovalState: awsRemediationApprovalStateExpired},
+		{CaseID: "blocked", ApprovalID: "approval-blocked", ApprovalState: awsRemediationApprovalStateBlocked},
+		{CaseID: "live", ExecutionID: "exec-low-risk"},
+		{CaseID: "verification-only", VerificationID: "verify-boundary", VerificationState: awsPostRemediationVerificationStateVerified},
+	}
+
+	summary := summarizeAWSRemediationCenterCases(entries, entries)
+	if summary.ApprovalPendingCount != 2 {
+		t.Fatalf("pending approvals must count only requested/under-review entries, got %+v", summary)
+	}
+	if summary.LiveActionCount != 1 || summary.VerificationCount != 1 {
+		t.Fatalf("summary must keep live-action and verification counts distinct: %+v", summary)
+	}
+}
+
 func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	now := time.Date(2026, 7, 4, 10, 30, 0, 0, time.UTC)
 	svc, ws := newRemediationCenterService(t, "project-remediation-center-scope", now)

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -372,6 +372,58 @@ func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	}
 }
 
+func TestGetAWSRemediationCenterPreservesUnfilteredTotals(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 40, 0, 0, time.UTC)
+	svc, ws := newRemediationCenterService(t, "project-remediation-center-unfiltered-totals", now)
+
+	full, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-unfiltered-totals", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation center: %v", err)
+	}
+	if len(full.Cases) < 2 {
+		t.Fatalf("expected multiple cases to filter, got %d", len(full.Cases))
+	}
+
+	severity := ""
+	filteredCount := 0
+	for value, count := range full.Summary.SeverityCounts {
+		if count > 0 && count < full.Summary.TotalCases {
+			severity = value
+			filteredCount = count
+			break
+		}
+	}
+	if severity == "" {
+		t.Fatalf("expected fixture to include a severity subset, got summary=%+v", full.Summary)
+	}
+
+	scoped, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-unfiltered-totals", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     severity,
+	})
+	if err != nil {
+		t.Fatalf("get remediation center (severity scoped): %v", err)
+	}
+	if scoped.Summary.TotalCases != full.Summary.TotalCases {
+		t.Fatalf("severity filter must preserve connector-wide total_cases: got=%d want=%d", scoped.Summary.TotalCases, full.Summary.TotalCases)
+	}
+	if scoped.Summary.FilteredCases != filteredCount || len(scoped.Cases) != filteredCount {
+		t.Fatalf("severity filter must only narrow filtered cases: summary=%+v len=%d want=%d severity=%s", scoped.Summary, len(scoped.Cases), filteredCount, severity)
+	}
+	if scoped.Summary.SeverityCounts[severity] != filteredCount || len(scoped.Summary.SeverityCounts) != 1 {
+		t.Fatalf("filtered severity facets must reflect the filtered case set: %+v severity=%s", scoped.Summary.SeverityCounts, severity)
+	}
+	for _, entry := range scoped.Cases {
+		if entry.Severity != severity {
+			t.Fatalf("severity filter leaked case %s with severity %s under severity=%s", entry.CaseID, entry.Severity, severity)
+		}
+	}
+}
+
 func TestFilterAWSRemediationCenterCases(t *testing.T) {
 	entries := []AWSRemediationCenterCase{
 		{CaseID: "c-1", Severity: "critical", Confidence: 0.95, IdentityType: "iam_role", ActionType: "iam_policy_diff", SourceType: "least_privilege", Lifecycle: "proposed", Stage: "dry_run", AccountID: "111111111111", Region: "us-east-1"},

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -346,6 +346,10 @@ func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	if len(scoped.Cases) != 1 || scoped.Cases[0].CaseID != target {
 		t.Fatalf("case_id filter must scope cases to %s: %+v", target, scoped.Cases)
 	}
+	tabCounts := map[string]int{}
+	for _, tab := range scoped.Tabs {
+		tabCounts[tab.ID] = tab.Count
+	}
 	// Every embedded lifecycle payload rendered by the tabs must be reconciled to
 	// the filtered case so a deep link never shows unrelated rows.
 	for _, e := range scoped.ApprovalQueue.Entries {
@@ -375,6 +379,9 @@ func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
 	}
 	if scoped.ApprovalQueue.Summary.FilteredEntries != len(scoped.ApprovalQueue.Entries) || scoped.ApprovalQueue.Summary.RelationshipCount != len(scoped.ApprovalQueue.Relationships) {
 		t.Fatalf("approval summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.ApprovalQueue.Summary, len(scoped.ApprovalQueue.Entries), len(scoped.ApprovalQueue.Relationships))
+	}
+	if tabCounts["approvals"] != len(scoped.ApprovalQueue.Entries) {
+		t.Fatalf("approvals tab count must match rendered approval rows: tab=%d rows=%d", tabCounts["approvals"], len(scoped.ApprovalQueue.Entries))
 	}
 	if scoped.DryRuns.Summary.FilteredEntries != len(scoped.DryRuns.Entries) || scoped.DryRuns.Summary.RelationshipCount != len(scoped.DryRuns.Relationships) {
 		t.Fatalf("dry-run summary must match scoped payload: summary=%+v entries=%d relationships=%d", scoped.DryRuns.Summary, len(scoped.DryRuns.Entries), len(scoped.DryRuns.Relationships))

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -383,6 +383,12 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 			VerificationState:      awsPostRemediationVerificationStateFailed,
 			VerificationEntryCount: 2,
 			VerificationStates:     []string{awsPostRemediationVerificationStateFailed, awsPostRemediationVerificationStateVerified},
+			AuditTrail: []AWSRemediationCenterAuditEntry{
+				{CaseID: "case-mixed", Stage: awsRemediationCenterStageCase, EventID: "case-mixed-created"},
+				{CaseID: "case-mixed", Stage: awsRemediationCenterStageVerification, EventID: "case-mixed-failed"},
+				{CaseID: "case-mixed", Stage: awsRemediationCenterStageVerification, EventID: "case-mixed-verified"},
+			},
+			AuditEntryCount: 3,
 		},
 		{
 			CaseID:                 "case-verified",
@@ -390,19 +396,25 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 			VerificationState:      awsPostRemediationVerificationStateVerified,
 			VerificationEntryCount: 1,
 			VerificationStates:     []string{awsPostRemediationVerificationStateVerified},
+			AuditTrail: []AWSRemediationCenterAuditEntry{
+				{CaseID: "case-verified", Stage: awsRemediationCenterStageCase, EventID: "case-verified-created"},
+				{CaseID: "case-verified", Stage: awsRemediationCenterStageVerification, EventID: "case-verified-verified"},
+			},
+			AuditEntryCount: 2,
 		},
 	}
 	verificationRows := []AWSPostRemediationVerificationEntry{
-		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed},
-		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified},
-		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified},
-		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified},
+		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-failed"}}},
+		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-verified"}}},
+		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-verified-verified"}}},
+		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-unfiltered-verified"}}},
 	}
 
 	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
 	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), awsPostRemediationVerificationStateVerified)
-	filtered = awsRemediationCenterCasesWithVerificationEntryCounts(filtered, scopedRows)
+	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
+	auditTrail := awsRemediationCenterAuditTrail(filtered)
 
 	if len(filtered) != 2 {
 		t.Fatalf("case-level status filter should keep both verified cases, got %+v", filtered)
@@ -429,6 +441,14 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if summary.VerificationCount != len(scopedRows) {
 		t.Fatalf("verification_count must match rendered status-scoped rows: count=%d rows=%d", summary.VerificationCount, len(scopedRows))
+	}
+	for _, audit := range auditTrail {
+		if audit.EventID == "case-mixed-failed" || audit.EventID == "case-unfiltered-verified" {
+			t.Errorf("audit event %s leaked outside status-scoped verification rows", audit.EventID)
+		}
+	}
+	if got, want := summary.AuditEntryCount, len(auditTrail); got != want {
+		t.Fatalf("audit_entry_count must match status-scoped audit rows: got=%d want=%d trail=%+v", got, want, auditTrail)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -645,6 +645,26 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 		t.Fatalf("account+verification status blocked gates must not count filtered sibling rows: %+v", matchedStatusSummary)
 	}
 
+	statusStageCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{
+		Status: awsPostRemediationVerificationStateVerified,
+		Stage:  awsRemediationCenterStageVerification,
+	})
+	statusStageRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(statusStageCases), statusStageCases, applied["status"], applied["account_id"])
+	statusStageCases = awsRemediationCenterCasesWithScopedVerificationRows(statusStageCases, statusStageRows, applied["status"], applied["stage"])
+
+	foundMixedStatusStage := false
+	for _, entry := range statusStageCases {
+		if entry.CaseID == "case-mixed" {
+			foundMixedStatusStage = true
+			if entry.Stage != awsRemediationCenterStageVerification || entry.VerificationID != "verify-verified" {
+				t.Fatalf("verification status+stage filter must rewrite the mixed case before applying stage: %+v", entry)
+			}
+		}
+	}
+	if !foundMixedStatusStage {
+		t.Fatalf("verification status+stage filter must keep the matching mixed case: got %+v rows=%+v", statusStageCases, statusStageRows)
+	}
+
 	stageVerificationCases, applied := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222", Stage: awsRemediationCenterStageVerification})
 	stageVerificationRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(stageVerificationCases), stageVerificationCases, applied["status"], applied["account_id"])
 	stageVerificationCases = awsRemediationCenterCasesWithScopedVerificationRows(stageVerificationCases, stageVerificationRows, applied["status"], applied["stage"])

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -118,45 +118,45 @@ func TestFilterAWSRemediationCenterCases(t *testing.T) {
 		{CaseID: "c-2", Severity: "high", Confidence: 0.6, IdentityType: "iam_identity", ActionType: "secret_rotation", SourceType: "aws_secret_key_rotation", Lifecycle: "in_review", Stage: "verification", AccountID: "222222222222", Region: "us-west-2", VerificationState: "verification_verified"},
 	}
 
-	filtered, applied := filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Severity: "critical"})
-	if applied["severity"] != normalizeAWSRuntimeEventFilterToken("critical") || len(filtered) != 1 || filtered[0].CaseID != "c-1" {
-		t.Fatalf("severity filter did not scope: applied=%+v filtered=%+v", applied, filtered)
+	// Each filter is independent of the others, so report every failure rather
+	// than aborting on the first — a regression in one filter must not hide a
+	// regression in the rest.
+	expectSingleCase := func(name string, filtered []AWSRemediationCenterCase, wantCaseID string) {
+		t.Helper()
+		if len(filtered) != 1 || filtered[0].CaseID != wantCaseID {
+			t.Errorf("%s filter did not scope to %s: %+v", name, wantCaseID, filtered)
+		}
 	}
+
+	filtered, applied := filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Severity: "critical"})
+	if applied["severity"] != normalizeAWSRuntimeEventFilterToken("critical") {
+		t.Errorf("severity filter did not record applied token: applied=%+v", applied)
+	}
+	expectSingleCase("severity", filtered, "c-1")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Stage: "verification"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
-		t.Fatalf("stage filter did not scope: %+v", filtered)
-	}
+	expectSingleCase("stage", filtered, "c-2")
 
 	filtered, applied = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Confidence: "0.9"})
-	if applied["confidence"] != "0.9" || len(filtered) != 1 || filtered[0].CaseID != "c-1" {
-		t.Fatalf("numeric confidence floor did not scope: applied=%+v filtered=%+v", applied, filtered)
+	if applied["confidence"] != "0.9" {
+		t.Errorf("numeric confidence floor did not record applied token: applied=%+v", applied)
 	}
+	expectSingleCase("numeric confidence floor", filtered, "c-1")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Confidence: "high"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-1" {
-		t.Fatalf("bucket confidence floor did not scope: %+v", filtered)
-	}
+	expectSingleCase("bucket confidence floor", filtered, "c-1")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{IdentityType: "iam_role"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-1" {
-		t.Fatalf("identity_type filter did not scope: %+v", filtered)
-	}
+	expectSingleCase("identity_type", filtered, "c-1")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{ActionType: "secret_rotation"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
-		t.Fatalf("action_type filter did not scope: %+v", filtered)
-	}
+	expectSingleCase("action_type", filtered, "c-2")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{AccountID: "222222222222"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
-		t.Fatalf("account_id filter did not scope: %+v", filtered)
-	}
+	expectSingleCase("account_id", filtered, "c-2")
 
 	filtered, _ = filterAWSRemediationCenterCases(entries, AWSRemediationCenterRequest{Status: "verification_verified"})
-	if len(filtered) != 1 || filtered[0].CaseID != "c-2" {
-		t.Fatalf("status filter must match execution/verification state: %+v", filtered)
-	}
+	expectSingleCase("status", filtered, "c-2")
 }
 
 func TestAWSRemediationCenterConfidenceFloor(t *testing.T) {

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -303,6 +303,9 @@ func TestAWSRemediationCenterCaseAggregatesAllVerificationAuditTrails(t *testing
 	if entry.VerificationEntryCount != len(verifications) {
 		t.Fatalf("case rollup must retain rendered verification row count, got %+v", entry)
 	}
+	if got, want := strings.Join(entry.VerificationStates, ","), strings.Join([]string{awsPostRemediationVerificationStateVerified, awsPostRemediationVerificationStateFailed}, ","); got != want {
+		t.Fatalf("case rollup must retain every verification state, got %q want %q", got, want)
+	}
 	wantEvents := map[string]bool{"case-created": true, "verify-target-a": true, "verify-target-b": true}
 	for _, audit := range entry.AuditTrail {
 		delete(wantEvents, audit.EventID)
@@ -427,7 +430,7 @@ func TestGetAWSRemediationCenterPreservesUnfilteredTotals(t *testing.T) {
 func TestFilterAWSRemediationCenterCases(t *testing.T) {
 	entries := []AWSRemediationCenterCase{
 		{CaseID: "c-1", Severity: "critical", Confidence: 0.95, IdentityType: "iam_role", ActionType: "iam_policy_diff", SourceType: "least_privilege", Lifecycle: "proposed", Stage: "dry_run", AccountID: "111111111111", Region: "us-east-1"},
-		{CaseID: "c-2", Severity: "high", Confidence: 0.6, IdentityType: "iam_identity", ActionType: "secret_rotation", SourceType: "aws_secret_key_rotation", Lifecycle: "in_review", Stage: "verification", AccountID: "222222222222", Region: "us-west-2", VerificationState: "verification_verified"},
+		{CaseID: "c-2", Severity: "high", Confidence: 0.6, IdentityType: "iam_identity", ActionType: "secret_rotation", SourceType: "aws_secret_key_rotation", Lifecycle: "in_review", Stage: "verification", AccountID: "222222222222", Region: "us-west-2", VerificationState: "verification_failed", VerificationStates: []string{"verification_failed", "verification_verified"}},
 	}
 
 	// Each filter is independent of the others, so report every failure rather

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -404,6 +404,8 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	centerCases := []AWSRemediationCenterCase{
 		{
 			CaseID:                 "case-mixed",
+			AccountID:              "111111111111",
+			TargetAccountIDs:       []string{"111111111111", "222222222222"},
 			VerificationID:         "verify-failed",
 			VerificationState:      awsPostRemediationVerificationStateFailed,
 			VerificationEntryCount: 2,
@@ -418,6 +420,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 		},
 		{
 			CaseID:                 "case-verified",
+			AccountID:              "333333333333",
 			VerificationID:         "verify-verified",
 			VerificationState:      awsPostRemediationVerificationStateVerified,
 			VerificationEntryCount: 1,
@@ -430,14 +433,14 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 		},
 	}
 	verificationRows := []AWSPostRemediationVerificationEntry{
-		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-failed"}}},
-		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-verified"}}},
-		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-verified-verified"}}},
-		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-unfiltered-verified"}}},
+		{CaseID: "case-mixed", VerificationID: "verify-failed", State: awsPostRemediationVerificationStateFailed, AccountID: "111111111111", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-failed"}}},
+		{CaseID: "case-mixed", VerificationID: "verify-verified", State: awsPostRemediationVerificationStateVerified, AccountID: "222222222222", TargetAccountIDs: []string{"222222222222"}, AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-mixed-verified"}}},
+		{CaseID: "case-verified", VerificationID: "verify-only-verified", State: awsPostRemediationVerificationStateVerified, AccountID: "333333333333", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-verified-verified"}}},
+		{CaseID: "case-unfiltered", VerificationID: "verify-outside-case-filter", State: awsPostRemediationVerificationStateVerified, AccountID: "222222222222", AuditTrail: []AWSPostRemediationVerificationAuditEntry{{EventID: "case-unfiltered-verified"}}},
 	}
 
 	filtered, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsPostRemediationVerificationStateVerified})
-	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), filtered, awsPostRemediationVerificationStateVerified)
+	scopedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(filtered), filtered, awsPostRemediationVerificationStateVerified, "")
 	filtered = awsRemediationCenterCasesWithScopedVerificationRows(filtered, scopedRows)
 	summary := summarizeAWSRemediationCenterCases(centerCases, filtered)
 	auditTrail := awsRemediationCenterAuditTrail(filtered)
@@ -478,7 +481,7 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 
 	approvedCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{Status: awsRemediationApprovalStateApproved})
-	approvedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(approvedCases), approvedCases, awsRemediationApprovalStateApproved)
+	approvedRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(approvedCases), approvedCases, awsRemediationApprovalStateApproved, "")
 	approvedCases = awsRemediationCenterCasesWithScopedVerificationRows(approvedCases, approvedRows)
 	approvedSummary := summarizeAWSRemediationCenterCases(centerCases, approvedCases)
 	approvedAudit := awsRemediationCenterAuditTrail(approvedCases)
@@ -498,6 +501,30 @@ func TestAWSRemediationCenterScopesVerificationRowsToStatus(t *testing.T) {
 	}
 	if !approvedAuditEvents["case-mixed-failed"] || !approvedAuditEvents["case-mixed-verified"] {
 		t.Fatalf("approval status must keep all verification audit events, got %+v", approvedAudit)
+	}
+
+	accountCases, _ := filterAWSRemediationCenterCases(centerCases, AWSRemediationCenterRequest{AccountID: "222222222222"})
+	accountRows := awsRemediationCenterScopeVerificationEntries(verificationRows, awsRemediationCenterCaseIDSet(accountCases), accountCases, "", "222222222222")
+	accountCases = awsRemediationCenterCasesWithScopedVerificationRows(accountCases, accountRows)
+	accountSummary := summarizeAWSRemediationCenterCases(centerCases, accountCases)
+	accountAudit := awsRemediationCenterAuditTrail(accountCases)
+
+	if len(accountCases) != 1 || accountCases[0].CaseID != "case-mixed" {
+		t.Fatalf("account filter should keep the multi-account matching case, got %+v", accountCases)
+	}
+	if len(accountRows) != 1 || accountRows[0].VerificationID != "verify-verified" {
+		t.Fatalf("account-scoped verification rows should keep only matching target rows, got %+v", accountRows)
+	}
+	if accountSummary.VerificationCount != len(accountRows) {
+		t.Fatalf("account-scoped verification_count must match rendered rows: count=%d rows=%d", accountSummary.VerificationCount, len(accountRows))
+	}
+	for _, audit := range accountAudit {
+		if audit.EventID == "case-mixed-failed" || audit.EventID == "case-unfiltered-verified" {
+			t.Errorf("audit event %s leaked outside account-scoped verification rows", audit.EventID)
+		}
+	}
+	if got, want := accountSummary.AuditEntryCount, len(accountAudit); got != want {
+		t.Fatalf("account-scoped audit_entry_count must match audit rows: got=%d want=%d trail=%+v", got, want, accountAudit)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -111,6 +111,9 @@ func TestGetAWSRemediationCenterStitchesLifecycle(t *testing.T) {
 	if result.Summary.DryRunCount == 0 || result.Summary.VerificationCount == 0 {
 		t.Fatalf("summary must count dry-run and verification stages: %+v", result.Summary)
 	}
+	if result.Summary.VerificationCount != len(result.Verification.Entries) {
+		t.Fatalf("verification count must match rendered verification rows: count=%d rows=%d", result.Summary.VerificationCount, len(result.Verification.Entries))
+	}
 
 	// The consolidated audit trail must match its own count and span more than the
 	// verification stage, so the audit tab is not empty for earlier lifecycle
@@ -133,6 +136,20 @@ func TestGetAWSRemediationCenterStitchesLifecycle(t *testing.T) {
 	}
 	if nonVerification == 0 {
 		t.Fatalf("audit trail must include non-verification lifecycle stages, got %+v", stages)
+	}
+	auditByCaseEvent := map[string]struct{}{}
+	for _, audit := range result.AuditTrail {
+		auditByCaseEvent[audit.CaseID+"\x00"+audit.EventID] = struct{}{}
+	}
+	for _, verification := range result.Verification.Entries {
+		for _, audit := range verification.AuditTrail {
+			if strings.TrimSpace(audit.EventID) == "" {
+				continue
+			}
+			if _, ok := auditByCaseEvent[verification.CaseID+"\x00"+audit.EventID]; !ok {
+				t.Fatalf("consolidated audit trail omitted verification audit event %q for case %q", audit.EventID, verification.CaseID)
+			}
+		}
 	}
 }
 
@@ -245,6 +262,57 @@ func TestAWSRemediationCenterAuditTrailDeduplicatesInheritedEvents(t *testing.T)
 		if wantStages[audit.EventID] != audit.Stage {
 			t.Fatalf("audit event %s stage=%s want=%s trail=%+v", audit.EventID, audit.Stage, wantStages[audit.EventID], entry.AuditTrail)
 		}
+	}
+}
+
+func TestAWSRemediationCenterCaseAggregatesAllVerificationAuditTrails(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 55, 0, 0, time.UTC)
+	caseAudit := AWSRemediationAuditEntry{EventID: "case-created", EventType: "case_projected", Actor: "case-engine", OccurredAt: now}
+	verifyA := AWSRemediationAuditEntry{EventID: "verify-target-a", EventType: "post_remediation_verification_projected", Actor: "verification-engine", OccurredAt: now}
+	verifyB := AWSRemediationAuditEntry{EventID: "verify-target-b", EventType: "post_remediation_verification_projected", Actor: "verification-engine", OccurredAt: now}
+	verifications := []AWSPostRemediationVerificationEntry{
+		{
+			VerificationID: "verify-a",
+			CaseID:         "case-multi-verify",
+			State:          awsPostRemediationVerificationStateVerified,
+			AuditTrail:     []AWSPostRemediationVerificationAuditEntry{caseAudit, verifyA},
+		},
+		{
+			VerificationID: "verify-b",
+			CaseID:         "case-multi-verify",
+			State:          awsPostRemediationVerificationStateFailed,
+			AuditTrail:     []AWSPostRemediationVerificationAuditEntry{caseAudit, verifyB},
+		},
+	}
+	selected, hasSelected := awsRemediationCenterSelectedVerification(verifications)
+	if !hasSelected {
+		t.Fatalf("expected selected verification")
+	}
+	entry := awsRemediationCenterCaseFromLifecycleWithVerifications(
+		AWSRemediationCase{CaseID: "case-multi-verify", Title: "Multi-target verification", AuditTrail: []AWSRemediationAuditEntry{caseAudit}},
+		AWSRemediationApprovalEntry{}, false,
+		AWSRemediationDryRunEntry{}, false,
+		AWSLowRiskRemediationEntry{}, false,
+		selected, true,
+		verifications,
+	)
+
+	if entry.VerificationID != "verify-b" || entry.Stage != awsRemediationCenterStageRollback {
+		t.Fatalf("case rollup must keep the worst verification state, got %+v", entry)
+	}
+	if entry.VerificationEntryCount != len(verifications) {
+		t.Fatalf("case rollup must retain rendered verification row count, got %+v", entry)
+	}
+	wantEvents := map[string]bool{"case-created": true, "verify-target-a": true, "verify-target-b": true}
+	for _, audit := range entry.AuditTrail {
+		delete(wantEvents, audit.EventID)
+	}
+	if len(wantEvents) != 0 || entry.AuditEntryCount != 3 {
+		t.Fatalf("case rollup must aggregate every unique verification audit event: missing=%+v trail=%+v", wantEvents, entry.AuditTrail)
+	}
+	summary := summarizeAWSRemediationCenterCases([]AWSRemediationCenterCase{entry}, []AWSRemediationCenterCase{entry})
+	if summary.VerificationCount != len(verifications) || summary.AuditEntryCount != entry.AuditEntryCount {
+		t.Fatalf("summary must count rendered verification rows and aggregated audit entries: %+v entry=%+v", summary, entry)
 	}
 }
 

--- a/internal/api/aws_remediation_center_test.go
+++ b/internal/api/aws_remediation_center_test.go
@@ -110,6 +110,85 @@ func TestGetAWSRemediationCenterStitchesLifecycle(t *testing.T) {
 	if result.Summary.DryRunCount == 0 || result.Summary.VerificationCount == 0 {
 		t.Fatalf("summary must count dry-run and verification stages: %+v", result.Summary)
 	}
+
+	// The consolidated audit trail must match its own count and span more than the
+	// verification stage, so the audit tab is not empty for earlier lifecycle
+	// states that still recorded audit entries.
+	if len(result.AuditTrail) != result.Summary.AuditEntryCount {
+		t.Fatalf("consolidated audit trail must match audit_entry_count: trail=%d count=%d", len(result.AuditTrail), result.Summary.AuditEntryCount)
+	}
+	stages := map[string]int{}
+	for _, audit := range result.AuditTrail {
+		if audit.CaseID == "" || audit.EventID == "" {
+			t.Fatalf("audit entry must carry its case and event id: %+v", audit)
+		}
+		stages[audit.Stage]++
+	}
+	nonVerification := 0
+	for stage, count := range stages {
+		if stage != awsRemediationCenterStageVerification {
+			nonVerification += count
+		}
+	}
+	if nonVerification == 0 {
+		t.Fatalf("audit trail must include non-verification lifecycle stages, got %+v", stages)
+	}
+}
+
+func TestGetAWSRemediationCenterScopesPayloadsToFilteredCases(t *testing.T) {
+	now := time.Date(2026, 7, 4, 10, 30, 0, 0, time.UTC)
+	svc, ws := newRemediationCenterService(t, "project-remediation-center-scope", now)
+
+	full, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-scope", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get remediation center: %v", err)
+	}
+	if len(full.Cases) < 2 {
+		t.Fatalf("expected multiple cases to scope against, got %d", len(full.Cases))
+	}
+	target := full.Cases[0].CaseID
+
+	scoped, err := svc.GetAWSRemediationCenter(defaultScopeContext(), ws, "project-remediation-center-scope", AWSRemediationCenterRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		CaseID:       target,
+	})
+	if err != nil {
+		t.Fatalf("get remediation center (scoped): %v", err)
+	}
+	if len(scoped.Cases) != 1 || scoped.Cases[0].CaseID != target {
+		t.Fatalf("case_id filter must scope cases to %s: %+v", target, scoped.Cases)
+	}
+	// Every embedded lifecycle payload rendered by the tabs must be reconciled to
+	// the filtered case so a deep link never shows unrelated rows.
+	for _, e := range scoped.ApprovalQueue.Entries {
+		if e.CaseID != target {
+			t.Errorf("approval queue leaked case %s under case_id=%s", e.CaseID, target)
+		}
+	}
+	for _, e := range scoped.DryRuns.Entries {
+		if e.CaseID != target {
+			t.Errorf("dry-run leaked case %s under case_id=%s", e.CaseID, target)
+		}
+	}
+	for _, e := range scoped.LiveActions.Entries {
+		if e.CaseID != target {
+			t.Errorf("live action leaked case %s under case_id=%s", e.CaseID, target)
+		}
+	}
+	for _, e := range scoped.Verification.Entries {
+		if e.CaseID != target {
+			t.Errorf("verification leaked case %s under case_id=%s", e.CaseID, target)
+		}
+	}
+	for _, e := range scoped.AuditTrail {
+		if e.CaseID != target {
+			t.Errorf("audit trail leaked case %s under case_id=%s", e.CaseID, target)
+		}
+	}
 }
 
 func TestFilterAWSRemediationCenterCases(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2990,6 +2990,45 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"detail": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/remediation-center", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSRemediationCenter(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSRemediationCenterRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			Confidence:   strings.TrimSpace(c.Query("confidence")),
+			IdentityType: strings.TrimSpace(c.Query("identity_type")),
+			ActionType:   strings.TrimSpace(c.Query("action_type")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			Stage:        strings.TrimSpace(c.Query("stage")),
+			CaseID:       strings.TrimSpace(c.Query("case_id")),
+			Tab:          strings.TrimSpace(c.Query("tab")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws remediation center request"})
+			default:
+				logger.Error("get aws remediation center",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws remediation center"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"remediation_center": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/bedrock-agents", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,7 @@ import {
   ProductAWSRuntimePage,
   ProductAWSAgentIdentityDetailPage,
   ProductAWSMachineIdentityDetailPage,
+  ProductAWSRemediationCenterPage,
   ProductDomainRoutePage,
   ProductAWSConnectPage,
   ProductAWSIdentitiesPage,
@@ -4835,6 +4836,7 @@ export function RoutedSite() {
             <Route path="aws/graph" element={<ProductAWSGraphPage />} />
             <Route path="aws/findings" element={<ProductAWSFindingsPage />} />
             <Route path="aws/remediation" element={<ProductAWSRemediationPage />} />
+            <Route path="aws/remediation/center" element={<ProductAWSRemediationCenterPage />} />
             <Route path="aws/governance" element={<ProductAWSGovernancePage />} />
             <Route path="github" element={<ProductGitHubControlCenterPage />} />
             <Route path="github/connect" element={<ProductGitHubConnectPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2568,6 +2568,8 @@ export type AWSRemediationCenterCase = {
   execution_state?: string;
   verification_id?: string;
   verification_state?: string;
+  verification_entry_count?: number;
+  verification_states?: string[];
   rollback_state?: string;
   rollback_strategy?: string;
   ready_for_apply: boolean;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2529,6 +2529,17 @@ export type AWSRemediationCenterSafetyGate = {
   rationale?: string;
 };
 
+export type AWSRemediationCenterAuditEntry = {
+  case_id: string;
+  stage: AWSRemediationCenterStage;
+  event_id: string;
+  event_type: string;
+  actor: string;
+  occurred_at: string;
+  evidence_ref?: string;
+  notes?: string;
+};
+
 export type AWSRemediationCenterCase = {
   case_id: string;
   title: string;
@@ -2566,6 +2577,7 @@ export type AWSRemediationCenterCase = {
   next_action: string;
   evidence_refs?: string[];
   evidence_boundary: string;
+  audit_trail: AWSRemediationCenterAuditEntry[];
   audit_entry_count: number;
   updated_at?: string;
 };
@@ -2616,6 +2628,7 @@ export type AWSRemediationCenterResult = {
   dry_runs: AWSRemediationDryRunResult;
   live_actions: AWSLowRiskRemediationResult;
   verification: AWSPostRemediationVerificationResult;
+  audit_trail: AWSRemediationCenterAuditEntry[];
   failure_reasons: string[];
   remediation_hints: string[];
   evidence_links: string[];

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2496,6 +2496,135 @@ export type AWSAgentIdentityDetailResult = {
   updated_at: string;
 };
 
+export type AWSRemediationCenterStatus = 'ready' | 'degraded' | 'blocked' | 'permission_denied' | string;
+export type AWSRemediationCenterStage =
+  | 'case'
+  | 'approval'
+  | 'dry_run'
+  | 'live_action'
+  | 'verification'
+  | 'rollback'
+  | string;
+
+export type AWSRemediationCenterQuery = {
+  connectorID?: string;
+  fixtureState?: AWSMachineIdentityDetailFixtureState;
+  accountID?: string;
+  region?: string;
+  severity?: string;
+  confidence?: string;
+  identityType?: string;
+  actionType?: string;
+  status?: string;
+  stage?: string;
+  caseID?: string;
+  tab?: string;
+  search?: string;
+};
+
+export type AWSRemediationCenterSafetyGate = {
+  source: string;
+  name: string;
+  status: string;
+  rationale?: string;
+};
+
+export type AWSRemediationCenterCase = {
+  case_id: string;
+  title: string;
+  summary: string;
+  source_type: string;
+  action_type: string;
+  lifecycle: string;
+  stage: AWSRemediationCenterStage;
+  severity: string;
+  score: number;
+  confidence: number;
+  account_id?: string;
+  target_account_ids?: string[];
+  region?: string;
+  identity_node_id?: string;
+  identity_name?: string;
+  identity_type?: string;
+  owner?: string;
+  owner_assigned: boolean;
+  approval_required: boolean;
+  approval_state?: string;
+  approval_id?: string;
+  dry_run_id?: string;
+  dry_run_outcome?: string;
+  execution_id?: string;
+  execution_state?: string;
+  verification_id?: string;
+  verification_state?: string;
+  rollback_state?: string;
+  rollback_strategy?: string;
+  ready_for_apply: boolean;
+  kill_switch_engaged: boolean;
+  tradeoffs: AWSRemediationTradeoff[];
+  safety_gates: AWSRemediationCenterSafetyGate[];
+  next_action: string;
+  evidence_refs?: string[];
+  evidence_boundary: string;
+  audit_entry_count: number;
+  updated_at?: string;
+};
+
+export type AWSRemediationCenterSummary = {
+  total_cases: number;
+  filtered_cases: number;
+  stage_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  action_type_counts: Record<string, number>;
+  identity_type_counts: Record<string, number>;
+  approval_pending_count: number;
+  dry_run_count: number;
+  live_action_count: number;
+  verification_count: number;
+  rollback_count: number;
+  ready_for_apply_count: number;
+  kill_switch_engaged_count: number;
+  blocked_safety_gate_count: number;
+  audit_entry_count: number;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSRemediationCenterResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSRemediationCenterStatus;
+  fixture_state?: AWSMachineIdentityDetailFixtureState;
+  confidence: number;
+  policy_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSRemediationCenterSummary;
+  tabs: AWSMachineIdentityDetailTab[];
+  cases: AWSRemediationCenterCase[];
+  remediation_cases: AWSRemediationCaseResult;
+  approval_queue: AWSRemediationApprovalResult;
+  dry_runs: AWSRemediationDryRunResult;
+  live_actions: AWSLowRiskRemediationResult;
+  verification: AWSPostRemediationVerificationResult;
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSMachineIdentityDetailCoverageGap[];
+  diagnostics: AWSMachineIdentityDetailDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
 export type AWSRuntimeEventStatus = 'ready' | 'degraded' | 'blocked';
 // AWSRuntimeEventFixtureStateRequest is the query-side enum: every
 // value here is one the backend accepts as `?fixture_state=...`. It
@@ -10315,6 +10444,31 @@ export const apiClient = {
         resource: query.resource,
         severity: query.severity,
         status: query.status
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectRemediationCenter(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSRemediationCenterQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ remediation_center: AWSRemediationCenterResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/remediation-center${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        severity: query?.severity,
+        confidence: query?.confidence,
+        identity_type: query?.identityType,
+        action_type: query?.actionType,
+        status: query?.status,
+        stage: query?.stage,
+        case_id: query?.caseID,
+        tab: query?.tab,
+        search: query?.search
       })}`,
       auth
     );

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -12,6 +12,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/graph',
   '/app/:tenantID/:workspaceID/aws/findings',
   '/app/:tenantID/:workspaceID/aws/remediation',
+  '/app/:tenantID/:workspaceID/aws/remediation/center',
   '/app/:tenantID/:workspaceID/aws/governance',
   '/app/:tenantID/:workspaceID/github',
   '/app/:tenantID/:workspaceID/github/connect',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2717,6 +2717,42 @@ describe('Domain-first app routes', () => {
     expect(DOMAIN_APP_ROUTE_MANIFEST).not.toContain('/app/:tenantID/:workspaceID/findings');
   });
 
+  it('links the AWS remediation page to the remediation center', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+
+    const { ProductAWSRemediationPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/remediation?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/remediation" element={<ProductAWSRemediationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Remediation' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS remediation plan surfaces' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open center' })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/remediation/center?environment=production'
+    );
+  });
+
   it('renders premium domain route shells with provider marks and environment scope', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3427,6 +3427,118 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('renders the consolidated remediation center audit trail across lifecycle stages', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const remediationCenter = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      status: 'ready',
+      fixture_state: 'success',
+      confidence: 0.9,
+      policy_version: 'aws-remediation-center-policy-v1',
+      current_issue_ref: '#1552',
+      applied_filters: {},
+      summary: {
+        filtered_cases: 1,
+        approval_pending_count: 0,
+        dry_run_count: 0,
+        live_action_count: 0,
+        verification_count: 0,
+        rollback_count: 0,
+        ready_for_apply_count: 0,
+        kill_switch_engaged_count: 0,
+        blocked_safety_gate_count: 0,
+        audit_entry_count: 2,
+        stage_counts: {},
+        severity_counts: {},
+        status_counts: {},
+        action_type_counts: {},
+        identity_type_counts: {},
+        total_cases: 1,
+        highest_score: 80,
+        average_confidence_pct: 90
+      },
+      tabs: [
+        { id: 'overview', label: 'Overview', status: 'ready', count: 1 },
+        { id: 'cases', label: 'Cases', status: 'ready', count: 1 },
+        { id: 'approvals', label: 'Approvals', status: 'ready', count: 0 },
+        { id: 'dry_runs', label: 'Dry-runs', status: 'ready', count: 0 },
+        { id: 'live_actions', label: 'Live actions', status: 'ready', count: 0 },
+        { id: 'verification', label: 'Verification', status: 'ready', count: 0 },
+        { id: 'audit', label: 'Audit', status: 'ready', count: 2 }
+      ],
+      cases: [],
+      remediation_cases: { cases: [{}] },
+      approval_queue: { entries: [] },
+      dry_runs: { entries: [] },
+      live_actions: { entries: [] },
+      verification: { entries: [] },
+      audit_trail: [
+        {
+          case_id: 'aws-remediation-case:orders',
+          stage: 'approval',
+          event_id: 'evt-approval-1',
+          event_type: 'approval_requested',
+          actor: 'iam-platform',
+          occurred_at: '2026-07-04T09:00:00Z',
+          notes: 'Approval requested.'
+        },
+        {
+          case_id: 'aws-remediation-case:orders',
+          stage: 'verification',
+          event_id: 'evt-verify-1',
+          event_type: 'verification_completed',
+          actor: 'identrail',
+          occurred_at: '2026-07-04T10:00:00Z',
+          notes: 'Verification completed.'
+        }
+      ],
+      failure_reasons: [],
+      remediation_hints: [],
+      evidence_links: [],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-07-04T10:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z'
+    } as unknown as AWSRemediationCenterResult;
+    vi.spyOn(api.apiClient, 'getAWSProjectRemediationCenter').mockResolvedValue({ remediation_center: remediationCenter });
+
+    const { ProductAWSRemediationCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/remediation/center?environment=production&tab=audit']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/remediation/center"
+            element={<ProductAWSRemediationCenterPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('table', { name: 'Remediation center audit trail' })).toBeInTheDocument();
+    // The audit tab consolidates every lifecycle stage, not just verification.
+    expect(screen.getByText('Approval requested.')).toBeInTheDocument();
+    expect(screen.getByText('Verification completed.')).toBeInTheDocument();
+  });
+
   it('forwards remediation center filters to the API and preserves them across tabs', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3427,6 +3427,115 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('loads the AWS remediation center without a connector identifier', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const remediationCenter = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      status: 'permission_denied',
+      fixture_state: 'permission_denied',
+      confidence: 0,
+      policy_version: 'aws-remediation-center-policy-v1',
+      parent_issue_number: 1472,
+      parent_issue_ref: '#1472',
+      current_issue_number: 1552,
+      current_issue_ref: '#1552',
+      version: 'aws-remediation-center-v1',
+      applied_filters: {},
+      summary: {
+        total_cases: 0,
+        filtered_cases: 0,
+        stage_counts: {},
+        severity_counts: {},
+        status_counts: {},
+        action_type_counts: {},
+        identity_type_counts: {},
+        approval_pending_count: 0,
+        dry_run_count: 0,
+        live_action_count: 0,
+        verification_count: 0,
+        rollback_count: 0,
+        ready_for_apply_count: 0,
+        kill_switch_engaged_count: 0,
+        blocked_safety_gate_count: 0,
+        audit_entry_count: 0,
+        highest_score: 0,
+        average_confidence_pct: 0
+      },
+      tabs: [
+        { id: 'overview', label: 'Overview', status: 'permission_denied', count: 0 },
+        { id: 'cases', label: 'Cases', status: 'permission_denied', count: 0 },
+        { id: 'approvals', label: 'Approvals', status: 'permission_denied', count: 0 },
+        { id: 'dry_runs', label: 'Dry-runs', status: 'permission_denied', count: 0 },
+        { id: 'live_actions', label: 'Live actions', status: 'permission_denied', count: 0 },
+        { id: 'verification', label: 'Verification', status: 'permission_denied', count: 0 },
+        { id: 'audit', label: 'Audit', status: 'permission_denied', count: 0 }
+      ],
+      cases: [],
+      remediation_cases: { cases: [] },
+      approval_queue: { entries: [] },
+      dry_runs: { entries: [] },
+      live_actions: { entries: [] },
+      verification: { entries: [] },
+      audit_trail: [],
+      failure_reasons: ['Connect an AWS connector before viewing remediation lifecycle evidence.'],
+      remediation_hints: ['Finish AWS connector setup or choose another environment.'],
+      evidence_links: [],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-07-04T10:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z'
+    } as unknown as AWSRemediationCenterResult;
+    const getRemediationCenter = vi
+      .spyOn(api.apiClient, 'getAWSProjectRemediationCenter')
+      .mockResolvedValue({ remediation_center: remediationCenter });
+
+    const { ProductAWSRemediationCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/remediation/center?environment=production']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/remediation/center"
+            element={<ProductAWSRemediationCenterPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Connect an AWS connector before viewing remediation lifecycle evidence.')).toBeInTheDocument();
+    expect(screen.getByText('Finish AWS connector setup or choose another environment.')).toBeInTheDocument();
+    expect(screen.queryByText('AWS connector is unavailable')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Overview\s+0/i })).toHaveAttribute('aria-selected', 'true');
+    expect(getRemediationCenter).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      {
+        tab: 'overview'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      }
+    );
+  });
+
   it('renders the consolidated remediation center audit trail across lifecycle stages', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3411,7 +3411,7 @@ describe('Domain-first app routes', () => {
 
     expect(await screen.findByText('Reduce orders-deployer policy')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Remediation Center' })).toBeInTheDocument();
-    expect(screen.getByRole('table', { name: 'Remediation center case lifecycle' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'Remediation center safety review' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Overview\s+1/i })).toHaveAttribute('aria-selected', 'true');
     expect(getRemediationCenter).toHaveBeenCalledWith(
       'workspace-a',
@@ -3425,6 +3425,150 @@ describe('Domain-first app routes', () => {
         workspaceID: 'workspace-a'
       }
     );
+  });
+
+  it('forwards remediation center filters to the API and preserves them across tabs', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const remediationCenter = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      current_issue_number: 1552,
+      current_issue_ref: '#1552',
+      version: 'aws-remediation-center-v1',
+      status: 'ready',
+      fixture_state: 'success',
+      confidence: 0.9,
+      policy_version: 'aws-remediation-center-policy-v1',
+      applied_filters: { severity: 'high', account_id: '123456789012' },
+      summary: {
+        total_cases: 1,
+        filtered_cases: 1,
+        stage_counts: {},
+        severity_counts: {},
+        status_counts: {},
+        action_type_counts: {},
+        identity_type_counts: {},
+        approval_pending_count: 0,
+        dry_run_count: 1,
+        live_action_count: 0,
+        verification_count: 0,
+        rollback_count: 0,
+        ready_for_apply_count: 0,
+        kill_switch_engaged_count: 0,
+        blocked_safety_gate_count: 0,
+        audit_entry_count: 0,
+        highest_score: 80,
+        average_confidence_pct: 90
+      },
+      tabs: [
+        { id: 'overview', label: 'Overview', status: 'ready', count: 1 },
+        { id: 'cases', label: 'Cases', status: 'ready', count: 1 },
+        { id: 'approvals', label: 'Approvals', status: 'ready', count: 0 },
+        { id: 'dry_runs', label: 'Dry-runs', status: 'ready', count: 1 },
+        { id: 'live_actions', label: 'Live actions', status: 'ready', count: 0 },
+        { id: 'verification', label: 'Verification', status: 'ready', count: 0 },
+        { id: 'audit', label: 'Audit', status: 'ready', count: 0 }
+      ],
+      cases: [
+        {
+          case_id: 'aws-remediation-case:least-privilege-orders',
+          title: 'Reduce orders-deployer policy',
+          summary: 'Remove unused IAM actions from orders-deployer.',
+          source_type: 'least_privilege',
+          action_type: 'iam_policy_diff',
+          lifecycle: 'proposed',
+          stage: 'dry_run',
+          severity: 'high',
+          score: 80,
+          confidence: 0.9,
+          account_id: '123456789012',
+          region: 'us-east-1',
+          identity_type: 'iam_role',
+          owner_assigned: true,
+          approval_required: true,
+          ready_for_apply: false,
+          kill_switch_engaged: false,
+          tradeoffs: [],
+          safety_gates: [],
+          next_action: 'Advance the approval workflow before scheduling a live action.',
+          evidence_boundary: 'metadata_only',
+          audit_entry_count: 0
+        }
+      ],
+      remediation_cases: { cases: [{}] },
+      approval_queue: { entries: [] },
+      dry_runs: { entries: [] },
+      live_actions: { entries: [] },
+      verification: { entries: [] },
+      failure_reasons: [],
+      remediation_hints: [],
+      evidence_links: [],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-07-04T10:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z'
+    } as unknown as AWSRemediationCenterResult;
+    const getRemediationCenter = vi
+      .spyOn(api.apiClient, 'getAWSProjectRemediationCenter')
+      .mockResolvedValue({ remediation_center: remediationCenter });
+
+    const { ProductAWSRemediationCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/app/tenant-a/workspace-a/aws/remediation/center?environment=production&tab=cases&severity=high&account_id=123456789012'
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/remediation/center"
+            element={<ProductAWSRemediationCenterPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Reduce orders-deployer policy')).toBeInTheDocument();
+    expect(getRemediationCenter).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      {
+        connectorID: 'aws-connector-1',
+        tab: 'cases',
+        severity: 'high',
+        accountID: '123456789012'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      }
+    );
+    // Tab links preserve the active filter params so deep links survive navigation.
+    const dryRunsTab = screen.getByRole('tab', { name: /Dry-runs\s+1/i });
+    const href = dryRunsTab.getAttribute('href') ?? '';
+    expect(href).toContain('severity=high');
+    expect(href).toContain('account_id=123456789012');
+    expect(href).toContain('tab=dry_runs');
   });
 
   it('renders AWS agent identity detail scoped to the selected agent and tab', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -18,6 +18,7 @@ import type {
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
+  AWSRemediationCenterResult,
   AWSRuntimeEventResult,
   AWSServiceCollectorContractResult,
   AWSUnusedDormantAccessResult,
@@ -2686,6 +2687,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/graph',
       '/app/:tenantID/:workspaceID/aws/findings',
       '/app/:tenantID/:workspaceID/aws/remediation',
+      '/app/:tenantID/:workspaceID/aws/remediation/center',
       '/app/:tenantID/:workspaceID/aws/governance',
       '/app/:tenantID/:workspaceID/github',
       '/app/:tenantID/:workspaceID/github/connect',
@@ -3272,6 +3274,151 @@ describe('Domain-first app routes', () => {
         connectorID: 'aws-connector-1',
         identity,
         tab: 'runtime'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      }
+    );
+  });
+
+  it('renders the AWS remediation center scoped to the selected tab', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const remediationCenter = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production',
+      connector_id: 'aws-connector-1',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      parent_issue_number: 1472,
+      parent_issue_ref: '#1472',
+      current_issue_number: 1552,
+      current_issue_ref: '#1552',
+      version: 'aws-remediation-center-v1',
+      status: 'ready',
+      fixture_state: 'success',
+      confidence: 0.9,
+      policy_version: 'aws-remediation-center-policy-v1',
+      applied_filters: {},
+      summary: {
+        total_cases: 1,
+        filtered_cases: 1,
+        stage_counts: { dry_run: 1 },
+        severity_counts: { high: 1 },
+        status_counts: { proposed: 1 },
+        action_type_counts: { iam_policy_diff: 1 },
+        identity_type_counts: { iam_role: 1 },
+        approval_pending_count: 1,
+        dry_run_count: 1,
+        live_action_count: 0,
+        verification_count: 0,
+        rollback_count: 0,
+        ready_for_apply_count: 0,
+        kill_switch_engaged_count: 0,
+        blocked_safety_gate_count: 0,
+        audit_entry_count: 0,
+        highest_score: 80,
+        average_confidence_pct: 90
+      },
+      tabs: [
+        { id: 'overview', label: 'Overview', status: 'ready', count: 1 },
+        { id: 'cases', label: 'Cases', status: 'ready', count: 1 },
+        { id: 'approvals', label: 'Approvals', status: 'ready', count: 1 },
+        { id: 'dry_runs', label: 'Dry-runs', status: 'ready', count: 1 },
+        { id: 'live_actions', label: 'Live actions', status: 'ready', count: 0 },
+        { id: 'verification', label: 'Verification', status: 'ready', count: 0 },
+        { id: 'audit', label: 'Audit', status: 'ready', count: 0 }
+      ],
+      cases: [
+        {
+          case_id: 'aws-remediation-case:least-privilege-orders',
+          title: 'Reduce orders-deployer policy',
+          summary: 'Remove unused IAM actions from orders-deployer.',
+          source_type: 'least_privilege',
+          action_type: 'iam_policy_diff',
+          lifecycle: 'proposed',
+          stage: 'dry_run',
+          severity: 'high',
+          score: 80,
+          confidence: 0.9,
+          account_id: '123456789012',
+          region: 'us-east-1',
+          identity_node_id: 'aws:identity:orders-deployer',
+          identity_type: 'iam_role',
+          owner: 'iam-platform',
+          owner_assigned: true,
+          approval_required: true,
+          approval_state: 'pending_approver',
+          approval_id: 'aws-remediation-approval:orders',
+          dry_run_id: 'aws-remediation-dry-run:orders',
+          dry_run_outcome: 'would_succeed',
+          ready_for_apply: false,
+          kill_switch_engaged: false,
+          tradeoffs: [],
+          safety_gates: [
+            { source: 'dry_run_prerequisite', name: 'approval_state_approved', status: 'blocked', rationale: 'Approval required.' }
+          ],
+          next_action: 'Advance the approval workflow before scheduling a live action.',
+          evidence_boundary: 'metadata_only_no_rendered_policy_bodies_no_secret_values_no_workload_payloads_tenant_workspace_project_connector_account_region_scoped',
+          audit_entry_count: 0
+        }
+      ],
+      remediation_cases: { cases: [{}] },
+      approval_queue: { entries: [] },
+      dry_runs: { entries: [] },
+      live_actions: { entries: [] },
+      verification: { entries: [] },
+      failure_reasons: [],
+      remediation_hints: [],
+      evidence_links: ['/docs/aws-remediation-center'],
+      coverage_gaps: [],
+      diagnostics: [],
+      generated_at: '2026-07-04T10:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z'
+    } as unknown as AWSRemediationCenterResult;
+    const getRemediationCenter = vi
+      .spyOn(api.apiClient, 'getAWSProjectRemediationCenter')
+      .mockResolvedValue({ remediation_center: remediationCenter });
+
+    const { ProductAWSRemediationCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/remediation/center?environment=production']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/remediation/center"
+            element={<ProductAWSRemediationCenterPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Reduce orders-deployer policy')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Remediation Center' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'Remediation center case lifecycle' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Overview\s+1/i })).toHaveAttribute('aria-selected', 'true');
+    expect(getRemediationCenter).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      {
+        connectorID: 'aws-connector-1',
+        tab: 'overview'
       },
       {
         tenantID: 'tenant-a',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -48,6 +48,8 @@ import {
   type AWSAIAgentIdentityInventoryResult,
   type AWSMachineIdentityDetailResult,
   type AWSAgentIdentityDetailResult,
+  type AWSRemediationCenterResult,
+  type AWSRemediationCenterCase,
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
@@ -10879,6 +10881,420 @@ export function ProductAWSAgentIdentityDetailPage() {
               detail={detail}
             />
             <AWSAgentIdentityDetailTabContent detail={detail} activeTab={activeTab} />
+          </>
+        ) : null}
+      </div>
+    </DomainPageShell>
+  );
+}
+
+const AWS_REMEDIATION_CENTER_TAB_IDS = ['overview', 'cases', 'approvals', 'dry_runs', 'live_actions', 'verification', 'audit'] as const;
+type AWSRemediationCenterTabID = (typeof AWS_REMEDIATION_CENTER_TAB_IDS)[number];
+const AWS_REMEDIATION_CENTER_TAB_LABELS: Record<AWSRemediationCenterTabID, string> = {
+  overview: 'Overview',
+  cases: 'Cases',
+  approvals: 'Approvals',
+  dry_runs: 'Dry-runs',
+  live_actions: 'Live actions',
+  verification: 'Verification',
+  audit: 'Audit'
+};
+
+function normalizeAWSRemediationCenterTab(value: string | null): AWSRemediationCenterTabID {
+  const normalized = normalizeValue(value ?? '').toLowerCase();
+  return AWS_REMEDIATION_CENTER_TAB_IDS.includes(normalized as AWSRemediationCenterTabID)
+    ? (normalized as AWSRemediationCenterTabID)
+    : 'overview';
+}
+
+function awsRemediationCenterStatusStage(status: string): AWSCapabilityStage {
+  if (status === 'ready') {
+    return 'wired';
+  }
+  if (status === 'blocked' || status === 'permission_denied') {
+    return 'not-available';
+  }
+  return 'coming';
+}
+
+function awsRemediationCenterStatusTone(status: string): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (status === 'ready') {
+    return 'success';
+  }
+  if (status === 'blocked' || status === 'permission_denied') {
+    return 'danger';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function awsRemediationCenterStageStage(stage: string, killSwitch: boolean): AWSCapabilityStage {
+  if (killSwitch || stage === 'rollback') {
+    return 'not-available';
+  }
+  if (stage === 'verification') {
+    return 'wired';
+  }
+  return 'coming';
+}
+
+function awsRemediationCenterLink(scope: ProductSession, environmentID: string, tab: AWSRemediationCenterTabID): string {
+  const params = new URLSearchParams();
+  const normalizedEnvironmentID = normalizeValue(environmentID);
+  if (normalizedEnvironmentID) {
+    params.set(ENVIRONMENT_QUERY_PARAM, normalizedEnvironmentID);
+  }
+  if (tab && tab !== 'overview') {
+    params.set('tab', tab);
+  }
+  const search = params.toString();
+  return `${buildScopedPath(scope, 'aws/remediation/center')}${search ? `?${search}` : ''}`;
+}
+
+function AWSRemediationCenterTabs({
+  scope,
+  selectedEnvironmentID,
+  activeTab,
+  center
+}: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
+  activeTab: AWSRemediationCenterTabID;
+  center: AWSRemediationCenterResult | null;
+}) {
+  const tabCounts = new Map((center?.tabs ?? []).map((tab) => [tab.id, tab.count]));
+  return (
+    <div className="idt-inline-actions" role="tablist" aria-label="Remediation center tabs">
+      {AWS_REMEDIATION_CENTER_TAB_IDS.map((tabID) => (
+        <Link
+          key={tabID}
+          role="tab"
+          aria-selected={activeTab === tabID}
+          aria-label={`${AWS_REMEDIATION_CENTER_TAB_LABELS[tabID]} ${tabCounts.get(tabID) ?? 0}`}
+          className={`idt-btn ${activeTab === tabID ? 'idt-btn-primary' : 'idt-btn-ghost'}`}
+          to={awsRemediationCenterLink(scope, selectedEnvironmentID, tabID)}
+        >
+          <span>{AWS_REMEDIATION_CENTER_TAB_LABELS[tabID]}</span>
+          <span>{tabCounts.get(tabID) ?? 0}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function awsRemediationCenterCaseGateLabel(entry: AWSRemediationCenterCase): string {
+  const blocked = entry.safety_gates.filter((gate) => gate.status === 'blocked' || gate.status === 'failed').length;
+  return `${entry.safety_gates.length - blocked}/${entry.safety_gates.length} gates`;
+}
+
+function AWSRemediationCenterCasesTable({ cases }: { cases: AWSRemediationCenterCase[] }) {
+  return (
+    <DomainDataTable
+      label="Remediation center case lifecycle"
+      rows={cases}
+      getRowKey={(row) => row.case_id}
+      emptyState={<DomainEmptyState eyebrow="Empty" title="No remediation cases" body="No remediation case matched the current filters for this environment." />}
+      columns={[
+        { key: 'case', header: 'Case', render: (row) => <strong>{row.title}</strong> },
+        { key: 'action', header: 'Action', render: (row) => formatTokenLabel(row.action_type) },
+        { key: 'stage', header: 'Stage', render: (row) => formatTokenLabel(row.stage) },
+        { key: 'gates', header: 'Safety gates', render: (row) => awsRemediationCenterCaseGateLabel(row) },
+        { key: 'next', header: 'Next action', render: (row) => row.next_action },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill
+              stage={awsRemediationCenterStageStage(row.stage, row.kill_switch_engaged)}
+              label={`${formatTokenLabel(row.severity)} / ${formatConfidenceScore(row.confidence)}`}
+            />
+          )
+        }
+      ]}
+    />
+  );
+}
+
+function AWSRemediationCenterTabContent({
+  center,
+  activeTab
+}: {
+  center: AWSRemediationCenterResult;
+  activeTab: AWSRemediationCenterTabID;
+}) {
+  if (activeTab === 'approvals') {
+    return (
+      <DomainDataTable
+        label="Remediation center approval queue"
+        rows={center.approval_queue.entries}
+        getRowKey={(row) => row.approval_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No approvals" body="No approval-queue entry matched the current filters." />}
+        columns={[
+          { key: 'approval', header: 'Approval', render: (row) => <strong>{row.title}</strong> },
+          { key: 'case', header: 'Case', render: (row) => row.case_id },
+          { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+          { key: 'ready', header: 'Ready', render: (row) => (row.ready_for_execution ? 'Ready' : 'Not ready') },
+          { key: 'severity', header: 'Severity', render: (row) => formatTokenLabel(row.severity) }
+        ]}
+      />
+    );
+  }
+  if (activeTab === 'dry_runs') {
+    return (
+      <DomainDataTable
+        label="Remediation center dry-runs"
+        rows={center.dry_runs.entries}
+        getRowKey={(row) => row.dry_run_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No dry-runs" body="No dry-run projection matched the current filters." />}
+        columns={[
+          { key: 'dryrun', header: 'Dry-run', render: (row) => <strong>{row.title}</strong> },
+          { key: 'case', header: 'Case', render: (row) => row.case_id },
+          { key: 'outcome', header: 'Outcome', render: (row) => formatTokenLabel(row.outcome) },
+          { key: 'ready', header: 'Ready', render: (row) => (row.ready_for_apply ? 'Ready for apply' : 'Not ready') },
+          { key: 'severity', header: 'Severity', render: (row) => formatTokenLabel(row.severity) }
+        ]}
+      />
+    );
+  }
+  if (activeTab === 'live_actions') {
+    return (
+      <DomainDataTable
+        label="Remediation center live actions"
+        rows={center.live_actions.entries}
+        getRowKey={(row) => row.execution_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No live actions" body="No low-risk live action matched the current filters." />}
+        columns={[
+          { key: 'action', header: 'Action', render: (row) => <strong>{row.title}</strong> },
+          { key: 'case', header: 'Case', render: (row) => row.case_id },
+          { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action },
+          { key: 'severity', header: 'Severity', render: (row) => formatTokenLabel(row.severity) }
+        ]}
+      />
+    );
+  }
+  if (activeTab === 'verification') {
+    return (
+      <DomainDataTable
+        label="Remediation center verification and rollback"
+        rows={center.verification.entries}
+        getRowKey={(row) => row.verification_id}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No verification records" body="No post-remediation verification record matched the current filters." />}
+        columns={[
+          { key: 'verification', header: 'Verification', render: (row) => <strong>{row.title}</strong> },
+          { key: 'case', header: 'Case', render: (row) => row.case_id },
+          { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
+          { key: 'rollback', header: 'Rollback', render: (row) => formatTokenLabel(row.rollback.state) },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action }
+        ]}
+      />
+    );
+  }
+  if (activeTab === 'audit') {
+    const auditRows = center.verification.entries.flatMap((entry) =>
+      entry.audit_trail.map((audit) => ({ ...audit, verification_id: entry.verification_id, case_id: entry.case_id }))
+    );
+    return (
+      <DomainDataTable
+        label="Remediation center audit trail"
+        rows={auditRows}
+        getRowKey={(row) => `${row.verification_id}-${row.event_id}`}
+        emptyState={<DomainEmptyState eyebrow="Empty" title="No audit entries" body="No immutable audit record matched the current filters." />}
+        columns={[
+          { key: 'event', header: 'Event', render: (row) => formatTokenLabel(row.event_type) },
+          { key: 'actor', header: 'Actor', render: (row) => row.actor },
+          { key: 'case', header: 'Case', render: (row) => row.case_id },
+          { key: 'occurred', header: 'Occurred', render: (row) => formatDateLabel(row.occurred_at) },
+          { key: 'notes', header: 'Notes', render: (row) => row.notes || '-' }
+        ]}
+      />
+    );
+  }
+  return <AWSRemediationCenterCasesTable cases={center.cases} />;
+}
+
+export function ProductAWSRemediationCenterPage() {
+  const data = useAWSInventoryData();
+  const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
+  const location = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const activeTab = normalizeAWSRemediationCenterTab(searchParams.get('tab'));
+  const [center, setCenter] = useState<AWSRemediationCenterResult | null>(null);
+  const [centerLoading, setCenterLoading] = useState(false);
+  const [centerError, setCenterError] = useState('');
+  const centerRequestRef = useRef(0);
+
+  const loadCenter = useCallback(async () => {
+    const requestID = ++centerRequestRef.current;
+    setCenter(null);
+    setCenterError('');
+    if (!scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setCenterLoading(false);
+      return;
+    }
+    setCenterLoading(true);
+    try {
+      const response = await apiClient.getAWSProjectRemediationCenter(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          tab: activeTab
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== centerRequestRef.current) {
+        return;
+      }
+      setCenter(response.remediation_center);
+    } catch (error) {
+      if (requestID !== centerRequestRef.current) {
+        return;
+      }
+      setCenterError(formatAPIError(error, 'Unable to load AWS remediation center.'));
+    } finally {
+      if (requestID === centerRequestRef.current) {
+        setCenterLoading(false);
+      }
+    }
+  }, [
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    activeTab,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadCenter();
+    return () => {
+      centerRequestRef.current += 1;
+    };
+  }, [loadCenter]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Remediation Center</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading the AWS Remediation Center.</p>
+      </section>
+    );
+  }
+
+  const remediationPath = awsRouteLink(scope, 'remediation', selectedEnvironmentID);
+  const governancePath = awsRouteLink(scope, 'governance', selectedEnvironmentID);
+  const status = environmentScope.loading || connectionLoading || centerLoading
+    ? 'Loading center'
+    : connectionError || centerError
+      ? 'Needs retry'
+      : center
+        ? formatTokenLabel(center.status)
+        : 'Not loaded';
+  const statusTone = connectionError || centerError
+    ? 'danger'
+    : center
+      ? awsRemediationCenterStatusTone(center.status)
+      : awsDomainTone(connection, environmentScope.loading || connectionLoading);
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow={null}
+      hideLogo
+      title="Remediation Center"
+      description="Unified read-only view of remediation cases, approvals, dry-runs, live actions, verification, rollback, and audit — with tradeoffs and safety gates before action."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
+      status={status}
+      statusTone={statusTone}
+      primaryAction={{ label: 'Back to remediation', to: remediationPath, variant: 'secondary' }}
+    >
+      <div className="idt-aws-risk-page">
+        {connectionError ? (
+          <DomainErrorState
+            title="Couldn't load AWS status"
+            body={connectionError}
+            retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
+          />
+        ) : null}
+        {!connectionError && !connectionLoading && !connection?.connector_id ? (
+          <DomainEmptyState
+            eyebrow="Connector required"
+            title="AWS connector is unavailable"
+            body="The selected environment does not have an AWS connector identifier to scope the remediation center request."
+          />
+        ) : null}
+        {centerError ? (
+          <DomainErrorState
+            title="Couldn't load the remediation center"
+            body={centerError}
+            retryAction={{ label: 'Retry', onClick: loadCenter }}
+          />
+        ) : null}
+        {!centerError && centerLoading ? <DomainLoadingState label="Loading remediation center" /> : null}
+        {center ? (
+          <>
+            <DomainKpiStrip
+              label="Remediation center metrics"
+              items={[
+                { label: 'Cases', value: center.summary.filtered_cases, detail: 'in lifecycle' },
+                { label: 'Approvals', value: center.summary.approval_pending_count, detail: 'pending' },
+                { label: 'Dry-runs', value: center.summary.dry_run_count, detail: 'projected' },
+                { label: 'Live actions', value: center.summary.live_action_count, detail: 'recorded' },
+                { label: 'Verification', value: center.summary.verification_count, detail: 'checks' },
+                { label: 'Blocked gates', value: center.summary.blocked_safety_gate_count, detail: 'safety gates' }
+              ]}
+            />
+            <DomainStatusPanel
+              eyebrow="Evidence contract"
+              title="Read-only remediation lifecycle"
+              status={<AWSInventoryPill stage={awsRemediationCenterStatusStage(center.status)} label={formatTokenLabel(center.status)} />}
+              tone={awsRemediationCenterStatusTone(center.status)}
+              actions={[
+                { label: 'Remediation', to: remediationPath, variant: 'secondary' },
+                { label: 'Governance', to: governancePath, variant: 'secondary' }
+              ]}
+            >
+              <dl className="idt-domain-route-facts">
+                <div>
+                  <dt>Ready for apply</dt>
+                  <dd>{center.summary.ready_for_apply_count}</dd>
+                </div>
+                <div>
+                  <dt>Kill switch engaged</dt>
+                  <dd>{center.summary.kill_switch_engaged_count}</dd>
+                </div>
+                <div>
+                  <dt>Rollbacks</dt>
+                  <dd>{center.summary.rollback_count}</dd>
+                </div>
+                <div>
+                  <dt>Account</dt>
+                  <dd>{center.account_id || 'Not reported'}</dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{formatConfidenceScore(center.confidence)}</dd>
+                </div>
+                <div>
+                  <dt>Policy</dt>
+                  <dd>{center.policy_version}</dd>
+                </div>
+                <div>
+                  <dt>Issue</dt>
+                  <dd>{center.current_issue_ref}</dd>
+                </div>
+              </dl>
+            </DomainStatusPanel>
+            <AWSRemediationCenterTabs
+              scope={scope}
+              selectedEnvironmentID={selectedEnvironmentID}
+              activeTab={activeTab}
+              center={center}
+            />
+            <AWSRemediationCenterTabContent center={center} activeTab={activeTab} />
           </>
         ) : null}
       </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -11247,20 +11247,23 @@ export function ProductAWSRemediationCenterPage() {
     const requestID = ++centerRequestRef.current;
     setCenter(null);
     setCenterError('');
-    if (!scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!scope || !selectedEnvironmentID || connectionLoading || connectionError) {
       setCenterLoading(false);
       return;
+    }
+    const request: AWSRemediationCenterQuery = {
+      tab: activeTab,
+      ...filters
+    };
+    if (connection?.connector_id) {
+      request.connectorID = connection.connector_id;
     }
     setCenterLoading(true);
     try {
       const response = await apiClient.getAWSProjectRemediationCenter(
         scope.workspaceID,
         selectedEnvironmentID,
-        {
-          connectorID: connection.connector_id,
-          tab: activeTab,
-          ...filters
-        },
+        request,
         buildProductAuthContext(scope)
       );
       if (requestID !== centerRequestRef.current) {
@@ -11283,6 +11286,8 @@ export function ProductAWSRemediationCenterPage() {
     selectedEnvironmentID,
     activeTab,
     filters,
+    connectionLoading,
+    connectionError,
     connection?.connector_id
   ]);
 
@@ -11336,13 +11341,6 @@ export function ProductAWSRemediationCenterPage() {
             title="Couldn't load AWS status"
             body={connectionError}
             retryAction={{ label: 'Retry', onClick: data.refreshConnection }}
-          />
-        ) : null}
-        {!connectionError && !connectionLoading && !connection?.connector_id ? (
-          <DomainEmptyState
-            eyebrow="Connector required"
-            title="AWS connector is unavailable"
-            body="The selected environment does not have an AWS connector identifier to scope the remediation center request."
           />
         ) : null}
         {centerError ? (
@@ -11404,6 +11402,14 @@ export function ProductAWSRemediationCenterPage() {
                 <div>
                   <dt>Issue</dt>
                   <dd>{center.current_issue_ref}</dd>
+                </div>
+                <div>
+                  <dt>Failures</dt>
+                  <dd>{center.failure_reasons.length ? center.failure_reasons.join(', ') : 'None'}</dd>
+                </div>
+                <div>
+                  <dt>Next actions</dt>
+                  <dd>{center.remediation_hints.length ? center.remediation_hints.join(', ') : 'None'}</dd>
                 </div>
               </dl>
             </DomainStatusPanel>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3280,6 +3280,10 @@ function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, envi
   return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
 }
 
+function awsRemediationCenterPath(scope: ProductSession, environmentID: string): string {
+  return appendEnvironmentQuery(buildScopedPath(scope, 'aws/remediation/center'), environmentID);
+}
+
 function awsMachineIdentityDetailLink(
   scope: ProductSession,
   environmentID: string,
@@ -17865,6 +17869,7 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const graphPath = awsRouteLink(scope, 'graph', selectedEnvironmentID);
   const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
   const remediationPath = awsRouteLink(scope, 'remediation', selectedEnvironmentID);
+  const remediationCenterPath = awsRemediationCenterPath(scope, selectedEnvironmentID);
   const governancePath = awsRouteLink(scope, 'governance', selectedEnvironmentID);
   const status =
     environmentScope.loading || connectionLoading
@@ -17897,6 +17902,18 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   void governancePath;
   void homePath;
 
+  const actionsUnavailable = connectionError || environmentScope.loading || connectionLoading;
+  const primaryAction = actionsUnavailable
+    ? undefined
+    : routeID === 'remediation' && connection?.connected
+      ? { label: 'Open center', to: remediationCenterPath, variant: 'primary' as const }
+      : connection?.connected
+        ? undefined
+        : { label: 'Connect AWS', to: connectPath, variant: 'primary' as const };
+  const secondaryActions = !actionsUnavailable && routeID === 'remediation' && !connection?.connected
+    ? [{ label: 'Open center', to: remediationCenterPath, variant: 'secondary' as const }]
+    : undefined;
+
   return (
     <DomainPageShell
       domain="aws"
@@ -17906,13 +17923,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       description={riskSubtitle}
       scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
       statusTone={connectionError ? 'danger' : statusTone}
-      primaryAction={
-        connectionError || environmentScope.loading || connectionLoading
-          ? undefined
-          : connection?.connected
-            ? undefined
-            : { label: 'Connect AWS', to: connectPath, variant: 'primary' }
-      }
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
     >
       <div className="idt-aws-risk-page">
         {connectionError ? (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -11182,17 +11182,15 @@ function AWSRemediationCenterTabContent({
     );
   }
   if (activeTab === 'audit') {
-    const auditRows = center.verification.entries.flatMap((entry) =>
-      entry.audit_trail.map((audit) => ({ ...audit, verification_id: entry.verification_id, case_id: entry.case_id }))
-    );
     return (
       <DomainDataTable
         label="Remediation center audit trail"
-        rows={auditRows}
-        getRowKey={(row) => `${row.verification_id}-${row.event_id}`}
+        rows={center.audit_trail}
+        getRowKey={(row) => `${row.case_id}-${row.stage}-${row.event_id}`}
         emptyState={<DomainEmptyState eyebrow="Empty" title="No audit entries" body="No immutable audit record matched the current filters." />}
         columns={[
           { key: 'event', header: 'Event', render: (row) => formatTokenLabel(row.event_type) },
+          { key: 'stage', header: 'Stage', render: (row) => formatTokenLabel(row.stage) },
           { key: 'actor', header: 'Actor', render: (row) => row.actor },
           { key: 'case', header: 'Case', render: (row) => row.case_id },
           { key: 'occurred', header: 'Occurred', render: (row) => formatDateLabel(row.occurred_at) },

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -50,6 +50,7 @@ import {
   type AWSAgentIdentityDetailResult,
   type AWSRemediationCenterResult,
   type AWSRemediationCenterCase,
+  type AWSRemediationCenterQuery,
   type AWSBedrockAgentsInventoryResult,
   type AWSBedrockAgentRecord,
   type AWSAIAgentIdentityRecord,
@@ -10907,6 +10908,33 @@ function normalizeAWSRemediationCenterTab(value: string | null): AWSRemediationC
     : 'overview';
 }
 
+// URL filter params for the remediation center, mapped to their API query keys.
+// These are preserved across tab navigation and forwarded to the API so deep
+// links with filters fetch the expected subset.
+const AWS_REMEDIATION_CENTER_FILTER_PARAMS: Record<string, Exclude<keyof AWSRemediationCenterQuery, 'fixtureState'>> = {
+  account_id: 'accountID',
+  region: 'region',
+  severity: 'severity',
+  confidence: 'confidence',
+  identity_type: 'identityType',
+  action_type: 'actionType',
+  status: 'status',
+  stage: 'stage',
+  case_id: 'caseID',
+  search: 'search'
+};
+
+function awsRemediationCenterFiltersFromParams(searchParams: URLSearchParams): Partial<AWSRemediationCenterQuery> {
+  const query: Partial<AWSRemediationCenterQuery> = {};
+  for (const [param, key] of Object.entries(AWS_REMEDIATION_CENTER_FILTER_PARAMS)) {
+    const value = normalizeValue(searchParams.get(param) ?? '');
+    if (value) {
+      query[key] = value;
+    }
+  }
+  return query;
+}
+
 function awsRemediationCenterStatusStage(status: string): AWSCapabilityStage {
   if (status === 'ready') {
     return 'wired';
@@ -10940,11 +10968,22 @@ function awsRemediationCenterStageStage(stage: string, killSwitch: boolean): AWS
   return 'coming';
 }
 
-function awsRemediationCenterLink(scope: ProductSession, environmentID: string, tab: AWSRemediationCenterTabID): string {
+function awsRemediationCenterLink(
+  scope: ProductSession,
+  environmentID: string,
+  tab: AWSRemediationCenterTabID,
+  searchParams: URLSearchParams
+): string {
   const params = new URLSearchParams();
   const normalizedEnvironmentID = normalizeValue(environmentID);
   if (normalizedEnvironmentID) {
     params.set(ENVIRONMENT_QUERY_PARAM, normalizedEnvironmentID);
+  }
+  for (const param of Object.keys(AWS_REMEDIATION_CENTER_FILTER_PARAMS)) {
+    const value = normalizeValue(searchParams.get(param) ?? '');
+    if (value) {
+      params.set(param, value);
+    }
   }
   if (tab && tab !== 'overview') {
     params.set('tab', tab);
@@ -10957,12 +10996,14 @@ function AWSRemediationCenterTabs({
   scope,
   selectedEnvironmentID,
   activeTab,
-  center
+  center,
+  searchParams
 }: {
   scope: ProductSession;
   selectedEnvironmentID: string;
   activeTab: AWSRemediationCenterTabID;
   center: AWSRemediationCenterResult | null;
+  searchParams: URLSearchParams;
 }) {
   const tabCounts = new Map((center?.tabs ?? []).map((tab) => [tab.id, tab.count]));
   return (
@@ -10974,7 +11015,7 @@ function AWSRemediationCenterTabs({
           aria-selected={activeTab === tabID}
           aria-label={`${AWS_REMEDIATION_CENTER_TAB_LABELS[tabID]} ${tabCounts.get(tabID) ?? 0}`}
           className={`idt-btn ${activeTab === tabID ? 'idt-btn-primary' : 'idt-btn-ghost'}`}
-          to={awsRemediationCenterLink(scope, selectedEnvironmentID, tabID)}
+          to={awsRemediationCenterLink(scope, selectedEnvironmentID, tabID, searchParams)}
         >
           <span>{AWS_REMEDIATION_CENTER_TAB_LABELS[tabID]}</span>
           <span>{tabCounts.get(tabID) ?? 0}</span>
@@ -10984,9 +11025,54 @@ function AWSRemediationCenterTabs({
   );
 }
 
+// A gate is considered blocking when it is explicitly blocked or failed, matching
+// the backend's blocked_safety_gate_count semantics. Every other state (passed,
+// pending, skipped, unknown, …) is reported as non-blocking rather than being
+// implicitly counted as passing, so the label never overstates gate health.
 function awsRemediationCenterCaseGateLabel(entry: AWSRemediationCenterCase): string {
+  const total = entry.safety_gates.length;
+  if (total === 0) {
+    return 'No gates';
+  }
   const blocked = entry.safety_gates.filter((gate) => gate.status === 'blocked' || gate.status === 'failed').length;
-  return `${entry.safety_gates.length - blocked}/${entry.safety_gates.length} gates`;
+  return blocked > 0 ? `${blocked}/${total} blocked` : `${total} clear`;
+}
+
+function awsRemediationCenterCaseTradeoffLabel(entry: AWSRemediationCenterCase): string {
+  const total = entry.tradeoffs.length;
+  if (total === 0) {
+    return 'None recorded';
+  }
+  const worsens = entry.tradeoffs.filter((tradeoff) => tradeoff.direction === 'worsens').length;
+  return worsens > 0 ? `${worsens}/${total} worsen` : `${total} recorded`;
+}
+
+function AWSRemediationCenterOverviewTable({ cases }: { cases: AWSRemediationCenterCase[] }) {
+  return (
+    <DomainDataTable
+      label="Remediation center safety review"
+      rows={cases}
+      getRowKey={(row) => row.case_id}
+      emptyState={<DomainEmptyState eyebrow="Empty" title="No remediation cases" body="No remediation case matched the current filters for this environment." />}
+      columns={[
+        { key: 'case', header: 'Case', render: (row) => <strong>{row.title}</strong> },
+        { key: 'tradeoffs', header: 'Tradeoffs', render: (row) => awsRemediationCenterCaseTradeoffLabel(row) },
+        { key: 'gates', header: 'Safety gates', render: (row) => awsRemediationCenterCaseGateLabel(row) },
+        { key: 'apply', header: 'Ready for apply', render: (row) => (row.ready_for_apply ? 'Ready' : 'Not ready') },
+        { key: 'kill', header: 'Kill switch', render: (row) => (row.kill_switch_engaged ? 'Engaged' : 'Clear') },
+        {
+          key: 'severity',
+          header: 'Severity',
+          render: (row) => (
+            <AWSInventoryPill
+              stage={awsRemediationCenterStageStage(row.stage, row.kill_switch_engaged)}
+              label={`${formatTokenLabel(row.severity)} / ${formatConfidenceScore(row.confidence)}`}
+            />
+          )
+        }
+      ]}
+    />
+  );
 }
 
 function AWSRemediationCenterCasesTable({ cases }: { cases: AWSRemediationCenterCase[] }) {
@@ -11024,6 +11110,9 @@ function AWSRemediationCenterTabContent({
   center: AWSRemediationCenterResult;
   activeTab: AWSRemediationCenterTabID;
 }) {
+  if (activeTab === 'overview') {
+    return <AWSRemediationCenterOverviewTable cases={center.cases} />;
+  }
   if (activeTab === 'approvals') {
     return (
       <DomainDataTable
@@ -11121,6 +11210,7 @@ export function ProductAWSRemediationCenterPage() {
   const location = useLocation();
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const activeTab = normalizeAWSRemediationCenterTab(searchParams.get('tab'));
+  const filters = useMemo(() => awsRemediationCenterFiltersFromParams(searchParams), [searchParams]);
   const [center, setCenter] = useState<AWSRemediationCenterResult | null>(null);
   const [centerLoading, setCenterLoading] = useState(false);
   const [centerError, setCenterError] = useState('');
@@ -11141,7 +11231,8 @@ export function ProductAWSRemediationCenterPage() {
         selectedEnvironmentID,
         {
           connectorID: connection.connector_id,
-          tab: activeTab
+          tab: activeTab,
+          ...filters
         },
         buildProductAuthContext(scope)
       );
@@ -11164,6 +11255,7 @@ export function ProductAWSRemediationCenterPage() {
     scope?.workspaceID,
     selectedEnvironmentID,
     activeTab,
+    filters,
     connection?.connector_id
   ]);
 
@@ -11293,6 +11385,7 @@ export function ProductAWSRemediationCenterPage() {
               selectedEnvironmentID={selectedEnvironmentID}
               activeTab={activeTab}
               center={center}
+              searchParams={searchParams}
             />
             <AWSRemediationCenterTabContent center={center} activeTab={activeTab} />
           </>


### PR DESCRIPTION
## Summary

Adds the read-only **AWS Remediation Center unified experience** (issue #1552). A
new endpoint stitches remediation cases, the approval queue, dry-run
projections, low-risk live actions, and post-remediation verification and
rollback into case-keyed lifecycle rollups, backing a new app route.

- Backend: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center`
  (`internal/api/aws_remediation_center.go`), wired into the router, authz policy
  bundle, and OpenAPI contract.
- Case-keyed rollups use the remediation `case_id` as the spine joining the
  approval, dry-run, live-action, and verification/rollback stages. The most
  safety-critical verification state is retained per case so kill-switch,
  failed, and rollback states are never masked by a later verified record.
- Filters: account, region, severity, confidence, identity type, action type,
  status, stage, case id, tab, and search.
- Per-case tradeoffs and safety gates are surfaced before any action.
- Web app: new client method + types, route manifest entry, and
  `/app/{tenant}/{workspace}/aws/remediation/center` page with overview, cases,
  approvals, dry-runs, live actions, verification, and audit tabs.
- Docs (`docs/aws-remediation-center.md` + index) and `CHANGELOG.md` updated.

## Why

Operators previously had to move across five separate AWS remediation surfaces
(cases, approvals, dry-runs, live actions, verification/rollback) to follow a
single remediation through its lifecycle. This unifies them into one scoped,
read-only operator center with consistent filters and safety context.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered (additive endpoint, route, and types)
- [x] Risk level assessed (read-only, metadata-only; no writes, no new storage)

## Validation

```bash
go test ./internal/api/...          # pass
make fmt-check                      # pass
go vet ./internal/api/...           # pass
./scripts/check_api_example_contract.sh    # pass
./scripts/check_web_route_integrity.sh     # pass
npx vitest run src/productShell.test.tsx src/api/client.test.ts  # 269 passed
npx tsc -b                          # clean
npm run build --prefix web          # built, 40 routes prerendered
```

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no

## Related Issues

Closes #1552

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only AWS Remediation Center that unifies cases, approvals, dry‑runs, live actions, and verification/rollback into case‑keyed lifecycle rollups behind a new API and app route, aligned with issue #1552. Linked from the AWS Remediation page for easy discovery.

- **New Features**
  - API: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center` returns case‑keyed lifecycle rollups, retains the most critical verification state, and exposes verification states for the UI.
  - Filters: `connector_id` (optional), `fixture_state`, account, region, severity, confidence, identity type, action type, status, `stage`, case id, tab, search; parsed from URL, forwarded to the API, preserved across tabs; lifecycle tabs reconcile to filtered case IDs for deep links.
  - Web: route `/app/{tenant}/{workspace}/aws/remediation/center` with overview, cases, approvals, dry‑runs, live actions, verification, and audit tabs; overview shows tradeoffs, blocked/total safety‑gate status, apply readiness, and kill‑switch; read‑only, metadata‑only; link added from `/app/{tenant}/{workspace}/aws/remediation`.

- **Bug Fixes**
  - Reconciled lifecycle counts and rows to the filtered case set; preserved unfiltered totals; re‑applied `stage` and `status` filters across tabs.
  - Aligned verification rollups so kill‑switch/failed/rollback states are never masked; scoped verification rows and audit entries by status and account; scoped safety gates to current filters and labeled as blocked/total.
  - Consolidated and deduplicated the audit trail across all stages; handled missing/unconfigured connectors with a non‑fatal response.
  - Normalized verification filter tokens so status‑scoped rows and rollups match the applied filters.

<sup>Written for commit ad6238ff7fe18041044b278f8d3abc2c5b59b072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

