### PR TITLE
Add AWS coverage dashboard

### DIFF
--- a/docs/aws-account-region-coverage-planner.md
+++ b/docs/aws-account-region-coverage-planner.md
@@ -111,6 +111,34 @@ Use the planner endpoint when you need target expansion and prerequisites. Use
 the public coverage API when an operator or dashboard needs filterable coverage
 state without reading logs or internal tables.
 
+## App Coverage Dashboard
+
+The app exposes the operator dashboard at:
+
+```text
+/app/{tenant_id}/{workspace_id}/aws/coverage?environment={project_id}
+```
+
+The page is read-only and composes the existing scoped coverage contracts:
+
+- coverage-plan targets for account, region, service, collector, cursor, and
+  next-action state
+- public account/region coverage records for filterable dashboard rows
+- fan-out execution summary for queued, retryable, denied, partial, and
+  throttled targets
+- AWS Organizations topology for account eligibility and OU context
+- StackSet onboarding status for missing read-only role rollout
+
+The dashboard preserves the tenant, workspace, project, connector, account, and
+region boundaries already enforced by the APIs. It shows loading, empty, error,
+degraded, and permission-denied states from the API payloads instead of
+inferring success from a partial response.
+
+Filters are local to the page and support account, region, coverage state, and
+search. Use the page when an operator needs to answer which account or region is
+covered, which service or collector is blocked, what cursor can be resumed, and
+which onboarding action closes the gap.
+
 ## Partial Failure Reports
 
 `partial_failure_reports` is a normalized dashboard and rerun contract. Each

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import {
   ProductAuthCallbackRedirectPage,
   ProductAIRisksPage,
   ProductAWSAccountsPage,
+  ProductAWSCoveragePage,
   ProductAWSAgentsPage,
   ProductAWSControlCenterPage,
   ProductAWSFindingsPage,
@@ -4827,6 +4828,7 @@ export function RoutedSite() {
             <Route path="aws" element={<ProductAWSControlCenterPage />} />
             <Route path="aws/connect" element={<ProductAWSConnectPage />} />
             <Route path="aws/accounts" element={<ProductAWSAccountsPage />} />
+            <Route path="aws/coverage" element={<ProductAWSCoveragePage />} />
             <Route path="aws/identities" element={<ProductAWSIdentitiesPage />} />
             <Route path="aws/identities/detail" element={<ProductAWSMachineIdentityDetailPage />} />
             <Route path="aws/agents" element={<ProductAWSAgentsPage />} />

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -3,6 +3,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws',
   '/app/:tenantID/:workspaceID/aws/connect',
   '/app/:tenantID/:workspaceID/aws/accounts',
+  '/app/:tenantID/:workspaceID/aws/coverage',
   '/app/:tenantID/:workspaceID/aws/identities',
   '/app/:tenantID/:workspaceID/aws/identities/detail',
   '/app/:tenantID/:workspaceID/aws/agents',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2769,6 +2769,42 @@ describe('ProductShellLayout', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /GitHub findings content/i })).toBeInTheDocument();
   });
 
