### PR TITLE
Polish findings cleanup controls

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7460,6 +7460,7 @@ describe('Domain-first app routes', () => {
 
 describe('ProductFindingsPage states', () => {
   afterEach(() => {
+    window.localStorage.clear();
     vi.restoreAllMocks();
     vi.doUnmock('./hooks/useMe');
     vi.resetModules();
@@ -7589,6 +7590,68 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
     expect(await screen.findByText('Completed scans')).toBeInTheDocument();
     expect(await screen.findByText('Legacy finding')).toBeInTheDocument();
+  });
+
+  it('lets operators remove a failed scan banner without hiding findings', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-dismissible',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-dismissible-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-dismissible',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical workflow finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Historical workflow finding')).toBeInTheDocument();
+  });
+
+  it('lets operators remove a failed-only scan state', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-only-dismissible',
+      status: 'failed',
+      finished_at: '2026-05-17T11:05:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+
+    await renderFindings({ repoScans: [failedScan] });
+
+    expect(await screen.findByText('Your last repository scan failed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {
@@ -8103,6 +8166,74 @@ describe('ProductFindingsPage states', () => {
     await waitFor(() => {
       expect(screen.queryByText('First clearable token finding')).not.toBeInTheDocument();
       expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+  });
+
+  it('falls back to individual deletes when the bulk endpoint is unavailable', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-bulk-missing',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+    const findings: Finding[] = [
+      {
+        id: 'finding-clear-fallback-first',
+        scan_id: scan.id,
+        type: 'secret_exposure',
+        severity: 'critical',
+        title: 'Fallback clearable token finding',
+        human_summary: 'A token-like value appears in a committed workflow.',
+        remediation: 'Rotate the credential and remove the committed value.',
+        created_at: '2026-05-17T11:06:00Z'
+      },
+      {
+        id: 'finding-clear-fallback-second',
+        scan_id: scan.id,
+        type: 'workflow_permission',
+        severity: 'high',
+        title: 'Fallback clearable workflow finding',
+        human_summary: 'A workflow grants broad repository permissions.',
+        remediation: 'Limit workflow permissions.',
+        created_at: '2026-05-17T11:07:00Z'
+      }
+    ];
+
+    const { deleteRepoFinding, deleteRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [] })
+    });
+    const { ApiError } = await import('./api/client');
+    deleteRepoFindings.mockRejectedValueOnce(new ApiError('Request failed (404)', 404));
+
+    expect(await screen.findByText('Fallback clearable token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable workflow finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
+      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+    });
+    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+      1,
+      findings[0].id,
+      scan.id,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+      2,
+      findings[1].id,
+      scan.id,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Fallback clearable token finding')).not.toBeInTheDocument();
+      expect(screen.queryByText('Fallback clearable workflow finding')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1639,6 +1639,66 @@ function mergeRepoFindingsBulkDeleteResponses(
   );
 }
 
+async function deleteRepoFindingsBatchWithFallback(
+  targets: RepoFindingDeleteTarget[],
+  auth: RequestAuthContext
+): Promise<RepoFindingsBulkDeleteResponse> {
+  try {
+    return await apiClient.deleteRepoFindings(targets, auth);
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 404) {
+      throw error;
+    }
+  }
+
+  const response: RepoFindingsBulkDeleteResponse = { deleted: [], failed: [] };
+  for (const target of targets) {
+    try {
+      await apiClient.deleteRepoFinding(target.finding_id, target.repo_scan_id, auth);
+      response.deleted.push(target);
+    } catch (deleteError) {
+      response.failed?.push({
+        ...target,
+        error: deleteError instanceof Error ? deleteError.message : 'Failed to delete finding.'
+      });
+    }
+  }
+  return response;
+}
+
+const DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY = 'idt:repo-failed-scan-dismissals:v1';
+
+function failedRepoScanDismissalKey(scope: ProductSession, scanID: string): string {
+  return `${scope.tenantID}:${scope.workspaceID}:${scanID}`;
+}
+
+function readDismissedRepoFailedScanKeys(): Set<string> {
+  if (typeof window === 'undefined') {
+    return new Set();
+  }
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY);
+    if (!raw) {
+      return new Set();
+    }
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissedRepoFailedScanKeys(keys: Set<string>) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY, JSON.stringify([...keys]));
+  } catch {
+    // Local storage is an enhancement here; the in-memory dismissal still applies.
+  }
+}
+
 function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
   return [...scores].sort((left, right) => {
     if (right.score !== left.score) {
@@ -27117,6 +27177,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filtersExpanded, setFiltersExpanded] = useState(true);
+  const [dismissedFailedScanKeys, setDismissedFailedScanKeys] = useState<Set<string>>(() =>
+    readDismissedRepoFailedScanKeys()
+  );
   const [hierarchyOpenState, setHierarchyOpenState] = useState<{
     repositories: Set<string>;
     scans: Set<string>;
@@ -27636,7 +27699,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         let batchError: unknown = null;
         for (const batch of chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding))) {
           try {
-            responses.push(await apiClient.deleteRepoFindings(batch, auth));
+            responses.push(await deleteRepoFindingsBatchWithFallback(batch, auth));
           } catch (requestError) {
             batchError = requestError;
             break;
@@ -27996,6 +28059,18 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     void loadTrendSignals(scope, 'refresh');
   };
 
+  const dismissFailedRepoScan = (scan: RepoScanRecord | null) => {
+    if (!scan) {
+      return;
+    }
+    setDismissedFailedScanKeys((current) => {
+      const next = new Set(current);
+      next.add(failedRepoScanDismissalKey(scope, scan.id));
+      writeDismissedRepoFailedScanKeys(next);
+      return next;
+    });
+  };
+
   const connectPath = buildScopedPath(scope, 'github/connect');
   const remediationPath = appendEnvironmentQuery(
     buildScopedPath(scope, 'github/remediation'),
@@ -28006,11 +28081,17 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   );
   const succeededScanCount = repoScans.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
   const failedScans = scansByRecency.filter((scan) => isFailedScanStatus(scan.status));
+  const visibleFailedScans = failedScans.filter(
+    (scan) => !dismissedFailedScanKeys.has(failedRepoScanDismissalKey(scope, scan.id))
+  );
   const latestScan = scansByRecency[0] ?? null;
-  const latestFailedScan = failedScans[0] ?? null;
+  const latestFailedScan = visibleFailedScans[0] ?? null;
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
-  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
+  const latestScanFailed = latestScan
+    ? isFailedScanStatus(latestScan.status) &&
+      !dismissedFailedScanKeys.has(failedRepoScanDismissalKey(scope, latestScan.id))
+    : false;
   const neverScanned = repoScans.length === 0;
   // "Has findings" must be independent of both active finding filters and the
   // recent-scan window (listRepoScans is capped). Combine the server-side
@@ -28106,6 +28187,13 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               <button
                 className="idt-btn idt-btn-ghost"
                 type="button"
+                onClick={() => dismissFailedRepoScan(latestFailedScan)}
+              >
+                Remove
+              </button>
+              <button
+                className="idt-btn idt-btn-ghost"
+                type="button"
                 onClick={handleRefresh}
                 disabled={refreshing || signalsRefreshing}
               >
@@ -28185,7 +28273,16 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       {latestScanFailed ? (
         <div className="idt-app-alert idt-app-alert-error idt-repo-scan-health">
           <span>Last scan failed: {describeScanFailure(latestFailedScan)}</span>
-          <Link to={connectPath}>Review &amp; re-run</Link>
+          <span className="idt-repo-scan-health-actions-inline">
+            <button
+              className="idt-repo-scan-health-remove"
+              type="button"
+              onClick={() => dismissFailedRepoScan(latestFailedScan)}
+            >
+              Remove
+            </button>
+            <Link to={connectPath}>Review &amp; re-run</Link>
+          </span>
         </div>
       ) : null}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5832,9 +5832,34 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   flex-wrap: wrap;
 }
 
+.idt-repo-scan-health-actions-inline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  white-space: nowrap;
+}
+
 .idt-repo-scan-health a {
   white-space: nowrap;
   font-weight: 600;
+}
+
+.idt-repo-scan-health-remove {
+  border: 0;
+  background: transparent;
+  color: #ffd0d0;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+  cursor: pointer;
+}
+
+.idt-repo-scan-health-remove:hover,
+.idt-repo-scan-health-remove:focus-visible {
+  color: #ffffff;
+  outline: none;
 }
 
 .idt-repo-scan-health-panel {
@@ -27827,13 +27852,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1rem;
-  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr) 1.1rem;
+  gap: 0.7rem;
   align-items: center;
-  min-height: 2.34rem;
+  min-height: 3rem;
   border: 1px solid transparent;
   border-radius: 7px;
-  padding: 0.44rem 0.54rem;
+  padding: 0.5rem 0.6rem;
   color: #dce3eb;
   text-decoration: none;
   text-align: left;
@@ -27856,11 +27881,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-link-copy {
-  display: grid;
-  gap: 0.08rem;
+  display: flex;
+  min-height: 100%;
   min-width: 0;
   align-self: center;
-  justify-items: start;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.08rem;
   text-align: left;
 }
 
@@ -27868,7 +27896,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   color: inherit;
   font-size: 0.86rem;
   font-weight: 750;
-  line-height: 1.2;
+  line-height: 1.15;
   white-space: nowrap;
 }
 
