### PR TITLE
Fix findings cleanup controls

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -111,6 +111,11 @@ x-identrail-route-authorizations:
     action: repo_scans.read
     resource_type: repo_scan
     resource_id_param: repo_scan_id
+  - method: DELETE
+    path: /v1/repo-scans/{repo_scan_id}
+    action: repo_scans.run
+    resource_type: repo_scan
+    resource_id_param: repo_scan_id
   - method: POST
     path: /v1/repo-scans/{repo_scan_id}/cancel
     action: repo_scans.run
@@ -9665,6 +9670,33 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+    delete:
+      tags: [RepositoryExposure]
+      summary: Remove failed repository scan
+      operationId: deleteRepoScan
+      description: Removes a failed repository scan record and cascades any findings attached to that scan.
+      parameters:
+        - in: path
+          name: repo_scan_id
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Failed repository scan removed
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -658,6 +658,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPost, Path: "/v1/scans/:scan_id/replay", Action: policyActionScansReplay, ResourceType: "scan", ResourceIDParam: "scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-scans", Action: policyActionRepoScansRead, ResourceType: "repo_scan"},
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
+		{Method: http.MethodDelete, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRun, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
 		{Method: http.MethodPost, Path: "/v1/repo-findings/bulk-delete", Action: policyActionRepoScansRun, ResourceType: "repo_finding_bulk_delete"},
 		{Method: http.MethodDelete, Path: "/v1/repo-findings/:finding_id", Action: policyActionRepoScansRun, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -139,7 +139,7 @@ func TestDefaultRoutePolicyBundleUsesRepoScansRunForDeleteRepoFinding(t *testing
 	}
 }
 
-func TestDefaultRoutePolicyBundleUsesRepoScansRunForCancel(t *testing.T) {
+func TestDefaultRoutePolicyBundleUsesRepoScansRunForCancelAndDeleteScan(t *testing.T) {
 	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
 	if err != nil {
 		t.Fatalf("compile built-in policy bundle: %v", err)
@@ -156,6 +156,19 @@ func TestDefaultRoutePolicyBundleUsesRepoScansRunForCancel(t *testing.T) {
 	}
 	if policy.ResourceIDParam != "repo_scan_id" {
 		t.Fatalf("expected resource id param %q, got %q", "repo_scan_id", policy.ResourceIDParam)
+	}
+	deletePolicy, exists := compiled.RouteRegistry.lookup("DELETE", "/v1/repo-scans/:repo_scan_id")
+	if !exists {
+		t.Fatal("expected built-in authz policy for DELETE /v1/repo-scans/:repo_scan_id")
+	}
+	if deletePolicy.Action != policyActionRepoScansRun {
+		t.Fatalf("expected delete action %q, got %q", policyActionRepoScansRun, deletePolicy.Action)
+	}
+	if deletePolicy.ResourceType != "repo_scan" {
+		t.Fatalf("expected delete resource type %q, got %q", "repo_scan", deletePolicy.ResourceType)
+	}
+	if deletePolicy.ResourceIDParam != "repo_scan_id" {
+		t.Fatalf("expected delete resource id param %q, got %q", "repo_scan_id", deletePolicy.ResourceIDParam)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -494,6 +494,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/repo-scans/:repo_scan_id", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
+		v1.DELETE("/repo-scans/:repo_scan_id", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
+		})
 		v1.GET("/repo-findings", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
@@ -946,6 +949,26 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, item)
 	})
 
+	v1.DELETE("/repo-scans/:repo_scan_id", func(c *gin.Context) {
+		repoScanID, ok := requiredUUIDParam(c, c.Param("repo_scan_id"), "repo_scan_id")
+		if !ok {
+			return
+		}
+		if err := svc.DeleteRepoScan(c.Request.Context(), repoScanID); err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "repo scan not found"})
+			case errors.Is(err, ErrRepoScanDeleteUnavailable):
+				c.JSON(http.StatusConflict, gin.H{"error": "repo scan cannot be removed"})
+			default:
+				logger.Error("delete repo scan", requestErrorLogFields(c, opts.AuditFingerprinter, "delete_repo_scan", telemetry.ZapError(err))...)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete repo scan"})
+			}
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
 	v1.GET("/repo-findings", func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
@@ -1024,20 +1047,59 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
 			return
 		}
-		if err := svc.DeleteRepoFinding(
-			c.Request.Context(),
-			strings.TrimSpace(c.Param("finding_id")),
-			repoScanID,
-		); err != nil {
+		targets, err := normalizeRepoFindingDeleteTargets([]RepoFindingDeleteTarget{{
+			FindingID:  strings.TrimSpace(c.Param("finding_id")),
+			RepoScanID: repoScanID,
+		}})
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			return
+		}
+		expandedTargets, err := svc.ExpandRepoFindingDeleteTargets(c.Request.Context(), targets)
+		if err != nil {
 			switch {
-			case errors.Is(err, db.ErrNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": "repo finding not found"})
+			case errors.Is(err, ErrInvalidRepoRemediationRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			default:
+				logger.Error("expand repo finding delete targets", telemetry.ZapError(err))
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete repo finding"})
+			}
+			return
+		}
+		authorized, err := authorizeRepoFindingDeleteTargets(
+			c,
+			centralPolicyResolver,
+			opts.WriteAPIKeys,
+			opts.APIKeyScopes,
+			authzStore,
+			opts.AuditFingerprinter,
+			metrics,
+			mergeRepoFindingDeleteTargets(targets, expandedTargets),
+		)
+		if err != nil {
+			if logger != nil {
+				logger.Error("authorize repo finding delete", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+			return
+		}
+		if !authorized {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		response, err := svc.DeleteRepoFindings(c.Request.Context(), targets, expandedTargets)
+		if err != nil {
+			switch {
 			case errors.Is(err, ErrInvalidRepoRemediationRequest):
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
 			default:
 				logger.Error("delete repo finding", telemetry.ZapError(err))
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete repo finding"})
 			}
+			return
+		}
+		if len(response.Deleted) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "repo finding not found"})
 			return
 		}
 		c.Status(http.StatusNoContent)
@@ -1061,6 +1123,17 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				return
 			}
 		}
+		expandedTargets, err := svc.ExpandRepoFindingDeleteTargets(c.Request.Context(), targets)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidRepoRemediationRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			default:
+				logger.Error("expand repo finding delete targets", telemetry.ZapError(err))
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete repo findings"})
+			}
+			return
+		}
 		authorized, err := authorizeRepoFindingDeleteTargets(
 			c,
 			centralPolicyResolver,
@@ -1069,7 +1142,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			authzStore,
 			opts.AuditFingerprinter,
 			metrics,
-			targets,
+			mergeRepoFindingDeleteTargets(targets, expandedTargets),
 		)
 		if err != nil {
 			if logger != nil {
@@ -1082,7 +1155,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 			return
 		}
-		response, err := svc.DeleteRepoFindings(c.Request.Context(), targets)
+		response, err := svc.DeleteRepoFindings(c.Request.Context(), targets, expandedTargets)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrInvalidRepoRemediationRequest):

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1189,6 +1189,116 @@ func TestRouterBulkDeleteRepoFindings(t *testing.T) {
 	})
 }
 
+func TestRouterBulkDeleteRepoFindingsRemovesLifecycleGroup(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+	oldScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("create old repo scan: %v", err)
+	}
+	latestScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create latest repo scan: %v", err)
+	}
+	oldFinding := domain.Finding{
+		ID:           "repo-bulk-lifecycle-old",
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "workflow write all",
+		HumanSummary: "Workflow uses write-all.",
+		Repository:   "owner/repo",
+		LifecycleKey: "repo-finding:workflow-write-all",
+		CreatedAt:    now.Add(-time.Hour),
+	}
+	latestFinding := oldFinding
+	latestFinding.ID = "repo-bulk-lifecycle-latest"
+	latestFinding.CreatedAt = now
+	if err := store.UpsertRepoFindings(defaultScopeContext(), oldScan.ID, []domain.Finding{oldFinding}); err != nil {
+		t.Fatalf("upsert old repo finding: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), latestScan.ID, []domain.Finding{latestFinding}); err != nil {
+		t.Fatalf("upsert latest repo finding: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), oldScan.ID, "completed", now.Add(-59*time.Minute), 1, 1, 1, false, db.RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete old repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), latestScan.ID, "completed", now.Add(time.Minute), 1, 1, 1, false, db.RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete latest repo scan: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+	payload, err := json.Marshal(RepoFindingsBulkDeleteRequest{
+		Items: []RepoFindingDeleteTarget{{FindingID: latestFinding.ID, RepoScanID: latestScan.ID}},
+	})
+	if err != nil {
+		t.Fatalf("marshal bulk delete request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected bulk delete repo findings 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body RepoFindingsBulkDeleteResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode bulk delete response: %v", err)
+	}
+	if len(body.Deleted) != 1 || body.Deleted[0].FindingID != latestFinding.ID {
+		t.Fatalf("expected latest target to be reported deleted, got %+v", body)
+	}
+	remaining, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected lifecycle group to be removed, got %+v", remaining)
+	}
+}
+
+func TestRouterDeleteFailedRepoScan(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+	failedScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create failed repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), failedScan.ID, "failed", now.Add(time.Minute), 0, 0, 0, false, db.RepoScanContext{}, "repository not found"); err != nil {
+		t.Fatalf("complete failed repo scan: %v", err)
+	}
+	succeededScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create succeeded repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), succeededScan.ID, "completed", now.Add(time.Hour+time.Minute), 0, 0, 0, false, db.RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete succeeded repo scan: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/repo-scans/"+failedScan.ID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected failed repo scan delete 204, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := svc.GetRepoScan(defaultScopeContext(), failedScan.ID); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected failed repo scan to be removed, got %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/v1/repo-scans/"+succeededScan.ID, nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected succeeded repo scan delete conflict, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestRouterRepoFindingRemediationPublish(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -572,6 +572,9 @@ var ErrRepoScanInProgress = errors.New("repo scan already in progress")
 // ErrRepoScanCancelUnavailable is returned when a repository scan is already terminal.
 var ErrRepoScanCancelUnavailable = errors.New("repo scan cancel is unavailable")
 
+// ErrRepoScanDeleteUnavailable is returned when a repository scan should remain auditable.
+var ErrRepoScanDeleteUnavailable = errors.New("repo scan delete is unavailable")
+
 var errRepoScanTerminalStateChanged = errors.New("repo scan terminal state changed")
 
 // ErrInvalidFindingTriageRequest indicates invalid triage payload or state transition.
@@ -2594,6 +2597,27 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 	return s.Store.GetRepoScan(ctx, id)
 }
 
