### PR TITLE
Add AWS platform observability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS Remediation Center unified experience: `aws-remediation-center.md`
 - AWS governance audit reporting: `aws-governance-audit-reporting.md`
 - AWS executive outcome view: `aws-executive-outcome-view.md`
+- AWS platform observability: `aws-platform-observability.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`

--- a/docs/aws-platform-observability.md
+++ b/docs/aws-platform-observability.md
@@ -1,0 +1,43 @@
+# AWS Platform Observability
+
+Issue #1556 adds a metadata-only platform observability view for AWS machine-identity operations. It composes existing Identrail source contracts so operators can see scan throughput, queue lag, throttling, collector failures, runtime lag, remediation state, verification outcomes, enforcement health, and governance exceptions without reading logs or database rows.
+
+## API
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/platform-observability`
+
+Response shape: `{ "platform_observability": AWSPlatformObservabilityResult }`.
+
+Supported filters:
+
+- `connector_id`
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, `permission_denied`
+- `account_id`
+- `region`
+- `service`
+- `component`: `collector`, `queue`, `runtime`, `remediation`, `verification`, `enforcement`, `governance`
+- `status`: `ready`, `degraded`, `blocked`
+- `search`
+
+The payload includes:
+
+- `summary`: dashboard counters for metrics, traces, alerts, scan throughput, queue lag, runtime lag, collector failures, throttling, remediation pending work, verification failures, and governance exceptions.
+- `metrics`: bounded platform health metrics with status, severity, confidence, account/region/service context, trace IDs, evidence refs, and next actions.
+- `traces`: operator-debuggable trace rows for fan-out targets, runtime evidence, and verification entries.
+- `alerts`: degraded or blocked metric alerts.
+- `coverage_gaps` and `diagnostics`: explicit source limits and retry guidance.
+
+## App Surface
+
+The AWS app adds `/app/:tenantID/:workspaceID/aws/observability`. The page includes summary cards, metric rows, trace rows, filters, loading state, empty state, degraded state, and permission-denied state using the existing AWS environment selector and scoped auth headers.
+
+## Evidence Boundary
+
+The observability view is read-only. It links to existing evidence refs and docs, and it does not collect or expose secret values, prompts, completions, browser output, code-interpreter output, database rows, object contents, policy bodies, or customer payloads.
+
+## Troubleshooting
+
+- `blocked` usually means the selected connector cannot read a required metadata source or an upstream source returned permission denied.
+- `degraded` means at least one source is partial, stale, throttled, failed, or verification/enforcement evidence needs operator attention.
+- Queue and runtime lag are derived from bounded source contracts. Use trace rows for account, region, service, retry, and evidence-ref drill-down.
+- Fixture states keep local validation deterministic; live AWS validation should use only authorized test accounts and should record account/region/service coverage without sensitive payloads.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -18953,7 +18953,9 @@ components:
       properties:
         alert_id: { type: string }
         severity: { type: string }
-        component: { type: string }
+        component:
+          type: string
+          enum: [collector, queue, runtime, remediation, verification, enforcement, governance]
         status:
           type: string
           enum: [ready, degraded, blocked]

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -668,6 +668,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/platform-observability
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
     action: tenancy.read
     resource_type: project
@@ -6481,6 +6486,76 @@ paths:
                     $ref: "#/components/schemas/AWSExecutiveOutcomeViewResult"
         "400":
           description: Invalid AWS executive outcome view request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/platform-observability:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS platform observability
+      operationId: getAWSProjectPlatformObservability
+      description: Composes metadata-only AWS platform health metrics, traces, and alerts for scan throughput, queue lag, throttling, collector failures, runtime lag, remediation state, verification outcomes, enforcement health, and governance outcomes. The endpoint is read-only and returns trace IDs, evidence refs, confidence, diagnostics, and coverage gaps without collecting secret values, prompts, completions, browser output, database rows, object contents, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: service
+          schema: { type: string }
+        - in: query
+          name: component
+          schema:
+            type: string
+            enum: [collector, queue, runtime, remediation, verification, enforcement, governance]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [ready, degraded, blocked]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS platform observability contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  platform_observability:
+                    $ref: "#/components/schemas/AWSPlatformObservabilityResult"
+        "400":
+          description: Invalid AWS platform observability request
           content:
             application/json:
               schema:
@@ -18779,6 +18854,194 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSExecutiveOutcomeMetric"
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        coverage_gaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeCoverageGap"
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPlatformObservabilityMetric:
+      type: object
+      properties:
+        metric_id: { type: string }
+        component:
+          type: string
+          enum: [collector, queue, runtime, remediation, verification, enforcement, governance]
+        signal: { type: string }
+        title: { type: string }
+        summary: { type: string }
+        value: { type: integer }
+        unit: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        severity: { type: string }
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        trace_id: { type: string }
+        evidence_ref: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        next_action: { type: string }
+        observed_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSPlatformObservabilityTrace:
+      type: object
+      properties:
+        trace_id: { type: string }
+        parent_trace_id: { type: string }
+        span_name: { type: string }
+        component:
+          type: string
+          enum: [collector, queue, runtime, remediation, verification, enforcement, governance]
+        account_id: { type: string }
+        region: { type: string }
+        service: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        duration_ms: { type: integer }
+        queue_lag_ms: { type: integer }
+        runtime_lag_ms: { type: integer }
+        retry_count: { type: integer }
+        throttled: { type: boolean }
+        evidence_ref: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        next_action: { type: string }
+        started_at:
+          type: string
+          format: date-time
+        ended_at:
+          type: string
+          format: date-time
+    AWSPlatformObservabilityAlert:
+      type: object
+      properties:
+        alert_id: { type: string }
+        severity: { type: string }
+        component: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        title: { type: string }
+        summary: { type: string }
+        evidence_ref: { type: string }
+        evidence_boundary: { type: string }
+        next_action: { type: string }
+        triggered_at:
+          type: string
+          format: date-time
+    AWSPlatformObservabilitySummary:
+      type: object
+      properties:
+        total_metrics: { type: integer }
+        filtered_metrics: { type: integer }
+        total_traces: { type: integer }
+        filtered_traces: { type: integer }
+        ready_signals: { type: integer }
+        degraded_signals: { type: integer }
+        blocked_signals: { type: integer }
+        alert_count: { type: integer }
+        critical_alert_count: { type: integer }
+        scan_throughput_per_hour: { type: integer }
+        queue_lag_p95_ms: { type: integer }
+        runtime_lag_p95_ms: { type: integer }
+        collector_failure_count: { type: integer }
+        throttled_target_count: { type: integer }
+        remediation_pending_count: { type: integer }
+        verification_failed_count: { type: integer }
+        governance_exception_count: { type: integer }
+        account_counts:
+          type: object
+          additionalProperties: { type: integer }
+        region_counts:
+          type: object
+          additionalProperties: { type: integer }
+        service_counts:
+          type: object
+          additionalProperties: { type: integer }
+        component_counts:
+          type: object
+          additionalProperties: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+    AWSPlatformObservabilityResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSPlatformObservabilitySummary"
+        metrics:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPlatformObservabilityMetric"
+        traces:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPlatformObservabilityTrace"
+        alerts:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPlatformObservabilityAlert"
         caveats:
           type: array
           items: { type: string }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -784,6 +784,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/limited-enforcement-pilot", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/governance-audit-reporting", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/executive-outcomes", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/platform-observability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -692,8 +692,8 @@ func awsPlatformObservabilityHasResultFilter(request AWSPlatformObservabilityReq
 	return awsPlatformObservabilityRequestedScopeValue(request.AccountID) != "" ||
 		awsPlatformObservabilityRequestedScopeValue(request.Region) != "" ||
 		awsPlatformObservabilitySourceServiceFilter(request.Service) != "" ||
-		strings.TrimSpace(request.Component) != "" ||
-		strings.TrimSpace(request.Status) != "" ||
+		awsPlatformObservabilityRequestedScopeValue(request.Component) != "" ||
+		awsPlatformObservabilityRequestedScopeValue(request.Status) != "" ||
 		strings.TrimSpace(request.Search) != ""
 }
 
@@ -754,6 +754,14 @@ func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetr
 		incrementCount(summary.ServiceCounts, trace.Service)
 		incrementCount(summary.ComponentCounts, trace.Component)
 		incrementCount(summary.StatusCounts, trace.Status)
+		switch trace.Status {
+		case awsPlatformDependencyStatusBlocked:
+			summary.BlockedSignals++
+		case awsPlatformDependencyStatusDegraded:
+			summary.DegradedSignals++
+		default:
+			summary.ReadySignals++
+		}
 		if trace.QueueLagMs > summary.QueueLagP95Ms {
 			summary.QueueLagP95Ms = trace.QueueLagMs
 		}

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -274,7 +274,7 @@ func (s *Service) GetAWSPlatformObservability(ctx context.Context, workspaceID s
 	filteredMetrics, filteredTraces, applied := filterAWSPlatformObservability(metrics, traces, request)
 	alerts := awsPlatformObservabilityAlerts(filteredMetrics, now)
 	summary := summarizeAWSPlatformObservability(metrics, filteredMetrics, traces, filteredTraces, alerts)
-	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, awsPlatformObservabilitySourceStatuses(sources)...)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics)
 	return AWSPlatformObservabilityResult{
 		TenantID:           scope.TenantID,
 		WorkspaceID:        project.WorkspaceID,
@@ -754,8 +754,8 @@ func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetr
 	return summary
 }
 
-func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric, statuses ...string) (string, float64) {
-	statuses = append(statuses, awsPlatformObservabilityMetricStatuses(metrics)...)
+func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric) (string, float64) {
+	statuses := awsPlatformObservabilityMetricStatuses(metrics)
 	status := awsPlatformObservabilitySourceStatus(statuses...)
 	switch status {
 	case awsPlatformDependencyStatusBlocked:

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -971,7 +971,7 @@ func awsPlatformObservabilityFanOutSummary(result AWSFanOutExecutionResult) AWSF
 		case state == "covered" || workerState == "covered" || workerState == "complete" || workerState == "completed":
 			summary.CoveredTargets++
 		}
-		if state == "queued" || workerState == "queued" {
+		if awsPlatformObservabilityIsQueuedFanOutState(state) || awsPlatformObservabilityIsQueuedFanOutState(workerState) {
 			summary.QueuedTargets++
 		}
 		if state == "in_progress" || workerState == "in_progress" || workerState == "running" {
@@ -1063,7 +1063,7 @@ func awsPlatformObservabilityTargetQueueLag(target AWSFanOutExecutionTarget) int
 	switch {
 	case target.Throttled:
 		return int((5 * time.Minute).Milliseconds())
-	case state == "queued":
+	case awsPlatformObservabilityIsQueuedFanOutState(state):
 		return int((2 * time.Minute).Milliseconds())
 	case state == "in_progress":
 		return int((30 * time.Second).Milliseconds())
@@ -1071,6 +1071,15 @@ func awsPlatformObservabilityTargetQueueLag(target AWSFanOutExecutionTarget) int
 		return int((5 * time.Minute).Milliseconds())
 	default:
 		return 0
+	}
+}
+
+func awsPlatformObservabilityIsQueuedFanOutState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "queued", "pending":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -1,0 +1,1087 @@
+package api
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	awsPlatformObservabilityCurrentIssue = 1556
+	awsPlatformObservabilityVersion      = "aws-platform-observability-v1"
+	awsPlatformObservabilityBoundary     = "metadata_only_platform_observability_no_secret_values_no_customer_payloads"
+)
+
+// AWSPlatformObservabilityRequest scopes the read-only AWS platform health
+// dashboard to one connector and bounded operator filters.
+type AWSPlatformObservabilityRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Service      string `json:"service,omitempty"`
+	Component    string `json:"component,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSPlatformObservabilityMetric struct {
+	MetricID         string    `json:"metric_id"`
+	Component        string    `json:"component"`
+	Signal           string    `json:"signal"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary"`
+	Value            int       `json:"value"`
+	Unit             string    `json:"unit"`
+	Status           string    `json:"status"`
+	Severity         string    `json:"severity,omitempty"`
+	Confidence       float64   `json:"confidence"`
+	AccountID        string    `json:"account_id,omitempty"`
+	Region           string    `json:"region,omitempty"`
+	Service          string    `json:"service,omitempty"`
+	TraceID          string    `json:"trace_id"`
+	EvidenceRef      string    `json:"evidence_ref,omitempty"`
+	EvidenceLinks    []string  `json:"evidence_links"`
+	EvidenceBoundary string    `json:"evidence_boundary"`
+	NextAction       string    `json:"next_action"`
+	ObservedAt       time.Time `json:"observed_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type AWSPlatformObservabilityTrace struct {
+	TraceID          string    `json:"trace_id"`
+	ParentTraceID    string    `json:"parent_trace_id,omitempty"`
+	SpanName         string    `json:"span_name"`
+	Component        string    `json:"component"`
+	AccountID        string    `json:"account_id,omitempty"`
+	Region           string    `json:"region,omitempty"`
+	Service          string    `json:"service,omitempty"`
+	Status           string    `json:"status"`
+	DurationMs       int       `json:"duration_ms,omitempty"`
+	QueueLagMs       int       `json:"queue_lag_ms,omitempty"`
+	RuntimeLagMs     int       `json:"runtime_lag_ms,omitempty"`
+	RetryCount       int       `json:"retry_count,omitempty"`
+	Throttled        bool      `json:"throttled"`
+	EvidenceRef      string    `json:"evidence_ref,omitempty"`
+	EvidenceLinks    []string  `json:"evidence_links"`
+	EvidenceBoundary string    `json:"evidence_boundary"`
+	NextAction       string    `json:"next_action"`
+	StartedAt        time.Time `json:"started_at,omitempty"`
+	EndedAt          time.Time `json:"ended_at,omitempty"`
+}
+
+type AWSPlatformObservabilityAlert struct {
+	AlertID          string    `json:"alert_id"`
+	Severity         string    `json:"severity"`
+	Component        string    `json:"component"`
+	Status           string    `json:"status"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary"`
+	EvidenceRef      string    `json:"evidence_ref,omitempty"`
+	EvidenceBoundary string    `json:"evidence_boundary"`
+	NextAction       string    `json:"next_action"`
+	TriggeredAt      time.Time `json:"triggered_at"`
+}
+
+type AWSPlatformObservabilityCoverageGap struct {
+	Capability  string `json:"capability"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type AWSPlatformObservabilityDiagnostic struct {
+	Collector   string `json:"collector"`
+	SourceID    string `json:"source_id,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
+}
+
+type AWSPlatformObservabilitySummary struct {
+	TotalMetrics             int            `json:"total_metrics"`
+	FilteredMetrics          int            `json:"filtered_metrics"`
+	TotalTraces              int            `json:"total_traces"`
+	FilteredTraces           int            `json:"filtered_traces"`
+	ReadySignals             int            `json:"ready_signals"`
+	DegradedSignals          int            `json:"degraded_signals"`
+	BlockedSignals           int            `json:"blocked_signals"`
+	AlertCount               int            `json:"alert_count"`
+	CriticalAlertCount       int            `json:"critical_alert_count"`
+	ScanThroughputPerHour    int            `json:"scan_throughput_per_hour"`
+	QueueLagP95Ms            int            `json:"queue_lag_p95_ms"`
+	RuntimeLagP95Ms          int            `json:"runtime_lag_p95_ms"`
+	CollectorFailureCount    int            `json:"collector_failure_count"`
+	ThrottledTargetCount     int            `json:"throttled_target_count"`
+	RemediationPendingCount  int            `json:"remediation_pending_count"`
+	VerificationFailedCount  int            `json:"verification_failed_count"`
+	GovernanceExceptionCount int            `json:"governance_exception_count"`
+	AccountCounts            map[string]int `json:"account_counts"`
+	RegionCounts             map[string]int `json:"region_counts"`
+	ServiceCounts            map[string]int `json:"service_counts"`
+	ComponentCounts          map[string]int `json:"component_counts"`
+	StatusCounts             map[string]int `json:"status_counts"`
+}
+
+type AWSPlatformObservabilityResult struct {
+	TenantID           string                                `json:"tenant_id"`
+	WorkspaceID        string                                `json:"workspace_id"`
+	ProjectID          string                                `json:"project_id"`
+	ConnectorID        string                                `json:"connector_id,omitempty"`
+	AccountID          string                                `json:"account_id,omitempty"`
+	Region             string                                `json:"region,omitempty"`
+	ParentIssueNumber  int                                   `json:"parent_issue_number"`
+	ParentIssueRef     string                                `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                   `json:"current_issue_number"`
+	CurrentIssueRef    string                                `json:"current_issue_ref"`
+	Version            string                                `json:"version"`
+	Status             string                                `json:"status"`
+	FixtureState       string                                `json:"fixture_state,omitempty"`
+	Confidence         float64                               `json:"confidence"`
+	CalculationVersion string                                `json:"calculation_version"`
+	AppliedFilters     map[string]string                     `json:"applied_filters"`
+	Summary            AWSPlatformObservabilitySummary       `json:"summary"`
+	Metrics            []AWSPlatformObservabilityMetric      `json:"metrics"`
+	Traces             []AWSPlatformObservabilityTrace       `json:"traces"`
+	Alerts             []AWSPlatformObservabilityAlert       `json:"alerts"`
+	Caveats            []string                              `json:"caveats"`
+	FailureReasons     []string                              `json:"failure_reasons"`
+	RemediationHints   []string                              `json:"remediation_hints"`
+	EvidenceLinks      []string                              `json:"evidence_links"`
+	CoverageGaps       []AWSPlatformObservabilityCoverageGap `json:"coverage_gaps"`
+	Diagnostics        []AWSPlatformObservabilityDiagnostic  `json:"diagnostics"`
+	GeneratedAt        time.Time                             `json:"generated_at"`
+	UpdatedAt          time.Time                             `json:"updated_at"`
+}
+
+type awsPlatformObservabilitySources struct {
+	Coverage     AWSAccountRegionCoverageResult
+	FanOut       AWSFanOutExecutionResult
+	Runtime      AWSRuntimeEventResult
+	Cases        AWSRemediationCaseResult
+	Verification AWSPostRemediationVerificationResult
+	Enforcement  AWSLimitedEnforcementResult
+	Governance   AWSGovernanceAuditReportingResult
+}
+
+func (s *Service) GetAWSPlatformObservability(ctx context.Context, workspaceID string, projectID string, request AWSPlatformObservabilityRequest) (AWSPlatformObservabilityResult, error) {
+	if !validAWSPlatformObservabilityFilter(request) {
+		return AWSPlatformObservabilityResult{}, ErrInvalidAWSConnectionRequest
+	}
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSGovernanceAuditReportingFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSPlatformObservabilityResult{}, ErrInvalidAWSConnectionRequest
+	}
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceAccountID := awsExecutiveOutcomeSourceScopeFilter(request.AccountID)
+	sourceRegion := awsExecutiveOutcomeSourceScopeFilter(request.Region)
+	sourceService := awsExecutiveOutcomeSourceScopeFilter(request.Service)
+	accountID := awsExecutiveOutcomeScopeValue(request.AccountID, connection.AccountID, "123456789012")
+	region := awsExecutiveOutcomeScopeValue(request.Region, connection.Region, "us-east-1")
+
+	coverage, err := s.GetAWSAccountRegionCoverage(ctx, workspaceID, projectID, AWSAccountRegionCoverageRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		Account:      sourceAccountID,
+		Region:       sourceRegion,
+		Service:      sourceService,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	fanout, err := s.GetAWSFanOutExecution(ctx, workspaceID, projectID, AWSFanOutExecutionRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		Account:      sourceAccountID,
+		Region:       sourceRegion,
+		Service:      sourceService,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	runtime, err := s.GetAWSRuntimeEvents(ctx, workspaceID, projectID, AWSRuntimeEventRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	cases, err := s.GetAWSRemediationCases(ctx, workspaceID, projectID, AWSRemediationCaseRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	verification, err := s.GetAWSPostRemediationVerification(ctx, workspaceID, projectID, AWSPostRemediationVerificationRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	enforcement, err := s.GetAWSLimitedEnforcement(ctx, workspaceID, projectID, AWSLimitedEnforcementRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSPlatformObservabilityResult{}, err
+	}
+
+	sources := awsPlatformObservabilitySources{
+		Coverage:     coverage,
+		FanOut:       fanout,
+		Runtime:      runtime,
+		Cases:        cases,
+		Verification: verification,
+		Enforcement:  enforcement,
+		Governance:   governance,
+	}
+	metrics := awsPlatformObservabilityMetrics(sources, request, accountID, region, sourceService, now)
+	traces := awsPlatformObservabilityTraces(sources, now)
+	filteredMetrics, filteredTraces, applied := filterAWSPlatformObservability(metrics, traces, request)
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, now)
+	summary := summarizeAWSPlatformObservability(metrics, filteredMetrics, traces, filteredTraces, alerts)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, awsPlatformObservabilitySourceStatuses(sources)...)
+	return AWSPlatformObservabilityResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsPlatformObservabilityCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsPlatformObservabilityCurrentIssue),
+		Version:            awsPlatformObservabilityVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsPlatformObservabilityVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Metrics:            filteredMetrics,
+		Traces:             filteredTraces,
+		Alerts:             alerts,
+		Caveats:            awsPlatformObservabilityCaveats(),
+		FailureReasons:     awsPlatformObservabilityFailureReasons(sources),
+		RemediationHints:   awsPlatformObservabilityRemediationHints(sources),
+		EvidenceLinks: dedupeStrings([]string{
+			awsIssueURL(awsPlatformDependencyParentIssue),
+			awsIssueURL(awsPlatformObservabilityCurrentIssue),
+			awsIssueURL(awsFanOutExecutionCurrentIssue),
+			awsIssueURL(awsRuntimeEventsCurrentIssue),
+			awsIssueURL(awsPostRemediationVerificationCurrentIssue),
+			"/docs/aws-platform-observability",
+			"/docs/observability",
+			awsBaselineProjectEvidenceURL(scope, project),
+		}),
+		CoverageGaps: awsPlatformObservabilityCoverageGaps(sources),
+		Diagnostics:  awsPlatformObservabilityDiagnostics(sources),
+		GeneratedAt:  now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func validAWSPlatformObservabilityFilter(request AWSPlatformObservabilityRequest) bool {
+	return validAWSPlatformObservabilityToken(request.Component, []string{"collector", "queue", "runtime", "remediation", "verification", "enforcement", "governance"}) &&
+		validAWSPlatformObservabilityToken(request.Status, []string{awsPlatformDependencyStatusReady, awsPlatformDependencyStatusDegraded, awsPlatformDependencyStatusBlocked})
+}
+
+func validAWSPlatformObservabilityToken(value string, allowed []string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" || value == "all" {
+		return true
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, request AWSPlatformObservabilityRequest, accountID, region, service string, now time.Time) []AWSPlatformObservabilityMetric {
+	if service == "" {
+		service = strings.TrimSpace(request.Service)
+	}
+	if service == "" {
+		service = "all"
+	}
+	collectorFailures := sources.Coverage.Summary.DegradedRecords + sources.Coverage.Summary.UnreachableRecords + sources.Coverage.Summary.StaleRecords + sources.Coverage.Summary.PermissionDeniedRecords + len(sources.Coverage.Diagnostics)
+	queueLag := awsPlatformObservabilityQueueLag(sources.FanOut.Summary)
+	runtimeLag := awsPlatformObservabilityRuntimeLag(sources.Runtime.Records)
+	remediationPending := sources.Cases.Summary.ApprovalRequiredCount + sources.Verification.Summary.PendingCount
+	verificationFailures := sources.Verification.Summary.FailedCount + sources.Verification.Summary.RollbackPlannedCount + sources.Verification.Summary.BlockedCount
+	enforcementBlocked := sources.Enforcement.Summary.KillSwitchEngagedCount + sources.Enforcement.Summary.FailedGateCount
+	return []AWSPlatformObservabilityMetric{
+		{
+			MetricID:         "scan-throughput",
+			Component:        "collector",
+			Signal:           "scan_throughput",
+			Title:            "Scan throughput",
+			Summary:          "Account, region, and service targets completed by the bounded fan-out and coverage collectors.",
+			Value:            maxInt(sources.FanOut.Summary.CoveredTargets, sources.Coverage.Summary.CoveredRecords),
+			Unit:             "targets_per_hour",
+			Status:           awsPlatformObservabilitySourceStatus(sources.Coverage.Status, sources.FanOut.Status),
+			Severity:         awsPlatformObservabilityMetricSeverity(sources.Coverage.Status, sources.FanOut.Status),
+			Confidence:       averageFloat64(sources.Coverage.Confidence, sources.FanOut.Confidence),
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "collector", accountID, region, service, "scan-throughput"),
+			EvidenceRef:      "aws-platform-observability://scan-throughput",
+			EvidenceLinks:    dedupeStrings(append(append([]string{}, sources.Coverage.EvidenceLinks...), sources.FanOut.EvidenceLinks...)),
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Use coverage and fan-out traces to confirm every expected account, region, and service is advancing.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "queue-lag",
+			Component:        "queue",
+			Signal:           "queue_lag",
+			Title:            "Queue lag",
+			Summary:          "Estimated backlog lag from queued and in-progress fan-out targets.",
+			Value:            queueLag,
+			Unit:             "milliseconds",
+			Status:           awsPlatformObservabilitySourceStatus(sources.FanOut.Status),
+			Severity:         awsPlatformObservabilityMetricSeverity(sources.FanOut.Status),
+			Confidence:       sources.FanOut.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "queue", accountID, region, service, "queue-lag"),
+			EvidenceRef:      "aws-platform-observability://queue-lag",
+			EvidenceLinks:    sources.FanOut.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Review queued and retryable targets before increasing scan concurrency.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "throttling",
+			Component:        "collector",
+			Signal:           "throttling",
+			Title:            "Throttling",
+			Summary:          "Fan-out targets currently throttled or waiting for bounded retry.",
+			Value:            sources.FanOut.Summary.ThrottledTargets,
+			Unit:             "targets",
+			Status:           awsPlatformObservabilityCountStatus(sources.FanOut.Summary.ThrottledTargets, sources.FanOut.Status),
+			Severity:         awsPlatformObservabilityCountSeverity(sources.FanOut.Summary.ThrottledTargets, sources.FanOut.Status),
+			Confidence:       sources.FanOut.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "collector", accountID, region, service, "throttling"),
+			EvidenceRef:      "aws-platform-observability://throttling",
+			EvidenceLinks:    sources.FanOut.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Let bounded backoff complete or reduce concurrency for throttled services.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "collector-failures",
+			Component:        "collector",
+			Signal:           "collector_failures",
+			Title:            "Collector failures",
+			Summary:          "Explicit degraded, unreachable, stale, permission-denied, or diagnostic collector states.",
+			Value:            collectorFailures,
+			Unit:             "signals",
+			Status:           awsPlatformObservabilityCountStatus(collectorFailures, sources.Coverage.Status),
+			Severity:         awsPlatformObservabilityCountSeverity(collectorFailures, sources.Coverage.Status),
+			Confidence:       sources.Coverage.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "collector", accountID, region, service, "collector-failures"),
+			EvidenceRef:      "aws-platform-observability://collector-failures",
+			EvidenceLinks:    sources.Coverage.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Inspect diagnostics and coverage gaps before treating the scan as complete.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "runtime-lag",
+			Component:        "runtime",
+			Signal:           "runtime_lag",
+			Title:            "Runtime lag",
+			Summary:          "P95 delay between runtime observation and collection for CloudTrail, last-used, and Access Analyzer signals.",
+			Value:            runtimeLag,
+			Unit:             "milliseconds",
+			Status:           awsPlatformObservabilitySourceStatus(sources.Runtime.Status),
+			Severity:         awsPlatformObservabilityMetricSeverity(sources.Runtime.Status),
+			Confidence:       sources.Runtime.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "runtime", accountID, region, service, "runtime-lag"),
+			EvidenceRef:      "aws-platform-observability://runtime-lag",
+			EvidenceLinks:    sources.Runtime.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Review runtime diagnostics when lag exceeds the ingestion window or live evidence is capability-gated.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "remediation-state",
+			Component:        "remediation",
+			Signal:           "remediation_state",
+			Title:            "Remediation state",
+			Summary:          "Remediation cases awaiting ownership, approval, verification, or rollback review.",
+			Value:            remediationPending,
+			Unit:             "items",
+			Status:           awsPlatformObservabilitySourceStatus(sources.Cases.Status, sources.Verification.Status),
+			Severity:         awsPlatformObservabilityMetricSeverity(sources.Cases.Status, sources.Verification.Status),
+			Confidence:       averageFloat64(sources.Cases.Confidence, sources.Verification.Confidence),
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "remediation", accountID, region, service, "remediation-state"),
+			EvidenceRef:      "aws-platform-observability://remediation-state",
+			EvidenceLinks:    dedupeStrings(append(append([]string{}, sources.Cases.EvidenceLinks...), sources.Verification.EvidenceLinks...)),
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Assign pending remediation cases and keep verification evidence attached before closure.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "verification-outcomes",
+			Component:        "verification",
+			Signal:           "verification_outcomes",
+			Title:            "Verification outcomes",
+			Summary:          "Failed, blocked, and rollback-planned verification outcomes after remediation projections.",
+			Value:            verificationFailures,
+			Unit:             "outcomes",
+			Status:           awsPlatformObservabilityCountStatus(verificationFailures, sources.Verification.Status),
+			Severity:         awsPlatformObservabilityCountSeverity(verificationFailures, sources.Verification.Status),
+			Confidence:       sources.Verification.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "verification", accountID, region, service, "verification-outcomes"),
+			EvidenceRef:      "aws-platform-observability://verification-outcomes",
+			EvidenceLinks:    sources.Verification.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Review failed checks and rollback plans before reporting remediation success.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "enforcement-health",
+			Component:        "enforcement",
+			Signal:           "enforcement_health",
+			Title:            "Enforcement health",
+			Summary:          "Limited-enforcement kill switch, failed gates, and ready-for-enforcement states.",
+			Value:            enforcementBlocked,
+			Unit:             "gates",
+			Status:           awsPlatformObservabilityCountStatus(enforcementBlocked, sources.Enforcement.Status),
+			Severity:         awsPlatformObservabilityCountSeverity(enforcementBlocked, sources.Enforcement.Status),
+			Confidence:       sources.Enforcement.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "enforcement", accountID, region, service, "enforcement-health"),
+			EvidenceRef:      "aws-platform-observability://enforcement-health",
+			EvidenceLinks:    sources.Enforcement.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Keep enforcement in advisory or canary mode until failed gates and kill switches are clear.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+		{
+			MetricID:         "governance-outcomes",
+			Component:        "governance",
+			Signal:           "governance_outcomes",
+			Title:            "Governance outcomes",
+			Summary:          "Export-safe decisions, approvals, remediations, enforcement outcomes, and exceptions.",
+			Value:            sources.Governance.Summary.ExceptionCount,
+			Unit:             "exceptions",
+			Status:           awsPlatformObservabilitySourceStatus(sources.Governance.Status),
+			Severity:         awsPlatformObservabilityMetricSeverity(sources.Governance.Status),
+			Confidence:       sources.Governance.Confidence,
+			AccountID:        accountID,
+			Region:           region,
+			Service:          service,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "governance", accountID, region, service, "governance-outcomes"),
+			EvidenceRef:      "aws-platform-observability://governance-outcomes",
+			EvidenceLinks:    sources.Governance.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       "Export governance rows and investigate exceptions before leadership reporting.",
+			ObservedAt:       now,
+			UpdatedAt:        now,
+		},
+	}
+}
+
+func awsPlatformObservabilityTraces(sources awsPlatformObservabilitySources, now time.Time) []AWSPlatformObservabilityTrace {
+	traces := []AWSPlatformObservabilityTrace{}
+	for _, target := range sources.FanOut.Targets {
+		status := awsPlatformObservabilityFanOutStatus(target)
+		traceID := awsPlatformObservabilityTraceID("fanout", "collector", target.AccountID, target.Region, target.Service, target.Key)
+		traces = append(traces, AWSPlatformObservabilityTrace{
+			TraceID:          traceID,
+			SpanName:         "aws.collector.fanout",
+			Component:        "collector",
+			AccountID:        target.AccountID,
+			Region:           target.Region,
+			Service:          target.Service,
+			Status:           status,
+			DurationMs:       maxInt(target.Attempts, 1) * 1000,
+			QueueLagMs:       awsPlatformObservabilityTargetQueueLag(target),
+			RetryCount:       target.Attempts,
+			Throttled:        target.Throttled,
+			EvidenceRef:      target.EvidenceRef,
+			EvidenceLinks:    sources.FanOut.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       target.NextAction,
+			StartedAt:        firstNonZeroTime(target.ObservedAt, now),
+			EndedAt:          now,
+		})
+	}
+	for _, record := range sources.Runtime.Records {
+		traces = append(traces, AWSPlatformObservabilityTrace{
+			TraceID:          awsPlatformObservabilityTraceID("runtime", "runtime", record.AccountID, record.Region, record.EventSource, record.EventID),
+			SpanName:         "aws.runtime.evidence",
+			Component:        "runtime",
+			AccountID:        record.AccountID,
+			Region:           record.Region,
+			Service:          record.EventSource,
+			Status:           awsPlatformObservabilityRuntimeStatus(record.Status),
+			RuntimeLagMs:     awsPlatformObservabilityDurationMs(record.ObservedAt, record.CollectedAt),
+			EvidenceRef:      record.EvidenceRef,
+			EvidenceLinks:    sources.Runtime.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       record.NextAction,
+			StartedAt:        record.ObservedAt,
+			EndedAt:          record.CollectedAt,
+		})
+	}
+	for _, entry := range sources.Verification.Entries {
+		traces = append(traces, AWSPlatformObservabilityTrace{
+			TraceID:          awsPlatformObservabilityTraceID("verification", "verification", entry.AccountID, entry.Region, entry.SourceType, entry.VerificationID),
+			SpanName:         "aws.remediation.verify",
+			Component:        "verification",
+			AccountID:        entry.AccountID,
+			Region:           entry.Region,
+			Service:          entry.SourceType,
+			Status:           awsPlatformObservabilityVerificationStatus(entry.State),
+			EvidenceRef:      entry.Rollback.EvidenceRef,
+			EvidenceLinks:    entry.EvidenceLinks,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       entry.NextAction,
+			StartedAt:        entry.ProjectedAt,
+			EndedAt:          entry.UpdatedAt,
+		})
+	}
+	sort.SliceStable(traces, func(i, j int) bool {
+		if traces[i].Status == traces[j].Status {
+			return traces[i].TraceID < traces[j].TraceID
+		}
+		return awsPlatformObservabilityStatusRank(traces[i].Status) > awsPlatformObservabilityStatusRank(traces[j].Status)
+	})
+	return traces
+}
+
+func filterAWSPlatformObservability(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace, request AWSPlatformObservabilityRequest) ([]AWSPlatformObservabilityMetric, []AWSPlatformObservabilityTrace, map[string]string) {
+	applied := map[string]string{}
+	matchToken := func(value, want string) bool {
+		want = strings.ToLower(strings.TrimSpace(want))
+		if want == "" || want == "all" {
+			return true
+		}
+		return strings.ToLower(strings.TrimSpace(value)) == want
+	}
+	matchSearch := func(values ...string) bool {
+		search := strings.ToLower(strings.TrimSpace(request.Search))
+		if search == "" {
+			return true
+		}
+		return strings.Contains(strings.ToLower(strings.Join(values, " ")), search)
+	}
+	filteredMetrics := make([]AWSPlatformObservabilityMetric, 0, len(metrics))
+	for _, metric := range metrics {
+		if !matchToken(metric.AccountID, request.AccountID) || !matchToken(metric.Region, request.Region) || !matchToken(metric.Service, request.Service) {
+			continue
+		}
+		if !matchToken(metric.Component, request.Component) || !matchToken(metric.Status, request.Status) {
+			continue
+		}
+		if !matchSearch(metric.MetricID, metric.Component, metric.Signal, metric.Title, metric.Summary, metric.Status, metric.TraceID, metric.EvidenceRef, metric.NextAction) {
+			continue
+		}
+		filteredMetrics = append(filteredMetrics, metric)
+	}
+	filteredTraces := make([]AWSPlatformObservabilityTrace, 0, len(traces))
+	for _, trace := range traces {
+		if !matchToken(trace.AccountID, request.AccountID) || !matchToken(trace.Region, request.Region) || !matchToken(trace.Service, request.Service) {
+			continue
+		}
+		if !matchToken(trace.Component, request.Component) || !matchToken(trace.Status, request.Status) {
+			continue
+		}
+		if !matchSearch(trace.TraceID, trace.SpanName, trace.Component, trace.Status, trace.Service, trace.EvidenceRef, trace.NextAction) {
+			continue
+		}
+		filteredTraces = append(filteredTraces, trace)
+	}
+	setAppliedAWSExecutiveOutcomeFilter(applied, "connector_id", request.ConnectorID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "fixture_state", request.FixtureState)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "account_id", request.AccountID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "region", request.Region)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "service", request.Service)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "component", request.Component)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "status", request.Status)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "search", request.Search)
+	return filteredMetrics, filteredTraces, applied
+}
+
+func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetric, filteredMetrics []AWSPlatformObservabilityMetric, allTraces []AWSPlatformObservabilityTrace, filteredTraces []AWSPlatformObservabilityTrace, alerts []AWSPlatformObservabilityAlert) AWSPlatformObservabilitySummary {
+	summary := AWSPlatformObservabilitySummary{
+		TotalMetrics:    len(allMetrics),
+		FilteredMetrics: len(filteredMetrics),
+		TotalTraces:     len(allTraces),
+		FilteredTraces:  len(filteredTraces),
+		AccountCounts:   map[string]int{},
+		RegionCounts:    map[string]int{},
+		ServiceCounts:   map[string]int{},
+		ComponentCounts: map[string]int{},
+		StatusCounts:    map[string]int{},
+		AlertCount:      len(alerts),
+	}
+	for _, alert := range alerts {
+		if alert.Severity == "critical" {
+			summary.CriticalAlertCount++
+		}
+	}
+	for _, metric := range filteredMetrics {
+		incrementCount(summary.AccountCounts, metric.AccountID)
+		incrementCount(summary.RegionCounts, metric.Region)
+		incrementCount(summary.ServiceCounts, metric.Service)
+		incrementCount(summary.ComponentCounts, metric.Component)
+		incrementCount(summary.StatusCounts, metric.Status)
+		switch metric.Status {
+		case awsPlatformDependencyStatusBlocked:
+			summary.BlockedSignals++
+		case awsPlatformDependencyStatusDegraded:
+			summary.DegradedSignals++
+		default:
+			summary.ReadySignals++
+		}
+		switch metric.MetricID {
+		case "scan-throughput":
+			summary.ScanThroughputPerHour = metric.Value
+		case "queue-lag":
+			summary.QueueLagP95Ms = metric.Value
+		case "runtime-lag":
+			summary.RuntimeLagP95Ms = metric.Value
+		case "collector-failures":
+			summary.CollectorFailureCount = metric.Value
+		case "throttling":
+			summary.ThrottledTargetCount = metric.Value
+		case "remediation-state":
+			summary.RemediationPendingCount = metric.Value
+		case "verification-outcomes":
+			summary.VerificationFailedCount = metric.Value
+		case "governance-outcomes":
+			summary.GovernanceExceptionCount = metric.Value
+		}
+	}
+	for _, trace := range filteredTraces {
+		incrementCount(summary.AccountCounts, trace.AccountID)
+		incrementCount(summary.RegionCounts, trace.Region)
+		incrementCount(summary.ServiceCounts, trace.Service)
+		incrementCount(summary.ComponentCounts, trace.Component)
+		incrementCount(summary.StatusCounts, trace.Status)
+		if trace.QueueLagMs > summary.QueueLagP95Ms {
+			summary.QueueLagP95Ms = trace.QueueLagMs
+		}
+		if trace.RuntimeLagMs > summary.RuntimeLagP95Ms {
+			summary.RuntimeLagP95Ms = trace.RuntimeLagMs
+		}
+	}
+	return summary
+}
+
+func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric, statuses ...string) (string, float64) {
+	statuses = append(statuses, awsPlatformObservabilityMetricStatuses(metrics)...)
+	status := awsPlatformObservabilitySourceStatus(statuses...)
+	switch status {
+	case awsPlatformDependencyStatusBlocked:
+		return status, 0.48
+	case awsPlatformDependencyStatusDegraded:
+		return status, 0.72
+	default:
+		if len(metrics) == 0 {
+			return awsPlatformDependencyStatusReady, 0.8
+		}
+		return awsPlatformDependencyStatusReady, 0.9
+	}
+}
+
+func awsPlatformObservabilityMetricStatuses(metrics []AWSPlatformObservabilityMetric) []string {
+	statuses := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		statuses = append(statuses, metric.Status)
+	}
+	return statuses
+}
+
+func awsPlatformObservabilitySourceStatuses(sources awsPlatformObservabilitySources) []string {
+	return []string{
+		sources.Coverage.Status,
+		sources.FanOut.Status,
+		sources.Runtime.Status,
+		sources.Cases.Status,
+		sources.Verification.Status,
+		sources.Enforcement.Status,
+		sources.Governance.Status,
+	}
+}
+
+func awsPlatformObservabilitySourceStatus(statuses ...string) string {
+	status := awsPlatformDependencyStatusReady
+	for _, candidate := range statuses {
+		switch strings.ToLower(strings.TrimSpace(candidate)) {
+		case awsPlatformDependencyStatusBlocked, "permission_denied":
+			return awsPlatformDependencyStatusBlocked
+		case awsPlatformDependencyStatusDegraded, "partial", "partial_failure":
+			status = awsPlatformDependencyStatusDegraded
+		}
+	}
+	return status
+}
+
+func awsPlatformObservabilityCountStatus(count int, statuses ...string) string {
+	if awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked
+	}
+	if count > 0 || awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded
+	}
+	return awsPlatformDependencyStatusReady
+}
+
+func awsPlatformObservabilityLagStatus(lagMs int, statuses ...string) string {
+	if awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusBlocked {
+		return awsPlatformDependencyStatusBlocked
+	}
+	if lagMs > int((15*time.Minute).Milliseconds()) || awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusDegraded {
+		return awsPlatformDependencyStatusDegraded
+	}
+	return awsPlatformDependencyStatusReady
+}
+
+func awsPlatformObservabilityMetricSeverity(statuses ...string) string {
+	switch awsPlatformObservabilitySourceStatus(statuses...) {
+	case awsPlatformDependencyStatusBlocked:
+		return "critical"
+	case awsPlatformDependencyStatusDegraded:
+		return "high"
+	default:
+		return "low"
+	}
+}
+
+func awsPlatformObservabilityCountSeverity(count int, statuses ...string) string {
+	if awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusBlocked {
+		return "critical"
+	}
+	if count > 0 || awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusDegraded {
+		return "high"
+	}
+	return "low"
+}
+
+func awsPlatformObservabilityLagSeverity(lagMs int, statuses ...string) string {
+	if awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusBlocked {
+		return "critical"
+	}
+	if lagMs > int((15*time.Minute).Milliseconds()) || awsPlatformObservabilitySourceStatus(statuses...) == awsPlatformDependencyStatusDegraded {
+		return "high"
+	}
+	return "low"
+}
+
+func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, now time.Time) []AWSPlatformObservabilityAlert {
+	alerts := []AWSPlatformObservabilityAlert{}
+	for _, metric := range metrics {
+		if metric.Status == awsPlatformDependencyStatusReady {
+			continue
+		}
+		alerts = append(alerts, AWSPlatformObservabilityAlert{
+			AlertID:          awsPlatformObservabilityTraceID("alert", metric.Component, metric.AccountID, metric.Region, metric.Service, metric.MetricID),
+			Severity:         metric.Severity,
+			Component:        metric.Component,
+			Status:           metric.Status,
+			Title:            metric.Title,
+			Summary:          metric.Summary,
+			EvidenceRef:      metric.EvidenceRef,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       metric.NextAction,
+			TriggeredAt:      now,
+		})
+	}
+	return alerts
+}
+
+func awsPlatformObservabilityQueueLag(summary AWSFanOutExecutionSummary) int {
+	return (summary.QueuedTargets * int((2 * time.Minute).Milliseconds())) + (summary.InProgressTargets * int((30 * time.Second).Milliseconds())) + (summary.RetryableTargets * int((5 * time.Minute).Milliseconds()))
+}
+
+func awsPlatformObservabilityTargetQueueLag(target AWSFanOutExecutionTarget) int {
+	state := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(target.WorkerState, target.State)))
+	switch {
+	case target.Throttled:
+		return int((5 * time.Minute).Milliseconds())
+	case state == "queued":
+		return int((2 * time.Minute).Milliseconds())
+	case state == "in_progress":
+		return int((30 * time.Second).Milliseconds())
+	case target.Retryable:
+		return int((5 * time.Minute).Milliseconds())
+	default:
+		return 0
+	}
+}
+
+func awsPlatformObservabilityRuntimeLag(records []AWSRuntimeEventRecord) int {
+	values := []int{}
+	for _, record := range records {
+		lag := awsPlatformObservabilityDurationMs(record.ObservedAt, record.CollectedAt)
+		if lag > 0 {
+			values = append(values, lag)
+		}
+	}
+	return awsPlatformObservabilityP95(values)
+}
+
+func awsPlatformObservabilityDurationMs(start, end time.Time) int {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return 0
+	}
+	return int(end.Sub(start).Milliseconds())
+}
+
+func awsPlatformObservabilityP95(values []int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	sort.Ints(values)
+	index := int(float64(len(values)-1) * 0.95)
+	return values[index]
+}
+
+func awsPlatformObservabilityFanOutStatus(target AWSFanOutExecutionTarget) string {
+	state := strings.ToLower(strings.TrimSpace(strings.Join([]string{target.WorkerState, target.State, target.FailureReason}, " ")))
+	switch {
+	case strings.Contains(state, "permission_denied"):
+		return awsPlatformDependencyStatusBlocked
+	case target.Throttled || target.Retryable || strings.Contains(state, "failed") || strings.Contains(state, "partial") || strings.Contains(state, "throttled"):
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
+func awsPlatformObservabilityRuntimeStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "permission_denied", "blocked":
+		return awsPlatformDependencyStatusBlocked
+	case "partial", "partial_failure", "degraded", "stale":
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
+func awsPlatformObservabilityVerificationStatus(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "blocked", "not_ready":
+		return awsPlatformDependencyStatusBlocked
+	case "verification_failed", "rollback_planned", "verification_pending", "pending":
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
+func awsPlatformObservabilityStatusRank(status string) int {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case awsPlatformDependencyStatusBlocked:
+		return 3
+	case awsPlatformDependencyStatusDegraded:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func awsPlatformObservabilityTraceID(parts ...string) string {
+	clean := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		part = strings.ReplaceAll(part, ":", "-")
+		part = strings.ReplaceAll(part, "/", "-")
+		part = strings.ReplaceAll(part, "|", "-")
+		part = strings.ReplaceAll(part, " ", "-")
+		part = strings.Trim(part, "-")
+		if part != "" && part != "all" {
+			clean = append(clean, part)
+		}
+	}
+	return strings.Join(clean, ":")
+}
+
+func awsPlatformObservabilityCaveats() []string {
+	return []string{
+		"Platform observability is metadata-only and links to evidence refs instead of exposing secret values, payloads, prompts, completions, browser output, database rows, object contents, or customer content.",
+		"Queue lag and runtime lag are dashboard signals derived from bounded source contracts; use trace rows and diagnostics for account, region, and service-level debugging.",
+		"Read-only fixtures keep loading, empty, degraded, and permission-denied states stable when live AWS observability sources are unavailable.",
+	}
+}
+
+func awsPlatformObservabilityFailureReasons(sources awsPlatformObservabilitySources) []string {
+	out := []string{}
+	for _, failures := range [][]string{
+		sources.Coverage.FailureReasons,
+		sources.FanOut.FailureReasons,
+		sources.Runtime.FailureReasons,
+		sources.Cases.FailureReasons,
+		sources.Verification.FailureReasons,
+		sources.Enforcement.FailureReasons,
+		sources.Governance.FailureReasons,
+	} {
+		out = append(out, failures...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsPlatformObservabilityRemediationHints(sources awsPlatformObservabilitySources) []string {
+	out := []string{
+		"Start with blocked or degraded alert rows, then drill into traces for the affected account, region, service, and evidence ref.",
+	}
+	for _, hints := range [][]string{
+		sources.Coverage.RemediationHints,
+		sources.FanOut.RemediationHints,
+		sources.Runtime.RemediationHints,
+		sources.Cases.RemediationHints,
+		sources.Verification.RemediationHints,
+		sources.Enforcement.RemediationHints,
+		sources.Governance.RemediationHints,
+	} {
+		out = append(out, hints...)
+	}
+	return dedupeStrings(out)
+}
+
+func awsPlatformObservabilityCoverageGaps(sources awsPlatformObservabilitySources) []AWSPlatformObservabilityCoverageGap {
+	out := []AWSPlatformObservabilityCoverageGap{}
+	seen := map[string]bool{}
+	add := func(capability, status, reason, remediation string) {
+		if capability == "" && status == "" && reason == "" {
+			return
+		}
+		key := strings.Join([]string{capability, status, reason, remediation}, "\x00")
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, AWSPlatformObservabilityCoverageGap{Capability: capability, Status: status, Reason: reason, Remediation: remediation})
+	}
+	for _, gap := range sources.Coverage.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.FanOut.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.Runtime.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.Cases.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.Verification.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.Enforcement.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	for _, gap := range sources.Governance.CoverageGaps {
+		add(gap.Capability, gap.Status, gap.Reason, gap.Remediation)
+	}
+	return out
+}
+
+func awsPlatformObservabilityDiagnostics(sources awsPlatformObservabilitySources) []AWSPlatformObservabilityDiagnostic {
+	out := []AWSPlatformObservabilityDiagnostic{}
+	seen := map[string]bool{}
+	add := func(collector, sourceID, code, message, remediation string, retryable bool) {
+		if collector == "" && code == "" && message == "" {
+			return
+		}
+		key := strings.Join([]string{collector, sourceID, code, message, remediation}, "\x00")
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, AWSPlatformObservabilityDiagnostic{Collector: collector, SourceID: sourceID, Code: code, Message: message, Remediation: remediation, Retryable: retryable})
+	}
+	for _, diagnostic := range sources.Coverage.Diagnostics {
+		add(firstNonEmptyAWSValue(diagnostic.Collector, diagnostic.Source), diagnostic.Scope, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.FanOut.Diagnostics {
+		add(firstNonEmptyAWSValue(diagnostic.Collector, diagnostic.Source), diagnostic.Scope, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.Runtime.Diagnostics {
+		add(diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.Cases.Diagnostics {
+		add(diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.Verification.Diagnostics {
+		add(diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.Enforcement.Diagnostics {
+		add(diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	for _, diagnostic := range sources.Governance.Diagnostics {
+		add(diagnostic.Collector, diagnostic.SourceID, diagnostic.Code, diagnostic.Message, diagnostic.Remediation, diagnostic.Retryable)
+	}
+	return out
+}

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -190,9 +190,9 @@ func (s *Service) GetAWSPlatformObservability(ctx context.Context, workspaceID s
 	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
 	sourceAccountID := awsExecutiveOutcomeSourceScopeFilter(request.AccountID)
 	sourceRegion := awsExecutiveOutcomeSourceScopeFilter(request.Region)
-	sourceService := awsExecutiveOutcomeSourceScopeFilter(request.Service)
-	accountID := awsExecutiveOutcomeScopeValue(request.AccountID, connection.AccountID, "123456789012")
-	region := awsExecutiveOutcomeScopeValue(request.Region, connection.Region, "us-east-1")
+	sourceService := awsPlatformObservabilitySourceServiceFilter(request.Service)
+	accountID := awsPlatformObservabilityRequestedScopeValue(request.AccountID)
+	region := awsPlatformObservabilityRequestedScopeValue(request.Region)
 
 	coverage, err := s.GetAWSAccountRegionCoverage(ctx, workspaceID, projectID, AWSAccountRegionCoverageRequest{
 		ConnectorID:  connectorID,
@@ -1008,8 +1008,28 @@ func awsPlatformObservabilityFanOutSummaryStatus(summary AWSFanOutExecutionSumma
 func awsPlatformObservabilityHasSourceScopeFilter(request AWSPlatformObservabilityRequest) bool {
 	service := awsPlatformObservabilityServiceToken(request.Service)
 	return (service != "" && service != "all") ||
-		strings.TrimSpace(request.AccountID) != "" ||
-		strings.TrimSpace(request.Region) != ""
+		awsPlatformObservabilityRequestedScopeValue(request.AccountID) != "" ||
+		awsPlatformObservabilityRequestedScopeValue(request.Region) != ""
+}
+
+func awsPlatformObservabilityRequestedScopeValue(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "all") {
+		return ""
+	}
+	return value
+}
+
+func awsPlatformObservabilitySourceServiceFilter(value string) string {
+	value = awsExecutiveOutcomeSourceScopeFilter(value)
+	if value == "" {
+		return ""
+	}
+	service := awsPlatformObservabilityServiceToken(value)
+	if service == "all" {
+		return ""
+	}
+	return service
 }
 
 func awsPlatformObservabilityServiceToken(value string) string {

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -342,8 +342,9 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 		service = "all"
 	}
 	aggregateService := "all"
+	fanOutSummary := awsPlatformObservabilityFanOutSummary(sources.FanOut)
 	collectorFailures := sources.Coverage.Summary.DegradedRecords + sources.Coverage.Summary.UnreachableRecords + sources.Coverage.Summary.StaleRecords + sources.Coverage.Summary.PermissionDeniedRecords + len(sources.Coverage.Diagnostics)
-	queueLag := awsPlatformObservabilityQueueLag(sources.FanOut.Summary)
+	queueLag := awsPlatformObservabilityQueueLag(fanOutSummary)
 	runtimeLag := awsPlatformObservabilityRuntimeLag(sources.Runtime.Records)
 	remediationPending := sources.Cases.Summary.ApprovalRequiredCount + sources.Verification.Summary.PendingCount
 	verificationFailures := sources.Verification.Summary.FailedCount + sources.Verification.Summary.RollbackPlannedCount + sources.Verification.Summary.BlockedCount
@@ -355,7 +356,7 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Signal:           "scan_throughput",
 			Title:            "Scan throughput",
 			Summary:          "Account, region, and service targets completed by the bounded fan-out and coverage collectors.",
-			Value:            maxInt(sources.FanOut.Summary.CoveredTargets, sources.Coverage.Summary.CoveredRecords),
+			Value:            maxInt(fanOutSummary.CoveredTargets, sources.Coverage.Summary.CoveredRecords),
 			Unit:             "targets_per_hour",
 			Status:           awsPlatformObservabilitySourceStatus(sources.Coverage.Status, sources.FanOut.Status),
 			Severity:         awsPlatformObservabilityMetricSeverity(sources.Coverage.Status, sources.FanOut.Status),
@@ -399,10 +400,10 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Signal:           "throttling",
 			Title:            "Throttling",
 			Summary:          "Fan-out targets currently throttled or waiting for bounded retry.",
-			Value:            sources.FanOut.Summary.ThrottledTargets,
+			Value:            fanOutSummary.ThrottledTargets,
 			Unit:             "targets",
-			Status:           awsPlatformObservabilityCountStatus(sources.FanOut.Summary.ThrottledTargets, sources.FanOut.Status),
-			Severity:         awsPlatformObservabilityCountSeverity(sources.FanOut.Summary.ThrottledTargets, sources.FanOut.Status),
+			Status:           awsPlatformObservabilityCountStatus(fanOutSummary.ThrottledTargets, sources.FanOut.Status),
+			Severity:         awsPlatformObservabilityCountSeverity(fanOutSummary.ThrottledTargets, sources.FanOut.Status),
 			Confidence:       sources.FanOut.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -865,6 +866,47 @@ func awsPlatformObservabilityQueueLag(summary AWSFanOutExecutionSummary) int {
 	return (summary.QueuedTargets * int((2 * time.Minute).Milliseconds())) + (summary.InProgressTargets * int((30 * time.Second).Milliseconds())) + (summary.RetryableTargets * int((5 * time.Minute).Milliseconds()))
 }
 
+func awsPlatformObservabilityFanOutSummary(result AWSFanOutExecutionResult) AWSFanOutExecutionSummary {
+	summary := AWSFanOutExecutionSummary{
+		ConcurrencyLimit: result.Summary.ConcurrencyLimit,
+		MaxAttempts:      result.Summary.MaxAttempts,
+	}
+	for _, target := range result.Targets {
+		state := strings.ToLower(strings.TrimSpace(target.State))
+		workerState := strings.ToLower(strings.TrimSpace(target.WorkerState))
+		combined := strings.TrimSpace(state + " " + workerState + " " + strings.ToLower(strings.TrimSpace(target.FailureReason)))
+		summary.TotalTargets++
+		if target.Enabled {
+			summary.ExecutableTargets++
+		} else {
+			summary.SkippedTargets++
+		}
+		switch {
+		case strings.Contains(combined, "permission_denied"):
+			summary.PermissionDeniedTargets++
+		case strings.Contains(combined, "partial"):
+			summary.PartialTargets++
+		case strings.Contains(combined, "failed"):
+			summary.FailedTargets++
+		case state == "covered" || workerState == "covered" || workerState == "complete" || workerState == "completed":
+			summary.CoveredTargets++
+		}
+		if state == "queued" || workerState == "queued" {
+			summary.QueuedTargets++
+		}
+		if state == "in_progress" || workerState == "in_progress" || workerState == "running" {
+			summary.InProgressTargets++
+		}
+		if target.Throttled || strings.Contains(combined, "throttled") {
+			summary.ThrottledTargets++
+		}
+		if target.Retryable {
+			summary.RetryableTargets++
+		}
+	}
+	return summary
+}
+
 func awsPlatformObservabilityTargetQueueLag(target AWSFanOutExecutionTarget) int {
 	state := strings.ToLower(strings.TrimSpace(firstNonEmptyAWSValue(target.WorkerState, target.State)))
 	switch {
@@ -924,7 +966,7 @@ func awsPlatformObservabilityRuntimeStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "permission_denied", "blocked":
 		return awsPlatformDependencyStatusBlocked
-	case "partial", "partial_failure", "degraded", "stale":
+	case "partial", "partial_failure", "degraded", "stale", "delayed":
 		return awsPlatformDependencyStatusDegraded
 	default:
 		return awsPlatformDependencyStatusReady

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -272,9 +272,10 @@ func (s *Service) GetAWSPlatformObservability(ctx context.Context, workspaceID s
 	metrics := awsPlatformObservabilityMetrics(sources, request, accountID, region, sourceService, now)
 	traces := awsPlatformObservabilityTraces(sources, now)
 	filteredMetrics, filteredTraces, applied := filterAWSPlatformObservability(metrics, traces, request)
-	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, now)
+	includeTraceSignals := awsPlatformObservabilityHasResultFilter(request)
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, includeTraceSignals, now)
 	summary := summarizeAWSPlatformObservability(metrics, filteredMetrics, traces, filteredTraces, alerts)
-	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces, includeTraceSignals)
 	return AWSPlatformObservabilityResult{
 		TenantID:           scope.TenantID,
 		WorkspaceID:        project.WorkspaceID,
@@ -687,6 +688,15 @@ func filterAWSPlatformObservability(metrics []AWSPlatformObservabilityMetric, tr
 	return filteredMetrics, filteredTraces, applied
 }
 
+func awsPlatformObservabilityHasResultFilter(request AWSPlatformObservabilityRequest) bool {
+	return awsPlatformObservabilityRequestedScopeValue(request.AccountID) != "" ||
+		awsPlatformObservabilityRequestedScopeValue(request.Region) != "" ||
+		awsPlatformObservabilitySourceServiceFilter(request.Service) != "" ||
+		strings.TrimSpace(request.Component) != "" ||
+		strings.TrimSpace(request.Status) != "" ||
+		strings.TrimSpace(request.Search) != ""
+}
+
 func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetric, filteredMetrics []AWSPlatformObservabilityMetric, allTraces []AWSPlatformObservabilityTrace, filteredTraces []AWSPlatformObservabilityTrace, alerts []AWSPlatformObservabilityAlert) AWSPlatformObservabilitySummary {
 	summary := AWSPlatformObservabilitySummary{
 		TotalMetrics:    len(allMetrics),
@@ -754,9 +764,11 @@ func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetr
 	return summary
 }
 
-func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace) (string, float64) {
+func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace, includeTraceSignals bool) (string, float64) {
 	statuses := awsPlatformObservabilityMetricStatuses(metrics)
-	if len(statuses) == 0 {
+	if includeTraceSignals {
+		statuses = append(statuses, awsPlatformObservabilityTraceStatuses(traces)...)
+	} else if len(statuses) == 0 {
 		statuses = awsPlatformObservabilityTraceStatuses(traces)
 	}
 	status := awsPlatformObservabilitySourceStatus(statuses...)
@@ -865,7 +877,7 @@ func awsPlatformObservabilityLagSeverity(lagMs int, statuses ...string) string {
 	return "low"
 }
 
-func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace, now time.Time) []AWSPlatformObservabilityAlert {
+func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace, includeTraceSignals bool, now time.Time) []AWSPlatformObservabilityAlert {
 	alerts := []AWSPlatformObservabilityAlert{}
 	for _, metric := range metrics {
 		if metric.Status == awsPlatformDependencyStatusReady {
@@ -884,7 +896,7 @@ func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, tr
 			TriggeredAt:      now,
 		})
 	}
-	if len(metrics) > 0 {
+	if !includeTraceSignals && len(metrics) > 0 {
 		return alerts
 	}
 	for _, trace := range traces {

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -342,8 +342,15 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 		service = "all"
 	}
 	aggregateService := "all"
+	sourceScoped := awsPlatformObservabilityHasSourceScopeFilter(request)
+	coverageSummary := awsPlatformObservabilityCoverageSummary(sources.Coverage)
 	fanOutSummary := awsPlatformObservabilityFanOutSummary(sources.FanOut)
-	collectorFailures := sources.Coverage.Summary.DegradedRecords + sources.Coverage.Summary.UnreachableRecords + sources.Coverage.Summary.StaleRecords + sources.Coverage.Summary.PermissionDeniedRecords + len(sources.Coverage.Diagnostics)
+	coverageStatus := awsPlatformObservabilityCoverageStatus(coverageSummary, sources.Coverage.Status, sourceScoped)
+	fanOutStatus := awsPlatformObservabilityFanOutSummaryStatus(fanOutSummary, sources.FanOut.Status, sourceScoped)
+	collectorFailures := coverageSummary.DegradedRecords + coverageSummary.UnreachableRecords + coverageSummary.StaleRecords + coverageSummary.PermissionDeniedRecords
+	if !sourceScoped {
+		collectorFailures += len(sources.Coverage.Diagnostics)
+	}
 	queueLag := awsPlatformObservabilityQueueLag(fanOutSummary)
 	runtimeLag := awsPlatformObservabilityRuntimeLag(sources.Runtime.Records)
 	remediationPending := sources.Cases.Summary.ApprovalRequiredCount + sources.Verification.Summary.PendingCount
@@ -356,10 +363,10 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Signal:           "scan_throughput",
 			Title:            "Scan throughput",
 			Summary:          "Account, region, and service targets completed by the bounded fan-out and coverage collectors.",
-			Value:            maxInt(fanOutSummary.CoveredTargets, sources.Coverage.Summary.CoveredRecords),
+			Value:            maxInt(fanOutSummary.CoveredTargets, coverageSummary.CoveredRecords),
 			Unit:             "targets_per_hour",
-			Status:           awsPlatformObservabilitySourceStatus(sources.Coverage.Status, sources.FanOut.Status),
-			Severity:         awsPlatformObservabilityMetricSeverity(sources.Coverage.Status, sources.FanOut.Status),
+			Status:           awsPlatformObservabilitySourceStatus(coverageStatus, fanOutStatus),
+			Severity:         awsPlatformObservabilityMetricSeverity(coverageStatus, fanOutStatus),
 			Confidence:       averageFloat64(sources.Coverage.Confidence, sources.FanOut.Confidence),
 			AccountID:        accountID,
 			Region:           region,
@@ -380,8 +387,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Summary:          "Estimated backlog lag from queued and in-progress fan-out targets.",
 			Value:            queueLag,
 			Unit:             "milliseconds",
-			Status:           awsPlatformObservabilityLagStatus(queueLag, sources.FanOut.Status),
-			Severity:         awsPlatformObservabilityLagSeverity(queueLag, sources.FanOut.Status),
+			Status:           awsPlatformObservabilityLagStatus(queueLag, fanOutStatus),
+			Severity:         awsPlatformObservabilityLagSeverity(queueLag, fanOutStatus),
 			Confidence:       sources.FanOut.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -402,8 +409,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Summary:          "Fan-out targets currently throttled or waiting for bounded retry.",
 			Value:            fanOutSummary.ThrottledTargets,
 			Unit:             "targets",
-			Status:           awsPlatformObservabilityCountStatus(fanOutSummary.ThrottledTargets, sources.FanOut.Status),
-			Severity:         awsPlatformObservabilityCountSeverity(fanOutSummary.ThrottledTargets, sources.FanOut.Status),
+			Status:           awsPlatformObservabilityCountStatus(fanOutSummary.ThrottledTargets, fanOutStatus),
+			Severity:         awsPlatformObservabilityCountSeverity(fanOutSummary.ThrottledTargets, fanOutStatus),
 			Confidence:       sources.FanOut.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -424,8 +431,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Summary:          "Explicit degraded, unreachable, stale, permission-denied, or diagnostic collector states.",
 			Value:            collectorFailures,
 			Unit:             "signals",
-			Status:           awsPlatformObservabilityCountStatus(collectorFailures, sources.Coverage.Status),
-			Severity:         awsPlatformObservabilityCountSeverity(collectorFailures, sources.Coverage.Status),
+			Status:           awsPlatformObservabilityCountStatus(collectorFailures, coverageStatus),
+			Severity:         awsPlatformObservabilityCountSeverity(collectorFailures, coverageStatus),
 			Confidence:       sources.Coverage.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -583,7 +590,7 @@ func awsPlatformObservabilityTraces(sources awsPlatformObservabilitySources, now
 			Component:        "runtime",
 			AccountID:        record.AccountID,
 			Region:           record.Region,
-			Service:          record.EventSource,
+			Service:          awsPlatformObservabilityServiceToken(record.EventSource),
 			Status:           awsPlatformObservabilityRuntimeStatus(record.Status),
 			RuntimeLagMs:     awsPlatformObservabilityDurationMs(record.ObservedAt, record.CollectedAt),
 			EvidenceRef:      record.EvidenceRef,
@@ -629,6 +636,13 @@ func filterAWSPlatformObservability(metrics []AWSPlatformObservabilityMetric, tr
 		}
 		return strings.ToLower(strings.TrimSpace(value)) == want
 	}
+	matchServiceToken := func(value, want string) bool {
+		want = awsPlatformObservabilityServiceToken(want)
+		if want == "" || want == "all" {
+			return true
+		}
+		return awsPlatformObservabilityServiceToken(value) == want
+	}
 	matchSearch := func(values ...string) bool {
 		search := strings.ToLower(strings.TrimSpace(request.Search))
 		if search == "" {
@@ -638,7 +652,7 @@ func filterAWSPlatformObservability(metrics []AWSPlatformObservabilityMetric, tr
 	}
 	filteredMetrics := make([]AWSPlatformObservabilityMetric, 0, len(metrics))
 	for _, metric := range metrics {
-		if !matchToken(metric.AccountID, request.AccountID) || !matchToken(metric.Region, request.Region) || !matchToken(metric.Service, request.Service) {
+		if !matchToken(metric.AccountID, request.AccountID) || !matchToken(metric.Region, request.Region) || !matchServiceToken(metric.Service, request.Service) {
 			continue
 		}
 		if !matchToken(metric.Component, request.Component) || !matchToken(metric.Status, request.Status) {
@@ -651,7 +665,7 @@ func filterAWSPlatformObservability(metrics []AWSPlatformObservabilityMetric, tr
 	}
 	filteredTraces := make([]AWSPlatformObservabilityTrace, 0, len(traces))
 	for _, trace := range traces {
-		if !matchToken(trace.AccountID, request.AccountID) || !matchToken(trace.Region, request.Region) || !matchToken(trace.Service, request.Service) {
+		if !matchToken(trace.AccountID, request.AccountID) || !matchToken(trace.Region, request.Region) || !matchServiceToken(trace.Service, request.Service) {
 			continue
 		}
 		if !matchToken(trace.Component, request.Component) || !matchToken(trace.Status, request.Status) {
@@ -866,6 +880,72 @@ func awsPlatformObservabilityQueueLag(summary AWSFanOutExecutionSummary) int {
 	return (summary.QueuedTargets * int((2 * time.Minute).Milliseconds())) + (summary.InProgressTargets * int((30 * time.Second).Milliseconds())) + (summary.RetryableTargets * int((5 * time.Minute).Milliseconds()))
 }
 
+func awsPlatformObservabilityCoverageSummary(result AWSAccountRegionCoverageResult) AWSAccountRegionCoverageSummary {
+	summary := AWSAccountRegionCoverageSummary{
+		TotalRecords:    len(result.Records),
+		FilteredRecords: len(result.Records),
+		StatusCounts:    map[string]int{},
+		StateCounts:     map[string]int{},
+		CollectorCounts: map[string]int{},
+	}
+	accounts := map[string]struct{}{}
+	regions := map[string]struct{}{}
+	services := map[string]struct{}{}
+	for _, record := range result.Records {
+		accounts[strings.TrimSpace(record.AccountID)] = struct{}{}
+		regions[strings.ToLower(strings.TrimSpace(record.Region))] = struct{}{}
+		services[awsPlatformObservabilityServiceToken(record.Service)] = struct{}{}
+		summary.StatusCounts[record.CoverageStatus]++
+		summary.StateCounts[record.State]++
+		if strings.TrimSpace(record.Collector) != "" {
+			summary.CollectorCounts[record.Collector]++
+		}
+		if record.Retryable {
+			summary.RetryableRecords++
+		}
+		switch strings.ToLower(strings.TrimSpace(record.CoverageStatus)) {
+		case "covered":
+			summary.CoveredRecords++
+		case "missing":
+			summary.MissingRecords++
+		case "degraded":
+			summary.DegradedRecords++
+		case "unreachable":
+			summary.UnreachableRecords++
+		case "suspended":
+			summary.SuspendedRecords++
+		case "disabled":
+			summary.DisabledRecords++
+		case "stale":
+			summary.StaleRecords++
+		case "permission_denied":
+			summary.PermissionDeniedRecords++
+		}
+	}
+	summary.AccountCount = len(accounts)
+	summary.RegionCount = len(regions)
+	summary.ServiceCount = len(services)
+	return summary
+}
+
+func awsPlatformObservabilityCoverageStatus(summary AWSAccountRegionCoverageSummary, fallback string, sourceScoped bool) string {
+	if summary.TotalRecords == 0 {
+		status := awsPlatformObservabilitySourceStatus(fallback)
+		if sourceScoped && status != awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusReady
+		}
+		return status
+	}
+	switch {
+	case summary.PermissionDeniedRecords > 0:
+		return awsPlatformDependencyStatusBlocked
+	case summary.StaleRecords > 0 || summary.DegradedRecords > 0 || summary.UnreachableRecords > 0 || summary.SuspendedRecords > 0:
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
 func awsPlatformObservabilityFanOutSummary(result AWSFanOutExecutionResult) AWSFanOutExecutionSummary {
 	summary := AWSFanOutExecutionSummary{
 		ConcurrencyLimit: result.Summary.ConcurrencyLimit,
@@ -905,6 +985,57 @@ func awsPlatformObservabilityFanOutSummary(result AWSFanOutExecutionResult) AWSF
 		}
 	}
 	return summary
+}
+
+func awsPlatformObservabilityFanOutSummaryStatus(summary AWSFanOutExecutionSummary, fallback string, sourceScoped bool) string {
+	if summary.TotalTargets == 0 {
+		status := awsPlatformObservabilitySourceStatus(fallback)
+		if sourceScoped && status != awsPlatformDependencyStatusBlocked {
+			return awsPlatformDependencyStatusReady
+		}
+		return status
+	}
+	switch {
+	case summary.PermissionDeniedTargets > 0:
+		return awsPlatformDependencyStatusBlocked
+	case summary.FailedTargets > 0 || summary.PartialTargets > 0 || summary.ThrottledTargets > 0:
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
+func awsPlatformObservabilityHasSourceScopeFilter(request AWSPlatformObservabilityRequest) bool {
+	service := awsPlatformObservabilityServiceToken(request.Service)
+	return (service != "" && service != "all") ||
+		strings.TrimSpace(request.AccountID) != "" ||
+		strings.TrimSpace(request.Region) != ""
+}
+
+func awsPlatformObservabilityServiceToken(value string) string {
+	token := strings.ToLower(strings.TrimSpace(value))
+	token = strings.TrimPrefix(token, "aws-service://")
+	token = strings.TrimSuffix(token, ".")
+	for _, suffix := range []string{".amazonaws.com.cn", ".amazonaws.com"} {
+		if strings.HasSuffix(token, suffix) {
+			token = strings.TrimSuffix(token, suffix)
+			break
+		}
+	}
+	if dot := strings.Index(token, "."); dot > 0 {
+		token = token[:dot]
+	}
+	token = normalizeAWSRuntimeEventFilterToken(token)
+	switch token {
+	case "secrets-manager":
+		return "secretsmanager"
+	case "states":
+		return "stepfunctions"
+	case "events":
+		return "eventbridge"
+	default:
+		return token
+	}
 }
 
 func awsPlatformObservabilityTargetQueueLag(target AWSFanOutExecutionTarget) int {

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -272,9 +272,9 @@ func (s *Service) GetAWSPlatformObservability(ctx context.Context, workspaceID s
 	metrics := awsPlatformObservabilityMetrics(sources, request, accountID, region, sourceService, now)
 	traces := awsPlatformObservabilityTraces(sources, now)
 	filteredMetrics, filteredTraces, applied := filterAWSPlatformObservability(metrics, traces, request)
-	alerts := awsPlatformObservabilityAlerts(filteredMetrics, now)
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, now)
 	summary := summarizeAWSPlatformObservability(metrics, filteredMetrics, traces, filteredTraces, alerts)
-	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces)
 	return AWSPlatformObservabilityResult{
 		TenantID:           scope.TenantID,
 		WorkspaceID:        project.WorkspaceID,
@@ -754,8 +754,11 @@ func summarizeAWSPlatformObservability(allMetrics []AWSPlatformObservabilityMetr
 	return summary
 }
 
-func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric) (string, float64) {
+func summarizeAWSPlatformObservabilityStatus(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace) (string, float64) {
 	statuses := awsPlatformObservabilityMetricStatuses(metrics)
+	if len(statuses) == 0 {
+		statuses = awsPlatformObservabilityTraceStatuses(traces)
+	}
 	status := awsPlatformObservabilitySourceStatus(statuses...)
 	switch status {
 	case awsPlatformDependencyStatusBlocked:
@@ -774,6 +777,14 @@ func awsPlatformObservabilityMetricStatuses(metrics []AWSPlatformObservabilityMe
 	statuses := make([]string, 0, len(metrics))
 	for _, metric := range metrics {
 		statuses = append(statuses, metric.Status)
+	}
+	return statuses
+}
+
+func awsPlatformObservabilityTraceStatuses(traces []AWSPlatformObservabilityTrace) []string {
+	statuses := make([]string, 0, len(traces))
+	for _, trace := range traces {
+		statuses = append(statuses, trace.Status)
 	}
 	return statuses
 }
@@ -854,7 +865,7 @@ func awsPlatformObservabilityLagSeverity(lagMs int, statuses ...string) string {
 	return "low"
 }
 
-func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, now time.Time) []AWSPlatformObservabilityAlert {
+func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, traces []AWSPlatformObservabilityTrace, now time.Time) []AWSPlatformObservabilityAlert {
 	alerts := []AWSPlatformObservabilityAlert{}
 	for _, metric := range metrics {
 		if metric.Status == awsPlatformDependencyStatusReady {
@@ -870,6 +881,26 @@ func awsPlatformObservabilityAlerts(metrics []AWSPlatformObservabilityMetric, no
 			EvidenceRef:      metric.EvidenceRef,
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
 			NextAction:       metric.NextAction,
+			TriggeredAt:      now,
+		})
+	}
+	if len(metrics) > 0 {
+		return alerts
+	}
+	for _, trace := range traces {
+		if trace.Status == awsPlatformDependencyStatusReady {
+			continue
+		}
+		alerts = append(alerts, AWSPlatformObservabilityAlert{
+			AlertID:          awsPlatformObservabilityTraceID("alert", trace.Component, trace.AccountID, trace.Region, trace.Service, trace.TraceID),
+			Severity:         awsPlatformObservabilityMetricSeverity(trace.Status),
+			Component:        trace.Component,
+			Status:           trace.Status,
+			Title:            trace.SpanName,
+			Summary:          trace.NextAction,
+			EvidenceRef:      trace.EvidenceRef,
+			EvidenceBoundary: awsPlatformObservabilityBoundary,
+			NextAction:       trace.NextAction,
 			TriggeredAt:      now,
 		})
 	}

--- a/internal/api/aws_platform_observability.go
+++ b/internal/api/aws_platform_observability.go
@@ -341,6 +341,7 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 	if service == "" {
 		service = "all"
 	}
+	aggregateService := "all"
 	collectorFailures := sources.Coverage.Summary.DegradedRecords + sources.Coverage.Summary.UnreachableRecords + sources.Coverage.Summary.StaleRecords + sources.Coverage.Summary.PermissionDeniedRecords + len(sources.Coverage.Diagnostics)
 	queueLag := awsPlatformObservabilityQueueLag(sources.FanOut.Summary)
 	runtimeLag := awsPlatformObservabilityRuntimeLag(sources.Runtime.Records)
@@ -378,8 +379,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Summary:          "Estimated backlog lag from queued and in-progress fan-out targets.",
 			Value:            queueLag,
 			Unit:             "milliseconds",
-			Status:           awsPlatformObservabilitySourceStatus(sources.FanOut.Status),
-			Severity:         awsPlatformObservabilityMetricSeverity(sources.FanOut.Status),
+			Status:           awsPlatformObservabilityLagStatus(queueLag, sources.FanOut.Status),
+			Severity:         awsPlatformObservabilityLagSeverity(queueLag, sources.FanOut.Status),
 			Confidence:       sources.FanOut.Confidence,
 			AccountID:        accountID,
 			Region:           region,
@@ -444,13 +445,13 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Summary:          "P95 delay between runtime observation and collection for CloudTrail, last-used, and Access Analyzer signals.",
 			Value:            runtimeLag,
 			Unit:             "milliseconds",
-			Status:           awsPlatformObservabilitySourceStatus(sources.Runtime.Status),
-			Severity:         awsPlatformObservabilityMetricSeverity(sources.Runtime.Status),
+			Status:           awsPlatformObservabilityLagStatus(runtimeLag, sources.Runtime.Status),
+			Severity:         awsPlatformObservabilityLagSeverity(runtimeLag, sources.Runtime.Status),
 			Confidence:       sources.Runtime.Confidence,
 			AccountID:        accountID,
 			Region:           region,
-			Service:          service,
-			TraceID:          awsPlatformObservabilityTraceID("metric", "runtime", accountID, region, service, "runtime-lag"),
+			Service:          aggregateService,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "runtime", accountID, region, aggregateService, "runtime-lag"),
 			EvidenceRef:      "aws-platform-observability://runtime-lag",
 			EvidenceLinks:    sources.Runtime.EvidenceLinks,
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
@@ -471,8 +472,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Confidence:       averageFloat64(sources.Cases.Confidence, sources.Verification.Confidence),
 			AccountID:        accountID,
 			Region:           region,
-			Service:          service,
-			TraceID:          awsPlatformObservabilityTraceID("metric", "remediation", accountID, region, service, "remediation-state"),
+			Service:          aggregateService,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "remediation", accountID, region, aggregateService, "remediation-state"),
 			EvidenceRef:      "aws-platform-observability://remediation-state",
 			EvidenceLinks:    dedupeStrings(append(append([]string{}, sources.Cases.EvidenceLinks...), sources.Verification.EvidenceLinks...)),
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
@@ -493,8 +494,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Confidence:       sources.Verification.Confidence,
 			AccountID:        accountID,
 			Region:           region,
-			Service:          service,
-			TraceID:          awsPlatformObservabilityTraceID("metric", "verification", accountID, region, service, "verification-outcomes"),
+			Service:          aggregateService,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "verification", accountID, region, aggregateService, "verification-outcomes"),
 			EvidenceRef:      "aws-platform-observability://verification-outcomes",
 			EvidenceLinks:    sources.Verification.EvidenceLinks,
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
@@ -515,8 +516,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Confidence:       sources.Enforcement.Confidence,
 			AccountID:        accountID,
 			Region:           region,
-			Service:          service,
-			TraceID:          awsPlatformObservabilityTraceID("metric", "enforcement", accountID, region, service, "enforcement-health"),
+			Service:          aggregateService,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "enforcement", accountID, region, aggregateService, "enforcement-health"),
 			EvidenceRef:      "aws-platform-observability://enforcement-health",
 			EvidenceLinks:    sources.Enforcement.EvidenceLinks,
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
@@ -537,8 +538,8 @@ func awsPlatformObservabilityMetrics(sources awsPlatformObservabilitySources, re
 			Confidence:       sources.Governance.Confidence,
 			AccountID:        accountID,
 			Region:           region,
-			Service:          service,
-			TraceID:          awsPlatformObservabilityTraceID("metric", "governance", accountID, region, service, "governance-outcomes"),
+			Service:          aggregateService,
+			TraceID:          awsPlatformObservabilityTraceID("metric", "governance", accountID, region, aggregateService, "governance-outcomes"),
 			EvidenceRef:      "aws-platform-observability://governance-outcomes",
 			EvidenceLinks:    sources.Governance.EvidenceLinks,
 			EvidenceBoundary: awsPlatformObservabilityBoundary,
@@ -903,7 +904,7 @@ func awsPlatformObservabilityP95(values []int) int {
 		return 0
 	}
 	sort.Ints(values)
-	index := int(float64(len(values)-1) * 0.95)
+	index := ((95*len(values))+99)/100 - 1
 	return values[index]
 }
 

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newPlatformObservabilityService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSPlatformObservabilityBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get platform observability: %v", err)
+	}
+	if result.CurrentIssueRef != "#1556" || result.Version != awsPlatformObservabilityVersion {
+		t.Fatalf("unexpected issue/version: %+v", result)
+	}
+	if result.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected degraded platform observability from failed verification outcomes, got %+v", result)
+	}
+	if result.Summary.TotalMetrics != 9 || result.Summary.FilteredMetrics != len(result.Metrics) {
+		t.Fatalf("unexpected metric summary: %+v metrics=%d", result.Summary, len(result.Metrics))
+	}
+	if result.Summary.TotalTraces == 0 || len(result.Traces) == 0 {
+		t.Fatalf("expected trace rows for collector/runtime/verification sources, got %+v", result.Summary)
+	}
+	required := map[string]bool{
+		"scan-throughput":       false,
+		"queue-lag":             false,
+		"runtime-lag":           false,
+		"remediation-state":     false,
+		"verification-outcomes": false,
+	}
+	for _, metric := range result.Metrics {
+		if metric.EvidenceBoundary != awsPlatformObservabilityBoundary {
+			t.Fatalf("unexpected metric boundary: %+v", metric)
+		}
+		if _, ok := required[metric.MetricID]; ok {
+			required[metric.MetricID] = true
+		}
+	}
+	for id, seen := range required {
+		if !seen {
+			t.Fatalf("missing platform metric %q in %+v", id, result.Metrics)
+		}
+	}
+	if len(result.Alerts) == 0 || result.Summary.CriticalAlertCount != 0 {
+		t.Fatalf("expected non-critical platform alerts for failed verification outcomes, got %+v", result.Alerts)
+	}
+}
+
+func TestAWSPlatformObservabilityFiltersComponentStatusAndSearch(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 5, 0, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-filter", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-filter", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "partial_failure",
+		Component:    "collector",
+		Status:       "degraded",
+		Search:       "throttling",
+	})
+	if err != nil {
+		t.Fatalf("get filtered platform observability: %v", err)
+	}
+	if result.AppliedFilters["component"] != "collector" || result.AppliedFilters["status"] != "degraded" || result.AppliedFilters["search"] != "throttling" {
+		t.Fatalf("expected filters to be applied, got %+v", result.AppliedFilters)
+	}
+	if len(result.Metrics) == 0 {
+		t.Fatalf("expected degraded collector metrics, got %+v", result)
+	}
+	for _, metric := range result.Metrics {
+		if metric.Component != "collector" || metric.Status != awsPlatformDependencyStatusDegraded {
+			t.Fatalf("metric did not honor collector/degraded filters: %+v", metric)
+		}
+	}
+	if _, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-filter", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Status:       "bogus",
+	}); err != ErrInvalidAWSConnectionRequest {
+		t.Fatalf("expected invalid status to be rejected, got %v", err)
+	}
+}
+
+func TestAWSPlatformObservabilityPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 10, 0, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-denied", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-denied", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("get permission denied platform observability: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusBlocked || result.Summary.BlockedSignals == 0 {
+		t.Fatalf("expected blocked platform observability, got %+v", result)
+	}
+	if len(result.Alerts) == 0 || result.Summary.CriticalAlertCount == 0 {
+		t.Fatalf("expected critical alerts for blocked platform observability, got %+v", result)
+	}
+	if len(result.CoverageGaps) == 0 && len(result.Diagnostics) == 0 {
+		t.Fatalf("expected explicit diagnostics or coverage gaps for permission denied, got %+v", result)
+	}
+}
+
+func TestRouterAWSPlatformObservability(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 15, 0, 0, time.UTC)
+	svc, _ := newPlatformObservabilityService(t, "project-platform-observability-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	query := url.Values{}
+	query.Set("connector_id", "aws-prod")
+	query.Set("fixture_state", "partial_failure")
+	query.Set("component", "collector")
+	query.Set("status", "degraded")
+	query.Set("service", "ecs")
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-platform-observability-route/aws/platform-observability?"+query.Encode(), "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Observability AWSPlatformObservabilityResult `json:"platform_observability"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Observability.CurrentIssueRef != "#1556" || body.Observability.AppliedFilters["component"] != "collector" {
+		t.Fatalf("unexpected route payload: %+v", body.Observability)
+	}
+	for _, metric := range body.Observability.Metrics {
+		if metric.Component != "collector" || metric.Status != awsPlatformDependencyStatusDegraded {
+			t.Fatalf("route did not apply filters: %+v", metric)
+		}
+	}
+}

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -74,8 +74,11 @@ func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.
 		FanOut: AWSFanOutExecutionResult{
 			Status:     awsPlatformDependencyStatusReady,
 			Confidence: 0.96,
-			Summary: AWSFanOutExecutionSummary{
-				QueuedTargets: 8,
+			Targets: []AWSFanOutExecutionTarget{
+				{Key: "ecs-queued-1", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", State: "queued", WorkerState: "queued", Enabled: true, Retryable: true},
+				{Key: "ecs-queued-2", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", State: "queued", WorkerState: "queued", Enabled: true, Retryable: true},
+				{Key: "ecs-queued-3", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", State: "queued", WorkerState: "queued", Enabled: true, Retryable: true},
+				{Key: "ecs-queued-4", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", State: "queued", WorkerState: "queued", Enabled: true, Retryable: true},
 			},
 		},
 		Runtime: AWSRuntimeEventResult{
@@ -139,6 +142,72 @@ func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.
 		if metric.Service != "ecs" {
 			t.Fatalf("service filter should not keep unscoped aggregate metrics: %+v", metric)
 		}
+	}
+}
+
+func TestAWSPlatformObservabilityFanOutMetricsUseFilteredTargets(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 3, 0, 0, time.UTC)
+	sources := awsPlatformObservabilitySources{
+		Coverage: AWSAccountRegionCoverageResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.98,
+		},
+		FanOut: AWSFanOutExecutionResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.96,
+			Summary: AWSFanOutExecutionSummary{
+				CoveredTargets:   12,
+				QueuedTargets:    9,
+				ThrottledTargets: 7,
+				RetryableTargets: 7,
+			},
+			Targets: []AWSFanOutExecutionTarget{
+				{Key: "ecs-covered", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", State: "covered", WorkerState: "covered", Enabled: true},
+			},
+		},
+	}
+
+	metrics := awsPlatformObservabilityMetrics(sources, AWSPlatformObservabilityRequest{Service: "ecs"}, "123456789012", "us-east-1", "ecs", now)
+	byID := map[string]AWSPlatformObservabilityMetric{}
+	for _, metric := range metrics {
+		byID[metric.MetricID] = metric
+	}
+	if got := byID["scan-throughput"].Value; got != 1 {
+		t.Fatalf("expected scan throughput to use filtered fan-out targets, got %d", got)
+	}
+	if got := byID["queue-lag"].Value; got != 0 {
+		t.Fatalf("expected queue lag to ignore unfiltered fan-out summary backlog, got %d", got)
+	}
+	if metric := byID["throttling"]; metric.Value != 0 || metric.Status != awsPlatformDependencyStatusReady {
+		t.Fatalf("expected throttling to use filtered fan-out targets, got %+v", metric)
+	}
+}
+
+func TestAWSPlatformObservabilityRuntimeTraceStatusIncludesDelayed(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 4, 0, 0, time.UTC)
+	traces := awsPlatformObservabilityTraces(awsPlatformObservabilitySources{
+		Runtime: AWSRuntimeEventResult{
+			Records: []AWSRuntimeEventRecord{
+				{
+					EventID:     "delayed-runtime",
+					AccountID:   "123456789012",
+					Region:      "us-east-1",
+					EventSource: "cloudtrail",
+					Status:      "delayed",
+					ObservedAt:  now.Add(-20 * time.Minute),
+					CollectedAt: now,
+					EvidenceRef: "aws-runtime://delayed-runtime",
+					NextAction:  "Wait for delayed runtime delivery to catch up.",
+					Confidence:  0.71,
+				},
+			},
+		},
+	}, now)
+	if len(traces) != 1 {
+		t.Fatalf("expected one runtime trace, got %+v", traces)
+	}
+	if traces[0].Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected delayed runtime trace to be degraded, got %+v", traces[0])
 	}
 }
 

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -64,6 +64,93 @@ func TestGetAWSPlatformObservabilityBuildsContract(t *testing.T) {
 	}
 }
 
