### PR TITLE
Fix GitHub findings cleanup reliability

### DIFF
--- a/internal/api/finding_baselines.go
+++ b/internal/api/finding_baselines.go
@@ -261,10 +261,10 @@ func (s *Service) loadTargetFindingsForBaselineImport(
 }
 
 func scoreFindingConfidence(finding domain.Finding) float64 {
+	if score, ok := normalizeFindingConfidenceScore(finding.ConfidenceScore); ok {
+		return score
+	}
 	if isRepoSecretClassifierFinding(finding) {
-		if score, ok := normalizeFindingConfidenceScore(finding.ConfidenceScore); ok {
-			return score
-		}
 		if score, ok := findingEvidenceFloat(finding.Evidence, "confidence_score"); ok {
 			if normalized, ok := normalizeFindingConfidenceScore(score); ok {
 				return normalized

--- a/internal/api/finding_baselines_test.go
+++ b/internal/api/finding_baselines_test.go
@@ -57,6 +57,18 @@ func TestScoreFindingConfidenceHonorsClassifierScore(t *testing.T) {
 	}
 }
 
+func TestScoreFindingConfidenceHonorsExplicitAdapterScore(t *testing.T) {
+	finding := domain.Finding{
+		Type:            domain.FindingRepoMisconfig,
+		ConfidenceScore: 0.92,
+		Repository:      "owner/repo",
+		Evidence:        map[string]any{"adapter_source": "github_posture"},
+	}
+	if got := scoreFindingConfidence(finding); got != 0.92 {
+		t.Fatalf("expected explicit adapter confidence score to win, got %.2f", got)
+	}
+}
+
 func TestScoreFindingConfidenceClampsClassifierScore(t *testing.T) {
 	finding := domain.Finding{
 		Type:            domain.FindingSecretExposure,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -707,11 +707,17 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	v1.GET("/repo-findings/trends", func(c *gin.Context) {
 		points := parseLimit(c.Query("points"), 10, 100)
+		minConfidence, _, err := parseOptionalFloat(firstNonEmpty(c.Query("confidence"), c.Query("min_confidence")))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid confidence"})
+			return
+		}
 		items, err := svc.GetRepoFindingsTrendFiltered(
 			c.Request.Context(),
 			points,
 			strings.TrimSpace(c.Query("severity")),
 			strings.TrimSpace(c.Query("type")),
+			minConfidence,
 		)
 		if err != nil {
 			logger.Error("repo findings trends", telemetry.ZapError(err))
@@ -1213,6 +1219,18 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
 			return
 		}
+		minConfidence, ok, err := parseOptionalFloat(c.Query("confidence"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid confidence"})
+			return
+		}
+		if !ok {
+			minConfidence, _, err = parseOptionalFloat(c.Query("min_confidence"))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_confidence"})
+				return
+			}
+		}
 		graph, err := svc.GetRepoRiskGraph(
 			c.Request.Context(),
 			RepoRiskGraphFilter{
@@ -1220,6 +1238,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				Repository:    strings.TrimSpace(c.Query("repository")),
 				Severity:      strings.TrimSpace(c.Query("severity")),
 				Type:          strings.TrimSpace(c.Query("type")),
+				MinConfidence: minConfidence,
 				DefaultBranch: strings.TrimSpace(c.Query("default_branch")),
 			},
 		)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -52,7 +52,8 @@ const (
 	repoFindingsTriageFilterStep     = maxCursorFetchLimit
 	repoFindingsTriageFilterCap      = maxCursorFetchLimit * 4
 	repoFindingSLAHighCritical       = 7 * 24 * time.Hour
-	maxRepoFindingBulkDeleteItems    = 500
+	maxRepoFindingBulkDeleteItems    = 5000
+	gitHubRepoFindingConfidenceFloor = 0.90
 )
 
 const (
@@ -396,6 +397,7 @@ type RepoRiskGraphFilter struct {
 	Repository    string
 	Severity      string
 	Type          string
+	MinConfidence float64
 	DefaultBranch string
 }
 
@@ -1926,6 +1928,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	sourceHealth, _ := db.NormalizeRepoScanSourceHealth("", sourceHealthDetails)
 	partialSourceRun := sourceHealth != db.RepoScanSourceHealthComplete
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
+	result.Findings = filterReportableRepoFindings(result.Findings)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		if errors.Is(err, db.ErrConflict) {
 			if cleanupErr := s.clearRepoScanFindingsAfterTerminalChange(ctx, record.ID); cleanupErr != nil {
@@ -2218,6 +2221,42 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		}
 	}
 	return findings, sourceErrors, nil
+}
+
+func filterRepoFindingsByMinimumConfidence(findings []domain.Finding, floor float64) []domain.Finding {
+	if floor <= 0 {
+		return findings
+	}
+	filtered := findings[:0]
+	for _, finding := range findings {
+		if finding.ConfidenceScore >= floor {
+			filtered = append(filtered, finding)
+		}
+	}
+	return filtered
+}
+
+func filterReportableRepoFindings(findings []domain.Finding) []domain.Finding {
+	filtered := findings[:0]
+	for _, finding := range findings {
+		if finding.ConfidenceScore < gitHubRepoFindingConfidenceFloor {
+			continue
+		}
+		if !isHighImpactRepoFinding(finding) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered
+}
+
+func isHighImpactRepoFinding(finding domain.Finding) bool {
+	switch finding.Severity {
+	case domain.SeverityCritical, domain.SeverityHigh:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) repoScanSourceHealthDetails(record db.RepoScanRecord, truncated bool, sourceErrors []providers.SourceError) []db.RepoScanSourceHealth {
@@ -2633,29 +2672,40 @@ func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingD
 	if err != nil {
 		return RepoFindingsBulkDeleteResponse{}, err
 	}
+	storeTargets := make([]db.RepoFindingDeleteTarget, 0, len(normalized))
+	for _, target := range normalized {
+		storeTargets = append(storeTargets, db.RepoFindingDeleteTarget{
+			RepoScanID: target.RepoScanID,
+			FindingID:  target.FindingID,
+		})
+	}
+	deletedTargets, err := s.Store.DeleteRepoFindingTargets(ctx, storeTargets)
+	if err != nil {
+		return RepoFindingsBulkDeleteResponse{}, err
+	}
+	deletedSet := make(map[string]struct{}, len(deletedTargets))
+	for _, target := range deletedTargets {
+		deletedSet[repoFindingDeleteTargetKey(target.RepoScanID, target.FindingID)] = struct{}{}
+	}
 	response := RepoFindingsBulkDeleteResponse{
 		Deleted: []RepoFindingDeleteTarget{},
 		Failed:  []RepoFindingDeleteFailure{},
 	}
 	for _, target := range normalized {
-		err := s.Store.DeleteRepoFinding(ctx, target.RepoScanID, target.FindingID)
-		if err == nil {
+		if _, ok := deletedSet[repoFindingDeleteTargetKey(target.RepoScanID, target.FindingID)]; ok {
 			response.Deleted = append(response.Deleted, target)
-			continue
-		}
-		if errors.Is(err, db.ErrNotFound) {
-			response.Failed = append(response.Failed, RepoFindingDeleteFailure{
-				RepoFindingDeleteTarget: target,
-				Error:                   "repo finding not found",
-			})
 			continue
 		}
 		response.Failed = append(response.Failed, RepoFindingDeleteFailure{
 			RepoFindingDeleteTarget: target,
-			Error:                   "failed to delete repo finding",
+			Error:                   "repo finding not found",
 		})
 	}
 	return response, nil
+}
+
+func repoFindingDeleteTargetKey(repoScanID string, findingID string) string {
+	return strings.TrimSpace(repoScanID) + "::" + strings.TrimSpace(findingID)
 }
 
 func normalizeRepoFindingDeleteTargets(targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
@@ -2762,12 +2812,13 @@ func (s *Service) GetRepoRiskGraph(ctx context.Context, filter RepoRiskGraphFilt
 	}
 
 	findings, err := s.Store.ListRepoFindings(ctx, db.RepoFindingFilter{
-		RepoScanID: strings.TrimSpace(filter.RepoScanID),
-		Repository: repository,
-		Severity:   strings.TrimSpace(filter.Severity),
-		Type:       strings.TrimSpace(filter.Type),
-		SortBy:     "created_at",
-		SortDesc:   true,
+		RepoScanID:    strings.TrimSpace(filter.RepoScanID),
+		Repository:    repository,
+		Severity:      strings.TrimSpace(filter.Severity),
+		Type:          strings.TrimSpace(filter.Type),
+		MinConfidence: filter.MinConfidence,
+		SortBy:        "created_at",
+		SortDesc:      true,
 	}, 0)
 	if err != nil {
 		return domain.RepoRiskGraph{}, err
@@ -3853,11 +3904,11 @@ func (s *Service) GetFindingsTrendFiltered(ctx context.Context, points int, seve
 
 // GetRepoFindingsTrend returns repository finding trend totals by repo scan.
 func (s *Service) GetRepoFindingsTrend(ctx context.Context, points int) ([]TrendPoint, error) {
-	return s.GetRepoFindingsTrendFiltered(ctx, points, "", "")
+	return s.GetRepoFindingsTrendFiltered(ctx, points, "", "", 0)
 }
 
 // GetRepoFindingsTrendFiltered returns repository finding trend with optional severity/type filters.
-func (s *Service) GetRepoFindingsTrendFiltered(ctx context.Context, points int, severity string, findingType string) ([]TrendPoint, error) {
+func (s *Service) GetRepoFindingsTrendFiltered(ctx context.Context, points int, severity string, findingType string, minConfidence float64) ([]TrendPoint, error) {
 	ctx = s.scopeContext(ctx)
 	if points <= 0 {
 		points = 10
@@ -3884,7 +3935,7 @@ func (s *Service) GetRepoFindingsTrendFiltered(ctx context.Context, points int, 
 		index[scan.ID] = &result[len(result)-1]
 	}
 
-	counts, err := s.Store.ListRepoFindingTrendCounts(ctx, repoScanIDs, severity, findingType)
+	counts, err := s.Store.ListRepoFindingTrendCounts(ctx, repoScanIDs, severity, findingType, minConfidence)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1928,7 +1928,9 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	sourceHealth, _ := db.NormalizeRepoScanSourceHealth("", sourceHealthDetails)
 	partialSourceRun := sourceHealth != db.RepoScanSourceHealthComplete
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
-	result.Findings = filterReportableRepoFindings(result.Findings)
+	if repoScanUsesGitHubAppSource(record) {
+		result.Findings = filterReportableRepoFindings(result.Findings)
+	}
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		if errors.Is(err, db.ErrConflict) {
 			if cleanupErr := s.clearRepoScanFindingsAfterTerminalChange(ctx, record.ID); cleanupErr != nil {
@@ -2223,17 +2225,9 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 	return findings, sourceErrors, nil
 }
 
-func filterRepoFindingsByMinimumConfidence(findings []domain.Finding, floor float64) []domain.Finding {
-	if floor <= 0 {
-		return findings
-	}
-	filtered := findings[:0]
-	for _, finding := range findings {
-		if finding.ConfidenceScore >= floor {
-			filtered = append(filtered, finding)
-		}
-	}
-	return filtered
+func repoScanUsesGitHubAppSource(record db.RepoScanRecord) bool {
+	source := record.Source.Normalize()
+	return source.Provider == "github_app"
 }
 
 func filterReportableRepoFindings(findings []domain.Finding) []domain.Finding {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2402,8 +2402,8 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 		t.Fatalf("create repo scan A: %v", err)
 	}
 	if err := store.UpsertRepoFindings(ctx, scanA.ID, []domain.Finding{
-		{ID: "f1", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, CreatedAt: now},
-		{ID: "f2", Severity: domain.SeverityHigh, Type: domain.FindingOwnerless, CreatedAt: now},
+		{ID: "f1", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, ConfidenceScore: 0.92, CreatedAt: now},
+		{ID: "f2", Severity: domain.SeverityHigh, Type: domain.FindingOwnerless, ConfidenceScore: 0.88, CreatedAt: now},
 	}); err != nil {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
@@ -2413,18 +2413,26 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 		t.Fatalf("create repo scan B: %v", err)
 	}
 	if err := store.UpsertRepoFindings(ctx, scanB.ID, []domain.Finding{
-		{ID: "f3", Severity: domain.SeverityLow, Type: domain.FindingOwnerless, CreatedAt: now.Add(3 * time.Minute)},
+		{ID: "f3", Severity: domain.SeverityLow, Type: domain.FindingOwnerless, ConfidenceScore: 0.95, CreatedAt: now.Add(3 * time.Minute)},
 	}); err != nil {
 		t.Fatalf("upsert repo findings for scan B: %v", err)
 	}
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	points, err := svc.GetRepoFindingsTrendFiltered(ctx, 10, "critical", "escalation_path")
+	points, err := svc.GetRepoFindingsTrendFiltered(ctx, 10, "critical", "escalation_path", 0)
 	if err != nil {
 		t.Fatalf("get filtered repo findings trend: %v", err)
 	}
 	if len(points) != 2 || points[0].Total != 1 || points[1].Total != 0 {
 		t.Fatalf("unexpected filtered repo trend points: %+v", points)
+	}
+
+	confidencePoints, err := svc.GetRepoFindingsTrendFiltered(ctx, 10, "", "", 0.9)
+	if err != nil {
+		t.Fatalf("get confidence-filtered repo findings trend: %v", err)
+	}
+	if len(confidencePoints) != 2 || confidencePoints[0].Total != 1 || confidencePoints[1].Total != 1 {
+		t.Fatalf("unexpected confidence-filtered repo trend points: %+v", confidencePoints)
 	}
 }
 
@@ -2464,6 +2472,40 @@ func TestServiceRunRepoScanSuccess(t *testing.T) {
 	}
 	if gotHistory != 800 || gotMax != 300 {
 		t.Fatalf("unexpected scanner args history=%d max=%d", gotHistory, gotMax)
+	}
+}
+
+func TestServiceRunRepoScanFiltersLowSignalFindings(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: 1,
+				FilesScanned:   2,
+				Findings: []domain.Finding{
+					{ID: "high-confidence-secret", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh},
+					{ID: "lower-confidence-policy", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh},
+					{ID: "high-confidence-medium", Type: domain.FindingRepoMisconfig, Severity: domain.SeverityMedium, ConfidenceScore: 0.95},
+				},
+			},
+		}
+	}
+
+	result, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("run repo scan: %v", err)
+	}
+	if len(result.Findings) != 1 || result.Findings[0].ID != "high-confidence-secret" {
+		t.Fatalf("expected only high-confidence finding to remain, got %+v", result.Findings)
+	}
+	if result.Findings[0].ConfidenceScore < gitHubRepoFindingConfidenceFloor {
+		t.Fatalf("expected remaining finding to meet confidence floor, got %.2f", result.Findings[0].ConfidenceScore)
+	}
+	if !isHighImpactRepoFinding(result.Findings[0]) {
+		t.Fatalf("expected remaining finding to meet severity floor, got %q", result.Findings[0].Severity)
 	}
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2476,6 +2476,25 @@ func TestServiceRunRepoScanSuccess(t *testing.T) {
 }
 
 func TestServiceRunRepoScanFiltersLowSignalFindings(t *testing.T) {
+	findings := []domain.Finding{
+		{ID: "high-confidence-secret", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh, ConfidenceScore: 0.95},
+		{ID: "lower-confidence-policy", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh, ConfidenceScore: 0.78},
+		{ID: "high-confidence-medium", Type: domain.FindingRepoMisconfig, Severity: domain.SeverityMedium, ConfidenceScore: 0.95},
+	}
+
+	filtered := filterReportableRepoFindings(findings)
+	if len(filtered) != 1 || filtered[0].ID != "high-confidence-secret" {
+		t.Fatalf("expected only high-confidence finding to remain, got %+v", filtered)
+	}
+	if filtered[0].ConfidenceScore < gitHubRepoFindingConfidenceFloor {
+		t.Fatalf("expected remaining finding to meet confidence floor, got %.2f", filtered[0].ConfidenceScore)
+	}
+	if !isHighImpactRepoFinding(filtered[0]) {
+		t.Fatalf("expected remaining finding to meet severity floor, got %q", filtered[0].Severity)
+	}
+}
+
+func TestServiceRunRepoScanKeepsLowSignalFindingsForManualScans(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/repo"}
@@ -2498,14 +2517,8 @@ func TestServiceRunRepoScanFiltersLowSignalFindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run repo scan: %v", err)
 	}
-	if len(result.Findings) != 1 || result.Findings[0].ID != "high-confidence-secret" {
-		t.Fatalf("expected only high-confidence finding to remain, got %+v", result.Findings)
-	}
-	if result.Findings[0].ConfidenceScore < gitHubRepoFindingConfidenceFloor {
-		t.Fatalf("expected remaining finding to meet confidence floor, got %.2f", result.Findings[0].ConfidenceScore)
-	}
-	if !isHighImpactRepoFinding(result.Findings[0]) {
-		t.Fatalf("expected remaining finding to meet severity floor, got %q", result.Findings[0].Severity)
+	if len(result.Findings) != 3 {
+		t.Fatalf("expected manual scan findings to remain unfiltered, got %+v", result.Findings)
 	}
 }
 

--- a/internal/connectors/github/posture_findings.go
+++ b/internal/connectors/github/posture_findings.go
@@ -181,7 +181,7 @@ func postureFindingSeverity(check RepositoryPostureCheck, detector string) domai
 func postureFindingConfidence(state RepositoryPostureState) float64 {
 	switch state {
 	case RepositoryPostureStateInsecure:
-		return 0.88
+		return 0.92
 	case RepositoryPostureStatePermissionLimited:
 		return 0.72
 	case RepositoryPostureStateUnavailable:

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1212,7 +1212,7 @@ func (m *MemoryStore) ListFindingTrendCounts(ctx context.Context, scanIDs []stri
 }
 
 // ListRepoFindingTrendCounts aggregates repository finding totals by repo scan and severity.
-func (m *MemoryStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error) {
+func (m *MemoryStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string, minConfidence float64) ([]FindingTrendCount, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -1257,6 +1257,9 @@ func (m *MemoryStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanID
 				continue
 			}
 			if normalizedType != "" && strings.ToLower(string(finding.Type)) != normalizedType {
+				continue
+			}
+			if minConfidence > 0 && finding.ConfidenceScore < minConfidence {
 				continue
 			}
 			counts[string(finding.Severity)]++
@@ -2454,6 +2457,58 @@ func (m *MemoryStore) DeleteRepoFinding(ctx context.Context, repoScanID string, 
 	repoScan.FindingCount = len(nextKeys)
 	m.repoScans[repoScanID] = repoScan
 	return nil
+}
+
+// DeleteRepoFindingTargets removes selected persisted repository findings.
+func (m *MemoryStore) DeleteRepoFindingTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deleted := make([]RepoFindingDeleteTarget, 0, len(targets))
+	deletedByScan := map[string]map[string]struct{}{}
+	for _, target := range targets {
+		repoScanID := strings.TrimSpace(target.RepoScanID)
+		findingID := strings.TrimSpace(target.FindingID)
+		if repoScanID == "" || findingID == "" {
+			continue
+		}
+		repoScan, exists := m.repoScans[repoScanID]
+		if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
+			continue
+		}
+		key := repoScanID + "|" + findingID
+		if _, exists := m.repoFindings[key]; !exists {
+			continue
+		}
+		delete(m.repoFindings, key)
+		if deletedByScan[repoScanID] == nil {
+			deletedByScan[repoScanID] = map[string]struct{}{}
+		}
+		deletedByScan[repoScanID][key] = struct{}{}
+		deleted = append(deleted, RepoFindingDeleteTarget{RepoScanID: repoScanID, FindingID: findingID})
+	}
+	for repoScanID, keysToDelete := range deletedByScan {
+		keys := m.repoFindingIDs[repoScanID]
+		nextKeys := keys[:0]
+		for _, existing := range keys {
+			if _, remove := keysToDelete[existing]; !remove {
+				nextKeys = append(nextKeys, existing)
+			}
+		}
+		if len(nextKeys) == 0 {
+			delete(m.repoFindingIDs, repoScanID)
+		} else {
+			m.repoFindingIDs[repoScanID] = nextKeys
+		}
+		repoScan := m.repoScans[repoScanID]
+		repoScan.FindingCount = len(nextKeys)
+		m.repoScans[repoScanID] = repoScan
+	}
+	return deleted, nil
 }
 
 // ListRepoScans returns latest repo scans first.

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -515,18 +515,18 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 		t.Fatalf("create repo scan B: %v", err)
 	}
 	if err := store.UpsertRepoFindings(ctx, scanA.ID, []domain.Finding{
-		{ID: "f1", ScanID: scanA.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now.Add(time.Second)},
-		{ID: "f2", ScanID: scanA.ID, Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical, CreatedAt: now.Add(2 * time.Second)},
+		{ID: "f1", ScanID: scanA.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, ConfidenceScore: 0.89, CreatedAt: now.Add(time.Second)},
+		{ID: "f2", ScanID: scanA.ID, Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical, ConfidenceScore: 0.92, CreatedAt: now.Add(2 * time.Second)},
 	}); err != nil {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
 	if err := store.UpsertRepoFindings(ctx, scanB.ID, []domain.Finding{
-		{ID: "f3", ScanID: scanB.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now.Add(3 * time.Second)},
+		{ID: "f3", ScanID: scanB.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityLow, ConfidenceScore: 0.95, CreatedAt: now.Add(3 * time.Second)},
 	}); err != nil {
 		t.Fatalf("upsert repo findings for scan B: %v", err)
 	}
 
-	trend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "", "")
+	trend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "", "", 0)
 	if err != nil {
 		t.Fatalf("list repo finding trend counts: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 		t.Fatalf("expected 3 repo trend rows, got %+v", trend)
 	}
 
-	filteredTrend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "critical", "escalation_path")
+	filteredTrend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "critical", "escalation_path", 0)
 	if err != nil {
 		t.Fatalf("list filtered repo finding trend counts: %v", err)
 	}
@@ -546,6 +546,20 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 	}
 	if filteredTrend[1].ScanID != scanB.ID || filteredTrend[1].TotalCount != 0 {
 		t.Fatalf("unexpected filtered repo trend row for scan B: %+v", filteredTrend[1])
+	}
+
+	confidenceFilteredTrend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "", "", 0.9)
+	if err != nil {
+		t.Fatalf("list confidence-filtered repo finding trend counts: %v", err)
+	}
+	if len(confidenceFilteredTrend) != 2 {
+		t.Fatalf("expected 2 confidence-filtered repo trend rows, got %+v", confidenceFilteredTrend)
+	}
+	if confidenceFilteredTrend[0].ScanID != scanA.ID || confidenceFilteredTrend[0].Severity != "critical" || confidenceFilteredTrend[0].TotalCount != 1 {
+		t.Fatalf("unexpected confidence-filtered repo trend row for scan A: %+v", confidenceFilteredTrend[0])
+	}
+	if confidenceFilteredTrend[1].ScanID != scanB.ID || confidenceFilteredTrend[1].Severity != "low" || confidenceFilteredTrend[1].TotalCount != 1 {
+		t.Fatalf("unexpected confidence-filtered repo trend row for scan B: %+v", confidenceFilteredTrend[1])
 	}
 }
 
@@ -831,6 +845,70 @@ func TestMemoryStoreDeleteRepoFindingUpdatesScanCount(t *testing.T) {
 	}
 	if storedScan.FindingCount != 0 {
 		t.Fatalf("expected repo scan finding count to reach zero after final delete, got %d", storedScan.FindingCount)
+	}
+}
+
+func TestMemoryStoreDeleteRepoFindingTargetsUpdatesScanCounts(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	scanA, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan A: %v", err)
+	}
+	scanB, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, RepoScanContext{}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("create repo scan B: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), scanA.ID, []domain.Finding{
+		{ID: "rf-a-1", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh, CreatedAt: now},
+		{ID: "rf-a-2", Type: domain.FindingRepoMisconfig, Severity: domain.SeverityMedium, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan A: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), scanB.ID, []domain.Finding{
+		{ID: "rf-b-1", Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan B: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), scanA.ID, "completed", now.Add(time.Minute), 2, 2, 2, false, RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete repo scan A: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), scanB.ID, "completed", now.Add(2*time.Minute), 1, 1, 1, false, RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete repo scan B: %v", err)
+	}
+
+	deleted, err := store.DeleteRepoFindingTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
+		{RepoScanID: scanA.ID, FindingID: "rf-a-1"},
+		{RepoScanID: scanA.ID, FindingID: "missing"},
+		{RepoScanID: scanB.ID, FindingID: "rf-b-1"},
+	})
+	if err != nil {
+		t.Fatalf("delete repo finding targets: %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected two deleted targets, got %+v", deleted)
+	}
+	storedScanA, err := store.GetRepoScan(defaultScopeContext(), scanA.ID)
+	if err != nil {
+		t.Fatalf("get repo scan A: %v", err)
+	}
+	if storedScanA.FindingCount != 1 {
+		t.Fatalf("expected scan A finding count to decrement, got %d", storedScanA.FindingCount)
+	}
+	storedScanB, err := store.GetRepoScan(defaultScopeContext(), scanB.ID)
+	if err != nil {
+		t.Fatalf("get repo scan B: %v", err)
+	}
+	if storedScanB.FindingCount != 0 {
+		t.Fatalf("expected scan B finding count to reset, got %d", storedScanB.FindingCount)
+	}
+	remaining, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{}, 10)
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "rf-a-2" {
+		t.Fatalf("expected only rf-a-2 to remain, got %+v", remaining)
 	}
 }
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1752,7 +1752,7 @@ func (p *PostgresStore) ListFindingTrendCounts(ctx context.Context, scanIDs []st
 }
 
 // ListRepoFindingTrendCounts aggregates repository finding totals by repo scan and severity.
-func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error) {
+func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string, minConfidence float64) ([]FindingTrendCount, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return nil, err
@@ -1775,10 +1775,10 @@ func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScan
 	}
 
 	placeholders := make([]string, 0, len(unique))
-	args := make([]any, 0, len(unique)+4)
-	args = append(args, scope.TenantID, scope.WorkspaceID, strings.ToLower(strings.TrimSpace(severity)), strings.ToLower(strings.TrimSpace(findingType)))
+	args := make([]any, 0, len(unique)+5)
+	args = append(args, scope.TenantID, scope.WorkspaceID, strings.ToLower(strings.TrimSpace(severity)), strings.ToLower(strings.TrimSpace(findingType)), minConfidence)
 	for i, repoScanID := range unique {
-		placeholders = append(placeholders, fmt.Sprintf("$%d", i+5))
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+6))
 		args = append(args, repoScanID)
 	}
 