+// DeleteRepoScan removes a failed repository scan record.
+func (s *Service) DeleteRepoScan(ctx context.Context, repoScanID string) error {
+	ctx = s.scopeContext(ctx)
+	id := strings.TrimSpace(repoScanID)
+	if id == "" {
+		return db.ErrNotFound
+	}
+	record, err := s.Store.GetRepoScan(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !isFailedRepoScanRecord(record) {
+		return ErrRepoScanDeleteUnavailable
+	}
+	return s.Store.DeleteRepoScan(ctx, id)
+}
+
+func isFailedRepoScanRecord(record db.RepoScanRecord) bool {
+	return strings.EqualFold(strings.TrimSpace(record.Status), scanLifecycleFailed)
+}
+
 // ListRepoFindings returns repository findings using optional filters.
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
@@ -2659,12 +2683,12 @@ func (s *Service) DeleteRepoFinding(ctx context.Context, findingID string, repoS
 	return s.Store.DeleteRepoFinding(ctx, repoScanID, findingID)
 }
 
-// DeleteRepoFindings permanently removes selected repository findings.
-func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingDeleteTarget) (RepoFindingsBulkDeleteResponse, error) {
+// ExpandRepoFindingDeleteTargets returns the concrete repository finding rows a delete request can remove.
+func (s *Service) ExpandRepoFindingDeleteTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
 	ctx = s.scopeContext(ctx)
 	normalized, err := normalizeRepoFindingDeleteTargets(targets)
 	if err != nil {
-		return RepoFindingsBulkDeleteResponse{}, err
+		return nil, err
 	}
 	storeTargets := make([]db.RepoFindingDeleteTarget, 0, len(normalized))
 	for _, target := range normalized {
@@ -2673,9 +2697,34 @@ func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingD
 			FindingID:  target.FindingID,
 		})
 	}
-	deletedTargets, err := s.Store.DeleteRepoFindingTargets(ctx, storeTargets)
+	expandedTargets, err := s.Store.ExpandRepoFindingDeleteTargets(ctx, storeTargets)
+	if err != nil {
+		return nil, err
+	}
+	return repoFindingDeleteTargetsFromStore(expandedTargets), nil
+}
+
+// DeleteRepoFindings permanently removes selected repository findings.
+func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingDeleteTarget, deleteTargetsOverride ...[]RepoFindingDeleteTarget) (RepoFindingsBulkDeleteResponse, error) {
+	ctx = s.scopeContext(ctx)
+	normalized, err := normalizeRepoFindingDeleteTargets(targets)
 	if err != nil {
 		return RepoFindingsBulkDeleteResponse{}, err
+	}
+	normalizedDeleteTargets := normalized
+	if len(deleteTargetsOverride) > 0 {
+		normalizedDeleteTargets, err = normalizeRepoFindingDeleteTargetsAllowEmpty(deleteTargetsOverride[0])
+		if err != nil {
+			return RepoFindingsBulkDeleteResponse{}, err
+		}
+	}
+	deletedTargets := []db.RepoFindingDeleteTarget{}
+	if len(normalizedDeleteTargets) > 0 {
+		storeTargets := repoFindingDeleteTargetsToStore(normalizedDeleteTargets)
+		deletedTargets, err = s.Store.DeleteRepoFindingTargets(ctx, storeTargets)
+		if err != nil {
+			return RepoFindingsBulkDeleteResponse{}, err
+		}
 	}
 	deletedSet := make(map[string]struct{}, len(deletedTargets))
 	for _, target := range deletedTargets {
@@ -2696,6 +2745,63 @@ func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingD
 		})
 	}
 	return response, nil
+}
+
+func repoFindingDeleteTargetsToStore(targets []RepoFindingDeleteTarget) []db.RepoFindingDeleteTarget {
+	storeTargets := make([]db.RepoFindingDeleteTarget, 0, len(targets))
+	for _, target := range targets {
+		storeTargets = append(storeTargets, db.RepoFindingDeleteTarget{
+			RepoScanID: target.RepoScanID,
+			FindingID:  target.FindingID,
+		})
+	}
+	return storeTargets
+}
+
+func repoFindingDeleteTargetsFromStore(targets []db.RepoFindingDeleteTarget) []RepoFindingDeleteTarget {
+	apiTargets := make([]RepoFindingDeleteTarget, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		repoScanID := strings.TrimSpace(target.RepoScanID)
+		findingID := strings.TrimSpace(target.FindingID)
+		if repoScanID == "" || findingID == "" {
+			continue
+		}
+		key := repoFindingDeleteTargetKey(repoScanID, findingID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		apiTargets = append(apiTargets, RepoFindingDeleteTarget{
+			FindingID:  findingID,
+			RepoScanID: repoScanID,
+		})
+	}
+	return apiTargets
+}
+
+func mergeRepoFindingDeleteTargets(groups ...[]RepoFindingDeleteTarget) []RepoFindingDeleteTarget {
+	merged := []RepoFindingDeleteTarget{}
+	seen := map[string]struct{}{}
+	for _, targets := range groups {
+		for _, target := range targets {
+			repoScanID := strings.TrimSpace(target.RepoScanID)
+			findingID := strings.TrimSpace(target.FindingID)
+			if repoScanID == "" || findingID == "" {
+				continue
+			}
+			key := repoFindingDeleteTargetKey(repoScanID, findingID)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, RepoFindingDeleteTarget{
+				FindingID:  findingID,
+				RepoScanID: repoScanID,
+			})
+		}
+	}
+	return merged
 }
 
 func repoFindingDeleteTargetKey(repoScanID string, findingID string) string {
@@ -2726,6 +2832,31 @@ func normalizeRepoFindingDeleteTargets(targets []RepoFindingDeleteTarget) ([]Rep
 	}
 	if len(normalized) == 0 {
 		return nil, ErrInvalidRepoRemediationRequest
+	}
+	return normalized, nil
+}
+
+func normalizeRepoFindingDeleteTargetsAllowEmpty(targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	if len(targets) == 0 {
+		return []RepoFindingDeleteTarget{}, nil
+	}
+	normalized := make([]RepoFindingDeleteTarget, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		findingID := strings.TrimSpace(target.FindingID)
+		repoScanID := strings.TrimSpace(target.RepoScanID)
+		if findingID == "" || repoScanID == "" {
+			return nil, ErrInvalidRepoRemediationRequest
+		}
+		key := repoScanID + "::" + findingID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, RepoFindingDeleteTarget{
+			FindingID:  findingID,
+			RepoScanID: repoScanID,
+		})
 	}
 	return normalized, nil
 }

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2233,6 +2233,34 @@ func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoS
 	return record, nil
 }
 