+func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 2, 0, 0, time.UTC)
+	sources := awsPlatformObservabilitySources{
+		Coverage: AWSAccountRegionCoverageResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.98,
+		},
+		FanOut: AWSFanOutExecutionResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.96,
+			Summary: AWSFanOutExecutionSummary{
+				QueuedTargets: 8,
+			},
+		},
+		Runtime: AWSRuntimeEventResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.94,
+			Records: []AWSRuntimeEventRecord{
+				{
+					EventID:     "runtime-lagged",
+					AccountID:   "123456789012",
+					Region:      "us-east-1",
+					EventSource: "cloudtrail",
+					ObservedAt:  now.Add(-20 * time.Minute),
+					CollectedAt: now,
+				},
+			},
+		},
+		Cases: AWSRemediationCaseResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.93,
+		},
+		Verification: AWSPostRemediationVerificationResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.92,
+		},
+		Enforcement: AWSLimitedEnforcementResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.91,
+		},
+		Governance: AWSGovernanceAuditReportingResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.9,
+		},
+	}
+
+	metrics := awsPlatformObservabilityMetrics(sources, AWSPlatformObservabilityRequest{Service: "ecs"}, "123456789012", "us-east-1", "ecs", now)
+	byID := map[string]AWSPlatformObservabilityMetric{}
+	for _, metric := range metrics {
+		byID[metric.MetricID] = metric
+	}
+	for _, id := range []string{"queue-lag", "runtime-lag"} {
+		metric, ok := byID[id]
+		if !ok {
+			t.Fatalf("missing lag metric %q in %+v", id, metrics)
+		}
+		if metric.Status != awsPlatformDependencyStatusDegraded || metric.Severity != "high" {
+			t.Fatalf("expected lag metric %q to be degraded/high, got %+v", id, metric)
+		}
+	}
+	for _, id := range []string{"runtime-lag", "remediation-state", "verification-outcomes", "enforcement-health", "governance-outcomes"} {
+		metric, ok := byID[id]
+		if !ok {
+			t.Fatalf("missing aggregate metric %q in %+v", id, metrics)
+		}
+		if metric.Service != "all" {
+			t.Fatalf("expected aggregate metric %q to remain service=all, got %+v", id, metric)
+		}
+	}
+
+	filtered, _, _ := filterAWSPlatformObservability(metrics, nil, AWSPlatformObservabilityRequest{Service: "ecs"})
+	for _, metric := range filtered {
+		if metric.Service != "ecs" {
+			t.Fatalf("service filter should not keep unscoped aggregate metrics: %+v", metric)
+		}
+	}
+}
+
+func TestAWSPlatformObservabilityP95UsesNearestRank(t *testing.T) {
+	if got := awsPlatformObservabilityP95([]int{10, 100}); got != 100 {
+		t.Fatalf("expected two-sample p95 to select upper nearest rank, got %d", got)
+	}
+	if got := awsPlatformObservabilityP95([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); got != 10 {
+		t.Fatalf("expected ten-sample p95 to select upper nearest rank, got %d", got)
+	}
+}
+
 func TestAWSPlatformObservabilityFiltersComponentStatusAndSearch(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 5, 0, 0, time.UTC)
 	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-filter", now)

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -149,11 +149,18 @@ func TestAWSPlatformObservabilityFanOutMetricsUseFilteredTargets(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 3, 0, 0, time.UTC)
 	sources := awsPlatformObservabilitySources{
 		Coverage: AWSAccountRegionCoverageResult{
-			Status:     awsPlatformDependencyStatusReady,
+			Status:     awsPlatformDependencyStatusDegraded,
 			Confidence: 0.98,
+			Summary: AWSAccountRegionCoverageSummary{
+				CoveredRecords:  12,
+				DegradedRecords: 4,
+			},
+			Records: []AWSAccountRegionCoverageRecord{
+				{Key: "ecs-covered", AccountID: "123456789012", Region: "us-east-1", Service: "ecs", CoverageStatus: "covered", State: "covered"},
+			},
 		},
 		FanOut: AWSFanOutExecutionResult{
-			Status:     awsPlatformDependencyStatusReady,
+			Status:     awsPlatformDependencyStatusDegraded,
 			Confidence: 0.96,
 			Summary: AWSFanOutExecutionSummary{
 				CoveredTargets:   12,
@@ -175,11 +182,17 @@ func TestAWSPlatformObservabilityFanOutMetricsUseFilteredTargets(t *testing.T) {
 	if got := byID["scan-throughput"].Value; got != 1 {
 		t.Fatalf("expected scan throughput to use filtered fan-out targets, got %d", got)
 	}
+	if metric := byID["scan-throughput"]; metric.Status != awsPlatformDependencyStatusReady || metric.Severity != "low" {
+		t.Fatalf("expected scan throughput status to use filtered source rows, got %+v", metric)
+	}
 	if got := byID["queue-lag"].Value; got != 0 {
 		t.Fatalf("expected queue lag to ignore unfiltered fan-out summary backlog, got %d", got)
 	}
 	if metric := byID["throttling"]; metric.Value != 0 || metric.Status != awsPlatformDependencyStatusReady {
 		t.Fatalf("expected throttling to use filtered fan-out targets, got %+v", metric)
+	}
+	if metric := byID["collector-failures"]; metric.Value != 0 || metric.Status != awsPlatformDependencyStatusReady {
+		t.Fatalf("expected collector failures to use filtered coverage rows, got %+v", metric)
 	}
 }
 
@@ -208,6 +221,41 @@ func TestAWSPlatformObservabilityRuntimeTraceStatusIncludesDelayed(t *testing.T)
 	}
 	if traces[0].Status != awsPlatformDependencyStatusDegraded {
 		t.Fatalf("expected delayed runtime trace to be degraded, got %+v", traces[0])
+	}
+}
+
+func TestAWSPlatformObservabilityNormalizesRuntimeServiceTokens(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 4, 30, 0, time.UTC)
+	traces := awsPlatformObservabilityTraces(awsPlatformObservabilitySources{
+		Runtime: AWSRuntimeEventResult{
+			Records: []AWSRuntimeEventRecord{
+				{
+					EventID:     "secret-runtime",
+					AccountID:   "123456789012",
+					Region:      "us-east-1",
+					EventSource: "secretsmanager.amazonaws.com",
+					Status:      "observed",
+					ObservedAt:  now.Add(-5 * time.Minute),
+					CollectedAt: now,
+					EvidenceRef: "aws-runtime://secret-runtime",
+					NextAction:  "Review secret runtime access.",
+				},
+			},
+		},
+	}, now)
+	if len(traces) != 1 || traces[0].Service != "secretsmanager" {
+		t.Fatalf("expected runtime event source to normalize to service token, got %+v", traces)
+	}
+
+	metrics := []AWSPlatformObservabilityMetric{
+		{MetricID: "s3-throughput", Component: "collector", Service: "s3", Status: awsPlatformDependencyStatusReady},
+	}
+	serviceTraces := []AWSPlatformObservabilityTrace{
+		{TraceID: "runtime-s3", Component: "runtime", Service: "s3", Status: awsPlatformDependencyStatusReady},
+	}
+	filteredMetrics, filteredTraces, _ := filterAWSPlatformObservability(metrics, serviceTraces, AWSPlatformObservabilityRequest{Service: "s3.amazonaws.com"})
+	if len(filteredMetrics) != 1 || len(filteredTraces) != 1 {
+		t.Fatalf("expected endpoint-form service filter to match canonical service tokens, metrics=%+v traces=%+v", filteredMetrics, filteredTraces)
 	}
 }
 

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -180,13 +180,47 @@ func TestAWSPlatformObservabilityTraceOnlyStatusAndAlerts(t *testing.T) {
 	if len(filteredMetrics) != 0 || len(filteredTraces) != 1 {
 		t.Fatalf("expected service filter to leave only runtime trace rows, metrics=%+v traces=%+v", filteredMetrics, filteredTraces)
 	}
-	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces, true)
 	if status != awsPlatformDependencyStatusDegraded || confidence != 0.72 {
 		t.Fatalf("expected trace-only degraded response status, got status=%q confidence=%v", status, confidence)
 	}
-	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, now)
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, true, now)
 	if len(alerts) != 1 || alerts[0].Status != awsPlatformDependencyStatusDegraded || alerts[0].Component != "runtime" {
 		t.Fatalf("expected trace-only degraded alert, got %+v", alerts)
+	}
+}
+
+func TestAWSPlatformObservabilityScopedStatusIncludesMetricAndTraceSignals(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 1, 45, 0, time.UTC)
+	metrics := []AWSPlatformObservabilityMetric{
+		{MetricID: "scan-throughput", Component: "collector", Service: "secretsmanager", Status: awsPlatformDependencyStatusReady},
+		{MetricID: "queue-lag", Component: "queue", Service: "secretsmanager", Status: awsPlatformDependencyStatusReady},
+	}
+	traces := []AWSPlatformObservabilityTrace{
+		{
+			TraceID:     "runtime-secretsmanager-delayed",
+			SpanName:    "aws.runtime.collect",
+			Component:   "runtime",
+			AccountID:   "123456789012",
+			Region:      "us-east-1",
+			Service:     "secretsmanager",
+			Status:      awsPlatformDependencyStatusDegraded,
+			EvidenceRef: "aws-runtime://secret-runtime",
+			NextAction:  "Review delayed runtime delivery.",
+		},
+	}
+
+	filteredMetrics, filteredTraces, _ := filterAWSPlatformObservability(metrics, traces, AWSPlatformObservabilityRequest{Service: "secretsmanager"})
+	if len(filteredMetrics) != 2 || len(filteredTraces) != 1 {
+		t.Fatalf("expected service filter to keep ready metrics and degraded trace, metrics=%+v traces=%+v", filteredMetrics, filteredTraces)
+	}
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces, true)
+	if status != awsPlatformDependencyStatusDegraded || confidence != 0.72 {
+		t.Fatalf("expected scoped status to include degraded trace beside ready metrics, got status=%q confidence=%v", status, confidence)
+	}
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, true, now)
+	if len(alerts) != 1 || alerts[0].Status != awsPlatformDependencyStatusDegraded || alerts[0].Component != "runtime" {
+		t.Fatalf("expected scoped trace alert beside ready metrics, got %+v", alerts)
 	}
 }
 

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -157,6 +157,39 @@ func TestGetAWSPlatformObservabilityScopesStatusToFilteredSignals(t *testing.T) 
 	}
 }
 