@@ -1790,6 +1790,7 @@ func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScan
 		   ON rf.repo_scan_id = rs.id
 		  AND ($3 = '' OR LOWER(rf.severity) = $3)
 		  AND ($4 = '' OR LOWER(rf.type) = $4)
+		  AND ($5 <= 0 OR rf.confidence_score >= $5)
 		 WHERE rs.tenant_id = $1
 		   AND rs.workspace_id = $2
 		   AND rs.id IN (%s)
@@ -3807,6 +3808,72 @@ func (p *PostgresStore) DeleteRepoFinding(ctx context.Context, repoScanID string
 		return err
 	}
 	return nil
+}
+
+// DeleteRepoFindingTargets removes selected repository findings in one scoped operation.
+func (p *PostgresStore) DeleteRepoFindingTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(targets)
+	if err != nil {
+		return nil, fmt.Errorf("marshal repo finding delete targets: %w", err)
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`WITH targets AS (
+			SELECT DISTINCT
+			       NULLIF(TRIM(repo_scan_id), '')::uuid AS repo_scan_id,
+			       NULLIF(TRIM(finding_id), '') AS finding_id
+			  FROM jsonb_to_recordset($1::jsonb) AS t(repo_scan_id text, finding_id text)
+			 WHERE NULLIF(TRIM(repo_scan_id), '') IS NOT NULL
+			   AND NULLIF(TRIM(finding_id), '') IS NOT NULL
+		), deleted AS (
+			DELETE FROM repo_findings rf
+			USING repo_scans rs, targets t
+			WHERE rf.repo_scan_id = rs.id
+			  AND rf.repo_scan_id = t.repo_scan_id
+			  AND rf.finding_id = t.finding_id
+			  AND rs.tenant_id = $2
+			  AND rs.workspace_id = $3
+			RETURNING rf.repo_scan_id::text, rf.finding_id
+		), updated AS (
+			UPDATE repo_scans rs
+			SET finding_count = GREATEST(0, rs.finding_count - counts.deleted_count)
+			FROM (
+				SELECT repo_scan_id, COUNT(*)::int AS deleted_count
+				FROM deleted
+				GROUP BY repo_scan_id
+			) counts
+			WHERE rs.id = counts.repo_scan_id
+			  AND rs.tenant_id = $2
+			  AND rs.workspace_id = $3
+			RETURNING rs.id
+		)
+		SELECT repo_scan_id, finding_id
+		  FROM deleted
+		 ORDER BY repo_scan_id, finding_id`,
+		string(payload),
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete repo finding targets: %w", err)
+	}
+	defer rows.Close()
+	deleted := []RepoFindingDeleteTarget{}
+	for rows.Next() {
+		var target RepoFindingDeleteTarget
+		if err := rows.Scan(&target.RepoScanID, &target.FindingID); err != nil {
+			return nil, fmt.Errorf("scan deleted repo finding target: %w", err)
+		}
+		deleted = append(deleted, target)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate deleted repo finding targets: %w", err)
+	}
+	return deleted, nil
 }
 
 // ListRepoScans returns latest repository scans first.

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1782,6 +1782,7 @@ func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScan
 		args = append(args, repoScanID)
 	}
 