+// DeleteRepoScan removes one persisted repository scan and its findings.
+func (m *MemoryStore) DeleteRepoScan(ctx context.Context, repoScanID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	record, exists := m.repoScans[repoScanID]
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+		return ErrNotFound
+	}
+	for _, key := range m.repoFindingIDs[repoScanID] {
+		delete(m.repoFindings, key)
+	}
+	delete(m.repoFindingIDs, repoScanID)
+	delete(m.repoScans, repoScanID)
+	nextScanIDs := m.repoScanIDs[:0]
+	for _, existing := range m.repoScanIDs {
+		if existing != repoScanID {
+			nextScanIDs = append(nextScanIDs, existing)
+		}
+	}
+	m.repoScanIDs = nextScanIDs
+	return nil
+}
+
 // CancelRepoScan marks a queued or running repository scan as terminal failed.
 func (m *MemoryStore) CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error) {
 	m.mu.Lock()
@@ -2426,37 +2454,91 @@ func (m *MemoryStore) DeleteRepoFindings(ctx context.Context, repoScanID string)
 
 // DeleteRepoFinding removes one persisted repository finding for one scan.
 func (m *MemoryStore) DeleteRepoFinding(ctx context.Context, repoScanID string, findingID string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	scope, err := RequireScope(ctx)
+	deleted, err := m.DeleteRepoFindingTargets(ctx, []RepoFindingDeleteTarget{{
+		RepoScanID: repoScanID,
+		FindingID:  findingID,
+	}})
 	if err != nil {
 		return err
 	}
-	repoScan, exists := m.repoScans[repoScanID]
-	if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
+	if len(deleted) == 0 {
 		return ErrNotFound
 	}
-	key := repoScanID + "|" + strings.TrimSpace(findingID)
-	if _, exists := m.repoFindings[key]; !exists {
-		return ErrNotFound
+	return nil
+}
+
+// ExpandRepoFindingDeleteTargets returns every concrete finding row a delete request may remove.
+func (m *MemoryStore) ExpandRepoFindingDeleteTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
 	}
-	delete(m.repoFindings, key)
-	keys := m.repoFindingIDs[repoScanID]
-	nextKeys := keys[:0]
-	for _, existing := range keys {
-		if existing != key {
-			nextKeys = append(nextKeys, existing)
+
+	expanded := make([]RepoFindingDeleteTarget, 0, len(targets))
+	seen := map[string]struct{}{}
+	addTarget := func(repoScanID string, findingID string) {
+		key := repoScanID + "::" + findingID
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		expanded = append(expanded, RepoFindingDeleteTarget{RepoScanID: repoScanID, FindingID: findingID})
+	}
+
+	for _, target := range targets {
+		repoScanID := strings.TrimSpace(target.RepoScanID)
+		findingID := strings.TrimSpace(target.FindingID)
+		if repoScanID == "" || findingID == "" {
+			continue
+		}
+		repoScan, exists := m.repoScans[repoScanID]
+		if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
+			continue
+		}
+		key := repoScanID + "|" + findingID
+		finding, exists := m.repoFindings[key]
+		if !exists {
+			continue
+		}
+		if finding.Repository == "" {
+			finding.Repository = repoScan.Repository
+		}
+		domain.NormalizeRepoFindingMetadata(&finding)
+		repositoryKey := strings.ToLower(strings.TrimSpace(finding.Repository))
+		lifecycleKey := strings.TrimSpace(finding.LifecycleKey)
+		addTarget(repoScanID, findingID)
+		if lifecycleKey == "" {
+			continue
+		}
+		for candidateKey, candidate := range m.repoFindings {
+			candidateScan, scanExists := m.repoScans[candidate.ScanID]
+			if !scanExists || !MatchScope(scope, candidateScan.TenantID, candidateScan.WorkspaceID) {
+				continue
+			}
+			if candidate.Repository == "" {
+				candidate.Repository = candidateScan.Repository
+			}
+			domain.NormalizeRepoFindingMetadata(&candidate)
+			if strings.TrimSpace(candidate.LifecycleKey) != lifecycleKey ||
+				!strings.EqualFold(strings.TrimSpace(candidate.Repository), repositoryKey) {
+				continue
+			}
+			keyParts := strings.SplitN(candidateKey, "|", 2)
+			if len(keyParts) != 2 {
+				continue
+			}
+			addTarget(candidate.ScanID, keyParts[1])
 		}
 	}
-	if len(nextKeys) == 0 {
-		delete(m.repoFindingIDs, repoScanID)
-	} else {
-		m.repoFindingIDs[repoScanID] = nextKeys
-	}
-	repoScan.FindingCount = len(nextKeys)
-	m.repoScans[repoScanID] = repoScan
-	return nil
+	sort.Slice(expanded, func(left, right int) bool {
+		if expanded[left].RepoScanID == expanded[right].RepoScanID {
+			return expanded[left].FindingID < expanded[right].FindingID
+		}
+		return expanded[left].RepoScanID < expanded[right].RepoScanID
+	})
+	return expanded, nil
 }
 
 // DeleteRepoFindingTargets removes selected persisted repository findings.
@@ -2469,6 +2551,7 @@ func (m *MemoryStore) DeleteRepoFindingTargets(ctx context.Context, targets []Re
 		return nil, err
 	}
 	deleted := make([]RepoFindingDeleteTarget, 0, len(targets))
+	deletedTargetKeys := map[string]struct{}{}
 	deletedByScan := map[string]map[string]struct{}{}
 	for _, target := range targets {
 		repoScanID := strings.TrimSpace(target.RepoScanID)
@@ -2489,7 +2572,11 @@ func (m *MemoryStore) DeleteRepoFindingTargets(ctx context.Context, targets []Re
 			deletedByScan[repoScanID] = map[string]struct{}{}
 		}
 		deletedByScan[repoScanID][key] = struct{}{}
-		deleted = append(deleted, RepoFindingDeleteTarget{RepoScanID: repoScanID, FindingID: findingID})
+		targetKey := repoScanID + "::" + findingID
+		if _, exists := deletedTargetKeys[targetKey]; !exists {
+			deleted = append(deleted, RepoFindingDeleteTarget{RepoScanID: repoScanID, FindingID: findingID})
+			deletedTargetKeys[targetKey] = struct{}{}
+		}
 	}
 	for repoScanID, keysToDelete := range deletedByScan {
 		keys := m.repoFindingIDs[repoScanID]

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -912,6 +912,160 @@ func TestMemoryStoreDeleteRepoFindingTargetsUpdatesScanCounts(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreExpandRepoFindingDeleteTargetsIncludesLifecycleGroup(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	oldScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("create old repo scan: %v", err)
+	}
+	latestScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create latest repo scan: %v", err)
+	}
+	oldFinding := domain.Finding{
+		ID:           "rf-lifecycle-old",
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "workflow write all",
+		HumanSummary: "Workflow uses write-all.",
+		Repository:   "owner/repo",
+		LifecycleKey: "repo-finding:workflow-write-all",
+		CreatedAt:    now.Add(-time.Hour),
+	}
+	latestFinding := oldFinding
+	latestFinding.ID = "rf-lifecycle-latest"
+	latestFinding.CreatedAt = now
+	if err := store.UpsertRepoFindings(defaultScopeContext(), oldScan.ID, []domain.Finding{oldFinding}); err != nil {
+		t.Fatalf("upsert old finding: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), latestScan.ID, []domain.Finding{latestFinding}); err != nil {
+		t.Fatalf("upsert latest finding: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), oldScan.ID, "completed", now.Add(-59*time.Minute), 1, 1, 1, false, RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete old repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), latestScan.ID, "completed", now.Add(time.Minute), 1, 1, 1, false, RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete latest repo scan: %v", err)
+	}
+
+	expanded, err := store.ExpandRepoFindingDeleteTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
+		{RepoScanID: latestScan.ID, FindingID: latestFinding.ID},
+	})
+	if err != nil {
+		t.Fatalf("expand lifecycle target: %v", err)
+	}
+	if len(expanded) != 2 {
+		t.Fatalf("expected lifecycle group to expand to two concrete targets, got %+v", expanded)
+	}
+	expandedKeys := map[string]struct{}{}
+	for _, target := range expanded {
+		expandedKeys[target.RepoScanID+"::"+target.FindingID] = struct{}{}
+	}
+	for _, want := range []RepoFindingDeleteTarget{
+		{RepoScanID: oldScan.ID, FindingID: oldFinding.ID},
+		{RepoScanID: latestScan.ID, FindingID: latestFinding.ID},
+	} {
+		if _, exists := expandedKeys[want.RepoScanID+"::"+want.FindingID]; !exists {
+			t.Fatalf("expected expanded targets to include %+v, got %+v", want, expanded)
+		}
+	}
+	deleted, err := store.DeleteRepoFindingTargets(defaultScopeContext(), expanded)
+	if err != nil {
+		t.Fatalf("delete expanded lifecycle targets: %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected expanded lifecycle group to be deleted, got %+v", deleted)
+	}
+	remaining, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{}, 10)
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected lifecycle group to be removed, got %+v", remaining)
+	}
+	for _, scanID := range []string{oldScan.ID, latestScan.ID} {
+		scan, err := store.GetRepoScan(defaultScopeContext(), scanID)
+		if err != nil {
+			t.Fatalf("get repo scan %s: %v", scanID, err)
+		}
+		if scan.FindingCount != 0 {
+			t.Fatalf("expected scan %s finding count to be zero, got %d", scanID, scan.FindingCount)
+		}
+	}
+}
+
+func TestMemoryStoreDeleteRepoFindingTargetsDeletesExactTargetsOnly(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	oldScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("create old repo scan: %v", err)
+	}
+	latestScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create latest repo scan: %v", err)
+	}
+	oldFinding := domain.Finding{
+		ID:           "rf-exact-old",
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Repository:   "owner/repo",
+		LifecycleKey: "repo-finding:exact-delete",
+		CreatedAt:    now.Add(-time.Hour),
+	}
+	latestFinding := oldFinding
+	latestFinding.ID = "rf-exact-latest"
+	latestFinding.CreatedAt = now
+	if err := store.UpsertRepoFindings(defaultScopeContext(), oldScan.ID, []domain.Finding{oldFinding}); err != nil {
+		t.Fatalf("upsert old finding: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), latestScan.ID, []domain.Finding{latestFinding}); err != nil {
+		t.Fatalf("upsert latest finding: %v", err)
+	}
+
+	deleted, err := store.DeleteRepoFindingTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
+		{RepoScanID: latestScan.ID, FindingID: latestFinding.ID},
+	})
+	if err != nil {
+		t.Fatalf("delete exact target: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0].FindingID != latestFinding.ID {
+		t.Fatalf("expected only latest target to be reported deleted, got %+v", deleted)
+	}
+	remaining, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{}, 10)
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != oldFinding.ID {
+		t.Fatalf("expected old lifecycle sibling to remain after exact delete, got %+v", remaining)
+	}
+}
+
+func TestMemoryStoreDeleteRepoScanCascadesFindings(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{
+		{ID: "rf-delete-scan", Type: domain.FindingRepoMisconfig, Severity: domain.SeverityHigh, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert repo finding: %v", err)
+	}
+	if err := store.DeleteRepoScan(defaultScopeContext(), repoScan.ID); err != nil {
+		t.Fatalf("delete repo scan: %v", err)
+	}
+	if _, err := store.GetRepoScan(defaultScopeContext(), repoScan.ID); err != ErrNotFound {
+		t.Fatalf("expected deleted repo scan to be missing, got %v", err)
+	}
+	remaining, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: repoScan.ID}, 10)
+	if err != ErrNotFound {
+		t.Fatalf("expected deleted scan findings to be missing, got findings=%+v err=%v", remaining, err)
+	}
+}
+
 func TestMemoryStoreGetRepoScanCursorCopiesPointerFields(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3230,6 +3230,28 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	return record, nil
 }
 