+func TestAWSPlatformObservabilityTraceOnlyStatusAndAlerts(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 1, 30, 0, time.UTC)
+	metrics := []AWSPlatformObservabilityMetric{
+		{MetricID: "runtime-lag", Component: "runtime", Service: "all", Status: awsPlatformDependencyStatusReady},
+	}
+	traces := []AWSPlatformObservabilityTrace{
+		{
+			TraceID:     "runtime-secretsmanager-delayed",
+			SpanName:    "aws.runtime.collect",
+			Component:   "runtime",
+			AccountID:   "123456789012",
+			Region:      "us-east-1",
+			Service:     "secretsmanager",
+			Status:      awsPlatformDependencyStatusDegraded,
+			EvidenceRef: "aws-runtime://secret-runtime",
+			NextAction:  "Review delayed runtime delivery.",
+		},
+	}
+
+	filteredMetrics, filteredTraces, _ := filterAWSPlatformObservability(metrics, traces, AWSPlatformObservabilityRequest{Service: "secretsmanager"})
+	if len(filteredMetrics) != 0 || len(filteredTraces) != 1 {
+		t.Fatalf("expected service filter to leave only runtime trace rows, metrics=%+v traces=%+v", filteredMetrics, filteredTraces)
+	}
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces)
+	if status != awsPlatformDependencyStatusDegraded || confidence != 0.72 {
+		t.Fatalf("expected trace-only degraded response status, got status=%q confidence=%v", status, confidence)
+	}
+	alerts := awsPlatformObservabilityAlerts(filteredMetrics, filteredTraces, now)
+	if len(alerts) != 1 || alerts[0].Status != awsPlatformDependencyStatusDegraded || alerts[0].Component != "runtime" {
+		t.Fatalf("expected trace-only degraded alert, got %+v", alerts)
+	}
+}
+
 func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 2, 0, 0, time.UTC)
 	sources := awsPlatformObservabilitySources{

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -222,6 +222,29 @@ func TestAWSPlatformObservabilityScopedStatusIncludesMetricAndTraceSignals(t *te
 	if len(alerts) != 1 || alerts[0].Status != awsPlatformDependencyStatusDegraded || alerts[0].Component != "runtime" {
 		t.Fatalf("expected scoped trace alert beside ready metrics, got %+v", alerts)
 	}
+	summary := summarizeAWSPlatformObservability(metrics, filteredMetrics, traces, filteredTraces, alerts)
+	if summary.ReadySignals != 2 || summary.DegradedSignals != 1 || summary.StatusCounts[awsPlatformDependencyStatusDegraded] != 1 {
+		t.Fatalf("expected trace status to contribute to scoped signal totals, got %+v", summary)
+	}
+}
+
+func TestAWSPlatformObservabilityAllFiltersDoNotEnableScopedTraceSignals(t *testing.T) {
+	request := AWSPlatformObservabilityRequest{Component: "all", Status: "all"}
+	if awsPlatformObservabilityHasResultFilter(request) {
+		t.Fatalf("expected all component/status tokens to behave like absent result filters")
+	}
+
+	metrics := []AWSPlatformObservabilityMetric{
+		{MetricID: "scan-throughput", Component: "collector", Service: "all", Status: awsPlatformDependencyStatusReady},
+	}
+	traces := []AWSPlatformObservabilityTrace{
+		{TraceID: "runtime-delayed", Component: "runtime", Service: "secretsmanager", Status: awsPlatformDependencyStatusDegraded},
+	}
+	filteredMetrics, filteredTraces, _ := filterAWSPlatformObservability(metrics, traces, request)
+	status, confidence := summarizeAWSPlatformObservabilityStatus(filteredMetrics, filteredTraces, awsPlatformObservabilityHasResultFilter(request))
+	if status != awsPlatformDependencyStatusReady || confidence != 0.9 {
+		t.Fatalf("expected explicit all filters to match omitted filter status behavior, got status=%q confidence=%v", status, confidence)
+	}
 }
 
 func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.T) {

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -260,6 +260,51 @@ func TestAWSPlatformObservabilityFanOutMetricsUseFilteredTargets(t *testing.T) {
 	}
 }
 