@@ -27876,7 +27904,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   justify-self: end;
   align-self: center;
   width: 1rem;
+  height: 1rem;
   min-width: 1rem;
+  display: block;
 }
 
 .idt-domain-flyout-link-copy span,
@@ -27896,12 +27926,12 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1rem;
+  grid-template-columns: minmax(0, 1fr) 1.1rem;
   align-items: center;
-  gap: 0.6rem;
-  min-height: 2.42rem;
+  gap: 0.7rem;
+  min-height: 3rem;
   border-radius: 7px;
-  padding: 0.45rem 0.5rem;
+  padding: 0.5rem 0.6rem;
   color: #f3f5f7;
   text-align: left;
   cursor: pointer;
@@ -27913,20 +27943,27 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary > span {
-  display: grid;
-  gap: 0.1rem;
+  display: flex;
   min-width: 0;
-  justify-items: start;
+  min-height: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.1rem;
   text-align: left;
 }
 
 .idt-domain-flyout-nested summary strong {
   font-size: 0.9rem;
-  line-height: 1.2;
+  line-height: 1.15;
 }
 
 .idt-domain-flyout-nested summary svg {
   justify-self: end;
+  align-self: center;
+  display: block;
+  width: 1rem;
+  height: 1rem;
   color: #8f98a4;
   transition: transform 0.14s ease;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5859,7 +5859,8 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 .idt-repo-scan-health-remove:hover,
 .idt-repo-scan-health-remove:focus-visible {
   color: #ffffff;
-  outline: none;
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 .idt-repo-scan-health-panel {


### PR DESCRIPTION
## Summary
- fall back to individual finding deletes when the bulk-delete endpoint is unavailable
- add Remove controls for failed repository scan notices
- tighten domain flyout row alignment for links, nested rows, and chevrons

## Validation
- npm test -- --run src/productShell.test.tsx
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves findings cleanup and scan health UX. Adds a fallback for bulk delete failures, lets operators dismiss failed scan notices, and polishes domain flyout alignment.

- **New Features**
  - “Clear all” now falls back to individual deletes when the bulk-delete endpoint is unavailable (404), ensuring cleanup still works on older backends.
  - Added Remove controls to failed repository scan notices (banner and panel) with aligned, accessible inline actions; dismissals persist per tenant/workspace/scan via `localStorage`.
  - Tightened domain flyout layout: better link/nested row alignment and consistent chevron sizing.

<sup>Written for commit b4f7819370d09fb3e8e12ce92fc1682b164e531b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