+	confidenceExpr := repoFindingConfidenceScoreExpression("rf")
 	rows, err := p.queryContext(
 		ctx,
 		fmt.Sprintf(`SELECT rs.id, rs.started_at, rf.severity, COUNT(rf.finding_id)
@@ -1790,11 +1791,11 @@ func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScan
 		   ON rf.repo_scan_id = rs.id
 		  AND ($3 = '' OR LOWER(rf.severity) = $3)
 		  AND ($4 = '' OR LOWER(rf.type) = $4)
-		  AND ($5 <= 0 OR rf.confidence_score >= $5)
+		  AND ($5 <= 0 OR %s >= $5)
 		 WHERE rs.tenant_id = $1
 		   AND rs.workspace_id = $2
 		   AND rs.id IN (%s)
-		 GROUP BY rs.id, rs.started_at, rf.severity`, strings.Join(placeholders, ",")),
+		 GROUP BY rs.id, rs.started_at, rf.severity`, confidenceExpr, strings.Join(placeholders, ",")),
 		args...,
 	)
 	if err != nil {
@@ -1818,6 +1819,17 @@ func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScan
 		return nil, fmt.Errorf("repo finding trend rows: %w", err)
 	}
 	return result, nil
+}
+
+func repoFindingConfidenceScoreExpression(alias string) string {
+	normalizedAlias := strings.TrimSpace(alias)
+	if normalizedAlias == "" {
+		normalizedAlias = "rf"
+	}
+	return fmt.Sprintf(`CASE
+		WHEN COALESCE(%s.evidence->>'confidence_score', '') ~ '^[0-9]+(\.[0-9]+)?$' THEN (%s.evidence->>'confidence_score')::double precision
+		ELSE 0
+	END`, normalizedAlias, normalizedAlias)
 }
 
 // UpsertAuthzEntityAttributes creates or updates trusted authorization attributes.
@@ -3816,7 +3828,18 @@ func (p *PostgresStore) DeleteRepoFindingTargets(ctx context.Context, targets []
 	if err != nil {
 		return nil, err
 	}
-	payload, err := json.Marshal(targets)
+	type repoFindingDeleteTargetPayload struct {
+		RepoScanID string `json:"repo_scan_id"`
+		FindingID  string `json:"finding_id"`
+	}
+	payloadTargets := make([]repoFindingDeleteTargetPayload, 0, len(targets))
+	for _, target := range targets {
+		payloadTargets = append(payloadTargets, repoFindingDeleteTargetPayload{
+			RepoScanID: target.RepoScanID,
+			FindingID:  target.FindingID,
+		})
+	}
+	payload, err := json.Marshal(payloadTargets)
 	if err != nil {
 		return nil, fmt.Errorf("marshal repo finding delete targets: %w", err)
 	}
@@ -3932,10 +3955,7 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	detectorExpr := `COALESCE(NULLIF(rf.evidence->>'detector', ''), '')`
 	ownerExpr := `COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'codeowners', ''), NULLIF(rf.evidence->>'assignee', ''), '')`
 	statusExpr := `COALESCE(NULLIF(rf.lifecycle_status, ''), 'open')`
-	confidenceExpr := `CASE
-		WHEN COALESCE(rf.evidence->>'confidence_score', '') ~ '^[0-9]+(\.[0-9]+)?$' THEN (rf.evidence->>'confidence_score')::double precision
-		ELSE 0
-	END`
+	confidenceExpr := repoFindingConfidenceScoreExpression("rf")
 	lifecycleKeyExpr := fmt.Sprintf(
 		`COALESCE(NULLIF(rf.lifecycle_key, ''), CONCAT_WS(E'\x1f', 'repo_finding', LOWER(%s), rf.type, LOWER(%s), LOWER(COALESCE(NULLIF(rf.evidence->>'file_path', ''), '')), COALESCE(NULLIF(rf.evidence->>'line_number', ''), ''), rf.finding_id))`,
 		repositoryExpr,

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1072,6 +1072,37 @@ func TestPostgresStoreDeleteRepoFindingDecrementsScanCount(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreDeleteRepoFindingTargetsReturnsDeletedTargets(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+	deletedRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id"}).
+		AddRow(scanID, "rf-1").
+		AddRow(scanID, "rf-2")
+	mock.ExpectQuery("WITH targets AS").
+		WithArgs(sqlmock.AnyArg(), "default", "default").
+		WillReturnRows(deletedRows)
+
+	deleted, err := store.DeleteRepoFindingTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
+		{RepoScanID: scanID, FindingID: "rf-1"},
+		{RepoScanID: scanID, FindingID: "rf-2"},
+	})
+	if err != nil {
+		t.Fatalf("delete repo finding targets: %v", err)
+	}
+	if len(deleted) != 2 || deleted[0].FindingID != "rf-1" || deleted[1].FindingID != "rf-2" {
+		t.Fatalf("unexpected deleted targets: %+v", deleted)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreListRepoFindingClustersPagesInStore(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -3588,14 +3619,15 @@ func TestPostgresStoreListRepoFindingTrendCounts(t *testing.T) {
 		   ON rf.repo_scan_id = rs.id
 		  AND ($3 = '' OR LOWER(rf.severity) = $3)
 		  AND ($4 = '' OR LOWER(rf.type) = $4)
+		  AND ($5 <= 0 OR rf.confidence_score >= $5)
 		 WHERE rs.tenant_id = $1
 		   AND rs.workspace_id = $2
-		   AND rs.id IN ($5,$6)
+		   AND rs.id IN ($6,$7)
 		 GROUP BY rs.id, rs.started_at, rf.severity`)).
