### PR TITLE
Add AWS executive outcome view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ## Unreleased
+- Add an **AWS executive outcome view** (#1555). Adds the metadata-only
+  `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes`
+  endpoint, composing account/region coverage, blast radius,
+  least-privilege recommendations, remediation cases, post-remediation
+  verification, limited enforcement, and governance audit reporting into
+  executive metrics for risk reduction, scan coverage, verified remediation,
+  enforcement readiness, remaining exposure, and governance outcomes. The
+  result supports connector, account, region, OU, identity type, severity,
+  outcome type, trend, and search filters, carries source evidence refs and
+  confidence, and stays inside the same export-safe boundary as the underlying
+  AWS contracts: no AWS write calls and no rendered policies, secret values,
+  prompts, completions, database rows, object contents, or workload payloads.
+  The app adds `/app/{tenant_id}/{workspace_id}/aws/outcomes` with summary
+  cards and a filterable outcome metric table for leadership review.
 - Add the **AWS Remediation Center unified experience** (read-only). A new
   `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/remediation-center`
   endpoint stitches remediation cases, the approval queue, dry-run projections,

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS high-confidence limited enforcement pilot: `aws-limited-enforcement-pilot.md`
 - AWS Remediation Center unified experience: `aws-remediation-center.md`
 - AWS governance audit reporting: `aws-governance-audit-reporting.md`
+- AWS executive outcome view: `aws-executive-outcome-view.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`

--- a/docs/aws-executive-outcome-view.md
+++ b/docs/aws-executive-outcome-view.md
@@ -1,0 +1,62 @@
+# AWS executive outcome view
+
+Issue #1555 adds a metadata-only executive rollup for AWS risk, coverage,
+remediation, enforcement, governance, and remaining exposure. It composes the
+existing AWS evidence APIs into a leadership-ready view without adding a new
+collector, executor, or AWS write path.
+
+The endpoint does not enforce, approve, remediate, mutate AWS resources, or
+export sensitive payloads.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes`
+
+Response shape: `{ "executive_outcomes": AWSExecutiveOutcomeViewResult }`.
+
+Supported filters: `connector_id`, `fixture_state`, `account_id`, `region`,
+`ou`, `identity_type`, `severity`, `outcome_type`, `trend`, and `search`.
+
+`outcome_type` can be `risk_reduction`, `coverage`, `remediation`,
+`enforcement`, `exposure`, or `governance`. `trend` can be `improving`,
+`stable`, or `needs_attention`.
+
+## Outcome metrics
+
+- `risk_reduction`: score derived from least-privilege recommendations,
+  remediation planning, verified remediation, enforcement readiness, and
+  residual exposure.
+- `coverage`: account, region, service, and collector coverage for the selected
+  AWS connector.
+- `remediation`: post-remediation verification and rollback state.
+- `enforcement`: limited-enforcement readiness, canary posture, and safety
+  gates.
+- `exposure`: open blast-radius findings plus least-privilege review work.
+- `governance`: export-safe governance decisions, approvals, remediations,
+  enforcement outcomes, and exceptions.
+
+## Evidence boundary
+
+Every metric carries source evidence links, confidence, account/region scope,
+severity, trend, and a next action. OU values are included only when upstream
+governance records provide real OU metadata.
+
+The result does not contain rendered policies, secret values, prompts,
+completions, browser pages, code-interpreter output, database rows, object
+contents, customer payloads, or workload payloads.
+
+## App surface
+
+The AWS Outcomes page renders summary cards for risk reduction, scan coverage,
+verified remediation, enforcement readiness, remaining exposure, and governance
+records, followed by a filterable outcome metric table. Loading, empty, error,
+degraded, permission-denied, and blocked states remain visible.
+
+## Out of scope
+
+- No live AWS mutation.
+- No new collector, scanner, or executor behavior.
+- No raw payload, policy-body, secret, prompt, completion, database, object, or
+  workload export.
+- No replacement for source drill-down pages; executive metrics link back to
+  the underlying evidence contracts.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -663,6 +663,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
     action: tenancy.read
     resource_type: project
@@ -6398,6 +6403,84 @@ paths:
                     $ref: "#/components/schemas/AWSGovernanceAuditReportingResult"
         "400":
           description: Invalid AWS governance audit reporting request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS executive outcome view
+      operationId: getAWSProjectExecutiveOutcomes
+      description: Composes executive AWS outcome metrics for risk reduction, scan coverage, verified remediation, enforcement readiness, remaining exposure, and governance outcomes from existing metadata-only AWS evidence contracts. The endpoint exposes confidence, trends, source evidence links, coverage gaps, and diagnostics without calling AWS write APIs or returning rendered policies, secret values, prompts, completions, database rows, object contents, or workload payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: ou
+          schema: { type: string }
+        - in: query
+          name: identity_type
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+        - in: query
+          name: outcome_type
+          schema:
+            type: string
+            enum: [risk_reduction, coverage, remediation, enforcement, exposure, governance]
+        - in: query
+          name: trend
+          schema:
+            type: string
+            enum: [improving, stable, needs_attention]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS executive outcome view contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  executive_outcomes:
+                    $ref: "#/components/schemas/AWSExecutiveOutcomeViewResult"
+        "400":
+          description: Invalid AWS executive outcome view request
           content:
             application/json:
               schema:
@@ -18568,6 +18651,134 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSGovernanceAuditReportRecord"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSExecutiveOutcomeMetric:
+      type: object
+      properties:
+        metric_id: { type: string }
+        category: { type: string }
+        outcome_type:
+          type: string
+          enum: [risk_reduction, coverage, remediation, enforcement, exposure, governance]
+        title: { type: string }
+        summary: { type: string }
+        value: { type: integer }
+        unit: { type: string }
+        trend:
+          type: string
+          enum: [improving, stable, needs_attention]
+        trend_delta: { type: integer }
+        score: { type: integer }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        ou: { type: string }
+        identity_type: { type: string }
+        severity: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_ref: { type: string }
+        evidence_boundary: { type: string }
+        next_action: { type: string }
+        updated_at:
+          type: string
+          format: date-time
+    AWSExecutiveOutcomeViewSummary:
+      type: object
+      properties:
+        total_metrics: { type: integer }
+        filtered_metrics: { type: integer }
+        risk_reduction_score: { type: integer }
+        scan_coverage_pct: { type: integer }
+        verified_remediation_count: { type: integer }
+        enforcement_ready_count: { type: integer }
+        remaining_exposure_count: { type: integer }
+        degraded_coverage_count: { type: integer }
+        governance_record_count: { type: integer }
+        exception_count: { type: integer }
+        account_counts:
+          type: object
+          additionalProperties: { type: integer }
+        ou_counts:
+          type: object
+          additionalProperties: { type: integer }
+        identity_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        severity_counts:
+          type: object
+          additionalProperties: { type: integer }
+        outcome_type_counts:
+          type: object
+          additionalProperties: { type: integer }
+        trend_counts:
+          type: object
+          additionalProperties: { type: integer }
+        highest_score: { type: integer }
+        average_confidence_pct: { type: integer }
+    AWSExecutiveOutcomeViewResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSExecutiveOutcomeViewSummary"
+        metrics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSExecutiveOutcomeMetric"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -783,6 +783,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/governance-audit-reporting", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/executive-outcomes", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -485,11 +485,12 @@ func summarizeAWSExecutiveOutcomeView(
 	enforcement AWSLimitedEnforcementResult,
 	governance AWSGovernanceAuditReportingResult,
 ) AWSExecutiveOutcomeViewSummary {
+	scanCoveragePct := percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords)
 	summary := AWSExecutiveOutcomeViewSummary{
 		TotalMetrics:             len(all),
 		FilteredMetrics:          len(filtered),
 		RiskReductionScore:       0,
-		ScanCoveragePct:          percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords),
+		ScanCoveragePct:          scanCoveragePct,
 		VerifiedRemediationCount: verification.Summary.VerifiedCount,
 		EnforcementReadyCount:    enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount,
 		RemainingExposureCount:   blast.Summary.FilteredFindings + least.Summary.ReviewCount,
@@ -502,7 +503,7 @@ func summarizeAWSExecutiveOutcomeView(
 		SeverityCounts:           map[string]int{},
 		OutcomeTypeCounts:        map[string]int{},
 		TrendCounts:              map[string]int{},
-		HighestScore:             maxInt(coverage.Summary.CoveredRecords, blast.Summary.HighestScore, least.Summary.HighestScore, cases.Summary.HighestScore, verification.Summary.HighestScore, enforcement.Summary.HighestScore, governance.Summary.HighestScore),
+		HighestScore:             maxInt(scanCoveragePct, blast.Summary.HighestScore, least.Summary.HighestScore, cases.Summary.HighestScore, verification.Summary.HighestScore, enforcement.Summary.HighestScore, governance.Summary.HighestScore),
 	}
 	confidenceTotal := 0.0
 	for _, metric := range filtered {
@@ -524,9 +525,6 @@ func summarizeAWSExecutiveOutcomeView(
 }
 
 func summarizeAWSExecutiveOutcomeViewStatus(metrics []AWSExecutiveOutcomeMetric, statuses ...string) (string, float64) {
-	if len(metrics) == 0 {
-		return "degraded", 0.65
-	}
 	blocked := false
 	degraded := false
 	for _, status := range statuses {
@@ -542,6 +540,9 @@ func summarizeAWSExecutiveOutcomeViewStatus(metrics []AWSExecutiveOutcomeMetric,
 	}
 	if degraded {
 		return "degraded", 0.74
+	}
+	if len(metrics) == 0 {
+		return "ready", 0.8
 	}
 	return "ready", 0.9
 }

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -362,7 +362,7 @@ func awsExecutiveOutcomeMetrics(
 			AccountID:        accountID,
 			Region:           region,
 			IdentityType:     "governed_identity",
-			Severity:         "high",
+			Severity:         awsExecutiveOutcomeLimitedEnforcementSeverity(enforcement.Entries),
 			EvidenceLinks:    enforcement.EvidenceLinks,
 			EvidenceRef:      "aws-executive-outcome://enforcement-status",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -433,6 +433,18 @@ func awsExecutiveOutcomeScopeValue(requestValue string, connectionValue string, 
 		return requestValue
 	}
 	return firstNonEmptyAWSValue(connectionValue, fallback)
+}
+
+func awsExecutiveOutcomeLimitedEnforcementSeverity(entries []AWSLimitedEnforcementEntry) string {
+	counts := map[string]int{}
+	for _, entry := range entries {
+		severity := normalizeAWSRuntimeEventFilterToken(entry.Severity)
+		if severity == "" || severity == "all" {
+			continue
+		}
+		counts[severity]++
+	}
+	return severityFromCounts(counts)
 }
 
 func awsExecutiveOutcomeFilteredSourceSummaries(

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -224,7 +224,10 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 		return AWSExecutiveOutcomeViewResult{}, err
 	}
 
-	metrics := awsExecutiveOutcomeMetrics(coverage, blast, least, cases, verification, enforcement, governance, accountID, region, now)
+	hasScopedSourceRows := awsExecutiveOutcomeHasSourceRows(coverage, blast, least, cases, verification, enforcement, governance)
+	metricAccountID := awsExecutiveOutcomeMetricScopeValue(request.AccountID, connection.AccountID, "123456789012", hasScopedSourceRows)
+	metricRegion := awsExecutiveOutcomeMetricScopeValue(request.Region, connection.Region, "us-east-1", hasScopedSourceRows)
+	metrics := awsExecutiveOutcomeMetrics(coverage, blast, least, cases, verification, enforcement, governance, metricAccountID, metricRegion, now)
 	filtered, applied := filterAWSExecutiveOutcomeMetrics(metrics, request)
 	summary := summarizeAWSExecutiveOutcomeView(metrics, filtered, coverage, blast, least, cases, verification, enforcement, governance)
 	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(filtered, awsExecutiveOutcomeSourceStatuses(request, sourceFixtureState, coverage, blast, least, cases, verification, enforcement, governance)...)
@@ -439,12 +442,32 @@ func awsExecutiveOutcomeScopeValue(requestValue string, connectionValue string, 
 	return firstNonEmptyAWSValue(connectionValue, fallback)
 }
 
+func awsExecutiveOutcomeMetricScopeValue(requestValue string, connectionValue string, fallback string, hasScopedSourceRows bool) string {
+	requestValue = strings.TrimSpace(requestValue)
+	if requestValue != "" && !strings.EqualFold(requestValue, "all") && hasScopedSourceRows {
+		return requestValue
+	}
+	return firstNonEmptyAWSValue(connectionValue, fallback)
+}
+
 func awsExecutiveOutcomeSourceScopeFilter(value string) string {
 	value = strings.TrimSpace(value)
 	if strings.EqualFold(value, "all") {
 		return ""
 	}
 	return value
+}
+
+func awsExecutiveOutcomeHasSourceRows(
+	coverage AWSAccountRegionCoverageResult,
+	blast AWSBlastRadiusResult,
+	least AWSLeastPrivilegeResult,
+	cases AWSRemediationCaseResult,
+	verification AWSPostRemediationVerificationResult,
+	enforcement AWSLimitedEnforcementResult,
+	governance AWSGovernanceAuditReportingResult,
+) bool {
+	return len(coverage.Records)+len(blast.Findings)+len(least.Recommendations)+len(cases.Cases)+len(verification.Entries)+len(enforcement.Entries)+len(governance.Records) > 0
 }
 
 func awsExecutiveOutcomeFilterLimitedEnforcementRows(result AWSLimitedEnforcementResult, request AWSExecutiveOutcomeViewRequest) AWSLimitedEnforcementResult {

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -146,6 +146,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	accountID := awsExecutiveOutcomeScopeValue(request.AccountID, connection.AccountID, "123456789012")
 	region := awsExecutiveOutcomeScopeValue(request.Region, connection.Region, "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceAccountID := awsExecutiveOutcomeSourceScopeFilter(request.AccountID)
+	sourceRegion := awsExecutiveOutcomeSourceScopeFilter(request.Region)
 	sourceFixtureState := fixtureState
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
 		sourceFixtureState = ""
@@ -154,8 +156,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	coverage, err := s.GetAWSAccountRegionCoverage(ctx, workspaceID, projectID, AWSAccountRegionCoverageRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		Account:      request.AccountID,
-		Region:       request.Region,
+		Account:      sourceAccountID,
+		Region:       sourceRegion,
 	})
 	if err != nil {
 		return AWSExecutiveOutcomeViewResult{}, err
@@ -163,8 +165,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 		Severity:     request.Severity,
 	})
 	if err != nil {
@@ -173,8 +175,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 		Severity:     request.Severity,
 	})
 	if err != nil {
@@ -183,8 +185,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 		Severity:     request.Severity,
 	})
 	if err != nil {
@@ -193,8 +195,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 		Severity:     request.Severity,
 	})
 	if err != nil {
@@ -203,8 +205,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	enforcement, err := s.GetAWSLimitedEnforcement(ctx, workspaceID, projectID, AWSLimitedEnforcementRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 	})
 	if err != nil {
 		return AWSExecutiveOutcomeViewResult{}, err
@@ -213,8 +215,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
-		AccountID:    request.AccountID,
-		Region:       request.Region,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
 		OU:           request.OU,
 		Search:       request.Search,
 	})
@@ -437,6 +439,14 @@ func awsExecutiveOutcomeScopeValue(requestValue string, connectionValue string, 
 	return firstNonEmptyAWSValue(connectionValue, fallback)
 }
 
+func awsExecutiveOutcomeSourceScopeFilter(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "all") {
+		return ""
+	}
+	return value
+}
+
 func awsExecutiveOutcomeFilterLimitedEnforcementRows(result AWSLimitedEnforcementResult, request AWSExecutiveOutcomeViewRequest) AWSLimitedEnforcementResult {
 	severity := normalizeAWSRuntimeEventFilterToken(request.Severity)
 	if severity == "" || severity == "all" {
@@ -614,7 +624,7 @@ func awsExecutiveOutcomeSourceStatuses(
 	enforcement AWSLimitedEnforcementResult,
 	governance AWSGovernanceAuditReportingResult,
 ) []string {
-	accountRegionFilterActive := strings.TrimSpace(request.AccountID) != "" || strings.TrimSpace(request.Region) != ""
+	accountRegionFilterActive := awsExecutiveOutcomeSourceScopeFilter(request.AccountID) != "" || awsExecutiveOutcomeSourceScopeFilter(request.Region) != ""
 	severitySourceFilterActive := accountRegionFilterActive || strings.TrimSpace(request.Severity) != ""
 	governanceFilterActive := accountRegionFilterActive || strings.TrimSpace(request.OU) != "" || strings.TrimSpace(request.Search) != ""
 

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -119,6 +119,16 @@ type AWSExecutiveOutcomeViewResult struct {
 	UpdatedAt          time.Time                        `json:"updated_at"`
 }
 
+type awsExecutiveOutcomeSourceSummaries struct {
+	Coverage     AWSAccountRegionCoverageSummary
+	Blast        AWSBlastRadiusSummary
+	Least        AWSLeastPrivilegeSummary
+	Cases        AWSRemediationCaseSummary
+	Verification AWSPostRemediationVerificationSummary
+	Enforcement  AWSLimitedEnforcementSummary
+	Governance   AWSGovernanceAuditReportingSummary
+}
+
 func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID string, projectID string, request AWSExecutiveOutcomeViewRequest) (AWSExecutiveOutcomeViewResult, error) {
 	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
 	if err != nil {
@@ -265,10 +275,11 @@ func awsExecutiveOutcomeMetrics(
 	region string,
 	now time.Time,
 ) []AWSExecutiveOutcomeMetric {
-	coveragePct := percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords)
-	remainingExposure := blast.Summary.FilteredFindings + least.Summary.ReviewCount
-	riskReduction := clampInt(least.Summary.RemoveCount*12+cases.Summary.VerificationPlanCount*10+verification.Summary.VerifiedCount*18+enforcement.Summary.CanaryReadyCount*8-remainingExposure*5, 0, 100)
-	degradedCoverage := coverage.Summary.DegradedRecords + coverage.Summary.UnreachableRecords + coverage.Summary.PermissionDeniedRecords + coverage.Summary.StaleRecords
+	summaries := awsExecutiveOutcomeFilteredSourceSummaries(coverage, blast, least, cases, verification, enforcement, governance)
+	coveragePct := percent(summaries.Coverage.CoveredRecords, summaries.Coverage.TotalRecords)
+	remainingExposure := summaries.Blast.FilteredFindings + summaries.Least.ReviewCount
+	riskReduction := clampInt(summaries.Least.RemoveCount*12+summaries.Cases.VerificationPlanCount*10+summaries.Verification.VerifiedCount*18+summaries.Enforcement.CanaryReadyCount*8-remainingExposure*5, 0, 100)
+	degradedCoverage := summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords
 	metrics := []AWSExecutiveOutcomeMetric{
 		{
 			MetricID:         "risk-reduction",
@@ -285,7 +296,7 @@ func awsExecutiveOutcomeMetrics(
 			AccountID:        accountID,
 			Region:           region,
 			IdentityType:     "machine_identity",
-			Severity:         severityFromCounts(blast.Summary.SeverityCounts, least.Summary.SeverityCounts, cases.Summary.SeverityCounts),
+			Severity:         severityFromCounts(summaries.Blast.SeverityCounts, summaries.Least.SeverityCounts, summaries.Cases.SeverityCounts),
 			EvidenceLinks:    dedupeStrings(append(append([]string{}, least.EvidenceLinks...), cases.EvidenceLinks...)),
 			EvidenceRef:      "aws-executive-outcome://risk-reduction",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -300,8 +311,8 @@ func awsExecutiveOutcomeMetrics(
 			Summary:          "Account, region, service, and collector coverage across the selected AWS connector.",
 			Value:            coveragePct,
 			Unit:             "percent",
-			Trend:            trendFromDelta(coverage.Summary.CoveredRecords - degradedCoverage),
-			TrendDelta:       coverage.Summary.CoveredRecords - degradedCoverage,
+			Trend:            trendFromDelta(summaries.Coverage.CoveredRecords - degradedCoverage),
+			TrendDelta:       summaries.Coverage.CoveredRecords - degradedCoverage,
 			Score:            coveragePct,
 			Confidence:       coverage.Confidence,
 			AccountID:        accountID,
@@ -320,16 +331,16 @@ func awsExecutiveOutcomeMetrics(
 			OutcomeType:      "remediation",
 			Title:            "Verified remediation",
 			Summary:          "Post-remediation verification and rollback state from read-only executor projections.",
-			Value:            verification.Summary.VerifiedCount,
+			Value:            summaries.Verification.VerifiedCount,
 			Unit:             "verified",
-			Trend:            trendFromDelta(verification.Summary.VerifiedCount - verification.Summary.FailedCount - verification.Summary.BlockedCount),
-			TrendDelta:       verification.Summary.VerifiedCount - verification.Summary.FailedCount - verification.Summary.BlockedCount,
-			Score:            verification.Summary.HighestScore,
+			Trend:            trendFromDelta(summaries.Verification.VerifiedCount - summaries.Verification.FailedCount - summaries.Verification.BlockedCount),
+			TrendDelta:       summaries.Verification.VerifiedCount - summaries.Verification.FailedCount - summaries.Verification.BlockedCount,
+			Score:            summaries.Verification.HighestScore,
 			Confidence:       verification.Confidence,
 			AccountID:        accountID,
 			Region:           region,
 			IdentityType:     "remediation_target",
-			Severity:         severityFromCounts(verification.Summary.SeverityCounts),
+			Severity:         severityFromCounts(summaries.Verification.SeverityCounts),
 			EvidenceLinks:    verification.EvidenceLinks,
 			EvidenceRef:      "aws-executive-outcome://verified-remediation",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -342,11 +353,11 @@ func awsExecutiveOutcomeMetrics(
 			OutcomeType:      "enforcement",
 			Title:            "Enforcement readiness",
 			Summary:          "Limited enforcement readiness, canary safety, and kill-switch status.",
-			Value:            enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount,
+			Value:            summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount,
 			Unit:             "ready",
-			Trend:            trendFromDelta(enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount - enforcement.Summary.KillSwitchEngagedCount - enforcement.Summary.FailedGateCount),
-			TrendDelta:       enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount - enforcement.Summary.KillSwitchEngagedCount - enforcement.Summary.FailedGateCount,
-			Score:            enforcement.Summary.HighestScore,
+			Trend:            trendFromDelta(summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount),
+			TrendDelta:       summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount,
+			Score:            summaries.Enforcement.HighestScore,
 			Confidence:       enforcement.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -368,12 +379,12 @@ func awsExecutiveOutcomeMetrics(
 			Unit:             "open",
 			Trend:            trendFromDelta(-remainingExposure),
 			TrendDelta:       -remainingExposure,
-			Score:            maxInt(blast.Summary.HighestScore, least.Summary.HighestScore),
+			Score:            maxInt(summaries.Blast.HighestScore, summaries.Least.HighestScore),
 			Confidence:       averageFloat64(blast.Confidence, least.Confidence),
 			AccountID:        accountID,
 			Region:           region,
 			IdentityType:     "machine_identity",
-			Severity:         severityFromCounts(blast.Summary.SeverityCounts, least.Summary.SeverityCounts),
+			Severity:         severityFromCounts(summaries.Blast.SeverityCounts, summaries.Least.SeverityCounts),
 			EvidenceLinks:    dedupeStrings(append(append([]string{}, blast.EvidenceLinks...), least.EvidenceLinks...)),
 			EvidenceRef:      "aws-executive-outcome://remaining-exposure",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -386,17 +397,17 @@ func awsExecutiveOutcomeMetrics(
 			OutcomeType:      "governance",
 			Title:            "Governance outcomes",
 			Summary:          "Export-safe decision, approval, remediation, enforcement, and exception rows available to leadership.",
-			Value:            governance.Summary.FilteredRecords,
+			Value:            summaries.Governance.FilteredRecords,
 			Unit:             "records",
-			Trend:            trendFromDelta(governance.Summary.EnforcementOutcomeCount + governance.Summary.RemediationCount - governance.Summary.ExceptionCount),
-			TrendDelta:       governance.Summary.EnforcementOutcomeCount + governance.Summary.RemediationCount - governance.Summary.ExceptionCount,
-			Score:            governance.Summary.HighestScore,
+			Trend:            trendFromDelta(summaries.Governance.EnforcementOutcomeCount + summaries.Governance.RemediationCount - summaries.Governance.ExceptionCount),
+			TrendDelta:       summaries.Governance.EnforcementOutcomeCount + summaries.Governance.RemediationCount - summaries.Governance.ExceptionCount,
+			Score:            summaries.Governance.HighestScore,
 			Confidence:       governance.Confidence,
 			AccountID:        accountID,
 			Region:           region,
 			OU:               awsExecutiveOutcomeMetricOU(governance.Records),
 			IdentityType:     "governance_record",
-			Severity:         severityFromFailureCount(governance.Summary.ExceptionCount),
+			Severity:         severityFromFailureCount(summaries.Governance.ExceptionCount),
 			EvidenceLinks:    governance.EvidenceLinks,
 			EvidenceRef:      "aws-executive-outcome://governance-outcomes",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -414,6 +425,26 @@ func awsExecutiveOutcomeMetrics(
 		return metrics[i].Score > metrics[j].Score
 	})
 	return metrics
+}
+
+func awsExecutiveOutcomeFilteredSourceSummaries(
+	coverage AWSAccountRegionCoverageResult,
+	blast AWSBlastRadiusResult,
+	least AWSLeastPrivilegeResult,
+	cases AWSRemediationCaseResult,
+	verification AWSPostRemediationVerificationResult,
+	enforcement AWSLimitedEnforcementResult,
+	governance AWSGovernanceAuditReportingResult,
+) awsExecutiveOutcomeSourceSummaries {
+	return awsExecutiveOutcomeSourceSummaries{
+		Coverage:     summarizeAWSAccountRegionCoverage(coverage.Records, len(coverage.Records)),
+		Blast:        summarizeAWSBlastRadius(blast.Findings, blast.Findings, nil),
+		Least:        summarizeAWSLeastPrivilege(least.Recommendations, least.Recommendations, nil),
+		Cases:        summarizeAWSRemediationCases(cases.Cases, cases.Cases, nil),
+		Verification: summarizeAWSPostRemediationVerificationEntries(verification.Entries, verification.Entries, nil),
+		Enforcement:  summarizeAWSLimitedEnforcementEntries(enforcement.Entries, enforcement.Entries, nil),
+		Governance:   summarizeAWSGovernanceAuditReportRecords(governance.Records, governance.Records),
+	}
 }
 
 func filterAWSExecutiveOutcomeMetrics(metrics []AWSExecutiveOutcomeMetric, request AWSExecutiveOutcomeViewRequest) ([]AWSExecutiveOutcomeMetric, map[string]string) {
@@ -485,25 +516,26 @@ func summarizeAWSExecutiveOutcomeView(
 	enforcement AWSLimitedEnforcementResult,
 	governance AWSGovernanceAuditReportingResult,
 ) AWSExecutiveOutcomeViewSummary {
-	scanCoveragePct := percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords)
+	summaries := awsExecutiveOutcomeFilteredSourceSummaries(coverage, blast, least, cases, verification, enforcement, governance)
+	scanCoveragePct := percent(summaries.Coverage.CoveredRecords, summaries.Coverage.TotalRecords)
 	summary := AWSExecutiveOutcomeViewSummary{
 		TotalMetrics:             len(all),
 		FilteredMetrics:          len(filtered),
 		RiskReductionScore:       0,
 		ScanCoveragePct:          scanCoveragePct,
-		VerifiedRemediationCount: verification.Summary.VerifiedCount,
-		EnforcementReadyCount:    enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount,
-		RemainingExposureCount:   blast.Summary.FilteredFindings + least.Summary.ReviewCount,
-		DegradedCoverageCount:    coverage.Summary.DegradedRecords + coverage.Summary.UnreachableRecords + coverage.Summary.PermissionDeniedRecords + coverage.Summary.StaleRecords,
-		GovernanceRecordCount:    governance.Summary.FilteredRecords,
-		ExceptionCount:           governance.Summary.ExceptionCount,
+		VerifiedRemediationCount: summaries.Verification.VerifiedCount,
+		EnforcementReadyCount:    summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount,
+		RemainingExposureCount:   summaries.Blast.FilteredFindings + summaries.Least.ReviewCount,
+		DegradedCoverageCount:    summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords,
+		GovernanceRecordCount:    summaries.Governance.FilteredRecords,
+		ExceptionCount:           summaries.Governance.ExceptionCount,
 		AccountCounts:            map[string]int{},
 		OUCounts:                 map[string]int{},
 		IdentityTypeCounts:       map[string]int{},
 		SeverityCounts:           map[string]int{},
 		OutcomeTypeCounts:        map[string]int{},
 		TrendCounts:              map[string]int{},
-		HighestScore:             maxInt(scanCoveragePct, blast.Summary.HighestScore, least.Summary.HighestScore, cases.Summary.HighestScore, verification.Summary.HighestScore, enforcement.Summary.HighestScore, governance.Summary.HighestScore),
+		HighestScore:             maxInt(scanCoveragePct, summaries.Blast.HighestScore, summaries.Least.HighestScore, summaries.Cases.HighestScore, summaries.Verification.HighestScore, summaries.Enforcement.HighestScore, summaries.Governance.HighestScore),
 	}
 	confidenceTotal := 0.0
 	for _, metric := range filtered {

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -574,30 +574,34 @@ func summarizeAWSExecutiveOutcomeView(
 	governance AWSGovernanceAuditReportingResult,
 ) AWSExecutiveOutcomeViewSummary {
 	summaries := awsExecutiveOutcomeFilteredSourceSummaries(coverage, blast, least, cases, verification, enforcement, governance)
-	scanCoveragePct := percent(summaries.Coverage.CoveredRecords, summaries.Coverage.TotalRecords)
 	summary := AWSExecutiveOutcomeViewSummary{
-		TotalMetrics:             len(all),
-		FilteredMetrics:          len(filtered),
-		RiskReductionScore:       0,
-		ScanCoveragePct:          scanCoveragePct,
-		VerifiedRemediationCount: summaries.Verification.VerifiedCount,
-		EnforcementReadyCount:    awsExecutiveOutcomeLimitedEnforcementReadyCount(enforcement.Entries),
-		RemainingExposureCount:   summaries.Blast.FilteredFindings + summaries.Least.ReviewCount,
-		DegradedCoverageCount:    summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords,
-		GovernanceRecordCount:    summaries.Governance.FilteredRecords,
-		ExceptionCount:           summaries.Governance.ExceptionCount,
-		AccountCounts:            map[string]int{},
-		OUCounts:                 map[string]int{},
-		IdentityTypeCounts:       map[string]int{},
-		SeverityCounts:           map[string]int{},
-		OutcomeTypeCounts:        map[string]int{},
-		TrendCounts:              map[string]int{},
-		HighestScore:             maxInt(scanCoveragePct, summaries.Blast.HighestScore, summaries.Least.HighestScore, summaries.Cases.HighestScore, summaries.Verification.HighestScore, summaries.Enforcement.HighestScore, summaries.Governance.HighestScore),
+		TotalMetrics:       len(all),
+		FilteredMetrics:    len(filtered),
+		RiskReductionScore: 0,
+		AccountCounts:      map[string]int{},
+		OUCounts:           map[string]int{},
+		IdentityTypeCounts: map[string]int{},
+		SeverityCounts:     map[string]int{},
+		OutcomeTypeCounts:  map[string]int{},
+		TrendCounts:        map[string]int{},
 	}
 	confidenceTotal := 0.0
 	for _, metric := range filtered {
-		if metric.MetricID == "risk-reduction" {
+		switch metric.MetricID {
+		case "risk-reduction":
 			summary.RiskReductionScore = metric.Value
+		case "scan-coverage":
+			summary.ScanCoveragePct = metric.Value
+			summary.DegradedCoverageCount = summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords
+		case "verified-remediation":
+			summary.VerifiedRemediationCount = metric.Value
+		case "enforcement-status":
+			summary.EnforcementReadyCount = metric.Value
+		case "remaining-exposure":
+			summary.RemainingExposureCount = metric.Value
+		case "governance-outcomes":
+			summary.GovernanceRecordCount = metric.Value
+			summary.ExceptionCount = summaries.Governance.ExceptionCount
 		}
 		incrementCount(summary.AccountCounts, metric.AccountID)
 		incrementDelimitedCount(summary.OUCounts, metric.OU)
@@ -605,6 +609,7 @@ func summarizeAWSExecutiveOutcomeView(
 		incrementCount(summary.SeverityCounts, metric.Severity)
 		incrementCount(summary.OutcomeTypeCounts, metric.OutcomeType)
 		incrementCount(summary.TrendCounts, metric.Trend)
+		summary.HighestScore = maxInt(summary.HighestScore, metric.Score)
 		confidenceTotal += metric.Confidence
 	}
 	if len(filtered) > 0 {

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -224,7 +224,7 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	metrics := awsExecutiveOutcomeMetrics(coverage, blast, least, cases, verification, enforcement, governance, accountID, region, now)
 	filtered, applied := filterAWSExecutiveOutcomeMetrics(metrics, request)
 	summary := summarizeAWSExecutiveOutcomeView(metrics, filtered, coverage, blast, least, cases, verification, enforcement, governance)
-	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(filtered, coverage.Status, blast.Status, least.Status, cases.Status, verification.Status, enforcement.Status, governance.Status)
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(filtered, awsExecutiveOutcomeSourceStatuses(request, sourceFixtureState, coverage, blast, least, cases, verification, enforcement, governance)...)
 	return AWSExecutiveOutcomeViewResult{
 		TenantID:           scope.TenantID,
 		WorkspaceID:        project.WorkspaceID,
@@ -554,6 +554,46 @@ func summarizeAWSExecutiveOutcomeView(
 		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
 	}
 	return summary
+}
+
+func awsExecutiveOutcomeSourceStatuses(
+	request AWSExecutiveOutcomeViewRequest,
+	sourceFixtureState string,
+	coverage AWSAccountRegionCoverageResult,
+	blast AWSBlastRadiusResult,
+	least AWSLeastPrivilegeResult,
+	cases AWSRemediationCaseResult,
+	verification AWSPostRemediationVerificationResult,
+	enforcement AWSLimitedEnforcementResult,
+	governance AWSGovernanceAuditReportingResult,
+) []string {
+	accountRegionFilterActive := strings.TrimSpace(request.AccountID) != "" || strings.TrimSpace(request.Region) != ""
+	severitySourceFilterActive := accountRegionFilterActive || strings.TrimSpace(request.Severity) != ""
+	governanceFilterActive := accountRegionFilterActive || strings.TrimSpace(request.OU) != "" || strings.TrimSpace(request.Search) != ""
+
+	return []string{
+		coverage.Status,
+		awsExecutiveOutcomeFilteredEmptyStatus(blast.Status, len(blast.Findings), severitySourceFilterActive, sourceFixtureState, blast.FailureReasons, len(blast.Diagnostics)),
+		awsExecutiveOutcomeFilteredEmptyStatus(least.Status, len(least.Recommendations), severitySourceFilterActive, sourceFixtureState, least.FailureReasons, len(least.Diagnostics)),
+		awsExecutiveOutcomeFilteredEmptyStatus(cases.Status, len(cases.Cases), severitySourceFilterActive, sourceFixtureState, cases.FailureReasons, len(cases.Diagnostics)),
+		awsExecutiveOutcomeFilteredEmptyStatus(verification.Status, len(verification.Entries), severitySourceFilterActive, sourceFixtureState, verification.FailureReasons, len(verification.Diagnostics)),
+		awsExecutiveOutcomeFilteredEmptyStatus(enforcement.Status, len(enforcement.Entries), accountRegionFilterActive, sourceFixtureState, enforcement.FailureReasons, len(enforcement.Diagnostics)),
+		awsExecutiveOutcomeFilteredEmptyStatus(governance.Status, len(governance.Records), governanceFilterActive, sourceFixtureState, governance.FailureReasons, len(governance.Diagnostics)),
+	}
+}
+
+func awsExecutiveOutcomeFilteredEmptyStatus(status string, rowCount int, filterActive bool, sourceFixtureState string, failureReasons []string, diagnosticCount int) string {
+	if strings.ToLower(strings.TrimSpace(status)) != awsPlatformDependencyStatusDegraded {
+		return status
+	}
+	if rowCount != 0 || !filterActive || len(failureReasons) != 0 || diagnosticCount != 0 {
+		return status
+	}
+	fixtureState := strings.ToLower(strings.TrimSpace(sourceFixtureState))
+	if fixtureState != "" && fixtureState != "success" {
+		return status
+	}
+	return awsPlatformDependencyStatusReady
 }
 
 func summarizeAWSExecutiveOutcomeViewStatus(metrics []AWSExecutiveOutcomeMetric, statuses ...string) (string, float64) {

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -143,8 +143,8 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	if fixtureState == "" {
 		return AWSExecutiveOutcomeViewResult{}, ErrInvalidAWSConnectionRequest
 	}
-	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
-	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	accountID := awsExecutiveOutcomeScopeValue(request.AccountID, connection.AccountID, "123456789012")
+	region := awsExecutiveOutcomeScopeValue(request.Region, connection.Region, "us-east-1")
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
 	sourceFixtureState := fixtureState
 	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
@@ -425,6 +425,14 @@ func awsExecutiveOutcomeMetrics(
 		return metrics[i].Score > metrics[j].Score
 	})
 	return metrics
+}
+
+func awsExecutiveOutcomeScopeValue(requestValue string, connectionValue string, fallback string) string {
+	requestValue = strings.TrimSpace(requestValue)
+	if requestValue != "" && !strings.EqualFold(requestValue, "all") {
+		return requestValue
+	}
+	return firstNonEmptyAWSValue(connectionValue, fallback)
 }
 
 func awsExecutiveOutcomeFilteredSourceSummaries(

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -322,7 +322,7 @@ func awsExecutiveOutcomeMetrics(
 			AccountID:        accountID,
 			Region:           region,
 			IdentityType:     "coverage_target",
-			Severity:         severityFromFailureCount(degradedCoverage),
+			Severity:         severityFromFailureCount(degradedCoverage, summaries.Coverage.TotalRecords),
 			EvidenceLinks:    coverage.EvidenceLinks,
 			EvidenceRef:      "aws-executive-outcome://scan-coverage",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -411,7 +411,7 @@ func awsExecutiveOutcomeMetrics(
 			Region:           region,
 			OU:               awsExecutiveOutcomeMetricOU(governance.Records),
 			IdentityType:     "governance_record",
-			Severity:         severityFromFailureCount(summaries.Governance.ExceptionCount),
+			Severity:         severityFromFailureCount(summaries.Governance.ExceptionCount, summaries.Governance.FilteredRecords),
 			EvidenceLinks:    governance.EvidenceLinks,
 			EvidenceRef:      "aws-executive-outcome://governance-outcomes",
 			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
@@ -811,7 +811,11 @@ func trendFromDelta(delta int) string {
 }
 
 func severityFromCounts(groups ...map[string]int) string {
+	total := 0
 	for _, group := range groups {
+		for _, count := range group {
+			total += count
+		}
 		if group["critical"] > 0 {
 			return "critical"
 		}
@@ -826,12 +830,23 @@ func severityFromCounts(groups ...map[string]int) string {
 			return "medium"
 		}
 	}
+	for _, group := range groups {
+		if group["low"] > 0 {
+			return "low"
+		}
+	}
+	if total == 0 {
+		return ""
+	}
 	return "low"
 }
 
-func severityFromFailureCount(count int) string {
+func severityFromFailureCount(count int, total int) string {
 	if count > 0 {
 		return "high"
+	}
+	if total <= 0 {
+		return ""
 	}
 	return "low"
 }

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -529,34 +529,46 @@ func awsExecutiveOutcomeFilteredSourceSummaries(
 
 func filterAWSExecutiveOutcomeMetrics(metrics []AWSExecutiveOutcomeMetric, request AWSExecutiveOutcomeViewRequest) ([]AWSExecutiveOutcomeMetric, map[string]string) {
 	applied := map[string]string{}
-	matchText := func(value, want string) bool {
+	matchToken := func(value, want string) bool {
 		want = strings.ToLower(strings.TrimSpace(want))
 		if want == "" || want == "all" {
 			return true
 		}
-		return strings.Contains(strings.ToLower(value), want)
+		return strings.ToLower(strings.TrimSpace(value)) == want
+	}
+	matchDelimitedToken := func(value, want string) bool {
+		want = strings.ToLower(strings.TrimSpace(want))
+		if want == "" || want == "all" {
+			return true
+		}
+		for _, token := range strings.Split(value, ",") {
+			if strings.ToLower(strings.TrimSpace(token)) == want {
+				return true
+			}
+		}
+		return false
 	}
 	filtered := make([]AWSExecutiveOutcomeMetric, 0, len(metrics))
 	for _, metric := range metrics {
-		if !matchText(metric.AccountID, request.AccountID) {
+		if !matchToken(metric.AccountID, request.AccountID) {
 			continue
 		}
-		if !matchText(metric.Region, request.Region) {
+		if !matchToken(metric.Region, request.Region) {
 			continue
 		}
-		if !matchText(metric.OU, request.OU) {
+		if !matchDelimitedToken(metric.OU, request.OU) {
 			continue
 		}
-		if !matchText(metric.IdentityType, request.IdentityType) {
+		if !matchToken(metric.IdentityType, request.IdentityType) {
 			continue
 		}
-		if !matchText(metric.Severity, request.Severity) {
+		if !matchToken(metric.Severity, request.Severity) {
 			continue
 		}
-		if !matchText(metric.OutcomeType, request.OutcomeType) {
+		if !matchToken(metric.OutcomeType, request.OutcomeType) {
 			continue
 		}
-		if !matchText(metric.Trend, request.Trend) {
+		if !matchToken(metric.Trend, request.Trend) {
 			continue
 		}
 		search := strings.ToLower(strings.TrimSpace(request.Search))

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -209,6 +209,7 @@ func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID st
 	if err != nil {
 		return AWSExecutiveOutcomeViewResult{}, err
 	}
+	enforcement = awsExecutiveOutcomeFilterLimitedEnforcementRows(enforcement, request)
 	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
 		ConnectorID:  connectorID,
 		FixtureState: sourceFixtureState,
@@ -280,6 +281,7 @@ func awsExecutiveOutcomeMetrics(
 	remainingExposure := summaries.Blast.FilteredFindings + summaries.Least.ReviewCount
 	riskReduction := clampInt(summaries.Least.RemoveCount*12+summaries.Cases.VerificationPlanCount*10+summaries.Verification.VerifiedCount*18+summaries.Enforcement.CanaryReadyCount*8-remainingExposure*5, 0, 100)
 	degradedCoverage := summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords
+	enforcementReady := awsExecutiveOutcomeLimitedEnforcementReadyCount(enforcement.Entries)
 	metrics := []AWSExecutiveOutcomeMetric{
 		{
 			MetricID:         "risk-reduction",
@@ -353,10 +355,10 @@ func awsExecutiveOutcomeMetrics(
 			OutcomeType:      "enforcement",
 			Title:            "Enforcement readiness",
 			Summary:          "Limited enforcement readiness, canary safety, and kill-switch status.",
-			Value:            summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount,
+			Value:            enforcementReady,
 			Unit:             "ready",
-			Trend:            trendFromDelta(summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount),
-			TrendDelta:       summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount,
+			Trend:            trendFromDelta(enforcementReady - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount),
+			TrendDelta:       enforcementReady - summaries.Enforcement.KillSwitchEngagedCount - summaries.Enforcement.FailedGateCount,
 			Score:            summaries.Enforcement.HighestScore,
 			Confidence:       enforcement.Confidence,
 			AccountID:        accountID,
@@ -433,6 +435,31 @@ func awsExecutiveOutcomeScopeValue(requestValue string, connectionValue string, 
 		return requestValue
 	}
 	return firstNonEmptyAWSValue(connectionValue, fallback)
+}
+
+func awsExecutiveOutcomeFilterLimitedEnforcementRows(result AWSLimitedEnforcementResult, request AWSExecutiveOutcomeViewRequest) AWSLimitedEnforcementResult {
+	severity := normalizeAWSRuntimeEventFilterToken(request.Severity)
+	if severity == "" || severity == "all" {
+		return result
+	}
+	out := result
+	out.Entries = make([]AWSLimitedEnforcementEntry, 0, len(result.Entries))
+	for _, entry := range result.Entries {
+		if normalizeAWSRuntimeEventFilterToken(entry.Severity) == severity {
+			out.Entries = append(out.Entries, entry)
+		}
+	}
+	return out
+}
+
+func awsExecutiveOutcomeLimitedEnforcementReadyCount(entries []AWSLimitedEnforcementEntry) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.ReadyForCanary || entry.ReadyForEnforcement {
+			count++
+		}
+	}
+	return count
 }
 
 func awsExecutiveOutcomeLimitedEnforcementSeverity(entries []AWSLimitedEnforcementEntry) string {
@@ -544,7 +571,7 @@ func summarizeAWSExecutiveOutcomeView(
 		RiskReductionScore:       0,
 		ScanCoveragePct:          scanCoveragePct,
 		VerifiedRemediationCount: summaries.Verification.VerifiedCount,
-		EnforcementReadyCount:    summaries.Enforcement.CanaryReadyCount + summaries.Enforcement.ReadyForEnforcementCount,
+		EnforcementReadyCount:    awsExecutiveOutcomeLimitedEnforcementReadyCount(enforcement.Entries),
 		RemainingExposureCount:   summaries.Blast.FilteredFindings + summaries.Least.ReviewCount,
 		DegradedCoverageCount:    summaries.Coverage.DegradedRecords + summaries.Coverage.UnreachableRecords + summaries.Coverage.PermissionDeniedRecords + summaries.Coverage.StaleRecords,
 		GovernanceRecordCount:    summaries.Governance.FilteredRecords,

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -619,13 +619,35 @@ func awsExecutiveOutcomeSourceStatuses(
 	governanceFilterActive := accountRegionFilterActive || strings.TrimSpace(request.OU) != "" || strings.TrimSpace(request.Search) != ""
 
 	return []string{
-		coverage.Status,
+		awsExecutiveOutcomeCoverageStatus(coverage, accountRegionFilterActive, sourceFixtureState),
 		awsExecutiveOutcomeFilteredEmptyStatus(blast.Status, len(blast.Findings), severitySourceFilterActive, sourceFixtureState, blast.FailureReasons, len(blast.Diagnostics)),
 		awsExecutiveOutcomeFilteredEmptyStatus(least.Status, len(least.Recommendations), severitySourceFilterActive, sourceFixtureState, least.FailureReasons, len(least.Diagnostics)),
 		awsExecutiveOutcomeFilteredEmptyStatus(cases.Status, len(cases.Cases), severitySourceFilterActive, sourceFixtureState, cases.FailureReasons, len(cases.Diagnostics)),
 		awsExecutiveOutcomeFilteredEmptyStatus(verification.Status, len(verification.Entries), severitySourceFilterActive, sourceFixtureState, verification.FailureReasons, len(verification.Diagnostics)),
 		awsExecutiveOutcomeFilteredEmptyStatus(enforcement.Status, len(enforcement.Entries), accountRegionFilterActive, sourceFixtureState, enforcement.FailureReasons, len(enforcement.Diagnostics)),
 		awsExecutiveOutcomeFilteredEmptyStatus(governance.Status, len(governance.Records), governanceFilterActive, sourceFixtureState, governance.FailureReasons, len(governance.Diagnostics)),
+	}
+}
+
+func awsExecutiveOutcomeCoverageStatus(coverage AWSAccountRegionCoverageResult, filterActive bool, sourceFixtureState string) string {
+	if !filterActive {
+		return coverage.Status
+	}
+	fixtureState := strings.ToLower(strings.TrimSpace(sourceFixtureState))
+	if fixtureState != "" && fixtureState != "success" {
+		return coverage.Status
+	}
+	if len(coverage.Records) == 0 {
+		return awsExecutiveOutcomeFilteredEmptyStatus(coverage.Status, 0, true, sourceFixtureState, coverage.FailureReasons, len(coverage.Diagnostics))
+	}
+	summary := summarizeAWSAccountRegionCoverage(coverage.Records, len(coverage.Records))
+	switch {
+	case summary.PermissionDeniedRecords > 0:
+		return awsPlatformDependencyStatusBlocked
+	case summary.DegradedRecords+summary.UnreachableRecords+summary.SuspendedRecords+summary.StaleRecords > 0:
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
 	}
 }
 

--- a/internal/api/aws_executive_outcome_view.go
+++ b/internal/api/aws_executive_outcome_view.go
@@ -1,0 +1,747 @@
+package api
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsExecutiveOutcomeViewCurrentIssue = 1555
+	awsExecutiveOutcomeViewVersion      = "aws-executive-outcome-view-v1"
+	awsExecutiveOutcomeViewBoundary     = "metadata_only_outcome_metrics_no_secret_values_no_customer_payloads"
+)
+
+// AWSExecutiveOutcomeViewRequest scopes the executive outcome rollup to one
+// AWS connector plus operator-visible filters. The endpoint composes existing
+// read-only AWS evidence contracts and never reads or persists payload content.
+type AWSExecutiveOutcomeViewRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	OU           string `json:"ou,omitempty"`
+	IdentityType string `json:"identity_type,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	OutcomeType  string `json:"outcome_type,omitempty"`
+	Trend        string `json:"trend,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSExecutiveOutcomeMetric struct {
+	MetricID         string    `json:"metric_id"`
+	Category         string    `json:"category"`
+	OutcomeType      string    `json:"outcome_type"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary"`
+	Value            int       `json:"value"`
+	Unit             string    `json:"unit"`
+	Trend            string    `json:"trend"`
+	TrendDelta       int       `json:"trend_delta"`
+	Score            int       `json:"score"`
+	Confidence       float64   `json:"confidence"`
+	AccountID        string    `json:"account_id,omitempty"`
+	Region           string    `json:"region,omitempty"`
+	OU               string    `json:"ou,omitempty"`
+	IdentityType     string    `json:"identity_type,omitempty"`
+	Severity         string    `json:"severity,omitempty"`
+	EvidenceLinks    []string  `json:"evidence_links"`
+	EvidenceRef      string    `json:"evidence_ref,omitempty"`
+	EvidenceBoundary string    `json:"evidence_boundary"`
+	NextAction       string    `json:"next_action"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type AWSExecutiveOutcomeCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSExecutiveOutcomeDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+type AWSExecutiveOutcomeViewSummary struct {
+	TotalMetrics             int            `json:"total_metrics"`
+	FilteredMetrics          int            `json:"filtered_metrics"`
+	RiskReductionScore       int            `json:"risk_reduction_score"`
+	ScanCoveragePct          int            `json:"scan_coverage_pct"`
+	VerifiedRemediationCount int            `json:"verified_remediation_count"`
+	EnforcementReadyCount    int            `json:"enforcement_ready_count"`
+	RemainingExposureCount   int            `json:"remaining_exposure_count"`
+	DegradedCoverageCount    int            `json:"degraded_coverage_count"`
+	GovernanceRecordCount    int            `json:"governance_record_count"`
+	ExceptionCount           int            `json:"exception_count"`
+	AccountCounts            map[string]int `json:"account_counts"`
+	OUCounts                 map[string]int `json:"ou_counts"`
+	IdentityTypeCounts       map[string]int `json:"identity_type_counts"`
+	SeverityCounts           map[string]int `json:"severity_counts"`
+	OutcomeTypeCounts        map[string]int `json:"outcome_type_counts"`
+	TrendCounts              map[string]int `json:"trend_counts"`
+	HighestScore             int            `json:"highest_score"`
+	AverageConfidencePct     int            `json:"average_confidence_pct"`
+}
+
+type AWSExecutiveOutcomeViewResult struct {
+	TenantID           string                           `json:"tenant_id"`
+	WorkspaceID        string                           `json:"workspace_id"`
+	ProjectID          string                           `json:"project_id"`
+	ConnectorID        string                           `json:"connector_id,omitempty"`
+	AccountID          string                           `json:"account_id,omitempty"`
+	Region             string                           `json:"region,omitempty"`
+	ParentIssueNumber  int                              `json:"parent_issue_number"`
+	ParentIssueRef     string                           `json:"parent_issue_ref"`
+	CurrentIssueNumber int                              `json:"current_issue_number"`
+	CurrentIssueRef    string                           `json:"current_issue_ref"`
+	Version            string                           `json:"version"`
+	Status             string                           `json:"status"`
+	FixtureState       string                           `json:"fixture_state,omitempty"`
+	Confidence         float64                          `json:"confidence"`
+	CalculationVersion string                           `json:"calculation_version"`
+	AppliedFilters     map[string]string                `json:"applied_filters"`
+	Summary            AWSExecutiveOutcomeViewSummary   `json:"summary"`
+	Metrics            []AWSExecutiveOutcomeMetric      `json:"metrics"`
+	Caveats            []string                         `json:"caveats"`
+	FailureReasons     []string                         `json:"failure_reasons"`
+	RemediationHints   []string                         `json:"remediation_hints"`
+	EvidenceLinks      []string                         `json:"evidence_links"`
+	CoverageGaps       []AWSExecutiveOutcomeCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSExecutiveOutcomeDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                        `json:"generated_at"`
+	UpdatedAt          time.Time                        `json:"updated_at"`
+}
+
+func (s *Service) GetAWSExecutiveOutcomeView(ctx context.Context, workspaceID string, projectID string, request AWSExecutiveOutcomeViewRequest) (AWSExecutiveOutcomeViewResult, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSGovernanceAuditReportingFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSExecutiveOutcomeViewResult{}, ErrInvalidAWSConnectionRequest
+	}
+	accountID := firstNonEmptyAWSValue(connection.AccountID, strings.TrimSpace(request.AccountID), "123456789012")
+	region := firstNonEmptyAWSValue(connection.Region, strings.TrimSpace(request.Region), "us-east-1")
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+
+	coverage, err := s.GetAWSAccountRegionCoverage(ctx, workspaceID, projectID, AWSAccountRegionCoverageRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		Account:      request.AccountID,
+		Region:       request.Region,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	blast, err := s.GetAWSBlastRadius(ctx, workspaceID, projectID, AWSBlastRadiusRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	least, err := s.GetAWSLeastPrivilegeRecommendations(ctx, workspaceID, projectID, AWSLeastPrivilegeRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		Severity:     request.Severity,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	enforcement, err := s.GetAWSLimitedEnforcement(ctx, workspaceID, projectID, AWSLimitedEnforcementRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    request.AccountID,
+		Region:       request.Region,
+		OU:           request.OU,
+		Search:       request.Search,
+	})
+	if err != nil {
+		return AWSExecutiveOutcomeViewResult{}, err
+	}
+
+	metrics := awsExecutiveOutcomeMetrics(coverage, blast, least, cases, verification, enforcement, governance, accountID, region, now)
+	filtered, applied := filterAWSExecutiveOutcomeMetrics(metrics, request)
+	summary := summarizeAWSExecutiveOutcomeView(metrics, filtered, coverage, blast, least, cases, verification, enforcement, governance)
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(filtered, coverage.Status, blast.Status, least.Status, cases.Status, verification.Status, enforcement.Status, governance.Status)
+	return AWSExecutiveOutcomeViewResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsExecutiveOutcomeViewCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsExecutiveOutcomeViewCurrentIssue),
+		Version:            awsExecutiveOutcomeViewVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsExecutiveOutcomeViewVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Metrics:            filtered,
+		Caveats:            awsExecutiveOutcomeViewCaveats(),
+		FailureReasons:     dedupeStrings(append(append(append(append(append(append([]string{}, coverage.FailureReasons...), blast.FailureReasons...), least.FailureReasons...), cases.FailureReasons...), verification.FailureReasons...), append(enforcement.FailureReasons, governance.FailureReasons...)...)),
+		RemediationHints:   awsExecutiveOutcomeViewRemediationHints(),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsExecutiveOutcomeViewCurrentIssue),
+			awsIssueURL(awsAccountRegionCoverageAPICurrentIssue),
+			awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+			awsIssueURL(awsGovernanceAuditReportingCurrentIssue),
+			"/docs/aws-executive-outcome-view",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: awsExecutiveOutcomeCoverageGaps(coverage.CoverageGaps, blast.CoverageGaps, least.CoverageGaps, cases.CoverageGaps, verification.CoverageGaps, enforcement.CoverageGaps, governance.CoverageGaps),
+		Diagnostics:  awsExecutiveOutcomeDiagnostics(coverage.Diagnostics, blast.Diagnostics, least.Diagnostics, cases.Diagnostics, verification.Diagnostics, enforcement.Diagnostics, governance.Diagnostics),
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func awsExecutiveOutcomeMetrics(
+	coverage AWSAccountRegionCoverageResult,
+	blast AWSBlastRadiusResult,
+	least AWSLeastPrivilegeResult,
+	cases AWSRemediationCaseResult,
+	verification AWSPostRemediationVerificationResult,
+	enforcement AWSLimitedEnforcementResult,
+	governance AWSGovernanceAuditReportingResult,
+	accountID string,
+	region string,
+	now time.Time,
+) []AWSExecutiveOutcomeMetric {
+	coveragePct := percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords)
+	remainingExposure := blast.Summary.FilteredFindings + least.Summary.ReviewCount
+	riskReduction := clampInt(least.Summary.RemoveCount*12+cases.Summary.VerificationPlanCount*10+verification.Summary.VerifiedCount*18+enforcement.Summary.CanaryReadyCount*8-remainingExposure*5, 0, 100)
+	degradedCoverage := coverage.Summary.DegradedRecords + coverage.Summary.UnreachableRecords + coverage.Summary.PermissionDeniedRecords + coverage.Summary.StaleRecords
+	metrics := []AWSExecutiveOutcomeMetric{
+		{
+			MetricID:         "risk-reduction",
+			Category:         "risk_reduction",
+			OutcomeType:      "risk_reduction",
+			Title:            "Risk reduction",
+			Summary:          "Projected reduction from least-privilege recommendations, remediation planning, verified remediation, and enforcement readiness.",
+			Value:            riskReduction,
+			Unit:             "score",
+			Trend:            trendFromDelta(riskReduction - remainingExposure),
+			TrendDelta:       riskReduction - remainingExposure,
+			Score:            riskReduction,
+			Confidence:       averageFloat64(blast.Confidence, least.Confidence, cases.Confidence, verification.Confidence),
+			AccountID:        accountID,
+			Region:           region,
+			IdentityType:     "machine_identity",
+			Severity:         severityFromCounts(blast.Summary.SeverityCounts, least.Summary.SeverityCounts, cases.Summary.SeverityCounts),
+			EvidenceLinks:    dedupeStrings(append(append([]string{}, least.EvidenceLinks...), cases.EvidenceLinks...)),
+			EvidenceRef:      "aws-executive-outcome://risk-reduction",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Review the top remaining exposures and approve low-breakage remediation plans.",
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "scan-coverage",
+			Category:         "scan_coverage",
+			OutcomeType:      "coverage",
+			Title:            "Scan coverage",
+			Summary:          "Account, region, service, and collector coverage across the selected AWS connector.",
+			Value:            coveragePct,
+			Unit:             "percent",
+			Trend:            trendFromDelta(coverage.Summary.CoveredRecords - degradedCoverage),
+			TrendDelta:       coverage.Summary.CoveredRecords - degradedCoverage,
+			Score:            coveragePct,
+			Confidence:       coverage.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			IdentityType:     "coverage_target",
+			Severity:         severityFromFailureCount(degradedCoverage),
+			EvidenceLinks:    coverage.EvidenceLinks,
+			EvidenceRef:      "aws-executive-outcome://scan-coverage",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Close degraded, stale, or permission-denied coverage before treating the outcome view as complete.",
+			UpdatedAt:        coverage.UpdatedAt,
+		},
+		{
+			MetricID:         "verified-remediation",
+			Category:         "verified_remediation",
+			OutcomeType:      "remediation",
+			Title:            "Verified remediation",
+			Summary:          "Post-remediation verification and rollback state from read-only executor projections.",
+			Value:            verification.Summary.VerifiedCount,
+			Unit:             "verified",
+			Trend:            trendFromDelta(verification.Summary.VerifiedCount - verification.Summary.FailedCount - verification.Summary.BlockedCount),
+			TrendDelta:       verification.Summary.VerifiedCount - verification.Summary.FailedCount - verification.Summary.BlockedCount,
+			Score:            verification.Summary.HighestScore,
+			Confidence:       verification.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			IdentityType:     "remediation_target",
+			Severity:         severityFromCounts(verification.Summary.SeverityCounts),
+			EvidenceLinks:    verification.EvidenceLinks,
+			EvidenceRef:      "aws-executive-outcome://verified-remediation",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Review failed, pending, or rollback-planned verification records before reporting closure.",
+			UpdatedAt:        verification.UpdatedAt,
+		},
+		{
+			MetricID:         "enforcement-status",
+			Category:         "enforcement_status",
+			OutcomeType:      "enforcement",
+			Title:            "Enforcement readiness",
+			Summary:          "Limited enforcement readiness, canary safety, and kill-switch status.",
+			Value:            enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount,
+			Unit:             "ready",
+			Trend:            trendFromDelta(enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount - enforcement.Summary.KillSwitchEngagedCount - enforcement.Summary.FailedGateCount),
+			TrendDelta:       enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount - enforcement.Summary.KillSwitchEngagedCount - enforcement.Summary.FailedGateCount,
+			Score:            enforcement.Summary.HighestScore,
+			Confidence:       enforcement.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			IdentityType:     "governed_identity",
+			Severity:         "high",
+			EvidenceLinks:    enforcement.EvidenceLinks,
+			EvidenceRef:      "aws-executive-outcome://enforcement-status",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Keep enforcement in advisory or canary mode until every safety gate and rollback path is explicit.",
+			UpdatedAt:        enforcement.UpdatedAt,
+		},
+		{
+			MetricID:         "remaining-exposure",
+			Category:         "remaining_exposure",
+			OutcomeType:      "exposure",
+			Title:            "Remaining exposure",
+			Summary:          "Open blast-radius findings and least-privilege review work that still require operator action.",
+			Value:            remainingExposure,
+			Unit:             "open",
+			Trend:            trendFromDelta(-remainingExposure),
+			TrendDelta:       -remainingExposure,
+			Score:            maxInt(blast.Summary.HighestScore, least.Summary.HighestScore),
+			Confidence:       averageFloat64(blast.Confidence, least.Confidence),
+			AccountID:        accountID,
+			Region:           region,
+			IdentityType:     "machine_identity",
+			Severity:         severityFromCounts(blast.Summary.SeverityCounts, least.Summary.SeverityCounts),
+			EvidenceLinks:    dedupeStrings(append(append([]string{}, blast.EvidenceLinks...), least.EvidenceLinks...)),
+			EvidenceRef:      "aws-executive-outcome://remaining-exposure",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Prioritize critical and high residual exposure before expanding live enforcement.",
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "governance-outcomes",
+			Category:         "governance_outcomes",
+			OutcomeType:      "governance",
+			Title:            "Governance outcomes",
+			Summary:          "Export-safe decision, approval, remediation, enforcement, and exception rows available to leadership.",
+			Value:            governance.Summary.FilteredRecords,
+			Unit:             "records",
+			Trend:            trendFromDelta(governance.Summary.EnforcementOutcomeCount + governance.Summary.RemediationCount - governance.Summary.ExceptionCount),
+			TrendDelta:       governance.Summary.EnforcementOutcomeCount + governance.Summary.RemediationCount - governance.Summary.ExceptionCount,
+			Score:            governance.Summary.HighestScore,
+			Confidence:       governance.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			OU:               awsExecutiveOutcomeMetricOU(governance.Records),
+			IdentityType:     "governance_record",
+			Severity:         severityFromFailureCount(governance.Summary.ExceptionCount),
+			EvidenceLinks:    governance.EvidenceLinks,
+			EvidenceRef:      "aws-executive-outcome://governance-outcomes",
+			EvidenceBoundary: awsExecutiveOutcomeViewBoundary,
+			NextAction:       "Export governance rows for leadership review and investigate exception records.",
+			UpdatedAt:        governance.UpdatedAt,
+		},
+	}
+	for i := range metrics {
+		metrics[i].EvidenceLinks = dedupeStrings(metrics[i].EvidenceLinks)
+	}
+	sort.SliceStable(metrics, func(i, j int) bool {
+		if metrics[i].Score == metrics[j].Score {
+			return metrics[i].MetricID < metrics[j].MetricID
+		}
+		return metrics[i].Score > metrics[j].Score
+	})
+	return metrics
+}
+
+func filterAWSExecutiveOutcomeMetrics(metrics []AWSExecutiveOutcomeMetric, request AWSExecutiveOutcomeViewRequest) ([]AWSExecutiveOutcomeMetric, map[string]string) {
+	applied := map[string]string{}
+	matchText := func(value, want string) bool {
+		want = strings.ToLower(strings.TrimSpace(want))
+		if want == "" || want == "all" {
+			return true
+		}
+		return strings.Contains(strings.ToLower(value), want)
+	}
+	filtered := make([]AWSExecutiveOutcomeMetric, 0, len(metrics))
+	for _, metric := range metrics {
+		if !matchText(metric.AccountID, request.AccountID) {
+			continue
+		}
+		if !matchText(metric.Region, request.Region) {
+			continue
+		}
+		if !matchText(metric.OU, request.OU) {
+			continue
+		}
+		if !matchText(metric.IdentityType, request.IdentityType) {
+			continue
+		}
+		if !matchText(metric.Severity, request.Severity) {
+			continue
+		}
+		if !matchText(metric.OutcomeType, request.OutcomeType) {
+			continue
+		}
+		if !matchText(metric.Trend, request.Trend) {
+			continue
+		}
+		search := strings.ToLower(strings.TrimSpace(request.Search))
+		if search != "" && !strings.Contains(strings.ToLower(strings.Join([]string{metric.Title, metric.Summary, metric.Category, metric.OutcomeType, metric.NextAction}, " ")), search) {
+			continue
+		}
+		filtered = append(filtered, metric)
+	}
+	setAppliedAWSExecutiveOutcomeFilter(applied, "connector_id", request.ConnectorID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "fixture_state", request.FixtureState)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "account_id", request.AccountID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "region", request.Region)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "ou", request.OU)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "identity_type", request.IdentityType)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "severity", request.Severity)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "outcome_type", request.OutcomeType)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "trend", request.Trend)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "search", request.Search)
+	return filtered, applied
+}
+
+func setAppliedAWSExecutiveOutcomeFilter(applied map[string]string, key, value string) {
+	value = strings.TrimSpace(value)
+	if value != "" && value != "all" {
+		applied[key] = value
+	}
+}
+
+func summarizeAWSExecutiveOutcomeView(
+	all []AWSExecutiveOutcomeMetric,
+	filtered []AWSExecutiveOutcomeMetric,
+	coverage AWSAccountRegionCoverageResult,
+	blast AWSBlastRadiusResult,
+	least AWSLeastPrivilegeResult,
+	cases AWSRemediationCaseResult,
+	verification AWSPostRemediationVerificationResult,
+	enforcement AWSLimitedEnforcementResult,
+	governance AWSGovernanceAuditReportingResult,
+) AWSExecutiveOutcomeViewSummary {
+	summary := AWSExecutiveOutcomeViewSummary{
+		TotalMetrics:             len(all),
+		FilteredMetrics:          len(filtered),
+		RiskReductionScore:       0,
+		ScanCoveragePct:          percent(coverage.Summary.CoveredRecords, coverage.Summary.TotalRecords),
+		VerifiedRemediationCount: verification.Summary.VerifiedCount,
+		EnforcementReadyCount:    enforcement.Summary.CanaryReadyCount + enforcement.Summary.ReadyForEnforcementCount,
+		RemainingExposureCount:   blast.Summary.FilteredFindings + least.Summary.ReviewCount,
+		DegradedCoverageCount:    coverage.Summary.DegradedRecords + coverage.Summary.UnreachableRecords + coverage.Summary.PermissionDeniedRecords + coverage.Summary.StaleRecords,
+		GovernanceRecordCount:    governance.Summary.FilteredRecords,
+		ExceptionCount:           governance.Summary.ExceptionCount,
+		AccountCounts:            map[string]int{},
+		OUCounts:                 map[string]int{},
+		IdentityTypeCounts:       map[string]int{},
+		SeverityCounts:           map[string]int{},
+		OutcomeTypeCounts:        map[string]int{},
+		TrendCounts:              map[string]int{},
+		HighestScore:             maxInt(coverage.Summary.CoveredRecords, blast.Summary.HighestScore, least.Summary.HighestScore, cases.Summary.HighestScore, verification.Summary.HighestScore, enforcement.Summary.HighestScore, governance.Summary.HighestScore),
+	}
+	confidenceTotal := 0.0
+	for _, metric := range filtered {
+		if metric.MetricID == "risk-reduction" {
+			summary.RiskReductionScore = metric.Value
+		}
+		incrementCount(summary.AccountCounts, metric.AccountID)
+		incrementDelimitedCount(summary.OUCounts, metric.OU)
+		incrementCount(summary.IdentityTypeCounts, metric.IdentityType)
+		incrementCount(summary.SeverityCounts, metric.Severity)
+		incrementCount(summary.OutcomeTypeCounts, metric.OutcomeType)
+		incrementCount(summary.TrendCounts, metric.Trend)
+		confidenceTotal += metric.Confidence
+	}
+	if len(filtered) > 0 {
+		summary.AverageConfidencePct = int((confidenceTotal/float64(len(filtered)))*100 + 0.5)
+	}
+	return summary
+}
+
+func summarizeAWSExecutiveOutcomeViewStatus(metrics []AWSExecutiveOutcomeMetric, statuses ...string) (string, float64) {
+	if len(metrics) == 0 {
+		return "degraded", 0.65
+	}
+	blocked := false
+	degraded := false
+	for _, status := range statuses {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "blocked", "permission_denied":
+			blocked = true
+		case "degraded", "partial", "partial_failure":
+			degraded = true
+		}
+	}
+	if blocked {
+		return "blocked", 0.55
+	}
+	if degraded {
+		return "degraded", 0.74
+	}
+	return "ready", 0.9
+}
+
+func awsExecutiveOutcomeViewCaveats() []string {
+	return []string{
+		"Executive outcomes are metadata-only rollups over existing AWS evidence; they do not prove live mutation or collect customer payloads.",
+		"Coverage gaps, permission-denied sources, and stale collectors reduce confidence instead of being counted as successful outcomes.",
+	}
+}
+
+func awsExecutiveOutcomeViewRemediationHints() []string {
+	return []string{
+		"Use coverage gaps and exception rows to explain why an executive outcome is degraded.",
+		"Treat enforcement readiness as advisory until canary, rollback, and governance audit records are all present.",
+	}
+}
+
+func awsExecutiveOutcomeCoverageGaps(
+	coverage []AWSCoveragePlanCoverageGap,
+	blast []AWSBlastRadiusCoverageGap,
+	least []AWSLeastPrivilegeCoverageGap,
+	cases []AWSRemediationCaseCoverageGap,
+	verification []AWSPostRemediationVerificationCoverageGap,
+	enforcement []AWSLimitedEnforcementCoverageGap,
+	governance []AWSGovernanceAuditReportingCoverageGap,
+) []AWSExecutiveOutcomeCoverageGap {
+	out := []AWSExecutiveOutcomeCoverageGap{}
+	for _, gap := range coverage {
+		out = append(out, AWSExecutiveOutcomeCoverageGap(gap))
+	}
+	for _, gap := range blast {
+		out = append(out, AWSExecutiveOutcomeCoverageGap(gap))
+	}
+	for _, group := range [][]AWSLeastPrivilegeCoverageGap{least, cases, verification, enforcement, governance} {
+		for _, gap := range group {
+			out = append(out, AWSExecutiveOutcomeCoverageGap(gap))
+		}
+	}
+	seen := map[string]bool{}
+	filtered := []AWSExecutiveOutcomeCoverageGap{}
+	for _, gap := range out {
+		key := strings.Join([]string{gap.Capability, gap.Status, gap.Reason, gap.Remediation}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		filtered = append(filtered, gap)
+	}
+	return filtered
+}
+
+func awsExecutiveOutcomeDiagnostics(
+	coverage []AWSCoveragePlanDiagnostic,
+	blast []AWSBlastRadiusDiagnostic,
+	least []AWSLeastPrivilegeDiagnostic,
+	cases []AWSRemediationCaseDiagnostic,
+	verification []AWSPostRemediationVerificationDiagnostic,
+	enforcement []AWSLimitedEnforcementDiagnostic,
+	governance []AWSGovernanceAuditReportingDiagnostic,
+) []AWSExecutiveOutcomeDiagnostic {
+	out := []AWSExecutiveOutcomeDiagnostic{}
+	for _, diagnostic := range coverage {
+		out = append(out, AWSExecutiveOutcomeDiagnostic{
+			Collector:   firstNonEmptyAWSValue(diagnostic.Collector, diagnostic.Source),
+			SourceID:    diagnostic.Scope,
+			Code:        diagnostic.Code,
+			Message:     diagnostic.Message,
+			Remediation: diagnostic.Remediation,
+			Retryable:   diagnostic.Retryable,
+		})
+	}
+	for _, diagnostic := range blast {
+		out = append(out, AWSExecutiveOutcomeDiagnostic(diagnostic))
+	}
+	for _, group := range [][]AWSLeastPrivilegeDiagnostic{least, cases, verification, enforcement, governance} {
+		for _, diagnostic := range group {
+			out = append(out, AWSExecutiveOutcomeDiagnostic(diagnostic))
+		}
+	}
+	seen := map[string]bool{}
+	filtered := []AWSExecutiveOutcomeDiagnostic{}
+	for _, diagnostic := range out {
+		key := strings.Join([]string{diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		filtered = append(filtered, diagnostic)
+	}
+	return filtered
+}
+
+func percent(part, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return int((float64(part)/float64(total))*100 + 0.5)
+}
+
+func trendFromDelta(delta int) string {
+	switch {
+	case delta > 0:
+		return "improving"
+	case delta < 0:
+		return "needs_attention"
+	default:
+		return "stable"
+	}
+}
+
+func severityFromCounts(groups ...map[string]int) string {
+	for _, group := range groups {
+		if group["critical"] > 0 {
+			return "critical"
+		}
+	}
+	for _, group := range groups {
+		if group["high"] > 0 {
+			return "high"
+		}
+	}
+	for _, group := range groups {
+		if group["medium"] > 0 {
+			return "medium"
+		}
+	}
+	return "low"
+}
+
+func severityFromFailureCount(count int) string {
+	if count > 0 {
+		return "high"
+	}
+	return "low"
+}
+
+func incrementCount(counts map[string]int, key string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	counts[key]++
+}
+
+func incrementDelimitedCount(counts map[string]int, keys string) {
+	for _, key := range strings.Split(keys, ",") {
+		incrementCount(counts, key)
+	}
+}
+
+func awsExecutiveOutcomeMetricOU(records []AWSGovernanceAuditReportRecord) string {
+	values := []string{}
+	seen := map[string]bool{}
+	for _, record := range records {
+		for _, value := range strings.Split(record.OU, ",") {
+			value = strings.TrimSpace(value)
+			if value == "" || seen[value] {
+				continue
+			}
+			seen[value] = true
+			values = append(values, value)
+		}
+	}
+	sort.Strings(values)
+	return strings.Join(values, ",")
+}
+
+func clampInt(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func maxInt(values ...int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
+func averageFloat64(values ...float64) float64 {
+	total := 0.0
+	count := 0
+	for _, value := range values {
+		if value <= 0 {
+			continue
+		}
+		total += value
+		count++
+	}
+	if count == 0 {
+		return 0
+	}
+	return total / float64(count)
+}

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -290,6 +290,105 @@ func TestAWSExecutiveOutcomeViewDerivesEnforcementSeverityFromRows(t *testing.T)
 	}
 }
 
+func TestAWSExecutiveOutcomeViewCountsDistinctEnforcementReadyRows(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 55, 0, 0, time.UTC)
+	enforcement := AWSLimitedEnforcementResult{
+		Entries: []AWSLimitedEnforcementEntry{{
+			Severity:            "high",
+			ReadyForCanary:      true,
+			ReadyForEnforcement: true,
+			Score:               88,
+			Confidence:          0.91,
+		}},
+	}
+	metrics := awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		enforcement,
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+
+	metric, ok := metricByID(metrics, "enforcement-status")
+	if !ok {
+		t.Fatalf("expected enforcement metric in executive view: %+v", metrics)
+	}
+	if metric.Value != 1 || metric.TrendDelta != 1 {
+		t.Fatalf("expected one distinct ready enforcement row, got metric=%+v", metric)
+	}
+
+	summary := summarizeAWSExecutiveOutcomeView(metrics, metrics,
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		enforcement,
+		AWSGovernanceAuditReportingResult{},
+	)
+	if summary.EnforcementReadyCount != 1 {
+		t.Fatalf("expected summary to count one distinct ready enforcement row, got %+v", summary)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewFiltersEnforcementRowsBeforeSeverityRollup(t *testing.T) {
+	now := time.Date(2026, 7, 9, 13, 0, 0, 0, time.UTC)
+	enforcement := awsExecutiveOutcomeFilterLimitedEnforcementRows(AWSLimitedEnforcementResult{
+		Entries: []AWSLimitedEnforcementEntry{
+			{
+				Severity:   "high",
+				Score:      42,
+				Confidence: 0.84,
+			},
+			{
+				Severity:            "low",
+				ReadyForCanary:      true,
+				ReadyForEnforcement: true,
+				Score:               96,
+				Confidence:          0.96,
+			},
+		},
+	}, AWSExecutiveOutcomeViewRequest{Severity: "high"})
+	metrics := awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		enforcement,
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+	high, _ := filterAWSExecutiveOutcomeMetrics(metrics, AWSExecutiveOutcomeViewRequest{Severity: "high"})
+	metric, ok := metricByID(high, "enforcement-status")
+	if !ok {
+		t.Fatalf("expected high enforcement metric after severity rollup filtering: %+v", high)
+	}
+	if metric.Value != 0 || metric.Score != 42 {
+		t.Fatalf("expected high rollup to exclude low ready rows, got %+v", metric)
+	}
+
+	summary := summarizeAWSExecutiveOutcomeView(metrics, high,
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		enforcement,
+		AWSGovernanceAuditReportingResult{},
+	)
+	if summary.EnforcementReadyCount != 0 {
+		t.Fatalf("expected high summary to exclude low ready rows, got %+v", summary)
+	}
+}
+
 func metricByID(metrics []AWSExecutiveOutcomeMetric, id string) (AWSExecutiveOutcomeMetric, bool) {
 	for _, metric := range metrics {
 		if metric.MetricID == id {

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -153,6 +153,40 @@ func TestAWSExecutiveOutcomeViewKeepsRequestedScopeMetricsVisible(t *testing.T) 
 	}
 }
 
+func TestAWSExecutiveOutcomeViewTreatsAllAccountRegionAsUnscoped(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 40, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-all-scope", now)
+
+	unscoped, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-all-scope", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get unscoped executive outcome view: %v", err)
+	}
+	allScoped, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-all-scope", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		AccountID:    "all",
+		Region:       "all",
+	})
+	if err != nil {
+		t.Fatalf("get all-scoped executive outcome view: %v", err)
+	}
+	if _, ok := allScoped.AppliedFilters["account_id"]; ok {
+		t.Fatalf("expected account_id=all to stay unapplied, got %+v", allScoped.AppliedFilters)
+	}
+	if _, ok := allScoped.AppliedFilters["region"]; ok {
+		t.Fatalf("expected region=all to stay unapplied, got %+v", allScoped.AppliedFilters)
+	}
+	if allScoped.Summary.ScanCoveragePct == 0 || allScoped.Summary.ScanCoveragePct != unscoped.Summary.ScanCoveragePct {
+		t.Fatalf("expected account/region all to preserve unscoped coverage, unscoped=%+v all=%+v", unscoped.Summary, allScoped.Summary)
+	}
+	if allScoped.Summary.TotalMetrics != unscoped.Summary.TotalMetrics || len(allScoped.Metrics) != len(unscoped.Metrics) {
+		t.Fatalf("expected account/region all to preserve unscoped metrics, unscoped=%+v all=%+v", unscoped.Summary, allScoped.Summary)
+	}
+}
+
 func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testing.T) {
 	summary := summarizeAWSExecutiveOutcomeView(nil, nil,
 		AWSAccountRegionCoverageResult{

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -144,25 +144,46 @@ func TestAWSExecutiveOutcomeViewKeepsRequestedScopeMetricsVisible(t *testing.T) 
 	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-scope", AWSExecutiveOutcomeViewRequest{
 		ConnectorID:  "aws-prod",
 		FixtureState: "success",
-		AccountID:    "222222222222",
-		Region:       "us-west-2",
+		AccountID:    "123456789012",
+		Region:       "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("get scoped executive outcome view: %v", err)
 	}
-	if result.AccountID != "222222222222" || result.Region != "us-west-2" {
+	if result.AccountID != "123456789012" || result.Region != "us-east-1" {
 		t.Fatalf("expected requested scope on result, got account=%q region=%q", result.AccountID, result.Region)
 	}
 	if len(result.Metrics) == 0 {
 		t.Fatalf("expected requested scope to keep executive metrics visible")
 	}
 	for _, metric := range result.Metrics {
-		if metric.AccountID != "222222222222" || metric.Region != "us-west-2" {
+		if metric.AccountID != "123456789012" || metric.Region != "us-east-1" {
 			t.Fatalf("expected metric to keep requested scope, got %+v", metric)
 		}
 	}
 	if result.Summary.FilteredMetrics != len(result.Metrics) {
 		t.Fatalf("expected filtered summary to match visible metrics, got summary=%+v metrics=%+v", result.Summary, result.Metrics)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewHidesUnsupportedRequestedScopeMetrics(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 37, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-empty-scope", now)
+
+	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-empty-scope", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		AccountID:    "999999999999",
+		Region:       "eu-north-1",
+	})
+	if err != nil {
+		t.Fatalf("get unsupported scoped executive outcome view: %v", err)
+	}
+	if result.AppliedFilters["account_id"] != "999999999999" || result.AppliedFilters["region"] != "eu-north-1" {
+		t.Fatalf("expected requested scope filters to be applied, got %+v", result.AppliedFilters)
+	}
+	if len(result.Metrics) != 0 || result.Summary.FilteredMetrics != 0 {
+		t.Fatalf("expected unsupported requested scope to hide aggregate metrics, summary=%+v metrics=%+v", result.Summary, result.Metrics)
 	}
 }
 

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newExecutiveOutcomeViewService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSExecutiveOutcomeViewBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes", now)
+
+	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get executive outcome view: %v", err)
+	}
+	if result.CurrentIssueRef != "#1555" || result.Version != awsExecutiveOutcomeViewVersion {
+		t.Fatalf("unexpected result metadata: %+v", result)
+	}
+	if result.Status != "ready" {
+		t.Fatalf("expected ready result, got %q failures=%+v", result.Status, result.FailureReasons)
+	}
+	if result.Summary.TotalMetrics < 5 || len(result.Metrics) != result.Summary.FilteredMetrics {
+		t.Fatalf("expected populated executive metrics, summary=%+v metrics=%+v", result.Summary, result.Metrics)
+	}
+	required := map[string]bool{
+		"risk_reduction": false,
+		"coverage":       false,
+		"remediation":    false,
+		"enforcement":    false,
+		"exposure":       false,
+		"governance":     false,
+	}
+	for _, metric := range result.Metrics {
+		if _, ok := required[metric.OutcomeType]; ok {
+			required[metric.OutcomeType] = true
+		}
+		if metric.EvidenceBoundary != awsExecutiveOutcomeViewBoundary {
+			t.Fatalf("metric crossed evidence boundary: %+v", metric)
+		}
+		if metric.EvidenceRef == "" || metric.NextAction == "" {
+			t.Fatalf("metric missing evidence/next action: %+v", metric)
+		}
+	}
+	for outcomeType, seen := range required {
+		if !seen {
+			t.Fatalf("expected outcome type %s in metrics: %+v", outcomeType, result.Metrics)
+		}
+	}
+	if result.Summary.ScanCoveragePct == 0 || result.Summary.GovernanceRecordCount == 0 {
+		t.Fatalf("expected coverage and governance rollups in summary: %+v", result.Summary)
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	lower := strings.ToLower(string(serialized))
+	for _, forbidden := range []string{"\"secret_access_key\"", "\"private_key\"", "\"prompt\"", "\"completion\"", "\"database_rows\"", "\"object_contents\"", "\"payload\""} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("executive outcome view serialized forbidden marker %q", forbidden)
+		}
+	}
+}
+
+func TestAWSExecutiveOutcomeViewFiltersOutcomeSeverityAndSearch(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 30, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-filter", now)
+
+	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-filter", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		OutcomeType:  "coverage",
+		Search:       "scan",
+	})
+	if err != nil {
+		t.Fatalf("get filtered executive outcome view: %v", err)
+	}
+	if result.AppliedFilters["outcome_type"] != "coverage" || result.AppliedFilters["search"] != "scan" {
+		t.Fatalf("expected applied filters, got %+v", result.AppliedFilters)
+	}
+	if len(result.Metrics) != 1 || result.Metrics[0].MetricID != "scan-coverage" {
+		t.Fatalf("expected only scan coverage metric, got %+v", result.Metrics)
+	}
+	if result.Summary.FilteredMetrics != 1 || result.Summary.OutcomeTypeCounts["coverage"] != 1 {
+		t.Fatalf("expected filtered summary to reflect coverage metric, got %+v", result.Summary)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 7, 9, 13, 0, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-denied", now)
+
+	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-denied", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("get permission denied executive outcome view: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected blocked result, got %q", result.Status)
+	}
+	if len(result.FailureReasons) == 0 || len(result.Diagnostics) == 0 {
+		t.Fatalf("expected explicit failure reasons and diagnostics, got failures=%+v diagnostics=%+v", result.FailureReasons, result.Diagnostics)
+	}
+}
+
+func TestRouterAWSExecutiveOutcomeView(t *testing.T) {
+	now := time.Date(2026, 7, 9, 13, 30, 0, 0, time.UTC)
+	svc, _ := newExecutiveOutcomeViewService(t, "project-executive-outcomes-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	query := url.Values{}
+	query.Set("connector_id", "aws-prod")
+	query.Set("fixture_state", "success")
+	query.Set("outcome_type", "governance")
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-executive-outcomes-route/aws/executive-outcomes?"+query.Encode(), "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Outcomes AWSExecutiveOutcomeViewResult `json:"executive_outcomes"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Outcomes.CurrentIssueRef != "#1555" || body.Outcomes.AppliedFilters["outcome_type"] != "governance" {
+		t.Fatalf("unexpected route payload: %+v", body.Outcomes)
+	}
+	for _, metric := range body.Outcomes.Metrics {
+		if metric.OutcomeType != "governance" {
+			t.Fatalf("route did not apply outcome_type filter: %+v", metric)
+		}
+	}
+}

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -236,6 +236,69 @@ func TestAWSExecutiveOutcomeViewUsesFilteredSourceRowsForExecutiveTotals(t *test
 	}
 }
 