+func TestAWSPlatformObservabilityTreatsPendingFanOutAsQueuedBacklog(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 3, 30, 0, time.UTC)
+	targets := make([]AWSFanOutExecutionTarget, 0, 8)
+	for i := 0; i < 8; i++ {
+		targets = append(targets, AWSFanOutExecutionTarget{
+			Key:         "ecs-pending",
+			AccountID:   "123456789012",
+			Region:      "us-east-1",
+			Service:     "ecs",
+			State:       "pending",
+			WorkerState: "pending",
+			Enabled:     true,
+		})
+	}
+	sources := awsPlatformObservabilitySources{
+		FanOut: AWSFanOutExecutionResult{
+			Status:     awsPlatformDependencyStatusReady,
+			Confidence: 0.96,
+			Targets:    targets,
+		},
+	}
+
+	metrics := awsPlatformObservabilityMetrics(sources, AWSPlatformObservabilityRequest{Service: "ecs"}, "123456789012", "us-east-1", "ecs", now)
+	byID := map[string]AWSPlatformObservabilityMetric{}
+	for _, metric := range metrics {
+		byID[metric.MetricID] = metric
+	}
+	if metric := byID["queue-lag"]; metric.Value != int((16*time.Minute).Milliseconds()) || metric.Status != awsPlatformDependencyStatusDegraded {
+		t.Fatalf("expected pending fan-out rows to contribute queued backlog, got %+v", metric)
+	}
+
+	traces := awsPlatformObservabilityTraces(sources, now)
+	if len(traces) == 0 {
+		t.Fatalf("expected pending fan-out traces, got none")
+	}
+	for _, trace := range traces {
+		if trace.Component != "collector" {
+			continue
+		}
+		if trace.QueueLagMs != int((2 * time.Minute).Milliseconds()) {
+			t.Fatalf("expected pending fan-out trace to use queued lag, got %+v", trace)
+		}
+	}
+}
+
 func TestAWSPlatformObservabilityRuntimeTraceStatusIncludesDelayed(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 4, 0, 0, time.UTC)
 	traces := awsPlatformObservabilityTraces(awsPlatformObservabilitySources{

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -128,6 +128,35 @@ func TestGetAWSPlatformObservabilityNormalizesServiceBeforeSourcePushdown(t *tes
 	}
 }
 
+func TestGetAWSPlatformObservabilityScopesStatusToFilteredSignals(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 1, 0, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-filtered-status", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-filtered-status", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Component:    "collector",
+		Status:       awsPlatformDependencyStatusReady,
+	})
+	if err != nil {
+		t.Fatalf("get status-filtered platform observability: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusReady || result.Confidence != 0.9 {
+		t.Fatalf("expected response status to follow returned ready collector signals, got %+v", result)
+	}
+	if len(result.Metrics) == 0 {
+		t.Fatalf("expected ready collector metrics, got %+v", result)
+	}
+	for _, metric := range result.Metrics {
+		if metric.Component != "collector" || metric.Status != awsPlatformDependencyStatusReady {
+			t.Fatalf("expected only ready collector metrics, got %+v", metric)
+		}
+	}
+	if len(result.Alerts) != 0 {
+		t.Fatalf("expected no alerts for ready filtered response, got %+v", result.Alerts)
+	}
+}
+
 func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 2, 0, 0, time.UTC)
 	sources := awsPlatformObservabilitySources{

--- a/internal/api/aws_platform_observability_test.go
+++ b/internal/api/aws_platform_observability_test.go
@@ -64,6 +64,70 @@ func TestGetAWSPlatformObservabilityBuildsContract(t *testing.T) {
 	}
 }
 