-		WithArgs("default", "default", "critical", "escalation_path", "scan-1", "scan-2").
+		WithArgs("default", "default", "critical", "escalation_path", 0.9, "scan-1", "scan-2").
 		WillReturnRows(trendRows)
 
-	trend, err := store.ListRepoFindingTrendCounts(defaultScopeContext(), []string{"scan-1", "scan-2", "scan-1"}, "critical", "escalation_path")
+	trend, err := store.ListRepoFindingTrendCounts(defaultScopeContext(), []string{"scan-1", "scan-2", "scan-1"}, "critical", "escalation_path", 0.9)
 	if err != nil {
 		t.Fatalf("list repo finding trend counts: %v", err)
 	}

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1084,8 +1084,9 @@ func TestPostgresStoreDeleteRepoFindingTargetsReturnsDeletedTargets(t *testing.T
 	deletedRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id"}).
 		AddRow(scanID, "rf-1").
 		AddRow(scanID, "rf-2")
+	expectedPayload := `[{"repo_scan_id":"11111111-1111-1111-1111-111111111111","finding_id":"rf-1"},{"repo_scan_id":"11111111-1111-1111-1111-111111111111","finding_id":"rf-2"}]`
 	mock.ExpectQuery("WITH targets AS").
-		WithArgs(sqlmock.AnyArg(), "default", "default").
+		WithArgs(expectedPayload, "default", "default").
 		WillReturnRows(deletedRows)
 
 	deleted, err := store.DeleteRepoFindingTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
@@ -3619,7 +3620,10 @@ func TestPostgresStoreListRepoFindingTrendCounts(t *testing.T) {
 		   ON rf.repo_scan_id = rs.id
 		  AND ($3 = '' OR LOWER(rf.severity) = $3)
 		  AND ($4 = '' OR LOWER(rf.type) = $4)
-		  AND ($5 <= 0 OR rf.confidence_score >= $5)
+		  AND ($5 <= 0 OR CASE
+		WHEN COALESCE(rf.evidence->>'confidence_score', '') ~ '^[0-9]+(\.[0-9]+)?$' THEN (rf.evidence->>'confidence_score')::double precision
+		ELSE 0
+	END >= $5)
 		 WHERE rs.tenant_id = $1
 		   AND rs.workspace_id = $2
 		   AND rs.id IN ($6,$7)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2772,6 +2772,12 @@ type RepoFindingFilter struct {
 	IncludeHistorical bool
 }
 
+// RepoFindingDeleteTarget identifies one persisted repository finding row.
+type RepoFindingDeleteTarget struct {
+	RepoScanID string
+	FindingID  string
+}
+
 // RepoFindingClusterListFilter controls repository finding cluster list queries.
 type RepoFindingClusterListFilter struct {
 	RepoScanID string
@@ -3061,7 +3067,7 @@ type Store interface {
 	ListFindingMetasByScan(ctx context.Context, scanID string) ([]FindingMeta, error)
 	ListFindingsByScanAndIDs(ctx context.Context, scanID string, findingIDs []string) ([]domain.Finding, error)
 	ListFindingTrendCounts(ctx context.Context, scanIDs []string, severity string, findingType string) ([]FindingTrendCount, error)
-	ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error)
+	ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string, minConfidence float64) ([]FindingTrendCount, error)
 	UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error
 	GetAuthzEntityAttributes(ctx context.Context, entityKind string, entityType string, entityID string) (AuthzEntityAttributes, error)
 	UpsertAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error
@@ -3335,6 +3341,7 @@ type Store interface {
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error
 	DeleteRepoFindings(ctx context.Context, repoScanID string) error
 	DeleteRepoFinding(ctx context.Context, repoScanID string, findingID string) error
+	DeleteRepoFindingTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error)
 	ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error)
 	ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error)
 	ListRepoFindingClusters(ctx context.Context, filter RepoFindingClusterListFilter) ([]domain.RepoFindingCluster, error)