+// DeleteRepoScan removes one repository scan and cascades its findings.
+func (p *PostgresStore) DeleteRepoScan(ctx context.Context, repoScanID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete repo scan: %w", err)
+	}
+	return ensureRowsAffected(result)
+}
+
 // CancelRepoScan atomically marks a queued or running repository scan as terminal failed.
 func (p *PostgresStore) CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)
@@ -3783,43 +3805,111 @@ func (p *PostgresStore) DeleteRepoFindings(ctx context.Context, repoScanID strin
 
 // DeleteRepoFinding removes one repository finding for one scan.
 func (p *PostgresStore) DeleteRepoFinding(ctx context.Context, repoScanID string, findingID string) error {
-	if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
-		return err
-	}
-	scope, err := RequireScope(ctx)
+	deleted, err := p.DeleteRepoFindingTargets(ctx, []RepoFindingDeleteTarget{{
+		RepoScanID: repoScanID,
+		FindingID:  findingID,
+	}})
 	if err != nil {
 		return err
 	}
-	result, err := p.execContext(
+	if len(deleted) == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ExpandRepoFindingDeleteTargets returns every concrete repository finding row a delete request may remove.
+func (p *PostgresStore) ExpandRepoFindingDeleteTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	type repoFindingDeleteTargetPayload struct {
+		RepoScanID string `json:"repo_scan_id"`
+		FindingID  string `json:"finding_id"`
+	}
+	payloadTargets := make([]repoFindingDeleteTargetPayload, 0, len(targets))
+	for _, target := range targets {
+		payloadTargets = append(payloadTargets, repoFindingDeleteTargetPayload{
+			RepoScanID: target.RepoScanID,
+			FindingID:  target.FindingID,
+		})
+	}
+	payload, err := json.Marshal(payloadTargets)
+	if err != nil {
+		return nil, fmt.Errorf("marshal repo finding delete targets: %w", err)
+	}
+	rows, err := p.queryContext(
 		ctx,
-		`WITH deleted AS (
-			DELETE FROM repo_findings rf
-			USING repo_scans rs
-			WHERE rf.repo_scan_id = rs.id
-			  AND rf.repo_scan_id = $1
-			  AND rf.finding_id = $2
-			  AND rs.tenant_id = $3
-			  AND rs.workspace_id = $4
-			RETURNING rf.repo_scan_id
+		`WITH targets AS (
+			SELECT DISTINCT
+			       NULLIF(TRIM(repo_scan_id), '')::uuid AS repo_scan_id,
+			       NULLIF(TRIM(finding_id), '') AS finding_id
+			  FROM jsonb_to_recordset($1::jsonb) AS t(repo_scan_id text, finding_id text)
+			 WHERE NULLIF(TRIM(repo_scan_id), '') IS NOT NULL
+			   AND NULLIF(TRIM(finding_id), '') IS NOT NULL
+		), matched AS (
+			SELECT
+			       rf.repo_scan_id AS matched_repo_scan_id,
+			       rf.finding_id AS matched_finding_id,
+			       LOWER(TRIM(COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository))) AS repository_key,
+			       COALESCE(NULLIF(TRIM(rf.lifecycle_key), ''), NULLIF(TRIM(rf.evidence->>'lifecycle_key'), '')) AS lifecycle_key
+			  FROM targets t
+			  JOIN repo_findings rf
+			    ON rf.repo_scan_id = t.repo_scan_id
+			   AND rf.finding_id = t.finding_id
+			  JOIN repo_scans rs
+			    ON rs.id = rf.repo_scan_id
+			   AND rs.tenant_id = $2
+			   AND rs.workspace_id = $3
+		), expanded AS (
+			SELECT DISTINCT
+			       rf.repo_scan_id::text AS repo_scan_id,
+			       rf.finding_id
+			  FROM matched m
+			  JOIN repo_findings rf
+			    ON (
+			      (rf.repo_scan_id = m.matched_repo_scan_id AND rf.finding_id = m.matched_finding_id)
+			      OR (
+			        m.lifecycle_key IS NOT NULL
+			        AND m.lifecycle_key <> ''
+			        AND COALESCE(NULLIF(TRIM(rf.lifecycle_key), ''), NULLIF(TRIM(rf.evidence->>'lifecycle_key'), '')) = m.lifecycle_key
+			      )
+			    )
+			  JOIN repo_scans rs
+			    ON rs.id = rf.repo_scan_id
+			   AND rs.tenant_id = $2
+			   AND rs.workspace_id = $3
+			 WHERE rf.repo_scan_id = m.matched_repo_scan_id
+			    OR (
+			      m.lifecycle_key IS NOT NULL
+			      AND m.lifecycle_key <> ''
+			      AND LOWER(TRIM(COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository))) = m.repository_key
+			    )
 		)
-		UPDATE repo_scans rs
-		SET finding_count = GREATEST(0, rs.finding_count - (SELECT COUNT(*) FROM deleted))
-		WHERE rs.id = $1
-		  AND rs.tenant_id = $3
-		  AND rs.workspace_id = $4
-		  AND EXISTS (SELECT 1 FROM deleted)`,
-		repoScanID,
-		strings.TrimSpace(findingID),
+		SELECT repo_scan_id, finding_id
+		  FROM expanded
+		 ORDER BY repo_scan_id, finding_id`,
+		string(payload),
 		scope.TenantID,
 		scope.WorkspaceID,
 	)
 	if err != nil {
-		return fmt.Errorf("delete repo finding: %w", err)
+		return nil, fmt.Errorf("expand repo finding delete targets: %w", err)
 	}
-	if err := ensureRowsAffected(result); err != nil {
-		return err
+	defer rows.Close()
+	expanded := []RepoFindingDeleteTarget{}
+	for rows.Next() {
+		var target RepoFindingDeleteTarget
+		if err := rows.Scan(&target.RepoScanID, &target.FindingID); err != nil {
+			return nil, fmt.Errorf("scan expanded repo finding delete target: %w", err)
+		}
+		expanded = append(expanded, target)
 	}
-	return nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate expanded repo finding delete targets: %w", err)
+	}
+	return expanded, nil
 }
 
 // DeleteRepoFindingTargets removes selected repository findings in one scoped operation.
@@ -3854,10 +3944,10 @@ func (p *PostgresStore) DeleteRepoFindingTargets(ctx context.Context, targets []
 			   AND NULLIF(TRIM(finding_id), '') IS NOT NULL
 		), deleted AS (
 			DELETE FROM repo_findings rf
-			USING repo_scans rs, targets t
-			WHERE rf.repo_scan_id = rs.id
-			  AND rf.repo_scan_id = t.repo_scan_id
+			USING targets t, repo_scans rs
+			WHERE rf.repo_scan_id = t.repo_scan_id
 			  AND rf.finding_id = t.finding_id
+			  AND rs.id = rf.repo_scan_id
 			  AND rs.tenant_id = $2
 			  AND rs.workspace_id = $3
 			RETURNING rf.repo_scan_id::text, rf.finding_id
@@ -3865,7 +3955,7 @@ func (p *PostgresStore) DeleteRepoFindingTargets(ctx context.Context, targets []
 			UPDATE repo_scans rs
 			SET finding_count = GREATEST(0, rs.finding_count - counts.deleted_count)
 			FROM (
-				SELECT repo_scan_id, COUNT(*)::int AS deleted_count
+				SELECT repo_scan_id::uuid AS repo_scan_id, COUNT(*)::int AS deleted_count
 				FROM deleted
 				GROUP BY repo_scan_id
 			) counts

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1036,36 +1036,69 @@ func TestPostgresStoreDeleteRepoFindingDecrementsScanCount(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	scanID := "11111111-1111-1111-1111-111111111111"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
-			SELECT 1
-			FROM repo_scans
-			WHERE id = $1
-			  AND tenant_id = $2
-			  AND workspace_id = $3
-		)`)).
-		WithArgs(scanID, "default", "default").
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectExec(regexp.QuoteMeta(`WITH deleted AS (
-			DELETE FROM repo_findings rf
-			USING repo_scans rs
-			WHERE rf.repo_scan_id = rs.id
-			  AND rf.repo_scan_id = $1
-			  AND rf.finding_id = $2
-			  AND rs.tenant_id = $3
-			  AND rs.workspace_id = $4
-			RETURNING rf.repo_scan_id
-		)
-		UPDATE repo_scans rs
-		SET finding_count = GREATEST(0, rs.finding_count - (SELECT COUNT(*) FROM deleted))
-		WHERE rs.id = $1
-		  AND rs.tenant_id = $3
-		  AND rs.workspace_id = $4
-		  AND EXISTS (SELECT 1 FROM deleted)`)).
-		WithArgs(scanID, "rf-1", "default", "default").
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectedPayload := `[{"repo_scan_id":"11111111-1111-1111-1111-111111111111","finding_id":"rf-1"}]`
+	mock.ExpectQuery("WITH targets AS").
+		WithArgs(expectedPayload, "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"repo_scan_id", "finding_id"}).AddRow(scanID, "rf-1"))
 
 	if err := store.DeleteRepoFinding(defaultScopeContext(), scanID, "rf-1"); err != nil {
 		t.Fatalf("delete repo finding: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteRepoScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`)).