+func TestAWSExecutiveOutcomeViewDerivesEnforcementSeverityFromRows(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 50, 0, 0, time.UTC)
+	metrics := awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		AWSLimitedEnforcementResult{
+			Entries: []AWSLimitedEnforcementEntry{{
+				Severity:            "critical",
+				ReadyForCanary:      true,
+				ReadyForEnforcement: true,
+				Score:               92,
+				Confidence:          0.93,
+			}},
+		},
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+
+	critical, _ := filterAWSExecutiveOutcomeMetrics(metrics, AWSExecutiveOutcomeViewRequest{Severity: "critical"})
+	if _, ok := metricByID(critical, "enforcement-status"); !ok {
+		t.Fatalf("expected critical enforcement rows to keep enforcement metric visible: %+v", critical)
+	}
+
+	metrics = awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		AWSLimitedEnforcementResult{
+			Entries: []AWSLimitedEnforcementEntry{{
+				Severity:            "medium",
+				ReadyForCanary:      true,
+				ReadyForEnforcement: true,
+				Score:               48,
+				Confidence:          0.82,
+			}},
+		},
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+	high, _ := filterAWSExecutiveOutcomeMetrics(metrics, AWSExecutiveOutcomeViewRequest{Severity: "high"})
+	if metric, ok := metricByID(high, "enforcement-status"); ok {
+		t.Fatalf("expected high filter to drop medium enforcement metric, got %+v", metric)
+	}
+}
+
+func metricByID(metrics []AWSExecutiveOutcomeMetric, id string) (AWSExecutiveOutcomeMetric, bool) {
+	for _, metric := range metrics {
+		if metric.MetricID == id {
+			return metric, true
+		}
+	}
+	return AWSExecutiveOutcomeMetric{}, false
+}
+
 func TestAWSExecutiveOutcomeViewStatusPreservesSourceStateWithNoMetrics(t *testing.T) {
 	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(nil, "permission_denied", "ready")
 	if status != "blocked" || confidence != 0.55 {

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -219,6 +219,45 @@ func TestAWSExecutiveOutcomeViewStatusPreservesSourceStateWithNoMetrics(t *testi
 	}
 }
 
+func TestAWSExecutiveOutcomeViewStatusTreatsFilteredEmptySourcesAsReady(t *testing.T) {
+	statuses := awsExecutiveOutcomeSourceStatuses(
+		AWSExecutiveOutcomeViewRequest{Severity: "critical"},
+		"success",
+		AWSAccountRegionCoverageResult{Status: awsPlatformDependencyStatusReady},
+		AWSBlastRadiusResult{Status: awsPlatformDependencyStatusDegraded},
+		AWSLeastPrivilegeResult{Status: awsPlatformDependencyStatusDegraded},
+		AWSRemediationCaseResult{Status: awsPlatformDependencyStatusDegraded},
+		AWSPostRemediationVerificationResult{Status: awsPlatformDependencyStatusReady},
+		AWSLimitedEnforcementResult{Status: awsPlatformDependencyStatusReady},
+		AWSGovernanceAuditReportingResult{Status: awsPlatformDependencyStatusReady},
+	)
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(nil, statuses...)
+	if status != awsPlatformDependencyStatusReady || confidence != 0.8 {
+		t.Fatalf("expected empty filtered sources to stay ready, got status=%q confidence=%v statuses=%+v", status, confidence, statuses)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewStatusKeepsRealSourceDegradation(t *testing.T) {
+	statuses := awsExecutiveOutcomeSourceStatuses(
+		AWSExecutiveOutcomeViewRequest{Severity: "critical"},
+		"success",
+		AWSAccountRegionCoverageResult{Status: awsPlatformDependencyStatusReady},
+		AWSBlastRadiusResult{
+			Status:         awsPlatformDependencyStatusDegraded,
+			FailureReasons: []string{"blast radius source returned retryable diagnostics"},
+		},
+		AWSLeastPrivilegeResult{Status: awsPlatformDependencyStatusReady},
+		AWSRemediationCaseResult{Status: awsPlatformDependencyStatusReady},
+		AWSPostRemediationVerificationResult{Status: awsPlatformDependencyStatusReady},
+		AWSLimitedEnforcementResult{Status: awsPlatformDependencyStatusReady},
+		AWSGovernanceAuditReportingResult{Status: awsPlatformDependencyStatusReady},
+	)
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(nil, statuses...)
+	if status != awsPlatformDependencyStatusDegraded || confidence != 0.74 {
+		t.Fatalf("expected real source degradation to survive empty filters, got status=%q confidence=%v statuses=%+v", status, confidence, statuses)
+	}
+}
+
 func TestAWSExecutiveOutcomeViewPermissionDeniedIsExplicit(t *testing.T) {
 	now := time.Date(2026, 7, 9, 13, 0, 0, 0, time.UTC)
 	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-denied", now)

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -99,6 +99,19 @@ func TestAWSExecutiveOutcomeViewFiltersOutcomeSeverityAndSearch(t *testing.T) {
 	if result.Summary.FilteredMetrics != 1 || result.Summary.OutcomeTypeCounts["coverage"] != 1 {
 		t.Fatalf("expected filtered summary to reflect coverage metric, got %+v", result.Summary)
 	}
+	if result.Summary.ScanCoveragePct == 0 || result.Summary.ScanCoveragePct != result.Metrics[0].Value {
+		t.Fatalf("expected scan coverage summary to follow visible coverage metric, got metric=%+v summary=%+v", result.Metrics[0], result.Summary)
+	}
+	if result.Summary.HighestScore != result.Metrics[0].Score {
+		t.Fatalf("expected highest score to come from visible metrics, got metric=%+v summary=%+v", result.Metrics[0], result.Summary)
+	}
+	if result.Summary.VerifiedRemediationCount != 0 ||
+		result.Summary.EnforcementReadyCount != 0 ||
+		result.Summary.RemainingExposureCount != 0 ||
+		result.Summary.GovernanceRecordCount != 0 ||
+		result.Summary.ExceptionCount != 0 {
+		t.Fatalf("expected hidden outcome summary buckets to be zeroed, got %+v", result.Summary)
+	}
 
 	severityResult, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-filter", AWSExecutiveOutcomeViewRequest{
 		ConnectorID:  "aws-prod",
@@ -188,14 +201,20 @@ func TestAWSExecutiveOutcomeViewTreatsAllAccountRegionAsUnscoped(t *testing.T) {
 }
 
 func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testing.T) {
-	summary := summarizeAWSExecutiveOutcomeView(nil, nil,
-		AWSAccountRegionCoverageResult{
-			Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 250, TotalRecords: 500},
-			Records: []AWSAccountRegionCoverageRecord{
-				{AccountID: "123456789012", Region: "us-east-1", Service: "iam", CoverageStatus: "covered"},
-				{AccountID: "123456789012", Region: "us-east-1", Service: "s3", CoverageStatus: "missing"},
-			},
+	coverage := AWSAccountRegionCoverageResult{
+		Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 250, TotalRecords: 500},
+		Records: []AWSAccountRegionCoverageRecord{
+			{AccountID: "123456789012", Region: "us-east-1", Service: "iam", CoverageStatus: "covered"},
+			{AccountID: "123456789012", Region: "us-east-1", Service: "s3", CoverageStatus: "missing"},
 		},
+	}
+	metrics := []AWSExecutiveOutcomeMetric{{
+		MetricID: "scan-coverage",
+		Value:    50,
+		Score:    50,
+	}}
+	summary := summarizeAWSExecutiveOutcomeView(metrics, metrics,
+		coverage,
 		AWSBlastRadiusResult{Summary: AWSBlastRadiusSummary{HighestScore: 40}},
 		AWSLeastPrivilegeResult{Summary: AWSLeastPrivilegeSummary{HighestScore: 30}},
 		AWSRemediationCaseResult{Summary: AWSRemediationCaseSummary{HighestScore: 20}},

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -343,6 +343,58 @@ func TestAWSExecutiveOutcomeViewDerivesEnforcementSeverityFromRows(t *testing.T)
 	}
 }
 
+func TestAWSExecutiveOutcomeViewDoesNotTagEmptySeverityRollupsLow(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 52, 0, 0, time.UTC)
+	metrics := awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		AWSLimitedEnforcementResult{},
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+	low, applied := filterAWSExecutiveOutcomeMetrics(metrics, AWSExecutiveOutcomeViewRequest{Severity: "low"})
+	if applied["severity"] != "low" {
+		t.Fatalf("expected low severity filter to be recorded, got %+v", applied)
+	}
+	if len(low) != 0 {
+		t.Fatalf("expected empty source rollups to stay hidden from low severity filter, got %+v", low)
+	}
+
+	metrics = awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{},
+		AWSBlastRadiusResult{},
+		AWSLeastPrivilegeResult{
+			Recommendations: []AWSLeastPrivilegeRecommendation{{
+				RecommendationID: "lp-low-review",
+				Decision:         "review",
+				Severity:         "low",
+				Status:           "open",
+				Score:            16,
+				Confidence:       0.88,
+				AccountID:        "123456789012",
+				Region:           "us-east-1",
+				Service:          "iam",
+			}},
+		},
+		AWSRemediationCaseResult{},
+		AWSPostRemediationVerificationResult{},
+		AWSLimitedEnforcementResult{},
+		AWSGovernanceAuditReportingResult{},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+	low, _ = filterAWSExecutiveOutcomeMetrics(metrics, AWSExecutiveOutcomeViewRequest{Severity: "low"})
+	if _, ok := metricByID(low, "remaining-exposure"); !ok {
+		t.Fatalf("expected real low severity source rows to stay visible, got %+v", low)
+	}
+}
+
 func TestAWSExecutiveOutcomeViewCountsDistinctEnforcementReadyRows(t *testing.T) {
 	now := time.Date(2026, 7, 9, 12, 55, 0, 0, time.UTC)
 	enforcement := AWSLimitedEnforcementResult{

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -126,7 +126,13 @@ func TestAWSExecutiveOutcomeViewFiltersOutcomeSeverityAndSearch(t *testing.T) {
 
 func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testing.T) {
 	summary := summarizeAWSExecutiveOutcomeView(nil, nil,
-		AWSAccountRegionCoverageResult{Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 250, TotalRecords: 500}},
+		AWSAccountRegionCoverageResult{
+			Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 250, TotalRecords: 500},
+			Records: []AWSAccountRegionCoverageRecord{
+				{AccountID: "123456789012", Region: "us-east-1", Service: "iam", CoverageStatus: "covered"},
+				{AccountID: "123456789012", Region: "us-east-1", Service: "s3", CoverageStatus: "missing"},
+			},
+		},
 		AWSBlastRadiusResult{Summary: AWSBlastRadiusSummary{HighestScore: 40}},
 		AWSLeastPrivilegeResult{Summary: AWSLeastPrivilegeSummary{HighestScore: 30}},
 		AWSRemediationCaseResult{Summary: AWSRemediationCaseSummary{HighestScore: 20}},
@@ -139,6 +145,65 @@ func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testin
 	}
 	if summary.HighestScore != 50 {
 		t.Fatalf("expected highest score to use coverage percent, got %+v", summary)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewUsesFilteredSourceRowsForExecutiveTotals(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 45, 0, 0, time.UTC)
+
+	metrics := awsExecutiveOutcomeMetrics(
+		AWSAccountRegionCoverageResult{
+			Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 1000, TotalRecords: 1000},
+			Records: []AWSAccountRegionCoverageRecord{
+				{AccountID: "123456789012", Region: "us-east-1", Service: "iam", CoverageStatus: "covered"},
+				{AccountID: "123456789012", Region: "us-east-1", Service: "s3", CoverageStatus: "missing"},
+			},
+		},
+		AWSBlastRadiusResult{Summary: AWSBlastRadiusSummary{FilteredFindings: 99, HighestScore: 99}},
+		AWSLeastPrivilegeResult{
+			Summary: AWSLeastPrivilegeSummary{RemoveCount: 99, ReviewCount: 99, HighestScore: 99},
+			Recommendations: []AWSLeastPrivilegeRecommendation{{
+				RecommendationID: "lp-filtered-review",
+				Decision:         "review",
+				Severity:         "critical",
+				Status:           "open",
+				Score:            42,
+				Confidence:       0.9,
+				AccountID:        "123456789012",
+				Region:           "us-east-1",
+				Service:          "iam",
+			}},
+		},
+		AWSRemediationCaseResult{Summary: AWSRemediationCaseSummary{VerificationPlanCount: 99, HighestScore: 99}},
+		AWSPostRemediationVerificationResult{Summary: AWSPostRemediationVerificationSummary{VerifiedCount: 99, HighestScore: 99}},
+		AWSLimitedEnforcementResult{Summary: AWSLimitedEnforcementSummary{CanaryReadyCount: 99, HighestScore: 99}},
+		AWSGovernanceAuditReportingResult{Summary: AWSGovernanceAuditReportingSummary{FilteredRecords: 99, HighestScore: 99}},
+		"123456789012",
+		"us-east-1",
+		now,
+	)
+
+	byID := map[string]AWSExecutiveOutcomeMetric{}
+	for _, metric := range metrics {
+		byID[metric.MetricID] = metric
+	}
+	if got := byID["scan-coverage"].Value; got != 50 {
+		t.Fatalf("expected scan coverage to use filtered coverage records, got %d", got)
+	}
+	if got := byID["remaining-exposure"].Value; got != 1 {
+		t.Fatalf("expected remaining exposure to use filtered findings/recommendations, got %d", got)
+	}
+	if got := byID["risk-reduction"].Value; got != 0 {
+		t.Fatalf("expected risk reduction to ignore unfiltered source summary totals, got %d", got)
+	}
+	if got := byID["verified-remediation"].Value; got != 0 {
+		t.Fatalf("expected verified remediation to use filtered verification entries, got %d", got)
+	}
+	if got := byID["enforcement-status"].Value; got != 0 {
+		t.Fatalf("expected enforcement readiness to use filtered enforcement entries, got %d", got)
+	}
+	if got := byID["governance-outcomes"].Value; got != 0 {
+		t.Fatalf("expected governance outcomes to use filtered governance records, got %d", got)
 	}
 }
 

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -185,6 +185,22 @@ func TestAWSExecutiveOutcomeViewHidesUnsupportedRequestedScopeMetrics(t *testing
 	if len(result.Metrics) != 0 || result.Summary.FilteredMetrics != 0 {
 		t.Fatalf("expected unsupported requested scope to hide aggregate metrics, summary=%+v metrics=%+v", result.Summary, result.Metrics)
 	}
+
+	prefixScoped, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-empty-scope", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		AccountID:    "12345678901",
+		Region:       "us",
+	})
+	if err != nil {
+		t.Fatalf("get prefix scoped executive outcome view: %v", err)
+	}
+	if prefixScoped.AppliedFilters["account_id"] != "12345678901" || prefixScoped.AppliedFilters["region"] != "us" {
+		t.Fatalf("expected prefix scope filters to be applied, got %+v", prefixScoped.AppliedFilters)
+	}
+	if len(prefixScoped.Metrics) != 0 || prefixScoped.Summary.FilteredMetrics != 0 {
+		t.Fatalf("expected prefix scoped request to hide aggregate metrics, summary=%+v metrics=%+v", prefixScoped.Summary, prefixScoped.Metrics)
+	}
 }
 
 func TestAWSExecutiveOutcomeViewTreatsAllAccountRegionAsUnscoped(t *testing.T) {

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -428,6 +428,50 @@ func TestAWSExecutiveOutcomeViewStatusTreatsFilteredEmptySourcesAsReady(t *testi
 	}
 }
 
+func TestAWSExecutiveOutcomeViewStatusScopesCoverageToFilteredRows(t *testing.T) {
+	request := AWSExecutiveOutcomeViewRequest{AccountID: "222222222222", Region: "us-west-2"}
+	healthyScopedCoverage := AWSAccountRegionCoverageResult{
+		Status: awsPlatformDependencyStatusDegraded,
+		Records: []AWSAccountRegionCoverageRecord{
+			{AccountID: "222222222222", Region: "us-west-2", Service: "iam", CoverageStatus: "covered"},
+		},
+	}
+	statuses := awsExecutiveOutcomeSourceStatuses(
+		request,
+		"",
+		healthyScopedCoverage,
+		AWSBlastRadiusResult{Status: awsPlatformDependencyStatusReady},
+		AWSLeastPrivilegeResult{Status: awsPlatformDependencyStatusReady},
+		AWSRemediationCaseResult{Status: awsPlatformDependencyStatusReady},
+		AWSPostRemediationVerificationResult{Status: awsPlatformDependencyStatusReady},
+		AWSLimitedEnforcementResult{Status: awsPlatformDependencyStatusReady},
+		AWSGovernanceAuditReportingResult{Status: awsPlatformDependencyStatusReady},
+	)
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(nil, statuses...)
+	if status != awsPlatformDependencyStatusReady || confidence != 0.8 {
+		t.Fatalf("expected healthy scoped coverage rows to override unscoped degradation, got status=%q confidence=%v statuses=%+v", status, confidence, statuses)
+	}
+
+	scopedPermissionDenied := healthyScopedCoverage
+	scopedPermissionDenied.Status = awsPlatformDependencyStatusReady
+	scopedPermissionDenied.Records[0].CoverageStatus = "permission_denied"
+	statuses = awsExecutiveOutcomeSourceStatuses(
+		request,
+		"",
+		scopedPermissionDenied,
+		AWSBlastRadiusResult{Status: awsPlatformDependencyStatusReady},
+		AWSLeastPrivilegeResult{Status: awsPlatformDependencyStatusReady},
+		AWSRemediationCaseResult{Status: awsPlatformDependencyStatusReady},
+		AWSPostRemediationVerificationResult{Status: awsPlatformDependencyStatusReady},
+		AWSLimitedEnforcementResult{Status: awsPlatformDependencyStatusReady},
+		AWSGovernanceAuditReportingResult{Status: awsPlatformDependencyStatusReady},
+	)
+	status, confidence = summarizeAWSExecutiveOutcomeViewStatus(nil, statuses...)
+	if status != awsPlatformDependencyStatusBlocked || confidence != 0.55 {
+		t.Fatalf("expected scoped permission-denied coverage row to stay blocked, got status=%q confidence=%v statuses=%+v", status, confidence, statuses)
+	}
+}
+
 func TestAWSExecutiveOutcomeViewStatusKeepsRealSourceDegradation(t *testing.T) {
 	statuses := awsExecutiveOutcomeSourceStatuses(
 		AWSExecutiveOutcomeViewRequest{Severity: "critical"},

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -124,6 +124,35 @@ func TestAWSExecutiveOutcomeViewFiltersOutcomeSeverityAndSearch(t *testing.T) {
 	}
 }
 
+func TestAWSExecutiveOutcomeViewKeepsRequestedScopeMetricsVisible(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 35, 0, 0, time.UTC)
+	svc, ws := newExecutiveOutcomeViewService(t, "project-executive-outcomes-scope", now)
+
+	result, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-scope", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		AccountID:    "222222222222",
+		Region:       "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("get scoped executive outcome view: %v", err)
+	}
+	if result.AccountID != "222222222222" || result.Region != "us-west-2" {
+		t.Fatalf("expected requested scope on result, got account=%q region=%q", result.AccountID, result.Region)
+	}
+	if len(result.Metrics) == 0 {
+		t.Fatalf("expected requested scope to keep executive metrics visible")
+	}
+	for _, metric := range result.Metrics {
+		if metric.AccountID != "222222222222" || metric.Region != "us-west-2" {
+			t.Fatalf("expected metric to keep requested scope, got %+v", metric)
+		}
+	}
+	if result.Summary.FilteredMetrics != len(result.Metrics) {
+		t.Fatalf("expected filtered summary to match visible metrics, got summary=%+v metrics=%+v", result.Summary, result.Metrics)
+	}
+}
+
 func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testing.T) {
 	summary := summarizeAWSExecutiveOutcomeView(nil, nil,
 		AWSAccountRegionCoverageResult{

--- a/internal/api/aws_executive_outcome_view_test.go
+++ b/internal/api/aws_executive_outcome_view_test.go
@@ -99,6 +99,59 @@ func TestAWSExecutiveOutcomeViewFiltersOutcomeSeverityAndSearch(t *testing.T) {
 	if result.Summary.FilteredMetrics != 1 || result.Summary.OutcomeTypeCounts["coverage"] != 1 {
 		t.Fatalf("expected filtered summary to reflect coverage metric, got %+v", result.Summary)
 	}
+
+	severityResult, err := svc.GetAWSExecutiveOutcomeView(defaultScopeContext(), ws, "project-executive-outcomes-filter", AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Severity:     "high",
+	})
+	if err != nil {
+		t.Fatalf("get severity-filtered executive outcome view: %v", err)
+	}
+	if severityResult.AppliedFilters["severity"] != "high" {
+		t.Fatalf("expected severity filter to be applied, got %+v", severityResult.AppliedFilters)
+	}
+	if len(severityResult.Metrics) == 0 {
+		t.Fatalf("expected high severity executive metrics, got none")
+	}
+	for _, metric := range severityResult.Metrics {
+		if metric.Severity != "high" {
+			t.Fatalf("expected only high severity metrics, got %+v", severityResult.Metrics)
+		}
+	}
+	if severityResult.Summary.SeverityCounts["high"] != len(severityResult.Metrics) {
+		t.Fatalf("expected severity summary to match filtered metrics, got %+v", severityResult.Summary)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewSummaryHighestScoreUsesCoveragePercent(t *testing.T) {
+	summary := summarizeAWSExecutiveOutcomeView(nil, nil,
+		AWSAccountRegionCoverageResult{Summary: AWSAccountRegionCoverageSummary{CoveredRecords: 250, TotalRecords: 500}},
+		AWSBlastRadiusResult{Summary: AWSBlastRadiusSummary{HighestScore: 40}},
+		AWSLeastPrivilegeResult{Summary: AWSLeastPrivilegeSummary{HighestScore: 30}},
+		AWSRemediationCaseResult{Summary: AWSRemediationCaseSummary{HighestScore: 20}},
+		AWSPostRemediationVerificationResult{Summary: AWSPostRemediationVerificationSummary{HighestScore: 10}},
+		AWSLimitedEnforcementResult{Summary: AWSLimitedEnforcementSummary{HighestScore: 45}},
+		AWSGovernanceAuditReportingResult{Summary: AWSGovernanceAuditReportingSummary{HighestScore: 35}},
+	)
+	if summary.ScanCoveragePct != 50 {
+		t.Fatalf("expected scan coverage percent 50, got %+v", summary)
+	}
+	if summary.HighestScore != 50 {
+		t.Fatalf("expected highest score to use coverage percent, got %+v", summary)
+	}
+}
+
+func TestAWSExecutiveOutcomeViewStatusPreservesSourceStateWithNoMetrics(t *testing.T) {
+	status, confidence := summarizeAWSExecutiveOutcomeViewStatus(nil, "permission_denied", "ready")
+	if status != "blocked" || confidence != 0.55 {
+		t.Fatalf("expected blocked source status to survive empty filters, got status=%q confidence=%v", status, confidence)
+	}
+
+	status, confidence = summarizeAWSExecutiveOutcomeViewStatus(nil, "ready")
+	if status != "ready" || confidence != 0.8 {
+		t.Fatalf("expected empty ready source to stay ready, got status=%q confidence=%v", status, confidence)
+	}
 }
 
 func TestAWSExecutiveOutcomeViewPermissionDeniedIsExplicit(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3829,6 +3829,42 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"governance_audit_reporting": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/executive-outcomes", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSExecutiveOutcomeView(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSExecutiveOutcomeViewRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			OU:           strings.TrimSpace(c.Query("ou")),
+			IdentityType: strings.TrimSpace(c.Query("identity_type")),
+			Severity:     strings.TrimSpace(c.Query("severity")),
+			OutcomeType:  strings.TrimSpace(c.Query("outcome_type")),
+			Trend:        strings.TrimSpace(c.Query("trend")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws executive outcome view request"})
+			default:
+				logger.Error("get aws executive outcome view",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws executive outcome view"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"executive_outcomes": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
   ProductAWSFindingsPage,
   ProductAWSGovernancePage,
   ProductAWSGraphPage,
+  ProductAWSOutcomesPage,
   ProductAWSRemediationPage,
   ProductAWSRuntimePage,
   ProductAWSAgentIdentityDetailPage,
@@ -4839,6 +4840,7 @@ export function RoutedSite() {
             <Route path="aws/findings" element={<ProductAWSFindingsPage />} />
             <Route path="aws/remediation" element={<ProductAWSRemediationPage />} />
             <Route path="aws/remediation/center" element={<ProductAWSRemediationCenterPage />} />
+            <Route path="aws/outcomes" element={<ProductAWSOutcomesPage />} />
             <Route path="aws/governance" element={<ProductAWSGovernancePage />} />
             <Route path="github" element={<ProductGitHubControlCenterPage />} />
             <Route path="github/connect" element={<ProductGitHubConnectPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4989,6 +4989,96 @@ export type AWSGovernanceAuditReportingQuery = {
   search?: string;
 };
 
+export type AWSExecutiveOutcomeViewStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSExecutiveOutcomeViewFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+
+export type AWSExecutiveOutcomeMetric = {
+  metric_id: string;
+  category: string;
+  outcome_type: string;
+  title: string;
+  summary: string;
+  value: number;
+  unit: string;
+  trend: string;
+  trend_delta: number;
+  score: number;
+  confidence: number;
+  account_id?: string;
+  region?: string;
+  ou?: string;
+  identity_type?: string;
+  severity?: string;
+  evidence_links: string[];
+  evidence_ref?: string;
+  evidence_boundary: string;
+  next_action: string;
+  updated_at: string;
+};
+
+export type AWSExecutiveOutcomeViewSummary = {
+  total_metrics: number;
+  filtered_metrics: number;
+  risk_reduction_score: number;
+  scan_coverage_pct: number;
+  verified_remediation_count: number;
+  enforcement_ready_count: number;
+  remaining_exposure_count: number;
+  degraded_coverage_count: number;
+  governance_record_count: number;
+  exception_count: number;
+  account_counts: Record<string, number>;
+  ou_counts: Record<string, number>;
+  identity_type_counts: Record<string, number>;
+  severity_counts: Record<string, number>;
+  outcome_type_counts: Record<string, number>;
+  trend_counts: Record<string, number>;
+  highest_score: number;
+  average_confidence_pct: number;
+};
+
+export type AWSExecutiveOutcomeViewResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSExecutiveOutcomeViewStatus;
+  fixture_state?: AWSExecutiveOutcomeViewFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSExecutiveOutcomeViewSummary;
+  metrics: AWSExecutiveOutcomeMetric[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSExecutiveOutcomeViewQuery = {
+  connectorID?: string;
+  fixtureState?: AWSExecutiveOutcomeViewFixtureState;
+  accountID?: string;
+  region?: string;
+  ou?: string;
+  identityType?: string;
+  severity?: string;
+  outcomeType?: string;
+  trend?: string;
+  search?: string;
+};
+
 export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
@@ -10915,6 +11005,28 @@ export const apiClient = {
         source_type: query?.sourceType,
         from: query?.from,
         to: query?.to,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectExecutiveOutcomes(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSExecutiveOutcomeViewQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ executive_outcomes: AWSExecutiveOutcomeViewResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/executive-outcomes${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        ou: query?.ou,
+        identity_type: query?.identityType,
+        severity: query?.severity,
+        outcome_type: query?.outcomeType,
+        trend: query?.trend,
         search: query?.search
       })}`,
       auth

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -14,6 +14,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/findings',
   '/app/:tenantID/:workspaceID/aws/remediation',
   '/app/:tenantID/:workspaceID/aws/remediation/center',
+  '/app/:tenantID/:workspaceID/aws/outcomes',
   '/app/:tenantID/:workspaceID/aws/governance',
   '/app/:tenantID/:workspaceID/github',
   '/app/:tenantID/:workspaceID/github/connect',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3350,6 +3350,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/findings',
       '/app/:tenantID/:workspaceID/aws/remediation',
       '/app/:tenantID/:workspaceID/aws/remediation/center',
+      '/app/:tenantID/:workspaceID/aws/outcomes',
       '/app/:tenantID/:workspaceID/aws/governance',
       '/app/:tenantID/:workspaceID/github',
       '/app/:tenantID/:workspaceID/github/connect',
@@ -7575,6 +7576,9 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Outcomes' })).toBeInTheDocument();
+    const scope = await screen.findByRole('region', { name: 'Outcomes scope' });
+    expect(within(scope).getByText('Read-only')).toBeInTheDocument();
+    expect(within(scope).queryByText('Advisory')).not.toBeInTheDocument();
     expect(await screen.findByRole('region', { name: 'AWS executive outcome summary' })).toBeInTheDocument();
     expect(await screen.findByRole('table', { name: 'AWS executive outcome metrics' })).toBeInTheDocument();
     expect(screen.getAllByText(/Risk reduction/i).length).toBeGreaterThan(0);

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7441,6 +7441,164 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText(/Organizations read access denied/i)).toBeInTheDocument();
   });
 
+  it('shows AWS executive outcome view and forwards outcome filters', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getExecutiveOutcomes = vi.spyOn(api.apiClient, 'getAWSProjectExecutiveOutcomes').mockResolvedValue({
+      executive_outcomes: {
+        status: 'ready',
+        confidence: 0.9,
+        current_issue_ref: '#1555',
+        version: 'aws-executive-outcome-view-v1',
+        applied_filters: {},
+        summary: {
+          total_metrics: 3,
+          filtered_metrics: 3,
+          risk_reduction_score: 72,
+          scan_coverage_pct: 83,
+          verified_remediation_count: 2,
+          enforcement_ready_count: 1,
+          remaining_exposure_count: 4,
+          degraded_coverage_count: 1,
+          governance_record_count: 3,
+          exception_count: 0,
+          account_counts: { '123456789012': 3 },
+          ou_counts: {},
+          identity_type_counts: { machine_identity: 2, coverage_target: 1 },
+          severity_counts: { high: 2, low: 1 },
+          outcome_type_counts: { risk_reduction: 1, coverage: 1, exposure: 1 },
+          trend_counts: { improving: 2, needs_attention: 1 },
+          highest_score: 92,
+          average_confidence_pct: 90
+        },
+        metrics: [
+          {
+            metric_id: 'risk-reduction',
+            category: 'risk_reduction',
+            outcome_type: 'risk_reduction',
+            title: 'Risk reduction',
+            summary: 'Projected reduction from remediation and verification.',
+            value: 72,
+            unit: 'score',
+            trend: 'improving',
+            trend_delta: 12,
+            score: 72,
+            confidence: 0.91,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_type: 'machine_identity',
+            severity: 'high',
+            evidence_links: ['/docs/aws-executive-outcome-view'],
+            evidence_ref: 'aws-executive-outcome://risk-reduction',
+            evidence_boundary: 'metadata_only_outcome_metrics_no_secret_values_no_customer_payloads',
+            next_action: 'Approve low-breakage remediation plans.',
+            updated_at: '2026-07-09T12:00:00Z'
+          },
+          {
+            metric_id: 'scan-coverage',
+            category: 'scan_coverage',
+            outcome_type: 'coverage',
+            title: 'Scan coverage',
+            summary: 'Account and region coverage.',
+            value: 83,
+            unit: 'percent',
+            trend: 'improving',
+            trend_delta: 5,
+            score: 83,
+            confidence: 0.9,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_type: 'coverage_target',
+            severity: 'low',
+            evidence_links: ['/docs/aws-account-region-coverage-planner'],
+            evidence_ref: 'aws-executive-outcome://scan-coverage',
+            evidence_boundary: 'metadata_only_outcome_metrics_no_secret_values_no_customer_payloads',
+            next_action: 'Close degraded coverage.',
+            updated_at: '2026-07-09T12:00:00Z'
+          },
+          {
+            metric_id: 'remaining-exposure',
+            category: 'remaining_exposure',
+            outcome_type: 'exposure',
+            title: 'Remaining exposure',
+            summary: 'Open high-severity exposure.',
+            value: 4,
+            unit: 'open',
+            trend: 'needs_attention',
+            trend_delta: -4,
+            score: 92,
+            confidence: 0.88,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            identity_type: 'machine_identity',
+            severity: 'high',
+            evidence_links: ['/docs/aws-blast-radius-engine'],
+            evidence_ref: 'aws-executive-outcome://remaining-exposure',
+            evidence_boundary: 'metadata_only_outcome_metrics_no_secret_values_no_customer_payloads',
+            next_action: 'Prioritize critical and high exposure.',
+            updated_at: '2026-07-09T12:00:00Z'
+          }
+        ],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: ['/docs/aws-executive-outcome-view'],
+        coverage_gaps: [],
+        diagnostics: [],
+        generated_at: '2026-07-09T12:00:00Z',
+        updated_at: '2026-07-09T12:00:00Z'
+      } as any
+    });
+
+    const { ProductAWSOutcomesPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/outcomes?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/outcomes" element={<ProductAWSOutcomesPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Outcomes' })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'AWS executive outcome summary' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS executive outcome metrics' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Risk reduction/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Remaining exposure/i).length).toBeGreaterThan(0);
+    expect(getExecutiveOutcomes).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Outcome' }), {
+      target: { value: 'exposure' }
+    });
+    await waitFor(() =>
+      expect(getExecutiveOutcomes).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', outcomeType: 'exposure' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('passes AWS findings filters to secret-permission equivalence queries', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -12130,7 +12130,7 @@ function AWSRiskOperationScope({
     ['Connector', connection?.display_name || connection?.connector_id || 'Connected AWS connector'],
     ['Scope', connection?.account_id ? awsAccountRegionLabel(connection) : selectedEnvironmentID ? 'Pending connector' : 'No environment'],
     ['Role', connection?.role_arn ? awsConnectionRoleLabel(connection) : 'Not connected'],
-    ['Mode', copy.routeID === 'governance' || copy.routeID === 'outcomes' ? 'Advisory' : 'Read-only']
+    ['Mode', copy.routeID === 'governance' ? 'Advisory' : 'Read-only']
   ];
 
   return (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -99,6 +99,9 @@ import {
   type AWSGovernanceAuditReportRecord,
   type AWSGovernanceAuditReportingQuery,
   type AWSGovernanceAuditReportingResult,
+  type AWSExecutiveOutcomeMetric,
+  type AWSExecutiveOutcomeViewQuery,
+  type AWSExecutiveOutcomeViewResult,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
   type AWSAgentCoreGatewayPolicyAdvisoryEntry,
@@ -460,6 +463,7 @@ type ProductDomainRouteID =
   | 'graph'
   | 'findings'
   | 'remediation'
+  | 'outcomes'
   | 'governance'
   | 'repositories'
   | 'actions'
@@ -558,6 +562,7 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
       productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
       productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
       productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
+      productDomainRoute('outcomes', 'Outcomes', 'outcomes', 'Outcomes', '', 'Executive outcome view for coverage, risk reduction, verified fixes, enforcement, and remaining exposure.'),
       productDomainRoute('governance', 'Governance', 'governance', 'Governance', '', "Advice on AWS access. Identrail won't apply changes for you.")
     ]
   },
@@ -11655,7 +11660,7 @@ export function ProductAWSResourcesPage() {
 
 type AWSRiskOperationRouteID = Extract<
   ProductDomainRouteID,
-  'runtime' | 'graph' | 'findings' | 'remediation' | 'governance'
+  'runtime' | 'graph' | 'findings' | 'remediation' | 'outcomes' | 'governance'
 >;
 
 type AWSRiskOperationPageCopy = {
@@ -11720,6 +11725,18 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     unavailableTitle: 'No fixes prepared',
     unavailableBody: 'Fixes will appear here after a finding has been triaged.'
   },
+  outcomes: {
+    routeID: 'outcomes',
+    title: 'Outcomes',
+    eyebrow: '',
+    description: 'Executive outcome view for risk reduction, coverage, verified fixes, enforcement status, and remaining exposure.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No outcomes yet',
+    unavailableBody: 'Outcome metrics will appear once Identrail has AWS coverage, risk, remediation, and governance evidence.'
+  },
   governance: {
     routeID: 'governance',
     title: 'Governance',
@@ -11741,6 +11758,7 @@ const AWS_RISK_OPERATION_FILTER_DEFAULTS: Record<AWSRiskOperationRouteID, AWSInv
   graph: { node: 'all', edge: 'all', evidence: 'all', search: '' },
   findings: { severity: 'all', account: 'all', region: 'all', evidence: 'all', status: 'all', search: '' },
   remediation: { change: 'all', approval: 'all', stage: 'all', search: '' },
+  outcomes: { outcome: 'all', trend: 'all', severity: 'all', identity: 'all', search: '' },
   governance: { decision: 'all', mode: 'all', evidence: 'all', search: '' }
 };
 
@@ -11935,6 +11953,54 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
       ]
     }
   ],
+  outcomes: [
+    {
+      id: 'outcome',
+      label: 'Outcome',
+      options: [
+        { label: 'All outcomes', value: 'all' },
+        { label: 'Risk reduction', value: 'risk_reduction' },
+        { label: 'Coverage', value: 'coverage' },
+        { label: 'Remediation', value: 'remediation' },
+        { label: 'Enforcement', value: 'enforcement' },
+        { label: 'Exposure', value: 'exposure' },
+        { label: 'Governance', value: 'governance' }
+      ]
+    },
+    {
+      id: 'trend',
+      label: 'Trend',
+      options: [
+        { label: 'All trends', value: 'all' },
+        { label: 'Improving', value: 'improving' },
+        { label: 'Stable', value: 'stable' },
+        { label: 'Needs attention', value: 'needs_attention' }
+      ]
+    },
+    {
+      id: 'severity',
+      label: 'Severity',
+      options: [
+        { label: 'All severities', value: 'all' },
+        { label: 'Critical', value: 'critical' },
+        { label: 'High', value: 'high' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'Low', value: 'low' }
+      ]
+    },
+    {
+      id: 'identity',
+      label: 'Identity',
+      options: [
+        { label: 'All identities', value: 'all' },
+        { label: 'Machine identity', value: 'machine_identity' },
+        { label: 'Coverage target', value: 'coverage_target' },
+        { label: 'Remediation target', value: 'remediation_target' },
+        { label: 'Governed identity', value: 'governed_identity' },
+        { label: 'Governance record', value: 'governance_record' }
+      ]
+    }
+  ],
   governance: [
     {
       id: 'decision',
@@ -11996,6 +12062,7 @@ function AWSRiskOperationFilterSet({
     graph: 'Search graph',
     findings: 'Search findings',
     remediation: 'Search changes',
+    outcomes: 'Search outcomes',
     governance: 'Search decisions'
   };
   const onFilterChange = (id: string, value: string): void => {
@@ -12063,7 +12130,7 @@ function AWSRiskOperationScope({
     ['Connector', connection?.display_name || connection?.connector_id || 'Connected AWS connector'],
     ['Scope', connection?.account_id ? awsAccountRegionLabel(connection) : selectedEnvironmentID ? 'Pending connector' : 'No environment'],
     ['Role', connection?.role_arn ? awsConnectionRoleLabel(connection) : 'Not connected'],
-    ['Mode', copy.routeID === 'governance' ? 'Advisory' : 'Read-only']
+    ['Mode', copy.routeID === 'governance' || copy.routeID === 'outcomes' ? 'Advisory' : 'Read-only']
   ];
 
   return (
@@ -14028,6 +14095,94 @@ function awsGovernanceAuditReportingStage(record: AWSGovernanceAuditReportRecord
     return 'wired';
   }
   return 'coming';
+}
+
+function awsExecutiveOutcomeStage(metric: AWSExecutiveOutcomeMetric): AWSCapabilityStage {
+  if (metric.trend === 'needs_attention') {
+    return metric.severity === 'critical' || metric.severity === 'high' ? 'not-available' : 'coming';
+  }
+  if (metric.trend === 'improving' || metric.outcome_type === 'coverage' || metric.outcome_type === 'risk_reduction') {
+    return 'wired';
+  }
+  return 'coming';
+}
+
+function AWSExecutiveOutcomeViewContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSExecutiveOutcomeViewResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.risk_reduction_score} risk score · ${result.summary.scan_coverage_pct}% coverage · ${result.summary.verified_remediation_count} verified · ${result.summary.enforcement_ready_count} enforcement-ready · ${result.summary.remaining_exposure_count} exposure remaining`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.metrics,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <>
+      {result ? (
+        <section className="idt-aws-inventory-coverage" aria-label="AWS executive outcome summary">
+          <DomainCoverageCard label="Risk reduction" scanned={result.summary.risk_reduction_score} total={100} detail="executive score" />
+          <DomainCoverageCard label="Scan coverage" scanned={result.summary.scan_coverage_pct} total={100} detail={`${result.summary.degraded_coverage_count} degraded`} />
+          <DomainCoverageCard label="Verified fixes" scanned={result.summary.verified_remediation_count} total={Math.max(result.summary.verified_remediation_count + result.summary.remaining_exposure_count, 1)} detail="post-remediation" />
+          <DomainCoverageCard label="Enforcement ready" scanned={result.summary.enforcement_ready_count} total={Math.max(result.summary.enforcement_ready_count + result.summary.exception_count, 1)} detail={`${result.summary.exception_count} exceptions`} />
+          <DomainCoverageCard
+            label="Exposure reduction"
+            scanned={result.summary.verified_remediation_count + result.summary.enforcement_ready_count}
+            total={Math.max(result.summary.verified_remediation_count + result.summary.enforcement_ready_count + result.summary.remaining_exposure_count, 1)}
+            detail={`${result.summary.remaining_exposure_count} remaining`}
+          />
+          <DomainCoverageCard
+            label="Governance records"
+            scanned={result.summary.governance_record_count}
+            total={Math.max(result.summary.governance_record_count + result.summary.exception_count, 1)}
+            detail={`${result.summary.exception_count} exceptions`}
+          />
+        </section>
+      ) : null}
+      <AWSExecutorProjectionPanel<AWSExecutiveOutcomeMetric>
+        result={panelResult}
+        loading={loading}
+        error={error}
+        onRetry={onRetry}
+        ariaLabel="AWS executive outcome view"
+        heading="AWS executive outcome view"
+        description={`Executive rollup for risk reduction, scan coverage, verified remediation, enforcement readiness, governance records, and remaining exposure. Metrics are metadata-only and keep evidence refs, confidence, account/region context, and next actions without exposing secrets or payloads. ${summaryLine}`}
+        errorTitle="Couldn't load AWS executive outcomes"
+        loadingTitle="Building executive outcome view"
+        loadingBody="Identrail is composing AWS coverage, risk, remediation, verification, enforcement, and governance signals into an executive rollup."
+        emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No outcomes')}
+        emptyTitle={(current) => (current.status === 'blocked' ? 'Executive outcomes need source evidence' : 'No executive outcome metrics matched')}
+        emptyBody={(current) => current.failure_reasons[0] ?? 'No AWS outcome metric matched the current filters.'}
+        tableLabel="AWS executive outcome metrics"
+        getRowKey={(row) => row.metric_id}
+        columns={[
+          { key: 'metric', header: 'Metric', render: (row) => <strong>{row.title}</strong> },
+          { key: 'outcome', header: 'Outcome', render: (row) => formatTokenLabel(row.outcome_type) },
+          { key: 'value', header: 'Value', render: (row) => `${row.value}${row.unit === 'percent' ? '%' : ` ${formatTokenLabel(row.unit)}`}` },
+          { key: 'trend', header: 'Trend', render: (row) => `${formatTokenLabel(row.trend)} (${row.trend_delta})` },
+          { key: 'scope', header: 'Scope', render: (row) => awsAccountRegionInventoryLabel(row.account_id, row.region) },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action },
+          {
+            key: 'confidence',
+            header: 'Confidence',
+            render: (row) => <AWSInventoryPill stage={awsExecutiveOutcomeStage(row)} label={`${Math.round(row.confidence * 100)}%`} />
+          }
+        ]}
+      />
+    </>
+  );
 }
 
 function AWSGovernanceAuditReportingContent({
@@ -16286,6 +16441,16 @@ function awsGovernanceAuditReportingQueryFromFilters(filters: AWSInventoryFilter
   return query;
 }
 
+function awsExecutiveOutcomeViewQueryFromFilters(filters: AWSInventoryFilterState): Partial<AWSExecutiveOutcomeViewQuery> {
+  return {
+    outcomeType: awsSecretPermissionEquivalenceFilterToken(filters.outcome),
+    trend: awsSecretPermissionEquivalenceFilterToken(filters.trend),
+    severity: awsSecretPermissionEquivalenceFilterToken(filters.severity),
+    identityType: awsSecretPermissionEquivalenceFilterToken(filters.identity),
+    search: normalizeFilterValue(filters.search ?? '') || undefined
+  };
+}
+
 function AWSGraphExplorerContent({
   graph,
   loading,
@@ -16835,6 +17000,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [governanceAuditReportingLoading, setGovernanceAuditReportingLoading] = useState(false);
   const [governanceAuditReportingError, setGovernanceAuditReportingError] = useState('');
   const governanceAuditReportingRequestRef = useRef(0);
+  const [executiveOutcomes, setExecutiveOutcomes] = useState<AWSExecutiveOutcomeViewResult | null>(null);
+  const [executiveOutcomesLoading, setExecutiveOutcomesLoading] = useState(false);
+  const [executiveOutcomesError, setExecutiveOutcomesError] = useState('');
+  const executiveOutcomesRequestRef = useRef(0);
   const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
@@ -17818,6 +17987,61 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       governanceAuditReportingRequestRef.current += 1;
     };
   }, [loadGovernanceAuditReporting]);
+
+  const loadExecutiveOutcomes = useCallback(async () => {
+    const requestID = ++executiveOutcomesRequestRef.current;
+    setExecutiveOutcomes(null);
+    setExecutiveOutcomesError('');
+    if (routeID !== 'outcomes' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setExecutiveOutcomesLoading(false);
+      return;
+    }
+    setExecutiveOutcomesLoading(true);
+    const requestFilters = awsExecutiveOutcomeViewQueryFromFilters(activeFilters);
+    try {
+      const response = await apiClient.getAWSProjectExecutiveOutcomes(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          ...requestFilters
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== executiveOutcomesRequestRef.current) {
+        return;
+      }
+      setExecutiveOutcomes(response.executive_outcomes);
+    } catch (error) {
+      if (requestID !== executiveOutcomesRequestRef.current) {
+        return;
+      }
+      setExecutiveOutcomesError(formatAPIError(error, 'Unable to load AWS executive outcomes.'));
+    } finally {
+      if (requestID === executiveOutcomesRequestRef.current) {
+        setExecutiveOutcomesLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    activeFilters.outcome,
+    activeFilters.trend,
+    activeFilters.severity,
+    activeFilters.identity,
+    activeFilters.search,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadExecutiveOutcomes();
+    return () => {
+      executiveOutcomesRequestRef.current += 1;
+    };
+  }, [loadExecutiveOutcomes]);
 
   const loadSessionPolicyRecommendations = useCallback(async () => {
     const requestID = ++sessionPolicyRecommendationsRequestRef.current;
@@ -18954,6 +19178,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
         {routeID === 'remediation' ? (
           <AWSRemediationContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
         ) : null}
+        {routeID === 'outcomes' ? (
+          <AWSRiskOperationFilterSet routeID="outcomes" filters={activeFilters} onChange={onFiltersChange} />
+        ) : null}
+        {routeID === 'outcomes' ? (
+          <AWSExecutiveOutcomeViewContent
+            result={executiveOutcomes}
+            loading={executiveOutcomesLoading}
+            error={executiveOutcomesError}
+            onRetry={loadExecutiveOutcomes}
+          />
+        ) : null}
         {routeID === 'governance' ? (
           <AWSGovernanceContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
         ) : null}
@@ -19000,6 +19235,10 @@ export function ProductAWSFindingsPage() {
 
 export function ProductAWSRemediationPage() {
   return <ProductAWSRiskOperationsPage routeID="remediation" />;
+}
+
+export function ProductAWSOutcomesPage() {
+  return <ProductAWSRiskOperationsPage routeID="outcomes" />;
 }
 
 export function ProductAWSGovernancePage() {


### PR DESCRIPTION
## Summary

Adds the AWS executive outcome view for issue #1555:

- backend endpoint `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes`
- metadata-only executive metrics for risk reduction, scan coverage, verified remediation, enforcement readiness, remaining exposure, and governance outcomes
- app route `/app/{tenant_id}/{workspace_id}/aws/outcomes` with summary cards, filters, and a metric table
- OpenAPI, docs, changelog, authz policy, API client types, and regression tests

## Why

Executives need one stable AWS outcome payload that rolls up existing coverage, risk, remediation, verification, enforcement, and governance evidence without exposing sensitive payloads or adding live AWS mutation paths.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api -run 'Test(GetAWSExecutiveOutcomeView|AWSExecutiveOutcomeView|RouterAWSExecutiveOutcomeView|OpenAPIV1Spec)'
go test ./internal/api
npm test -- run src/productShell.test.tsx -t "shows AWS executive outcome view"
npm test -- run src/productShell.test.tsx
npm run build
```

`npm run build` was verified with the local untracked scratch file `web/src/App 2.tsx` temporarily moved outside `web/src` and restored afterward; that file is not part of this PR.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed: local tests and build listed above

## Related Issues

Fixes #1555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AWS executive outcomes view with a metadata-only, read-only API and a new app page so leaders can see risk, coverage, remediation verification, enforcement readiness, exposure, and governance in one place. Implements #1555.

- New Features
  - API: `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/executive-outcomes` with filters for connector, fixture_state, scope (account/region/OU/identity), severity, outcome_type, trend, and search. Returns metrics with evidence refs, confidence, trends, coverage gaps, and diagnostics. Export-safe with authz, OpenAPI, docs, and changelog.
  - Backend: Composes coverage, blast radius, least-privilege, remediation, verification, limited enforcement, and governance. Computes summaries, trend deltas, OU aggregation, and status (ready/degraded/blocked).
  - App: New `/app/{tenant_id}/{workspace_id}/aws/outcomes` page with summary cards and a filterable table. Forwards filters and handles loading/empty/error/permission-denied states.
  - Client + Tests: Added `apiClient.getAWSProjectExecutiveOutcomes` and types. Service/router/web tests for contract shape, exact filter forwarding, states, and routing.

- Bug Fixes
  - Filters match exact values across connector, scope, severity, outcome_type, trend, and search.
  - Summaries derive from filtered, visible metrics and source rows.
  - Enforcement severity derives from entry rows; rollups tightened for accuracy.
  - Empty, filter-culled sources report ready; avoid low-severity tags for empty outcomes.
  - Scope remains visible and normalized across account, region, OU, and identity; hide metrics when the requested scope has no rows.

<sup>Written for commit e13a106f193421f33e3127eab84f1a0b58bb81dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