--- a/testdata/contracts/api_v1_findings_list_response.snapshot.json
+++ b/testdata/contracts/api_v1_findings_list_response.snapshot.json
@@ -1,7 +1,7 @@
 {
   "items": [
     {
-      "confidence_score": 0.91,
+      "confidence_score": 0.88,
       "created_at": "\u003ctimestamp\u003e",
       "evidence": {
         "compliance_frameworks": [

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10025,7 +10025,7 @@ export const apiClient = {
     return request<{ items: TrendPoint[] }>(`/v1/findings/trends${buildQuery(filters)}`, auth);
   },
   getRepoFindingsTrends(
-    filters: { points?: number; severity?: string; type?: string } = {},
+    filters: { points?: number; severity?: string; type?: string; min_confidence?: number } = {},
     auth?: RequestAuthContext
   ) {
     return request<{ items: TrendPoint[] }>(`/v1/repo-findings/trends${buildQuery(filters)}`, auth);
@@ -10159,6 +10159,7 @@ export const apiClient = {
       default_branch?: string;
       severity?: string;
       type?: string;
+      min_confidence?: number;
     } = {},
     auth?: RequestAuthContext
   ) {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8718,7 +8718,7 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
-  it('falls back to individual deletes when the bulk endpoint is unavailable', async () => {
+  it('keeps clear all on the bulk path when the bulk endpoint fails', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-bulk-missing',
@@ -8765,25 +8765,11 @@ describe('ProductFindingsPage states', () => {
 
     await waitFor(() => {
       expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
-      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+      expect(deleteRepoFinding).not.toHaveBeenCalled();
+      expect(screen.getByText('Request failed (404)')).toBeInTheDocument();
     });
-    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
-      1,
-      findings[0].id,
-      scan.id,
-      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
-    );
-    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
-      2,
-      findings[1].id,
-      scan.id,
-      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
-    );
-    await waitFor(() => {
-      expect(screen.queryByText('Fallback clearable token finding')).not.toBeInTheDocument();
-      expect(screen.queryByText('Fallback clearable workflow finding')).not.toBeInTheDocument();
-    });
-    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable workflow finding')).toBeInTheDocument();
   });
 
   it('reloads repository findings after clearing a paged list', async () => {
@@ -8833,7 +8819,7 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('Next page workflow finding')).toBeInTheDocument();
   });
 
-  it('chunks clear all requests above the repository finding bulk limit', async () => {
+  it('sends large clear all requests as one repository finding bulk operation', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-large',
@@ -8852,10 +8838,10 @@ describe('ProductFindingsPage states', () => {
       created_at: '2026-05-17T11:07:00Z'
     }));
 
-    const { deleteRepoFindings } = await renderFindings({
-      repoScans: [scan],
-      repoFindings: findings
-    });
+	const { deleteRepoFindings } = await renderFindings({
+	  repoScans: [scan],
+	  listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [findings[500]] })
+	});
 
     expect(await screen.findByText('Large clear all finding 0')).toBeInTheDocument();
 
@@ -8864,17 +8850,15 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
 
     await waitFor(() => {
-      expect(deleteRepoFindings).toHaveBeenCalledTimes(2);
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
     });
-    const firstBatch = deleteRepoFindings.mock.calls[0]?.[0] ?? [];
-    const secondBatch = deleteRepoFindings.mock.calls[1]?.[0] ?? [];
-    expect(firstBatch).toHaveLength(500);
-    expect(secondBatch).toHaveLength(1);
-    expect(firstBatch[0]).toEqual({ finding_id: findings[0].id, repo_scan_id: scan.id });
-    expect(secondBatch[0]).toEqual({ finding_id: findings[500].id, repo_scan_id: scan.id });
+    const targets = deleteRepoFindings.mock.calls[0]?.[0] ?? [];
+    expect(targets).toHaveLength(501);
+    expect(targets[0]).toEqual({ finding_id: findings[0].id, repo_scan_id: scan.id });
+    expect(targets[500]).toEqual({ finding_id: findings[500].id, repo_scan_id: scan.id });
   });
 
-  it('preserves completed clear all batches when a later batch fails', async () => {
+  it('preserves completed clear all deletes when the bulk response is partial', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-batch-failure',
@@ -8895,16 +8879,15 @@ describe('ProductFindingsPage states', () => {
 
     const { deleteRepoFindings } = await renderFindings({
       repoScans: [scan],
-      repoFindings: findings
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [findings[500]] })
     });
-    deleteRepoFindings
-      .mockResolvedValueOnce({
-        deleted: findings.slice(0, 500).map((finding) => ({
-          finding_id: finding.id,
-          repo_scan_id: finding.scan_id
-        }))
-      })
-      .mockRejectedValueOnce(new Error('rate limit exceeded'));
+    deleteRepoFindings.mockResolvedValueOnce({
+      deleted: findings.slice(0, 500).map((finding) => ({
+        finding_id: finding.id,
+        repo_scan_id: finding.scan_id
+      })),
+      failed: [{ finding_id: findings[500].id, repo_scan_id: findings[500].scan_id, error: 'repo finding not found' }]
+    });
 
     expect(await screen.findByText('Batch failure finding 0')).toBeInTheDocument();
     expect(await screen.findByText('Batch failure finding 500')).toBeInTheDocument();
@@ -8914,7 +8897,7 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
 
     await waitFor(() => {
-      expect(deleteRepoFindings).toHaveBeenCalledTimes(2);
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
     });
     expect(await screen.findByText('500 deleted. 1 remaining.')).toBeInTheDocument();
     expect(screen.queryByText('Batch failure finding 0')).not.toBeInTheDocument();
@@ -8954,10 +8937,10 @@ describe('ProductFindingsPage states', () => {
       }
     ];
 
-    const { deleteRepoFindings } = await renderFindings({
-      repoScans: [scan],
-      repoFindings: findings
-    });
+	const { deleteRepoFindings } = await renderFindings({
+	  repoScans: [scan],
+	  listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [findings[1]] })
+	});
     deleteRepoFindings.mockResolvedValueOnce({
       deleted: [{ finding_id: findings[0].id, repo_scan_id: scan.id }],
       failed: [{ finding_id: findings[1].id, repo_scan_id: scan.id, error: 'repo finding not found' }]

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8442,6 +8442,81 @@ describe('ProductFindingsPage states', () => {
     });
   });
 
+  it('hides the risk graph when unsupported finding filters are active', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-risk-graph-source-filter',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-risk-graph-source-filter',
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Source-filtered workflow permission',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      source: 'github_code_scanning',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+
+    await renderFindings({
+      repoScans: [scan],
+      repoFindings: [finding],
+      getRepoRiskGraph: () => ({
+        repository: 'identrail/identrail',
+        nodes: [
+          {
+            id: 'node-1',
+            kind: 'finding',
+            label: 'Finding',
+            repository: 'identrail/identrail',
+            evidence_state: 'known'
+          }
+        ],
+        edges: [],
+        scores: [
+          {
+            finding_id: finding.id,
+            finding_node_id: 'node-1',
+            score: 92,
+            severity: 'high',
+            confidence: 0.92,
+            factors: {
+              severity: 80,
+              confidence: 92,
+              exploitability: 80,
+              privilege: 70,
+              exposure: 70,
+              environment_criticality: 60,
+              freshness: 90
+            },
+            unknowns: []
+          }
+        ],
+        summary: {
+          finding_count: 1,
+          node_count: 1,
+          edge_count: 0,
+          unknown_node_count: 0,
+          unknown_edge_count: 0,
+          high_risk_findings: 1,
+          critical_findings: 0
+        }
+      })
+    });
+
+    expect(await screen.findByText('1 nodes · 0 paths · identrail/identrail')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Source name'), { target: { value: 'github_code_scanning' } });
+
+    expect(await screen.findByText('Hidden for current filters')).toBeInTheDocument();
+    expect(screen.getByText('Clear source, assignee, or lifecycle filters to view the graph.')).toBeInTheDocument();
+    expect(screen.queryByText('High-risk findings')).not.toBeInTheDocument();
+  });
+
   it('ignores stale finding delete completions after refreshing the findings list', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
@@ -8819,7 +8894,21 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('Next page workflow finding')).toBeInTheDocument();
   });
 
-  it('sends large clear all requests as one repository finding bulk operation', async () => {
+  it('chunks clear all targets at the repository finding bulk limit', async () => {
+    const { chunkRepoFindingDeleteTargets, REPO_FINDING_BULK_DELETE_BATCH_SIZE } = await import('./productShell');
+    const targets = Array.from({ length: REPO_FINDING_BULK_DELETE_BATCH_SIZE + 1 }, (_, index) => ({
+      finding_id: `finding-bulk-limit-${index}`,
+      repo_scan_id: 'repo-scan-bulk-limit'
+    }));
+
+    const batches = chunkRepoFindingDeleteTargets(targets);
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toHaveLength(REPO_FINDING_BULK_DELETE_BATCH_SIZE);
+    expect(batches[1]).toEqual([{ finding_id: 'finding-bulk-limit-5000', repo_scan_id: 'repo-scan-bulk-limit' }]);
+  });
+
+  it('sends large clear all requests below the server limit as one repository finding bulk operation', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-large',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8458,7 +8458,7 @@ describe('ProductFindingsPage states', () => {
       title: 'Source-filtered workflow permission',
       human_summary: 'A workflow grants broad repository permissions.',
       remediation: 'Limit workflow permissions.',
-      source: 'github_code_scanning',
+      adapter_source: 'github_code_scanning',
       created_at: '2026-05-17T11:06:00Z'
     };
 
@@ -8906,6 +8906,25 @@ describe('ProductFindingsPage states', () => {
     expect(batches).toHaveLength(2);
     expect(batches[0]).toHaveLength(REPO_FINDING_BULK_DELETE_BATCH_SIZE);
     expect(batches[1]).toEqual([{ finding_id: 'finding-bulk-limit-5000', repo_scan_id: 'repo-scan-bulk-limit' }]);
+  });
+
+  it('preserves completed clear all batches when a later batch request fails', async () => {
+    const { deleteRepoFindingTargetsInBatches } = await import('./productShell');
+    const targets = Array.from({ length: 3 }, (_, index) => ({
+      finding_id: `finding-bulk-partial-${index}`,
+      repo_scan_id: 'repo-scan-bulk-partial'
+    }));
+    const deleteTargets = vi
+      .fn()
+      .mockResolvedValueOnce({ deleted: targets.slice(0, 2) })
+      .mockRejectedValueOnce(new Error('rate limit exceeded'));
+
+    const result = await deleteRepoFindingTargetsInBatches(targets, deleteTargets, 2);
+
+    expect(deleteTargets).toHaveBeenCalledTimes(2);
+    expect(result.response.deleted).toEqual(targets.slice(0, 2));
+    expect(result.response.failed).toEqual([]);
+    expect(result.errorMessage).toBe('rate limit exceeded');
   });
 
   it('sends large clear all requests below the server limit as one repository finding bulk operation', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1620,55 +1620,6 @@ function repoFindingDeleteTargetKeyFromFinding(finding: ApiFinding): string {
   return repoFindingDeleteTargetKey(repoFindingDeleteTargetFromFinding(finding));
 }
 
-const REPO_FINDING_BULK_DELETE_BATCH_SIZE = 500;
-
-function chunkRepoFindingDeleteTargets(targets: RepoFindingDeleteTarget[]): RepoFindingDeleteTarget[][] {
-  const chunks: RepoFindingDeleteTarget[][] = [];
-  for (let index = 0; index < targets.length; index += REPO_FINDING_BULK_DELETE_BATCH_SIZE) {
-    chunks.push(targets.slice(index, index + REPO_FINDING_BULK_DELETE_BATCH_SIZE));
-  }
-  return chunks;
-}
-
-function mergeRepoFindingsBulkDeleteResponses(
-  responses: RepoFindingsBulkDeleteResponse[]
-): RepoFindingsBulkDeleteResponse {
-  return responses.reduce<RepoFindingsBulkDeleteResponse>(
-    (acc, response) => ({
-      deleted: [...acc.deleted, ...response.deleted],
-      failed: [...(acc.failed ?? []), ...(response.failed ?? [])]
-    }),
-    { deleted: [], failed: [] }
-  );
-}
-
-async function deleteRepoFindingsBatchWithFallback(
-  targets: RepoFindingDeleteTarget[],
-  auth: RequestAuthContext
-): Promise<RepoFindingsBulkDeleteResponse> {
-  try {
-    return await apiClient.deleteRepoFindings(targets, auth);
-  } catch (error) {
-    if (!(error instanceof ApiError) || error.status !== 404) {
-      throw error;
-    }
-  }
-
-  const response: RepoFindingsBulkDeleteResponse = { deleted: [], failed: [] };
-  for (const target of targets) {
-    try {
-      await apiClient.deleteRepoFinding(target.finding_id, target.repo_scan_id, auth);
-      response.deleted.push(target);
-    } catch (deleteError) {
-      response.failed?.push({
-        ...target,
-        error: deleteError instanceof Error ? deleteError.message : 'Failed to delete finding.'
-      });
-    }
-  }
-  return response;
-}
-
 const DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY = 'idt:repo-failed-scan-dismissals:v1';
 
 function failedRepoScanDismissalKey(scope: ProductSession, scanID: string): string {
@@ -28077,12 +28028,15 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       const severity = severityFilter !== 'all' ? severityFilter : undefined;
       const type = typeFilter !== 'all' ? typeFilter : undefined;
       const repoScanID = normalizeValue(repoScanFilter) || undefined;
+      const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
+      const minConfidence = Number.isFinite(normalizedMinConfidence) ? normalizedMinConfidence : undefined;
       const [trendResult, riskGraphResult] = await Promise.allSettled([
         apiClient.getRepoFindingsTrends(
           {
             points: TREND_POINTS,
             severity,
-            type
+            type,
+            min_confidence: minConfidence
           },
           auth
         ),
@@ -28090,7 +28044,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           {
             repo_scan_id: repoScanID,
             severity,
-            type
+            type,
+            min_confidence: minConfidence
           },
           auth
         )
@@ -28220,17 +28175,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const responses: RepoFindingsBulkDeleteResponse[] = [];
-        let batchError: unknown = null;
-        for (const batch of chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding))) {
-          try {
-            responses.push(await deleteRepoFindingsBatchWithFallback(batch, auth));
-          } catch (requestError) {
-            batchError = requestError;
-            break;
-          }
-        }
-        const response = mergeRepoFindingsBulkDeleteResponses(responses);
+        const response = await apiClient.deleteRepoFindings(candidates.map(repoFindingDeleteTargetFromFinding), auth);
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
         const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
         deletedFindings = candidates.filter((candidate) =>
@@ -28240,10 +28185,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           const key = repoFindingDeleteTargetKeyFromFinding(candidate);
           return failedKeys.has(key) || !deletedKeys.has(key);
         });
-        failureMessage =
-          batchError instanceof Error
-            ? batchError.message
-            : response.failed?.[0]?.error || failureMessage;
+        failureMessage = response.failed?.[0]?.error || failureMessage;
       } else {
         const candidate = candidates[0];
         if (candidate) {
@@ -28261,19 +28203,12 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       if (failedCandidates.length > 0) {
         applyFailedRepoFindingDeletes(failedCandidates, deletedFindings.length, failureMessage, bulkDeleteActive);
         if (deletedFindings.length > 0) {
+          await loadRepoFindings(scope, 'refresh');
           await loadTrendSignals(scope, 'refresh');
         }
         return;
       }
-      const repoScanFilterSelected = normalizeValue(repoScanFilter);
-      const shouldReloadFindings =
-        bulkDeleteActive
-          ? !agenticOnly
-          : deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
-            repoScanFilterSelected === '';
-      if (shouldReloadFindings) {
-        await loadRepoFindings(scope, 'refresh');
-      }
+      await loadRepoFindings(scope, 'refresh');
       await loadTrendSignals(scope, 'refresh');
       closeFindingDeleteDialog({ allowDuringLoading: true });
     } catch (requestError) {
@@ -28751,7 +28686,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   });
 
   const trendDisplayLoading = signalsLoading;
-  const riskGraphSummary = repoRiskGraph?.summary;
+  const visibleRepoRiskGraph = filteredFindings.length > 0 ? repoRiskGraph : null;
+  const riskGraphSummary = visibleRepoRiskGraph?.summary;
   const riskGraphUnknownEvidenceCount =
     (riskGraphSummary?.unknown_node_count ?? 0) + (riskGraphSummary?.unknown_edge_count ?? 0);
   const selectedFindingPreviewKey = selectedFinding ? buildRepoFindingSelectionKey(selectedFinding) : '';
@@ -29489,8 +29425,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           <h3>Risk graph</h3>
           {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading graph</span> : null}
           <span className="idt-repo-finding-trend-subtitle">
-            {repoRiskGraph
-              ? `${repoRiskGraph.nodes.length} nodes · ${repoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(repoRiskGraph.repository) || repoRiskGraph.repository || 'repository scope'}`
+            {visibleRepoRiskGraph
+              ? `${visibleRepoRiskGraph.nodes.length} nodes · ${visibleRepoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(visibleRepoRiskGraph.repository) || visibleRepoRiskGraph.repository || 'repository scope'}`
               : 'No graph loaded yet'}
           </span>
         </summary>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1612,6 +1612,32 @@ function repoFindingDeleteTargetFromFinding(finding: ApiFinding): RepoFindingDel
   };
 }
 
+export const REPO_FINDING_BULK_DELETE_BATCH_SIZE = 5000;
+
+export function chunkRepoFindingDeleteTargets(
+  targets: RepoFindingDeleteTarget[],
+  batchSize = REPO_FINDING_BULK_DELETE_BATCH_SIZE
+): RepoFindingDeleteTarget[][] {
+  const normalizedBatchSize = Math.max(1, Math.floor(batchSize));
+  const batches: RepoFindingDeleteTarget[][] = [];
+  for (let index = 0; index < targets.length; index += normalizedBatchSize) {
+    batches.push(targets.slice(index, index + normalizedBatchSize));
+  }
+  return batches;
+}
+
+function mergeRepoFindingsBulkDeleteResponses(
+  responses: RepoFindingsBulkDeleteResponse[]
+): RepoFindingsBulkDeleteResponse {
+  return responses.reduce<RepoFindingsBulkDeleteResponse>(
+    (acc, response) => ({
+      deleted: [...acc.deleted, ...response.deleted],
+      failed: [...(acc.failed ?? []), ...(response.failed ?? [])]
+    }),
+    { deleted: [], failed: [] }
+  );
+}
+
 function repoFindingDeleteTargetKey(target: RepoFindingDeleteTarget): string {
   return `${target.repo_scan_id}::${target.finding_id}`;
 }
@@ -27863,6 +27889,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     });
   }, [scopedRepoFindings, statusFilter, assigneeFilter]);
 