+		WithArgs(scanID, "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.DeleteRepoScan(defaultScopeContext(), scanID); err != nil {
+		t.Fatalf("delete repo scan: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreExpandRepoFindingDeleteTargetsReturnsConcreteTargets(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+	oldScanID := "22222222-2222-2222-2222-222222222222"
+	expandedRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id"}).
+		AddRow(oldScanID, "rf-old").
+		AddRow(scanID, "rf-latest")
+	expectedPayload := `[{"repo_scan_id":"11111111-1111-1111-1111-111111111111","finding_id":"rf-latest"}]`
+	mock.ExpectQuery("WITH targets AS").
+		WithArgs(expectedPayload, "default", "default").
+		WillReturnRows(expandedRows)
+
+	expanded, err := store.ExpandRepoFindingDeleteTargets(defaultScopeContext(), []RepoFindingDeleteTarget{
+		{RepoScanID: scanID, FindingID: "rf-latest"},
+	})
+	if err != nil {
+		t.Fatalf("expand repo finding targets: %v", err)
+	}
+	if len(expanded) != 2 || expanded[0].FindingID != "rf-old" || expanded[1].FindingID != "rf-latest" {
+		t.Fatalf("unexpected expanded targets: %+v", expanded)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3335,12 +3335,14 @@ type Store interface {
 	FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
 	CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error)
+	DeleteRepoScan(ctx context.Context, repoScanID string) error
 	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error
 	GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error)
 	UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error
 	DeleteRepoFindings(ctx context.Context, repoScanID string) error
 	DeleteRepoFinding(ctx context.Context, repoScanID string, findingID string) error
+	ExpandRepoFindingDeleteTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error)
 	DeleteRepoFindingTargets(ctx context.Context, targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error)
 	ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error)
 	ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -301,6 +301,23 @@ describe('apiClient', () => {
     expect(headers.get('X-Identrail-Workspace-ID')).toBe('workspace-a');
   });
 
+  it('deletes failed repository scans with the scoped auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.deleteRepoScan('repo/scan with space', { tenantID: 'tenant-a', workspaceID: 'workspace-a' });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/repo-scans/repo%2Fscan%20with%20space');
+    expect(options.method).toBe('DELETE');
+    const headers = options.headers as Headers;
+    expect(headers.get('X-Identrail-Tenant-ID')).toBe('tenant-a');
+    expect(headers.get('X-Identrail-Workspace-ID')).toBe('workspace-a');
+  });
+
   it('encodes scan id for diff URL', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10094,6 +10094,11 @@ export const apiClient = {
       method: 'POST'
     });
   },