+  it('preserves the selected environment when routing to AWS coverage from workspace finder', async () => {
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const { ProductShellLayout } = await import('./productShell');
+
+    function LocationHeading() {
+      const location = useLocation();
+      return <h2>{`${location.pathname}${location.search}`}</h2>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/identities?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route path="aws/identities" element={<h2>AWS identities content</h2>} />
+            <Route path="aws/coverage" element={<LocationHeading />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS identities content' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: '/' });
+    const finder = screen.getByRole('dialog', { name: /Workspace finder/i });
+    fireEvent.change(within(finder).getByLabelText(/Search workspace commands/i), { target: { value: 'aws coverage' } });
+    fireEvent.keyDown(within(finder).getByLabelText(/Search workspace commands/i), { key: 'Enter' });
+
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: '/app/tenant-a/workspace-a/aws/coverage?environment=production'
+      })
+    ).toBeInTheDocument();
+  });
+
   it('uses Windows shortcut labels when rendering the app shell outside macOS', async () => {
     vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
     mockConnectorFeatureFlags({ github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3,24 +3,29 @@ import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-rou
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   AuthConfigResponse,
+  AWSAccountRegionCoverageResult,
   AWSConnectorStartResponse,
   AWSCodeBuildServiceRoleInventoryResult,
   AWSConnectionStatus,
   AWSAIAgentIdentityInventoryResult,
   AWSBedrockAgentsInventoryResult,
+  AWSCoveragePlanResult,
   AWSEC2InstanceProfileInventoryResult,
   AWSEKSWorkloadIdentityInventoryResult,
   AWSECSTaskRoleInventoryResult,
+  AWSFanOutExecutionResult,
   AWSLambdaExecutionRoleInventoryResult,
   AWSLeastPrivilegeResult,
   AWSAgentIdentityDetailResult,
   AWSMachineIdentityDetailResult,
+  AWSOrganizationsTopologyResult,
   AWSPlatformBaselineResult,
   AWSPlatformDependencyIndexResult,
   AWSPlatformValidationHarnessResult,
   AWSRemediationCenterResult,
   AWSRuntimeEventResult,
   AWSServiceCollectorContractResult,
+  AWSStackSetOnboardingResult,
   AWSUnusedDormantAccessResult,
   CurrentUserContext,
   Finding,
@@ -164,6 +169,463 @@ const connectedAWS: AWSConnectionStatus = {
   updated_at: '2026-05-17T10:00:00Z',
   last_validated_at: '2026-05-17T10:00:00Z'
 };
+
+const readyAWSCoveragePlan: AWSCoveragePlanResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1503,
+  parent_issue_ref: '#1503',
+  current_issue_number: 1553,
+  current_issue_ref: '#1553',
+  version: 'aws-coverage-plan-v1',
+  status: 'degraded',
+  fixture_state: 'partial_failure',
+  confidence: 0.96,
+  filtered_targets: 2,
+  summary: {
+    total_targets: 2,
+    enabled_targets: 2,
+    disabled_targets: 0,
+    account_count: 1,
+    region_count: 2,
+    service_count: 2,
+    outstanding_targets: 1,
+    covered_targets: 1,
+    blocked_targets: 0,
+    failed_targets: 1,
+    permission_denied_targets: 0,
+    resumable_targets: 1,
+    coverage_percent: 50,
+    state_counts: { covered: 1, partial: 1 },
+    priority_counts: { critical: 1, high: 1 },
+    prerequisites: []
+  },
+  targets: [
+    {
+      key: '123456789012/us-east-1/iam',
+      account_id: '123456789012',
+      account_name: 'Production',
+      region: 'us-east-1',
+      region_name: 'US East (N. Virginia)',
+      service: 'iam',
+      service_name: 'IAM',
+      collector: 'iam_roles',
+      global: true,
+      enabled: true,
+      priority: 'critical',
+      priority_rank: 1,
+      reason: 'Global IAM anchor',
+      prerequisites: [],
+      state: 'covered',
+      resumable: false,
+      next_action: 'No action required.',
+      evidence_ref: 'aws-coverage-plan:iam',
+      observed_at: '2026-06-12T12:00:00Z'
+    },
+    {
+      key: '123456789012/us-west-2/lambda',
+      account_id: '123456789012',
+      account_name: 'Production',
+      region: 'us-west-2',
+      region_name: 'US West (Oregon)',
+      service: 'lambda',
+      service_name: 'Lambda',
+      collector: 'lambda_execution_roles',
+      global: false,
+      enabled: true,
+      priority: 'high',
+      priority_rank: 2,
+      reason: 'Regional execution-role collector',
+      prerequisites: ['Deploy the read-only StackSet instance to us-west-2.'],
+      state: 'partial',
+      cursor: 'lambda-page-2',
+      failure_reason: 'Lambda collector stopped at page 2.',
+      attempts: 2,
+      resumable: true,
+      next_action: 'Resume Lambda collector from saved cursor.',
+      evidence_ref: 'aws-coverage-plan:lambda',
+      observed_at: '2026-06-12T12:05:00Z'
+    }
+  ],
+  failure_reasons: ['Lambda collector stopped at page 2.'],
+  remediation_hints: ['Resume Lambda collector from saved cursor.'],
+  evidence_links: ['/docs/aws-account-region-coverage-planner'],
+  partial_failure_reports: [
+    {
+      key: '123456789012/us-west-2/lambda',
+      account_id: '123456789012',
+      region: 'us-west-2',
+      service: 'lambda',
+      collector: 'lambda_execution_roles',
+      state: 'partial',
+      worker_state: 'failed',
+      reason_code: 'collector_partial_failure',
+      failure_reason: 'Lambda collector stopped at page 2.',
+      retryable: true,
+      attempts: 2,
+      cursor: 'lambda-page-2',
+      evidence_ref: 'aws-coverage-partial:lambda',
+      next_action: 'Resume Lambda collector from saved cursor.',
+      observed_at: '2026-06-12T12:05:00Z'
+    }
+  ],
+  coverage_gaps: [
+    {
+      capability: 'regional_lambda',
+      status: 'partial',
+      reason: 'US West 2 Lambda coverage is partial.',
+      remediation: 'Resume Lambda collector from the stored checkpoint.'
+    }
+  ],
+  diagnostics: [
+    {
+      source: 'coverage_planner',
+      scope: '123456789012/us-west-2/lambda',
+      code: 'collector_partial_failure',
+      message: 'Lambda coverage is partial.',
+      remediation: 'Resume Lambda collector from checkpoint.',
+      retryable: true
+    }
+  ],
+  generated_at: '2026-06-12T12:10:00Z',
+  updated_at: '2026-06-12T12:10:00Z'
+};
+
+const readyAWSAccountRegionCoverage: AWSAccountRegionCoverageResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1503,
+  parent_issue_ref: '#1503',
+  current_issue_number: 1553,
+  current_issue_ref: '#1553',
+  version: 'aws-account-region-coverage-v1',
+  status: 'degraded',
+  fixture_state: 'partial_failure',
+  confidence: 0.96,
+  summary: {
+    total_records: 2,
+    filtered_records: 2,
+    account_count: 1,
+    region_count: 2,
+    service_count: 2,
+    covered_records: 1,
+    missing_records: 0,
+    degraded_records: 1,
+    unreachable_records: 0,
+    suspended_records: 0,
+    disabled_records: 0,
+    stale_records: 0,
+    permission_denied_records: 0,
+    retryable_records: 1,
+    status_counts: { covered: 1, degraded: 1 },
+    state_counts: { covered: 1, partial: 1 },
+    collector_counts: { iam_roles: 1, lambda_execution_roles: 1 }
+  },
+  records: [
+    {
+      key: '123456789012/us-east-1/iam',
+      account_id: '123456789012',
+      account_name: 'Production',
+      region: 'us-east-1',
+      region_name: 'US East (N. Virginia)',
+      service: 'iam',
+      service_name: 'IAM',
+      collector: 'iam_roles',
+      global: true,
+      enabled: true,
+      state: 'covered',
+      coverage_status: 'covered',
+      retryable: false,
+      stale: false,
+      evidence_ref: 'aws-account-region-coverage:iam',
+      next_action: 'No action required.',
+      observed_at: '2026-06-12T12:00:00Z',
+      updated_at: '2026-06-12T12:00:00Z'
+    },
+    {
+      key: '123456789012/us-west-2/lambda',
+      account_id: '123456789012',
+      account_name: 'Production',
+      region: 'us-west-2',
+      region_name: 'US West (Oregon)',
+      service: 'lambda',
+      service_name: 'Lambda',
+      collector: 'lambda_execution_roles',
+      global: false,
+      enabled: true,
+      state: 'partial',
+      coverage_status: 'degraded',
+      cursor: 'lambda-page-2',
+      checkpoint: 'lambda-page-2',
+      attempts: 2,
+      failure_reason: 'Lambda collector stopped at page 2.',
+      retryable: true,
+      stale: false,
+      evidence_ref: 'aws-account-region-coverage:lambda',
+      next_action: 'Resume Lambda collector from saved cursor.',
+      observed_at: '2026-06-12T12:05:00Z',
+      updated_at: '2026-06-12T12:05:00Z'
+    }
+  ],
+  failure_reasons: ['Lambda collector stopped at page 2.'],
+  remediation_hints: ['Resume Lambda collector from saved cursor.'],
+  evidence_links: ['/docs/aws-account-region-coverage-planner'],
+  coverage_gaps: readyAWSCoveragePlan.coverage_gaps,
+  diagnostics: readyAWSCoveragePlan.diagnostics,
+  generated_at: '2026-06-12T12:10:00Z',
+  updated_at: '2026-06-12T12:10:00Z'
+};
+
+const readyAWSFanOutExecution: AWSFanOutExecutionResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1503,
+  parent_issue_ref: '#1503',
+  current_issue_number: 1553,
+  current_issue_ref: '#1553',
+  version: 'aws-fanout-execution-v1',
+  status: 'degraded',
+  fixture_state: 'partial_failure',
+  confidence: 0.94,
+  filtered_targets: 2,
+  summary: {
+    total_targets: 2,
+    executable_targets: 2,
+    skipped_targets: 0,
+    queued_targets: 1,
+    in_progress_targets: 1,
+    covered_targets: 1,
+    partial_targets: 1,
+    failed_targets: 0,
+    permission_denied_targets: 0,
+    throttled_targets: 0,
+    retryable_targets: 1,
+    concurrency_limit: 4,
+    max_attempts: 3
+  },
+  targets: [],
+  failure_reasons: ['Lambda collector stopped at page 2.'],
+  remediation_hints: ['Queue or resume retryable targets from their checkpoints.'],
+  evidence_links: ['/docs/aws-account-region-coverage-planner'],
+  partial_failure_reports: readyAWSCoveragePlan.partial_failure_reports,
+  coverage_gaps: readyAWSCoveragePlan.coverage_gaps,
+  diagnostics: [],
+  generated_at: '2026-06-12T12:10:00Z',
+  updated_at: '2026-06-12T12:10:00Z'
+};
+
+const readyAWSOrganizationsTopology: AWSOrganizationsTopologyResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  parent_issue_number: 1503,
+  parent_issue_ref: '#1503',
+  current_issue_number: 1553,
+  current_issue_ref: '#1553',
+  organization_id: 'o-identrail',
+  management_account_id: '123456789012',
+  partition: 'aws',
+  version: 'aws-organizations-topology-v1',
+  status: 'ready',
+  fixture_state: 'success',
+  confidence: 0.95,
+  filtered_accounts: 1,
+  summary: {
+    account_count: 1,
+    organizational_unit_count: 1,
+    management_account_count: 1,
+    delegated_admin_account_count: 0,
+    suspended_account_count: 0,
+    connector_scoped_accounts: 1,
+    scan_eligible_accounts: 1,
+    blocked_accounts: 0,
+    permission_denied_accounts: 0,
+    failed_accounts: 0,
+    resumable_accounts: 0,
+    state_counts: { covered: 1 },
+    status_counts: { active: 1 }
+  },
+  organizational_units: [{ id: 'r-identrail', name: 'Root', path: '/', enabled: true }],
+  accounts: [
+    {
+      account_id: '123456789012',
+      account_name: 'Production',
+      status: 'active',
+      parent_id: 'r-identrail',
+      ou_path: '/',
+      partition: 'aws',
+      management: true,
+      delegated_admin_services: [],
+      connector_scoped: true,
+      scan_eligible: true,
+      state: 'covered',
+      resumable: false,
+      next_action: 'Use this account for downstream coverage.',
+      evidence_ref: 'aws-organizations:aws-connector-1:123456789012'
+    }
+  ],
+  relationships: [
+    {
+      parent_id: 'r-identrail',
+      child_id: '123456789012',
+      child_type: 'account',
+      relationship: 'contains'
+    }
+  ],
+  failure_reasons: [],
+  remediation_hints: [],
+  evidence_links: ['/docs/aws-account-region-coverage-planner'],
+  coverage_gaps: [],
+  diagnostics: [],
+  generated_at: '2026-06-12T12:10:00Z',
+  updated_at: '2026-06-12T12:10:00Z'
+};
+
+const readyAWSStackSetOnboarding: AWSStackSetOnboardingResult = {
+  tenant_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'production',
+  connector_id: 'aws-connector-1',
+  account_id: '123456789012',
+  region: 'us-east-1',
+  organization_id: 'o-identrail',
+  management_account_id: '123456789012',
+  stack_set_name: 'IdentrailReadOnlyCoverage',
+  deployment_mode: 'service_managed',
+  partition: 'aws',
+  parent_issue_number: 1503,
+  parent_issue_ref: '#1503',
+  current_issue_number: 1553,
+  current_issue_ref: '#1553',
+  version: 'aws-stackset-onboarding-v1',
+  status: 'degraded',
+  fixture_state: 'partial_failure',
+  confidence: 0.92,
+  validation: {
+    status: 'degraded',
+    confidence: 0.92,
+    blocking_count: 0,
+    advisory_count: 1,
+    prerequisites: [
+      {
+        id: 'us-west-2-instance',
+        title: 'Deploy us-west-2 read-only role',
+        severity: 'advisory',
+        satisfied: false,
+        reason: 'The regional StackSet instance has not reported active yet.',
+        remediation: 'Deploy the read-only StackSet instance to us-west-2.'
+      }
+    ],
+    failure_reasons: ['The regional StackSet instance has not reported active yet.'],
+    remediation_hints: ['Deploy the read-only StackSet instance to us-west-2.']
+  },
+  permission_preview: [],
+  targets: {
+    organization_id: 'o-identrail',
+    organizational_units: [{ id: 'r-identrail', name: 'Root', path: '/', enabled: true }],
+    accounts: [{ account_id: '123456789012', name: 'Production', ou_path: '/', management: true }],
+    regions: [
+      { region: 'us-east-1', name: 'US East (N. Virginia)' },
+      { region: 'us-west-2', name: 'US West (Oregon)', opt_in: false }
+    ]
+  },
+  instances: [
+    {
+      key: '123456789012/us-west-2',
+      account_id: '123456789012',
+      account_name: 'Production',
+      ou_path: '/',
+      region: 'us-west-2',
+      region_name: 'US West (Oregon)',
+      state: 'degraded',
+      failure_reason: 'The regional StackSet instance has not reported active yet.',
+      attempts: 1,
+      resumable: true,
+      next_action: 'Redeploy or refresh the StackSet instance.',
+      coverage_targets: 1,
+      evidence_ref: 'aws-stackset-onboarding:us-west-2',
+      observed_at: '2026-06-12T12:05:00Z'
+    }
+  ],
+  coverage_expectation: {
+    expected_accounts: 1,
+    expected_regions: 2,
+    expected_instances: 2,
+    expected_coverage_targets: 2,
+    coverage_percent: 50,
+    global_service_notes: 'IAM remains anchored in the home region.'
+  },
+  recovery_actions: [
+    {
+      id: 'redeploy-us-west-2',
+      title: 'Redeploy regional StackSet instance',
+      description: 'Refresh the us-west-2 read-only role so collectors can continue.',
+      targets: ['123456789012/us-west-2']
+    }
+  ],
+  summary: {
+    target_accounts: 1,
+    target_regions: 2,
+    total_instances: 2,
+    pending_instances: 0,
+    active_instances: 1,
+    blocked_instances: 0,
+    failed_instances: 0,
+    degraded_instances: 1,
+    suspended_instances: 0,
+    permission_denied_instances: 0,
+    unsupported_instances: 0,
+    resumable_instances: 1,
+    deployed_percent: 50,
+    state_counts: { active: 1, degraded: 1 }
+  },
+  failure_reasons: ['The regional StackSet instance has not reported active yet.'],
+  remediation_hints: ['Deploy the read-only StackSet instance to us-west-2.'],
+  evidence_links: ['/docs/aws-account-region-coverage-planner'],
+  coverage_gaps: [{ capability: 'regional_stackset', status: 'degraded', reason: 'us-west-2 needs a read-only role.' }],
+  diagnostics: [],
+  generated_at: '2026-06-12T12:10:00Z',
+  updated_at: '2026-06-12T12:10:00Z'
+};
+
+function mockAWSCoverageDashboardAPIs(api: typeof import('./api/client')) {
+  const getCoveragePlan = vi.spyOn(api.apiClient, 'getAWSProjectCoveragePlan').mockResolvedValue({ plan: readyAWSCoveragePlan });
+  const getAccountRegionCoverage = vi
+    .spyOn(api.apiClient, 'getAWSProjectAccountRegionCoverage')
+    .mockResolvedValue({ coverage: readyAWSAccountRegionCoverage });
+  const getFanOutExecution = vi
+    .spyOn(api.apiClient, 'getAWSProjectFanOutExecution')
+    .mockResolvedValue({ execution: readyAWSFanOutExecution });
+  const getOrganizationsTopology = vi
+    .spyOn(api.apiClient, 'getAWSProjectOrganizationsTopology')
+    .mockResolvedValue({ topology: readyAWSOrganizationsTopology });
+  const getStackSetOnboarding = vi
+    .spyOn(api.apiClient, 'getAWSProjectStackSetOnboarding')
+    .mockResolvedValue({ onboarding: readyAWSStackSetOnboarding });
+
+  return {
+    getCoveragePlan,
+    getAccountRegionCoverage,
+    getFanOutExecution,
+    getOrganizationsTopology,
+    getStackSetOnboarding
+  };
+}
 
 const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
   tenant_id: 'tenant-a',