+  const riskGraphFiltersUnsupported =
+    statusFilter !== 'all' ||
+    normalizeValue(assigneeFilter) !== '' ||
+    normalizeValue(sourceFilter) !== '';
+
   const findingHierarchy = useMemo(
     () =>
       groupRepoFindingsByRepositoryDateSeverity(filteredFindings, {
@@ -27904,7 +27935,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
 
   const topRiskGraphScores = useMemo(
     () => {
-      if (filteredFindings.length === 0) {
+      if (filteredFindings.length === 0 || riskGraphFiltersUnsupported) {
         return [];
       }
       const visibleFindingIDs = new Set(filteredFindings.map((finding) => finding.id));
@@ -27912,7 +27943,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         .filter((score) => visibleFindingIDs.has(score.finding_id))
         .slice(0, 3);
     },
-    [filteredFindings, repoRiskGraph]
+    [filteredFindings, repoRiskGraph, riskGraphFiltersUnsupported]
   );
 
   const criticalFindingCount = useMemo(
@@ -28175,7 +28206,12 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const response = await apiClient.deleteRepoFindings(candidates.map(repoFindingDeleteTargetFromFinding), auth);
+        const batches = chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding));
+        const responses: RepoFindingsBulkDeleteResponse[] = [];
+        for (const batch of batches) {
+          responses.push(await apiClient.deleteRepoFindings(batch, auth));
+        }
+        const response = mergeRepoFindingsBulkDeleteResponses(responses);
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
         const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
         deletedFindings = candidates.filter((candidate) =>
@@ -28686,8 +28722,12 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   });
 
   const trendDisplayLoading = signalsLoading;
-  const visibleRepoRiskGraph = filteredFindings.length > 0 ? repoRiskGraph : null;
+  const visibleRepoRiskGraph = filteredFindings.length > 0 && !riskGraphFiltersUnsupported ? repoRiskGraph : null;
   const riskGraphSummary = visibleRepoRiskGraph?.summary;
+  const riskGraphHiddenByFilters = filteredFindings.length > 0 && riskGraphFiltersUnsupported;
+  const riskGraphUnavailableBody = riskGraphHiddenByFilters
+    ? 'Clear source, assignee, or lifecycle filters to view the graph.'
+    : 'Run a repository exposure scan so machine-identity paths and finding risk scores can appear here.';
   const riskGraphUnknownEvidenceCount =
     (riskGraphSummary?.unknown_node_count ?? 0) + (riskGraphSummary?.unknown_edge_count ?? 0);
   const selectedFindingPreviewKey = selectedFinding ? buildRepoFindingSelectionKey(selectedFinding) : '';
@@ -29427,6 +29467,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           <span className="idt-repo-finding-trend-subtitle">
             {visibleRepoRiskGraph
               ? `${visibleRepoRiskGraph.nodes.length} nodes · ${visibleRepoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(visibleRepoRiskGraph.repository) || visibleRepoRiskGraph.repository || 'repository scope'}`
+              : riskGraphHiddenByFilters
+                ? 'Hidden for current filters'
               : 'No graph loaded yet'}
           </span>
         </summary>
@@ -29469,7 +29511,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         ) : (
           <AppShellEmptyState
             title="Risk graph unavailable"
-            body="Run a repository exposure scan so machine-identity paths and finding risk scores can appear here."
+            body={riskGraphUnavailableBody}
           />
         )}
       </details>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1638,6 +1638,35 @@ function mergeRepoFindingsBulkDeleteResponses(
   );
 }
 
