### PR TITLE
Polish repo finding delete actions

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2420,9 +2420,9 @@ describe('App', () => {
     }
 
     fireEvent.click(within(findingRow as HTMLElement).getByRole('button', { name: /Open actions for Potential AWS access key/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
-    const deleteDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    fireEvent.click(within(deleteDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
+    const deleteDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    fireEvent.click(within(deleteDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7338,7 +7338,10 @@ describe('Domain-first app routes', () => {
       repoScans?: RepoScanRecord[];
       repoFindings?: Finding[];
       repoFindingSummary?: RepoFindingsSummary;
-      listRepoFindings?: (params: unknown, call: number) => { items: Finding[]; summary?: RepoFindingsSummary };
+      listRepoFindings?: (
+        params: unknown,
+        call: number
+      ) => { items: Finding[]; summary?: RepoFindingsSummary } | Promise<{ items: Finding[]; summary?: RepoFindingsSummary }>;
       getRepoFindingsTrends?: (params: unknown) => { items: TrendPoint[] };
       getRepoRiskGraph?: (params: unknown) => RepoRiskGraph;
       role?: CurrentUserContext['role'];
@@ -7862,7 +7865,7 @@ describe('ProductFindingsPage states', () => {
     expect(within(confirmDialog).getByText(/Remove/i)).toBeInTheDocument();
     fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
-    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Refresh$/i }));
     await waitFor(() => {
       expect(deleteRepoFinding).toHaveBeenCalledWith(
         finding.id,
@@ -8091,6 +8094,52 @@ describe('ProductFindingsPage states', () => {
       expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+  });
+
+  it('disables clear all while repository findings are refreshing', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-refreshing',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-clear-all-refreshing',
+      scan_id: scan.id,
+      type: 'secret_exposure',
+      severity: 'critical',
+      title: 'Refresh-protected token finding',
+      human_summary: 'A token-like value appears in a committed workflow.',
+      remediation: 'Rotate the credential and remove the committed value.',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+    const refreshFindings = deferred<{ items: Finding[] }>();
+
+    const { deleteRepoFinding } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => (call === 1 ? { items: [finding] } : refreshFindings.promise)
+    });
+
+    expect(await screen.findByText('Refresh-protected token finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Refresh$/i }));
+    const clearAllButton = screen.getByRole('button', { name: /Clear all/i });
+    await waitFor(() => {
+      expect(clearAllButton).toBeDisabled();
+    });
+
+    fireEvent.click(clearAllButton);
+    expect(screen.queryByRole('dialog', { name: /Clear findings/i })).not.toBeInTheDocument();
+    expect(deleteRepoFinding).not.toHaveBeenCalled();
+
+    await act(async () => {
+      refreshFindings.resolve({ items: [] });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Refresh-protected token finding')).not.toBeInTheDocument();
+    });
   });
 
   it('recomputes mean time to fix after deleting fixed findings', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7697,10 +7697,10 @@ describe('ProductFindingsPage states', () => {
 
     const actionButton = within(row).getByRole('button', { name: /Open actions for Potential token exposed/i });
     fireEvent.click(actionButton);
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
 
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    expect(within(confirmDialog).getByText(/This permanently removes/i)).toBeInTheDocument();
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    expect(within(confirmDialog).getByText(/Remove/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Finding actions' })).not.toBeInTheDocument();
 
     const confirmCancelButton = within(confirmDialog).getByRole('button', { name: /Cancel/i });
@@ -7710,18 +7710,18 @@ describe('ProductFindingsPage states', () => {
 
     fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Delete this finding/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: /Delete finding/i })).not.toBeInTheDocument();
     });
     await waitFor(() => {
       expect(document.activeElement).toBe(actionButton);
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Open actions for Potential token exposed/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
 
-    const reopenConfirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
+    const reopenConfirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
     expect(reopenConfirmDialog).toBeInTheDocument();
-    fireEvent.click(within(reopenConfirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(within(reopenConfirmDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(deleteRepoFinding).toHaveBeenCalledWith(
@@ -7807,9 +7807,9 @@ describe('ProductFindingsPage states', () => {
     expect(initialRiskCalls).toBeGreaterThanOrEqual(1);
 
     fireEvent.click(within(row).getByRole('button', { name: /Open actions for Potential token exposed/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(deleteRepoFinding).toHaveBeenCalledWith(
@@ -7856,11 +7856,11 @@ describe('ProductFindingsPage states', () => {
     if (!row) return;
 
     fireEvent.click(within(row).getByRole('button', { name: /Open actions for Potential token exposed in release artifacts/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
 
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    expect(within(confirmDialog).getByText(/This permanently removes/i)).toBeInTheDocument();
-    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    expect(within(confirmDialog).getByText(/Remove/i)).toBeInTheDocument();
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
     fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
     await waitFor(() => {
@@ -7930,9 +7930,9 @@ describe('ProductFindingsPage states', () => {
     if (!row) return;
 
     fireEvent.click(within(row).getByRole('button', { name: /Open actions for Potential token exposed/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(screen.queryByText('Potential token exposed in workflow history')).not.toBeInTheDocument();
@@ -8026,9 +8026,9 @@ describe('ProductFindingsPage states', () => {
     if (!row) return;
 
     fireEvent.click(within(row).getByRole('button', { name: /Open actions for Visible paginated token finding/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(screen.queryByText('Visible paginated token finding')).not.toBeInTheDocument();
@@ -8036,6 +8036,61 @@ describe('ProductFindingsPage states', () => {
     await waitFor(() => {
       expect(within(summary).getByText('229')).toBeInTheDocument();
     });
+  });
+
+  it('clears all visible repository findings and updates loaded counts', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-findings',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+
+    const findings: Finding[] = [
+      {
+        id: 'finding-clear-all-1',
+        scan_id: scan.id,
+        type: 'secret_exposure',
+        severity: 'critical',
+        title: 'First clearable token finding',
+        human_summary: 'A token-like value appears in a committed workflow.',
+        remediation: 'Rotate the credential and remove the committed value.',
+        created_at: '2026-05-17T11:06:00Z'
+      },
+      {
+        id: 'finding-clear-all-2',
+        scan_id: scan.id,
+        type: 'workflow_permission',
+        severity: 'high',
+        title: 'Second clearable workflow finding',
+        human_summary: 'A workflow grants broad repository permissions.',
+        remediation: 'Limit workflow permissions.',
+        created_at: '2026-05-17T11:07:00Z'
+      }
+    ];
+
+    const { deleteRepoFinding } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [] })
+    });
+
+    expect(await screen.findByText('First clearable token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Second clearable workflow finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    expect(within(confirmDialog).getByText(/2 visible findings/i)).toBeInTheDocument();
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('First clearable token finding')).not.toBeInTheDocument();
+      expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
   it('recomputes mean time to fix after deleting fixed findings', async () => {
@@ -8113,9 +8168,9 @@ describe('ProductFindingsPage states', () => {
     if (!row) return;
 
     fireEvent.click(within(row).getByRole('button', { name: /Open actions for Fixed token exposure finding/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Delete permanently/i }));
-    const confirmDialog = await screen.findByRole('dialog', { name: /Delete this finding/i });
-    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete permanently/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Delete finding/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete/i }));
 
     await waitFor(() => {
       expect(screen.queryByText('Fixed token exposure finding')).not.toBeInTheDocument();
@@ -8219,10 +8274,10 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByRole('dialog', { name: /Keyboard menu finding/i })).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
-    expect(screen.getByRole('menuitem', { name: /Delete permanently/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Delete/i })).toBeInTheDocument();
 
     fireEvent.keyDown(trigger, { key: 'Escape' });
-    expect(screen.queryByRole('menuitem', { name: /Delete permanently/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Delete/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: /Keyboard menu finding/i })).not.toBeInTheDocument();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8265,6 +8265,35 @@ describe('ProductFindingsPage states', () => {
     });
   });
 
+  it('invalidates GitHub domain cache epochs without revisiting reinserted keys', async () => {
+    const productShell = await import('./productShell');
+    productShell.clearProductAuthSessionCacheForTests();
+    const matchingKey = productShell.primeGitHubDomainDataCacheEpochForTests(
+      { tenantID: 'tenant-a', workspaceID: 'workspace-a' },
+      'project-a',
+      50,
+      2
+    );
+    const secondMatchingKey = productShell.primeGitHubDomainDataCacheEpochForTests(
+      { tenantID: 'tenant-a', workspaceID: 'workspace-a' },
+      'project-b',
+      50,
+      4
+    );
+    const unrelatedKey = productShell.primeGitHubDomainDataCacheEpochForTests(
+      { tenantID: 'tenant-b', workspaceID: 'workspace-b' },
+      'project-a',
+      50,
+      7
+    );
+
+    productShell.invalidateGitHubDomainDataCacheForScopeForTests({ tenantID: 'tenant-a', workspaceID: 'workspace-a' });
+
+    expect(productShell.readGitHubDomainDataCacheEpochForTests(matchingKey)).toBe(3);
+    expect(productShell.readGitHubDomainDataCacheEpochForTests(secondMatchingKey)).toBe(5);
+    expect(productShell.readGitHubDomainDataCacheEpochForTests(unrelatedKey)).toBe(7);
+  });
+
   it('hides the repository finding delete menu from read-only users', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8142,6 +8142,59 @@ describe('ProductFindingsPage states', () => {
     });
   });
 
+  it('closes open finding delete menus while repository findings are refreshing', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-row-menu-refreshing',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-row-menu-refreshing',
+      scan_id: scan.id,
+      type: 'secret_exposure',
+      severity: 'critical',
+      title: 'Refresh-protected row menu finding',
+      human_summary: 'A token-like value appears in a committed workflow.',
+      remediation: 'Rotate the credential and remove the committed value.',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+    const refreshFindings = deferred<{ items: Finding[] }>();
+
+    const { deleteRepoFinding } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => (call === 1 ? { items: [finding] } : refreshFindings.promise)
+    });
+
+    expect(await screen.findByText('Refresh-protected row menu finding')).toBeInTheDocument();
+
+    const row = screen
+      .getAllByRole('listitem')
+      .find((node) => node.textContent?.includes('Refresh-protected row menu finding')) as HTMLElement | undefined;
+    expect(row).toBeDefined();
+    if (!row) return;
+
+    const actionButton = within(row).getByRole('button', { name: /Open actions for Refresh-protected row menu finding/i });
+    fireEvent.click(actionButton);
+    expect(screen.getByRole('menuitem', { name: /Delete/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Refresh$/i }));
+    await waitFor(() => {
+      expect(actionButton).toBeDisabled();
+    });
+    expect(screen.queryByRole('menuitem', { name: /Delete/i })).not.toBeInTheDocument();
+
+    fireEvent.click(actionButton);
+    expect(screen.queryByRole('dialog', { name: /Delete finding/i })).not.toBeInTheDocument();
+    expect(deleteRepoFinding).not.toHaveBeenCalled();
+
+    await act(async () => {
+      refreshFindings.resolve({ items: [] });
+    });
+  });
+
   it('recomputes mean time to fix after deleting fixed findings', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -671,20 +671,17 @@ function invalidateGitHubDomainDataCacheForScope(scope: ProductSession | null) {
     return;
   }
   const cachePrefix = `${productScopedCacheKey([scope.tenantID, scope.workspaceID])}::`;
-  for (const key of gitHubDomainDataCache.keys()) {
-    if (key.startsWith(cachePrefix)) {
-      gitHubDomainDataCache.delete(key);
-    }
+  const cacheKeys = [...gitHubDomainDataCache.keys()].filter((key) => key.startsWith(cachePrefix));
+  const requestKeys = [...gitHubDomainDataRequests.keys()].filter((key) => key.startsWith(cachePrefix));
+  const epochKeys = [...gitHubDomainDataCacheEpochs.keys()].filter((key) => key.startsWith(cachePrefix));
+  for (const key of cacheKeys) {
+    gitHubDomainDataCache.delete(key);
   }
-  for (const key of gitHubDomainDataRequests.keys()) {
-    if (key.startsWith(cachePrefix)) {
-      gitHubDomainDataRequests.delete(key);
-    }
+  for (const key of requestKeys) {
+    gitHubDomainDataRequests.delete(key);
   }
-  for (const key of gitHubDomainDataCacheEpochs.keys()) {
-    if (key.startsWith(cachePrefix)) {
-      bumpGitHubDomainDataCacheEpoch(key);
-    }
+  for (const key of epochKeys) {
+    bumpGitHubDomainDataCacheEpoch(key);
   }
 }
 
@@ -20061,6 +20058,25 @@ function gitHubDomainDataCacheKey(
     return '';
   }
   return productScopedCacheKey([scope.tenantID, scope.workspaceID, trimmedProject, String(scanLimit)]);
+}
+
+export function primeGitHubDomainDataCacheEpochForTests(
+  scope: ProductSession,
+  projectID: string,
+  scanLimit: number,
+  epoch: number
+): string {
+  const key = gitHubDomainDataCacheKey(scope, projectID, scanLimit);
+  rememberGitHubDomainDataCacheEpoch(key, epoch);
+  return key;
+}
+
+export function readGitHubDomainDataCacheEpochForTests(key: string): number | undefined {
+  return gitHubDomainDataCacheEpochs.get(key);
+}
+
+export function invalidateGitHubDomainDataCacheForScopeForTests(scope: ProductSession | null) {
+  invalidateGitHubDomainDataCacheForScope(scope);
 }
 
 function rememberGitHubDomainDataCacheEpoch(key: string, epoch: number) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -666,6 +666,28 @@ function clearProductScopedDataCaches() {
   gitHubDomainDataCacheEpochs.clear();
 }
 
+function invalidateGitHubDomainDataCacheForScope(scope: ProductSession | null) {
+  if (!scope) {
+    return;
+  }
+  const cachePrefix = `${productScopedCacheKey([scope.tenantID, scope.workspaceID])}::`;
+  for (const key of gitHubDomainDataCache.keys()) {
+    if (key.startsWith(cachePrefix)) {
+      gitHubDomainDataCache.delete(key);
+    }
+  }
+  for (const key of gitHubDomainDataRequests.keys()) {
+    if (key.startsWith(cachePrefix)) {
+      gitHubDomainDataRequests.delete(key);
+    }
+  }
+  for (const key of gitHubDomainDataCacheEpochs.keys()) {
+    if (key.startsWith(cachePrefix)) {
+      bumpGitHubDomainDataCacheEpoch(key);
+    }
+  }
+}
+
 function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider | null {
   return DOMAIN_NAV_ORDER.includes(provider) ? provider : null;
 }
@@ -1245,6 +1267,16 @@ export function decrementRepoFindingsSummaryForDeletedFinding(
     nextSummary.sla_aged_count = Math.max(0, summary.sla_aged_count - 1);
   }
   return nextSummary;
+}
+
+export function decrementRepoFindingsSummaryForDeletedFindings(
+  summary: RepoFindingsSummary | null,
+  findings: ApiFinding[]
+): RepoFindingsSummary | null {
+  return findings.reduce<RepoFindingsSummary | null>(
+    (current, finding) => decrementRepoFindingsSummaryForDeletedFinding(current, finding),
+    summary
+  );
 }
 
 function repoFindingStatusClass(status: FindingLifecycleStatus | RepoFindingLifecycleStatus): string {
@@ -27044,7 +27076,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const [selectedFindingKey, setSelectedFindingKey] = useState('');
   const [findingDetailOpen, setFindingDetailOpen] = useState(false);
   const [findingMenuKey, setFindingMenuKey] = useState('');
+  const [findingMenuPlacement, setFindingMenuPlacement] = useState<'down' | 'up'>('down');
   const [deleteCandidate, setDeleteCandidate] = useState<ApiFinding | null>(null);
+  const [bulkDeleteCandidates, setBulkDeleteCandidates] = useState<ApiFinding[]>([]);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState('');
   const [remediationPreview, setRemediationPreview] = useState<RepoFindingRemediationPreview | null>(null);
@@ -27141,6 +27175,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       return;
     }
     setDeleteCandidate(null);
+    setBulkDeleteCandidates([]);
     setDeleteError('');
     const opener = findingDeleteOpenerRef.current;
     findingDeleteOpenerRef.current = null;
@@ -27310,6 +27345,12 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const mttrSeconds = repoFindingSummary?.mean_time_to_resolve_seconds;
   const mttrLabel = typeof mttrSeconds === 'number' && Number.isFinite(mttrSeconds) ? formatExecutiveDuration(mttrSeconds) : 'N/A';
   const canDeleteRepoFindings = hasRepoFindingDeleteAccess(me);
+  const activeDeleteCandidates = bulkDeleteCandidates.length > 0
+    ? bulkDeleteCandidates
+    : deleteCandidate
+      ? [deleteCandidate]
+      : [];
+  const bulkDeleteActive = bulkDeleteCandidates.length > 0;
 
   const loadRepoFindings = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
     const requestID = ++requestRef.current;
@@ -27442,6 +27483,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const invalidateFindingDeleteState = () => {
     findDeleteRequestRef.current += 1;
     setDeleteCandidate(null);
+    setBulkDeleteCandidates([]);
     setDeleteLoading(false);
     setDeleteError('');
   };
@@ -27449,6 +27491,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const requestDeleteFinding = (finding: ApiFinding, opener: HTMLElement | null = null) => {
     setFindingMenuKey('');
     setDeleteCandidate(finding);
+    setBulkDeleteCandidates([]);
     setDeleteError('');
     findingDeleteOpenerRef.current =
       opener ??
@@ -27457,45 +27500,93 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         : null);
   };
 
-  const handleConfirmDeleteFinding = async () => {
-    if (!scope || !deleteCandidate || deleteLoading) {
+  const requestDeleteAllVisibleFindings = (opener: HTMLElement | null = null) => {
+    if (filteredFindings.length === 0) {
       return;
     }
-    const candidate = deleteCandidate;
-    const deletedKey = buildRepoFindingSelectionKey(candidate);
+    setFindingMenuKey('');
+    setDeleteCandidate(null);
+    setBulkDeleteCandidates(filteredFindings);
+    setDeleteError('');
+    findingDeleteOpenerRef.current =
+      opener ??
+      (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null);
+  };
+
+  const applyDeletedRepoFindings = (deletedFindings: ApiFinding[]) => {
+    if (deletedFindings.length === 0) {
+      return;
+    }
+    const deletedKeys = new Set(deletedFindings.map(buildRepoFindingSelectionKey));
+    const deleteCountsByScan = deletedFindings.reduce<Map<string, number>>((acc, finding) => {
+      acc.set(finding.scan_id, (acc.get(finding.scan_id) ?? 0) + 1);
+      return acc;
+    }, new Map());
+    setRepoFindings((current) => current.filter((finding) => !deletedKeys.has(buildRepoFindingSelectionKey(finding))));
+    setRepoScans((current) =>
+      current.map((scan) => {
+        const deletedCount = deleteCountsByScan.get(scan.id) ?? 0;
+        if (deletedCount === 0) {
+          return scan;
+        }
+        return { ...scan, finding_count: Math.max(0, (scan.finding_count ?? 0) - deletedCount) };
+      })
+    );
+    setRepoFindingSummary((current) => decrementRepoFindingsSummaryForDeletedFindings(current, deletedFindings));
+    if (selectedFindingKey && deletedKeys.has(selectedFindingKey)) {
+      setSelectedFindingKey('');
+      setFindingDetailOpen(false);
+      findingDetailOpenerRef.current = null;
+    }
+  };
+
+  const handleConfirmDeleteFinding = async () => {
+    if (!scope || activeDeleteCandidates.length === 0 || deleteLoading) {
+      return;
+    }
+    const candidates = activeDeleteCandidates;
     const requestID = ++findDeleteRequestRef.current;
     setDeleteLoading(true);
     setDeleteError('');
     try {
-      await apiClient.deleteRepoFinding(candidate.id, candidate.scan_id, buildProductAuthContext(scope));
+      const auth = buildProductAuthContext(scope);
+      const settled = await Promise.allSettled(
+        candidates.map((candidate) => apiClient.deleteRepoFinding(candidate.id, candidate.scan_id, auth))
+      );
       if (findDeleteRequestRef.current !== requestID) {
         return;
       }
-      const normalizedLifecycleStatus = normalizeRepoFindingLifecycleStatus(candidate.lifecycle_status);
-      const repoScanFilterSelected = normalizeValue(repoScanFilter);
-      const shouldReloadFindings = normalizedLifecycleStatus === 'fixed' || repoScanFilterSelected === '';
-      if (shouldReloadFindings) {
-        if (selectedFindingKey === deletedKey) {
-          setSelectedFindingKey('');
-          setFindingDetailOpen(false);
-          findingDetailOpenerRef.current = null;
-        }
-        await loadRepoFindings(scope, 'refresh');
-      } else {
-        setRepoFindings((current) => current.filter((finding) => buildRepoFindingSelectionKey(finding) !== deletedKey));
-        setRepoScans((current) =>
-          current.map((scan) =>
-            scan.id === candidate.scan_id
-              ? { ...scan, finding_count: Math.max(0, (scan.finding_count ?? 0) - 1) }
-              : scan
-          )
+      const deletedFindings = candidates.filter((_, index) => settled[index]?.status === 'fulfilled');
+      const failedDeletes = settled.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
+      if (deletedFindings.length > 0) {
+        invalidateGitHubDomainDataCacheForScope(scope);
+        applyDeletedRepoFindings(deletedFindings);
+      }
+      if (failedDeletes.length > 0) {
+        const failedCandidates = candidates.filter((_, index) => settled[index]?.status === 'rejected');
+        setBulkDeleteCandidates(failedCandidates.length > 1 ? failedCandidates : []);
+        setDeleteCandidate(failedCandidates.length === 1 ? failedCandidates[0] : null);
+        setDeleteError(
+          deletedFindings.length > 0
+            ? `${deletedFindings.length} deleted. ${failedDeletes.length} could not be deleted.`
+            : failedDeletes[0].reason instanceof Error
+              ? failedDeletes[0].reason.message
+              : 'Failed to delete finding.'
         );
-        setRepoFindingSummary((current) => decrementRepoFindingsSummaryForDeletedFinding(current, candidate));
-        if (selectedFindingKey === deletedKey) {
-          setSelectedFindingKey('');
-          setFindingDetailOpen(false);
-          findingDetailOpenerRef.current = null;
+        if (deletedFindings.length > 0) {
+          await loadRepoFindings(scope, 'refresh');
+          await loadTrendSignals(scope, 'refresh');
         }
+        return;
+      }
+      const repoScanFilterSelected = normalizeValue(repoScanFilter);
+      const shouldReloadFindings =
+        deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
+        repoScanFilterSelected === '';
+      if (shouldReloadFindings) {
+        await loadRepoFindings(scope, 'refresh');
       }
       await loadTrendSignals(scope, 'refresh');
       closeFindingDeleteDialog({ allowDuringLoading: true });
@@ -27746,7 +27837,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   }, [findingDetailOpen, selectedFindingKey]);
 
   useEffect(() => {
-    if (!deleteCandidate || typeof document === 'undefined') {
+    if (activeDeleteCandidates.length === 0 || typeof document === 'undefined') {
       return undefined;
     }
     const root = document.documentElement;
@@ -27759,17 +27850,17 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       root.style.overflow = previousRootOverflow;
       body.style.overflow = previousBodyOverflow;
     };
-  }, [deleteCandidate]);
+  }, [activeDeleteCandidates.length]);
 
   useEffect(() => {
-    if (!deleteCandidate || typeof window === 'undefined') {
+    if (activeDeleteCandidates.length === 0 || typeof window === 'undefined') {
       return undefined;
     }
     const frame = window.requestAnimationFrame(() => {
       findingDeleteCloseRef.current?.focus();
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [deleteCandidate]);
+  }, [activeDeleteCandidates.length]);
 
   const closeFindingDetail = () => {
     setFindingDetailOpen(false);
@@ -27963,9 +28054,6 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           <h2>GitHub findings</h2>
         </div>
         <div className="idt-inline-actions">
-          <Link className="idt-btn idt-btn-primary" to={remediationPath}>
-            Open remediation
-          </Link>
           <button
             className="idt-btn idt-btn-ghost"
             type="button"
@@ -27974,6 +28062,20 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           >
             {refreshing || signalsRefreshing ? 'Refreshing...' : 'Refresh'}
           </button>
+          {canDeleteRepoFindings && filteredFindings.length > 0 ? (
+            <button
+              className="idt-btn idt-btn-danger idt-repo-clear-all-btn"
+              type="button"
+              onClick={(event) => requestDeleteAllVisibleFindings(event.currentTarget)}
+              disabled={deleteLoading}
+            >
+              <Trash2 size={15} strokeWidth={2} aria-hidden="true" />
+              Clear all
+            </button>
+          ) : null}
+          <Link className="idt-btn idt-btn-primary" to={remediationPath}>
+            Open remediation
+          </Link>
         </div>
       </div>
 
@@ -28237,7 +28339,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                         role="listitem"
                                         tabIndex={0}
                                         aria-haspopup="dialog"
-                                        className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
+                                        className={`idt-repo-finding-row idt-repo-finding-action-row${isSelected ? ' is-selected' : ''}`}
                                         onClick={(event) => selectRepoFinding(selectionKey, true, event.currentTarget)}
                                         onKeyDown={(event) => {
                                           if (event.target !== event.currentTarget) {
@@ -28253,9 +28355,6 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                         <div className="idt-repo-finding-row-copy">
                                           <div className="idt-repo-finding-row-top">
                                             <strong>{finding.title}</strong>
-                                            <span className={repoFindingSeverityClass(finding.severity)}>
-                                              {formatTokenLabel(finding.severity)}
-                                            </span>
                                           </div>
                                           <div className="idt-repo-finding-row-meta">
                                             <span>{repositoryLabel}</span>
@@ -28265,6 +28364,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                             <span>{finding.owner || finding.triage?.assignee || 'Unassigned'}</span>
                                           </div>
                                         </div>
+                                        <span className={repoFindingSeverityClass(finding.severity)}>
+                                          {formatTokenLabel(finding.severity)}
+                                        </span>
                                         {canDeleteRepoFindings ? (
                                           <div
                                             className="idt-repo-finding-row-actions"
@@ -28277,7 +28379,14 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                               aria-label={`Open actions for ${finding.title}`}
                                               aria-haspopup="menu"
                                               aria-expanded={findingMenuKey === selectionKey}
-                                              onClick={() => {
+                                              onClick={(event) => {
+                                                const nextOpen = findingMenuKey !== selectionKey;
+                                                if (nextOpen && typeof window !== 'undefined') {
+                                                  const rect = event.currentTarget.getBoundingClientRect();
+                                                  const spaceBelow = window.innerHeight - rect.bottom;
+                                                  const spaceAbove = rect.top;
+                                                  setFindingMenuPlacement(spaceBelow < 120 && spaceAbove > spaceBelow ? 'up' : 'down');
+                                                }
                                                 setFindingMenuKey((current) => (current === selectionKey ? '' : selectionKey));
                                                 setDeleteError('');
                                               }}
@@ -28286,7 +28395,10 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                               <MoreHorizontal size={16} strokeWidth={2} aria-hidden="true" />
                                             </button>
                                             {findingMenuKey === selectionKey ? (
-                                              <div className="idt-repo-finding-menu" role="menu">
+                                              <div
+                                                className={`idt-repo-finding-menu${findingMenuPlacement === 'up' ? ' is-up' : ''}`}
+                                                role="menu"
+                                              >
                                                 <button
                                                   type="button"
                                                   role="menuitem"
@@ -28300,7 +28412,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                                   }}
                                                 >
                                                   <Trash2 size={15} strokeWidth={2} aria-hidden="true" />
-                                                  Delete permanently
+                                                  Delete
                                                 </button>
                                               </div>
                                             ) : null}
@@ -28590,7 +28702,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         </div>
       ) : null}
 
-      {deleteCandidate ? (
+      {activeDeleteCandidates.length > 0 ? (
         <div
           className="idt-modal-backdrop idt-repo-finding-delete-backdrop"
           role="presentation"
@@ -28612,16 +28724,19 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           >
             <header>
               <div>
-                <p className="idt-app-kicker">Permanent delete</p>
-                <h3 id="repo-finding-delete-title">Delete this finding?</h3>
+                <h3 id="repo-finding-delete-title">{bulkDeleteActive ? 'Clear findings?' : 'Delete finding?'}</h3>
               </div>
             </header>
             <div className="idt-danger-modal-body">
-              <p>
-                This permanently removes <strong>{deleteCandidate.title}</strong> from this repository scan.
-              </p>
+              {bulkDeleteActive ? (
+                <p>Delete {formatCountLabel(activeDeleteCandidates.length, 'visible finding')}.</p>
+              ) : (
+                <p>
+                  Remove <strong>{activeDeleteCandidates[0]?.title}</strong>.
+                </p>
+              )}
               <p className="idt-danger-modal-help">
-                The finding can appear again if a future scan rediscovers the same risk.
+                Future scans can rediscover the same risk.
               </p>
               {deleteError ? <div className="idt-danger-modal-error">{deleteError}</div> : null}
               <div className="idt-danger-modal-actions">
@@ -28640,7 +28755,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                   onClick={() => void handleConfirmDeleteFinding()}
                   disabled={deleteLoading}
                 >
-                  {deleteLoading ? 'Deleting...' : 'Delete permanently'}
+                  {deleteLoading ? 'Deleting...' : bulkDeleteActive ? 'Delete all' : 'Delete'}
                 </button>
               </div>
             </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -27499,6 +27499,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
 
   const invalidateFindingDeleteState = () => {
     findDeleteRequestRef.current += 1;
+    setFindingMenuKey('');
     setDeleteCandidate(null);
     setBulkDeleteCandidates([]);
     setDeleteLoading(false);
@@ -27506,6 +27507,10 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   };
 
   const requestDeleteFinding = (finding: ApiFinding, opener: HTMLElement | null = null) => {
+    if (deleteActionsDisabled) {
+      setFindingMenuKey('');
+      return;
+    }
     setFindingMenuKey('');
     setDeleteCandidate(finding);
     setBulkDeleteCandidates([]);
@@ -27560,7 +27565,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   };
 
   const handleConfirmDeleteFinding = async () => {
-    if (!scope || activeDeleteCandidates.length === 0 || deleteLoading) {
+    if (!scope || activeDeleteCandidates.length === 0 || deleteActionsDisabled) {
       return;
     }
     const candidates = activeDeleteCandidates;
@@ -28412,7 +28417,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                             >
                                               <MoreHorizontal size={16} strokeWidth={2} aria-hidden="true" />
                                             </button>
-                                            {findingMenuKey === selectionKey ? (
+                                            {findingMenuKey === selectionKey && !deleteActionsDisabled ? (
                                               <div
                                                 className={`idt-repo-finding-menu${findingMenuPlacement === 'up' ? ' is-up' : ''}`}
                                                 role="menu"

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -27351,6 +27351,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       ? [deleteCandidate]
       : [];
   const bulkDeleteActive = bulkDeleteCandidates.length > 0;
+  const deleteActionsDisabled = deleteLoading || refreshing || signalsRefreshing;
 
   const loadRepoFindings = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
     const requestID = ++requestRef.current;
@@ -27501,7 +27502,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   };
 
   const requestDeleteAllVisibleFindings = (opener: HTMLElement | null = null) => {
-    if (filteredFindings.length === 0) {
+    if (deleteActionsDisabled || filteredFindings.length === 0) {
       return;
     }
     setFindingMenuKey('');
@@ -28067,7 +28068,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               className="idt-btn idt-btn-danger idt-repo-clear-all-btn"
               type="button"
               onClick={(event) => requestDeleteAllVisibleFindings(event.currentTarget)}
-              disabled={deleteLoading}
+              disabled={deleteActionsDisabled}
             >
               <Trash2 size={15} strokeWidth={2} aria-hidden="true" />
               Clear all
@@ -28379,6 +28380,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                               aria-label={`Open actions for ${finding.title}`}
                                               aria-haspopup="menu"
                                               aria-expanded={findingMenuKey === selectionKey}
+                                              disabled={deleteActionsDisabled}
                                               onClick={(event) => {
                                                 const nextOpen = findingMenuKey !== selectionKey;
                                                 if (nextOpen && typeof window !== 'undefined') {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6198,7 +6198,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   border: 1px solid rgba(126, 157, 211, 0.24);
   border-radius: 0.75rem;
   background: rgba(8, 13, 22, 0.72);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .idt-repo-finding-bucket summary {
@@ -6225,6 +6225,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   gap: 0.75rem;
   border-top: 1px solid rgba(126, 157, 211, 0.18);
   padding: 0.85rem;
+  overflow: visible;
 }
 
 .idt-repo-finding-scan,
@@ -6330,6 +6331,20 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
 }
 
+.idt-repo-finding-action-row {
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  column-gap: 0.9rem;
+  row-gap: 0.45rem;
+  overflow: visible;
+}
+
+.idt-repo-finding-action-row .idt-source-logo-mark.is-row,
+.idt-repo-finding-action-row .idt-repo-finding-severity,
+.idt-repo-finding-action-row .idt-repo-finding-row-actions {
+  align-self: center;
+}
+
 .idt-repo-finding-row:hover,
 .idt-repo-finding-row:focus-visible,
 .idt-repo-finding-row.is-selected {
@@ -6342,7 +6357,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   display: flex;
   justify-content: space-between;
   gap: 0.8rem;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .idt-repo-finding-row-top strong {
@@ -6365,7 +6380,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 
 .idt-repo-finding-row-actions {
   position: relative;
-  z-index: 2;
+  z-index: 8;
   flex: 0 0 auto;
   align-self: center;
 }
@@ -6402,6 +6417,11 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   padding: 0.35rem;
 }
 
+.idt-repo-finding-menu.is-up {
+  top: auto;
+  bottom: calc(100% + 0.35rem);
+}
+
 .idt-repo-finding-menu-item {
   width: 100%;
   display: flex;
@@ -6425,6 +6445,12 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 
 .idt-repo-finding-menu-item.is-danger {
   color: #fecaca;
+}
+
+.idt-repo-clear-all-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
 .idt-repo-finding-severity {
@@ -6584,6 +6610,12 @@ html[data-diff-markers='symbols'] .idt-repo-finding-code-marker {
 .idt-repo-finding-modal-backdrop {
   align-items: start;
   overflow-y: auto;
+}
+
+.idt-repo-finding-delete-backdrop {
+  background: #000000;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 
 .idt-repo-finding-detail-modal {
@@ -26210,6 +26242,20 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-grou
     padding: 0.85rem;
   }
 
+  .idt-app-console-layout .idt-repo-finding-action-row {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-action-row .idt-repo-finding-severity {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-action-row .idt-repo-finding-row-actions {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+  }
+
   .idt-app-console-layout .idt-repo-finding-row-copy,
   .idt-app-console-layout .idt-repo-finding-row-top,
   .idt-app-console-layout .idt-repo-finding-row-meta,
@@ -27774,8 +27820,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1rem;
-  gap: 0.8rem;
+  grid-template-columns: minmax(0, 1fr) 1.25rem;
+  gap: 0.65rem;
   align-items: center;
   min-height: 2.28rem;
   border: 1px solid transparent;
@@ -27804,6 +27850,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-link-copy {
   display: grid;
   gap: 0.08rem;
+  min-width: 0;
+  align-self: center;
 }
 
 .idt-domain-flyout-link-copy strong {
@@ -27816,6 +27864,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link > svg {
   justify-self: end;
+  align-self: center;
   width: 1rem;
   min-width: 1rem;
 }
@@ -27836,8 +27885,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1.25rem;
+  align-items: start;
   gap: 0.6rem;
   border-radius: 7px;
   padding: 0.45rem 0.5rem;
@@ -27853,7 +27903,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-nested summary > span {
   display: grid;
   gap: 0.1rem;
-  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .idt-domain-flyout-nested summary strong {
@@ -27862,8 +27912,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary svg {
-  flex: 0 0 auto;
-  margin-left: auto;
+  justify-self: end;
+  margin-top: 0.18rem;
   color: #8f98a4;
   transition: transform 0.14s ease;
 }


### PR DESCRIPTION
## Summary

- Moves repository finding deletion into concise row actions with cleaner severity/action alignment.
- Adds a header-level Clear all action for the visible findings set, with confirmation and partial-failure handling.
- Keeps finding, scan, summary, and GitHub domain cache counts fresh after deletes.
- Tightens delete modal copy/background and prevents row action menus from being clipped near bucket edges.

## Why

Users need a fast, low-overhead way to delete individual findings and visible groups of findings without stale counts, hidden menus, or noisy confirmation copy.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk: moderate UI/data-state change around destructive actions. The backend endpoint remains unchanged; the new bulk action composes the existing scan-scoped delete API.

## Validation

```bash
npm run test -- src/productShell.test.tsx src/App.test.tsx
npm run build
```

Both checks pass. The build still emits the existing Vite large-chunk warning, but it completes successfully.

## Checklist

- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

Docs/CHANGELOG not updated because this is focused product UI polish rather than an operator-facing contract change.

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: focused tests and production build

## Related Issues

No issue: user-requested UI polish and delete-action follow-up from screenshot feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished repository finding deletion with compact row actions and a header “Clear all” for visible findings. Adds confirmations with partial-failure handling, disables all delete actions during refresh (and closes open menus), live-updates counts/MTTR/trends, and fixes a GitHub domain cache invalidation loop.

- **New Features**
  - Inline row menu with “Delete” and a shorter “Delete finding?” dialog; bulk shows “Clear findings?” and “Delete all”.
  - “Clear all” deletes all visible findings via per-finding calls; shows partial failures and keeps failed ones selected.
  - Live updates: remove deleted items, decrement scan counts, recompute summaries/MTTR, refresh trend signals, and invalidate per-scope GitHub domain caches.

- **Bug Fixes**
  - Delete actions are disabled and any open row menus close while findings/signals refresh.
  - Action menus auto-place upward when space is tight and no longer clip; z-index/overflow tuned.
  - Improved modal focus and a solid backdrop; Escape reliably closes menus.
  - Fixed GitHub domain cache invalidation to bump epochs per scope without revisiting reinserted keys.

<sup>Written for commit a5b90221bb254b7fb84d1c7db1520050a89f43c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