@@ -2678,6 +3140,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws',
       '/app/:tenantID/:workspaceID/aws/connect',
       '/app/:tenantID/:workspaceID/aws/accounts',
+      '/app/:tenantID/:workspaceID/aws/coverage',
       '/app/:tenantID/:workspaceID/aws/identities',
       '/app/:tenantID/:workspaceID/aws/identities/detail',
       '/app/:tenantID/:workspaceID/aws/agents',
@@ -3051,6 +3514,7 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    mockAWSCoverageDashboardAPIs(api);
 
     const { ProductAWSAccountsPage } = await import('./productShell');
 
@@ -3070,6 +3534,97 @@ describe('Domain-first app routes', () => {
     expect(screen.getByRole('link', { name: /Open Connect AWS/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/connect?environment=production'
+    );
+  });
+
+  it('renders AWS coverage dashboard with scoped coverage, topology, fan-out, and onboarding data', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const {
+      getCoveragePlan,
+      getAccountRegionCoverage,
+      getFanOutExecution,
+      getOrganizationsTopology,
+      getStackSetOnboarding
+    } = mockAWSCoverageDashboardAPIs(api);
+
+    const { ProductAWSCoveragePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/coverage?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/coverage" element={<ProductAWSCoveragePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Coverage' })).toBeInTheDocument();
+    expect(await screen.findByText('Public account and region coverage records')).toBeInTheDocument();
+    expect(screen.getByRole('search', { name: /Coverage filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS account-region coverage API records' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS account and region coverage' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS Organizations topology' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'StackSet onboarding instances' })).toBeInTheDocument();
+    expect(screen.getByText('Partial failure reporting')).toBeInTheDocument();
+    expect(screen.getByText('Queue or resume retryable targets from their checkpoints.')).toBeInTheDocument();
+    expect(screen.getAllByText(/Lambda collector stopped at page 2/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Open Connect AWS/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/connect?environment=production'
+    );
+    expect(getCoveragePlan).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getAccountRegionCoverage).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getFanOutExecution).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      { maxConcurrency: 4 },
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getOrganizationsTopology).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(getStackSetOnboarding).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      'aws-connector-1',
+      undefined,
+      undefined,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
   });
 
@@ -12559,9 +13114,9 @@ describe('AWS copy redundancy guard (#1582)', () => {
   );
 
   it('AWS inventory copy entries keep the legacy roadmap-in-UI fields blank', () => {
-    // The four AWSInventoryPageCopy entries were the source of every
+    // The AWSInventoryPageCopy entries were the source of every
     // `Wired now / Planned coverage / Statuslabel` repeat across the
-    // Accounts / Identities / Agents / Resources sub-pages. The fields
+    // AWS inventory sub-pages. The fields
     // still exist on the type so the surrounding shell continues to
     // compile, but their *values* must stay empty so the deleted panel
     // cannot accidentally reappear if a future PR re-renders them.

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -441,6 +441,7 @@ type ProductDomainRouteID =
   | 'overview'
   | 'connect'
   | 'accounts'
+  | 'coverage'
   | 'identities'
   | 'agents'
   | 'resources'
@@ -538,6 +539,7 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
       productDomainRoute('overview', 'Overview', '', 'AWS', '', 'AWS for this workspace.'),
       productDomainRoute('connect', 'Connect AWS', 'connect', 'Connect AWS', '', 'Connect an AWS account so Identrail can scan it.'),
       productDomainRoute('accounts', 'Accounts', 'accounts', 'Accounts', '', "Which AWS account and region you're connected to."),
+      productDomainRoute('coverage', 'Coverage', 'coverage', 'Coverage', '', 'Account, region, service, and collector coverage states.'),
       productDomainRoute('identities', 'Identities', 'identities', 'Identities', '', 'IAM roles, workload identities, and what they can reach.'),
       productDomainRoute('agents', 'Agents', 'agents', 'Agents', '', 'Bedrock and MCP agents Identrail can see.'),
       productDomainRoute('resources', 'Resources', 'resources', 'Resources', '', 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'),
@@ -3147,6 +3149,14 @@ const AWS_CONTROL_CARDS: AWSControlCard[] = [
     detail: "Which AWS account and region you're connected to."
   },
   {
+    id: 'coverage',
+    label: 'Coverage',
+    routeID: 'coverage',
+    stage: 'wired',
+    metric: '',
+    detail: 'Track account, region, service, and collector coverage states.'
+  },
+  {
     id: 'identities',
     label: 'Identities',
     routeID: 'identities',
@@ -3902,7 +3912,8 @@ function AWSServiceCollectorContractSummary({
   );
 }
 
-type AWSInventoryRouteID = Extract<ProductDomainRouteID, 'accounts' | 'identities' | 'agents' | 'resources'>;
+type AWSInventoryRouteID = Extract<ProductDomainRouteID, 'accounts' | 'coverage' | 'identities' | 'agents' | 'resources'>;
+type AWSCoverageInventoryRouteID = Extract<AWSInventoryRouteID, 'accounts' | 'coverage'>;
 
 type AWSInventoryPageCopy = {
   routeID: AWSInventoryRouteID;
@@ -3923,6 +3934,16 @@ const AWS_INVENTORY_PAGE_COPY: Record<AWSInventoryRouteID, AWSInventoryPageCopy>
     description: "Which AWS account and region you're connected to.",
     statusLabel: '',
     primaryKpi: 'Account scope',
+    currentCapability: '',
+    plannedCapability: ''
+  },
+  coverage: {
+    routeID: 'coverage',
+    title: 'Coverage',
+    eyebrow: '',
+    description: 'Account, region, service, and collector coverage for this AWS environment.',
+    statusLabel: '',
+    primaryKpi: 'Target coverage',
     currentCapability: '',
     plannedCapability: ''
   },
@@ -4166,6 +4187,7 @@ type AWSInventoryCoverageRow = AWSInventoryFilterable & {
 
 const AWS_INVENTORY_FILTER_DEFAULTS: Record<AWSInventoryRouteID, AWSInventoryFilterState> = {
   accounts: { account: 'all', region: 'all', coverage: 'all', search: '' },
+  coverage: { account: 'all', region: 'all', coverage: 'all', search: '' },
   identities: { identityType: 'all', service: 'all', risk: 'all', status: 'all', search: '' },
   agents: { surface: 'all', relationship: 'all', provider: 'all', runtime: 'all', risk: 'all', confidence: 'all', status: 'all', search: '' },
   resources: { category: 'all', sensitivity: 'all', readPosture: 'all', search: '' }
@@ -4173,6 +4195,27 @@ const AWS_INVENTORY_FILTER_DEFAULTS: Record<AWSInventoryRouteID, AWSInventoryFil
 
 const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
   accounts: [
+    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Planned accounts', value: 'planned' }] },
+    { id: 'region', label: 'Region', options: [{ label: 'All regions', value: 'all' }, { label: 'Current region', value: 'current' }, { label: 'Uncovered regions', value: 'uncovered' }] },
+    {
+      id: 'coverage',
+      label: 'Coverage',
+      options: [
+        { label: 'All coverage', value: 'all' },
+        { label: 'Covered', value: 'covered' },
+        { label: 'Planned', value: 'planned' },
+        { label: 'Missing', value: 'missing' },
+        { label: 'Blocked', value: 'blocked' },
+        { label: 'Unsupported', value: 'unsupported' },
+        { label: 'Disabled', value: 'disabled' },
+        { label: 'Degraded', value: 'degraded' },
+        { label: 'Failed', value: 'failed' },
+        { label: 'Permission denied', value: 'permission_denied' },
+        { label: 'Not yet available', value: 'not-yet-available' }
+      ]
+    }
+  ],
+  coverage: [
     { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Planned accounts', value: 'planned' }] },
     { id: 'region', label: 'Region', options: [{ label: 'All regions', value: 'all' }, { label: 'Current region', value: 'current' }, { label: 'Uncovered regions', value: 'uncovered' }] },
     {
@@ -5003,6 +5046,7 @@ function AWSInventoryFilterSet({
 }) {
   const searchPlaceholder: Record<AWSInventoryRouteID, string> = {
     accounts: 'Search account or region',
+    coverage: 'Search coverage scope',
     identities: 'Search identity ARN',
     agents: 'Search agent surface',
     resources: 'Search resource metadata'
@@ -5055,6 +5099,10 @@ function buildAWSInventoryKpis(routeID: AWSInventoryRouteID, connection: AWSConn
       ? connection?.account_id
         ? '1 account'
         : 'Pending'
+      : routeID === 'coverage'
+        ? connection?.connected
+          ? 'Tracking'
+          : 'Pending'
       : routeID === 'identities'
         ? connection?.role_arn
           ? '1 role'
@@ -5164,6 +5212,7 @@ function AWSInventoryPrerequisites({
 }
 
 function AWSAccountsInventoryContent({
+  routeID,
   connection,
   connectPath,
   coveragePlanState,
@@ -5174,6 +5223,7 @@ function AWSAccountsInventoryContent({
   filters,
   onFiltersChange
 }: {
+  routeID: AWSCoverageInventoryRouteID;
   connection: AWSConnectionStatus | null;
   connectPath: string;
   coveragePlanState: AWSInventoryCoveragePlanState;
@@ -5217,7 +5267,7 @@ function AWSAccountsInventoryContent({
 
   return (
     <>
-      <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
+      <AWSInventoryFilterSet routeID={routeID} filters={filters} onChange={onFiltersChange} />
       {coveragePlanState.loading ? <DomainLoadingState label="Loading account and region coverage plan" /> : null}
       {accountRegionCoverageState.loading ? <DomainLoadingState label="Loading account and region coverage API" /> : null}
       {fanOutExecutionState.loading ? <DomainLoadingState label="Loading fan-out execution state" /> : null}
@@ -8709,6 +8759,10 @@ function awsSQSSNSReachabilityRow(record: AWSSQSSNSReachabilityRecord): AWSInven
   };
 }
 
+function isAWSCoverageInventoryRoute(routeID: AWSInventoryRouteID): routeID is AWSCoverageInventoryRouteID {
+  return routeID === 'accounts' || routeID === 'coverage';
+}
+
 function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) {
   const data = useAWSInventoryData();
   const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
@@ -9511,7 +9565,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++coveragePlanRequestRef.current;
     setCoveragePlan(null);
     setCoveragePlanError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setCoveragePlanLoading(false);
       return;
     }
@@ -9563,7 +9617,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++accountRegionCoverageRequestRef.current;
     setAccountRegionCoverage(null);
     setAccountRegionCoverageError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setAccountRegionCoverageLoading(false);
       return;
     }
@@ -9615,7 +9669,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++fanOutExecutionRequestRef.current;
     setFanOutExecution(null);
     setFanOutExecutionError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setFanOutExecutionLoading(false);
       return;
     }
@@ -9667,7 +9721,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++organizationsTopologyRequestRef.current;
     setOrganizationsTopology(null);
     setOrganizationsTopologyError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setOrganizationsTopologyLoading(false);
       return;
     }
@@ -9719,7 +9773,7 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
     const requestID = ++stackSetOnboardingRequestRef.current;
     setStackSetOnboarding(null);
     setStackSetOnboardingError('');
-    if (routeID !== 'accounts' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+    if (!isAWSCoverageInventoryRoute(routeID) || !scope || !selectedEnvironmentID || !connection?.connector_id) {
       setStackSetOnboardingLoading(false);
       return;
     }
@@ -9833,8 +9887,9 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         />
       ) : null}
 
-      {routeID === 'accounts' ? (
+      {isAWSCoverageInventoryRoute(routeID) ? (
         <AWSAccountsInventoryContent
+          routeID={routeID}
           connection={connection}
           connectPath={connectPath}
           coveragePlanState={{
@@ -10004,6 +10059,10 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
 
 export function ProductAWSAccountsPage() {
   return <ProductAWSInventoryPage routeID="accounts" />;
+}
+
+export function ProductAWSCoveragePage() {
+  return <ProductAWSInventoryPage routeID="coverage" />;
 }
 
 export function ProductAWSIdentitiesPage() {
@@ -24083,6 +24142,13 @@ export function ProductShellLayout() {
         description: 'AWS machine identity control center',
         keywords: ['aws', 'cloud', 'iam', 'identity'],
         path: `${basePath}/aws`
+      });
+      items.push({
+        id: 'aws-coverage',
+        label: 'AWS coverage',
+        description: 'Account, region, service, and collector coverage dashboard',
+        keywords: ['aws', 'coverage', 'account', 'region', 'collector'],
+        path: `${basePath}/aws/coverage`
       });
       items.push({
         id: 'aws-findings',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -24125,6 +24125,8 @@ export function ProductShellLayout() {
     if (!scope) {
       return [];
     }
+    const currentEnvironmentID = environmentIDFromSearch(location.search);
+    const domainCommandPath = (path: string) => appendEnvironmentQuery(path, currentEnvironmentID);
     const items: CommandPaletteItem[] = [
       {
         id: 'overview',
@@ -24141,21 +24143,21 @@ export function ProductShellLayout() {
         label: 'AWS',
         description: 'AWS machine identity control center',
         keywords: ['aws', 'cloud', 'iam', 'identity'],
-        path: `${basePath}/aws`
+        path: domainCommandPath(`${basePath}/aws`)
       });
       items.push({
         id: 'aws-coverage',
         label: 'AWS coverage',
         description: 'Account, region, service, and collector coverage dashboard',
         keywords: ['aws', 'coverage', 'account', 'region', 'collector'],
-        path: `${basePath}/aws/coverage`
+        path: domainCommandPath(`${basePath}/aws/coverage`)
       });
       items.push({
         id: 'aws-findings',
         label: 'AWS findings',
         description: 'Domain-scoped AWS risk queue',
         keywords: ['aws', 'findings', 'risk', 'iam'],
-        path: `${basePath}/aws/findings`
+        path: domainCommandPath(`${basePath}/aws/findings`)
       });
       if (sourceAvailability.aws.available) {
         items.push({
@@ -24163,7 +24165,7 @@ export function ProductShellLayout() {
           label: 'Connect AWS',
           description: 'Start AWS account and identity onboarding',
           keywords: ['aws', 'connect', 'account', 'role'],
-          path: `${basePath}/aws/connect`
+          path: domainCommandPath(`${basePath}/aws/connect`)
         });
       }
     }
@@ -24174,21 +24176,21 @@ export function ProductShellLayout() {
         label: 'GitHub',
         description: 'Repositories, Actions/OIDC, and agentic risk',
         keywords: ['github', 'repositories', 'actions', 'oidc'],
-        path: `${basePath}/github`
+        path: domainCommandPath(`${basePath}/github`)
       });
       items.push({
         id: 'github-findings',
         label: 'GitHub findings',
         description: 'Repository risk inside the GitHub section',
         keywords: ['github', 'findings', 'repository', 'triage'],
-        path: `${basePath}/github/findings`
+        path: domainCommandPath(`${basePath}/github/findings`)
       });
       items.push({
         id: 'github-agentic-risk',
         label: 'GitHub AI / Agentic Risk',
         description: 'Agent identities, MCP tools, prompts, secrets, and workflow trust paths',
         keywords: ['github', 'agentic', 'ai', 'mcp', 'tools', 'prompts', 'secrets', 'workflow'],
-        path: `${basePath}/github/agentic-risk`
+        path: domainCommandPath(`${basePath}/github/agentic-risk`)
       });
       if (sourceAvailability.github.available) {
         items.push({
@@ -24196,7 +24198,7 @@ export function ProductShellLayout() {
           label: 'Connect GitHub',
           description: 'Start GitHub App onboarding',
           keywords: ['github', 'connect', 'app', 'install'],
-          path: `${basePath}/github/connect`
+          path: domainCommandPath(`${basePath}/github/connect`)
         });
       }
     }
@@ -24207,14 +24209,14 @@ export function ProductShellLayout() {
         label: 'Kubernetes',
         description: 'Clusters, workloads, service accounts, and RBAC',
         keywords: ['kubernetes', 'k8s', 'clusters', 'rbac'],
-        path: `${basePath}/kubernetes`
+        path: domainCommandPath(`${basePath}/kubernetes`)
       });
       items.push({
         id: 'kubernetes-findings',
         label: 'Kubernetes findings',
         description: 'Cluster and service-account risk queue',
         keywords: ['kubernetes', 'k8s', 'findings', 'rbac'],
-        path: `${basePath}/kubernetes/findings`
+        path: domainCommandPath(`${basePath}/kubernetes/findings`)
       });
       if (sourceAvailability.kubernetes.available) {
         items.push({
@@ -24222,7 +24224,7 @@ export function ProductShellLayout() {
           label: 'Connect Kubernetes',
           description: 'Start cluster onboarding',
           keywords: ['kubernetes', 'k8s', 'connect', 'cluster'],
-          path: `${basePath}/kubernetes/connect`
+          path: domainCommandPath(`${basePath}/kubernetes/connect`)
         });
       }
     }
@@ -24258,7 +24260,7 @@ export function ProductShellLayout() {
       }
     );
     return items;
-  }, [basePath, navigate, scope, sourceAvailability]);
+  }, [basePath, location.search, navigate, scope, sourceAvailability]);
 
   useEffect(() => {
     setOpenDomainFlyout(null);


### PR DESCRIPTION
## Summary
- add a dedicated AWS coverage dashboard route at `/aws/coverage`
- reuse the existing coverage-plan, public account/region coverage, fan-out, Organizations topology, and StackSet onboarding contracts
- register the route in app routing, the domain manifest, AWS navigation, command palette, docs, and regression tests

Closes #1553

## Tests
- `npm run test -- --run src/productShell.test.tsx -t "Domain-first app routes|AWS copy redundancy guard"`
- `npm run build`
- `go test ./internal/providers/awscontract ./internal/api -run 'Coverage|FanOut|OrganizationsTopology|StackSet'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS coverage dashboard at `/aws/coverage` to show account, region, service, and collector coverage in one place. Preserves the selected environment when navigating via the command palette to fulfill #1553.

- **New Features**
  - New route `'/app/:tenantID/:workspaceID/aws/coverage'` with page `ProductAWSCoveragePage`; linked from the AWS Control Center Coverage card and the command palette.
  - Dashboard composes existing contracts: coverage-plan, public account/region coverage, fan-out execution, Organizations topology, and StackSet onboarding; shows loading, empty, error, degraded, and permission-denied states; docs updated (“App Coverage Dashboard”).
  - Coverage filters (account, region, coverage, search); honors tenant/workspace/project/connector scoping.
  - Command palette now keeps the `?environment=` query for AWS coverage and other domain commands; updated route manifest, app routing, and tests for route rendering, API calls, and environment preservation.

<sup>Written for commit 4d00f2c2acb32dbf6408cfd6ecac5ffe904e7651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

