### PR TITLE
Add AWS GA demo hardening experience

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - AWS governance audit reporting: `aws-governance-audit-reporting.md`
 - AWS executive outcome view: `aws-executive-outcome-view.md`
 - AWS platform observability: `aws-platform-observability.md`
+- AWS GA demo hardening: `aws-ga-demo-hardening.md`
 - AWS session policy recommendation path: `aws-session-policy-recommendation.md`
 - AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`

--- a/docs/aws-ga-demo-hardening.md
+++ b/docs/aws-ga-demo-hardening.md
@@ -1,0 +1,85 @@
+# AWS GA demo hardening
+
+Issue #1557 adds a metadata-only GA walkthrough for the AWS platform. It gives
+operators one app/API surface for onboarding, discovery, agent identities,
+runtime evidence, risk, remediation, approval, verification, governance
+reporting, executive handoff, and platform observability.
+
+Endpoint:
+
+`GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ga-demo-hardening`
+
+Response shape: `{ "ga_demo_hardening": AWSGADemoHardeningResult }`.
+
+## Query filters
+
+- `connector_id`: pins the AWS connector.
+- `fixture_state`: `success`, `empty`, `degraded`, `partial_failure`, or
+  `permission_denied`.
+- `account_id` / `region`: scope the composed source evidence.
+- `stage`: `onboarding`, `discovery`, `agents`, `runtime`, `risk`,
+  `remediation`, `approval`, `verification`, `governance`, `reporting`, or
+  `observability`.
+- `status`: `ready`, `degraded`, or `blocked`.
+- `search`: searches stage titles, summaries, evidence refs, next actions, and
+  failure reasons.
+
+## Expected output
+
+The result includes:
+
+- ordered demo stages with status, confidence, account/region context, evidence
+  refs, evidence links, next actions, and failure reasons;
+- readiness checks for validation fixtures, read-only boundaries, permissions,
+  source confidence, and governance export;
+- permission prerequisites, safety notes, limitations, troubleshooting, caveats,
+  failure reasons, remediation hints, and evidence links;
+- stable loading, empty, degraded, permission-denied, filtered, and search
+  states for the AWS app page.
+
+## Permissions
+
+The walkthrough depends on read-only AWS metadata APIs such as:
+
+- `sts:GetCallerIdentity`
+- IAM role and policy read APIs
+- Access Analyzer list/read APIs
+- CloudTrail event lookup
+- AWS Organizations list APIs
+- service inventory list APIs for Lambda, ECS, EKS, Secrets Manager, KMS, and S3
+
+The endpoint does not require AWS write APIs.
+
+## Data intentionally not collected
+
+Identrail does not read, return, log, or persist secret values, prompts,
+completions, browser pages, code-interpreter output, database rows, object
+contents, rendered policy bodies, or customer payloads for this walkthrough.
+Evidence is limited to metadata, source IDs, evidence refs, confidence,
+timestamps, account/region context, and operator next actions.
+
+## Limitations
+
+- The demo reflects the configured connector permissions and available source
+  evidence.
+- Permission-denied and degraded states are explicit outcomes, not successful
+  collection.
+- Remediation and enforcement remain projections unless a downstream approved,
+  safety-gated execution endpoint is invoked.
+- Service coverage is bounded by existing collector contracts.
+
+## Troubleshooting
+
+- If onboarding is blocked, verify the connector role ARN, external ID, account
+  ID, region, and connection diagnostics.
+- If discovery is empty, run success and empty fixtures before treating the
+  absence of rows as expected.
+- If graph or agent stages are degraded, inspect collector coverage gaps,
+  runtime lag, PassRole evidence, and AI-agent diagnostics.
+- If remediation, approval, or verification stages are degraded, inspect case
+  ownership, approval state, dry-run outcomes, kill-switch state, rollback
+  state, and verification evidence.
+- If governance or reporting is degraded, export governance rows and resolve
+  exceptions before executive handoff.
+- If observability is degraded, review queue lag, throttling, collector
+  failures, runtime lag, verification alerts, and source confidence.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -673,6 +673,11 @@ x-identrail-route-authorizations:
     resource_type: project
     resource_id_param: project_id
   - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ga-demo-hardening
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
     path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/session-policy-recommendations
     action: tenancy.read
     resource_type: project
@@ -6556,6 +6561,73 @@ paths:
                     $ref: "#/components/schemas/AWSPlatformObservabilityResult"
         "400":
           description: Invalid AWS platform observability request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ga-demo-hardening:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+      - in: path
+        name: workspace_id
+        required: true
+        schema: { type: string }
+      - in: path
+        name: project_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [ProjectManagement]
+      summary: Get AWS GA demo hardening
+      operationId: getAWSProjectGADemoHardening
+      description: Composes the metadata-only AWS end-to-end operator walkthrough for onboarding, discovery, agent identities, runtime evidence, risk, remediation, approval, verification, governance reporting, executive handoff, and platform observability. The endpoint exposes confidence, evidence refs, permission documentation, limitations, troubleshooting, and degraded or permission-denied states without calling AWS write APIs or returning secret values, prompts, completions, browser pages, database rows, object contents, or customer payloads.
+      parameters:
+        - in: query
+          name: connector_id
+          schema: { type: string }
+        - in: query
+          name: fixture_state
+          schema:
+            type: string
+            enum: [success, empty, degraded, partial_failure, permission_denied]
+        - in: query
+          name: account_id
+          schema: { type: string }
+        - in: query
+          name: region
+          schema: { type: string }
+        - in: query
+          name: stage
+          schema:
+            type: string
+            enum: [onboarding, discovery, agents, runtime, risk, remediation, approval, verification, governance, reporting, observability]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [ready, degraded, blocked]
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        "200":
+          description: AWS GA demo hardening contract
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ga_demo_hardening:
+                    $ref: "#/components/schemas/AWSGADemoHardeningResult"
+        "400":
+          description: Invalid AWS GA demo hardening request
           content:
             application/json:
               schema:
@@ -19064,6 +19136,138 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSLeastPrivilegeDiagnostic"
+        generated_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AWSGADemoHardeningStage:
+      type: object
+      properties:
+        stage_id: { type: string }
+        order: { type: integer }
+        title: { type: string }
+        summary: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        account_id: { type: string }
+        region: { type: string }
+        primary_route: { type: string }
+        evidence_ref: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
+        evidence_boundary: { type: string }
+        next_action: { type: string }
+        failure_reason: { type: string }
+        updated_at:
+          type: string
+          format: date-time
+    AWSGADemoHardeningReadinessCheck:
+      type: object
+      properties:
+        check_id: { type: string }
+        title: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        owner: { type: string }
+        summary: { type: string }
+        evidence:
+          type: array
+          items: { type: string }
+        next_action: { type: string }
+        required: { type: boolean }
+        permissions:
+          type: array
+          items: { type: string }
+    AWSGADemoHardeningSummary:
+      type: object
+      properties:
+        total_stages: { type: integer }
+        filtered_stages: { type: integer }
+        ready_stages: { type: integer }
+        degraded_stages: { type: integer }
+        blocked_stages: { type: integer }
+        readiness_checks: { type: integer }
+        passed_checks: { type: integer }
+        required_checks: { type: integer }
+        failed_checks: { type: integer }
+        permission_warnings: { type: integer }
+        status_counts:
+          type: object
+          additionalProperties: { type: integer }
+        stage_counts:
+          type: object
+          additionalProperties: { type: integer }
+    AWSGADemoHardeningResult:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        connector_id: { type: string }
+        account_id: { type: string }
+        region: { type: string }
+        parent_issue_number: { type: integer }
+        parent_issue_ref: { type: string }
+        current_issue_number: { type: integer }
+        current_issue_ref: { type: string }
+        version: { type: string }
+        status:
+          type: string
+          enum: [ready, degraded, blocked]
+        fixture_state:
+          type: string
+          enum: [success, empty, degraded, partial_failure, permission_denied]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        calculation_version: { type: string }
+        applied_filters:
+          type: object
+          additionalProperties: { type: string }
+        summary:
+          $ref: "#/components/schemas/AWSGADemoHardeningSummary"
+        stages:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSGADemoHardeningStage"
+        readiness_checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSGADemoHardeningReadinessCheck"
+        permissions:
+          type: array
+          items: { type: string }
+        safety_notes:
+          type: array
+          items: { type: string }
+        limitations:
+          type: array
+          items: { type: string }
+        troubleshooting:
+          type: array
+          items: { type: string }
+        caveats:
+          type: array
+          items: { type: string }
+        failure_reasons:
+          type: array
+          items: { type: string }
+        remediation_hints:
+          type: array
+          items: { type: string }
+        evidence_links:
+          type: array
+          items: { type: string }
         generated_at:
           type: string
           format: date-time

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -785,6 +785,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/governance-audit-reporting", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/executive-outcomes", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/platform-observability", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/ga-demo-hardening", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/agentcore-gateway-policy-advisory", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
 		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id/aws/blast-radius", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},

--- a/internal/api/aws_ga_demo_hardening.go
+++ b/internal/api/aws_ga_demo_hardening.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -207,7 +209,7 @@ func (s *Service) GetAWSGADemoHardening(ctx context.Context, workspaceID string,
 		Outcomes:      outcomes,
 		Observability: observability,
 	}
-	stages := awsGADemoHardeningStages(sources, accountID, region, now)
+	stages := awsGADemoHardeningStages(sources, accountID, region, scope.TenantID, project.WorkspaceID, project.ProjectID, now)
 	filteredStages, applied := filterAWSGADemoHardeningStages(stages, request)
 	checks := awsGADemoHardeningReadinessChecks(sources)
 	filteredChecks := filterAWSGADemoHardeningReadinessChecks(checks, request)
@@ -252,20 +254,35 @@ func validAWSGADemoHardeningFilter(request AWSGADemoHardeningRequest) bool {
 		validAWSPlatformObservabilityToken(request.Stage, []string{"onboarding", "discovery", "agents", "runtime", "risk", "remediation", "approval", "verification", "governance", "reporting", "observability"})
 }
 
-func awsGADemoHardeningStages(s awsGADemoHardeningSources, accountID, region string, now time.Time) []AWSGADemoHardeningStage {
+func awsGADemoHardeningStages(s awsGADemoHardeningSources, accountID, region, tenantID, workspaceID, projectID string, now time.Time) []AWSGADemoHardeningStage {
 	return []AWSGADemoHardeningStage{
-		awsGADemoStage("onboarding", 1, "Onboarding and validation", "AWS connector setup and deterministic app/API validation fixtures are available for the operator walkthrough.", s.Validation.Status, s.Validation.Confidence, accountID, region, "/app/aws/connect", "aws-ga-demo://onboarding", s.Validation.EvidenceLinks, "Open connector diagnostics and run success, empty, degraded, and permission-denied fixtures.", firstAWSGADemoString(s.Validation.FailureReasons), now),
-		awsGADemoStage("discovery", 2, "Discovery and graph", "Machine identities, resources, edges, impacted paths, and evidence refs are ready for graph drilldown.", s.Graph.Status, s.Graph.Confidence, accountID, region, "/app/aws/graph", "aws-ga-demo://discovery-graph", s.Graph.EvidenceLinks, "Review graph nodes, edges, runtime paths, PassRole paths, and evidence refs.", firstAWSGADemoString(s.Graph.FailureReasons), now),
-		awsGADemoStage("agents", 3, "Agent identities", "Bedrock, AgentCore, gateway, capability, custom, and external provider agent identities are mapped without resolving secrets.", s.Agents.Status, s.Agents.Confidence, accountID, region, "/app/aws/agents", "aws-ga-demo://agent-identities", s.Agents.EvidenceLinks, "Open agent details to inspect provider, runtime role, tools, capability metadata, and credential-reference refs.", firstAWSGADemoString(s.Agents.FailureReasons), now),
-		awsGADemoStage("runtime", 4, "Runtime evidence", "Runtime traces and platform lag signals show what roles and agents actually did across observed evidence sources.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/runtime", "aws-ga-demo://runtime-evidence", s.Observability.EvidenceLinks, "Use runtime and observability filters to confirm lag, throttling, and source diagnostics.", firstAWSGADemoString(s.Observability.FailureReasons), now),
-		awsGADemoStage("risk", 5, "Risk and outcomes", "Executive outcome metrics summarize risk reduction, scan coverage, verified fixes, enforcement readiness, and remaining exposure.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, "/app/aws/outcomes", "aws-ga-demo://risk-outcomes", s.Outcomes.EvidenceLinks, "Review outcome metrics and remaining exposure before reporting GA readiness.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
-		awsGADemoStage("remediation", 6, "Remediation center", "Cases, approvals, dry-runs, live-action projections, verification, rollback, and audit trail rows are joined by case.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, "/app/aws/remediation/center", "aws-ga-demo://remediation-center", s.Remediation.EvidenceLinks, "Assign owners and keep approvals, dry-runs, and verification evidence attached before closure.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
-		awsGADemoStage("approval", 7, "Approval and safety gates", "Approval, RBAC, feature-flag, dry-run, kill-switch, and rollback gates remain operator-visible before any execution layer.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, "/app/aws/remediation/center", "aws-ga-demo://approval-safety", s.Remediation.EvidenceLinks, "Confirm approval and dry-run gates before treating a remediation as executable.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
-		awsGADemoStage("verification", 8, "Verification", "Post-remediation verification and rollback states are visible in remediation and observability signals.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/observability", "aws-ga-demo://verification", s.Observability.EvidenceLinks, "Investigate failed or rollback-planned verification outcomes before marking success.", firstAWSGADemoString(s.Observability.FailureReasons), now),
-		awsGADemoStage("governance", 9, "Governance reporting", "Decision, approval, remediation, enforcement, exception, and audit metadata can be exported without payloads.", s.Governance.Status, s.Governance.Confidence, accountID, region, "/app/aws/governance", "aws-ga-demo://governance-reporting", s.Governance.EvidenceLinks, "Export governance rows and resolve exceptions before executive handoff.", firstAWSGADemoString(s.Governance.FailureReasons), now),
-		awsGADemoStage("reporting", 10, "Executive handoff", "Leadership-ready coverage, risk, remediation, enforcement, governance, confidence, caveats, and evidence links are in one flow.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, "/app/aws/outcomes", "aws-ga-demo://executive-handoff", s.Outcomes.EvidenceLinks, "Share outcome view together with permission, limitation, and troubleshooting docs.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
-		awsGADemoStage("observability", 11, "GA operations", "Platform health metrics, traces, alerts, degraded states, and confidence handling are visible to operators.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/observability", "aws-ga-demo://ga-operations", s.Observability.EvidenceLinks, "Keep observability clear of critical alerts before GA handoff.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+		awsGADemoStage("onboarding", 1, "Onboarding and validation", "AWS connector setup and deterministic app/API validation fixtures are available for the operator walkthrough.", s.Validation.Status, s.Validation.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "connect"), "aws-ga-demo://onboarding", s.Validation.EvidenceLinks, "Open connector diagnostics and run success, empty, degraded, and permission-denied fixtures.", firstAWSGADemoString(s.Validation.FailureReasons), now),
+		awsGADemoStage("discovery", 2, "Discovery and graph", "Machine identities, resources, edges, impacted paths, and evidence refs are ready for graph drilldown.", s.Graph.Status, s.Graph.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "graph"), "aws-ga-demo://discovery-graph", s.Graph.EvidenceLinks, "Review graph nodes, edges, runtime paths, PassRole paths, and evidence refs.", firstAWSGADemoString(s.Graph.FailureReasons), now),
+		awsGADemoStage("agents", 3, "Agent identities", "Bedrock, AgentCore, gateway, capability, custom, and external provider agent identities are mapped without resolving secrets.", s.Agents.Status, s.Agents.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "agents"), "aws-ga-demo://agent-identities", s.Agents.EvidenceLinks, "Open agent details to inspect provider, runtime role, tools, capability metadata, and credential-reference refs.", firstAWSGADemoString(s.Agents.FailureReasons), now),
+		awsGADemoStage("runtime", 4, "Runtime evidence", "Runtime traces and platform lag signals show what roles and agents actually did across observed evidence sources.", s.Observability.Status, s.Observability.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "runtime"), "aws-ga-demo://runtime-evidence", s.Observability.EvidenceLinks, "Use runtime and observability filters to confirm lag, throttling, and source diagnostics.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+		awsGADemoStage("risk", 5, "Risk and outcomes", "Executive outcome metrics summarize risk reduction, scan coverage, verified fixes, enforcement readiness, and remaining exposure.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "outcomes"), "aws-ga-demo://risk-outcomes", s.Outcomes.EvidenceLinks, "Review outcome metrics and remaining exposure before reporting GA readiness.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
+		awsGADemoStage("remediation", 6, "Remediation center", "Cases, approvals, dry-runs, live-action projections, verification, rollback, and audit trail rows are joined by case.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "remediation/center"), "aws-ga-demo://remediation-center", s.Remediation.EvidenceLinks, "Assign owners and keep approvals, dry-runs, and verification evidence attached before closure.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
+		awsGADemoStage("approval", 7, "Approval and safety gates", "Approval, RBAC, feature-flag, dry-run, kill-switch, and rollback gates remain operator-visible before any execution layer.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "remediation/center"), "aws-ga-demo://approval-safety", s.Remediation.EvidenceLinks, "Confirm approval and dry-run gates before treating a remediation as executable.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
+		awsGADemoStage("verification", 8, "Verification", "Post-remediation verification and rollback states are visible in remediation and observability signals.", s.Observability.Status, s.Observability.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "observability"), "aws-ga-demo://verification", s.Observability.EvidenceLinks, "Investigate failed or rollback-planned verification outcomes before marking success.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+		awsGADemoStage("governance", 9, "Governance reporting", "Decision, approval, remediation, enforcement, exception, and audit metadata can be exported without payloads.", s.Governance.Status, s.Governance.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "governance"), "aws-ga-demo://governance-reporting", s.Governance.EvidenceLinks, "Export governance rows and resolve exceptions before executive handoff.", firstAWSGADemoString(s.Governance.FailureReasons), now),
+		awsGADemoStage("reporting", 10, "Executive handoff", "Leadership-ready coverage, risk, remediation, enforcement, governance, confidence, caveats, and evidence links are in one flow.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "outcomes"), "aws-ga-demo://executive-handoff", s.Outcomes.EvidenceLinks, "Share outcome view together with permission, limitation, and troubleshooting docs.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
+		awsGADemoStage("observability", 11, "GA operations", "Platform health metrics, traces, alerts, degraded states, and confidence handling are visible to operators.", s.Observability.Status, s.Observability.Confidence, accountID, region, awsGADemoHardeningAppRoute(tenantID, workspaceID, projectID, "observability"), "aws-ga-demo://ga-operations", s.Observability.EvidenceLinks, "Keep observability clear of critical alerts before GA handoff.", firstAWSGADemoString(s.Observability.FailureReasons), now),
 	}
+}
+
+func awsGADemoHardeningAppRoute(tenantID string, workspaceID string, projectID string, suffix string) string {
+	path := "aws"
+	suffix = strings.Trim(strings.TrimSpace(suffix), "/")
+	if suffix != "" {
+		path += "/" + suffix
+	}
+	return fmt.Sprintf(
+		"/app/%s/%s/%s?environment=%s",
+		url.PathEscape(tenantID),
+		url.PathEscape(workspaceID),
+		path,
+		url.QueryEscape(projectID),
+	)
 }
 
 func awsGADemoStage(id string, order int, title, summary, status string, confidence float64, accountID, region, route, evidenceRef string, evidenceLinks []string, nextAction, failureReason string, now time.Time) AWSGADemoHardeningStage {

--- a/internal/api/aws_ga_demo_hardening.go
+++ b/internal/api/aws_ga_demo_hardening.go
@@ -1,0 +1,515 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+const (
+	awsGADemoHardeningCurrentIssue = 1557
+	awsGADemoHardeningVersion      = "aws-ga-demo-hardening-v1"
+	awsGADemoHardeningBoundary     = "metadata_only_ga_demo_no_secret_values_no_customer_payloads"
+)
+
+// AWSGADemoHardeningRequest scopes the end-to-end AWS platform demo to one
+// connector and bounded operator filters. The response composes existing
+// read-only AWS contracts rather than creating another collector.
+type AWSGADemoHardeningRequest struct {
+	ConnectorID  string `json:"connector_id,omitempty"`
+	FixtureState string `json:"fixture_state,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Search       string `json:"search,omitempty"`
+}
+
+type AWSGADemoHardeningStage struct {
+	StageID          string    `json:"stage_id"`
+	Order            int       `json:"order"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary"`
+	Status           string    `json:"status"`
+	Confidence       float64   `json:"confidence"`
+	AccountID        string    `json:"account_id,omitempty"`
+	Region           string    `json:"region,omitempty"`
+	PrimaryRoute     string    `json:"primary_route"`
+	EvidenceRef      string    `json:"evidence_ref"`
+	EvidenceLinks    []string  `json:"evidence_links"`
+	EvidenceBoundary string    `json:"evidence_boundary"`
+	NextAction       string    `json:"next_action"`
+	FailureReason    string    `json:"failure_reason,omitempty"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type AWSGADemoHardeningReadinessCheck struct {
+	CheckID     string   `json:"check_id"`
+	Title       string   `json:"title"`
+	Status      string   `json:"status"`
+	Owner       string   `json:"owner"`
+	Summary     string   `json:"summary"`
+	Evidence    []string `json:"evidence"`
+	NextAction  string   `json:"next_action"`
+	Required    bool     `json:"required"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+type AWSGADemoHardeningSummary struct {
+	TotalStages        int            `json:"total_stages"`
+	FilteredStages     int            `json:"filtered_stages"`
+	ReadyStages        int            `json:"ready_stages"`
+	DegradedStages     int            `json:"degraded_stages"`
+	BlockedStages      int            `json:"blocked_stages"`
+	ReadinessChecks    int            `json:"readiness_checks"`
+	PassedChecks       int            `json:"passed_checks"`
+	RequiredChecks     int            `json:"required_checks"`
+	FailedChecks       int            `json:"failed_checks"`
+	PermissionWarnings int            `json:"permission_warnings"`
+	StatusCounts       map[string]int `json:"status_counts"`
+	StageCounts        map[string]int `json:"stage_counts"`
+}
+
+type AWSGADemoHardeningResult struct {
+	TenantID           string                             `json:"tenant_id"`
+	WorkspaceID        string                             `json:"workspace_id"`
+	ProjectID          string                             `json:"project_id"`
+	ConnectorID        string                             `json:"connector_id,omitempty"`
+	AccountID          string                             `json:"account_id,omitempty"`
+	Region             string                             `json:"region,omitempty"`
+	ParentIssueNumber  int                                `json:"parent_issue_number"`
+	ParentIssueRef     string                             `json:"parent_issue_ref"`
+	CurrentIssueNumber int                                `json:"current_issue_number"`
+	CurrentIssueRef    string                             `json:"current_issue_ref"`
+	Version            string                             `json:"version"`
+	Status             string                             `json:"status"`
+	FixtureState       string                             `json:"fixture_state,omitempty"`
+	Confidence         float64                            `json:"confidence"`
+	CalculationVersion string                             `json:"calculation_version"`
+	AppliedFilters     map[string]string                  `json:"applied_filters"`
+	Summary            AWSGADemoHardeningSummary          `json:"summary"`
+	Stages             []AWSGADemoHardeningStage          `json:"stages"`
+	ReadinessChecks    []AWSGADemoHardeningReadinessCheck `json:"readiness_checks"`
+	Permissions        []string                           `json:"permissions"`
+	SafetyNotes        []string                           `json:"safety_notes"`
+	Limitations        []string                           `json:"limitations"`
+	Troubleshooting    []string                           `json:"troubleshooting"`
+	Caveats            []string                           `json:"caveats"`
+	FailureReasons     []string                           `json:"failure_reasons"`
+	RemediationHints   []string                           `json:"remediation_hints"`
+	EvidenceLinks      []string                           `json:"evidence_links"`
+	GeneratedAt        time.Time                          `json:"generated_at"`
+	UpdatedAt          time.Time                          `json:"updated_at"`
+}
+
+type awsGADemoHardeningSources struct {
+	Validation    AWSPlatformValidationHarnessResult
+	Agents        AWSAIAgentIdentityInventoryResult
+	Graph         AWSGraphExplorerResult
+	Remediation   AWSRemediationCenterResult
+	Governance    AWSGovernanceAuditReportingResult
+	Outcomes      AWSExecutiveOutcomeViewResult
+	Observability AWSPlatformObservabilityResult
+}
+
+func (s *Service) GetAWSGADemoHardening(ctx context.Context, workspaceID string, projectID string, request AWSGADemoHardeningRequest) (AWSGADemoHardeningResult, error) {
+	if !validAWSGADemoHardeningFilter(request) {
+		return AWSGADemoHardeningResult{}, ErrInvalidAWSConnectionRequest
+	}
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	connection, hasConnection, err := s.awsBaselineConnection(ctx, project, strings.TrimSpace(request.ConnectorID))
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	now := s.Now().UTC()
+	fixtureState := normalizeAWSGovernanceAuditReportingFixtureState(request.FixtureState, connection, hasConnection)
+	if fixtureState == "" {
+		return AWSGADemoHardeningResult{}, ErrInvalidAWSConnectionRequest
+	}
+	sourceFixtureState := fixtureState
+	if strings.TrimSpace(request.FixtureState) == "" && hasConnection && connection.Connected {
+		sourceFixtureState = ""
+	}
+	connectorID := firstNonEmptyAWSValue(connection.ConnectorID, strings.TrimSpace(request.ConnectorID))
+	sourceAccountID := awsExecutiveOutcomeSourceScopeFilter(request.AccountID)
+	sourceRegion := awsExecutiveOutcomeSourceScopeFilter(request.Region)
+	accountID := awsExecutiveOutcomeScopeValue(request.AccountID, connection.AccountID, "123456789012")
+	region := awsExecutiveOutcomeScopeValue(request.Region, connection.Region, "us-east-1")
+
+	validation, err := s.GetAWSPlatformValidationHarness(ctx, workspaceID, projectID, AWSPlatformValidationHarnessRequest{ConnectorID: connectorID})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	agents, err := s.GetAWSAIAgentIdentityInventory(ctx, workspaceID, projectID, AWSAIAgentIdentityInventoryRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	graph, err := s.GetAWSGraphExplorer(ctx, workspaceID, projectID, AWSGraphExplorerRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	remediation, err := s.GetAWSRemediationCenter(ctx, workspaceID, projectID, AWSRemediationCenterRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	governance, err := s.GetAWSGovernanceAuditReporting(ctx, workspaceID, projectID, AWSGovernanceAuditReportingRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	outcomes, err := s.GetAWSExecutiveOutcomeView(ctx, workspaceID, projectID, AWSExecutiveOutcomeViewRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+	observability, err := s.GetAWSPlatformObservability(ctx, workspaceID, projectID, AWSPlatformObservabilityRequest{
+		ConnectorID:  connectorID,
+		FixtureState: sourceFixtureState,
+		AccountID:    sourceAccountID,
+		Region:       sourceRegion,
+	})
+	if err != nil {
+		return AWSGADemoHardeningResult{}, err
+	}
+
+	sources := awsGADemoHardeningSources{
+		Validation:    validation,
+		Agents:        agents,
+		Graph:         graph,
+		Remediation:   remediation,
+		Governance:    governance,
+		Outcomes:      outcomes,
+		Observability: observability,
+	}
+	stages := awsGADemoHardeningStages(sources, accountID, region, now)
+	filteredStages, applied := filterAWSGADemoHardeningStages(stages, request)
+	checks := awsGADemoHardeningReadinessChecks(sources)
+	summary := summarizeAWSGADemoHardening(stages, filteredStages, checks)
+	status, confidence := summarizeAWSGADemoHardeningStatus(filteredStages, checks)
+
+	return AWSGADemoHardeningResult{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        project.WorkspaceID,
+		ProjectID:          project.ProjectID,
+		ConnectorID:        connectorID,
+		AccountID:          accountID,
+		Region:             region,
+		ParentIssueNumber:  awsPlatformDependencyParentIssue,
+		ParentIssueRef:     awsIssueRef(awsPlatformDependencyParentIssue),
+		CurrentIssueNumber: awsGADemoHardeningCurrentIssue,
+		CurrentIssueRef:    awsIssueRef(awsGADemoHardeningCurrentIssue),
+		Version:            awsGADemoHardeningVersion,
+		Status:             status,
+		FixtureState:       sourceFixtureState,
+		Confidence:         confidence,
+		CalculationVersion: awsGADemoHardeningVersion,
+		AppliedFilters:     applied,
+		Summary:            summary,
+		Stages:             filteredStages,
+		ReadinessChecks:    checks,
+		Permissions:        awsGADemoHardeningPermissions(),
+		SafetyNotes:        awsGADemoHardeningSafetyNotes(),
+		Limitations:        awsGADemoHardeningLimitations(),
+		Troubleshooting:    awsGADemoHardeningTroubleshooting(sources),
+		Caveats:            awsGADemoHardeningCaveats(),
+		FailureReasons:     awsGADemoHardeningFailureReasons(sources),
+		RemediationHints:   awsGADemoHardeningRemediationHints(sources),
+		EvidenceLinks:      awsGADemoHardeningEvidenceLinks(sources),
+		GeneratedAt:        now,
+		UpdatedAt:          now,
+	}, nil
+}
+
+func validAWSGADemoHardeningFilter(request AWSGADemoHardeningRequest) bool {
+	return validAWSPlatformObservabilityToken(request.Status, []string{awsPlatformDependencyStatusReady, awsPlatformDependencyStatusDegraded, awsPlatformDependencyStatusBlocked}) &&
+		validAWSPlatformObservabilityToken(request.Stage, []string{"onboarding", "discovery", "agents", "runtime", "risk", "remediation", "approval", "verification", "governance", "reporting", "observability"})
+}
+
+func awsGADemoHardeningStages(s awsGADemoHardeningSources, accountID, region string, now time.Time) []AWSGADemoHardeningStage {
+	return []AWSGADemoHardeningStage{
+		awsGADemoStage("onboarding", 1, "Onboarding and validation", "AWS connector setup and deterministic app/API validation fixtures are available for the operator walkthrough.", s.Validation.Status, s.Validation.Confidence, accountID, region, "/app/aws/connect", "aws-ga-demo://onboarding", s.Validation.EvidenceLinks, "Open connector diagnostics and run success, empty, degraded, and permission-denied fixtures.", firstAWSGADemoString(s.Validation.FailureReasons), now),
+		awsGADemoStage("discovery", 2, "Discovery and graph", "Machine identities, resources, edges, impacted paths, and evidence refs are ready for graph drilldown.", s.Graph.Status, s.Graph.Confidence, accountID, region, "/app/aws/graph", "aws-ga-demo://discovery-graph", s.Graph.EvidenceLinks, "Review graph nodes, edges, runtime paths, PassRole paths, and evidence refs.", firstAWSGADemoString(s.Graph.FailureReasons), now),
+		awsGADemoStage("agents", 3, "Agent identities", "Bedrock, AgentCore, gateway, capability, custom, and external provider agent identities are mapped without resolving secrets.", s.Agents.Status, s.Agents.Confidence, accountID, region, "/app/aws/agents", "aws-ga-demo://agent-identities", s.Agents.EvidenceLinks, "Open agent details to inspect provider, runtime role, tools, capability metadata, and credential-reference refs.", firstAWSGADemoString(s.Agents.FailureReasons), now),
+		awsGADemoStage("runtime", 4, "Runtime evidence", "Runtime traces and platform lag signals show what roles and agents actually did across observed evidence sources.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/runtime", "aws-ga-demo://runtime-evidence", s.Observability.EvidenceLinks, "Use runtime and observability filters to confirm lag, throttling, and source diagnostics.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+		awsGADemoStage("risk", 5, "Risk and outcomes", "Executive outcome metrics summarize risk reduction, scan coverage, verified fixes, enforcement readiness, and remaining exposure.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, "/app/aws/outcomes", "aws-ga-demo://risk-outcomes", s.Outcomes.EvidenceLinks, "Review outcome metrics and remaining exposure before reporting GA readiness.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
+		awsGADemoStage("remediation", 6, "Remediation center", "Cases, approvals, dry-runs, live-action projections, verification, rollback, and audit trail rows are joined by case.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, "/app/aws/remediation/center", "aws-ga-demo://remediation-center", s.Remediation.EvidenceLinks, "Assign owners and keep approvals, dry-runs, and verification evidence attached before closure.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
+		awsGADemoStage("approval", 7, "Approval and safety gates", "Approval, RBAC, feature-flag, dry-run, kill-switch, and rollback gates remain operator-visible before any execution layer.", s.Remediation.Status, s.Remediation.Confidence, accountID, region, "/app/aws/remediation/center", "aws-ga-demo://approval-safety", s.Remediation.EvidenceLinks, "Confirm approval and dry-run gates before treating a remediation as executable.", firstAWSGADemoString(s.Remediation.FailureReasons), now),
+		awsGADemoStage("verification", 8, "Verification", "Post-remediation verification and rollback states are visible in remediation and observability signals.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/observability", "aws-ga-demo://verification", s.Observability.EvidenceLinks, "Investigate failed or rollback-planned verification outcomes before marking success.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+		awsGADemoStage("governance", 9, "Governance reporting", "Decision, approval, remediation, enforcement, exception, and audit metadata can be exported without payloads.", s.Governance.Status, s.Governance.Confidence, accountID, region, "/app/aws/governance", "aws-ga-demo://governance-reporting", s.Governance.EvidenceLinks, "Export governance rows and resolve exceptions before executive handoff.", firstAWSGADemoString(s.Governance.FailureReasons), now),
+		awsGADemoStage("reporting", 10, "Executive handoff", "Leadership-ready coverage, risk, remediation, enforcement, governance, confidence, caveats, and evidence links are in one flow.", s.Outcomes.Status, s.Outcomes.Confidence, accountID, region, "/app/aws/outcomes", "aws-ga-demo://executive-handoff", s.Outcomes.EvidenceLinks, "Share outcome view together with permission, limitation, and troubleshooting docs.", firstAWSGADemoString(s.Outcomes.FailureReasons), now),
+		awsGADemoStage("observability", 11, "GA operations", "Platform health metrics, traces, alerts, degraded states, and confidence handling are visible to operators.", s.Observability.Status, s.Observability.Confidence, accountID, region, "/app/aws/observability", "aws-ga-demo://ga-operations", s.Observability.EvidenceLinks, "Keep observability clear of critical alerts before GA handoff.", firstAWSGADemoString(s.Observability.FailureReasons), now),
+	}
+}
+
+func awsGADemoStage(id string, order int, title, summary, status string, confidence float64, accountID, region, route, evidenceRef string, evidenceLinks []string, nextAction, failureReason string, now time.Time) AWSGADemoHardeningStage {
+	return AWSGADemoHardeningStage{
+		StageID:          id,
+		Order:            order,
+		Title:            title,
+		Summary:          summary,
+		Status:           awsGADemoHardeningStatus(status),
+		Confidence:       confidence,
+		AccountID:        accountID,
+		Region:           region,
+		PrimaryRoute:     route,
+		EvidenceRef:      evidenceRef,
+		EvidenceLinks:    evidenceLinks,
+		EvidenceBoundary: awsGADemoHardeningBoundary,
+		NextAction:       nextAction,
+		FailureReason:    failureReason,
+		UpdatedAt:        now,
+	}
+}
+
+func filterAWSGADemoHardeningStages(stages []AWSGADemoHardeningStage, request AWSGADemoHardeningRequest) ([]AWSGADemoHardeningStage, map[string]string) {
+	applied := map[string]string{}
+	filtered := make([]AWSGADemoHardeningStage, 0, len(stages))
+	matchToken := func(value, want string) bool {
+		want = strings.ToLower(strings.TrimSpace(want))
+		if want == "" || want == "all" {
+			return true
+		}
+		return strings.ToLower(strings.TrimSpace(value)) == want
+	}
+	matchSearch := func(stage AWSGADemoHardeningStage) bool {
+		search := strings.ToLower(strings.TrimSpace(request.Search))
+		if search == "" {
+			return true
+		}
+		return strings.Contains(strings.ToLower(strings.Join([]string{stage.StageID, stage.Title, stage.Summary, stage.Status, stage.EvidenceRef, stage.NextAction, stage.FailureReason}, " ")), search)
+	}
+	for _, stage := range stages {
+		if !matchToken(stage.StageID, request.Stage) || !matchToken(stage.Status, request.Status) || !matchToken(stage.AccountID, request.AccountID) || !matchToken(stage.Region, request.Region) || !matchSearch(stage) {
+			continue
+		}
+		filtered = append(filtered, stage)
+	}
+	setAppliedAWSExecutiveOutcomeFilter(applied, "connector_id", request.ConnectorID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "fixture_state", request.FixtureState)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "account_id", request.AccountID)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "region", request.Region)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "stage", request.Stage)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "status", request.Status)
+	setAppliedAWSExecutiveOutcomeFilter(applied, "search", request.Search)
+	return filtered, applied
+}
+
+func summarizeAWSGADemoHardening(all []AWSGADemoHardeningStage, filtered []AWSGADemoHardeningStage, checks []AWSGADemoHardeningReadinessCheck) AWSGADemoHardeningSummary {
+	summary := AWSGADemoHardeningSummary{
+		TotalStages:     len(all),
+		FilteredStages:  len(filtered),
+		ReadinessChecks: len(checks),
+		StatusCounts:    map[string]int{},
+		StageCounts:     map[string]int{},
+	}
+	for _, stage := range filtered {
+		incrementCount(summary.StatusCounts, stage.Status)
+		incrementCount(summary.StageCounts, stage.StageID)
+		switch stage.Status {
+		case awsPlatformDependencyStatusBlocked:
+			summary.BlockedStages++
+		case awsPlatformDependencyStatusDegraded:
+			summary.DegradedStages++
+		default:
+			summary.ReadyStages++
+		}
+	}
+	for _, check := range checks {
+		if check.Required {
+			summary.RequiredChecks++
+		}
+		switch check.Status {
+		case awsPlatformDependencyStatusBlocked:
+			summary.FailedChecks++
+		case awsPlatformDependencyStatusDegraded:
+			summary.PermissionWarnings++
+		default:
+			summary.PassedChecks++
+		}
+	}
+	return summary
+}
+
+func summarizeAWSGADemoHardeningStatus(stages []AWSGADemoHardeningStage, checks []AWSGADemoHardeningReadinessCheck) (string, float64) {
+	if len(stages) == 0 {
+		return awsPlatformDependencyStatusBlocked, 0.4
+	}
+	status := awsPlatformDependencyStatusReady
+	confidences := make([]float64, 0, len(stages)+len(checks))
+	for _, stage := range stages {
+		confidences = append(confidences, stage.Confidence)
+		if stage.Status == awsPlatformDependencyStatusBlocked {
+			status = awsPlatformDependencyStatusBlocked
+		} else if stage.Status == awsPlatformDependencyStatusDegraded && status == awsPlatformDependencyStatusReady {
+			status = awsPlatformDependencyStatusDegraded
+		}
+	}
+	for _, check := range checks {
+		if check.Required && check.Status == awsPlatformDependencyStatusBlocked {
+			status = awsPlatformDependencyStatusBlocked
+		} else if check.Status == awsPlatformDependencyStatusDegraded && status == awsPlatformDependencyStatusReady {
+			status = awsPlatformDependencyStatusDegraded
+		}
+	}
+	return status, averageFloat64(confidences...)
+}
+
+func awsGADemoHardeningReadinessChecks(s awsGADemoHardeningSources) []AWSGADemoHardeningReadinessCheck {
+	return []AWSGADemoHardeningReadinessCheck{
+		{CheckID: "validation-fixtures", Title: "App and API fixtures", Status: awsGADemoHardeningStatus(s.Validation.Status), Owner: "platform", Summary: "Success, empty, degraded, partial-failure, permission-denied, and unsupported-service scenarios are documented for app validation.", Evidence: s.Validation.EvidenceLinks, NextAction: "Run the validation harness before merging GA-facing AWS changes.", Required: true},
+		{CheckID: "read-only-boundary", Title: "Read-only safety boundary", Status: awsPlatformDependencyStatusReady, Owner: "security", Summary: "The GA demo composes metadata-only evidence and does not call AWS write APIs.", Evidence: []string{"/docs/aws-ga-demo-hardening", "/docs/aws-platform-baseline"}, NextAction: "Keep remediation execution behind approval and safety-gated endpoints.", Required: true},
+		{CheckID: "permission-docs", Title: "Permission documentation", Status: awsPlatformDependencyStatusReady, Owner: "security", Summary: "Prerequisites list IAM read APIs and explicitly excludes secret values, prompts, completions, browser pages, database rows, object contents, and customer payloads.", Evidence: []string{"/docs/aws-ga-demo-hardening", "/docs/aws-service-collector-contract"}, NextAction: "Attach permission docs to onboarding and handoff material.", Required: true, Permissions: awsGADemoHardeningPermissions()},
+		{CheckID: "source-confidence", Title: "Source confidence", Status: awsGADemoHardeningStatus(s.Observability.Status), Owner: "operations", Summary: "Platform observability carries confidence, trace, degraded, and alert state for GA checks.", Evidence: s.Observability.EvidenceLinks, NextAction: "Clear blocked observability signals before marking GA-ready.", Required: true},
+		{CheckID: "governance-export", Title: "Governance export", Status: awsGADemoHardeningStatus(s.Governance.Status), Owner: "governance", Summary: "Governance reporting exposes export-safe decision, approval, remediation, enforcement, exception, and audit metadata.", Evidence: s.Governance.EvidenceLinks, NextAction: "Resolve governance exceptions before executive handoff.", Required: false},
+	}
+}
+
+func awsGADemoHardeningStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case awsPlatformDependencyStatusBlocked, "permission_denied":
+		return awsPlatformDependencyStatusBlocked
+	case awsPlatformDependencyStatusDegraded, "partial_failure":
+		return awsPlatformDependencyStatusDegraded
+	default:
+		return awsPlatformDependencyStatusReady
+	}
+}
+
+func awsGADemoHardeningEvidenceLinks(s awsGADemoHardeningSources) []string {
+	links := []string{
+		awsIssueURL(awsPlatformDependencyParentIssue),
+		awsIssueURL(awsGADemoHardeningCurrentIssue),
+		"/docs/aws-ga-demo-hardening",
+		"/docs/aws-platform-baseline",
+		"/docs/aws-platform-validation-harness",
+		"/docs/aws-service-collector-contract",
+	}
+	links = append(links, s.Validation.EvidenceLinks...)
+	links = append(links, s.Agents.EvidenceLinks...)
+	links = append(links, s.Graph.EvidenceLinks...)
+	links = append(links, s.Remediation.EvidenceLinks...)
+	links = append(links, s.Governance.EvidenceLinks...)
+	links = append(links, s.Outcomes.EvidenceLinks...)
+	links = append(links, s.Observability.EvidenceLinks...)
+	return dedupeStrings(links)
+}
+
+func awsGADemoHardeningFailureReasons(s awsGADemoHardeningSources) []string {
+	reasons := []string{}
+	reasons = append(reasons, s.Validation.FailureReasons...)
+	reasons = append(reasons, s.Agents.FailureReasons...)
+	reasons = append(reasons, s.Graph.FailureReasons...)
+	reasons = append(reasons, s.Remediation.FailureReasons...)
+	reasons = append(reasons, s.Governance.FailureReasons...)
+	reasons = append(reasons, s.Outcomes.FailureReasons...)
+	reasons = append(reasons, s.Observability.FailureReasons...)
+	return dedupeStrings(reasons)
+}
+
+func awsGADemoHardeningRemediationHints(s awsGADemoHardeningSources) []string {
+	hints := []string{}
+	hints = append(hints, s.Validation.RemediationHints...)
+	hints = append(hints, s.Agents.RemediationHints...)
+	hints = append(hints, s.Graph.RemediationHints...)
+	hints = append(hints, s.Remediation.RemediationHints...)
+	hints = append(hints, s.Governance.RemediationHints...)
+	hints = append(hints, s.Outcomes.RemediationHints...)
+	hints = append(hints, s.Observability.RemediationHints...)
+	return dedupeStrings(hints)
+}
+
+func awsGADemoHardeningTroubleshooting(s awsGADemoHardeningSources) []string {
+	items := []string{
+		"If onboarding is blocked, verify the connector role ARN, external ID, account ID, and region in the AWS connection diagnostics.",
+		"If discovery is empty, run the validation harness with empty and degraded fixtures before treating missing rows as success.",
+		"If remediation or governance is degraded, inspect case approvals, dry-run outcomes, verification states, and governance exceptions.",
+		"If observability is degraded, review queue lag, throttling, collector failures, runtime lag, and verification alerts.",
+	}
+	items = append(items, awsGADemoHardeningFailureReasons(s)...)
+	return dedupeStrings(items)
+}
+
+func awsGADemoHardeningPermissions() []string {
+	return []string{
+		"sts:GetCallerIdentity",
+		"iam:GetRole",
+		"iam:ListRoles",
+		"iam:GetPolicy",
+		"iam:GetPolicyVersion",
+		"iam:ListAttachedRolePolicies",
+		"iam:ListRolePolicies",
+		"iam:GetRolePolicy",
+		"access-analyzer:ListAnalyzers",
+		"access-analyzer:ListFindings",
+		"cloudtrail:LookupEvents",
+		"organizations:ListAccounts",
+		"organizations:ListRoots",
+		"organizations:ListOrganizationalUnitsForParent",
+		"lambda:ListFunctions",
+		"ecs:ListClusters",
+		"ecs:ListServices",
+		"eks:ListClusters",
+		"secretsmanager:ListSecrets",
+		"kms:ListKeys",
+		"s3:ListAllMyBuckets",
+	}
+}
+
+func awsGADemoHardeningSafetyNotes() []string {
+	return []string{
+		"Read-only: this endpoint does not mutate AWS IAM, resource policies, permission boundaries, SCPs, secrets, objects, queues, databases, agents, or Identrail governance state.",
+		"Metadata-only: secret values, prompts, completions, browser pages, code-interpreter output, database rows, object contents, and customer payloads are never returned.",
+		"Tenant/workspace/project/connector/account/region boundaries are preserved by the same scoped services used by the underlying AWS surfaces.",
+		"Remediation and enforcement remain projections unless a downstream, approved, safety-gated execution endpoint is explicitly invoked.",
+	}
+}
+
+func awsGADemoHardeningLimitations() []string {
+	return []string{
+		"The GA demo reflects the evidence available to the configured connector and fixture state; it does not prove coverage for services outside the configured collector contracts.",
+		"Permission-denied and degraded states are first-class outputs, not successful collection results.",
+		"Executive and governance metrics are derived from existing metadata-only source contracts and should be interpreted with their attached confidence and caveats.",
+	}
+}
+
+func awsGADemoHardeningCaveats() []string {
+	return []string{
+		"GA readiness depends on current connector permissions, source freshness, and unresolved degraded or blocked stage state.",
+		"Evidence links point to Identrail routes and documentation, not raw AWS customer payloads.",
+	}
+}
+
+func firstAWSGADemoString(values []string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/api/aws_ga_demo_hardening.go
+++ b/internal/api/aws_ga_demo_hardening.go
@@ -210,8 +210,9 @@ func (s *Service) GetAWSGADemoHardening(ctx context.Context, workspaceID string,
 	stages := awsGADemoHardeningStages(sources, accountID, region, now)
 	filteredStages, applied := filterAWSGADemoHardeningStages(stages, request)
 	checks := awsGADemoHardeningReadinessChecks(sources)
-	summary := summarizeAWSGADemoHardening(stages, filteredStages, checks)
-	status, confidence := summarizeAWSGADemoHardeningStatus(filteredStages, checks)
+	filteredChecks := filterAWSGADemoHardeningReadinessChecks(checks, request)
+	summary := summarizeAWSGADemoHardening(stages, filteredStages, filteredChecks)
+	status, confidence := summarizeAWSGADemoHardeningStatus(filteredStages, filteredChecks)
 
 	return AWSGADemoHardeningResult{
 		TenantID:           scope.TenantID,
@@ -232,7 +233,7 @@ func (s *Service) GetAWSGADemoHardening(ctx context.Context, workspaceID string,
 		AppliedFilters:     applied,
 		Summary:            summary,
 		Stages:             filteredStages,
-		ReadinessChecks:    checks,
+		ReadinessChecks:    filteredChecks,
 		Permissions:        awsGADemoHardeningPermissions(),
 		SafetyNotes:        awsGADemoHardeningSafetyNotes(),
 		Limitations:        awsGADemoHardeningLimitations(),
@@ -320,6 +321,41 @@ func filterAWSGADemoHardeningStages(stages []AWSGADemoHardeningStage, request AW
 	return filtered, applied
 }
 
+func filterAWSGADemoHardeningReadinessChecks(checks []AWSGADemoHardeningReadinessCheck, request AWSGADemoHardeningRequest) []AWSGADemoHardeningReadinessCheck {
+	filtered := make([]AWSGADemoHardeningReadinessCheck, 0, len(checks))
+	matchStatus := func(status string) bool {
+		want := strings.ToLower(strings.TrimSpace(request.Status))
+		if want == "" || want == "all" {
+			return true
+		}
+		return strings.ToLower(strings.TrimSpace(status)) == want
+	}
+	matchSearch := func(check AWSGADemoHardeningReadinessCheck) bool {
+		search := strings.ToLower(strings.TrimSpace(request.Search))
+		if search == "" {
+			return true
+		}
+		values := []string{
+			check.CheckID,
+			check.Title,
+			check.Status,
+			check.Owner,
+			check.Summary,
+			check.NextAction,
+		}
+		values = append(values, check.Evidence...)
+		values = append(values, check.Permissions...)
+		return strings.Contains(strings.ToLower(strings.Join(values, " ")), search)
+	}
+	for _, check := range checks {
+		if !matchStatus(check.Status) || !matchSearch(check) {
+			continue
+		}
+		filtered = append(filtered, check)
+	}
+	return filtered
+}
+
 func summarizeAWSGADemoHardening(all []AWSGADemoHardeningStage, filtered []AWSGADemoHardeningStage, checks []AWSGADemoHardeningReadinessCheck) AWSGADemoHardeningSummary {
 	summary := AWSGADemoHardeningSummary{
 		TotalStages:     len(all),
@@ -392,12 +428,14 @@ func awsGADemoHardeningReadinessChecks(s awsGADemoHardeningSources) []AWSGADemoH
 
 func awsGADemoHardeningStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
+	case awsPlatformDependencyStatusReady:
+		return awsPlatformDependencyStatusReady
 	case awsPlatformDependencyStatusBlocked, "permission_denied":
 		return awsPlatformDependencyStatusBlocked
 	case awsPlatformDependencyStatusDegraded, "partial_failure":
 		return awsPlatformDependencyStatusDegraded
 	default:
-		return awsPlatformDependencyStatusReady
+		return awsPlatformDependencyStatusDegraded
 	}
 }
 

--- a/internal/api/aws_ga_demo_hardening_test.go
+++ b/internal/api/aws_ga_demo_hardening_test.go
@@ -86,12 +86,47 @@ func TestAWSGADemoHardeningFiltersStageStatusAndSearch(t *testing.T) {
 	if len(result.Stages) != 1 || result.Stages[0].StageID != "governance" {
 		t.Fatalf("expected only governance stage, got %+v", result.Stages)
 	}
+	for _, check := range result.ReadinessChecks {
+		if check.CheckID != "governance-export" {
+			t.Fatalf("expected search-filtered readiness checks to stay relevant, got %+v", result.ReadinessChecks)
+		}
+	}
 	if _, err := svc.GetAWSGADemoHardening(defaultScopeContext(), ws, "project-ga-demo-hardening-filter", AWSGADemoHardeningRequest{
 		ConnectorID:  "aws-prod",
 		FixtureState: "success",
 		Stage:        "not-a-stage",
 	}); err != ErrInvalidAWSConnectionRequest {
 		t.Fatalf("expected invalid stage to be rejected, got %v", err)
+	}
+}
+
+func TestAWSGADemoHardeningFiltersReadinessChecksOutOfStatus(t *testing.T) {
+	stages := []AWSGADemoHardeningStage{
+		{StageID: "onboarding", Status: awsPlatformDependencyStatusReady, Confidence: 0.95},
+	}
+	checks := []AWSGADemoHardeningReadinessCheck{
+		{CheckID: "ready-check", Title: "Ready check", Status: awsPlatformDependencyStatusReady, Required: true},
+		{CheckID: "blocked-check", Title: "Blocked check", Status: awsPlatformDependencyStatusBlocked, Required: true},
+	}
+
+	filteredChecks := filterAWSGADemoHardeningReadinessChecks(checks, AWSGADemoHardeningRequest{Status: awsPlatformDependencyStatusReady})
+	status, confidence := summarizeAWSGADemoHardeningStatus(stages, filteredChecks)
+	if len(filteredChecks) != 1 || filteredChecks[0].CheckID != "ready-check" {
+		t.Fatalf("expected only ready readiness check, got %+v", filteredChecks)
+	}
+	if status != awsPlatformDependencyStatusReady || confidence != 0.95 {
+		t.Fatalf("filtered-out blocked check should not affect status, got status=%q confidence=%v", status, confidence)
+	}
+}
+
+func TestAWSGADemoHardeningUnknownStatusDegrades(t *testing.T) {
+	for _, status := range []string{"", "unexpected", "ok"} {
+		if got := awsGADemoHardeningStatus(status); got != awsPlatformDependencyStatusDegraded {
+			t.Fatalf("expected unknown status %q to degrade, got %q", status, got)
+		}
+	}
+	if got := awsGADemoHardeningStatus(awsPlatformDependencyStatusReady); got != awsPlatformDependencyStatusReady {
+		t.Fatalf("expected ready to remain ready, got %q", got)
 	}
 }
 

--- a/internal/api/aws_ga_demo_hardening_test.go
+++ b/internal/api/aws_ga_demo_hardening_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +50,12 @@ func TestGetAWSGADemoHardeningBuildsContract(t *testing.T) {
 	for _, stage := range result.Stages {
 		if stage.EvidenceBoundary != awsGADemoHardeningBoundary {
 			t.Fatalf("unexpected evidence boundary: %+v", stage)
+		}
+		if stage.PrimaryRoute == "" || stage.PrimaryRoute[0:13] != "/app/default/" {
+			t.Fatalf("expected scoped app route, got %+v", stage)
+		}
+		if !strings.Contains(stage.PrimaryRoute, "?environment=project-ga-demo-hardening") {
+			t.Fatalf("expected stage route to preserve project environment, got %+v", stage)
 		}
 		if _, ok := required[stage.StageID]; ok {
 			required[stage.StageID] = true

--- a/internal/api/aws_ga_demo_hardening_test.go
+++ b/internal/api/aws_ga_demo_hardening_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newGADemoHardeningService(t *testing.T, project string, now time.Time) (*Service, string) {
+	t.Helper()
+	return newBlastRadiusService(t, project, now)
+}
+
+func TestGetAWSGADemoHardeningBuildsContract(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	svc, ws := newGADemoHardeningService(t, "project-ga-demo-hardening", now)
+
+	result, err := svc.GetAWSGADemoHardening(defaultScopeContext(), ws, "project-ga-demo-hardening", AWSGADemoHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+	})
+	if err != nil {
+		t.Fatalf("get ga demo hardening: %v", err)
+	}
+	if result.CurrentIssueRef != "#1557" || result.Version != awsGADemoHardeningVersion {
+		t.Fatalf("unexpected issue/version: %+v", result)
+	}
+	if result.Summary.TotalStages != 11 || result.Summary.FilteredStages != len(result.Stages) {
+		t.Fatalf("unexpected stage summary: %+v stages=%d", result.Summary, len(result.Stages))
+	}
+	required := map[string]bool{
+		"onboarding":    false,
+		"discovery":     false,
+		"agents":        false,
+		"runtime":       false,
+		"risk":          false,
+		"remediation":   false,
+		"approval":      false,
+		"verification":  false,
+		"governance":    false,
+		"reporting":     false,
+		"observability": false,
+	}
+	for _, stage := range result.Stages {
+		if stage.EvidenceBoundary != awsGADemoHardeningBoundary {
+			t.Fatalf("unexpected evidence boundary: %+v", stage)
+		}
+		if _, ok := required[stage.StageID]; ok {
+			required[stage.StageID] = true
+		}
+	}
+	for id, seen := range required {
+		if !seen {
+			t.Fatalf("missing ga demo stage %q in %+v", id, result.Stages)
+		}
+	}
+	if len(result.ReadinessChecks) == 0 || result.Summary.RequiredChecks == 0 {
+		t.Fatalf("expected readiness checks, got %+v", result)
+	}
+	if len(result.Permissions) == 0 || len(result.SafetyNotes) == 0 || len(result.Limitations) == 0 {
+		t.Fatalf("expected permission, safety, and limitation docs in contract: %+v", result)
+	}
+}
+
+func TestAWSGADemoHardeningFiltersStageStatusAndSearch(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 5, 0, 0, time.UTC)
+	svc, ws := newGADemoHardeningService(t, "project-ga-demo-hardening-filter", now)
+
+	result, err := svc.GetAWSGADemoHardening(defaultScopeContext(), ws, "project-ga-demo-hardening-filter", AWSGADemoHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Stage:        "governance",
+		Search:       "export",
+	})
+	if err != nil {
+		t.Fatalf("get filtered ga demo hardening: %v", err)
+	}
+	if result.AppliedFilters["stage"] != "governance" || result.AppliedFilters["search"] != "export" {
+		t.Fatalf("expected applied filters, got %+v", result.AppliedFilters)
+	}
+	if len(result.Stages) != 1 || result.Stages[0].StageID != "governance" {
+		t.Fatalf("expected only governance stage, got %+v", result.Stages)
+	}
+	if _, err := svc.GetAWSGADemoHardening(defaultScopeContext(), ws, "project-ga-demo-hardening-filter", AWSGADemoHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "success",
+		Stage:        "not-a-stage",
+	}); err != ErrInvalidAWSConnectionRequest {
+		t.Fatalf("expected invalid stage to be rejected, got %v", err)
+	}
+}
+
+func TestAWSGADemoHardeningPermissionDeniedIsExplicit(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 10, 0, 0, time.UTC)
+	svc, ws := newGADemoHardeningService(t, "project-ga-demo-hardening-denied", now)
+
+	result, err := svc.GetAWSGADemoHardening(defaultScopeContext(), ws, "project-ga-demo-hardening-denied", AWSGADemoHardeningRequest{
+		ConnectorID:  "aws-prod",
+		FixtureState: "permission_denied",
+	})
+	if err != nil {
+		t.Fatalf("get permission denied ga demo hardening: %v", err)
+	}
+	if result.Status != awsPlatformDependencyStatusBlocked || result.Summary.BlockedStages == 0 {
+		t.Fatalf("expected blocked ga demo hardening, got %+v", result)
+	}
+	if len(result.Troubleshooting) == 0 || len(result.FailureReasons) == 0 {
+		t.Fatalf("expected troubleshooting and failure reasons for permission denied, got %+v", result)
+	}
+}
+
+func TestRouterAWSGADemoHardening(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 15, 0, 0, time.UTC)
+	svc, _ := newGADemoHardeningService(t, "project-ga-demo-hardening-route", now)
+	r := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{})
+
+	query := url.Values{}
+	query.Set("connector_id", "aws-prod")
+	query.Set("fixture_state", "success")
+	query.Set("stage", "governance")
+	resp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/default/projects/project-ga-demo-hardening-route/aws/ga-demo-hardening?"+query.Encode(), "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		GADemo AWSGADemoHardeningResult `json:"ga_demo_hardening"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.GADemo.CurrentIssueRef != "#1557" || body.GADemo.AppliedFilters["stage"] != "governance" {
+		t.Fatalf("unexpected route payload: %+v", body.GADemo)
+	}
+	if len(body.GADemo.Stages) != 1 || body.GADemo.Stages[0].StageID != "governance" {
+		t.Fatalf("route did not apply stage filter: %+v", body.GADemo.Stages)
+	}
+}

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -209,6 +209,7 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 		"AWSLambdaExecutionRoleInventoryResult:",
 		"AWSCodeBuildServiceRoleInventoryResult:",
 		"AWSGraphExplorerResult:",
+		"AWSGADemoHardeningResult:",
 		"GitHubConnectionStartRequest:",
 		"GitHubConnectionCompleteRequest:",
 		"GitHubConnectionRepositorySelectionRequest:",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3899,6 +3899,39 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 		c.JSON(http.StatusOK, gin.H{"platform_observability": record})
 	})
 
+	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/ga-demo-hardening", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetAWSGADemoHardening(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"), AWSGADemoHardeningRequest{
+			ConnectorID:  strings.TrimSpace(c.Query("connector_id")),
+			FixtureState: strings.TrimSpace(c.Query("fixture_state")),
+			AccountID:    strings.TrimSpace(c.Query("account_id")),
+			Region:       strings.TrimSpace(c.Query("region")),
+			Stage:        strings.TrimSpace(c.Query("stage")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			Search:       strings.TrimSpace(c.Query("search")),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "project or connector not found"})
+			case errors.Is(err, ErrInvalidAWSConnectionRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid aws ga demo hardening request"})
+			default:
+				logger.Error("get aws ga demo hardening",
+					zap.String("workspace_id", c.Param("workspace_id")),
+					zap.String("project_id", c.Param("project_id")),
+					telemetry.ZapError(err),
+				)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get aws ga demo hardening"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ga_demo_hardening": record})
+	})
+
 	v1.GET("/workspaces/:workspace_id/projects/:project_id/aws/session-policy-recommendations", func(c *gin.Context) {
 		if svc == nil {
 			tenancyServiceUnavailable(c)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import {
   ProductAWSControlCenterPage,
   ProductAWSFindingsPage,
   ProductAWSGovernancePage,
+  ProductAWSGADemoPage,
   ProductAWSGraphPage,
   ProductAWSOutcomesPage,
   ProductAWSPlatformObservabilityPage,
@@ -4838,6 +4839,7 @@ export function RoutedSite() {
             <Route path="aws/resources" element={<ProductAWSResourcesPage />} />
             <Route path="aws/runtime" element={<ProductAWSRuntimePage />} />
             <Route path="aws/observability" element={<ProductAWSPlatformObservabilityPage />} />
+            <Route path="aws/ga-demo" element={<ProductAWSGADemoPage />} />
             <Route path="aws/graph" element={<ProductAWSGraphPage />} />
             <Route path="aws/findings" element={<ProductAWSFindingsPage />} />
             <Route path="aws/remediation" element={<ProductAWSRemediationPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5207,6 +5207,96 @@ export type AWSPlatformObservabilityQuery = {
   search?: string;
 };
 
+export type AWSGADemoHardeningStatus = 'ready' | 'degraded' | 'blocked';
+export type AWSGADemoHardeningFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
+
+export type AWSGADemoHardeningStage = {
+  stage_id: string;
+  order: number;
+  title: string;
+  summary: string;
+  status: AWSGADemoHardeningStatus;
+  confidence: number;
+  account_id?: string;
+  region?: string;
+  primary_route: string;
+  evidence_ref: string;
+  evidence_links: string[];
+  evidence_boundary: string;
+  next_action: string;
+  failure_reason?: string;
+  updated_at: string;
+};
+
+export type AWSGADemoHardeningReadinessCheck = {
+  check_id: string;
+  title: string;
+  status: AWSGADemoHardeningStatus;
+  owner: string;
+  summary: string;
+  evidence: string[];
+  next_action: string;
+  required: boolean;
+  permissions?: string[];
+};
+
+export type AWSGADemoHardeningSummary = {
+  total_stages: number;
+  filtered_stages: number;
+  ready_stages: number;
+  degraded_stages: number;
+  blocked_stages: number;
+  readiness_checks: number;
+  passed_checks: number;
+  required_checks: number;
+  failed_checks: number;
+  permission_warnings: number;
+  status_counts: Record<string, number>;
+  stage_counts: Record<string, number>;
+};
+
+export type AWSGADemoHardeningResult = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  connector_id?: string;
+  account_id?: string;
+  region?: string;
+  parent_issue_number: number;
+  parent_issue_ref: string;
+  current_issue_number: number;
+  current_issue_ref: string;
+  version: string;
+  status: AWSGADemoHardeningStatus;
+  fixture_state?: AWSGADemoHardeningFixtureState;
+  confidence: number;
+  calculation_version: string;
+  applied_filters: Record<string, string>;
+  summary: AWSGADemoHardeningSummary;
+  stages: AWSGADemoHardeningStage[];
+  readiness_checks: AWSGADemoHardeningReadinessCheck[];
+  permissions: string[];
+  safety_notes: string[];
+  limitations: string[];
+  troubleshooting: string[];
+  caveats: string[];
+  failure_reasons: string[];
+  remediation_hints: string[];
+  evidence_links: string[];
+  generated_at: string;
+  updated_at: string;
+};
+
+export type AWSGADemoHardeningQuery = {
+  connectorID?: string;
+  fixtureState?: AWSGADemoHardeningFixtureState;
+  accountID?: string;
+  region?: string;
+  stage?: string;
+  status?: string;
+  search?: string;
+};
+
 export type AWSSessionPolicyRecommendationStatus = 'ready' | 'degraded' | 'blocked';
 export type AWSSessionPolicyRecommendationFixtureState = 'success' | 'empty' | 'degraded' | 'partial_failure' | 'permission_denied';
 export type AWSSessionPolicyRecommendationDecision = 'remove' | 'review' | string;
@@ -11174,6 +11264,25 @@ export const apiClient = {
         region: query?.region,
         service: query?.service,
         component: query?.component,
+        status: query?.status,
+        search: query?.search
+      })}`,
+      auth
+    );
+  },
+  getAWSProjectGADemoHardening(
+    workspaceID: string,
+    projectID: string,
+    query?: AWSGADemoHardeningQuery,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ ga_demo_hardening: AWSGADemoHardeningResult }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/ga-demo-hardening${buildQuery({
+        connector_id: query?.connectorID,
+        fixture_state: query?.fixtureState,
+        account_id: query?.accountID,
+        region: query?.region,
+        stage: query?.stage,
         status: query?.status,
         search: query?.search
       })}`,

--- a/web/src/productDomainRoutes.ts
+++ b/web/src/productDomainRoutes.ts
@@ -11,6 +11,7 @@ export const DOMAIN_APP_ROUTE_MANIFEST = [
   '/app/:tenantID/:workspaceID/aws/resources',
   '/app/:tenantID/:workspaceID/aws/runtime',
   '/app/:tenantID/:workspaceID/aws/observability',
+  '/app/:tenantID/:workspaceID/aws/ga-demo',
   '/app/:tenantID/:workspaceID/aws/graph',
   '/app/:tenantID/:workspaceID/aws/findings',
   '/app/:tenantID/:workspaceID/aws/remediation',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7620,6 +7620,151 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('shows AWS GA demo hardening and forwards stage filters', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+    const getGADemoHardening = vi.spyOn(api.apiClient, 'getAWSProjectGADemoHardening').mockResolvedValue({
+      ga_demo_hardening: {
+        status: 'degraded',
+        confidence: 0.86,
+        current_issue_ref: '#1557',
+        version: 'aws-ga-demo-hardening-v1',
+        applied_filters: {},
+        summary: {
+          total_stages: 2,
+          filtered_stages: 2,
+          ready_stages: 1,
+          degraded_stages: 1,
+          blocked_stages: 0,
+          readiness_checks: 2,
+          passed_checks: 1,
+          required_checks: 2,
+          failed_checks: 0,
+          permission_warnings: 1,
+          status_counts: { ready: 1, degraded: 1 },
+          stage_counts: { onboarding: 1, governance: 1 }
+        },
+        stages: [
+          {
+            stage_id: 'onboarding',
+            order: 1,
+            title: 'Onboarding and validation',
+            summary: 'AWS connector setup and validation fixtures.',
+            status: 'ready',
+            confidence: 0.94,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            primary_route: '/app/aws/connect',
+            evidence_ref: 'aws-ga-demo://onboarding',
+            evidence_links: ['/docs/aws-ga-demo-hardening'],
+            evidence_boundary: 'metadata_only_ga_demo_no_secret_values_no_customer_payloads',
+            next_action: 'Open connector diagnostics.',
+            updated_at: '2026-07-10T09:00:00Z'
+          },
+          {
+            stage_id: 'governance',
+            order: 9,
+            title: 'Governance reporting',
+            summary: 'Export-safe governance metadata.',
+            status: 'degraded',
+            confidence: 0.78,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            primary_route: '/app/aws/governance',
+            evidence_ref: 'aws-ga-demo://governance-reporting',
+            evidence_links: ['/docs/aws-governance-audit-reporting'],
+            evidence_boundary: 'metadata_only_ga_demo_no_secret_values_no_customer_payloads',
+            next_action: 'Resolve governance exceptions.',
+            failure_reason: 'Governance exception requires review.',
+            updated_at: '2026-07-10T09:00:00Z'
+          }
+        ],
+        readiness_checks: [
+          {
+            check_id: 'validation-fixtures',
+            title: 'App and API fixtures',
+            status: 'ready',
+            owner: 'platform',
+            summary: 'Fixture states are documented.',
+            evidence: ['/docs/aws-platform-validation-harness'],
+            next_action: 'Run the validation harness.',
+            required: true
+          },
+          {
+            check_id: 'permission-docs',
+            title: 'Permission documentation',
+            status: 'degraded',
+            owner: 'security',
+            summary: 'Permission docs need review.',
+            evidence: ['/docs/aws-ga-demo-hardening'],
+            next_action: 'Attach permission docs to handoff.',
+            required: true,
+            permissions: ['sts:GetCallerIdentity']
+          }
+        ],
+        permissions: ['sts:GetCallerIdentity'],
+        safety_notes: ['Read-only.'],
+        limitations: ['Coverage is bounded by source contracts.'],
+        troubleshooting: ['Review connector diagnostics.'],
+        caveats: [],
+        failure_reasons: ['Governance exception requires review.'],
+        remediation_hints: ['Resolve governance exceptions before handoff.'],
+        evidence_links: ['/docs/aws-ga-demo-hardening'],
+        generated_at: '2026-07-10T09:00:00Z',
+        updated_at: '2026-07-10T09:00:00Z'
+      } as any
+    });
+
+    const { ProductAWSGADemoPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/ga-demo?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/ga-demo" element={<ProductAWSGADemoPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'GA Demo' })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'AWS GA demo readiness summary' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS GA demo stages' })).toBeInTheDocument();
+    expect(await screen.findByRole('table', { name: 'AWS GA readiness checks' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Governance reporting/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Permission documentation/i).length).toBeGreaterThan(0);
+    expect(getGADemoHardening).toHaveBeenCalledWith(
+      'workspace-a',
+      'production',
+      expect.objectContaining({ connectorID: 'aws-connector-1' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Stage' }), {
+      target: { value: 'governance' }
+    });
+    await waitFor(() =>
+      expect(getGADemoHardening).toHaveBeenLastCalledWith(
+        'workspace-a',
+        'production',
+        expect.objectContaining({ connectorID: 'aws-connector-1', stage: 'governance' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('shows AWS executive outcome view and forwards outcome filters', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3347,6 +3347,7 @@ describe('Domain-first app routes', () => {
       '/app/:tenantID/:workspaceID/aws/resources',
       '/app/:tenantID/:workspaceID/aws/runtime',
       '/app/:tenantID/:workspaceID/aws/observability',
+      '/app/:tenantID/:workspaceID/aws/ga-demo',
       '/app/:tenantID/:workspaceID/aws/graph',
       '/app/:tenantID/:workspaceID/aws/findings',
       '/app/:tenantID/:workspaceID/aws/remediation',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -106,6 +106,10 @@ import {
   type AWSPlatformObservabilityQuery,
   type AWSPlatformObservabilityResult,
   type AWSPlatformObservabilityTrace,
+  type AWSGADemoHardeningQuery,
+  type AWSGADemoHardeningResult,
+  type AWSGADemoHardeningStage,
+  type AWSGADemoHardeningReadinessCheck,
   type AWSSessionPolicyRecommendationEntry,
   type AWSSessionPolicyRecommendationResult,
   type AWSAgentCoreGatewayPolicyAdvisoryEntry,
@@ -465,6 +469,7 @@ type ProductDomainRouteID =
   | 'resources'
   | 'runtime'
   | 'observability'
+  | 'ga-demo'
   | 'graph'
   | 'findings'
   | 'remediation'
@@ -565,6 +570,7 @@ const PRODUCT_DOMAIN_CONFIGS: Record<SourceProvider, ProductDomainConfig> = {
       productDomainRoute('resources', 'Resources', 'resources', 'Resources', '', 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'),
       productDomainRoute('runtime', 'Runtime', 'runtime', 'Runtime', '', 'What your AWS roles actually did, from runtime evidence.'),
       productDomainRoute('observability', 'Observability', 'observability', 'Observability', '', 'Platform health, metrics, traces, and alerts for AWS collection and governance.'),
+      productDomainRoute('ga-demo', 'GA Demo', 'ga-demo', 'GA Demo', '', 'End-to-end AWS operator walkthrough, permission docs, and GA readiness checks.'),
       productDomainRoute('graph', 'Graph', 'graph', 'Graph', '', 'How AWS roles can reach things, visualised.'),
       productDomainRoute('findings', 'Findings', 'findings', 'Findings', '', 'Risks Identrail found in your AWS setup.'),
       productDomainRoute('remediation', 'Remediation', 'remediation', 'Remediation', '', 'AWS fixes Identrail prepares for you to approve.'),
@@ -11666,7 +11672,7 @@ export function ProductAWSResourcesPage() {
 
 type AWSRiskOperationRouteID = Extract<
   ProductDomainRouteID,
-  'runtime' | 'observability' | 'graph' | 'findings' | 'remediation' | 'outcomes' | 'governance'
+  'runtime' | 'observability' | 'ga-demo' | 'graph' | 'findings' | 'remediation' | 'outcomes' | 'governance'
 >;
 
 type AWSRiskOperationPageCopy = {
@@ -11706,6 +11712,18 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     nextAction: '',
     unavailableTitle: 'No observability signals yet',
     unavailableBody: 'Platform observability will appear once Identrail has collector, runtime, remediation, verification, and governance evidence.'
+  },
+  'ga-demo': {
+    routeID: 'ga-demo',
+    title: 'GA Demo',
+    eyebrow: '',
+    description: 'End-to-end AWS operator walkthrough, permission documentation, limitations, troubleshooting, and GA readiness checks.',
+    statusLabel: '',
+    currentCapability: '',
+    plannedCapability: '',
+    nextAction: '',
+    unavailableTitle: 'No GA demo stages yet',
+    unavailableBody: 'GA demo hardening will appear once Identrail can compose validation, discovery, runtime, remediation, governance, outcome, and observability evidence.'
   },
   graph: {
     routeID: 'graph',
@@ -11774,6 +11792,7 @@ type AWSRiskOperationFilterConfigMap = Record<AWSRiskOperationRouteID, AWSInvent
 const AWS_RISK_OPERATION_FILTER_DEFAULTS: Record<AWSRiskOperationRouteID, AWSInventoryFilterState> = {
   runtime: { event: 'all', evidence: 'all', owner: 'all', status: 'all', search: '' },
   observability: { component: 'all', status: 'all', service: 'all', search: '' },
+  'ga-demo': { stage: 'all', status: 'all', search: '' },
   graph: { node: 'all', edge: 'all', evidence: 'all', search: '' },
   findings: { severity: 'all', account: 'all', region: 'all', evidence: 'all', status: 'all', search: '' },
   remediation: { change: 'all', approval: 'all', stage: 'all', search: '' },
@@ -11869,6 +11888,36 @@ const AWS_RISK_OPERATION_FILTERS: AWSRiskOperationFilterConfigMap = {
         { label: 'S3', value: 's3.amazonaws.com' },
         { label: 'KMS', value: 'kms.amazonaws.com' },
         { label: 'Agent runtime', value: 'bedrock-agentcore.amazonaws.com' }
+      ]
+    }
+  ],
+  'ga-demo': [
+    {
+      id: 'stage',
+      label: 'Stage',
+      options: [
+        { label: 'All stages', value: 'all' },
+        { label: 'Onboarding', value: 'onboarding' },
+        { label: 'Discovery', value: 'discovery' },
+        { label: 'Agents', value: 'agents' },
+        { label: 'Runtime', value: 'runtime' },
+        { label: 'Risk', value: 'risk' },
+        { label: 'Remediation', value: 'remediation' },
+        { label: 'Approval', value: 'approval' },
+        { label: 'Verification', value: 'verification' },
+        { label: 'Governance', value: 'governance' },
+        { label: 'Reporting', value: 'reporting' },
+        { label: 'Observability', value: 'observability' }
+      ]
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      options: [
+        { label: 'All statuses', value: 'all' },
+        { label: 'Ready', value: 'ready' },
+        { label: 'Degraded', value: 'degraded' },
+        { label: 'Blocked', value: 'blocked' }
       ]
     }
   ],
@@ -12119,6 +12168,7 @@ function AWSRiskOperationFilterSet({
   const searchPlaceholder: Record<AWSRiskOperationRouteID, string> = {
     runtime: 'Search events',
     observability: 'Search signals',
+    'ga-demo': 'Search stages',
     graph: 'Search graph',
     findings: 'Search findings',
     remediation: 'Search changes',
@@ -14345,6 +14395,110 @@ function AWSPlatformObservabilityContent({
                 key: 'status',
                 header: 'Status',
                 render: (row) => <AWSInventoryPill stage={awsPlatformObservabilityStage(row.status)} label={formatTokenLabel(row.status)} />
+              }
+            ]}
+          />
+        </section>
+      ) : null}
+    </>
+  );
+}
+
+function awsGADemoHardeningStageStatus(status: string): AWSCapabilityStage {
+  if (status === 'blocked') {
+    return 'not-available';
+  }
+  if (status === 'degraded') {
+    return 'coming';
+  }
+  return 'wired';
+}
+
+function AWSGADemoHardeningContent({
+  result,
+  loading,
+  error,
+  onRetry
+}: {
+  result: AWSGADemoHardeningResult | null;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const summaryLine = result
+    ? `${result.summary.filtered_stages}/${result.summary.total_stages} stages · ${result.summary.passed_checks}/${result.summary.readiness_checks} checks · ${Math.round(result.confidence * 100)}% confidence`
+    : '';
+  const panelResult = result
+    ? {
+        status: result.status,
+        entries: result.stages,
+        caveats: result.caveats,
+        failure_reasons: result.failure_reasons
+      }
+    : null;
+  return (
+    <>
+      {result ? (
+        <section className="idt-aws-inventory-coverage" aria-label="AWS GA demo readiness summary">
+          <DomainCoverageCard label="Ready stages" scanned={result.summary.ready_stages} total={Math.max(result.summary.filtered_stages, 1)} detail={`${result.summary.degraded_stages} degraded`} />
+          <DomainCoverageCard label="Blocked stages" scanned={Math.max(0, result.summary.filtered_stages - result.summary.blocked_stages)} total={Math.max(result.summary.filtered_stages, 1)} detail={`${result.summary.blocked_stages} blocked`} />
+          <DomainCoverageCard label="Checks passed" scanned={result.summary.passed_checks} total={Math.max(result.summary.readiness_checks, 1)} detail={`${result.summary.required_checks} required`} />
+          <DomainCoverageCard label="Permission warnings" scanned={Math.max(0, result.summary.readiness_checks - result.summary.permission_warnings)} total={Math.max(result.summary.readiness_checks, 1)} detail={`${result.summary.permission_warnings} warnings`} />
+          <DomainCoverageCard label="Confidence" scanned={Math.round(result.confidence * 100)} total={100} detail="source average" />
+          <DomainCoverageCard label="Evidence links" scanned={result.evidence_links.length} total={Math.max(result.evidence_links.length, 1)} detail="metadata-only" />
+        </section>
+      ) : null}
+      <AWSExecutorProjectionPanel<AWSGADemoHardeningStage>
+        result={panelResult}
+        loading={loading}
+        error={error}
+        onRetry={onRetry}
+        ariaLabel="AWS GA demo hardening"
+        heading="AWS GA demo hardening"
+        description={`End-to-end operator walkthrough from onboarding to discovery, agents, runtime, risk, remediation, approval, verification, governance reporting, and platform observability. Stages keep evidence refs, confidence, account/region context, and next actions without exposing secrets or payloads. ${summaryLine}`}
+        errorTitle="Couldn't load AWS GA demo hardening"
+        loadingTitle="Building AWS GA demo"
+        loadingBody="Identrail is composing validation, discovery, agent, runtime, remediation, governance, outcome, and observability evidence."
+        emptyEyebrow={(current) => (current.status === 'blocked' ? 'Permission required' : 'No stages')}
+        emptyTitle={(current) => (current.status === 'blocked' ? 'GA demo needs source evidence' : 'No GA demo stages matched')}
+        emptyBody={(current) => current.failure_reasons[0] ?? 'No GA demo stage matched the current filters.'}
+        tableLabel="AWS GA demo stages"
+        getRowKey={(row) => row.stage_id}
+        columns={[
+          { key: 'stage', header: 'Stage', render: (row) => <strong>{row.title}</strong> },
+          { key: 'scope', header: 'Scope', render: (row) => awsAccountRegionInventoryLabel(row.account_id, row.region) },
+          { key: 'evidence', header: 'Evidence', render: (row) => row.evidence_ref },
+          { key: 'next', header: 'Next action', render: (row) => row.next_action },
+          {
+            key: 'confidence',
+            header: 'Confidence',
+            render: (row) => <AWSInventoryPill stage={awsGADemoHardeningStageStatus(row.status)} label={`${Math.round(row.confidence * 100)}%`} />
+          },
+          {
+            key: 'status',
+            header: 'Status',
+            render: (row) => <AWSInventoryPill stage={awsGADemoHardeningStageStatus(row.status)} label={formatTokenLabel(row.status)} />
+          }
+        ]}
+      />
+      {!error && !loading && result ? (
+        <section className="idt-aws-runtime-correlation" aria-label="AWS GA readiness checks">
+          <h3>AWS GA readiness checks</h3>
+          <p className="idt-app-kicker">Checks keep owner, required/optional scope, permission coverage, evidence links, and next-action context for handoff.</p>
+          <DomainDataTable<AWSGADemoHardeningReadinessCheck>
+            label="AWS GA readiness checks"
+            rows={result.readiness_checks}
+            getRowKey={(row) => row.check_id}
+            columns={[
+              { key: 'check', header: 'Check', render: (row) => <strong>{row.title}</strong> },
+              { key: 'owner', header: 'Owner', render: (row) => formatTokenLabel(row.owner) },
+              { key: 'required', header: 'Required', render: (row) => (row.required ? 'Required' : 'Optional') },
+              { key: 'evidence', header: 'Evidence', render: (row) => `${row.evidence.length} links` },
+              { key: 'next', header: 'Next action', render: (row) => row.next_action },
+              {
+                key: 'status',
+                header: 'Status',
+                render: (row) => <AWSInventoryPill stage={awsGADemoHardeningStageStatus(row.status)} label={formatTokenLabel(row.status)} />
               }
             ]}
           />
@@ -16629,6 +16783,14 @@ function awsPlatformObservabilityQueryFromFilters(filters: AWSInventoryFilterSta
   };
 }
 
+function awsGADemoHardeningQueryFromFilters(filters: AWSInventoryFilterState): Partial<AWSGADemoHardeningQuery> {
+  return {
+    stage: awsSecretPermissionEquivalenceFilterToken(filters.stage),
+    status: awsSecretPermissionEquivalenceFilterToken(filters.status),
+    search: normalizeFilterValue(filters.search ?? '') || undefined
+  };
+}
+
 function AWSGraphExplorerContent({
   graph,
   loading,
@@ -17186,6 +17348,10 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
   const [platformObservabilityLoading, setPlatformObservabilityLoading] = useState(false);
   const [platformObservabilityError, setPlatformObservabilityError] = useState('');
   const platformObservabilityRequestRef = useRef(0);
+  const [gaDemoHardening, setGADemoHardening] = useState<AWSGADemoHardeningResult | null>(null);
+  const [gaDemoHardeningLoading, setGADemoHardeningLoading] = useState(false);
+  const [gaDemoHardeningError, setGADemoHardeningError] = useState('');
+  const gaDemoHardeningRequestRef = useRef(0);
   const [sessionPolicyRecommendations, setSessionPolicyRecommendations] = useState<AWSSessionPolicyRecommendationResult | null>(null);
   const [sessionPolicyRecommendationsLoading, setSessionPolicyRecommendationsLoading] = useState(false);
   const [sessionPolicyRecommendationsError, setSessionPolicyRecommendationsError] = useState('');
@@ -18278,6 +18444,59 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
       platformObservabilityRequestRef.current += 1;
     };
   }, [loadPlatformObservability]);
+
+  const loadGADemoHardening = useCallback(async () => {
+    const requestID = ++gaDemoHardeningRequestRef.current;
+    setGADemoHardening(null);
+    setGADemoHardeningError('');
+    if (routeID !== 'ga-demo' || !scope || !selectedEnvironmentID || !connection?.connector_id) {
+      setGADemoHardeningLoading(false);
+      return;
+    }
+    setGADemoHardeningLoading(true);
+    const requestFilters = awsGADemoHardeningQueryFromFilters(activeFilters);
+    try {
+      const response = await apiClient.getAWSProjectGADemoHardening(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        {
+          connectorID: connection.connector_id,
+          ...requestFilters
+        },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== gaDemoHardeningRequestRef.current) {
+        return;
+      }
+      setGADemoHardening(response.ga_demo_hardening);
+    } catch (error) {
+      if (requestID !== gaDemoHardeningRequestRef.current) {
+        return;
+      }
+      setGADemoHardeningError(formatAPIError(error, 'Unable to load AWS GA demo hardening.'));
+    } finally {
+      if (requestID === gaDemoHardeningRequestRef.current) {
+        setGADemoHardeningLoading(false);
+      }
+    }
+  }, [
+    routeID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedEnvironmentID,
+    activeFilters.stage,
+    activeFilters.status,
+    activeFilters.search,
+    connection?.connected,
+    connection?.connector_id
+  ]);
+
+  useEffect(() => {
+    void loadGADemoHardening();
+    return () => {
+      gaDemoHardeningRequestRef.current += 1;
+    };
+  }, [loadGADemoHardening]);
 
   const loadSessionPolicyRecommendations = useCallback(async () => {
     const requestID = ++sessionPolicyRecommendationsRequestRef.current;
@@ -19403,6 +19622,17 @@ function ProductAWSRiskOperationsPage({ routeID }: { routeID: AWSRiskOperationRo
             onRetry={loadPlatformObservability}
           />
         ) : null}
+        {routeID === 'ga-demo' ? (
+          <AWSRiskOperationFilterSet routeID="ga-demo" filters={activeFilters} onChange={onFiltersChange} />
+        ) : null}
+        {routeID === 'ga-demo' ? (
+          <AWSGADemoHardeningContent
+            result={gaDemoHardening}
+            loading={gaDemoHardeningLoading}
+            error={gaDemoHardeningError}
+            onRetry={loadGADemoHardening}
+          />
+        ) : null}
         {routeID === 'graph' ? (
           <AWSGraphExplorerContent
             graph={graphExplorer}
@@ -19474,6 +19704,10 @@ export function ProductAWSRuntimePage() {
 
 export function ProductAWSPlatformObservabilityPage() {
   return <ProductAWSRiskOperationsPage routeID="observability" />;
+}
+
+export function ProductAWSGADemoPage() {
+  return <ProductAWSRiskOperationsPage routeID="ga-demo" />;
 }
 
 export function ProductAWSGraphPage() {


### PR DESCRIPTION
## Summary
- Add a read-only AWS GA demo hardening API that composes existing validation, agent, graph, remediation, governance, outcome, and observability contracts into one operator walkthrough.
- Add the AWS GA Demo app route with stage/status/search filters, readiness cards, stage evidence, and readiness checks.
- Document permissions, intentionally excluded data, limitations, troubleshooting, OpenAPI schema, and route policy coverage.

Fixes #1557

## Validation
- `go test ./internal/api`
- `npm --prefix web run build`
- `npm --prefix web test -- --run src/productShell.test.tsx -t "AWS GA demo hardening"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only AWS GA demo hardening walkthrough that composes existing AWS metadata into one API and app page with filters, readiness checks, and clear safety boundaries. Helps operators verify GA readiness without write APIs or secret exposure, aligning with `#1557`.

- **New Features**
  - API: GET /v1/workspaces/{workspace_id}/projects/{project_id}/aws/ga-demo-hardening returns ga_demo_hardening with summary, stages, readiness checks, permissions/safety notes/limitations/troubleshooting/caveats, and evidence links; supports connector_id, fixture_state, account_id, region, stage, status, and search filters; OpenAPI, router, and route authz updated; status normalization and error handling refined.
  - Composition: Reuses validation, agent identities, graph, remediation, governance, executive outcomes, and observability to build staged GA readiness.
  - Web: New ProductAWSGADemoPage at /app/:tenantID/:workspaceID/aws/ga-demo with Stage/Status/Search filters, readiness summary cards, stages table with confidence, and readiness checks table; stage links use scoped app routes and preserve the project `environment` param; client types and `apiClient.getAWSProjectGADemoHardening` added.
  - Docs: docs/aws-ga-demo-hardening.md with permissions, read-only boundary, limitations, troubleshooting; docs index and OpenAPI spec updated.
  - Tests: Contract build, filter/search behavior, permission-denied mapped to blocked, router wiring, OpenAPI presence, app route/filter forwarding, and scoped stage route generation verified.

<sup>Written for commit 81c1ef114fec3fefd60dd756e7e72d0dd1894a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