+type RepoFindingBulkDeleteBatchResult = {
+  response: RepoFindingsBulkDeleteResponse;
+  errorMessage?: string;
+};
+
+function repoFindingDeleteBatchErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Failed to delete finding.';
+}
+
+export async function deleteRepoFindingTargetsInBatches(
+  targets: RepoFindingDeleteTarget[],
+  deleteTargets: (batch: RepoFindingDeleteTarget[]) => Promise<RepoFindingsBulkDeleteResponse>,
+  batchSize = REPO_FINDING_BULK_DELETE_BATCH_SIZE
+): Promise<RepoFindingBulkDeleteBatchResult> {
+  const responses: RepoFindingsBulkDeleteResponse[] = [];
+  for (const batch of chunkRepoFindingDeleteTargets(targets, batchSize)) {
+    try {
+      responses.push(await deleteTargets(batch));
+    } catch (requestError) {
+      const response = mergeRepoFindingsBulkDeleteResponses(responses);
+      if (response.deleted.length === 0 && (response.failed ?? []).length === 0) {
+        throw requestError;
+      }
+      return { response, errorMessage: repoFindingDeleteBatchErrorMessage(requestError) };
+    }
+  }
+  return { response: mergeRepoFindingsBulkDeleteResponses(responses) };
+}
+
 function repoFindingDeleteTargetKey(target: RepoFindingDeleteTarget): string {
   return `${target.repo_scan_id}::${target.finding_id}`;
 }