+func TestGetAWSPlatformObservabilityLeavesUnfilteredScopeUnlabeled(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 0, 30, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-unfiltered-scope", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-unfiltered-scope", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get unfiltered platform observability: %v", err)
+	}
+	if result.AccountID != "" || result.Region != "" {
+		t.Fatalf("expected unfiltered platform scope to remain empty, got account=%q region=%q", result.AccountID, result.Region)
+	}
+	for _, metric := range result.Metrics {
+		if metric.AccountID != "" || metric.Region != "" {
+			t.Fatalf("expected aggregate platform metric scope to remain empty, got %+v", metric)
+		}
+	}
+	if result.Summary.AccountCounts["123456789012"] == 0 || result.Summary.RegionCounts["us-east-1"] == 0 {
+		t.Fatalf("expected source traces to preserve real account/region counts, got %+v", result.Summary)
+	}
+}
+
+func TestGetAWSPlatformObservabilityNormalizesServiceBeforeSourcePushdown(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 0, 45, 0, time.UTC)
+	svc, ws := newPlatformObservabilityService(t, "project-platform-observability-service-pushdown", now)
+
+	result, err := svc.GetAWSPlatformObservability(defaultScopeContext(), ws, "project-platform-observability-service-pushdown", AWSPlatformObservabilityRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Service:      "secrets-manager.amazonaws.com",
+	})
+	if err != nil {
+		t.Fatalf("get service-filtered platform observability: %v", err)
+	}
+	if result.AppliedFilters["service"] != "secrets-manager.amazonaws.com" {
+		t.Fatalf("expected original service filter to remain visible, got %+v", result.AppliedFilters)
+	}
+	collectorTrace := false
+	for _, trace := range result.Traces {
+		if trace.Component != "collector" {
+			continue
+		}
+		collectorTrace = true
+		if trace.Service != "secretsmanager" {
+			t.Fatalf("expected collector trace to use canonical service token, got %+v", trace)
+		}
+	}
+	if !collectorTrace {
+		t.Fatalf("expected normalized service pushdown to keep collector traces, got %+v", result.Traces)
+	}
+	for _, metric := range result.Metrics {
+		if metric.Component == "collector" || metric.Component == "queue" {
+			if metric.Service != "secretsmanager" {
+				t.Fatalf("expected source-scoped metric to use canonical service token, got %+v", metric)
+			}
+			if metric.AccountID != "" || metric.Region != "" {
+				t.Fatalf("expected service-only metrics to avoid connector account/region labels, got %+v", metric)
+			}
+		}
+	}
+}
+
 func TestAWSPlatformObservabilityMetricsUseLagAndScopedServiceLabels(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 2, 0, 0, time.UTC)
 	sources := awsPlatformObservabilitySources{

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -187,6 +187,7 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/lambda-execution-roles:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/eks-workload-identities:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/graph-explorer:",
+		"/v1/workspaces/{workspace_id}/projects/{project_id}/aws/platform-observability:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/complete:",
 		"/v1/workspaces/{workspace_id}/projects/{project_id}/github/connection:",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3865,6 +3865,40 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"executive_outcomes": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/platform-observability", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSPlatformObservability(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSPlatformObservabilityRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Service:      strings.TrimSpace(c.Query("service")),
+			Component:    strings.TrimSpace(c.Query("component")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws platform observability request"})
+			default:
+				logger.Error("get aws platform observability",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws platform observability"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform_observability": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ import {
   ProductAWSGovernancePage,
   ProductAWSGraphPage,
   ProductAWSOutcomesPage,
+  ProductAWSPlatformObservabilityPage,
   ProductAWSRemediationPage,
   ProductAWSRuntimePage,
   ProductAWSAgentIdentityDetailPage,
@@ -4836,6 +4837,7 @@ export function RoutedSite() {
             <Route path="aws/agents/detail" element={<ProductAWSAgentIdentityDetailPage />} />
             <Route path="aws/resources" element={<ProductAWSResourcesPage />} />
             <Route path="aws/runtime" element={<ProductAWSRuntimePage />} />
+            <Route path="aws/observability" element={<ProductAWSPlatformObservabilityPage />} />
             <Route path="aws/graph" element={<ProductAWSGraphPage />} />
             <Route path="aws/findings" element={<ProductAWSFindingsPage />} />
             <Route path="aws/remediation" element={<ProductAWSRemediationPage />} />

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1161,6 +1161,44 @@ describe('apiClient', () => {
     expect(headers.get('authorization')).toBe('Bearer token-a');
   });
 
+  it('gets AWS platform observability with scoped headers and filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ platform_observability: { status: 'degraded', summary: { total_metrics: 9 }, metrics: [], traces: [] } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.getAWSProjectPlatformObservability(
+      'workspace/a',
+      'project 1',
+      {
+        connectorID: 'aws-prod',
+        fixtureState: 'partial_failure',
+        accountID: '111111111111',
+        region: 'us-east-1',
+        service: 'ecs',
+        component: 'collector',
+        status: 'degraded',
+        search: 'throttling'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects/project%201/aws/platform-observability?connector_id=aws-prod&fixture_state=partial_failure&account_id=111111111111&region=us-east-1&service=ecs&component=collector&status=degraded&search=throttling'
+    );
+    expect(options.method ?? 'GET').toBe('GET');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
   it('gets AWS Organizations topology with scoped headers, fixture state, and filters', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5079,6 +5079,134 @@ export type AWSExecutiveOutcomeViewQuery = {
   search?: string;
 };
 
+export type AWSPlatformObservabilityStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSPlatformObservabilityFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+
+export type AWSPlatformObservabilityMetric = {
+  metric_id: string;
+  component: string;
+  signal: string;
+  title: string;
+  summary: string;
+  value: number;
+  unit: string;
+  status: AWSPlatformObservabilityStatus | string;
+  severity?: string;
+  confidence: number;
+  account_id?: string;
+  region?: string;
+  service?: string;
+  trace_id: string;
+  evidence_ref?: string;
+  evidence_links: string[];
+  evidence_boundary: string;
+  next_action: string;
+  observed_at: string;
+  updated_at: string;
+};
+
+export type AWSPlatformObservabilityTrace = {
+  trace_id: string;
+  parent_trace_id?: string;
+  span_name: string;
+  component: string;
+  account_id?: string;
+  region?: string;
+  service?: string;
+  status: AWSPlatformObservabilityStatus | string;
+  duration_ms?: number;
+  queue_lag_ms?: number;
+  runtime_lag_ms?: number;
+  retry_count?: number;
+  throttled: boolean;
+  evidence_ref?: string;
+  evidence_links: string[];
+  evidence_boundary: string;
+  next_action: string;
+  started_at?: string;
+  ended_at?: string;
+};
+
+export type AWSPlatformObservabilityAlert = {
+  alert_id: string;
+  severity: string;
+  component: string;
+  status: AWSPlatformObservabilityStatus | string;
+  title: string;
+  summary: string;
+  evidence_ref?: string;
+  evidence_boundary: string;
+  next_action: string;
+  triggered_at: string;
+};
+
+export type AWSPlatformObservabilitySummary = {
+  total_metrics: number;
+  filtered_metrics: number;
+  total_traces: number;
+  filtered_traces: number;
+  ready_signals: number;
+  degraded_signals: number;
+  blocked_signals: number;
+  alert_count: number;
+  critical_alert_count: number;
+  scan_throughput_per_hour: number;
+  queue_lag_p95_ms: number;
+  runtime_lag_p95_ms: number;
+  collector_failure_count: number;
+  throttled_target_count: number;
+  remediation_pending_count: number;
+  verification_failed_count: number;
+  governance_exception_count: number;
+  account_counts: Record<string, number>;
+  region_counts: Record<string, number>;
+  service_counts: Record<string, number>;
+  component_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+};
+
+export type AWSPlatformObservabilityResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSPlatformObservabilityStatus;
+  fixture_state?: AWSPlatformObservabilityFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSPlatformObservabilitySummary;
+  metrics: AWSPlatformObservabilityMetric[];
+  traces: AWSPlatformObservabilityTrace[];
+  alerts: AWSPlatformObservabilityAlert[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  coverage_gaps: AWSLeastPrivilegeCoverageGap[];
+  diagnostics: AWSLeastPrivilegeDiagnostic[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSPlatformObservabilityQuery = {
+  connectorID?: string;
+  fixtureState?: AWSPlatformObservabilityFixtureState;
+  accountID?: string;
+  region?: string;
+  service?: string;
+  component?: string;
+  status?: string;
+  search?: string;
+};
+
 export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
@@ -11027,6 +11155,26 @@ export const apiClient = {
         severity: query?.severity,
         outcome_type: query?.outcomeType,
         trend: query?.trend,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectPlatformObservability(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSPlatformObservabilityQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ platform_observability: AWSPlatformObservabilityResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/platform-observability${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        service: query?.service,
+        component: query?.component,
+        status: query?.status,
         search: query?.search
       })}`,
       auth

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -10,6 +10,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/agents/detail',
   '/app/:tenantID/:workspaceID/aws/resources',
   '/app/:tenantID/:workspaceID/aws/runtime',
+  '/app/:tenantID/:workspaceID/aws/observability',
   '/app/:tenantID/:workspaceID/aws/graph',
   '/app/:tenantID/:workspaceID/aws/findings',
   '/app/:tenantID/:workspaceID/aws/remediation',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3346,6 +3346,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/agents/detail',
       '/app/:tenantID/:workspaceID/aws/resources',
       '/app/:tenantID/:workspaceID/aws/runtime',
+      '/app/:tenantID/:workspaceID/aws/observability',
       '/app/:tenantID/:workspaceID/aws/graph',
       '/app/:tenantID/:workspaceID/aws/findings',
       '/app/:tenantID/:workspaceID/aws/remediation',
@@ -7440,6 +7441,183 @@ describe('Domain-first app routes', () => {
     );
     expect(await screen.findByText(/Permission required/i)).toBeInTheDocument();
     expect(screen.getByText(/Organizations read access denied/i)).toBeInTheDocument();
+  });
+
+  it('shows AWS platform observability and forwards health filters', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getPlatformObservability = vi.spyOn(api.apiClient, 'getAWSProjectPlatformObservability').mockResolvedValue({
+      platform_observability: {
+        status: 'degraded',
+        confidence: 0.82,
+        current_issue_ref: '#1556',
+        version: 'aws-platform-observability-v1',
+        applied_filters: {},
+        summary: {
+          total_metrics: 2,
+          filtered_metrics: 2,
+          total_traces: 1,
+          filtered_traces: 1,
+          ready_signals: 1,
+          degraded_signals: 1,
+          blocked_signals: 0,
+          alert_count: 1,
+          critical_alert_count: 0,
+          scan_throughput_per_hour: 12,
+          queue_lag_p95_ms: 120000,
+          runtime_lag_p95_ms: 60000,
+          collector_failure_count: 0,
+          throttled_target_count: 0,
+          remediation_pending_count: 3,
+          verification_failed_count: 1,
+          governance_exception_count: 0,
+          account_counts: { '123456789012': 2 },
+          region_counts: { 'us-east-1': 2 },
+          service_counts: { iam: 1, all: 1 },
+          component_counts: { collector: 1, verification: 1 },
+          status_counts: { ready: 1, degraded: 1 }
+        },
+        metrics: [
+          {
+            metric_id: 'scan-throughput',
+            component: 'collector',
+            signal: 'scan_throughput',
+            title: 'Scan throughput',
+            summary: 'Targets completed by fan-out.',
+            value: 12,
+            unit: 'targets_per_hour',
+            status: 'ready',
+            severity: 'low',
+            confidence: 0.94,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'iam',
+            trace_id: 'metric:collector:scan-throughput',
+            evidence_links: ['/docs/aws-platform-observability'],
+            evidence_ref: 'aws-platform-observability://scan-throughput',
+            evidence_boundary: 'metadata_only_platform_observability_no_secret_values_no_customer_payloads',
+            next_action: 'Confirm expected targets are advancing.',
+            observed_at: '2026-07-09T12:00:00Z',
+            updated_at: '2026-07-09T12:00:00Z'
+          },
+          {
+            metric_id: 'verification-outcomes',
+            component: 'verification',
+            signal: 'verification_outcomes',
+            title: 'Verification outcomes',
+            summary: 'Failed verification outcomes.',
+            value: 1,
+            unit: 'outcomes',
+            status: 'degraded',
+            severity: 'high',
+            confidence: 0.78,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'all',
+            trace_id: 'metric:verification:verification-outcomes',
+            evidence_links: ['/docs/aws-post-remediation-verification'],
+            evidence_ref: 'aws-platform-observability://verification-outcomes',
+            evidence_boundary: 'metadata_only_platform_observability_no_secret_values_no_customer_payloads',
+            next_action: 'Review failed checks before reporting closure.',
+            observed_at: '2026-07-09T12:00:00Z',
+            updated_at: '2026-07-09T12:00:00Z'
+          }
+        ],
+        traces: [
+          {
+            trace_id: 'trace:verification:case-1',
+            span_name: 'aws.remediation.verify',
+            component: 'verification',
+            account_id: '123456789012',
+            region: 'us-east-1',
+            service: 'aws_scp_guardrail_executor',
+            status: 'degraded',
+            duration_ms: 2000,
+            queue_lag_ms: 0,
+            runtime_lag_ms: 0,
+            retry_count: 1,
+            throttled: false,
+            evidence_links: ['/docs/aws-post-remediation-verification'],
+            evidence_ref: 'verification://case-1',
+            evidence_boundary: 'metadata_only_platform_observability_no_secret_values_no_customer_payloads',
+            next_action: 'Review failed checks.',
+            started_at: '2026-07-09T11:59:00Z',
+            ended_at: '2026-07-09T12:00:00Z'
+          }
+        ],
+        alerts: [
+          {
+            alert_id: 'alert:verification',
+            severity: 'high',
+            component: 'verification',
+            status: 'degraded',
+            title: 'Verification outcomes',
+            summary: 'Failed verification outcomes.',
+            evidence_ref: 'aws-platform-observability://verification-outcomes',
+            evidence_boundary: 'metadata_only_platform_observability_no_secret_values_no_customer_payloads',
+            next_action: 'Review failed checks before reporting closure.',
+            triggered_at: '2026-07-09T12:00:00Z'
+          }
+        ],
+        caveats: [],
+        failure_reasons: [],
+        remediation_hints: [],
+        evidence_links: ['/docs/aws-platform-observability'],
+        coverage_gaps: [],
+        diagnostics: [],
+        generated_at: '2026-07-09T12:00:00Z',
+        updated_at: '2026-07-09T12:00:00Z'
+      } as any
+    });
+
+    const { ProductAWSPlatformObservabilityPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/observability?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/observability" element={<ProductAWSPlatformObservabilityPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Observability' })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'AWS platform observability summary' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS platform observability metrics' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS platform observability traces' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Scan throughput/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Verification outcomes/i).length).toBeGreaterThan(0);
+    expect(getPlatformObservability).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Component' }), {
+      target: { value: 'verification' }
+    });
+    await waitFor(() =>
+      expect(getPlatformObservability).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', component: 'verification' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('shows AWS executive outcome view and forwards outcome filters', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -102,6 +102,10 @@ import {
   type AWSExecutiveOutcomeMetric,
   type AWSExecutiveOutcomeViewQuery,
   type AWSExecutiveOutcomeViewResult,
+  type AWSPlatformObservabilityMetric,
+  type AWSPlatformObservabilityQuery,
+  type AWSPlatformObservabilityResult,
+  type AWSPlatformObservabilityTrace,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
   type AWSAgentCoreGatewayPolicyAdvisoryEntry,
@@ -460,6 +464,7 @@ type ProductDomainRouteID =
   | 'agents'
   | 'resources'
   | 'runtime'
+  | 'observability'
   | 'graph'
   | 'findings'
   | 'remediation'
@@ -559,6 +564,7 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
       productDomainRoute('agents', 'Agents', 'agents', 'Agents', '', 'Bedrock and MCP agents Identrail can see.'),
       productDomainRoute('resources', 'Resources', 'resources', 'Resources', '', 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'),
       productDomainRoute('runtime', 'Runtime', 'runtime', 'Runtime', '', 'What your AWS roles actually did, from runtime evidence.'),
+      productDomainRoute('observability', 'Observability', 'observability', 'Observability', '', 'Platform health, metrics, traces, and alerts for AWS collection and governance.'),
       productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
       productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
       productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
@@ -11660,7 +11666,7 @@ export function ProductAWSResourcesPage() {
 
 type AWSRiskOperationRouteID = Extract<
   ProductDomainRouteID,
-  'runtime' | 'graph' | 'findings' | 'remediation' | 'outcomes' | 'governance'
+  'runtime' | 'observability' | 'graph' | 'findings' | 'remediation' | 'outcomes' | 'governance'
 >;
 
 type AWSRiskOperationPageCopy = {
@@ -11688,6 +11694,18 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     nextAction: '',
     unavailableTitle: 'No runtime events yet',
     unavailableBody: "Runtime activity will appear here once Identrail starts ingesting your AWS logs."
+  },
+  observability: {
+    routeID: 'observability',
+    title: 'Observability',
+    eyebrow: '',
+    description: 'Platform health, metrics, traces, and alerts for AWS collection and governance.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No observability signals yet',
+    unavailableBody: 'Platform observability will appear once Identrail has collector, runtime, remediation, verification, and governance evidence.'
   },
   graph: {
     routeID: 'graph',
@@ -11755,6 +11773,7 @@ type AWSRiskOperationFilterConfigMap = Record<AWSRiskOperationRouteID, AWSInvent
 
 const AWS_RISK_OPERATION_FILTER_DEFAULTS: Record<AWSRiskOperationRouteID, AWSInventoryFilterState> = {
   runtime: { event: 'all', evidence: 'all', owner: 'all', status: 'all', search: '' },
+  observability: { component: 'all', status: 'all', service: 'all', search: '' },
   graph: { node: 'all', edge: 'all', evidence: 'all', search: '' },
   findings: { severity: 'all', account: 'all', region: 'all', evidence: 'all', status: 'all', search: '' },
   remediation: { change: 'all', approval: 'all', stage: 'all', search: '' },
@@ -11810,6 +11829,46 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
         { label: 'Resolved', value: 'resolved' },
         { label: 'Archived', value: 'archived' },
         { label: 'Stale', value: 'stale' }
+      ]
+    }
+  ],
+  observability: [
+    {
+      id: 'component',
+      label: 'Component',
+      options: [
+        { label: 'All components', value: 'all' },
+        { label: 'Collector', value: 'collector' },
+        { label: 'Queue', value: 'queue' },
+        { label: 'Runtime', value: 'runtime' },
+        { label: 'Remediation', value: 'remediation' },
+        { label: 'Verification', value: 'verification' },
+        { label: 'Enforcement', value: 'enforcement' },
+        { label: 'Governance', value: 'governance' }
+      ]
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      options: [
+        { label: 'All statuses', value: 'all' },
+        { label: 'Ready', value: 'ready' },
+        { label: 'Degraded', value: 'degraded' },
+        { label: 'Blocked', value: 'blocked' }
+      ]
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      options: [
+        { label: 'All services', value: 'all' },
+        { label: 'IAM', value: 'iam' },
+        { label: 'Lambda', value: 'lambda' },
+        { label: 'ECS', value: 'ecs' },
+        { label: 'Secrets Manager', value: 'secretsmanager' },
+        { label: 'S3', value: 's3.amazonaws.com' },
+        { label: 'KMS', value: 'kms.amazonaws.com' },
+        { label: 'Agent runtime', value: 'bedrock-agentcore.amazonaws.com' }
       ]
     }
   ],
@@ -12059,6 +12118,7 @@ function AWSRiskOperationFilterSet({
 }) {
   const searchPlaceholder: Record<AWSRiskOperationRouteID, string> = {
     runtime: 'Search events',
+    observability: 'Search signals',
     graph: 'Search graph',
     findings: 'Search findings',
     remediation: 'Search changes',
@@ -14181,6 +14241,115 @@ function AWSExecutiveOutcomeViewContent({
           }
         ]}
       />
+    </>
+  );
+}
+
+function awsPlatformObservabilityStage(status: string): AWSCapabilityStage {
+  if (status === 'blocked') {
+    return 'not-available';
+  }
+  if (status === 'degraded') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function awsPlatformObservabilityMetricValue(metric: AWSPlatformObservabilityMetric): string {
+  if (metric.unit === 'milliseconds') {
+    return `${Math.round(metric.value / 1000)}s`;
+  }
+  return `${metric.value} ${formatTokenLabel(metric.unit)}`;
+}
+
+function AWSPlatformObservabilityContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSPlatformObservabilityResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.filtered_metrics} metrics · ${result.summary.filtered_traces} traces · ${result.summary.alert_count} alerts · ${Math.round(result.confidence * 100)}% confidence`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.metrics,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <>
+      {result ? (
+        <section className="idt-aws-inventory-coverage" aria-label="AWS platform observability summary">
+          <DomainCoverageCard label="Scan throughput" scanned={result.summary.scan_throughput_per_hour} total={Math.max(result.summary.scan_throughput_per_hour, 1)} detail="targets/hour" />
+          <DomainCoverageCard label="Queue lag" scanned={Math.max(0, 900000 - result.summary.queue_lag_p95_ms)} total={900000} detail={`${Math.round(result.summary.queue_lag_p95_ms / 1000)}s p95`} />
+          <DomainCoverageCard label="Runtime lag" scanned={Math.max(0, 900000 - result.summary.runtime_lag_p95_ms)} total={900000} detail={`${Math.round(result.summary.runtime_lag_p95_ms / 1000)}s p95`} />
+          <DomainCoverageCard label="Collector failures" scanned={Math.max(0, result.summary.filtered_metrics - result.summary.collector_failure_count)} total={Math.max(result.summary.filtered_metrics, 1)} detail={`${result.summary.collector_failure_count} signals`} />
+          <DomainCoverageCard label="Verification alerts" scanned={Math.max(0, result.summary.filtered_metrics - result.summary.verification_failed_count)} total={Math.max(result.summary.filtered_metrics, 1)} detail={`${result.summary.verification_failed_count} outcomes`} />
+          <DomainCoverageCard label="Platform alerts" scanned={Math.max(0, result.summary.filtered_metrics - result.summary.alert_count)} total={Math.max(result.summary.filtered_metrics, 1)} detail={`${result.summary.critical_alert_count} critical`} />
+        </section>
+      ) : null}
+      <AWSExecutorProjectionPanel<AWSPlatformObservabilityMetric>
+        result={panelResult}
+        loading={loading}
+        error={error}
+        onRetry={onRetry}
+        ariaLabel="AWS platform observability"
+        heading="AWS platform observability"
+        description={`Read-only platform health across scan throughput, queue lag, throttling, collector failures, runtime lag, remediation state, verification outcomes, enforcement safety, and governance exceptions. Signals keep trace IDs, evidence refs, account/region/service context, and metadata-only boundaries. ${summaryLine}`}
+        errorTitle="Couldn't load AWS platform observability"
+        loadingTitle="Loading platform observability"
+        loadingBody="Identrail is composing collector, queue, runtime, remediation, verification, enforcement, and governance health signals."
+        emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No signals')}
+        emptyTitle={(current) => (current.status === 'blocked' ? 'Observability needs source evidence' : 'No platform observability signals matched')}
+        emptyBody={(current) => current.failure_reasons[0] ?? 'No platform observability signal matched the current filters.'}
+        tableLabel="AWS platform observability metrics"
+        getRowKey={(row) => row.metric_id}
+        columns={[
+          { key: 'metric', header: 'Metric', render: (row) => <strong>{row.title}</strong> },
+          { key: 'component', header: 'Component', render: (row) => formatTokenLabel(row.component) },
+          { key: 'value', header: 'Value', render: (row) => awsPlatformObservabilityMetricValue(row) },
+          { key: 'scope', header: 'Scope', render: (row) => awsAccountRegionInventoryLabel(row.account_id, row.region) },
+          { key: 'trace', header: 'Trace', render: (row) => row.trace_id },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action },
+          {
+            key: 'status',
+            header: 'Status',
+            render: (row) => <AWSInventoryPill stage={awsPlatformObservabilityStage(row.status)} label={formatTokenLabel(row.status)} />
+          }
+        ]}
+      />
+      {!error && !loading && result && result.traces.length > 0 ? (
+        <section className="idt-aws-runtime-correlation" aria-label="AWS platform observability traces">
+          <h3>AWS platform traces</h3>
+          <p className="idt-app-kicker">Trace rows connect health metrics to account, region, service, status, evidence refs, lag, retry, and next-action context.</p>
+          <DomainDataTable<AWSPlatformObservabilityTrace>
+            label="AWS platform observability traces"
+            rows={result.traces.slice(0, 40)}
+            getRowKey={(row) => row.trace_id}
+            columns={[
+              { key: 'span', header: 'Span', render: (row) => <strong>{row.span_name}</strong> },
+              { key: 'component', header: 'Component', render: (row) => formatTokenLabel(row.component) },
+              { key: 'service', header: 'Service', render: (row) => formatTokenLabel(row.service ?? 'all') },
+              { key: 'scope', header: 'Scope', render: (row) => awsAccountRegionInventoryLabel(row.account_id, row.region) },
+              { key: 'lag', header: 'Lag', render: (row) => `${Math.round(((row.queue_lag_ms ?? 0) + (row.runtime_lag_ms ?? 0)) / 1000)}s` },
+              { key: 'next', header: 'Next action', render: (row) => row.next_action },
+              {
+                key: 'status',
+                header: 'Status',
+                render: (row) => <AWSInventoryPill stage={awsPlatformObservabilityStage(row.status)} label={formatTokenLabel(row.status)} />
+              }
+            ]}
+          />
+        </section>
+      ) : null}
     </>
   );
 }
@@ -16451,6 +16620,15 @@ function awsExecutiveOutcomeViewQueryFromFilters(filters: AWSInventoryFilterStat
   };
 }
 
+function awsPlatformObservabilityQueryFromFilters(filters: AWSInventoryFilterState): Partial<AWSPlatformObservabilityQuery> {
+  return {
+    component: awsSecretPermissionEquivalenceFilterToken(filters.component),
+    status: awsSecretPermissionEquivalenceFilterToken(filters.status),
+    service: awsSecretPermissionEquivalenceFilterToken(filters.service),
+    search: normalizeFilterValue(filters.search ?? '') || undefined
+  };
+}
+
 function AWSGraphExplorerContent({
   graph,
   loading,
@@ -17004,6 +17182,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [executiveOutcomesLoading, setExecutiveOutcomesLoading] = useState(false);
   const [executiveOutcomesError, setExecutiveOutcomesError] = useState('');
   const executiveOutcomesRequestRef = useRef(0);
+  const [platformObservability, setPlatformObservability] = useState<AWSPlatformObservabilityResult | null>(null);
+  const [platformObservabilityLoading, setPlatformObservabilityLoading] = useState(false);
+  const [platformObservabilityError, setPlatformObservabilityError] = useState('');
+  const platformObservabilityRequestRef = useRef(0);
   const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
@@ -18042,6 +18224,60 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       executiveOutcomesRequestRef.current += 1;
     };
   }, [loadExecutiveOutcomes]);
+
+  const loadPlatformObservability = useCallback(async () => {
+    const requestID = ++platformObservabilityRequestRef.current;
+    setPlatformObservability(null);
+    setPlatformObservabilityError('');
+    if (routeID !== 'observability' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setPlatformObservabilityLoading(false);
+      return;
+    }
+    setPlatformObservabilityLoading(true);
+    const requestFilters = awsPlatformObservabilityQueryFromFilters(activeFilters);
+    try {
+      const response = await apiClient.getAWSProjectPlatformObservability(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          ...requestFilters
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== platformObservabilityRequestRef.current) {
+        return;
+      }
+      setPlatformObservability(response.platform_observability);
+    } catch (error) {
+      if (requestID !== platformObservabilityRequestRef.current) {
+        return;
+      }
+      setPlatformObservabilityError(formatAPIError(error, 'Unable to load AWS platform observability.'));
+    } finally {
+      if (requestID === platformObservabilityRequestRef.current) {
+        setPlatformObservabilityLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    activeFilters.component,
+    activeFilters.status,
+    activeFilters.service,
+    activeFilters.search,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadPlatformObservability();
+    return () => {
+      platformObservabilityRequestRef.current += 1;
+    };
+  }, [loadPlatformObservability]);
 
   const loadSessionPolicyRecommendations = useCallback(async () => {
     const requestID = ++sessionPolicyRecommendationsRequestRef.current;
@@ -19156,6 +19392,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             onRetry={loadSecretPermissionEquivalence}
           />
         ) : null}
+        {routeID === 'observability' ? (
+          <AWSRiskOperationFilterSet routeID="observability" filters={activeFilters} onChange={onFiltersChange} />
+        ) : null}
+        {routeID === 'observability' ? (
+          <AWSPlatformObservabilityContent
+            result={platformObservability}
+            loading={platformObservabilityLoading}
+            error={platformObservabilityError}
+            onRetry={loadPlatformObservability}
+          />
+        ) : null}
         {routeID === 'graph' ? (
           <AWSGraphExplorerContent
             graph={graphExplorer}
@@ -19223,6 +19470,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
 
 export function ProductAWSRuntimePage() {
   return <ProductAWSRiskOperationsPage routeID="runtime" />;
+}
+
+export function ProductAWSPlatformObservabilityPage() {
+  return <ProductAWSRiskOperationsPage routeID="observability" />;
 }
 
 export function ProductAWSGraphPage() {


### PR DESCRIPTION
## Summary

Adds AWS platform observability for issue #1556 across the backend contract, frontend route, and operator documentation.

## Why

Operators need a read-only health surface that combines AWS collection throughput, queue lag, throttling, collector failures, runtime lag, remediation state, verification outcomes, enforcement health, and governance outcomes without introducing new AWS mutations or secret exposure.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api
npm test -- --run src/api/client.test.ts -t "platform observability"
npm test -- --run src/productShell.test.tsx -t "platform observability|route manifest"
npm run build
```

All checks passed locally. The web build completed with the existing Vite large-chunk warning and prerendered 40 routes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: no
- Tools used:
- Areas where used:
- Human verification performed: Local backend tests, focused frontend tests, production web build, staged diff review, and DCO range check.

## Related Issues

Closes #1556

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS platform observability API and UI so operators can see throughput, queue lag, throttling, collector/runtime health, remediation/verification/enforcement status, governance outcomes, and pending fan-out backlog. Implements issue #1556 with a metadata-only boundary (no secrets or customer payloads) and normalized filters and trace counts.

- **New Features**
  - Backend: Project-scoped `GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/platform-observability` returns status, summary (includes pending fan-out backlog), metrics, and traces with evidence refs; route policy and OpenAPI updated; tests cover contract and routing; supports health filters (connector, fixture_state, account, region, service, component, status, search).
  - Frontend: AWS Platform Observability page at `/aws/observability`, API client types/method to fetch data, wired into the domain route manifest; tests verify rendering.
  - Docs: Adds `aws-platform-observability.md` and updates the docs index.

- **Bug Fixes**
  - Correctly scopes traces to the selected connector/project and active filters, fixing parent/child trace linkage.
  - Includes scoped trace health in the top-level status and marks degraded on trace-only issues.
  - Fixes scope filters so the UI forwards connector/account/region/service/component/status/search to the API and results apply consistently.
  - Normalizes all filters and trace counts so summary and status match the filtered results.

<sup>Written for commit 661a620875d97dfdc0280b1928dcb05b41d90802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