+  deleteRepoScan(repoScanID: string, auth?: RequestAuthContext) {
+    return request<void>(`/v1/repo-scans/${encodeURIComponent(repoScanID)}`, auth, {
+      method: 'DELETE'
+    });
+  },
   listFindings(
     filters: {
       limit?: number;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7954,6 +7954,7 @@ describe('Domain-first app routes', () => {
       };
     });
     const deleteRepoFinding = vi.spyOn(api.apiClient, 'deleteRepoFinding').mockResolvedValue(undefined);
+    const deleteRepoScan = vi.spyOn(api.apiClient, 'deleteRepoScan').mockResolvedValue(undefined);
     const deleteRepoFindings = vi
       .spyOn(api.apiClient, 'deleteRepoFindings')
       .mockImplementation(async (items) => ({ deleted: items }));
@@ -8000,6 +8001,7 @@ describe('Domain-first app routes', () => {
       listRepoFindings,
       triageFinding,
       deleteRepoFinding,
+      deleteRepoScan,
       deleteRepoFindings,
       getRepoFindingsTrends,
       getRepoRiskGraph
@@ -8168,7 +8170,7 @@ describe('ProductFindingsPage states', () => {
       created_at: '2026-05-17T11:07:00Z'
     };
 
-    await renderFindings({
+    const { deleteRepoScan } = await renderFindings({
       repoScans: [failedScan, oldSucceededScan],
       repoFindings: [finding]
     });
@@ -8177,9 +8179,57 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
 
     await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledWith(
+        failedScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
       expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
     });
     expect(await screen.findByText('Historical workflow finding')).toBeInTheDocument();
+  });
+
+  it('lets viewers dismiss a failed scan banner without deleting the scan', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-viewer-dismissible',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-viewer-dismissible-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-viewer-dismissible',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical viewer workflow finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    const { deleteRepoScan } = await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding],
+      role: 'viewer'
+    });
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Dismiss$/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoScan).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Historical viewer workflow finding')).toBeInTheDocument();
   });
 
   it('lets operators remove a failed-only scan state', async () => {
@@ -8191,15 +8241,64 @@ describe('ProductFindingsPage states', () => {
       error_message: 'Repository not found or access revoked'
     };
 
-    await renderFindings({ repoScans: [failedScan] });
+    const { deleteRepoScan } = await renderFindings({ repoScans: [failedScan] });
 
     expect(await screen.findByText('Your last repository scan failed')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
 
     await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledWith(
+        failedScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
       expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
+  });
+
+  it('falls back to hiding failed scan banners when scan removal is not deployed yet', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-remove-unsupported',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-remove-unsupported-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-remove-unsupported',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical unsupported remove finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    const { deleteRepoScan } = await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+    const { ApiError } = await import('./api/client');
+    deleteRepoScan.mockRejectedValueOnce(new ApiError('Request failed (404)', 404));
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Historical unsupported remove finding')).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {
@@ -8793,7 +8892,7 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
-  it('keeps clear all on the bulk path when the bulk endpoint fails', async () => {
+  it('falls back to single finding deletes when the bulk endpoint is not deployed yet', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-bulk-missing',
@@ -8840,11 +8939,25 @@ describe('ProductFindingsPage states', () => {
 
     await waitFor(() => {
       expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
-      expect(deleteRepoFinding).not.toHaveBeenCalled();
-      expect(screen.getByText('Request failed (404)')).toBeInTheDocument();
+      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+      expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+        1,
+        findings[0].id,
+        scan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
+      expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+        2,
+        findings[1].id,
+        scan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
     });
-    expect(await screen.findByText('Fallback clearable token finding')).toBeInTheDocument();
-    expect(await screen.findByText('Fallback clearable workflow finding')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Fallback clearable token finding')).not.toBeInTheDocument();
+      expect(screen.queryByText('Fallback clearable workflow finding')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
   it('reloads repository findings after clearing a paged list', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8924,6 +8924,90 @@ describe('ProductFindingsPage states', () => {
     ).toBe(false);
   });
 
+  it('uses live finding filters when failed scan removal refreshes', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-live-finding-filters',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-live-finding-filter-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-live-finding-filter',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'critical',
+      title: 'Historical live finding-filter finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+    const deleteCompletion = deferred<void>();
+
+    const { deleteRepoScan, listRepoFindings, getRepoFindingsTrends, getRepoRiskGraph } = await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+    deleteRepoScan.mockImplementation(() => deleteCompletion.promise);
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+    await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledWith(
+        failedScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText(/Severity/i), { target: { value: 'critical' } });
+    await waitFor(() => {
+      expect(
+        listRepoFindings.mock.calls.some(
+          ([params]) => (params as { severity?: string } | undefined)?.severity === 'critical'
+        )
+      ).toBe(true);
+    });
+
+    listRepoFindings.mockClear();
+    getRepoFindingsTrends.mockClear();
+    getRepoRiskGraph.mockClear();
+    await act(async () => {
+      deleteCompletion.resolve();
+      await deleteCompletion.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+      expect(listRepoFindings).toHaveBeenCalled();
+      expect(getRepoFindingsTrends).toHaveBeenCalled();
+      expect(getRepoRiskGraph).toHaveBeenCalled();
+    });
+    expect(
+      listRepoFindings.mock.calls.every(
+        ([params]) => (params as { severity?: string } | undefined)?.severity === 'critical'
+      )
+    ).toBe(true);
+    expect(
+      getRepoFindingsTrends.mock.calls.every(
+        ([params]) => (params as { severity?: string } | undefined)?.severity === 'critical'
+      )
+    ).toBe(true);
+    expect(
+      getRepoRiskGraph.mock.calls.every(
+        ([params]) => (params as { severity?: string } | undefined)?.severity === 'critical'
+      )
+    ).toBe(true);
+  });
+
   it('lets viewers dismiss a failed scan banner without deleting the scan', async () => {
     const failedScan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8847,6 +8847,83 @@ describe('ProductFindingsPage states', () => {
     ).toBe(false);
   });
 
+  it('clears a failed scan filter selected while removal is in flight', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-live-filter',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-live-filter-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-live-filter',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical live-filter finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+    const deleteCompletion = deferred<void>();
+
+    const { deleteRepoScan, listRepoFindings, getRepoRiskGraph } = await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+    deleteRepoScan.mockImplementation(() => deleteCompletion.promise);
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+    await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledWith(
+        failedScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
+    });
+
+    const repositoryScanFilter = screen.getByLabelText(/Repository scan/i) as HTMLSelectElement;
+    fireEvent.change(repositoryScanFilter, { target: { value: failedScan.id } });
+    await waitFor(() => {
+      expect(
+        listRepoFindings.mock.calls.some(
+          ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+        )
+      ).toBe(true);
+    });
+
+    listRepoFindings.mockClear();
+    getRepoRiskGraph.mockClear();
+    await act(async () => {
+      deleteCompletion.resolve();
+      await deleteCompletion.promise;
+    });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/Repository scan/i) as HTMLSelectElement).value).toBe('');
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(
+      listRepoFindings.mock.calls.some(
+        ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+      )
+    ).toBe(false);
+    expect(
+      getRepoRiskGraph.mock.calls.some(
+        ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+      )
+    ).toBe(false);
+  });
+
   it('lets viewers dismiss a failed scan banner without deleting the scan', async () => {
     const failedScan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -9551,7 +9551,7 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
-  it('falls back to single finding deletes when the bulk endpoint is not deployed yet', async () => {
+  it('does not report clear all success when the bulk endpoint is not deployed yet', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-clear-all-bulk-missing',
@@ -9584,7 +9584,7 @@ describe('ProductFindingsPage states', () => {
 
     const { deleteRepoFinding, deleteRepoFindings } = await renderFindings({
       repoScans: [scan],
-      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [] })
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [findings[1]] })
     });
     const { ApiError } = await import('./api/client');
     deleteRepoFindings.mockRejectedValueOnce(new ApiError('Request failed (404)', 404));
@@ -9598,25 +9598,13 @@ describe('ProductFindingsPage states', () => {
 
     await waitFor(() => {
       expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
-      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
-      expect(deleteRepoFinding).toHaveBeenNthCalledWith(
-        1,
-        findings[0].id,
-        scan.id,
-        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
-      );
-      expect(deleteRepoFinding).toHaveBeenNthCalledWith(
-        2,
-        findings[1].id,
-        scan.id,
-        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
-      );
+      expect(deleteRepoFinding).not.toHaveBeenCalled();
     });
-    await waitFor(() => {
-      expect(screen.queryByText('Fallback clearable token finding')).not.toBeInTheDocument();
-      expect(screen.queryByText('Fallback clearable workflow finding')).not.toBeInTheDocument();
-    });
-    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+    expect(await screen.findByText(/Clear all requires the bulk delete API/i)).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable workflow finding')).toBeInTheDocument();
+    expect(screen.queryByText('No exposure found')).not.toBeInTheDocument();
+    expect(within(confirmDialog).getByText(/2 visible findings/i)).toBeInTheDocument();
   });
 
   it('reloads repository findings after clearing a paged list', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8779,6 +8779,74 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('Historical workflow finding')).toBeInTheDocument();
   });
 
+  it('clears a selected failed scan filter before refreshing after removal', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-selected-filter',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-selected-filter-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-selected-filter',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical selected-filter finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    const { deleteRepoScan, listRepoFindings, getRepoRiskGraph } = await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    const repositoryScanFilter = screen.getByLabelText(/Repository scan/i) as HTMLSelectElement;
+    fireEvent.change(repositoryScanFilter, { target: { value: failedScan.id } });
+    await waitFor(() => {
+      expect(
+        listRepoFindings.mock.calls.some(
+          ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+        )
+      ).toBe(true);
+    });
+
+    listRepoFindings.mockClear();
+    getRepoRiskGraph.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoScan).toHaveBeenCalledWith(
+        failedScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
+      expect((screen.getByLabelText(/Repository scan/i) as HTMLSelectElement).value).toBe('');
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(
+      listRepoFindings.mock.calls.some(
+        ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+      )
+    ).toBe(false);
+    expect(
+      getRepoRiskGraph.mock.calls.some(
+        ([params]) => (params as { repo_scan_id?: string } | undefined)?.repo_scan_id === failedScan.id
+      )
+    ).toBe(false);
+  });
+
   it('lets viewers dismiss a failed scan banner without deleting the scan', async () => {
     const failedScan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -428,6 +428,17 @@ const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
 const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolved'] as const;
+type RepoFindingFilterSnapshot = {
+  repoScanFilter: string;
+  severityFilter: (typeof REPO_FINDING_SEVERITY_FILTERS)[number];
+  typeFilter: (typeof REPO_FINDING_TYPE_FILTERS)[number];
+  statusFilter: (typeof REPO_FINDING_STATUS_FILTERS)[number];
+  assigneeFilter: string;
+  sourceFilter: string;
+  minConfidenceFilter: string;
+  sortBy: (typeof REPO_FINDING_SORT_FIELDS)[number];
+  sortOrder: 'asc' | 'desc';
+};
 const ENVIRONMENT_QUERY_PARAM = 'environment';
 const OVERVIEW_FINDING_LIMIT = 50;
 const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
@@ -27814,6 +27825,17 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const [minConfidenceFilter, setMinConfidenceFilter] = useState('');
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const repoFindingFilterSnapshot: RepoFindingFilterSnapshot = {
+    repoScanFilter,
+    severityFilter,
+    typeFilter,
+    statusFilter,
+    assigneeFilter,
+    sourceFilter,
+    minConfidenceFilter,
+    sortBy,
+    sortOrder
+  };
   const [filtersExpanded, setFiltersExpanded] = useState(true);
   const [dismissedFailedScanKeys, setDismissedFailedScanKeys] = useState<Set<string>>(() =>
     readDismissedRepoFailedScanKeys()
@@ -27857,7 +27879,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const findDeleteRequestRef = useRef(0);
   const failedScanRemoveRequestRef = useRef(0);
   const currentScopeKeyRef = useRef(scopeKey);
-  const repoScanFilterRef = useRef(repoScanFilter);
+  const repoFindingFilterRef = useRef<RepoFindingFilterSnapshot>(repoFindingFilterSnapshot);
   const remediationPreviewRequestRef = useRef(0);
   const remediationPublishRequestRef = useRef(0);
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
@@ -27867,7 +27889,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const findingDeleteModalRef = useRef<HTMLElement | null>(null);
   const findingDeleteOpenerRef = useRef<HTMLElement | null>(null);
   currentScopeKeyRef.current = scopeKey;
-  repoScanFilterRef.current = repoScanFilter;
+  repoFindingFilterRef.current = repoFindingFilterSnapshot;
 
   const updateHierarchyOpenState = (
     level: 'repositories' | 'scans' | 'severities',
@@ -28124,7 +28146,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const loadRepoFindings = async (
     targetScope: ProductSession,
     mode: 'initial' | 'refresh',
-    overrides?: { repoScanFilter?: string }
+    overrides?: Partial<RepoFindingFilterSnapshot>
   ) => {
     const requestID = ++requestRef.current;
     if (mode === 'initial') {
@@ -28135,18 +28157,18 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     setError('');
     try {
       const auth = buildProductAuthContext(targetScope);
-      const sourceFilterValue = normalizeValue(sourceFilter).toLowerCase();
-      const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
-      const selectedRepoScanFilter = overrides?.repoScanFilter ?? repoScanFilter;
+      const filters = { ...repoFindingFilterRef.current, ...overrides };
+      const sourceFilterValue = normalizeValue(filters.sourceFilter).toLowerCase();
+      const normalizedMinConfidence = Number.parseFloat(normalizeValue(filters.minConfidenceFilter));
       const repoFindingRequest = {
-        repo_scan_id: normalizeValue(selectedRepoScanFilter) || undefined,
-        severity: severityFilter !== 'all' ? severityFilter : undefined,
-        type: typeFilter !== 'all' ? typeFilter : undefined,
+        repo_scan_id: normalizeValue(filters.repoScanFilter) || undefined,
+        severity: filters.severityFilter !== 'all' ? filters.severityFilter : undefined,
+        type: filters.typeFilter !== 'all' ? filters.typeFilter : undefined,
         source: sourceFilterValue || undefined,
-        assignee: normalizeValue(assigneeFilter) || undefined,
+        assignee: normalizeValue(filters.assigneeFilter) || undefined,
         min_confidence: Number.isFinite(normalizedMinConfidence) ? normalizedMinConfidence : undefined,
-        sort_by: sortBy,
-        sort_order: sortOrder
+        sort_by: filters.sortBy,
+        sort_order: filters.sortOrder
       };
 
       const [repoScanResponse, repoFindingResponse] = await Promise.all([
@@ -28157,7 +28179,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               {
                 ...repoFindingRequest,
                 limit: 100,
-                lifecycle_status: statusFilter !== 'all' ? statusFilter : undefined
+                lifecycle_status: filters.statusFilter !== 'all' ? filters.statusFilter : undefined
               },
               auth
             )
@@ -28195,7 +28217,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const loadTrendSignals = async (
     targetScope: ProductSession,
     mode: 'initial' | 'refresh',
-    overrides?: { repoScanFilter?: string }
+    overrides?: Partial<RepoFindingFilterSnapshot>
   ) => {
     const requestID = ++signalRequestRef.current;
     if (mode === 'initial') {
@@ -28208,11 +28230,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     setRiskGraphError('');
     try {
       const auth = buildProductAuthContext(targetScope);
-      const severity = severityFilter !== 'all' ? severityFilter : undefined;
-      const type = typeFilter !== 'all' ? typeFilter : undefined;
-      const selectedRepoScanFilter = overrides?.repoScanFilter ?? repoScanFilter;
-      const repoScanID = normalizeValue(selectedRepoScanFilter) || undefined;
-      const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
+      const filters = { ...repoFindingFilterRef.current, ...overrides };
+      const severity = filters.severityFilter !== 'all' ? filters.severityFilter : undefined;
+      const type = filters.typeFilter !== 'all' ? filters.typeFilter : undefined;
+      const repoScanID = normalizeValue(filters.repoScanFilter) || undefined;
+      const normalizedMinConfidence = Number.parseFloat(normalizeValue(filters.minConfidenceFilter));
       const minConfidence = Number.isFinite(normalizedMinConfidence) ? normalizedMinConfidence : undefined;
       const [trendResult, riskGraphResult] = await Promise.allSettled([
         apiClient.getRepoFindingsTrends(
@@ -28747,16 +28769,17 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         writeDismissedRepoFailedScanKeys(next);
         return next;
       });
-      const refreshOverrides = normalizeValue(repoScanFilterRef.current) === scan.id ? { repoScanFilter: '' } : undefined;
-      if (refreshOverrides) {
-        repoScanFilterRef.current = '';
+      const refreshOverrides: RepoFindingFilterSnapshot = { ...repoFindingFilterRef.current };
+      if (normalizeValue(refreshOverrides.repoScanFilter) === scan.id) {
+        refreshOverrides.repoScanFilter = '';
+        repoFindingFilterRef.current = { ...repoFindingFilterRef.current, repoScanFilter: '' };
         setRepoScanFilter('');
       }
       await loadRepoFindings(targetScope, 'refresh', refreshOverrides);
       if (!isActiveRequest()) {
         return;
       }
-      await loadTrendSignals(targetScope, 'refresh', refreshOverrides);
+      await loadTrendSignals(targetScope, 'refresh', repoFindingFilterRef.current);
     } catch (requestError) {
       if (!isActiveRequest()) {
         return;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1292,6 +1292,13 @@ function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
   };
 }
 
+function productSessionKey(scope: ProductSession | null | undefined): string {
+  if (!scope) {
+    return '';
+  }
+  return `${scope.tenantID}:${scope.workspaceID}:${scope.projectID ?? ''}`;
+}
+
 function normalizeMemberID(value: string): string {
   const normalized = value
     .toLowerCase()
@@ -1665,6 +1672,41 @@ export async function deleteRepoFindingTargetsInBatches(
     }
   }
   return { response: mergeRepoFindingsBulkDeleteResponses(responses) };
+}
+
+function isUnsupportedDeleteEndpointError(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 404 || error.status === 405);
+}
+
+async function deleteRepoFindingTargetsWithCompatibilityFallback(
+  targets: RepoFindingDeleteTarget[],
+  auth: RequestAuthContext
+): Promise<RepoFindingBulkDeleteBatchResult> {
+  try {
+    return await deleteRepoFindingTargetsInBatches(targets, (batch) => apiClient.deleteRepoFindings(batch, auth));
+  } catch (error) {
+    if (!isUnsupportedDeleteEndpointError(error)) {
+      throw error;
+    }
+  }
+
+  const failed: NonNullable<RepoFindingsBulkDeleteResponse['failed']> = [];
+  const response: RepoFindingsBulkDeleteResponse = { deleted: [], failed };
+  for (const target of targets) {
+    try {
+      await apiClient.deleteRepoFinding(target.finding_id, target.repo_scan_id, auth);
+      response.deleted.push(target);
+    } catch (fallbackError) {
+      failed.push({
+        ...target,
+        error: formatAPIError(fallbackError, 'Failed to delete finding.')
+      });
+    }
+  }
+  return {
+    response,
+    errorMessage: failed[0]?.error
+  };
 }
 
 function repoFindingDeleteTargetKey(target: RepoFindingDeleteTarget): string {
@@ -27683,6 +27725,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const location = useLocation();
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
+  const scopeKey = productSessionKey(scope);
   const { me } = useMe();
 
   const [loading, setLoading] = useState(true);
@@ -27711,6 +27754,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const [dismissedFailedScanKeys, setDismissedFailedScanKeys] = useState<Set<string>>(() =>
     readDismissedRepoFailedScanKeys()
   );
+  const [removingFailedScanID, setRemovingFailedScanID] = useState('');
   const [hierarchyOpenState, setHierarchyOpenState] = useState<{
     repositories: Set<string>;
     scans: Set<string>;
@@ -27747,6 +27791,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const requestRef = useRef(0);
   const signalRequestRef = useRef(0);
   const findDeleteRequestRef = useRef(0);
+  const failedScanRemoveRequestRef = useRef(0);
+  const currentScopeKeyRef = useRef(scopeKey);
   const remediationPreviewRequestRef = useRef(0);
   const remediationPublishRequestRef = useRef(0);
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
@@ -27755,6 +27801,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const findingDeleteCloseRef = useRef<HTMLButtonElement | null>(null);
   const findingDeleteModalRef = useRef<HTMLElement | null>(null);
   const findingDeleteOpenerRef = useRef<HTMLElement | null>(null);
+  currentScopeKeyRef.current = scopeKey;
 
   const updateHierarchyOpenState = (
     level: 'repositories' | 'scans' | 'severities',
@@ -27999,6 +28046,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const mttrSeconds = repoFindingSummary?.mean_time_to_resolve_seconds;
   const mttrLabel = typeof mttrSeconds === 'number' && Number.isFinite(mttrSeconds) ? formatExecutiveDuration(mttrSeconds) : 'N/A';
   const canDeleteRepoFindings = hasRepoFindingDeleteAccess(me);
+  const canRemoveFailedRepoScans = canDeleteRepoFindings;
   const activeDeleteCandidates = bulkDeleteCandidates.length > 0
     ? bulkDeleteCandidates
     : deleteCandidate
@@ -28235,9 +28283,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const { response, errorMessage } = await deleteRepoFindingTargetsInBatches(
+        const { response, errorMessage } = await deleteRepoFindingTargetsWithCompatibilityFallback(
           candidates.map(repoFindingDeleteTargetFromFinding),
-          (batch) => apiClient.deleteRepoFindings(batch, auth)
+          auth
         );
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
         const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
@@ -28437,6 +28485,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   };
 
   useEffect(() => {
+    failedScanRemoveRequestRef.current += 1;
+    setRemovingFailedScanID('');
+  }, [scopeKey]);
+
+  useEffect(() => {
     if (!scope) {
       setLoading(false);
       setError('Workspace route context is missing.');
@@ -28582,7 +28635,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     void loadTrendSignals(scope, 'refresh');
   };
 
-  const dismissFailedRepoScan = (scan: RepoScanRecord | null) => {
+  const hideFailedRepoScan = (scan: RepoScanRecord | null) => {
     if (!scan) {
       return;
     }
@@ -28592,6 +28645,51 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       writeDismissedRepoFailedScanKeys(next);
       return next;
     });
+  };
+
+  const removeFailedRepoScan = async (scan: RepoScanRecord | null) => {
+    if (!scope || !scan || removingFailedScanID) {
+      return;
+    }
+    const targetScope = scope;
+    const targetScopeKey = productSessionKey(targetScope);
+    const requestID = ++failedScanRemoveRequestRef.current;
+    const isActiveRequest = () =>
+      failedScanRemoveRequestRef.current === requestID && currentScopeKeyRef.current === targetScopeKey;
+    const auth = buildProductAuthContext(targetScope);
+    setRemovingFailedScanID(scan.id);
+    setError('');
+    try {
+      await apiClient.deleteRepoScan(scan.id, auth);
+      if (!isActiveRequest()) {
+        return;
+      }
+      setRepoScans((current) => current.filter((item) => item.id !== scan.id));
+      setDismissedFailedScanKeys((current) => {
+        const next = new Set(current);
+        next.add(failedRepoScanDismissalKey(targetScope, scan.id));
+        writeDismissedRepoFailedScanKeys(next);
+        return next;
+      });
+      await loadRepoFindings(targetScope, 'refresh');
+      if (!isActiveRequest()) {
+        return;
+      }
+      await loadTrendSignals(targetScope, 'refresh');
+    } catch (requestError) {
+      if (!isActiveRequest()) {
+        return;
+      }
+      if (isUnsupportedDeleteEndpointError(requestError)) {
+        hideFailedRepoScan(scan);
+        return;
+      }
+      setError(formatAPIError(requestError, 'Failed to remove failed scan.'));
+    } finally {
+      if (isActiveRequest()) {
+        setRemovingFailedScanID('');
+      }
+    }
   };
 
   const connectPath = buildScopedPath(scope, 'github/connect');
@@ -28707,13 +28805,24 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               <Link className="idt-app-empty-state-action" to={connectPath}>
                 Review &amp; re-run scan
               </Link>
-              <button
-                className="idt-btn idt-btn-ghost"
-                type="button"
-                onClick={() => dismissFailedRepoScan(latestFailedScan)}
-              >
-                Remove
-              </button>
+              {canRemoveFailedRepoScans ? (
+                <button
+                  className="idt-btn idt-btn-ghost"
+                  type="button"
+                  onClick={() => void removeFailedRepoScan(latestFailedScan)}
+                  disabled={Boolean(removingFailedScanID)}
+                >
+                  {removingFailedScanID === latestFailedScan?.id ? 'Removing...' : 'Remove'}
+                </button>
+              ) : (
+                <button
+                  className="idt-btn idt-btn-ghost"
+                  type="button"
+                  onClick={() => hideFailedRepoScan(latestFailedScan)}
+                >
+                  Dismiss
+                </button>
+              )}
               <button
                 className="idt-btn idt-btn-ghost"
                 type="button"
@@ -28802,13 +28911,24 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         <div className="idt-app-alert idt-app-alert-error idt-repo-scan-health">
           <span>Last scan failed: {describeScanFailure(latestFailedScan)}</span>
           <span className="idt-repo-scan-health-actions-inline">
-            <button
-              className="idt-repo-scan-health-remove"
-              type="button"
-              onClick={() => dismissFailedRepoScan(latestFailedScan)}
-            >
-              Remove
-            </button>
+            {canRemoveFailedRepoScans ? (
+              <button
+                className="idt-repo-scan-health-remove"
+                type="button"
+                onClick={() => void removeFailedRepoScan(latestFailedScan)}
+                disabled={Boolean(removingFailedScanID)}
+              >
+                {removingFailedScanID === latestFailedScan?.id ? 'Removing...' : 'Remove'}
+              </button>
+            ) : (
+              <button
+                className="idt-repo-scan-health-remove"
+                type="button"
+                onClick={() => hideFailedRepoScan(latestFailedScan)}
+              >
+                Dismiss
+              </button>
+            )}
             <Link to={connectPath}>Review &amp; re-run</Link>
           </span>
         </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -28123,7 +28123,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const bulkDeleteActive = bulkDeleteCandidates.length > 0;
   const deleteActionsDisabled = deleteLoading || refreshing || signalsRefreshing;
 
-  const loadRepoFindings = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
+  const loadRepoFindings = async (
+    targetScope: ProductSession,
+    mode: 'initial' | 'refresh',
+    overrides?: { repoScanFilter?: string }
+  ) => {
     const requestID = ++requestRef.current;
     if (mode === 'initial') {
       setLoading(true);
@@ -28135,8 +28139,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       const auth = buildProductAuthContext(targetScope);
       const sourceFilterValue = normalizeValue(sourceFilter).toLowerCase();
       const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
+      const selectedRepoScanFilter = overrides?.repoScanFilter ?? repoScanFilter;
       const repoFindingRequest = {
-        repo_scan_id: normalizeValue(repoScanFilter) || undefined,
+        repo_scan_id: normalizeValue(selectedRepoScanFilter) || undefined,
         severity: severityFilter !== 'all' ? severityFilter : undefined,
         type: typeFilter !== 'all' ? typeFilter : undefined,
         source: sourceFilterValue || undefined,
@@ -28189,7 +28194,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     }
   };
 
-  const loadTrendSignals = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
+  const loadTrendSignals = async (
+    targetScope: ProductSession,
+    mode: 'initial' | 'refresh',
+    overrides?: { repoScanFilter?: string }
+  ) => {
     const requestID = ++signalRequestRef.current;
     if (mode === 'initial') {
       setSignalsLoading(true);
@@ -28203,7 +28212,8 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       const auth = buildProductAuthContext(targetScope);
       const severity = severityFilter !== 'all' ? severityFilter : undefined;
       const type = typeFilter !== 'all' ? typeFilter : undefined;
-      const repoScanID = normalizeValue(repoScanFilter) || undefined;
+      const selectedRepoScanFilter = overrides?.repoScanFilter ?? repoScanFilter;
+      const repoScanID = normalizeValue(selectedRepoScanFilter) || undefined;
       const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
       const minConfidence = Number.isFinite(normalizedMinConfidence) ? normalizedMinConfidence : undefined;
       const [trendResult, riskGraphResult] = await Promise.allSettled([
@@ -28739,11 +28749,15 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         writeDismissedRepoFailedScanKeys(next);
         return next;
       });
-      await loadRepoFindings(targetScope, 'refresh');
+      const refreshOverrides = normalizeValue(repoScanFilter) === scan.id ? { repoScanFilter: '' } : undefined;
+      if (refreshOverrides) {
+        setRepoScanFilter('');
+      }
+      await loadRepoFindings(targetScope, 'refresh', refreshOverrides);
       if (!isActiveRequest()) {
         return;
       }
-      await loadTrendSignals(targetScope, 'refresh');
+      await loadTrendSignals(targetScope, 'refresh', refreshOverrides);
     } catch (requestError) {
       if (!isActiveRequest()) {
         return;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1680,7 +1680,10 @@ function isUnsupportedDeleteEndpointError(error: unknown): boolean {
   return error instanceof ApiError && (error.status === 404 || error.status === 405);
 }
 
-async function deleteRepoFindingTargetsWithCompatibilityFallback(
+const UNSUPPORTED_REPO_FINDING_BULK_DELETE_MESSAGE =
+  'Clear all requires the bulk delete API. Delete findings individually or update the API.';
+
+async function deleteRepoFindingTargetsWithBulkEndpoint(
   targets: RepoFindingDeleteTarget[],
   auth: RequestAuthContext
 ): Promise<RepoFindingBulkDeleteBatchResult> {
@@ -1692,22 +1695,15 @@ async function deleteRepoFindingTargetsWithCompatibilityFallback(
     }
   }
 
-  const failed: NonNullable<RepoFindingsBulkDeleteResponse['failed']> = [];
-  const response: RepoFindingsBulkDeleteResponse = { deleted: [], failed };
-  for (const target of targets) {
-    try {
-      await apiClient.deleteRepoFinding(target.finding_id, target.repo_scan_id, auth);
-      response.deleted.push(target);
-    } catch (fallbackError) {
-      failed.push({
-        ...target,
-        error: formatAPIError(fallbackError, 'Failed to delete finding.')
-      });
-    }
-  }
   return {
-    response,
-    errorMessage: failed[0]?.error
+    response: {
+      deleted: [],
+      failed: targets.map((target) => ({
+        ...target,
+        error: UNSUPPORTED_REPO_FINDING_BULK_DELETE_MESSAGE
+      }))
+    },
+    errorMessage: UNSUPPORTED_REPO_FINDING_BULK_DELETE_MESSAGE
   };
 }
 
@@ -28361,7 +28357,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const { response, errorMessage } = await deleteRepoFindingTargetsWithCompatibilityFallback(
+        const { response, errorMessage } = await deleteRepoFindingTargetsWithBulkEndpoint(
           candidates.map(repoFindingDeleteTargetFromFinding),
           auth
         );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -27857,6 +27857,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const findDeleteRequestRef = useRef(0);
   const failedScanRemoveRequestRef = useRef(0);
   const currentScopeKeyRef = useRef(scopeKey);
+  const repoScanFilterRef = useRef(repoScanFilter);
   const remediationPreviewRequestRef = useRef(0);
   const remediationPublishRequestRef = useRef(0);
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
@@ -27866,6 +27867,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const findingDeleteModalRef = useRef<HTMLElement | null>(null);
   const findingDeleteOpenerRef = useRef<HTMLElement | null>(null);
   currentScopeKeyRef.current = scopeKey;
+  repoScanFilterRef.current = repoScanFilter;
 
   const updateHierarchyOpenState = (
     level: 'repositories' | 'scans' | 'severities',
@@ -28745,8 +28747,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         writeDismissedRepoFailedScanKeys(next);
         return next;
       });
-      const refreshOverrides = normalizeValue(repoScanFilter) === scan.id ? { repoScanFilter: '' } : undefined;
+      const refreshOverrides = normalizeValue(repoScanFilterRef.current) === scan.id ? { repoScanFilter: '' } : undefined;
       if (refreshOverrides) {
+        repoScanFilterRef.current = '';
         setRepoScanFilter('');
       }
       await loadRepoFindings(targetScope, 'refresh', refreshOverrides);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27884,11 +27884,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-link-copy {
   display: grid;
   min-width: 0;
-  align-self: stretch;
+  align-self: center;
   align-content: center;
-  justify-items: center;
+  justify-items: start;
   gap: 0.08rem;
-  text-align: center;
+  text-align: left;
 }
 
 .idt-domain-flyout-link-copy strong {
@@ -27944,11 +27944,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 .idt-domain-flyout-nested summary > span {
   display: grid;
   min-width: 0;
-  align-self: stretch;
+  align-self: center;
   align-content: center;
-  justify-items: center;
+  justify-items: start;
   gap: 0.1rem;
-  text-align: center;
+  text-align: left;
 }
 
 .idt-domain-flyout-nested summary strong {
@@ -27958,7 +27958,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary svg {
   justify-self: end;
-  align-self: start;
+  align-self: center;
   display: block;
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
## Summary
- make repository finding deletes remove the full lifecycle group so older duplicates cannot reappear after deleting the visible row
- keep Clear all on the scalable bulk-delete path, with a 404/405 compatibility fallback to single deletes for older deployments
- add persistent failed-scan removal via DELETE /v1/repo-scans/:id with authz/OpenAPI coverage
- align the side flyout labels and chevrons, then verify with Playwright measurements

## Testing
- `go test ./internal/db ./internal/api`
- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx -t "delete|Delete|Remove|clear all|failed scan|failed repository scans"` from `web/`
- `npm run build` from `web/`
- Playwright visual check on the flyout fixture: labels are left-aligned, label inset is 10-11px, and every chevron measured `iconCenterDelta: 0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes findings cleanup and failed-scan UX. Deletes now remove the full lifecycle group server-side; operators can remove failed scans, “Clear all” is guarded when the bulk API isn’t deployed, and refresh after removal uses live filters while clearing any failed-scan filter.

- **New Features**
  - Added DELETE `/v1/repo-scans/{repo_scan_id}` (authz `repo_scans.run`) to remove failed scans and cascade attached findings; returns 204/404/409 with OpenAPI and route policy updates. Wired `apiClient.deleteRepoScan()` with “Remove” (loading) for operators and “Dismiss” for viewers; on 404/405 we hide the banner. After removal, the page refreshes findings, trends, and risk using current filters, and clears a failed-scan filter (even if it was selected during or before removal).

- **Bug Fixes**
  - Repo finding deletes (single and bulk) expand server-side to the full lifecycle group across scans with proper authorization; single delete returns 404 when no targets.
  - “Clear all” is guarded: when the bulk delete endpoint isn’t available (404/405), we show a clear message and do not fall back to per-item deletes. Also aligns side flyout labels and chevrons for consistent left alignment.

<sup>Written for commit f3aa298eb5026fc1e9a1d9676d3a304a729e9722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

No issue: follow-up cleanup for findings cleanup controls.
