### PR TITLE
Add AWS runtime timeline UX

### DIFF
--- a/docs/aws-runtime-events.md
+++ b/docs/aws-runtime-events.md
@@ -64,6 +64,42 @@ The response is returned as `{ "runtime": ... }` and includes:
 - graph relationships from observed actors, runtime sessions, chained actors, or agents to target resources
 - explicit diagnostics, coverage gaps, failure reasons, and remediation hints
 
+## App runtime timeline UX (#1554)
+
+The AWS Runtime app page now presents the runtime envelope as a metadata-only
+timeline before the raw event table. The timeline keeps the existing API
+contract intact and composes records from the runtime events endpoint with the
+Secrets Manager/KMS, S3, agent-runtime, remediation-case, live-action, and
+post-remediation verification envelopes when those responses are available.
+
+Each timeline entry shows only:
+
+- event type, event name, action, observed timestamp, status, and confidence
+- actor principal ARN / identity node ID and STS session lineage metadata
+- SourceIdentity, role-session name, original actor, chained actor, and lineage state when supplied
+- target resource metadata such as ARN, node ID, resource type, or redacted display name
+- evidence refs and the explicit redaction boundary
+
+The correlation highlight block is likewise metadata-only. It surfaces observed
+event IDs, session IDs, action names, safe S3 prefixes, static source labels,
+agent/tool identifiers, and correlation status. It never renders secret values,
+decrypted plaintext, object bodies, object keys, prompts, completions, tool
+payloads, browser pages, code-interpreter output, database rows, or customer
+payloads.
+
+The remediation marker block joins before/after refs from remediation cases,
+low-risk live-action projections, and post-remediation verification records.
+These markers are audit/projection metadata only. They do not imply the app has
+mutated AWS state, and they preserve the same tenant/workspace/project/
+connector/account/region scope as the source envelope.
+
+The runtime filter bar supports the API-backed `event_type`, `evidence`,
+`owner`, and `status` filters plus local text search. Filtered timeline entries
+and raw rows share the same client-side filter normalization so CloudTrail,
+STS, Secrets Manager, KMS, agent-tool, IAM last-used, Access Analyzer, observed,
+delayed, permission-denied, resolved, archived, and stale states stay aligned
+between the app and API request.
+
 ## Safety boundaries
 
 The runtime contract is read-only and metadata-only. It must not read, expose,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -6920,10 +6920,12 @@ describe('Domain-first app routes', () => {
     );
     expect(screen.getByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
     expect(screen.queryByText(/CloudTrail: GetObject/i)).not.toBeInTheDocument();
-    expect(within(runtimeTimeline).queryByText(/Secret · prod\/ai\/openai-key/i)).not.toBeInTheDocument();
-    expect(within(runtimeTimeline).queryByText(/S3 · billing-artifacts-123456789012/i)).not.toBeInTheDocument();
-    expect(within(runtimeTimeline).queryByText(/Agent · runtime-case-triage · case-router/i)).not.toBeInTheDocument();
-    expect(within(runtimeTimeline).queryByText(/Case · Rotate external credential for support-assistant/i)).not.toBeInTheDocument();
+    const staleRuntimeTimeline = screen.getByRole('region', { name: 'AWS runtime correlation timeline' });
+    expect(within(staleRuntimeTimeline).getByText(/Access Analyzer.*Finding/i)).toBeInTheDocument();
+    expect(within(staleRuntimeTimeline).queryByText(/Secret · prod\/ai\/openai-key/i)).not.toBeInTheDocument();
+    expect(within(staleRuntimeTimeline).queryByText(/S3 · billing-artifacts-123456789012/i)).not.toBeInTheDocument();
+    expect(within(staleRuntimeTimeline).queryByText(/Agent · runtime-case-triage · case-router/i)).not.toBeInTheDocument();
+    expect(within(staleRuntimeTimeline).queryByText(/Case · Rotate external credential for support-assistant/i)).not.toBeInTheDocument();
   });
 
   it('shows AWS limited enforcement framework on the governance route', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -644,27 +644,75 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
   confidence: 0.92,
   applied_filters: {},
   summary: {
-    total_events: 3,
-    filtered_events: 3,
-    event_type_counts: { 'api-call': 1, 'agent-tool': 1, 'access-analyzer': 1 },
-    status_counts: { observed: 3 },
-    owner_counts: { security: 3 },
+    total_events: 6,
+    filtered_events: 6,
+    event_type_counts: { 'sts-session': 1, 'api-call': 1, 'secret-read': 1, 'kms-decrypt': 1, 'agent-tool': 1, 'access-analyzer': 1 },
+    status_counts: { observed: 5, stale: 1 },
+    owner_counts: { security: 6 },
     account_count: 1,
     region_count: 1,
-    identity_count: 1,
-    resource_count: 3,
+    identity_count: 3,
+    resource_count: 5,
     agent_event_count: 1,
-    secret_read_count: 0,
-    kms_decrypt_count: 0,
+    secret_read_count: 1,
+    kms_decrypt_count: 1,
     api_call_count: 1,
-    sts_session_count: 0,
+    sts_session_count: 1,
     iam_last_used_signal_count: 0,
     access_analyzer_finding_count: 1,
     dormant_access_count: 0,
-    relationship_count: 2,
+    lineage_resolved_count: 1,
+    missing_source_identity_count: 0,
+    ambiguous_lineage_count: 0,
+    relationship_count: 5,
     permission_denied_events: 0
   },
   records: [
+    {
+      event_id: 'evt-assume-role',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'sts-session',
+      event_source: 'sts.amazonaws.com',
+      event_name: 'AssumeRole',
+      action: 'sts:AssumeRole',
+      actor_principal_arn: 'arn:aws:iam::123456789012:user/billing-operator',
+      actor_principal_type: 'iam_user',
+      actor_identity_node_id: 'aws:identity:user/billing-operator',
+      session: {
+        session_id: 'sess-invoice-agent',
+        session_node_id: 'aws:runtime-session:sess-invoice-agent',
+        principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        principal_type: 'assumed_role',
+        assumed_role_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        session_issuer_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        source_identity: 'billing-operator@example.com',
+        role_session_name: 'invoice-agent-run',
+        session_tag_keys: ['tenant', 'job'],
+        transitive_tag_keys: ['tenant'],
+        original_actor_arn: 'arn:aws:iam::123456789012:user/billing-operator',
+        original_actor_node_id: 'aws:identity:user/billing-operator',
+        lineage_status: 'resolved',
+        lineage_reason: 'SourceIdentity and role session name matched the CloudTrail STS event.',
+        source_ip_address: '203.0.113.10',
+        user_agent: 'aws-sdk-js/3',
+        started_at: '2026-06-14T17:00:00Z',
+        expires_at: '2026-06-14T18:00:00Z'
+      },
+      target_resource_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      target_resource_type: 'AWS::IAM::Role',
+      target_resource_name: 'lambda-invoice-agent',
+      resource_node_id: 'aws:identity:lambda-invoice-agent',
+      owner: 'security',
+      evidence_category: 'cloudtrail',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-assume-role',
+      confidence: 0.93,
+      observed_at: '2026-06-14T17:01:00Z',
+      collected_at: '2026-06-14T17:03:00Z',
+      status: 'observed',
+      next_action: 'Use the resolved STS lineage to correlate downstream actions.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    },
     {
       event_id: 'evt-s3-access',
       account_id: '123456789012',
@@ -678,9 +726,17 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
       actor_identity_node_id: 'aws:identity:lambda-invoice-agent',
       session: {
         session_id: 'sess-invoice-agent',
+        session_node_id: 'aws:runtime-session:sess-invoice-agent',
         principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
         principal_type: 'assumed_role',
-        started_at: '2026-06-14T17:00:00Z'
+        source_identity: 'billing-operator@example.com',
+        role_session_name: 'invoice-agent-run',
+        original_actor_arn: 'arn:aws:iam::123456789012:user/billing-operator',
+        original_actor_node_id: 'aws:identity:user/billing-operator',
+        lineage_status: 'resolved',
+        lineage_reason: 'Downstream data event reused the resolved STS session.',
+        started_at: '2026-06-14T17:00:00Z',
+        expires_at: '2026-06-14T18:00:00Z'
       },
       target_resource_arn: 'arn:aws:s3:::billing-artifacts-123456789012/reports/redacted',
       target_resource_type: 's3_object_metadata',
@@ -695,6 +751,84 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
       status: 'observed',
       next_action: 'Correlate runtime evidence with identity and resource graph context.',
       redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    },
+    {
+      event_id: 'evt-secret-read',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'secret-read',
+      event_source: 'secretsmanager.amazonaws.com',
+      event_name: 'GetSecretValue',
+      action: 'secretsmanager:GetSecretValue',
+      actor_principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      actor_principal_type: 'assumed_role',
+      actor_identity_node_id: 'aws:identity:lambda-invoice-agent',
+      session: {
+        session_id: 'sess-invoice-agent',
+        session_node_id: 'aws:runtime-session:sess-invoice-agent',
+        principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        principal_type: 'assumed_role',
+        source_identity: 'billing-operator@example.com',
+        role_session_name: 'invoice-agent-run',
+        original_actor_arn: 'arn:aws:iam::123456789012:user/billing-operator',
+        original_actor_node_id: 'aws:identity:user/billing-operator',
+        lineage_status: 'resolved',
+        lineage_reason: 'Secret read reused the resolved STS session.',
+        started_at: '2026-06-14T17:00:00Z',
+        expires_at: '2026-06-14T18:00:00Z'
+      },
+      target_resource_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/ai/openai-key',
+      target_resource_type: 'AWS::SecretsManager::Secret',
+      target_resource_name: 'prod/ai/openai-key',
+      resource_node_id: 'aws:runtime-resource:aws--secretsmanager--secret:openai-key',
+      owner: 'security',
+      evidence_category: 'cloudtrail',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-secret-read',
+      confidence: 0.91,
+      observed_at: '2026-06-14T17:16:00Z',
+      collected_at: '2026-06-14T17:18:00Z',
+      status: 'observed',
+      next_action: 'Join the secret read with static secret reachability and rotation evidence.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
+    },
+    {
+      event_id: 'evt-kms-decrypt',
+      account_id: '123456789012',
+      region: 'us-east-1',
+      event_type: 'kms-decrypt',
+      event_source: 'kms.amazonaws.com',
+      event_name: 'Decrypt',
+      action: 'kms:Decrypt',
+      actor_principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+      actor_principal_type: 'assumed_role',
+      actor_identity_node_id: 'aws:identity:lambda-invoice-agent',
+      session: {
+        session_id: 'sess-invoice-agent',
+        session_node_id: 'aws:runtime-session:sess-invoice-agent',
+        principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+        principal_type: 'assumed_role',
+        source_identity: 'billing-operator@example.com',
+        role_session_name: 'invoice-agent-run',
+        original_actor_arn: 'arn:aws:iam::123456789012:user/billing-operator',
+        original_actor_node_id: 'aws:identity:user/billing-operator',
+        lineage_status: 'resolved',
+        lineage_reason: 'KMS decrypt reused the resolved STS session.',
+        started_at: '2026-06-14T17:00:00Z',
+        expires_at: '2026-06-14T18:00:00Z'
+      },
+      target_resource_arn: 'arn:aws:kms:us-east-1:123456789012:key/openai-provider',
+      target_resource_type: 'AWS::KMS::Key',
+      target_resource_name: 'openai-provider',
+      resource_node_id: 'aws:runtime-resource:kms-key:openai-provider',
+      owner: 'security',
+      evidence_category: 'cloudtrail',
+      evidence_ref: 'runtime-evidence://123456789012/us-east-1/evt-kms-decrypt',
+      confidence: 0.91,
+      observed_at: '2026-06-14T17:16:30Z',
+      collected_at: '2026-06-14T17:18:00Z',
+      status: 'observed',
+      next_action: 'Join the decrypt event with static KMS reachability.',
+      redaction_boundary: 'metadata_only_no_payloads_no_secret_values_no_decrypted_plaintext'
     },
     {
       event_id: 'evt-agent-tool',
@@ -761,7 +895,7 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
       confidence: 0.9,
       observed_at: '2026-06-14T17:49:00Z',
       collected_at: '2026-06-14T17:58:00Z',
-      status: 'observed',
+      status: 'stale',
       next_action: 'Review Access Analyzer scope and finding status before trusting or remediating access.',
       redaction_boundary: 'metadata_only_no_payloads_no_secret_values'
     }
@@ -3796,6 +3930,7 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const s3RuntimeRecord = readyAWSRuntimeEvents.records.find((record) => record.event_id === 'evt-s3-access') ?? readyAWSRuntimeEvents.records[0];
     const machineIdentityDetail = {
       tenant_id: 'tenant-a',
       workspace_id: 'workspace-a',
@@ -3853,7 +3988,7 @@ describe('Domain-first app routes', () => {
       findings: [],
       governance_decisions: [],
       relationships: [],
-      runtime: { ...readyAWSRuntimeEvents, records: [readyAWSRuntimeEvents.records[0]] },
+      runtime: { ...readyAWSRuntimeEvents, records: [s3RuntimeRecord] },
       permissions: readyAWSLeastPrivilege,
       secrets: { findings: [] },
       blast_radius: { findings: [] },
@@ -4835,13 +4970,208 @@ describe('Domain-first app routes', () => {
       .spyOn(api.apiClient, 'getAWSProjectRuntimeEvents')
       .mockResolvedValue({ runtime: readyAWSRuntimeEvents });
     vi.spyOn(api.apiClient, 'getAWSProjectSecretsKMSRuntimeAccess').mockResolvedValue({
-      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+      correlation: {
+        status: 'ready',
+        fixture_state: 'success',
+        confidence: 0.91,
+        applied_filters: {},
+        summary: {
+          total_correlations: 2,
+          filtered_correlations: 2,
+          status_counts: { confirmed: 2 },
+          confirmed_count: 2,
+          observed_without_grant_count: 0,
+          granted_unused_count: 0,
+          secret_correlation_count: 1,
+          kms_key_correlation_count: 1,
+          identity_count: 1,
+          resource_count: 2,
+          observed_access_count: 2,
+          static_grant_count: 2,
+          relationship_count: 2
+        },
+        records: [
+          {
+            correlation_id: 'secret-openai-key',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:identity:lambda-invoice-agent',
+            principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+            resource_kind: 'secret',
+            resource_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/ai/openai-key',
+            resource_name: 'prod/ai/openai-key',
+            resource_node_id: 'aws:runtime-resource:aws--secretsmanager--secret:openai-key',
+            status: 'confirmed',
+            confidence: 0.91,
+            observed_count: 1,
+            observed_event_ids: ['evt-secret-read'],
+            actions: ['secretsmanager:GetSecretValue'],
+            session_ids: ['sess-invoice-agent'],
+            first_observed_at: '2026-06-14T17:16:00Z',
+            last_observed_at: '2026-06-14T17:16:00Z',
+            static_sources: ['identity_policy'],
+            evidence_ref: 'secrets-kms-runtime-access://secret-openai-key',
+            evidence_refs: ['runtime-evidence://123456789012/us-east-1/evt-secret-read'],
+            next_action: 'Review secret read scope before approving rotation.',
+            redaction_boundary: 'metadata_only_no_secret_values_no_decrypted_plaintext'
+          },
+          {
+            correlation_id: 'kms-openai-provider',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:identity:lambda-invoice-agent',
+            principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+            resource_kind: 'kms_key',
+            resource_arn: 'arn:aws:kms:us-east-1:123456789012:key/openai-provider',
+            resource_name: 'openai-provider',
+            resource_node_id: 'aws:runtime-resource:kms-key:openai-provider',
+            status: 'confirmed',
+            confidence: 0.91,
+            observed_count: 1,
+            observed_event_ids: ['evt-kms-decrypt'],
+            actions: ['kms:Decrypt'],
+            session_ids: ['sess-invoice-agent'],
+            first_observed_at: '2026-06-14T17:16:30Z',
+            last_observed_at: '2026-06-14T17:16:30Z',
+            static_sources: ['identity_policy'],
+            evidence_ref: 'secrets-kms-runtime-access://kms-openai-provider',
+            evidence_refs: ['runtime-evidence://123456789012/us-east-1/evt-kms-decrypt'],
+            next_action: 'Review decrypt scope before approving key policy changes.',
+            redaction_boundary: 'metadata_only_no_secret_values_no_decrypted_plaintext'
+          }
+        ],
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
     });
     vi.spyOn(api.apiClient, 'getAWSProjectS3RuntimeAccess').mockResolvedValue({
-      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+      correlation: {
+        status: 'ready',
+        fixture_state: 'success',
+        confidence: 0.9,
+        applied_filters: {},
+        summary: {
+          total_correlations: 1,
+          filtered_correlations: 1,
+          status_counts: { confirmed: 1 },
+          confirmed_count: 1,
+          observed_without_grant_count: 0,
+          granted_unused_count: 0,
+          read_count: 1,
+          write_count: 0,
+          list_count: 0,
+          sensitive_exposed_count: 0,
+          mode_exceeds_grant_count: 0,
+          identity_count: 1,
+          bucket_count: 1,
+          observed_access_count: 1,
+          static_grant_count: 1,
+          relationship_count: 1
+        },
+        records: [
+          {
+            correlation_id: 's3-billing-artifacts',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_node_id: 'aws:identity:lambda-invoice-agent',
+            principal_arn: 'arn:aws:iam::123456789012:role/lambda-invoice-agent',
+            bucket_arn: 'arn:aws:s3:::billing-artifacts-123456789012',
+            bucket_name: 'billing-artifacts-123456789012',
+            resource_node_id: 'aws:runtime-resource:s3-bucket:billing-artifacts',
+            status: 'confirmed',
+            confidence: 0.9,
+            observed_count: 1,
+            observed_event_ids: ['evt-s3-access'],
+            observed_modes: ['read'],
+            granted_modes: ['read'],
+            safe_prefixes: ['reports/redacted'],
+            actions: ['s3:GetObject'],
+            session_ids: ['sess-invoice-agent'],
+            first_observed_at: '2026-06-14T17:15:00Z',
+            last_observed_at: '2026-06-14T17:15:00Z',
+            static_sources: ['identity_policy'],
+            sensitivity: 'business_metadata',
+            evidence_ref: 's3-runtime-access://billing-artifacts',
+            evidence_refs: ['runtime-evidence://123456789012/us-east-1/evt-s3-access'],
+            next_action: 'Keep object-key details redacted and verify prefix-level scope.',
+            redaction_boundary: 'metadata_only_no_object_keys_no_object_payloads'
+          }
+        ],
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
     });
     vi.spyOn(api.apiClient, 'getAWSProjectAgentRuntimeAccess').mockResolvedValue({
-      correlation: { status: 'degraded', records: [], summary: {}, caveats: [], failure_reasons: [], remediation_hints: [] } as any
+      correlation: {
+        status: 'ready',
+        fixture_state: 'success',
+        confidence: 0.9,
+        applied_filters: {},
+        summary: {
+          total_correlations: 1,
+          filtered_correlations: 1,
+          status_counts: { confirmed: 1 },
+          confirmed_count: 1,
+          observed_without_declaration_count: 0,
+          declared_unused_count: 0,
+          shadow_agent_count: 0,
+          undeclared_tool_count: 0,
+          backing_role_mismatch_count: 0,
+          failed_tool_call_count: 0,
+          agent_count: 1,
+          tool_count: 1,
+          observed_tool_call_count: 1,
+          declared_tool_count: 1,
+          relationship_count: 1
+        },
+        records: [
+          {
+            correlation_id: 'agent-runtime-case-router',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            agent_node_id: 'aws:agent:runtime-case-triage',
+            agent_id: 'runtime-case-triage',
+            agent_name: 'runtime-case-triage',
+            agent_type: 'agentcore_runtime',
+            tool_name: 'case-router',
+            tool_target_ref: 'case-router-policy-checker',
+            status: 'confirmed',
+            confidence: 0.9,
+            observed_count: 1,
+            observed_event_ids: ['evt-agent-tool'],
+            backing_role_arns: ['arn:aws:iam::123456789012:role/agentcore-case-triage-runtime'],
+            target_resource_arns: [
+              'arn:aws:bedrock-agentcore:us-east-1:123456789012:agent-runtime-endpoint/runtime-case-triage/blue'
+            ],
+            outcomes: ['allowed'],
+            session_ids: ['sess-agentcore-runtime'],
+            first_observed_at: '2026-06-14T17:19:00Z',
+            last_observed_at: '2026-06-14T17:19:00Z',
+            declared_in_inventory: true,
+            evidence_ref: 'agent-runtime-access://case-router',
+            evidence_refs: ['runtime-evidence://123456789012/us-east-1/evt-agent-tool'],
+            next_action: 'Review declared tool target and backing role scope.',
+            redaction_boundary: 'metadata_only_no_prompts_no_completions_no_tool_payloads'
+          }
+        ],
+        relationships: [],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: [],
+        coverage_gaps: [],
+        diagnostics: []
+      } as any
     });
     const getAIAgentRisk = vi.spyOn(api.apiClient, 'getAWSProjectAIAgentRisk').mockResolvedValue({
       findings: {
@@ -6376,10 +6706,21 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Runtime' })).toBeInTheDocument();
     expect(await screen.findByText(/CloudTrail: GetObject/i)).toBeInTheDocument();
     expect(await screen.findByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
+    const runtimeTimeline = await screen.findByRole('region', { name: 'AWS runtime correlation timeline' });
+    expect(within(runtimeTimeline).getByRole('heading', { level: 3, name: 'Runtime timeline' })).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByText(/STS AssumeRole.*AssumeRole/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getAllByText(/SourceIdentity billing-operator@example.com/i).length).toBeGreaterThan(0);
+    expect(within(runtimeTimeline).getByText(/runtime-evidence:\/\/123456789012\/us-east-1\/evt-assume-role/i)).toBeInTheDocument();
+    expect(await within(runtimeTimeline).findByText(/Secret · prod\/ai\/openai-key/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByText(/S3 · billing-artifacts-123456789012/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByText(/Agent · runtime-case-triage · case-router/i)).toBeInTheDocument();
+    expect(await within(runtimeTimeline).findByText(/Case · Rotate external credential for support-assistant/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByText(/Before evidence:\/\/agent\/support-assistant\/anthropic/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByText(/After secret:\/\/aws:resource:credential-reference:support-anthropic-key\/scoped-projection/i)).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS AI agent risk findings' })).toBeInTheDocument();
     expect(screen.getAllByText(/External credential exposure/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS remediation cases' })).toBeInTheDocument();
-    expect(screen.getByText(/Rotate external credential for support-assistant/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Rotate external credential for support-assistant/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Secret rotation/i).length).toBeGreaterThan(0);
     expect(await screen.findByRole('table', { name: 'AWS IAM policy diffs' })).toBeInTheDocument();
     expect(screen.getByText(/Scope data-loader: remove 2 action\(s\)/i)).toBeInTheDocument();
@@ -6527,6 +6868,27 @@ describe('Domain-first app routes', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Event type' }), {
+      target: { value: 'all' }
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Evidence' }), {
+      target: { value: 'all' }
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Status' }), {
+      target: { value: 'stale' }
+    });
+
+    await waitFor(() =>
+      expect(getRuntimeEvents).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', status: 'stale' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(screen.getByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
+    expect(screen.queryByText(/CloudTrail: GetObject/i)).not.toBeInTheDocument();
   });
 
   it('shows AWS limited enforcement framework on the governance route', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -661,7 +661,7 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
     iam_last_used_signal_count: 0,
     access_analyzer_finding_count: 1,
     dormant_access_count: 0,
-    lineage_resolved_count: 1,
+    lineage_resolved_count: 4,
     missing_source_identity_count: 0,
     ambiguous_lineage_count: 0,
     relationship_count: 5,
@@ -903,7 +903,7 @@ const readyAWSRuntimeEvents: AWSRuntimeEventResult = {
   relationships: [],
   failure_reasons: [],
   remediation_hints: [],
-  evidence_links: ['/docs/aws-runtime-events'],
+  evidence_links: ['/docs/aws-runtime-events', 'javascript:alert(1)', 'https://docs.identrail.com/aws-runtime-events'],
   coverage_gaps: [],
   diagnostics: [],
   generated_at: '2026-06-14T17:30:00Z',
@@ -3931,6 +3931,28 @@ describe('Domain-first app routes', () => {
     });
     vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
     const s3RuntimeRecord = readyAWSRuntimeEvents.records.find((record) => record.event_id === 'evt-s3-access') ?? readyAWSRuntimeEvents.records[0];
+    const machineIdentityRuntimeEvents: AWSRuntimeEventResult = {
+      ...readyAWSRuntimeEvents,
+      summary: {
+        ...readyAWSRuntimeEvents.summary,
+        total_events: 1,
+        filtered_events: 1,
+        event_type_counts: { 'api-call': 1 },
+        status_counts: { observed: 1 },
+        owner_counts: { security: 1 },
+        identity_count: 1,
+        resource_count: 1,
+        agent_event_count: 0,
+        secret_read_count: 0,
+        kms_decrypt_count: 0,
+        api_call_count: 1,
+        sts_session_count: 0,
+        access_analyzer_finding_count: 0,
+        lineage_resolved_count: 1,
+        relationship_count: 1
+      },
+      records: [s3RuntimeRecord]
+    };
     const machineIdentityDetail = {
       tenant_id: 'tenant-a',
       workspace_id: 'workspace-a',
@@ -3988,7 +4010,7 @@ describe('Domain-first app routes', () => {
       findings: [],
       governance_decisions: [],
       relationships: [],
-      runtime: { ...readyAWSRuntimeEvents, records: [s3RuntimeRecord] },
+      runtime: machineIdentityRuntimeEvents,
       permissions: readyAWSLeastPrivilege,
       secrets: { findings: [] },
       blast_radius: { findings: [] },
@@ -6711,6 +6733,15 @@ describe('Domain-first app routes', () => {
     expect(within(runtimeTimeline).getByText(/STS AssumeRole.*AssumeRole/i)).toBeInTheDocument();
     expect(within(runtimeTimeline).getAllByText(/SourceIdentity billing-operator@example.com/i).length).toBeGreaterThan(0);
     expect(within(runtimeTimeline).getByText(/runtime-evidence:\/\/123456789012\/us-east-1\/evt-assume-role/i)).toBeInTheDocument();
+    expect(within(runtimeTimeline).getByRole('link', { name: '/docs/aws-runtime-events' })).toHaveAttribute(
+      'href',
+      '/docs/aws-runtime-events'
+    );
+    expect(within(runtimeTimeline).getByRole('link', { name: 'https://docs.identrail.com/aws-runtime-events' })).toHaveAttribute(
+      'href',
+      'https://docs.identrail.com/aws-runtime-events'
+    );
+    expect(within(runtimeTimeline).queryByRole('link', { name: /javascript:alert/i })).not.toBeInTheDocument();
     expect(await within(runtimeTimeline).findByText(/Secret · prod\/ai\/openai-key/i)).toBeInTheDocument();
     expect(within(runtimeTimeline).getByText(/S3 · billing-artifacts-123456789012/i)).toBeInTheDocument();
     expect(within(runtimeTimeline).getByText(/Agent · runtime-case-triage · case-router/i)).toBeInTheDocument();
@@ -6889,6 +6920,10 @@ describe('Domain-first app routes', () => {
     );
     expect(screen.getByText(/Access Analyzer: Finding/i)).toBeInTheDocument();
     expect(screen.queryByText(/CloudTrail: GetObject/i)).not.toBeInTheDocument();
+    expect(within(runtimeTimeline).queryByText(/Secret · prod\/ai\/openai-key/i)).not.toBeInTheDocument();
+    expect(within(runtimeTimeline).queryByText(/S3 · billing-artifacts-123456789012/i)).not.toBeInTheDocument();
+    expect(within(runtimeTimeline).queryByText(/Agent · runtime-case-triage · case-router/i)).not.toBeInTheDocument();
+    expect(within(runtimeTimeline).queryByText(/Case · Rotate external credential for support-assistant/i)).not.toBeInTheDocument();
   });
 
   it('shows AWS limited enforcement framework on the governance route', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -12174,7 +12174,6 @@ type AWSRuntimeTimelineFilterContext = {
   eventIDs: Set<string>;
   sessionIDs: Set<string>;
   evidenceRefs: Set<string>;
-  nodeIDs: Set<string>;
   agentIDs: Set<string>;
 };
 
@@ -12337,18 +12336,12 @@ function awsRuntimeTimelineFilterContext(records: AWSRuntimeEventRecord[]): AWSR
     eventIDs: new Set(),
     sessionIDs: new Set(),
     evidenceRefs: new Set(),
-    nodeIDs: new Set(),
     agentIDs: new Set()
   };
   for (const record of records) {
     addToSet(context.eventIDs, record.event_id);
     addToSet(context.sessionIDs, record.session?.session_id);
     addToSet(context.evidenceRefs, record.evidence_ref);
-    addToSet(context.nodeIDs, record.actor_identity_node_id);
-    addToSet(context.nodeIDs, record.resource_node_id);
-    addToSet(context.nodeIDs, record.session?.session_node_id);
-    addToSet(context.nodeIDs, record.session?.original_actor_node_id);
-    addToSet(context.nodeIDs, record.session?.chained_from_node_id);
     addToSet(context.agentIDs, record.agent_id);
     addToSet(context.agentIDs, record.agent_node_id);
   }
@@ -12489,7 +12482,6 @@ function awsRuntimeCorrelationHighlights(
         eventIDs: record.observed_event_ids,
         sessionIDs: record.session_ids,
         evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
-        nodeIDs: [record.identity_node_id, record.resource_node_id, record.agent_node_id],
         agentIDs: [record.agent_id, record.agent_node_id]
       })
     )
@@ -12516,7 +12508,6 @@ function awsRuntimeCorrelationHighlights(
         eventIDs: record.observed_event_ids,
         sessionIDs: record.session_ids,
         evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
-        nodeIDs: [record.identity_node_id, record.resource_node_id, record.agent_node_id],
         agentIDs: [record.agent_id, record.agent_node_id]
       })
     )
@@ -12544,12 +12535,6 @@ function awsRuntimeCorrelationHighlights(
         eventIDs: record.observed_event_ids,
         sessionIDs: record.session_ids,
         evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
-        nodeIDs: [
-          record.agent_node_id,
-          record.declared_backing_role_node_id,
-          ...(record.backing_role_node_ids ?? []),
-          ...(record.target_resource_node_ids ?? [])
-        ],
         agentIDs: [record.agent_id, record.agent_node_id]
       })
     )
@@ -12579,7 +12564,6 @@ function awsRuntimeMatchesFilterContext(
     eventIDs?: string[];
     sessionIDs?: string[];
     evidenceRefs?: Array<string | undefined>;
-    nodeIDs?: Array<string | undefined>;
     agentIDs?: Array<string | undefined>;
   }
 ): boolean {
@@ -12590,7 +12574,6 @@ function awsRuntimeMatchesFilterContext(
     intersectsSet(context.eventIDs, values.eventIDs) ||
     intersectsSet(context.sessionIDs, values.sessionIDs) ||
     intersectsSet(context.evidenceRefs, values.evidenceRefs) ||
-    intersectsSet(context.nodeIDs, values.nodeIDs) ||
     intersectsSet(context.agentIDs, values.agentIDs)
   );
 }
@@ -12626,12 +12609,6 @@ function awsRuntimeRemediationMarkers(
           remediationCase.rollback_plan.evidence_ref,
           remediationCase.verification_plan.evidence_ref,
           ...remediationCase.evidence.map((evidence) => evidence.evidence_ref)
-        ],
-        nodeIDs: [
-          remediationCase.identity_node_id,
-          ...(remediationCase.resource_node_ids ?? []),
-          ...remediationCase.impacted_nodes,
-          ...remediationCase.impacted_path.map((step) => step.node_id)
         ]
       })
     )
@@ -12658,8 +12635,7 @@ function awsRuntimeRemediationMarkers(
           entry.rollback_plan.evidence_ref,
           entry.verification_plan.evidence_ref,
           ...entry.evidence.map((evidence) => evidence.evidence_ref)
-        ],
-        nodeIDs: [...entry.impacted_nodes, ...entry.impacted_path.map((step) => step.node_id)]
+        ]
       })
     )
     .slice(0, 2)
@@ -12679,8 +12655,7 @@ function awsRuntimeRemediationMarkers(
   const verificationMarkers = (postRemediationVerification?.entries ?? [])
     .filter((entry) =>
       awsRuntimeMatchesFilterContext(filterContext, {
-        evidenceRefs: entry.evidence_links,
-        nodeIDs: entry.impacted_nodes
+        evidenceRefs: entry.evidence_links
       })
     )
     .slice(0, 2)

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -12099,6 +12099,7 @@ function AWSRuntimeEvidenceContent({
   const displayedRows = filterAWSInventoryRows(rows, displayFilters);
   const displayedRecordIDs = new Set(displayedRows.map((row) => row.id.replace(/^runtime-/, '')));
   const displayedRecords = runtime?.records.filter((record) => displayedRecordIDs.has(record.event_id)) ?? [];
+  const timelineFiltered = awsRuntimeTimelineHasActiveFilters(displayFilters);
 
   return (
     <>
@@ -12122,6 +12123,7 @@ function AWSRuntimeEvidenceContent({
         <AWSRuntimeTimelineOverview
           runtime={runtime}
           records={displayedRecords}
+          filtered={timelineFiltered}
           secretsKMSAccess={secretsKMSAccess}
           s3RuntimeAccess={s3RuntimeAccess}
           agentRuntimeAccess={agentRuntimeAccess}
@@ -12168,9 +12170,24 @@ type AWSRuntimeRemediationMarker = {
   stage: AWSCapabilityStage;
 };
 
+type AWSRuntimeTimelineFilterContext = {
+  eventIDs: Set<string>;
+  sessionIDs: Set<string>;
+  evidenceRefs: Set<string>;
+  nodeIDs: Set<string>;
+  agentIDs: Set<string>;
+};
+
+type AWSRuntimeEvidenceLink = {
+  href: string;
+  label: string;
+  external: boolean;
+};
+
 function AWSRuntimeTimelineOverview({
   runtime,
   records,
+  filtered,
   secretsKMSAccess,
   s3RuntimeAccess,
   agentRuntimeAccess,
@@ -12180,6 +12197,7 @@ function AWSRuntimeTimelineOverview({
 }: {
   runtime: AWSRuntimeEventResult;
   records: AWSRuntimeEventRecord[];
+  filtered: boolean;
   secretsKMSAccess: AWSSecretsKMSRuntimeAccessResult | null;
   s3RuntimeAccess: AWSS3RuntimeAccessResult | null;
   agentRuntimeAccess: AWSAgentRuntimeAccessResult | null;
@@ -12192,9 +12210,10 @@ function AWSRuntimeTimelineOverview({
   }
 
   const entries = awsRuntimeTimelineEntries(records);
-  const highlights = awsRuntimeCorrelationHighlights(secretsKMSAccess, s3RuntimeAccess, agentRuntimeAccess);
-  const markers = awsRuntimeRemediationMarkers(remediationCases, lowRiskRemediation, postRemediationVerification);
-  const evidenceLinks = runtime.evidence_links.slice(0, 4);
+  const filterContext = filtered ? awsRuntimeTimelineFilterContext(records) : null;
+  const highlights = awsRuntimeCorrelationHighlights(secretsKMSAccess, s3RuntimeAccess, agentRuntimeAccess, filterContext);
+  const markers = awsRuntimeRemediationMarkers(remediationCases, lowRiskRemediation, postRemediationVerification, filterContext);
+  const evidenceLinks = runtime.evidence_links.map((link) => awsRuntimeSafeEvidenceLink(link)).filter((link): link is AWSRuntimeEvidenceLink => Boolean(link)).slice(0, 4);
   const boundaryNotes = awsRuntimeBoundaryNotes(runtime);
   const summaryItems = awsRuntimeTimelineSummaryItems(runtime, records, highlights, markers);
 
@@ -12221,14 +12240,14 @@ function AWSRuntimeTimelineOverview({
       {evidenceLinks.length > 0 ? (
         <div className="idt-aws-runtime-evidence-links" aria-label="Runtime evidence links">
           {evidenceLinks.map((link) =>
-            link.startsWith('/') ? (
-              <Link key={link} to={link}>
-                {link}
-              </Link>
-            ) : (
-              <a key={link} href={link} target="_blank" rel="noreferrer">
-                {link}
+            link.external ? (
+              <a key={link.href} href={link.href} target="_blank" rel="noreferrer">
+                {link.label}
               </a>
+            ) : (
+              <Link key={link.href} to={link.href}>
+                {link.label}
+              </Link>
             )
           )}
         </div>
@@ -12302,6 +12321,63 @@ function awsRuntimeTimelineSummaryItems(
     { label: 'Correlations', value: String(highlights.length) },
     { label: 'Markers', value: String(markers.length) }
   ];
+}
+
+function awsRuntimeTimelineHasActiveFilters(filters: AWSInventoryFilterState): boolean {
+  return Object.entries(filters).some(([filterID, value]) => {
+    if (filterID === 'search') {
+      return Boolean(value.trim());
+    }
+    return Boolean(value && value !== 'all');
+  });
+}
+
+function awsRuntimeTimelineFilterContext(records: AWSRuntimeEventRecord[]): AWSRuntimeTimelineFilterContext {
+  const context: AWSRuntimeTimelineFilterContext = {
+    eventIDs: new Set(),
+    sessionIDs: new Set(),
+    evidenceRefs: new Set(),
+    nodeIDs: new Set(),
+    agentIDs: new Set()
+  };
+  for (const record of records) {
+    addToSet(context.eventIDs, record.event_id);
+    addToSet(context.sessionIDs, record.session?.session_id);
+    addToSet(context.evidenceRefs, record.evidence_ref);
+    addToSet(context.nodeIDs, record.actor_identity_node_id);
+    addToSet(context.nodeIDs, record.resource_node_id);
+    addToSet(context.nodeIDs, record.session?.session_node_id);
+    addToSet(context.nodeIDs, record.session?.original_actor_node_id);
+    addToSet(context.nodeIDs, record.session?.chained_from_node_id);
+    addToSet(context.agentIDs, record.agent_id);
+    addToSet(context.agentIDs, record.agent_node_id);
+  }
+  return context;
+}
+
+function addToSet(set: Set<string>, value: string | undefined): void {
+  if (value) {
+    set.add(value);
+  }
+}
+
+function awsRuntimeSafeEvidenceLink(value: string): AWSRuntimeEvidenceLink | null {
+  const trimmed = value.trim();
+  if (!trimmed || /[\u0000-\u001F\u007F]/.test(trimmed)) {
+    return null;
+  }
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//') && !trimmed.startsWith('/\\')) {
+    return { href: trimmed, label: trimmed, external: false };
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return { href: parsed.href, label: trimmed, external: true };
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 function awsRuntimeBoundaryNotes(runtime: AWSRuntimeEventResult): string[] {
@@ -12404,58 +12480,123 @@ function awsRuntimeStatusStage(status: string): AWSCapabilityStage {
 function awsRuntimeCorrelationHighlights(
   secretsKMSAccess: AWSSecretsKMSRuntimeAccessResult | null,
   s3RuntimeAccess: AWSS3RuntimeAccessResult | null,
-  agentRuntimeAccess: AWSAgentRuntimeAccessResult | null
+  agentRuntimeAccess: AWSAgentRuntimeAccessResult | null,
+  filterContext: AWSRuntimeTimelineFilterContext | null
 ): AWSRuntimeCorrelationHighlight[] {
-  const secretHighlights = (secretsKMSAccess?.records ?? []).slice(0, 3).map((record) => ({
-    id: `secret-kms-${record.correlation_id}`,
-    title: `${record.resource_kind === 'kms_key' ? 'KMS' : 'Secret'} · ${record.resource_name || record.resource_arn}`,
-    detail: awsRuntimeCorrelationDetail([
-      record.principal_arn || record.identity_node_id,
-      `${record.observed_count} observed`,
-      awsRuntimeJoinedLabel('events', record.observed_event_ids),
-      awsRuntimeJoinedLabel('sessions', record.session_ids),
-      awsRuntimeJoinedLabel('actions', record.actions),
-      formatConfidenceScore(record.confidence),
-      formatTokenLabel(record.redaction_boundary)
-    ]),
-    evidenceRef: record.evidence_ref,
-    status: record.status,
-    stage: awsSecretsKMSCorrelationStage(record.status)
-  }));
-  const s3Highlights = (s3RuntimeAccess?.records ?? []).slice(0, 3).map((record) => ({
-    id: `s3-${record.correlation_id}`,
-    title: `S3 · ${record.bucket_name || record.bucket_arn}`,
-    detail: awsRuntimeCorrelationDetail([
-      record.principal_arn || record.identity_node_id,
-      `${record.observed_count} observed`,
-      awsRuntimeJoinedLabel('events', record.observed_event_ids),
-      awsRuntimeJoinedLabel('sessions', record.session_ids),
-      awsRuntimeJoinedLabel('modes', record.observed_modes),
-      record.sensitivity ? `Sensitivity ${formatTokenLabel(record.sensitivity)}` : '',
-      formatConfidenceScore(record.confidence),
-      formatTokenLabel(record.redaction_boundary)
-    ]),
-    evidenceRef: record.evidence_ref,
-    status: record.status,
-    stage: awsSecretsKMSCorrelationStage(record.status)
-  }));
-  const agentHighlights = (agentRuntimeAccess?.records ?? []).slice(0, 3).map((record) => ({
-    id: `agent-runtime-${record.correlation_id}`,
-    title: `Agent · ${awsAgentRuntimeAccessLabel(record)}`,
-    detail: awsRuntimeCorrelationDetail([
-      awsRuntimeJoinedLabel('roles', record.backing_role_arns),
-      `${record.observed_count} observed`,
-      awsRuntimeJoinedLabel('events', record.observed_event_ids),
-      awsRuntimeJoinedLabel('sessions', record.session_ids),
-      awsRuntimeJoinedLabel('targets', record.target_resource_arns),
-      formatConfidenceScore(record.confidence),
-      formatTokenLabel(record.redaction_boundary)
-    ]),
-    evidenceRef: record.evidence_ref,
-    status: record.status,
-    stage: awsAgentRuntimeAccessStage(record.status)
-  }));
+  const secretHighlights = (secretsKMSAccess?.records ?? [])
+    .filter((record) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        eventIDs: record.observed_event_ids,
+        sessionIDs: record.session_ids,
+        evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
+        nodeIDs: [record.identity_node_id, record.resource_node_id, record.agent_node_id],
+        agentIDs: [record.agent_id, record.agent_node_id]
+      })
+    )
+    .slice(0, 3)
+    .map((record) => ({
+      id: `secret-kms-${record.correlation_id}`,
+      title: `${record.resource_kind === 'kms_key' ? 'KMS' : 'Secret'} · ${record.resource_name || record.resource_arn}`,
+      detail: awsRuntimeCorrelationDetail([
+        record.principal_arn || record.identity_node_id,
+        `${record.observed_count} observed`,
+        awsRuntimeJoinedLabel('events', record.observed_event_ids),
+        awsRuntimeJoinedLabel('sessions', record.session_ids),
+        awsRuntimeJoinedLabel('actions', record.actions),
+        formatConfidenceScore(record.confidence),
+        formatTokenLabel(record.redaction_boundary)
+      ]),
+      evidenceRef: record.evidence_ref,
+      status: record.status,
+      stage: awsSecretsKMSCorrelationStage(record.status)
+    }));
+  const s3Highlights = (s3RuntimeAccess?.records ?? [])
+    .filter((record) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        eventIDs: record.observed_event_ids,
+        sessionIDs: record.session_ids,
+        evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
+        nodeIDs: [record.identity_node_id, record.resource_node_id, record.agent_node_id],
+        agentIDs: [record.agent_id, record.agent_node_id]
+      })
+    )
+    .slice(0, 3)
+    .map((record) => ({
+      id: `s3-${record.correlation_id}`,
+      title: `S3 · ${record.bucket_name || record.bucket_arn}`,
+      detail: awsRuntimeCorrelationDetail([
+        record.principal_arn || record.identity_node_id,
+        `${record.observed_count} observed`,
+        awsRuntimeJoinedLabel('events', record.observed_event_ids),
+        awsRuntimeJoinedLabel('sessions', record.session_ids),
+        awsRuntimeJoinedLabel('modes', record.observed_modes),
+        record.sensitivity ? `Sensitivity ${formatTokenLabel(record.sensitivity)}` : '',
+        formatConfidenceScore(record.confidence),
+        formatTokenLabel(record.redaction_boundary)
+      ]),
+      evidenceRef: record.evidence_ref,
+      status: record.status,
+      stage: awsSecretsKMSCorrelationStage(record.status)
+    }));
+  const agentHighlights = (agentRuntimeAccess?.records ?? [])
+    .filter((record) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        eventIDs: record.observed_event_ids,
+        sessionIDs: record.session_ids,
+        evidenceRefs: [record.evidence_ref, ...(record.evidence_refs ?? [])],
+        nodeIDs: [
+          record.agent_node_id,
+          record.declared_backing_role_node_id,
+          ...(record.backing_role_node_ids ?? []),
+          ...(record.target_resource_node_ids ?? [])
+        ],
+        agentIDs: [record.agent_id, record.agent_node_id]
+      })
+    )
+    .slice(0, 3)
+    .map((record) => ({
+      id: `agent-runtime-${record.correlation_id}`,
+      title: `Agent · ${awsAgentRuntimeAccessLabel(record)}`,
+      detail: awsRuntimeCorrelationDetail([
+        awsRuntimeJoinedLabel('roles', record.backing_role_arns),
+        `${record.observed_count} observed`,
+        awsRuntimeJoinedLabel('events', record.observed_event_ids),
+        awsRuntimeJoinedLabel('sessions', record.session_ids),
+        awsRuntimeJoinedLabel('targets', record.target_resource_arns),
+        formatConfidenceScore(record.confidence),
+        formatTokenLabel(record.redaction_boundary)
+      ]),
+      evidenceRef: record.evidence_ref,
+      status: record.status,
+      stage: awsAgentRuntimeAccessStage(record.status)
+    }));
   return [...secretHighlights, ...s3Highlights, ...agentHighlights].slice(0, 6);
+}
+
+function awsRuntimeMatchesFilterContext(
+  context: AWSRuntimeTimelineFilterContext | null,
+  values: {
+    eventIDs?: string[];
+    sessionIDs?: string[];
+    evidenceRefs?: Array<string | undefined>;
+    nodeIDs?: Array<string | undefined>;
+    agentIDs?: Array<string | undefined>;
+  }
+): boolean {
+  if (!context) {
+    return true;
+  }
+  return (
+    intersectsSet(context.eventIDs, values.eventIDs) ||
+    intersectsSet(context.sessionIDs, values.sessionIDs) ||
+    intersectsSet(context.evidenceRefs, values.evidenceRefs) ||
+    intersectsSet(context.nodeIDs, values.nodeIDs) ||
+    intersectsSet(context.agentIDs, values.agentIDs)
+  );
+}
+
+function intersectsSet(set: Set<string>, values: Array<string | undefined> | undefined): boolean {
+  return (values ?? []).some((value) => Boolean(value && set.has(value)));
 }
 
 function awsRuntimeCorrelationDetail(parts: Array<string | undefined>): string {
@@ -12473,47 +12614,89 @@ function awsRuntimeJoinedLabel(label: string, values: string[] | undefined): str
 function awsRuntimeRemediationMarkers(
   remediationCases: AWSRemediationCaseResult | null,
   lowRiskRemediation: AWSLowRiskRemediationResult | null,
-  postRemediationVerification: AWSPostRemediationVerificationResult | null
+  postRemediationVerification: AWSPostRemediationVerificationResult | null,
+  filterContext: AWSRuntimeTimelineFilterContext | null
 ): AWSRuntimeRemediationMarker[] {
-  const caseMarkers = (remediationCases?.cases ?? []).slice(0, 3).map((remediationCase) => ({
-    id: `runtime-marker-case-${remediationCase.case_id}`,
-    title: `Case · ${remediationCase.title}`,
-    detail: awsRuntimeCorrelationDetail([
-      `Before ${remediationCase.diff_intent.before_ref || remediationCase.evidence[0]?.evidence_ref || 'pending'}`,
-      `After ${remediationCase.diff_intent.after_ref || 'pending'}`,
-      formatTokenLabel(remediationCase.diff_intent.kind),
-      `Verification ${formatTokenLabel(remediationCase.verification_plan.strategy)}`,
-      `Boundary ${formatTokenLabel(remediationCase.evidence_boundary)}`
-    ]),
-    status: `${remediationCase.severity} / ${remediationCase.approval_state}`,
-    stage: awsRemediationCaseStage(remediationCase)
-  }));
-  const liveMarkers = (lowRiskRemediation?.entries ?? []).slice(0, 2).map((entry) => ({
-    id: `runtime-marker-live-${entry.execution_id}`,
-    title: `Live projection · ${entry.title}`,
-    detail: awsRuntimeCorrelationDetail([
-      `Before ${entry.mutation.before_ref || 'captured evidence'}`,
-      `After ${entry.mutation.after_ref || 'projected mutation'}`,
-      `${entry.mutation.service}:${entry.mutation.operation}`,
-      `Projected ${formatDateLabel(entry.projected_at)}`,
-      `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
-    ]),
-    status: entry.state,
-    stage: awsLowRiskRemediationStage(entry)
-  }));
-  const verificationMarkers = (postRemediationVerification?.entries ?? []).slice(0, 2).map((entry) => ({
-    id: `runtime-marker-verification-${entry.verification_id}`,
-    title: `Verification · ${entry.title}`,
-    detail: awsRuntimeCorrelationDetail([
-      entry.operation,
-      entry.target_resource,
-      `${entry.checks.length} check(s)`,
-      `Projected ${formatDateLabel(entry.projected_at)}`,
-      `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
-    ]),
-    status: entry.state,
-    stage: awsPostRemediationVerificationStage(entry)
-  }));
+  const caseMarkers = (remediationCases?.cases ?? [])
+    .filter((remediationCase) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        evidenceRefs: [
+          remediationCase.diff_intent.before_ref,
+          remediationCase.diff_intent.after_ref,
+          remediationCase.rollback_plan.evidence_ref,
+          remediationCase.verification_plan.evidence_ref,
+          ...remediationCase.evidence.map((evidence) => evidence.evidence_ref)
+        ],
+        nodeIDs: [
+          remediationCase.identity_node_id,
+          ...(remediationCase.resource_node_ids ?? []),
+          ...remediationCase.impacted_nodes,
+          ...remediationCase.impacted_path.map((step) => step.node_id)
+        ]
+      })
+    )
+    .slice(0, 3)
+    .map((remediationCase) => ({
+      id: `runtime-marker-case-${remediationCase.case_id}`,
+      title: `Case · ${remediationCase.title}`,
+      detail: awsRuntimeCorrelationDetail([
+        `Before ${remediationCase.diff_intent.before_ref || remediationCase.evidence[0]?.evidence_ref || 'pending'}`,
+        `After ${remediationCase.diff_intent.after_ref || 'pending'}`,
+        formatTokenLabel(remediationCase.diff_intent.kind),
+        `Verification ${formatTokenLabel(remediationCase.verification_plan.strategy)}`,
+        `Boundary ${formatTokenLabel(remediationCase.evidence_boundary)}`
+      ]),
+      status: `${remediationCase.severity} / ${remediationCase.approval_state}`,
+      stage: awsRemediationCaseStage(remediationCase)
+    }));
+  const liveMarkers = (lowRiskRemediation?.entries ?? [])
+    .filter((entry) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        evidenceRefs: [
+          entry.mutation.before_ref,
+          entry.mutation.after_ref,
+          entry.rollback_plan.evidence_ref,
+          entry.verification_plan.evidence_ref,
+          ...entry.evidence.map((evidence) => evidence.evidence_ref)
+        ],
+        nodeIDs: [...entry.impacted_nodes, ...entry.impacted_path.map((step) => step.node_id)]
+      })
+    )
+    .slice(0, 2)
+    .map((entry) => ({
+      id: `runtime-marker-live-${entry.execution_id}`,
+      title: `Live projection · ${entry.title}`,
+      detail: awsRuntimeCorrelationDetail([
+        `Before ${entry.mutation.before_ref || 'captured evidence'}`,
+        `After ${entry.mutation.after_ref || 'projected mutation'}`,
+        `${entry.mutation.service}:${entry.mutation.operation}`,
+        `Projected ${formatDateLabel(entry.projected_at)}`,
+        `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
+      ]),
+      status: entry.state,
+      stage: awsLowRiskRemediationStage(entry)
+    }));
+  const verificationMarkers = (postRemediationVerification?.entries ?? [])
+    .filter((entry) =>
+      awsRuntimeMatchesFilterContext(filterContext, {
+        evidenceRefs: entry.evidence_links,
+        nodeIDs: entry.impacted_nodes
+      })
+    )
+    .slice(0, 2)
+    .map((entry) => ({
+      id: `runtime-marker-verification-${entry.verification_id}`,
+      title: `Verification · ${entry.title}`,
+      detail: awsRuntimeCorrelationDetail([
+        entry.operation,
+        entry.target_resource,
+        `${entry.checks.length} check(s)`,
+        `Projected ${formatDateLabel(entry.projected_at)}`,
+        `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
+      ]),
+      status: entry.state,
+      stage: awsPostRemediationVerificationStage(entry)
+    }));
   return [...caseMarkers, ...liveMarkers, ...verificationMarkers].slice(0, 6);
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -11688,7 +11688,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
 type AWSRiskOperationFilterConfigMap = Record<AWSRiskOperationRouteID, AWSInventoryFilterConfig[]>;
 
 const AWS_RISK_OPERATION_FILTER_DEFAULTS: Record<AWSRiskOperationRouteID, AWSInventoryFilterState> = {
-  runtime: { event: 'all', evidence: 'all', owner: 'all', search: '' },
+  runtime: { event: 'all', evidence: 'all', owner: 'all', status: 'all', search: '' },
   graph: { node: 'all', edge: 'all', evidence: 'all', search: '' },
   findings: { severity: 'all', account: 'all', region: 'all', evidence: 'all', status: 'all', search: '' },
   remediation: { change: 'all', approval: 'all', stage: 'all', search: '' },
@@ -11730,6 +11730,19 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
         { label: 'Security', value: 'security' },
         { label: 'Platform', value: 'platform' },
         { label: 'Application', value: 'application' }
+      ]
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      options: [
+        { label: 'All statuses', value: 'all' },
+        { label: 'Observed', value: 'observed' },
+        { label: 'Delayed', value: 'delayed' },
+        { label: 'Permission denied', value: 'permission-denied' },
+        { label: 'Resolved', value: 'resolved' },
+        { label: 'Archived', value: 'archived' },
+        { label: 'Stale', value: 'stale' }
       ]
     }
   ],
@@ -12056,6 +12069,12 @@ function AWSRiskOperationPrerequisites({
 
 function AWSRuntimeEvidenceContent({
   runtime,
+  secretsKMSAccess,
+  s3RuntimeAccess,
+  agentRuntimeAccess,
+  remediationCases,
+  lowRiskRemediation,
+  postRemediationVerification,
   loading,
   error,
   filters,
@@ -12063,6 +12082,12 @@ function AWSRuntimeEvidenceContent({
   onRetry
 }: {
   runtime: AWSRuntimeEventResult | null;
+  secretsKMSAccess: AWSSecretsKMSRuntimeAccessResult | null;
+  s3RuntimeAccess: AWSS3RuntimeAccessResult | null;
+  agentRuntimeAccess: AWSAgentRuntimeAccessResult | null;
+  remediationCases: AWSRemediationCaseResult | null;
+  lowRiskRemediation: AWSLowRiskRemediationResult | null;
+  postRemediationVerification: AWSPostRemediationVerificationResult | null;
   loading: boolean;
   error: string;
   filters: AWSInventoryFilterState;
@@ -12072,6 +12097,8 @@ function AWSRuntimeEvidenceContent({
   const rows: AWSRiskOperationTableRow[] = runtime ? runtime.records.map((record) => awsRuntimeEventRow(record)) : [];
   const displayFilters = awsRuntimeEventDisplayFilters(filters);
   const displayedRows = filterAWSInventoryRows(rows, displayFilters);
+  const displayedRecordIDs = new Set(displayedRows.map((row) => row.id.replace(/^runtime-/, '')));
+  const displayedRecords = runtime?.records.filter((record) => displayedRecordIDs.has(record.event_id)) ?? [];
 
   return (
     <>
@@ -12089,6 +12116,18 @@ function AWSRuntimeEvidenceContent({
           eyebrow={runtime.status === 'blocked' ? 'Permission required' : 'No runtime events'}
           title={runtime.status === 'blocked' ? 'Runtime events need read-only event access' : 'No runtime events matched'}
           body={runtime.failure_reasons[0] ?? 'Runtime event ingestion returned no events for the current environment and filters.'}
+        />
+      ) : null}
+      {!error && !loading && runtime ? (
+        <AWSRuntimeTimelineOverview
+          runtime={runtime}
+          records={displayedRecords}
+          secretsKMSAccess={secretsKMSAccess}
+          s3RuntimeAccess={s3RuntimeAccess}
+          agentRuntimeAccess={agentRuntimeAccess}
+          remediationCases={remediationCases}
+          lowRiskRemediation={lowRiskRemediation}
+          postRemediationVerification={postRemediationVerification}
         />
       ) : null}
       <DomainDataTable
@@ -12110,6 +12149,377 @@ function AWSRuntimeEvidenceContent({
       />
     </>
   );
+}
+
+type AWSRuntimeCorrelationHighlight = {
+  id: string;
+  title: string;
+  detail: string;
+  evidenceRef: string;
+  status: string;
+  stage: AWSCapabilityStage;
+};
+
+type AWSRuntimeRemediationMarker = {
+  id: string;
+  title: string;
+  detail: string;
+  status: string;
+  stage: AWSCapabilityStage;
+};
+
+function AWSRuntimeTimelineOverview({
+  runtime,
+  records,
+  secretsKMSAccess,
+  s3RuntimeAccess,
+  agentRuntimeAccess,
+  remediationCases,
+  lowRiskRemediation,
+  postRemediationVerification
+}: {
+  runtime: AWSRuntimeEventResult;
+  records: AWSRuntimeEventRecord[];
+  secretsKMSAccess: AWSSecretsKMSRuntimeAccessResult | null;
+  s3RuntimeAccess: AWSS3RuntimeAccessResult | null;
+  agentRuntimeAccess: AWSAgentRuntimeAccessResult | null;
+  remediationCases: AWSRemediationCaseResult | null;
+  lowRiskRemediation: AWSLowRiskRemediationResult | null;
+  postRemediationVerification: AWSPostRemediationVerificationResult | null;
+}) {
+  if (runtime.records.length === 0) {
+    return null;
+  }
+
+  const entries = awsRuntimeTimelineEntries(records);
+  const highlights = awsRuntimeCorrelationHighlights(secretsKMSAccess, s3RuntimeAccess, agentRuntimeAccess);
+  const markers = awsRuntimeRemediationMarkers(remediationCases, lowRiskRemediation, postRemediationVerification);
+  const evidenceLinks = runtime.evidence_links.slice(0, 4);
+  const boundaryNotes = awsRuntimeBoundaryNotes(runtime);
+  const summaryItems = awsRuntimeTimelineSummaryItems(runtime, records, highlights, markers);
+
+  return (
+    <section className="idt-aws-runtime-timeline-panel" aria-label="AWS runtime correlation timeline">
+      <header className="idt-aws-runtime-timeline-header">
+        <div>
+          <h3>Runtime timeline</h3>
+          <p className="idt-app-kicker">
+            {awsAccountRegionInventoryLabel(runtime.account_id, runtime.region)} · {formatTokenLabel(runtime.fixture_state)} ·{' '}
+            {formatConfidenceScore(runtime.confidence)}
+          </p>
+        </div>
+        <AWSInventoryPill stage={awsRuntimeStatusStage(runtime.status)} label={formatTokenLabel(runtime.status)} />
+      </header>
+      <dl className="idt-aws-runtime-timeline-summary">
+        {summaryItems.map((item) => (
+          <div key={item.label}>
+            <dt>{item.label}</dt>
+            <dd>{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+      {evidenceLinks.length > 0 ? (
+        <div className="idt-aws-runtime-evidence-links" aria-label="Runtime evidence links">
+          {evidenceLinks.map((link) =>
+            link.startsWith('/') ? (
+              <Link key={link} to={link}>
+                {link}
+              </Link>
+            ) : (
+              <a key={link} href={link} target="_blank" rel="noreferrer">
+                {link}
+              </a>
+            )
+          )}
+        </div>
+      ) : null}
+      {boundaryNotes.length > 0 ? (
+        <ul className="idt-aws-runtime-boundary-notes">
+          {boundaryNotes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+      {entries.length > 0 ? (
+        <DomainTimeline label="AWS runtime timeline" entries={entries} />
+      ) : (
+        <DomainEmptyState
+          eyebrow="Filtered"
+          title="No runtime timeline events matched"
+          body="The current filters did not match any runtime event rows."
+        />
+      )}
+      {highlights.length > 0 ? (
+        <div className="idt-aws-runtime-highlight-block" aria-label="Runtime correlation highlights">
+          <h4>Correlation highlights</h4>
+          <ul>
+            {highlights.map((highlight) => (
+              <li key={highlight.id}>
+                <div>
+                  <strong>{highlight.title}</strong>
+                  <span>{highlight.detail}</span>
+                  <code>{highlight.evidenceRef}</code>
+                </div>
+                <AWSInventoryPill stage={highlight.stage} label={formatTokenLabel(highlight.status)} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {markers.length > 0 ? (
+        <div className="idt-aws-runtime-highlight-block" aria-label="Runtime remediation markers">
+          <h4>Before / after remediation markers</h4>
+          <ul>
+            {markers.map((marker) => (
+              <li key={marker.id}>
+                <div>
+                  <strong>{marker.title}</strong>
+                  <span>{marker.detail}</span>
+                </div>
+                <AWSInventoryPill stage={marker.stage} label={formatTokenLabel(marker.status)} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function awsRuntimeTimelineSummaryItems(
+  runtime: AWSRuntimeEventResult,
+  records: AWSRuntimeEventRecord[],
+  highlights: AWSRuntimeCorrelationHighlight[],
+  markers: AWSRuntimeRemediationMarker[]
+): Array<{ label: string; value: string }> {
+  const sessionIDs = new Set(records.map((record) => record.session?.session_id).filter(Boolean));
+  const actorIDs = new Set(records.map((record) => record.actor_identity_node_id).filter(Boolean));
+  return [
+    { label: 'Shown', value: `${records.length}/${runtime.summary.filtered_events || runtime.records.length}` },
+    { label: 'Sessions', value: String(sessionIDs.size) },
+    { label: 'Actors', value: String(actorIDs.size) },
+    { label: 'Graph edges', value: String(runtime.summary.relationship_count) },
+    { label: 'Correlations', value: String(highlights.length) },
+    { label: 'Markers', value: String(markers.length) }
+  ];
+}
+
+function awsRuntimeBoundaryNotes(runtime: AWSRuntimeEventResult): string[] {
+  const notes = [
+    ...runtime.failure_reasons.map((reason) => `Failure: ${reason}`),
+    ...runtime.remediation_hints.map((hint) => `Hint: ${hint}`),
+    ...runtime.coverage_gaps.map((gap) =>
+      `${formatTokenLabel(gap.status)} ${formatTokenLabel(gap.capability)}: ${gap.reason}${gap.remediation ? ` · ${gap.remediation}` : ''}`
+    ),
+    ...runtime.diagnostics.map((diagnostic) =>
+      `${formatTokenLabel(diagnostic.code)} from ${formatTokenLabel(diagnostic.collector)}: ${diagnostic.message}`
+    )
+  ];
+  if (runtime.status !== 'ready' && notes.length === 0) {
+    notes.push(`${formatTokenLabel(runtime.status)} runtime coverage is explicit for this scope.`);
+  }
+  return notes.slice(0, 4);
+}
+
+function awsRuntimeTimelineEntries(records: AWSRuntimeEventRecord[]): DomainTimelineEntry[] {
+  return [...records]
+    .sort((left, right) => awsTimestampValue(left.observed_at) - awsTimestampValue(right.observed_at))
+    .slice(0, 10)
+    .map((record) => ({
+      id: `runtime-timeline-${record.event_id}`,
+      timestamp: formatDateLabel(record.observed_at),
+      title: `${awsRuntimeEventLabel(record)} · ${record.event_name}`,
+      detail: awsRuntimeTimelineDetail(record),
+      actor: formatTokenLabel(record.status),
+      tone: awsRuntimeTimelineTone(record)
+    }));
+}
+
+function awsRuntimeTimelineDetail(record: AWSRuntimeEventRecord): string {
+  return [
+    record.action,
+    awsRuntimeEventActorLabel(record),
+    awsRuntimeEventSessionSummary(record),
+    awsRuntimeEventTargetLabel(record),
+    record.evidence_ref,
+    formatConfidenceScore(record.confidence),
+    formatTokenLabel(record.redaction_boundary)
+  ]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function awsRuntimeEventActorLabel(record: AWSRuntimeEventRecord): string {
+  const actor = record.actor_principal_arn || record.actor_identity_node_id || 'Unknown actor';
+  return `Actor ${actor}`;
+}
+
+function awsRuntimeEventSessionSummary(record: AWSRuntimeEventRecord): string {
+  const session = record.session;
+  if (!session) {
+    return 'Session unknown';
+  }
+  const labels = [
+    session.session_id ? `Session ${session.session_id}` : '',
+    session.source_identity ? `SourceIdentity ${session.source_identity}` : '',
+    session.role_session_name ? `Role session ${session.role_session_name}` : '',
+    session.original_actor_arn ? `Original ${session.original_actor_arn}` : '',
+    session.chained_from_principal_arn ? `Chained from ${session.chained_from_principal_arn}` : '',
+    awsRuntimeEventLineageLabel(record)
+  ].filter(Boolean);
+  return labels.length > 0 ? labels.join(' · ') : 'Session unknown';
+}
+
+function awsRuntimeEventTargetLabel(record: AWSRuntimeEventRecord): string {
+  const target = record.target_resource_name || record.target_resource_type || record.target_resource_arn || record.resource_node_id;
+  if (target) {
+    return `Target ${target}`;
+  }
+  if (record.tool_name || record.tool_target_ref) {
+    return `Tool ${[record.tool_name, record.tool_target_ref].filter(Boolean).join(' / ')}`;
+  }
+  return 'Target unknown';
+}
+
+function awsRuntimeTimelineTone(record: AWSRuntimeEventRecord): DomainTimelineEntry['tone'] {
+  if (record.status === 'permission-denied' || record.session?.lineage_status === 'ambiguous') {
+    return 'danger';
+  }
+  if (record.status === 'delayed' || record.status === 'stale' || record.session?.lineage_status === 'source_identity_missing') {
+    return 'warning';
+  }
+  return 'success';
+}
+
+function awsRuntimeStatusStage(status: string): AWSCapabilityStage {
+  if (status === 'ready') {
+    return 'wired';
+  }
+  if (status === 'blocked') {
+    return 'not-available';
+  }
+  return 'coming';
+}
+
+function awsRuntimeCorrelationHighlights(
+  secretsKMSAccess: AWSSecretsKMSRuntimeAccessResult | null,
+  s3RuntimeAccess: AWSS3RuntimeAccessResult | null,
+  agentRuntimeAccess: AWSAgentRuntimeAccessResult | null
+): AWSRuntimeCorrelationHighlight[] {
+  const secretHighlights = (secretsKMSAccess?.records ?? []).slice(0, 3).map((record) => ({
+    id: `secret-kms-${record.correlation_id}`,
+    title: `${record.resource_kind === 'kms_key' ? 'KMS' : 'Secret'} · ${record.resource_name || record.resource_arn}`,
+    detail: awsRuntimeCorrelationDetail([
+      record.principal_arn || record.identity_node_id,
+      `${record.observed_count} observed`,
+      awsRuntimeJoinedLabel('events', record.observed_event_ids),
+      awsRuntimeJoinedLabel('sessions', record.session_ids),
+      awsRuntimeJoinedLabel('actions', record.actions),
+      formatConfidenceScore(record.confidence),
+      formatTokenLabel(record.redaction_boundary)
+    ]),
+    evidenceRef: record.evidence_ref,
+    status: record.status,
+    stage: awsSecretsKMSCorrelationStage(record.status)
+  }));
+  const s3Highlights = (s3RuntimeAccess?.records ?? []).slice(0, 3).map((record) => ({
+    id: `s3-${record.correlation_id}`,
+    title: `S3 · ${record.bucket_name || record.bucket_arn}`,
+    detail: awsRuntimeCorrelationDetail([
+      record.principal_arn || record.identity_node_id,
+      `${record.observed_count} observed`,
+      awsRuntimeJoinedLabel('events', record.observed_event_ids),
+      awsRuntimeJoinedLabel('sessions', record.session_ids),
+      awsRuntimeJoinedLabel('modes', record.observed_modes),
+      record.sensitivity ? `Sensitivity ${formatTokenLabel(record.sensitivity)}` : '',
+      formatConfidenceScore(record.confidence),
+      formatTokenLabel(record.redaction_boundary)
+    ]),
+    evidenceRef: record.evidence_ref,
+    status: record.status,
+    stage: awsSecretsKMSCorrelationStage(record.status)
+  }));
+  const agentHighlights = (agentRuntimeAccess?.records ?? []).slice(0, 3).map((record) => ({
+    id: `agent-runtime-${record.correlation_id}`,
+    title: `Agent · ${awsAgentRuntimeAccessLabel(record)}`,
+    detail: awsRuntimeCorrelationDetail([
+      awsRuntimeJoinedLabel('roles', record.backing_role_arns),
+      `${record.observed_count} observed`,
+      awsRuntimeJoinedLabel('events', record.observed_event_ids),
+      awsRuntimeJoinedLabel('sessions', record.session_ids),
+      awsRuntimeJoinedLabel('targets', record.target_resource_arns),
+      formatConfidenceScore(record.confidence),
+      formatTokenLabel(record.redaction_boundary)
+    ]),
+    evidenceRef: record.evidence_ref,
+    status: record.status,
+    stage: awsAgentRuntimeAccessStage(record.status)
+  }));
+  return [...secretHighlights, ...s3Highlights, ...agentHighlights].slice(0, 6);
+}
+
+function awsRuntimeCorrelationDetail(parts: Array<string | undefined>): string {
+  return parts.filter((part): part is string => Boolean(part && part.trim().length > 0)).join(' · ');
+}
+
+function awsRuntimeJoinedLabel(label: string, values: string[] | undefined): string {
+  const safeValues = (values ?? []).filter(Boolean);
+  if (safeValues.length === 0) {
+    return '';
+  }
+  return `${label} ${safeValues.slice(0, 3).join(', ')}${safeValues.length > 3 ? ` +${safeValues.length - 3}` : ''}`;
+}
+
+function awsRuntimeRemediationMarkers(
+  remediationCases: AWSRemediationCaseResult | null,
+  lowRiskRemediation: AWSLowRiskRemediationResult | null,
+  postRemediationVerification: AWSPostRemediationVerificationResult | null
+): AWSRuntimeRemediationMarker[] {
+  const caseMarkers = (remediationCases?.cases ?? []).slice(0, 3).map((remediationCase) => ({
+    id: `runtime-marker-case-${remediationCase.case_id}`,
+    title: `Case · ${remediationCase.title}`,
+    detail: awsRuntimeCorrelationDetail([
+      `Before ${remediationCase.diff_intent.before_ref || remediationCase.evidence[0]?.evidence_ref || 'pending'}`,
+      `After ${remediationCase.diff_intent.after_ref || 'pending'}`,
+      formatTokenLabel(remediationCase.diff_intent.kind),
+      `Verification ${formatTokenLabel(remediationCase.verification_plan.strategy)}`,
+      `Boundary ${formatTokenLabel(remediationCase.evidence_boundary)}`
+    ]),
+    status: `${remediationCase.severity} / ${remediationCase.approval_state}`,
+    stage: awsRemediationCaseStage(remediationCase)
+  }));
+  const liveMarkers = (lowRiskRemediation?.entries ?? []).slice(0, 2).map((entry) => ({
+    id: `runtime-marker-live-${entry.execution_id}`,
+    title: `Live projection · ${entry.title}`,
+    detail: awsRuntimeCorrelationDetail([
+      `Before ${entry.mutation.before_ref || 'captured evidence'}`,
+      `After ${entry.mutation.after_ref || 'projected mutation'}`,
+      `${entry.mutation.service}:${entry.mutation.operation}`,
+      `Projected ${formatDateLabel(entry.projected_at)}`,
+      `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
+    ]),
+    status: entry.state,
+    stage: awsLowRiskRemediationStage(entry)
+  }));
+  const verificationMarkers = (postRemediationVerification?.entries ?? []).slice(0, 2).map((entry) => ({
+    id: `runtime-marker-verification-${entry.verification_id}`,
+    title: `Verification · ${entry.title}`,
+    detail: awsRuntimeCorrelationDetail([
+      entry.operation,
+      entry.target_resource,
+      `${entry.checks.length} check(s)`,
+      `Projected ${formatDateLabel(entry.projected_at)}`,
+      `Boundary ${formatTokenLabel(entry.evidence_boundary)}`
+    ]),
+    status: entry.state,
+    stage: awsPostRemediationVerificationStage(entry)
+  }));
+  return [...caseMarkers, ...liveMarkers, ...verificationMarkers].slice(0, 6);
+}
+
+function awsTimestampValue(value: string): number {
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function awsSecretsKMSCorrelationStatusLabel(status: string): string {
@@ -15418,6 +15828,7 @@ function awsRuntimeEventRow(record: AWSRuntimeEventRecord): AWSRiskOperationTabl
       event: awsRuntimeEventUIEventFilterToken(record.event_type),
       evidence: awsRuntimeEventFilterToken(record.evidence_category),
       owner: awsRuntimeEventFilterToken(record.owner),
+      status: awsRuntimeEventFilterToken(record.status),
       search: ''
     },
     searchText: inventorySearchText([
@@ -16436,7 +16847,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
           connectorID: connection.connector_id,
           eventType: awsRuntimeEventAPIEventFilterToken(activeFilters.event),
           evidence: awsRuntimeEventAPIEvidenceFilterToken(activeFilters.evidence),
-          owner: activeFilters.owner && activeFilters.owner !== 'all' ? activeFilters.owner : undefined
+          owner: activeFilters.owner && activeFilters.owner !== 'all' ? activeFilters.owner : undefined,
+          status: activeFilters.status && activeFilters.status !== 'all' ? activeFilters.status : undefined
         },
         buildProductAuthContext(scope)
       );
@@ -16463,7 +16875,8 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
     connection?.connector_id,
     activeFilters.event,
     activeFilters.evidence,
-    activeFilters.owner
+    activeFilters.owner,
+    activeFilters.status
   ]);
 
   useEffect(() => {
@@ -18075,6 +18488,12 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         {routeID === 'runtime' ? (
           <AWSRuntimeEvidenceContent
             runtime={runtimeEvents}
+            secretsKMSAccess={secretsKMSAccess}
+            s3RuntimeAccess={s3RuntimeAccess}
+            agentRuntimeAccess={agentRuntimeAccess}
+            remediationCases={remediationCases}
+            lowRiskRemediation={lowRiskRemediation}
+            postRemediationVerification={postRemediationVerification}
             loading={runtimeEventsLoading}
             error={runtimeEventsError}
             filters={activeFilters}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24154,6 +24154,156 @@ html[data-theme='light'] .idt-app-shell-screen select {
   padding: 1rem;
 }
 
+.idt-aws-runtime-timeline-panel {
+  display: grid;
+  gap: 0.7rem;
+  min-width: 0;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.82rem;
+  background: #080809;
+}
+
+.idt-aws-runtime-timeline-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.idt-aws-runtime-timeline-header h3,
+.idt-aws-runtime-highlight-block h4 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.98rem;
+}
+
+.idt-aws-runtime-timeline-summary {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+}
+
+.idt-aws-runtime-timeline-summary div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+  border-right: 1px solid var(--app-border-soft);
+  padding: 0.55rem 0.65rem;
+}
+
+.idt-aws-runtime-timeline-summary div:last-child {
+  border-right: 0;
+}
+
+.idt-aws-runtime-timeline-summary dt {
+  color: var(--app-dim);
+  font-size: 0.68rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-runtime-timeline-summary dd {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 900;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-runtime-evidence-links,
+.idt-aws-runtime-boundary-notes,
+.idt-aws-runtime-highlight-block ul {
+  margin: 0;
+}
+
+.idt-aws-runtime-evidence-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.idt-aws-runtime-evidence-links a,
+.idt-aws-runtime-highlight-block code {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  background: #050505;
+  color: #b9d7ff;
+  font-family: var(--idt-mono);
+  font-size: 0.72rem;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-runtime-boundary-notes {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-aws-runtime-boundary-notes li {
+  border-left: 2px solid rgba(245, 196, 81, 0.58);
+  padding: 0.18rem 0 0.18rem 0.5rem;
+  color: var(--app-muted);
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-runtime-highlight-block {
+  display: grid;
+  gap: 0.48rem;
+  min-width: 0;
+}
+
+.idt-aws-runtime-highlight-block ul {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-aws-runtime-highlight-block li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: start;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.62rem 0.72rem;
+  background: #050505;
+}
+
+.idt-aws-runtime-highlight-block li > div {
+  display: grid;
+  gap: 0.24rem;
+  min-width: 0;
+}
+
+.idt-aws-runtime-highlight-block strong {
+  color: #ffffff;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-runtime-highlight-block span {
+  color: var(--app-muted);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-runtime-highlight-block code {
+  width: fit-content;
+  max-width: 100%;
+  border-radius: 8px;
+}
+
 .idt-kubernetes-page {
   display: grid;
   gap: 0.85rem;
@@ -24388,6 +24538,28 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
   }
 
   .idt-aws-risk-scope div:nth-child(n + 3) {
+    border-top: 1px solid var(--app-border-soft);
+  }
+
+  .idt-aws-runtime-timeline-header,
+  .idt-aws-runtime-highlight-block li {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .idt-aws-runtime-timeline-header {
+    display: grid;
+  }
+
+  .idt-aws-runtime-timeline-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-aws-runtime-timeline-summary div:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .idt-aws-runtime-timeline-summary div:nth-child(n + 3) {
     border-top: 1px solid var(--app-border-soft);
   }
 


### PR DESCRIPTION
## Summary

- Added a metadata-only AWS Runtime timeline above the raw event table.
- Added correlation highlights for Secrets Manager/KMS, S3, and agent tool-call runtime access using existing API envelopes.
- Added before/after remediation markers from remediation-case, low-risk live-action, and post-remediation verification payloads.
- Added an API-backed runtime `status` filter and kept local row filtering aligned.
- Updated runtime contract docs and frontend regression coverage.

## Why

Issue #1554 asks for runtime timeline polish and correlation UX across STS sessions, CloudTrail events, secret/KMS/S3 access, agent tool calls, evidence links, filters, before/after remediation markers, and explicit degraded/blocked/partial safety states.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm test -- --run src/productShell.test.tsx --prefix web
npm run build --prefix web
npm test -- --run --prefix web
```

All checks passed locally. The full web test suite passed with 16 files and 500 tests.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: Local tests and build listed above.

## Related Issues

Closes #1554

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only AWS Runtime timeline with STS lineage, correlation highlights, and remediation markers for fast, at-a-glance context. Addresses #1554 and ensures the timeline, highlights, and markers honor active filters with safe evidence links.

- **New Features**
  - Added a timeline above the event table composing STS sessions, CloudTrail, S3, Secrets/KMS, agent runtime, and remediation artifacts.
  - Added correlation highlights and lineage context for Secrets/KMS, S3, and agent runtime; metadata-only with evidence refs and redaction boundaries.
  - Added before/after remediation markers from remediation cases, low-risk live actions, and post-remediation verification.
  - Added an API-backed filter bar for `event`, `evidence`, `owner`, and `status`; timeline and table stay in sync; sanitized `evidence_links` (only internal paths or http/https).
  - Updated `docs/aws-runtime-events.md`, tests, and styles for the new timeline panel.

- **Bug Fixes**
  - Fixed filtered runtime timeline correlations so highlights and remediation markers only show entries matching the displayed events and sessions.

<sup>Written for commit 393151def6b3beedd5b172051c837f2aef4b64b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

