### PR TITLE
Align domain flyout chevrons

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1,4 +1,6 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
@@ -48,6 +50,8 @@ import type { BackendFeatureState } from './hooks/useBackendFeatures';
 // time, so the AWS copy-redundancy guard below can scan productShell.tsx
 // without needing node's `require` or fs typings.
 import productShellSource from './productShell.tsx?raw';
+
+const stylesSource = readFileSync(join(process.cwd(), 'src/styles.css'), 'utf8');
 
 const loggedInWithoutWorkspace: CurrentUserContext = {
   user: {
@@ -2901,6 +2905,31 @@ describe('ProductShellLayout', () => {
     fireEvent.keyDown(screen.getByLabelText(/Search workspace commands/i), { key: 'Enter' });
 
     expect(await screen.findByRole('heading', { level: 2, name: /GitHub findings content/i })).toBeInTheDocument();
+  });
+
+  it('keeps collapsed sidebar styles from centering domain flyout links', async () => {
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    window.localStorage.setItem('idt:sidebar:collapsed', '1');
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route index element={<h2>Overview content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
+    const awsFlyout = screen.getByRole('dialog', { name: 'AWS' });
+    expect(within(awsFlyout).getByRole('link', { name: 'AWS Overview' })).toHaveClass('idt-domain-flyout-link');
+    expect(stylesSource).toContain('.idt-domain-flyout-link {\n  display: grid;\n  grid-template-columns: minmax(0, 1fr) 1.25rem;');
+    expect(stylesSource).toContain('.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav > a');
+    expect(stylesSource).not.toContain('.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a,');
+    expect(stylesSource).not.toMatch(/idt-app-shell-nav\s+a/);
   });
 
   it('preserves the selected environment when routing to AWS coverage from workspace finder', async () => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4483,7 +4483,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.45rem;
 }
 
-.idt-app-shell-nav a {
+.idt-app-shell-nav > a {
   color: #bfd2ee;
   text-decoration: none;
   font-weight: 600;
@@ -4493,7 +4493,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   background: rgba(14, 23, 36, 0.72);
 }
 
-.idt-app-shell-nav a.active {
+.idt-app-shell-nav > a.active {
   color: #0f223f;
   background: #d7e5ff;
   border-color: #d7e5ff;
@@ -8111,13 +8111,13 @@ html[data-theme='light'] .idt-app-panel {
   border-color: rgba(35, 64, 111, 0.2);
 }
 
-html[data-theme='light'] .idt-app-shell-nav a {
+html[data-theme='light'] .idt-app-shell-nav > a {
   color: #24406e;
   background: rgba(239, 246, 255, 0.95);
   border-color: rgba(35, 64, 111, 0.23);
 }
 
-html[data-theme='light'] .idt-app-shell-nav a.active {
+html[data-theme='light'] .idt-app-shell-nav > a.active {
   color: #12284c;
   background: #dbe8ff;
   border-color: #dbe8ff;
@@ -21571,8 +21571,8 @@ html[data-theme='light'] .idt-executive-report-shell .idt-btn-dark {
   gap: 0.28rem;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
+.idt-app-console-layout .idt-app-shell-nav > a,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a {
   display: flex;
   align-items: center;
   min-height: 2.45rem;
@@ -21591,12 +21591,12 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
  * in this file (search for "Workspace shell redesign"). Keeping only the
  * shared text-decoration reset here so the higher-specificity light-theme
  * rule doesn't repaint the active item white in the dark console shell. */
-.idt-app-console-layout .idt-app-shell-nav a:hover,
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible,
-.idt-app-console-layout .idt-app-shell-nav a.active,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:hover,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a.active {
+.idt-app-console-layout .idt-app-shell-nav > a:hover,
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible,
+.idt-app-console-layout .idt-app-shell-nav > a.active,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a:hover,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a:focus-visible,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a.active {
   text-decoration: none;
 }
 
@@ -22469,7 +22469,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-trend 
     padding-bottom: 0.2rem;
   }
 
-  .idt-app-console-layout .idt-app-shell-nav a {
+  .idt-app-console-layout .idt-app-shell-nav > a {
     flex: 0 0 auto;
   }
 
@@ -22519,7 +22519,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-trend 
     overflow-x: visible;
   }
 
-  .idt-app-console-layout .idt-app-shell-nav a {
+  .idt-app-console-layout .idt-app-shell-nav > a {
     min-width: 0;
     width: 100%;
     justify-content: center;
@@ -27652,8 +27652,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   padding: 0.55rem 0;
 }
 
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a,
-html[data-theme='light'] .idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a {
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav > a,
+html[data-theme='light'] .idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav > a {
   grid-template-columns: 1fr;
   justify-items: center;
   justify-content: center;
@@ -27708,8 +27708,8 @@ html[data-theme='light'] .idt-app-console-layout.is-sidebar-collapsed .idt-app-s
   gap: 0.1rem;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
+.idt-app-console-layout .idt-app-shell-nav > a,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a {
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 1.35rem minmax(0, 1fr);
@@ -27731,20 +27731,20 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 @media (min-width: 641px) and (max-width: 960px) {
-  .idt-app-console-layout .idt-app-shell-nav a,
-  html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
+  .idt-app-console-layout .idt-app-shell-nav > a,
+  html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a {
     width: auto;
   }
 }
 
-.idt-app-console-layout .idt-app-shell-nav a:hover,
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible {
+.idt-app-console-layout .idt-app-shell-nav > a:hover,
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible {
   background: #131318;
   color: #ffffff;
   border-color: transparent;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a.active {
+.idt-app-console-layout .idt-app-shell-nav > a.active {
   background: #1c1c22;
   color: #ffffff;
   border-color: transparent;
@@ -27769,15 +27769,15 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   opacity: 1;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon,
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon,
-.idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon {
+.idt-app-console-layout .idt-app-shell-nav > a:hover .idt-app-nav-icon,
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible .idt-app-nav-icon,
+.idt-app-console-layout .idt-app-shell-nav > a.active .idt-app-nav-icon {
   color: #ffffff;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon img,
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon img,
-.idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon img {
+.idt-app-console-layout .idt-app-shell-nav > a:hover .idt-app-nav-icon img,
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible .idt-app-nav-icon img,
+.idt-app-console-layout .idt-app-shell-nav > a.active .idt-app-nav-icon img {
   filter: none;
   opacity: 1;
 }
@@ -29398,16 +29398,16 @@ html[data-theme='light'] .idt-app-scroll-navigator-thumb {
 
 /* Active-nav fix: dark fill + a left accent bar instead of the broken white
  * default that bled through from the light theme. */
-.idt-app-console-layout .idt-app-shell-nav a {
+.idt-app-console-layout .idt-app-shell-nav > a {
   position: relative;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a.active {
+.idt-app-console-layout .idt-app-shell-nav > a.active {
   background: transparent;
   color: #ffffff;
 }
 
-.idt-app-console-layout .idt-app-shell-nav a.active::before {
+.idt-app-console-layout .idt-app-shell-nav > a.active::before {
   content: '';
   position: absolute;
   left: 0;
@@ -29418,14 +29418,14 @@ html[data-theme='light'] .idt-app-scroll-navigator-thumb {
   background: #ffffff;
 }
 
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a.active::before {
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav > a.active::before {
   top: 4px;
   bottom: 4px;
 }
 
 /* Hover state is quieter than active — no accent bar, soft background only. */
-.idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active) {
+.idt-app-console-layout .idt-app-shell-nav > a:hover:not(.active),
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible:not(.active) {
   background: #131318;
   color: #ffffff;
 }
@@ -29630,26 +29630,26 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-quick-find {
   background: var(--idt-console-rail-hover);
 }
 
-.idt-app-console-layout .idt-app-shell-nav a,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
+.idt-app-console-layout .idt-app-shell-nav > a,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a {
   color: var(--app-muted);
 }
 
-.idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
-.idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active),
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active) {
+.idt-app-console-layout .idt-app-shell-nav > a:hover:not(.active),
+.idt-app-console-layout .idt-app-shell-nav > a:focus-visible:not(.active),
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a:hover:not(.active),
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a:focus-visible:not(.active) {
   background: var(--idt-console-rail-hover);
   color: var(--app-text);
 }
 
-.idt-app-console-layout .idt-app-shell-nav a.active,
-html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a.active {
+.idt-app-console-layout .idt-app-shell-nav > a.active,
+html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav > a.active {
   background: transparent;
   color: var(--app-text);
 }
 
-.idt-app-console-layout .idt-app-shell-nav a.active::before {
+.idt-app-console-layout .idt-app-shell-nav > a.active::before {
   background: var(--idt-console-focus);
 }
 
@@ -31012,7 +31012,7 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
     padding-bottom: 0;
   }
 
-  .idt-app-console-layout .idt-app-shell-nav a,
+  .idt-app-console-layout .idt-app-shell-nav > a,
   .idt-app-console-layout .idt-app-nav-domain-trigger {
     min-width: 0;
     width: 100%;
@@ -31716,7 +31716,7 @@ html[data-appearance-ready='true'] .idt-app-console-layout :is(
 }
 
 html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-quick-find,
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a {
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a {
   color: var(--app-muted);
 }
 
@@ -31744,19 +31744,19 @@ html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-work
 html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger:hover,
 html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger:focus-visible,
 html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-sidebar-account-trigger[aria-expanded='true'],
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active) {
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a:hover:not(.active),
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a:focus-visible:not(.active) {
   color: var(--app-text);
 }
 
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a.active {
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a.active {
   background: transparent;
   color: var(--app-text);
 }
 
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon,
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon,
-html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon {
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a:hover .idt-app-nav-icon,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a:focus-visible .idt-app-nav-icon,
+html[data-appearance-ready='true'] .idt-app-console-layout .idt-app-shell-nav > a.active .idt-app-nav-icon {
   color: var(--app-text);
 }
 

--- a/web/src/test-node-shims.d.ts
+++ b/web/src/test-node-shims.d.ts
@@ -1,0 +1,11 @@
+declare module 'node:fs' {
+  export function readFileSync(path: string, options: string): string;
+}
+
+declare module 'node:path' {
+  export function join(...paths: string[]): string;
+}
+
+declare const process: {
+  cwd(): string;
+};


### PR DESCRIPTION
## Summary
No issue: visual polish for domain flyout alignment.

- Scope app-shell nav anchor styles to direct rail links so collapsed-sidebar rules no longer cascade into provider flyout links.
- Preserve the flyout row grid so labels stay attached to the left side of each row while chevrons remain at the row end.
- Add a regression test covering the collapsed-sidebar flyout selector boundary.

## Validation
- `npm test -- --run src/productShell.test.tsx -t "collapsed sidebar styles"`
- `npm test -- --run src/productShell.test.tsx`
- Local visual before/after captures for AWS, GitHub, and Kubernetes flyouts in collapsed sidebar mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned chevrons in domain flyouts when the sidebar is collapsed by scoping nav link styles to the rail and preserving the flyout row grid. Ensures consistent label-left, chevron-right layout across AWS, GitHub, and Kubernetes flyouts.

- **Bug Fixes**
  - Scoped `.idt-app-shell-nav` styles to direct child links (`> a`) so collapsed-rail rules don’t bleed into flyout links.
  - Preserved `.idt-domain-flyout-link` grid layout so labels stay left and chevrons stay at row end.
  - Added a regression test that reads `styles.css` to assert `> a` scoping and the flyout grid, and added Node shims for `node:fs`/`node:path` to satisfy test typings.

<sup>Written for commit dbf771c9a23f5f0d99c749b5a924a1b2b298dff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