@@ -28206,12 +28235,10 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const batches = chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding));
-        const responses: RepoFindingsBulkDeleteResponse[] = [];
-        for (const batch of batches) {
-          responses.push(await apiClient.deleteRepoFindings(batch, auth));
-        }
-        const response = mergeRepoFindingsBulkDeleteResponses(responses);
+        const { response, errorMessage } = await deleteRepoFindingTargetsInBatches(
+          candidates.map(repoFindingDeleteTargetFromFinding),
+          (batch) => apiClient.deleteRepoFindings(batch, auth)
+        );
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
         const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
         deletedFindings = candidates.filter((candidate) =>
@@ -28221,7 +28248,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           const key = repoFindingDeleteTargetKeyFromFinding(candidate);
           return failedKeys.has(key) || !deletedKeys.has(key);
         });
-        failureMessage = response.failed?.[0]?.error || failureMessage;
+        failureMessage = response.failed?.[0]?.error || errorMessage || failureMessage;
       } else {
         const candidate = candidates[0];
         if (candidate) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27906,7 +27906,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   height: 1rem;
   min-width: 1rem;
   display: block;
-  color: #9da7b2;
 }
 
 .idt-domain-flyout-link-copy span,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27853,8 +27853,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1.1rem;
-  gap: 0.7rem;
+  grid-template-columns: minmax(0, 1fr) 1.25rem;
+  gap: 0.55rem;
   align-items: center;
   min-height: 3rem;
   border: 1px solid transparent;
@@ -27882,15 +27882,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-link-copy {
-  display: flex;
-  min-height: 100%;
+  display: grid;
   min-width: 0;
-  align-self: center;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+  align-self: stretch;
+  align-content: center;
+  justify-items: center;
   gap: 0.08rem;
-  text-align: left;
+  text-align: center;
 }
 
 .idt-domain-flyout-link-copy strong {
@@ -27908,6 +27906,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   height: 1rem;
   min-width: 1rem;
   display: block;
+  color: #9da7b2;
 }
 
 .idt-domain-flyout-link-copy span,
@@ -27927,9 +27926,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1.1rem;
+  grid-template-columns: minmax(0, 1fr) 1.25rem;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.55rem;
   min-height: 3rem;
   border-radius: 7px;
   padding: 0.5rem 0.6rem;
@@ -27944,14 +27943,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary > span {
-  display: flex;
+  display: grid;
   min-width: 0;
-  min-height: 100%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+  align-self: stretch;
+  align-content: center;
+  justify-items: center;
   gap: 0.1rem;
-  text-align: left;
+  text-align: center;
 }
 
 .idt-domain-flyout-nested summary strong {
@@ -27961,7 +27959,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary svg {
   justify-self: end;
-  align-self: center;
+  align-self: start;
   display: block;
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
## Summary
- replace per-finding clear-all loops with one scoped bulk repository-finding delete in the store
- keep finding totals, trend filters, and risk graph data aligned after deletes
- tune GitHub repository scan output to high-confidence, high-impact findings only
- polish domain flyout chevron alignment across AWS, GitHub, and Kubernetes panels

## Root Cause
Clear-all was issuing many frontend-driven delete calls and falling back to individual deletes, which made the operation slow, rate-limit prone, and inconsistent when stale targets were present. The UI also reused stale graph/count data after delete refreshes, and nested flyout chevrons were centering against two-line content instead of the subsection title.

## Validation
- go test ./...
- npm --prefix web test -- productShell --run
- npm --prefix web run build
- local browser visual measurement for flyout rows: max title/chevron delta 0.3px

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “Clear all” for GitHub repository findings reliable by using a single store‑level bulk delete (up to 5000), preserving partial progress on failures, and keeping counts, trends, and the risk graph in sync. Also report only high‑signal GitHub findings and refine flyout chevron alignment; the risk graph now hides when unsupported filters are active.

- **Bug Fixes**
  - Replace per-item deletes with one store bulk delete (limit 5000); no per-item fallback; preserve partial progress and surface errors when bulk responses are partial or a batch fails.
  - Refresh findings, trends, and risk graph after deletes; hide the risk graph when no findings are visible or when source, assignee, or lifecycle filters are set.
  - Implement bulk target deletes in `memory` and `postgres` stores and keep scan finding counts accurate.

- **New Features**
  - Report only high-confidence (>=0.90) and High/Critical GitHub findings for GitHub App scans; raise “insecure” posture confidence to 0.92; confidence scoring honors explicit adapter scores first.
  - Add `min_confidence` (alias `confidence`) to `/v1/repo-findings/trends` and `/v1/repo-risk-graph` and wire through the `web` client.
  - Align domain flyout chevrons across AWS, GitHub, and Kubernetes panels.

<sup>Written for commit f840adf8da2fb421a571c907e06ee98d2ddd0d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

No issue: follow-up polish for PR review and CI remediation.