### PR TITLE
Completion

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -120,6 +120,10 @@ x-identrail-route-authorizations:
     path: /v1/repo-findings
     action: repo_scans.read
     resource_type: repo_finding
+  - method: POST
+    path: /v1/repo-findings/bulk-delete
+    action: repo_scans.run
+    resource_type: repo_finding
   - method: DELETE
     path: /v1/repo-findings/{finding_id}
     action: repo_scans.run
@@ -9695,6 +9699,33 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/repo-findings/bulk-delete:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [RepositoryExposure]
+      summary: Delete selected repository findings
+      operationId: bulkDeleteRepoFindings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepoFindingsBulkDeleteRequest"
+      responses:
+        "200":
+          description: Selected repository findings delete result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoFindingsBulkDeleteResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /v1/repo-findings/{finding_id}:
@@ -24562,6 +24593,43 @@ components:
           type: string
         summary:
           $ref: "#/components/schemas/RepoFindingsSummary"
+    RepoFindingDeleteTarget:
+      type: object
+      required: [finding_id, repo_scan_id]
+      properties:
+        finding_id:
+          type: string
+        repo_scan_id:
+          type: string
+    RepoFindingDeleteFailure:
+      allOf:
+        - $ref: "#/components/schemas/RepoFindingDeleteTarget"
+        - type: object
+          required: [error]
+          properties:
+            error:
+              type: string
+    RepoFindingsBulkDeleteRequest:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          minItems: 1
+          maxItems: 500
+          items:
+            $ref: "#/components/schemas/RepoFindingDeleteTarget"
+    RepoFindingsBulkDeleteResponse:
+      type: object
+      properties:
+        deleted:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoFindingDeleteTarget"
+        failed:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoFindingDeleteFailure"
     RepoFindingRemediationPreviewRequest:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -123,7 +123,7 @@ x-identrail-route-authorizations:
   - method: POST
     path: /v1/repo-findings/bulk-delete
     action: repo_scans.run
-    resource_type: repo_finding
+    resource_type: repo_finding_bulk_delete
   - method: DELETE
     path: /v1/repo-findings/{finding_id}
     action: repo_scans.run
@@ -9726,6 +9726,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /v1/repo-findings/{finding_id}:

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -684,6 +684,10 @@ func authorizeRepoFindingDeleteTargets(
 		Action:       policyActionRepoScansRun,
 		ResourceType: "repo_finding",
 	}
+	var allowedDecision *PolicyDecision
+	var allowedInput PolicyInput
+	var allowedDecisionSource string
+	var allowedDecisionVersion int
 	for _, target := range targets {
 		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
 		if err != nil {
@@ -717,6 +721,13 @@ func authorizeRepoFindingDeleteTargets(
 			setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
 			return false, nil
 		}
+		allowedDecision = &decision
+		allowedInput = input
+		allowedDecisionSource = decisionSource
+		allowedDecisionVersion = decisionVersion
+	}
+	if allowedDecision != nil {
+		setAuthzDecisionContext(c, runtimePolicy.PolicySetID, allowedDecisionVersion, allowedDecisionSource, runtimePolicy.RolloutMode, *allowedDecision, allowedInput, fingerprinter)
 	}
 	return true, nil
 }

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -636,6 +636,67 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKey
 	return input, nil
 }
 
+func authorizeRepoFindingDeleteTargets(
+	c *gin.Context,
+	resolver centralPolicyRuntimeResolver,
+	writeKeys []string,
+	scopedKeys map[string][]string,
+	store db.Store,
+	fingerprinter *audit.Fingerprinter,
+	targets []RepoFindingDeleteTarget,
+) (bool, error) {
+	if !hasAuthContext(c) {
+		return true, nil
+	}
+	if resolver == nil {
+		resolver = newCentralPolicyRuntimeResolver(store)
+	}
+	runtimePolicy, err := resolver.Resolve(c.Request.Context())
+	if err != nil {
+		return false, err
+	}
+	normalizedWriteKeys := normalizeKeyList(writeKeys)
+	policy := routePolicy{
+		Action:       policyActionRepoScansRun,
+		ResourceType: "repo_finding",
+	}
+	for _, target := range targets {
+		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
+		if err != nil {
+			return false, err
+		}
+		input.Resource.ID = strings.TrimSpace(target.FindingID)
+		input.Resource.Attributes = nil
+		input.Context.Attributes[policyContextABACResourceAttrsLoadedKey] = "false"
+		input.Context.Attributes["repo_scan_id"] = strings.TrimSpace(target.RepoScanID)
+		if err := loadTrustedPolicyAttributes(c.Request.Context(), store, &input); err != nil {
+			return false, err
+		}
+
+		decisionEngine := runtimePolicy.Engine
+		decisionSource := runtimePolicy.Source
+		decisionVersion := runtimePolicy.Version
+		if runtimePolicy.Rollout.Mode == db.AuthzPolicyRolloutModeEnforce &&
+			shouldTargetRolloutRequest(runtimePolicy.Rollout, input) &&
+			runtimePolicy.CandidateEngine != nil &&
+			rolloutVersionValidated(runtimePolicy.Rollout, runtimePolicy.CandidateVersion) {
+			decisionEngine = runtimePolicy.CandidateEngine
+			decisionSource = runtimePolicy.CandidateSource
+			decisionVersion = runtimePolicy.CandidateVersion
+		}
+
+		decision, err := decisionEngine.Decide(c.Request.Context(), input)
+		if err != nil {
+			return false, err
+		}
+		if !decision.Allowed {
+			setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func firstNonEmpty(primary string, fallback string) string {
 	if strings.TrimSpace(primary) != "" {
 		return strings.TrimSpace(primary)

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -40,6 +40,9 @@ const (
 
 	policyContextABACSubjectAttrsLoadedKey  = "abac.subject_attributes_loaded"
 	policyContextABACResourceAttrsLoadedKey = "abac.resource_attributes_loaded"
+
+	authzShadowEvalCountKey       = "authz.shadow_eval_count"
+	authzShadowDivergenceCountKey = "authz.shadow_divergence_count"
 )
 
 type routePolicy struct {
@@ -315,6 +318,7 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 				})
 				return
 			}
+			setAuthzShadowCounters(c, &shadowEvalCount, &shadowDivergenceCount)
 			c.Next()
 			return
 		}
@@ -374,6 +378,33 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 
 		c.Next()
 	}
+}
+
+func setAuthzShadowCounters(c *gin.Context, shadowEvalCount *uint64, shadowDivergenceCount *uint64) {
+	if c == nil {
+		return
+	}
+	c.Set(authzShadowEvalCountKey, shadowEvalCount)
+	c.Set(authzShadowDivergenceCountKey, shadowDivergenceCount)
+}
+
+func authzShadowCounters(c *gin.Context) (*uint64, *uint64) {
+	if c == nil {
+		return nil, nil
+	}
+	var shadowEvalCount *uint64
+	if value, exists := c.Get(authzShadowEvalCountKey); exists {
+		if typed, ok := value.(*uint64); ok {
+			shadowEvalCount = typed
+		}
+	}
+	var shadowDivergenceCount *uint64
+	if value, exists := c.Get(authzShadowDivergenceCountKey); exists {
+		if typed, ok := value.(*uint64); ok {
+			shadowDivergenceCount = typed
+		}
+	}
+	return shadowEvalCount, shadowDivergenceCount
 }
 
 func recordPolicyShadowEvaluation(
@@ -714,8 +745,7 @@ func authorizeRepoFindingDeleteTargets(
 	var allowedInput PolicyInput
 	var allowedDecisionSource string
 	var allowedDecisionVersion int
-	var shadowEvalCount uint64
-	var shadowDivergenceCount uint64
+	shadowEvalCount, shadowDivergenceCount := authzShadowCounters(c)
 	for _, target := range targets {
 		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
 		if err != nil {
@@ -747,7 +777,7 @@ func authorizeRepoFindingDeleteTargets(
 			return false, err
 		}
 		recordPolicyDecisionMetric(metrics, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision.Allowed)
-		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, &shadowEvalCount, &shadowDivergenceCount)
+		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, shadowEvalCount, shadowDivergenceCount)
 		if !decision.Allowed {
 			setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
 			return false, nil

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -347,30 +347,7 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 		}
 		recordPolicyDecisionMetric(metrics, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision.Allowed)
 
-		if runtimePolicy.Rollout.Mode == db.AuthzPolicyRolloutModeShadow &&
-			targeted &&
-			runtimePolicy.CandidateEngine != nil &&
-			rolloutVersionValidated(runtimePolicy.Rollout, runtimePolicy.CandidateVersion) {
-			if metrics != nil && metrics.AuthzPolicyShadowEvaluationsTotal != nil {
-				metrics.AuthzPolicyShadowEvaluationsTotal.Inc()
-			}
-			totalEvaluations := atomic.AddUint64(&shadowEvalCount, 1)
-			candidateDecision, err := runtimePolicy.CandidateEngine.Decide(c.Request.Context(), input)
-			if err != nil {
-				if metrics != nil && metrics.AuthzPolicyShadowEvaluationErrorsTotal != nil {
-					metrics.AuthzPolicyShadowEvaluationErrorsTotal.Inc()
-				}
-			} else if policyDecisionsDiverge(decision, candidateDecision) {
-				if metrics != nil && metrics.AuthzPolicyShadowDivergencesTotal != nil {
-					metrics.AuthzPolicyShadowDivergencesTotal.Inc()
-				}
-				atomic.AddUint64(&shadowDivergenceCount, 1)
-			}
-			if metrics != nil && metrics.AuthzPolicyShadowDivergenceRate != nil && totalEvaluations > 0 {
-				divergences := atomic.LoadUint64(&shadowDivergenceCount)
-				metrics.AuthzPolicyShadowDivergenceRate.Set(float64(divergences) / float64(totalEvaluations))
-			}
-		}
+		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, &shadowEvalCount, &shadowDivergenceCount)
 
 		setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
 
@@ -396,6 +373,48 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 		}
 
 		c.Next()
+	}
+}
+
+func recordPolicyShadowEvaluation(
+	ctx context.Context,
+	runtimePolicy resolvedCentralPolicyRuntime,
+	targeted bool,
+	input PolicyInput,
+	decision PolicyDecision,
+	metrics *telemetry.Metrics,
+	shadowEvalCount *uint64,
+	shadowDivergenceCount *uint64,
+) {
+	if runtimePolicy.Rollout.Mode != db.AuthzPolicyRolloutModeShadow ||
+		!targeted ||
+		runtimePolicy.CandidateEngine == nil ||
+		!rolloutVersionValidated(runtimePolicy.Rollout, runtimePolicy.CandidateVersion) {
+		return
+	}
+	if metrics != nil && metrics.AuthzPolicyShadowEvaluationsTotal != nil {
+		metrics.AuthzPolicyShadowEvaluationsTotal.Inc()
+	}
+	totalEvaluations := uint64(0)
+	if shadowEvalCount != nil {
+		totalEvaluations = atomic.AddUint64(shadowEvalCount, 1)
+	}
+	candidateDecision, err := runtimePolicy.CandidateEngine.Decide(ctx, input)
+	if err != nil {
+		if metrics != nil && metrics.AuthzPolicyShadowEvaluationErrorsTotal != nil {
+			metrics.AuthzPolicyShadowEvaluationErrorsTotal.Inc()
+		}
+	} else if policyDecisionsDiverge(decision, candidateDecision) {
+		if metrics != nil && metrics.AuthzPolicyShadowDivergencesTotal != nil {
+			metrics.AuthzPolicyShadowDivergencesTotal.Inc()
+		}
+		if shadowDivergenceCount != nil {
+			atomic.AddUint64(shadowDivergenceCount, 1)
+		}
+	}
+	if metrics != nil && metrics.AuthzPolicyShadowDivergenceRate != nil && totalEvaluations > 0 && shadowDivergenceCount != nil {
+		divergences := atomic.LoadUint64(shadowDivergenceCount)
+		metrics.AuthzPolicyShadowDivergenceRate.Set(float64(divergences) / float64(totalEvaluations))
 	}
 }
 
@@ -667,6 +686,7 @@ func authorizeRepoFindingDeleteTargets(
 	scopedKeys map[string][]string,
 	store db.Store,
 	fingerprinter *audit.Fingerprinter,
+	metrics *telemetry.Metrics,
 	targets []RepoFindingDeleteTarget,
 ) (bool, error) {
 	if !hasAuthContext(c) {
@@ -704,8 +724,9 @@ func authorizeRepoFindingDeleteTargets(
 		decisionEngine := runtimePolicy.Engine
 		decisionSource := runtimePolicy.Source
 		decisionVersion := runtimePolicy.Version
+		targeted := shouldTargetRolloutRequest(runtimePolicy.Rollout, input)
 		if runtimePolicy.Rollout.Mode == db.AuthzPolicyRolloutModeEnforce &&
-			shouldTargetRolloutRequest(runtimePolicy.Rollout, input) &&
+			targeted &&
 			runtimePolicy.CandidateEngine != nil &&
 			rolloutVersionValidated(runtimePolicy.Rollout, runtimePolicy.CandidateVersion) {
 			decisionEngine = runtimePolicy.CandidateEngine
@@ -717,6 +738,8 @@ func authorizeRepoFindingDeleteTargets(
 		if err != nil {
 			return false, err
 		}
+		recordPolicyDecisionMetric(metrics, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision.Allowed)
+		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, nil, nil)
 		if !decision.Allowed {
 			setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
 			return false, nil

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -700,14 +700,22 @@ func authorizeRepoFindingDeleteTargets(
 		return false, err
 	}
 	normalizedWriteKeys := normalizeKeyList(writeKeys)
+	targetAction := policyActionRepoScansRun
+	if routePolicy, exists := runtimePolicy.Registry.lookup(c.Request.Method, c.FullPath()); exists && usesBodyAwareAuthorization(routePolicy) {
+		if action := strings.TrimSpace(routePolicy.Action); action != "" {
+			targetAction = action
+		}
+	}
 	policy := routePolicy{
-		Action:       policyActionRepoScansRun,
+		Action:       targetAction,
 		ResourceType: "repo_finding",
 	}
 	var allowedDecision *PolicyDecision
 	var allowedInput PolicyInput
 	var allowedDecisionSource string
 	var allowedDecisionVersion int
+	var shadowEvalCount uint64
+	var shadowDivergenceCount uint64
 	for _, target := range targets {
 		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
 		if err != nil {
@@ -739,7 +747,7 @@ func authorizeRepoFindingDeleteTargets(
 			return false, err
 		}
 		recordPolicyDecisionMetric(metrics, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision.Allowed)
-		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, nil, nil)
+		recordPolicyShadowEvaluation(c.Request.Context(), runtimePolicy, targeted, input, decision, metrics, &shadowEvalCount, &shadowDivergenceCount)
 		if !decision.Allowed {
 			setAuthzDecisionContext(c, runtimePolicy.PolicySetID, decisionVersion, decisionSource, runtimePolicy.RolloutMode, decision, input, fingerprinter)
 			return false, nil

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -299,6 +299,26 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 			return
 		}
 
+		if usesBodyAwareAuthorization(policy) {
+			blocked, workspace, err := inactiveWorkspaceBlock(c, policy, store)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+				return
+			}
+			if blocked {
+				c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+					"error":        "workspace is not active",
+					"code":         "workspace_inactive",
+					"status":       workspace.Status,
+					"suspended_at": workspace.SuspendedAt,
+					"deleted_at":   workspace.DeletedAt,
+				})
+				return
+			}
+			c.Next()
+			return
+		}
+
 		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
@@ -377,6 +397,10 @@ func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, write
 
 		c.Next()
 	}
+}
+
+func usesBodyAwareAuthorization(policy routePolicy) bool {
+	return strings.TrimSpace(policy.ResourceType) == "repo_finding_bulk_delete"
 }
 
 func inactiveWorkspaceBlock(c *gin.Context, policy routePolicy, store db.Store) (bool, db.TenancyWorkspace, error) {

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -103,6 +103,20 @@ func TestAuthorizeRepoFindingDeleteTargetsChecksRequestBodyTargets(t *testing.T)
 				c.Status(http.StatusForbidden)
 				return
 			}
+			authzDecision, exists := c.Get("authz.audit_decision")
+			if !exists {
+				t.Fatal("expected allowed body-aware delete target to set authz audit decision")
+			}
+			auditDecision, ok := authzDecision.(audit.AuditAuthzDecision)
+			if !ok {
+				t.Fatalf("expected authz audit decision, got %T", authzDecision)
+			}
+			if !auditDecision.Allowed {
+				t.Fatal("expected allowed authz audit decision")
+			}
+			if auditDecision.Input.ResourceType != "repo_finding" {
+				t.Fatalf("expected repo_finding audit resource type, got %q", auditDecision.Input.ResourceType)
+			}
 			c.Status(http.StatusNoContent)
 		})
 

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -95,7 +95,7 @@ func TestAuthorizeRepoFindingDeleteTargetsChecksRequestBodyTargets(t *testing.T)
 			c.Next()
 		})
 		r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
-			allowed, err := authorizeRepoFindingDeleteTargets(c, resolver, nil, nil, nil, nil, targets)
+			allowed, err := authorizeRepoFindingDeleteTargets(c, resolver, nil, nil, nil, nil, nil, targets)
 			if err != nil {
 				t.Fatalf("authorize targets: %v", err)
 			}
@@ -192,6 +192,7 @@ func TestRequireCentralPolicyMiddlewareDefersBulkDeleteToBodyAuthorization(t *te
 			nil,
 			nil,
 			nil,
+			nil,
 			[]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}},
 		)
 		if err != nil {
@@ -209,6 +210,89 @@ func TestRequireCentralPolicyMiddlewareDefersBulkDeleteToBodyAuthorization(t *te
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("expected body-authorized bulk delete to pass, got %d", w.Code)
+	}
+}
+
+func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	currentCompiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		t.Fatalf("compile current policy bundle: %v", err)
+	}
+	candidateBundle := defaultBuiltInRouteAuthorizationPolicyBundle()
+	candidateBundle.RBACActionRole[policyActionRepoScansRun] = []string{scopeAdmin}
+	candidateCompiled, err := compileRouteAuthorizationPolicyBundle(candidateBundle)
+	if err != nil {
+		t.Fatalf("compile candidate policy bundle: %v", err)
+	}
+
+	activeVersion := 1
+	candidateVersion := 2
+	resolver := staticPolicyRuntimeResolver{
+		runtime: resolvedCentralPolicyRuntime{
+			PolicySetID: defaultCentralPolicySetID,
+			Version:     activeVersion,
+			Source:      "persisted_active_version",
+			RolloutMode: db.AuthzPolicyRolloutModeShadow,
+			Engine:      newCentralPolicyEngineFromCompiled(nil, currentCompiled),
+			Registry:    currentCompiled.RouteRegistry,
+			Rollout: db.AuthzPolicyRollout{
+				PolicySetID:        defaultCentralPolicySetID,
+				ActiveVersion:      &activeVersion,
+				CandidateVersion:   &candidateVersion,
+				Mode:               db.AuthzPolicyRolloutModeShadow,
+				CanaryPercentage:   100,
+				TenantAllowlist:    []string{"tenant-a"},
+				WorkspaceAllowlist: []string{"workspace-a"},
+				ValidatedVersions:  []int{activeVersion, candidateVersion},
+			},
+			CandidateEngine:  newCentralPolicyEngineFromCompiled(nil, candidateCompiled),
+			CandidateSource:  "persisted_candidate_version",
+			CandidateVersion: candidateVersion,
+		},
+	}
+
+	metrics := telemetry.NewMetrics()
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+		c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+		c.Set("auth.principal_type", "subject")
+		c.Set("auth.principal_id", "principal-1")
+		c.Next()
+	})
+	r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
+		allowed, err := authorizeRepoFindingDeleteTargets(
+			c,
+			resolver,
+			nil,
+			nil,
+			nil,
+			nil,
+			metrics,
+			[]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}},
+		)
+		if err != nil {
+			t.Fatalf("authorize targets: %v", err)
+		}
+		if !allowed {
+			c.Status(http.StatusForbidden)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowEvaluationsTotal); got != 1 {
+		t.Fatalf("expected one shadow evaluation, got %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergencesTotal); got != 1 {
+		t.Fatalf("expected one shadow divergence, got %v", got)
 	}
 }
 

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -213,6 +213,72 @@ func TestRequireCentralPolicyMiddlewareDefersBulkDeleteToBodyAuthorization(t *te
 	}
 }
 
+func TestAuthorizeRepoFindingDeleteTargetsUsesBulkRouteAction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const customBulkDeleteAction = "repo_findings.delete"
+	bundle := defaultBuiltInRouteAuthorizationPolicyBundle()
+	for index := range bundle.RoutePolicies {
+		if bundle.RoutePolicies[index].Method == http.MethodPost &&
+			bundle.RoutePolicies[index].Path == "/v1/repo-findings/bulk-delete" {
+			bundle.RoutePolicies[index].Action = customBulkDeleteAction
+			bundle.RoutePolicies[index].ResourceType = "repo_finding_bulk_delete"
+		}
+	}
+	bundle.RBACActionRole[customBulkDeleteAction] = []string{scopeAdmin}
+	bundle.ABACPolicies[customBulkDeleteAction] = abacActionPolicy{AnyOf: []abacClause{{}}}
+	compiled, err := compileRouteAuthorizationPolicyBundle(bundle)
+	if err != nil {
+		t.Fatalf("compile custom policy bundle: %v", err)
+	}
+	resolver := staticPolicyRuntimeResolver{
+		runtime: resolvedCentralPolicyRuntime{
+			PolicySetID: defaultCentralPolicySetID,
+			Version:     1,
+			Source:      "test",
+			RolloutMode: db.AuthzPolicyRolloutModeDisabled,
+			Engine:      newCentralPolicyEngineFromCompiled(nil, compiled),
+			Registry:    compiled.RouteRegistry,
+			Rollout:     db.AuthzPolicyRollout{Mode: db.AuthzPolicyRolloutModeDisabled},
+		},
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+		c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+		c.Set("auth.principal_type", "subject")
+		c.Set("auth.principal_id", "principal-1")
+		c.Next()
+	})
+	r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
+		allowed, err := authorizeRepoFindingDeleteTargets(
+			c,
+			resolver,
+			nil,
+			nil,
+			nil,
+			nil,
+			telemetry.NewMetrics(),
+			[]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}},
+		)
+		if err != nil {
+			t.Fatalf("authorize targets: %v", err)
+		}
+		if !allowed {
+			c.Status(http.StatusForbidden)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected custom bulk delete action to deny scopeWrite caller, got %d", w.Code)
+	}
+}
+
 func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	currentCompiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
@@ -293,6 +359,9 @@ func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T)
 	}
 	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergencesTotal); got != 1 {
 		t.Fatalf("expected one shadow divergence, got %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergenceRate); got != 1 {
+		t.Fatalf("expected shadow divergence rate to update, got %v", got)
 	}
 }
 

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -123,6 +123,81 @@ func TestAuthorizeRepoFindingDeleteTargetsChecksRequestBodyTargets(t *testing.T)
 	}
 }
 
+func TestRequireCentralPolicyMiddlewareDefersBulkDeleteToBodyAuthorization(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := NewPolicyEngine(
+		newTenantIsolationEvaluator(),
+		newRBACPolicyEvaluator(nil),
+		newABACPolicyEvaluator(map[string]abacActionPolicy{
+			policyActionRepoScansRun: {
+				OnNoMatch: PolicyOutcomeDeny,
+				AnyOf: []abacClause{{
+					AllOf: []abacPredicate{
+						{
+							Source:   abacAttributeSourceResource,
+							Key:      "id",
+							Operator: abacOperatorEquals,
+							Value:    "finding-allowed",
+						},
+					},
+				}},
+			},
+		}),
+		nil,
+	)
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		t.Fatalf("compile built-in policy bundle: %v", err)
+	}
+	resolver := staticPolicyRuntimeResolver{
+		runtime: resolvedCentralPolicyRuntime{
+			PolicySetID: defaultCentralPolicySetID,
+			Version:     1,
+			Source:      "test",
+			RolloutMode: db.AuthzPolicyRolloutModeDisabled,
+			Engine:      engine,
+			Registry:    compiled.RouteRegistry,
+			Rollout:     db.AuthzPolicyRollout{Mode: db.AuthzPolicyRolloutModeDisabled},
+		},
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+		c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+		c.Set("auth.principal_type", "subject")
+		c.Set("auth.principal_id", "principal-1")
+		c.Next()
+	})
+	r.Use(requireCentralPolicyMiddleware(resolver, nil, nil, nil, telemetry.NewMetrics(), nil))
+	r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
+		allowed, err := authorizeRepoFindingDeleteTargets(
+			c,
+			resolver,
+			nil,
+			nil,
+			nil,
+			nil,
+			[]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}},
+		)
+		if err != nil {
+			t.Fatalf("authorize targets: %v", err)
+		}
+		if !allowed {
+			c.Status(http.StatusForbidden)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected body-authorized bulk delete to pass, got %d", w.Code)
+	}
+}
+
 func TestPolicyRolesFromAuthLegacyKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -46,6 +46,83 @@ func TestPolicyRolesFromScope(t *testing.T) {
 	}
 }
 
+func TestAuthorizeRepoFindingDeleteTargetsChecksRequestBodyTargets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := NewPolicyEngine(
+		newTenantIsolationEvaluator(),
+		newRBACPolicyEvaluator(nil),
+		newABACPolicyEvaluator(map[string]abacActionPolicy{
+			policyActionRepoScansRun: {
+				OnNoMatch: PolicyOutcomeDeny,
+				AnyOf: []abacClause{{
+					AllOf: []abacPredicate{
+						{
+							Source:   abacAttributeSourceResource,
+							Key:      "id",
+							Operator: abacOperatorEquals,
+							Value:    "finding-allowed",
+						},
+						{
+							Source:   abacAttributeSourceContext,
+							Key:      "repo_scan_id",
+							Operator: abacOperatorEquals,
+							Value:    "repo-scan-1",
+						},
+					},
+				}},
+			},
+		}),
+		nil,
+	)
+	resolver := staticPolicyRuntimeResolver{
+		runtime: resolvedCentralPolicyRuntime{
+			PolicySetID: defaultCentralPolicySetID,
+			Version:     1,
+			Source:      "test",
+			RolloutMode: db.AuthzPolicyRolloutModeDisabled,
+			Engine:      engine,
+			Rollout:     db.AuthzPolicyRollout{Mode: db.AuthzPolicyRolloutModeDisabled},
+		},
+	}
+
+	runRequest := func(targets []RepoFindingDeleteTarget) int {
+		r := gin.New()
+		r.Use(func(c *gin.Context) {
+			c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+			c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+			c.Set("auth.principal_type", "subject")
+			c.Set("auth.principal_id", "principal-1")
+			c.Next()
+		})
+		r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
+			allowed, err := authorizeRepoFindingDeleteTargets(c, resolver, nil, nil, nil, nil, targets)
+			if err != nil {
+				t.Fatalf("authorize targets: %v", err)
+			}
+			if !allowed {
+				c.Status(http.StatusForbidden)
+				return
+			}
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if got := runRequest([]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}}); got != http.StatusNoContent {
+		t.Fatalf("expected allowed target to pass, got %d", got)
+	}
+	if got := runRequest([]RepoFindingDeleteTarget{
+		{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"},
+		{FindingID: "finding-denied", RepoScanID: "repo-scan-1"},
+	}); got != http.StatusForbidden {
+		t.Fatalf("expected denied body target to fail, got %d", got)
+	}
+}
+
 func TestPolicyRolesFromAuthLegacyKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -286,7 +286,17 @@ func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T)
 		t.Fatalf("compile current policy bundle: %v", err)
 	}
 	candidateBundle := defaultBuiltInRouteAuthorizationPolicyBundle()
-	candidateBundle.RBACActionRole[policyActionRepoScansRun] = []string{scopeAdmin}
+	candidateBundle.ABACPolicies[policyActionRepoScansRun] = abacActionPolicy{
+		OnNoMatch: PolicyOutcomeDeny,
+		AnyOf: []abacClause{{
+			AllOf: []abacPredicate{{
+				Source:   abacAttributeSourceResource,
+				Key:      "id",
+				Operator: abacOperatorEquals,
+				Value:    "finding-shared",
+			}},
+		}},
+	}
 	candidateCompiled, err := compileRouteAuthorizationPolicyBundle(candidateBundle)
 	if err != nil {
 		t.Fatalf("compile candidate policy bundle: %v", err)
@@ -327,7 +337,12 @@ func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T)
 		c.Set("auth.principal_id", "principal-1")
 		c.Next()
 	})
+	r.Use(requireCentralPolicyMiddleware(resolver, nil, nil, nil, metrics, nil))
 	r.POST("/v1/repo-findings/bulk-delete", func(c *gin.Context) {
+		findingID := strings.TrimSpace(c.Query("finding"))
+		if findingID == "" {
+			findingID = "finding-divergent"
+		}
 		allowed, err := authorizeRepoFindingDeleteTargets(
 			c,
 			resolver,
@@ -336,7 +351,7 @@ func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T)
 			nil,
 			nil,
 			metrics,
-			[]RepoFindingDeleteTarget{{FindingID: "finding-allowed", RepoScanID: "repo-scan-1"}},
+			[]RepoFindingDeleteTarget{{FindingID: findingID, RepoScanID: "repo-scan-1"}},
 		)
 		if err != nil {
 			t.Fatalf("authorize targets: %v", err)
@@ -348,19 +363,21 @@ func TestAuthorizeRepoFindingDeleteTargetsShadowEvaluatesCandidate(t *testing.T)
 		c.Status(http.StatusNoContent)
 	})
 
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", nil)
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d", w.Code)
+	for _, findingID := range []string{"finding-divergent", "finding-shared"} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete?finding="+findingID, nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204 for %s, got %d", findingID, w.Code)
+		}
 	}
-	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowEvaluationsTotal); got != 1 {
-		t.Fatalf("expected one shadow evaluation, got %v", got)
+	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowEvaluationsTotal); got != 2 {
+		t.Fatalf("expected two shadow evaluations, got %v", got)
 	}
 	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergencesTotal); got != 1 {
 		t.Fatalf("expected one shadow divergence, got %v", got)
 	}
-	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergenceRate); got != 1 {
+	if got := testutil.ToFloat64(metrics.AuthzPolicyShadowDivergenceRate); got != 0.5 {
 		t.Fatalf("expected shadow divergence rate to update, got %v", got)
 	}
 }

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -659,6 +659,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-scans", Action: policyActionRepoScansRead, ResourceType: "repo_scan"},
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
+		{Method: http.MethodPost, Path: "/v1/repo-findings/bulk-delete", Action: policyActionRepoScansRun, ResourceType: "repo_finding"},
 		{Method: http.MethodDelete, Path: "/v1/repo-findings/:finding_id", Action: policyActionRepoScansRun, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodPost, Path: "/v1/repo-findings/:finding_id/remediation/preview", Action: policyActionRepoScansRead, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodPost, Path: "/v1/repo-findings/:finding_id/remediation/publish", Action: policyActionRepoScansRun, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -659,7 +659,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-scans", Action: policyActionRepoScansRead, ResourceType: "repo_scan"},
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
-		{Method: http.MethodPost, Path: "/v1/repo-findings/bulk-delete", Action: policyActionRepoScansRun, ResourceType: "repo_finding"},
+		{Method: http.MethodPost, Path: "/v1/repo-findings/bulk-delete", Action: policyActionRepoScansRun, ResourceType: "repo_finding_bulk_delete"},
 		{Method: http.MethodDelete, Path: "/v1/repo-findings/:finding_id", Action: policyActionRepoScansRun, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodPost, Path: "/v1/repo-findings/:finding_id/remediation/preview", Action: policyActionRepoScansRead, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodPost, Path: "/v1/repo-findings/:finding_id/remediation/publish", Action: policyActionRepoScansRun, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -114,6 +114,19 @@ func TestDefaultRoutePolicyBundleUsesRepoScansRunForDeleteRepoFinding(t *testing
 	if err != nil {
 		t.Fatalf("compile built-in policy bundle: %v", err)
 	}
+	bulkPolicy, exists := compiled.RouteRegistry.lookup("POST", "/v1/repo-findings/bulk-delete")
+	if !exists {
+		t.Fatal("expected built-in authz policy for POST /v1/repo-findings/bulk-delete")
+	}
+	if bulkPolicy.Action != policyActionRepoScansRun {
+		t.Fatalf("expected action %q, got %q", policyActionRepoScansRun, bulkPolicy.Action)
+	}
+	if bulkPolicy.ResourceType != "repo_finding_bulk_delete" {
+		t.Fatalf("expected bulk delete resource type, got %q", bulkPolicy.ResourceType)
+	}
+	if bulkPolicy.ResourceIDParam != "" {
+		t.Fatalf("expected bulk delete route to defer target IDs to the request body, got %q", bulkPolicy.ResourceIDParam)
+	}
 	policy, exists := compiled.RouteRegistry.lookup("DELETE", "/v1/repo-findings/:finding_id")
 	if !exists {
 		t.Fatal("expected built-in authz policy for DELETE /v1/repo-findings/:finding_id")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -497,6 +497,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/repo-findings", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
+		v1.POST("/repo-findings/bulk-delete", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
+		})
 		v1.DELETE("/repo-findings/:finding_id", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
@@ -1032,6 +1035,33 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		c.Status(http.StatusNoContent)
+	})
+
+	v1.POST("/repo-findings/bulk-delete", func(c *gin.Context) {
+		var request RepoFindingsBulkDeleteRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			return
+		}
+		for _, item := range request.Items {
+			repoScanID := strings.TrimSpace(item.RepoScanID)
+			if repoScanID == "" || !isValidUUID(repoScanID) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+				return
+			}
+		}
+		response, err := svc.DeleteRepoFindings(c.Request.Context(), request.Items)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidRepoRemediationRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			default:
+				logger.Error("delete repo findings", telemetry.ZapError(err))
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete repo findings"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, response)
 	})
 
 	v1.POST("/repo-findings/:finding_id/remediation/preview", func(c *gin.Context) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1043,14 +1043,39 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
 			return
 		}
-		for _, item := range request.Items {
+		targets, err := normalizeRepoFindingDeleteTargets(request.Items)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo finding delete request"})
+			return
+		}
+		for _, item := range targets {
 			repoScanID := strings.TrimSpace(item.RepoScanID)
 			if repoScanID == "" || !isValidUUID(repoScanID) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
 				return
 			}
 		}
-		response, err := svc.DeleteRepoFindings(c.Request.Context(), request.Items)
+		authorized, err := authorizeRepoFindingDeleteTargets(
+			c,
+			centralPolicyResolver,
+			opts.WriteAPIKeys,
+			opts.APIKeyScopes,
+			authzStore,
+			opts.AuditFingerprinter,
+			targets,
+		)
+		if err != nil {
+			if logger != nil {
+				logger.Error("authorize repo findings bulk delete", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+			return
+		}
+		if !authorized {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		response, err := svc.DeleteRepoFindings(c.Request.Context(), targets)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrInvalidRepoRemediationRequest):

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1062,6 +1062,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			opts.APIKeyScopes,
 			authzStore,
 			opts.AuditFingerprinter,
+			metrics,
 			targets,
 		)
 		if err != nil {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1157,6 +1157,36 @@ func TestRouterBulkDeleteRepoFindings(t *testing.T) {
 	if len(repoScans) != 1 || repoScans[0].FindingCount != 1 {
 		t.Fatalf("expected repo scan count to refresh after bulk delete, got %+v", repoScans)
 	}
+
+	t.Run("reports missing items", func(t *testing.T) {
+		missingPayload, err := json.Marshal(RepoFindingsBulkDeleteRequest{
+			Items: []RepoFindingDeleteTarget{
+				{FindingID: "repo-bulk-missing", RepoScanID: repoScan.ID},
+				{FindingID: "repo-bulk-keep", RepoScanID: repoScan.ID},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal bulk delete missing request: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", bytes.NewReader(missingPayload))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected partial bulk delete 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		var body RepoFindingsBulkDeleteResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode partial bulk delete response: %v", err)
+		}
+		if len(body.Deleted) != 1 || body.Deleted[0].FindingID != "repo-bulk-keep" {
+			t.Fatalf("expected repo-bulk-keep deleted, got %+v", body.Deleted)
+		}
+		if len(body.Failed) != 1 || body.Failed[0].FindingID != "repo-bulk-missing" || body.Failed[0].Error == "" {
+			t.Fatalf("expected missing finding failure, got %+v", body.Failed)
+		}
+	})
 }
 
 func TestRouterRepoFindingRemediationPublish(t *testing.T) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1075,6 +1075,90 @@ func TestRouterDeleteRepoFinding(t *testing.T) {
 	}
 }
 
+func TestRouterBulkDeleteRepoFindings(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	findings := []domain.Finding{
+		{
+			ID:           "repo-bulk-delete-a",
+			Type:         domain.FindingSecretExposure,
+			Severity:     domain.SeverityCritical,
+			Title:        "token exposed",
+			HumanSummary: "Token-like value in repository history.",
+			CreatedAt:    now,
+		},
+		{
+			ID:           "repo-bulk-delete-b",
+			Type:         domain.FindingRepoMisconfig,
+			Severity:     domain.SeverityHigh,
+			Title:        "workflow write all",
+			HumanSummary: "Workflow uses write-all.",
+			CreatedAt:    now,
+		},
+		{
+			ID:           "repo-bulk-keep",
+			Type:         domain.FindingRepoMisconfig,
+			Severity:     domain.SeverityMedium,
+			Title:        "workflow read all",
+			HumanSummary: "Workflow reads too broadly.",
+			CreatedAt:    now,
+		},
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, findings); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(time.Minute), 3, 3, len(findings), false, db.RepoScanContext{}, ""); err != nil {
+		t.Fatalf("complete repo scan: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+	payload, err := json.Marshal(RepoFindingsBulkDeleteRequest{
+		Items: []RepoFindingDeleteTarget{
+			{FindingID: "repo-bulk-delete-a", RepoScanID: repoScan.ID},
+			{FindingID: "repo-bulk-delete-b", RepoScanID: repoScan.ID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal bulk delete request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/bulk-delete", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected bulk delete repo findings 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body RepoFindingsBulkDeleteResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode bulk delete response: %v", err)
+	}
+	if len(body.Deleted) != 2 || len(body.Failed) != 0 {
+		t.Fatalf("expected two deleted and no failures, got %+v", body)
+	}
+
+	remaining, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{RepoScanID: repoScan.ID})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "repo-bulk-keep" {
+		t.Fatalf("expected only repo-bulk-keep after bulk delete, got %+v", remaining)
+	}
+	repoScans, err := svc.Store.ListRepoScans(defaultScopeContext(), 10)
+	if err != nil {
+		t.Fatalf("list repo scans: %v", err)
+	}
+	if len(repoScans) != 1 || repoScans[0].FindingCount != 1 {
+		t.Fatalf("expected repo scan count to refresh after bulk delete, got %+v", repoScans)
+	}
+}
+
 func TestRouterRepoFindingRemediationPublish(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -52,6 +52,7 @@ const (
 	repoFindingsTriageFilterStep     = maxCursorFetchLimit
 	repoFindingsTriageFilterCap      = maxCursorFetchLimit * 4
 	repoFindingSLAHighCritical       = 7 * 24 * time.Hour
+	maxRepoFindingBulkDeleteItems    = 500
 )
 
 const (
@@ -474,6 +475,29 @@ type RepoFindingsSummary struct {
 	ByOwner                  map[string]int `json:"by_owner"`
 	ByDetector               map[string]int `json:"by_detector"`
 	BySeverity               map[string]int `json:"by_severity"`
+}
+
+// RepoFindingDeleteTarget identifies one repository finding inside one scan.
+type RepoFindingDeleteTarget struct {
+	FindingID  string `json:"finding_id"`
+	RepoScanID string `json:"repo_scan_id"`
+}
+
+// RepoFindingsBulkDeleteRequest captures selected repository findings to remove.
+type RepoFindingsBulkDeleteRequest struct {
+	Items []RepoFindingDeleteTarget `json:"items"`
+}
+
+// RepoFindingDeleteFailure records a selected finding that could not be removed.
+type RepoFindingDeleteFailure struct {
+	RepoFindingDeleteTarget
+	Error string `json:"error"`
+}
+
+// RepoFindingsBulkDeleteResponse reports which selected findings were removed.
+type RepoFindingsBulkDeleteResponse struct {
+	Deleted []RepoFindingDeleteTarget  `json:"deleted"`
+	Failed  []RepoFindingDeleteFailure `json:"failed,omitempty"`
 }
 
 // ScanDiff captures delta between one scan and its previous scan for same provider.
@@ -2600,6 +2624,63 @@ func (s *Service) DeleteRepoFinding(ctx context.Context, findingID string, repoS
 		return ErrInvalidRepoRemediationRequest
 	}
 	return s.Store.DeleteRepoFinding(ctx, repoScanID, findingID)
+}
+
+// DeleteRepoFindings permanently removes selected repository findings.
+func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingDeleteTarget) (RepoFindingsBulkDeleteResponse, error) {
+	ctx = s.scopeContext(ctx)
+	normalized, err := normalizeRepoFindingDeleteTargets(targets)
+	if err != nil {
+		return RepoFindingsBulkDeleteResponse{}, err
+	}
+	response := RepoFindingsBulkDeleteResponse{
+		Deleted: []RepoFindingDeleteTarget{},
+		Failed:  []RepoFindingDeleteFailure{},
+	}
+	for _, target := range normalized {
+		err := s.Store.DeleteRepoFinding(ctx, target.RepoScanID, target.FindingID)
+		if err == nil {
+			response.Deleted = append(response.Deleted, target)
+			continue
+		}
+		if errors.Is(err, db.ErrNotFound) {
+			response.Failed = append(response.Failed, RepoFindingDeleteFailure{
+				RepoFindingDeleteTarget: target,
+				Error:                   "repo finding not found",
+			})
+			continue
+		}
+		return response, err
+	}
+	return response, nil
+}
+
+func normalizeRepoFindingDeleteTargets(targets []RepoFindingDeleteTarget) ([]RepoFindingDeleteTarget, error) {
+	if len(targets) == 0 || len(targets) > maxRepoFindingBulkDeleteItems {
+		return nil, ErrInvalidRepoRemediationRequest
+	}
+	normalized := make([]RepoFindingDeleteTarget, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		findingID := strings.TrimSpace(target.FindingID)
+		repoScanID := strings.TrimSpace(target.RepoScanID)
+		if findingID == "" || repoScanID == "" {
+			return nil, ErrInvalidRepoRemediationRequest
+		}
+		key := repoScanID + "::" + findingID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, RepoFindingDeleteTarget{
+			FindingID:  findingID,
+			RepoScanID: repoScanID,
+		})
+	}
+	if len(normalized) == 0 {
+		return nil, ErrInvalidRepoRemediationRequest
+	}
+	return normalized, nil
 }
 
 func (s *Service) listRepoFindingsWithPostTriageFilter(

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -2650,7 +2650,10 @@ func (s *Service) DeleteRepoFindings(ctx context.Context, targets []RepoFindingD
 			})
 			continue
 		}
-		return response, err
+		response.Failed = append(response.Failed, RepoFindingDeleteFailure{
+			RepoFindingDeleteTarget: target,
+			Error:                   "failed to delete repo finding",
+		})
 	}
 	return response, nil
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -65,6 +65,20 @@ export type RepoFindingsSummary = {
   by_severity: Record<string, number>;
 };
 
+export type RepoFindingDeleteTarget = {
+  finding_id: string;
+  repo_scan_id: string;
+};
+
+export type RepoFindingDeleteFailure = RepoFindingDeleteTarget & {
+  error: string;
+};
+
+export type RepoFindingsBulkDeleteResponse = {
+  deleted: RepoFindingDeleteTarget[];
+  failed?: RepoFindingDeleteFailure[];
+};
+
 export type RepoScanSourceHealthStatus =
   | 'complete'
   | 'partial'
@@ -9987,6 +10001,12 @@ export const apiClient = {
         method: 'DELETE'
       }
     );
+  },
+  deleteRepoFindings(items: RepoFindingDeleteTarget[], auth?: RequestAuthContext) {
+    return request<RepoFindingsBulkDeleteResponse>('/v1/repo-findings/bulk-delete', auth, {
+      method: 'POST',
+      body: JSON.stringify({ items })
+    });
   },
   getRepoRiskGraph(
     filters: {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7460,6 +7460,7 @@ describe('Domain-first app routes', () => {
 
 describe('ProductFindingsPage states', () => {
   afterEach(() => {
+    window.localStorage.clear();
     vi.restoreAllMocks();
     vi.doUnmock('./hooks/useMe');
     vi.resetModules();
@@ -7589,6 +7590,68 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
     expect(await screen.findByText('Completed scans')).toBeInTheDocument();
     expect(await screen.findByText('Legacy finding')).toBeInTheDocument();
+  });
+
+  it('lets operators remove a failed scan banner without hiding findings', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-dismissible',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-dismissible-succeeded',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 1
+    };
+    const finding: Finding = {
+      id: 'finding-dismissible',
+      scan_id: oldSucceededScan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Historical workflow finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [finding]
+    });
+
+    expect(await screen.findByText(/Last scan failed:/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Last scan failed:/i)).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Historical workflow finding')).toBeInTheDocument();
+  });
+
+  it('lets operators remove a failed-only scan state', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-only-dismissible',
+      status: 'failed',
+      finished_at: '2026-05-17T11:05:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+
+    await renderFindings({ repoScans: [failedScan] });
+
+    expect(await screen.findByText('Your last repository scan failed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {
@@ -8103,6 +8166,74 @@ describe('ProductFindingsPage states', () => {
     await waitFor(() => {
       expect(screen.queryByText('First clearable token finding')).not.toBeInTheDocument();
       expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+  });
+
+  it('falls back to individual deletes when the bulk endpoint is unavailable', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-bulk-missing',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+    const findings: Finding[] = [
+      {
+        id: 'finding-clear-fallback-first',
+        scan_id: scan.id,
+        type: 'secret_exposure',
+        severity: 'critical',
+        title: 'Fallback clearable token finding',
+        human_summary: 'A token-like value appears in a committed workflow.',
+        remediation: 'Rotate the credential and remove the committed value.',
+        created_at: '2026-05-17T11:06:00Z'
+      },
+      {
+        id: 'finding-clear-fallback-second',
+        scan_id: scan.id,
+        type: 'workflow_permission',
+        severity: 'high',
+        title: 'Fallback clearable workflow finding',
+        human_summary: 'A workflow grants broad repository permissions.',
+        remediation: 'Limit workflow permissions.',
+        created_at: '2026-05-17T11:07:00Z'
+      }
+    ];
+
+    const { deleteRepoFinding, deleteRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [] })
+    });
+    const { ApiError } = await import('./api/client');
+    deleteRepoFindings.mockRejectedValueOnce(new ApiError('Request failed (404)', 404));
+
+    expect(await screen.findByText('Fallback clearable token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Fallback clearable workflow finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(1);
+      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+    });
+    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+      1,
+      findings[0].id,
+      scan.id,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(deleteRepoFinding).toHaveBeenNthCalledWith(
+      2,
+      findings[1].id,
+      scan.id,
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Fallback clearable token finding')).not.toBeInTheDocument();
+      expect(screen.queryByText('Fallback clearable workflow finding')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8085,7 +8085,7 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('First clearable token finding')).toBeInTheDocument();
     expect(await screen.findByText('Second clearable workflow finding')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
     const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
     expect(within(confirmDialog).getByText(/2 visible findings/i)).toBeInTheDocument();
     fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
@@ -8105,6 +8105,47 @@ describe('ProductFindingsPage states', () => {
       expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+  });
+
+  it('chunks clear all requests above the repository finding bulk limit', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-large',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 501
+    };
+    const findings: Finding[] = Array.from({ length: 501 }, (_, index) => ({
+      id: `finding-clear-all-large-${index}`,
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: `Large clear all finding ${index}`,
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    }));
+
+    const { deleteRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      repoFindings: findings
+    });
+
+    expect(await screen.findByText('Large clear all finding 0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(2);
+    });
+    const firstBatch = deleteRepoFindings.mock.calls[0]?.[0] ?? [];
+    const secondBatch = deleteRepoFindings.mock.calls[1]?.[0] ?? [];
+    expect(firstBatch).toHaveLength(500);
+    expect(secondBatch).toHaveLength(1);
+    expect(firstBatch[0]).toEqual({ finding_id: findings[0].id, repo_scan_id: scan.id });
+    expect(secondBatch[0]).toEqual({ finding_id: findings[500].id, repo_scan_id: scan.id });
   });
 
   it('keeps only failed repository findings in the clear all dialog', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -8107,6 +8107,53 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
   });
 
+  it('reloads repository findings after clearing a paged list', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-paged',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+    const firstPageFinding: Finding = {
+      id: 'finding-clear-paged-first',
+      scan_id: scan.id,
+      type: 'secret_exposure',
+      severity: 'critical',
+      title: 'First page clearable token finding',
+      human_summary: 'A token-like value appears in a committed workflow.',
+      remediation: 'Rotate the credential and remove the committed value.',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+    const nextPageFinding: Finding = {
+      id: 'finding-clear-paged-next',
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: 'Next page workflow finding',
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    };
+
+    const { listRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      listRepoFindings: (_params, call) => ({ items: call === 1 ? [firstPageFinding] : [nextPageFinding] })
+    });
+
+    expect(await screen.findByText('First page clearable token finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(listRepoFindings).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByText('First page clearable token finding')).not.toBeInTheDocument();
+    expect(await screen.findByText('Next page workflow finding')).toBeInTheDocument();
+  });
+
   it('chunks clear all requests above the repository finding bulk limit', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
@@ -8146,6 +8193,54 @@ describe('ProductFindingsPage states', () => {
     expect(secondBatch).toHaveLength(1);
     expect(firstBatch[0]).toEqual({ finding_id: findings[0].id, repo_scan_id: scan.id });
     expect(secondBatch[0]).toEqual({ finding_id: findings[500].id, repo_scan_id: scan.id });
+  });
+
+  it('preserves completed clear all batches when a later batch fails', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-batch-failure',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 501
+    };
+    const findings: Finding[] = Array.from({ length: 501 }, (_, index) => ({
+      id: `finding-clear-all-batch-failure-${index}`,
+      scan_id: scan.id,
+      type: 'workflow_permission',
+      severity: 'high',
+      title: `Batch failure finding ${index}`,
+      human_summary: 'A workflow grants broad repository permissions.',
+      remediation: 'Limit workflow permissions.',
+      created_at: '2026-05-17T11:07:00Z'
+    }));
+
+    const { deleteRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      repoFindings: findings
+    });
+    deleteRepoFindings
+      .mockResolvedValueOnce({
+        deleted: findings.slice(0, 500).map((finding) => ({
+          finding_id: finding.id,
+          repo_scan_id: finding.scan_id
+        }))
+      })
+      .mockRejectedValueOnce(new Error('rate limit exceeded'));
+
+    expect(await screen.findByText('Batch failure finding 0')).toBeInTheDocument();
+    expect(await screen.findByText('Batch failure finding 500')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clear all$/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(deleteRepoFindings).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('500 deleted. 1 remaining.')).toBeInTheDocument();
+    expect(screen.queryByText('Batch failure finding 0')).not.toBeInTheDocument();
+    expect(await screen.findByText('Batch failure finding 500')).toBeInTheDocument();
+    expect(within(confirmDialog).getByText(/1 visible finding/i)).toBeInTheDocument();
   });
 
   it('keeps only failed repository findings in the clear all dialog', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -7406,6 +7406,9 @@ describe('Domain-first app routes', () => {
       };
     });
     const deleteRepoFinding = vi.spyOn(api.apiClient, 'deleteRepoFinding').mockResolvedValue(undefined);
+    const deleteRepoFindings = vi
+      .spyOn(api.apiClient, 'deleteRepoFindings')
+      .mockImplementation(async (items) => ({ deleted: items }));
     const getRepoFindingsTrends = vi
       .spyOn(api.apiClient, 'getRepoFindingsTrends')
       .mockImplementation(async (params) => {
@@ -7449,6 +7452,7 @@ describe('Domain-first app routes', () => {
       listRepoFindings,
       triageFinding,
       deleteRepoFinding,
+      deleteRepoFindings,
       getRepoFindingsTrends,
       getRepoRiskGraph
     };
@@ -8073,7 +8077,7 @@ describe('ProductFindingsPage states', () => {
       }
     ];
 
-    const { deleteRepoFinding } = await renderFindings({
+    const { deleteRepoFinding, deleteRepoFindings } = await renderFindings({
       repoScans: [scan],
       listRepoFindings: (_params, call) => ({ items: call === 1 ? findings : [] })
     });
@@ -8087,13 +8091,76 @@ describe('ProductFindingsPage states', () => {
     fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
 
     await waitFor(() => {
-      expect(deleteRepoFinding).toHaveBeenCalledTimes(2);
+      expect(deleteRepoFindings).toHaveBeenCalledWith(
+        [
+          { finding_id: findings[0].id, repo_scan_id: scan.id },
+          { finding_id: findings[1].id, repo_scan_id: scan.id }
+        ],
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      );
     });
+    expect(deleteRepoFinding).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.queryByText('First clearable token finding')).not.toBeInTheDocument();
       expect(screen.queryByText('Second clearable workflow finding')).not.toBeInTheDocument();
     });
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+  });
+
+  it('keeps only failed repository findings in the clear all dialog', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-clear-all-partial',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 2
+    };
+
+    const findings: Finding[] = [
+      {
+        id: 'finding-clear-partial-deleted',
+        scan_id: scan.id,
+        type: 'secret_exposure',
+        severity: 'critical',
+        title: 'Deleted bulk token finding',
+        human_summary: 'A token-like value appears in a committed workflow.',
+        remediation: 'Rotate the credential and remove the committed value.',
+        created_at: '2026-05-17T11:06:00Z'
+      },
+      {
+        id: 'finding-clear-partial-remaining',
+        scan_id: scan.id,
+        type: 'workflow_permission',
+        severity: 'high',
+        title: 'Remaining bulk workflow finding',
+        human_summary: 'A workflow grants broad repository permissions.',
+        remediation: 'Limit workflow permissions.',
+        created_at: '2026-05-17T11:07:00Z'
+      }
+    ];
+
+    const { deleteRepoFindings } = await renderFindings({
+      repoScans: [scan],
+      repoFindings: findings
+    });
+    deleteRepoFindings.mockResolvedValueOnce({
+      deleted: [{ finding_id: findings[0].id, repo_scan_id: scan.id }],
+      failed: [{ finding_id: findings[1].id, repo_scan_id: scan.id, error: 'repo finding not found' }]
+    });
+
+    expect(await screen.findByText('Deleted bulk token finding')).toBeInTheDocument();
+    expect(await screen.findByText('Remaining bulk workflow finding')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }));
+    const confirmDialog = await screen.findByRole('dialog', { name: /Clear findings/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: /Delete all/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Deleted bulk token finding')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Remaining bulk workflow finding')).toBeInTheDocument();
+    expect(await screen.findByText('1 deleted. 1 remaining.')).toBeInTheDocument();
+    expect(within(confirmDialog).getByText(/1 visible finding/i)).toBeInTheDocument();
   });
 
   it('disables clear all while repository findings are refreshing', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1639,6 +1639,66 @@ function mergeRepoFindingsBulkDeleteResponses(
   );
 }
 
+async function deleteRepoFindingsBatchWithFallback(
+  targets: RepoFindingDeleteTarget[],
+  auth: RequestAuthContext
+): Promise<RepoFindingsBulkDeleteResponse> {
+  try {
+    return await apiClient.deleteRepoFindings(targets, auth);
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 404) {
+      throw error;
+    }
+  }
+
+  const response: RepoFindingsBulkDeleteResponse = { deleted: [], failed: [] };
+  for (const target of targets) {
+    try {
+      await apiClient.deleteRepoFinding(target.finding_id, target.repo_scan_id, auth);
+      response.deleted.push(target);
+    } catch (deleteError) {
+      response.failed?.push({
+        ...target,
+        error: deleteError instanceof Error ? deleteError.message : 'Failed to delete finding.'
+      });
+    }
+  }
+  return response;
+}
+
+const DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY = 'idt:repo-failed-scan-dismissals:v1';
+
+function failedRepoScanDismissalKey(scope: ProductSession, scanID: string): string {
+  return `${scope.tenantID}:${scope.workspaceID}:${scanID}`;
+}
+
+function readDismissedRepoFailedScanKeys(): Set<string> {
+  if (typeof window === 'undefined') {
+    return new Set();
+  }
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY);
+    if (!raw) {
+      return new Set();
+    }
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissedRepoFailedScanKeys(keys: Set<string>) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(DISMISSED_REPO_FAILED_SCAN_STORAGE_KEY, JSON.stringify([...keys]));
+  } catch {
+    // Local storage is an enhancement here; the in-memory dismissal still applies.
+  }
+}
+
 function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
   return [...scores].sort((left, right) => {
     if (right.score !== left.score) {
@@ -27117,6 +27177,9 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filtersExpanded, setFiltersExpanded] = useState(true);
+  const [dismissedFailedScanKeys, setDismissedFailedScanKeys] = useState<Set<string>>(() =>
+    readDismissedRepoFailedScanKeys()
+  );
   const [hierarchyOpenState, setHierarchyOpenState] = useState<{
     repositories: Set<string>;
     scans: Set<string>;
@@ -27636,7 +27699,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
         let batchError: unknown = null;
         for (const batch of chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding))) {
           try {
-            responses.push(await apiClient.deleteRepoFindings(batch, auth));
+            responses.push(await deleteRepoFindingsBatchWithFallback(batch, auth));
           } catch (requestError) {
             batchError = requestError;
             break;
@@ -27996,6 +28059,18 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     void loadTrendSignals(scope, 'refresh');
   };
 
+  const dismissFailedRepoScan = (scan: RepoScanRecord | null) => {
+    if (!scan) {
+      return;
+    }
+    setDismissedFailedScanKeys((current) => {
+      const next = new Set(current);
+      next.add(failedRepoScanDismissalKey(scope, scan.id));
+      writeDismissedRepoFailedScanKeys(next);
+      return next;
+    });
+  };
+
   const connectPath = buildScopedPath(scope, 'github/connect');
   const remediationPath = appendEnvironmentQuery(
     buildScopedPath(scope, 'github/remediation'),
@@ -28006,11 +28081,17 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
   );
   const succeededScanCount = repoScans.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
   const failedScans = scansByRecency.filter((scan) => isFailedScanStatus(scan.status));
+  const visibleFailedScans = failedScans.filter(
+    (scan) => !dismissedFailedScanKeys.has(failedRepoScanDismissalKey(scope, scan.id))
+  );
   const latestScan = scansByRecency[0] ?? null;
-  const latestFailedScan = failedScans[0] ?? null;
+  const latestFailedScan = visibleFailedScans[0] ?? null;
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
-  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
+  const latestScanFailed = latestScan
+    ? isFailedScanStatus(latestScan.status) &&
+      !dismissedFailedScanKeys.has(failedRepoScanDismissalKey(scope, latestScan.id))
+    : false;
   const neverScanned = repoScans.length === 0;
   // "Has findings" must be independent of both active finding filters and the
   // recent-scan window (listRepoScans is capped). Combine the server-side
@@ -28106,6 +28187,13 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               <button
                 className="idt-btn idt-btn-ghost"
                 type="button"
+                onClick={() => dismissFailedRepoScan(latestFailedScan)}
+              >
+                Remove
+              </button>
+              <button
+                className="idt-btn idt-btn-ghost"
+                type="button"
                 onClick={handleRefresh}
                 disabled={refreshing || signalsRefreshing}
               >
@@ -28185,7 +28273,16 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       {latestScanFailed ? (
         <div className="idt-app-alert idt-app-alert-error idt-repo-scan-health">
           <span>Last scan failed: {describeScanFailure(latestFailedScan)}</span>
-          <Link to={connectPath}>Review &amp; re-run</Link>
+          <span className="idt-repo-scan-health-actions-inline">
+            <button
+              className="idt-repo-scan-health-remove"
+              type="button"
+              onClick={() => dismissFailedRepoScan(latestFailedScan)}
+            >
+              Remove
+            </button>
+            <Link to={connectPath}>Review &amp; re-run</Link>
+          </span>
         </div>
       ) : null}
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -27633,8 +27633,14 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
         const responses: RepoFindingsBulkDeleteResponse[] = [];
+        let batchError: unknown = null;
         for (const batch of chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding))) {
-          responses.push(await apiClient.deleteRepoFindings(batch, auth));
+          try {
+            responses.push(await apiClient.deleteRepoFindings(batch, auth));
+          } catch (requestError) {
+            batchError = requestError;
+            break;
+          }
         }
         const response = mergeRepoFindingsBulkDeleteResponses(responses);
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
@@ -27646,7 +27652,10 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
           const key = repoFindingDeleteTargetKeyFromFinding(candidate);
           return failedKeys.has(key) || !deletedKeys.has(key);
         });
-        failureMessage = response.failed?.[0]?.error || failureMessage;
+        failureMessage =
+          batchError instanceof Error
+            ? batchError.message
+            : response.failed?.[0]?.error || failureMessage;
       } else {
         const candidate = candidates[0];
         if (candidate) {
@@ -27670,9 +27679,10 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       }
       const repoScanFilterSelected = normalizeValue(repoScanFilter);
       const shouldReloadFindings =
-        !bulkDeleteActive &&
-        (deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
-          repoScanFilterSelected === '');
+        bulkDeleteActive
+          ? !agenticOnly
+          : deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
+            repoScanFilterSelected === '';
       if (shouldReloadFindings) {
         await loadRepoFindings(scope, 'refresh');
       }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -175,6 +175,7 @@ import {
   type RepoFindingRemediationPublishResponse,
   type RepoFindingRemediationPreview,
   type RepoFindingDeleteTarget,
+  type RepoFindingsBulkDeleteResponse,
   type RepoFindingsSummary,
   type RepoFindingLifecycleStatus,
   type RepoRiskGraph,
@@ -1614,6 +1615,28 @@ function repoFindingDeleteTargetKey(target: RepoFindingDeleteTarget): string {
 
 function repoFindingDeleteTargetKeyFromFinding(finding: ApiFinding): string {
   return repoFindingDeleteTargetKey(repoFindingDeleteTargetFromFinding(finding));
+}
+
+const REPO_FINDING_BULK_DELETE_BATCH_SIZE = 500;
+
+function chunkRepoFindingDeleteTargets(targets: RepoFindingDeleteTarget[]): RepoFindingDeleteTarget[][] {
+  const chunks: RepoFindingDeleteTarget[][] = [];
+  for (let index = 0; index < targets.length; index += REPO_FINDING_BULK_DELETE_BATCH_SIZE) {
+    chunks.push(targets.slice(index, index + REPO_FINDING_BULK_DELETE_BATCH_SIZE));
+  }
+  return chunks;
+}
+
+function mergeRepoFindingsBulkDeleteResponses(
+  responses: RepoFindingsBulkDeleteResponse[]
+): RepoFindingsBulkDeleteResponse {
+  return responses.reduce<RepoFindingsBulkDeleteResponse>(
+    (acc, response) => ({
+      deleted: [...acc.deleted, ...response.deleted],
+      failed: [...(acc.failed ?? []), ...(response.failed ?? [])]
+    }),
+    { deleted: [], failed: [] }
+  );
 }
 
 function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
@@ -27609,7 +27632,11 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
       let failedCandidates: ApiFinding[] = [];
       let failureMessage = 'Failed to delete finding.';
       if (bulkDeleteActive) {
-        const response = await apiClient.deleteRepoFindings(candidates.map(repoFindingDeleteTargetFromFinding), auth);
+        const responses: RepoFindingsBulkDeleteResponse[] = [];
+        for (const batch of chunkRepoFindingDeleteTargets(candidates.map(repoFindingDeleteTargetFromFinding))) {
+          responses.push(await apiClient.deleteRepoFindings(batch, auth));
+        }
+        const response = mergeRepoFindingsBulkDeleteResponses(responses);
         const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
         const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
         deletedFindings = candidates.filter((candidate) =>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -174,6 +174,7 @@ import {
   type ProjectRecord,
   type RepoFindingRemediationPublishResponse,
   type RepoFindingRemediationPreview,
+  type RepoFindingDeleteTarget,
   type RepoFindingsSummary,
   type RepoFindingLifecycleStatus,
   type RepoRiskGraph,
@@ -1598,6 +1599,21 @@ function countGitHubPostureChecks(
 
 function formatCountLabel(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function repoFindingDeleteTargetFromFinding(finding: ApiFinding): RepoFindingDeleteTarget {
+  return {
+    finding_id: finding.id,
+    repo_scan_id: finding.scan_id
+  };
+}
+
+function repoFindingDeleteTargetKey(target: RepoFindingDeleteTarget): string {
+  return `${target.repo_scan_id}::${target.finding_id}`;
+}
+
+function repoFindingDeleteTargetKeyFromFinding(finding: ApiFinding): string {
+  return repoFindingDeleteTargetKey(repoFindingDeleteTargetFromFinding(finding));
 }
 
 function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
@@ -27564,6 +27580,21 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     }
   };
 
+  const applyFailedRepoFindingDeletes = (
+    failedCandidates: ApiFinding[],
+    deletedCount: number,
+    fallback = 'Failed to delete finding.',
+    keepBulkContext = false
+  ) => {
+    setBulkDeleteCandidates(keepBulkContext ? failedCandidates : failedCandidates.length > 1 ? failedCandidates : []);
+    setDeleteCandidate(keepBulkContext ? null : failedCandidates.length === 1 ? failedCandidates[0] : null);
+    setDeleteError(
+      deletedCount > 0
+        ? `${deletedCount} deleted. ${failedCandidates.length} remaining.`
+        : fallback
+    );
+  };
+
   const handleConfirmDeleteFinding = async () => {
     if (!scope || activeDeleteCandidates.length === 0 || deleteActionsDisabled) {
       return;
@@ -27574,39 +27605,47 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
     setDeleteError('');
     try {
       const auth = buildProductAuthContext(scope);
-      const settled = await Promise.allSettled(
-        candidates.map((candidate) => apiClient.deleteRepoFinding(candidate.id, candidate.scan_id, auth))
-      );
+      let deletedFindings: ApiFinding[] = [];
+      let failedCandidates: ApiFinding[] = [];
+      let failureMessage = 'Failed to delete finding.';
+      if (bulkDeleteActive) {
+        const response = await apiClient.deleteRepoFindings(candidates.map(repoFindingDeleteTargetFromFinding), auth);
+        const deletedKeys = new Set(response.deleted.map(repoFindingDeleteTargetKey));
+        const failedKeys = new Set((response.failed ?? []).map(repoFindingDeleteTargetKey));
+        deletedFindings = candidates.filter((candidate) =>
+          deletedKeys.has(repoFindingDeleteTargetKeyFromFinding(candidate))
+        );
+        failedCandidates = candidates.filter((candidate) => {
+          const key = repoFindingDeleteTargetKeyFromFinding(candidate);
+          return failedKeys.has(key) || !deletedKeys.has(key);
+        });
+        failureMessage = response.failed?.[0]?.error || failureMessage;
+      } else {
+        const candidate = candidates[0];
+        if (candidate) {
+          await apiClient.deleteRepoFinding(candidate.id, candidate.scan_id, auth);
+          deletedFindings = [candidate];
+        }
+      }
       if (findDeleteRequestRef.current !== requestID) {
         return;
       }
-      const deletedFindings = candidates.filter((_, index) => settled[index]?.status === 'fulfilled');
-      const failedDeletes = settled.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
       if (deletedFindings.length > 0) {
         invalidateGitHubDomainDataCacheForScope(scope);
         applyDeletedRepoFindings(deletedFindings);
       }
-      if (failedDeletes.length > 0) {
-        const failedCandidates = candidates.filter((_, index) => settled[index]?.status === 'rejected');
-        setBulkDeleteCandidates(failedCandidates.length > 1 ? failedCandidates : []);
-        setDeleteCandidate(failedCandidates.length === 1 ? failedCandidates[0] : null);
-        setDeleteError(
-          deletedFindings.length > 0
-            ? `${deletedFindings.length} deleted. ${failedDeletes.length} could not be deleted.`
-            : failedDeletes[0].reason instanceof Error
-              ? failedDeletes[0].reason.message
-              : 'Failed to delete finding.'
-        );
+      if (failedCandidates.length > 0) {
+        applyFailedRepoFindingDeletes(failedCandidates, deletedFindings.length, failureMessage, bulkDeleteActive);
         if (deletedFindings.length > 0) {
-          await loadRepoFindings(scope, 'refresh');
           await loadTrendSignals(scope, 'refresh');
         }
         return;
       }
       const repoScanFilterSelected = normalizeValue(repoScanFilter);
       const shouldReloadFindings =
-        deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
-        repoScanFilterSelected === '';
+        !bulkDeleteActive &&
+        (deletedFindings.some((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed') ||
+          repoScanFilterSelected === '');
       if (shouldReloadFindings) {
         await loadRepoFindings(scope, 'refresh');
       }
@@ -28361,7 +28400,7 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
                                         role="listitem"
                                         tabIndex={0}
                                         aria-haspopup="dialog"
-                                        className={`idt-repo-finding-row idt-repo-finding-action-row${isSelected ? ' is-selected' : ''}`}
+                                        className={`idt-repo-finding-row idt-repo-finding-action-row${isSelected ? ' is-selected' : ''}${findingMenuKey === selectionKey ? ' is-menu-open' : ''}`}
                                         onClick={(event) => selectRepoFinding(selectionKey, true, event.currentTarget)}
                                         onKeyDown={(event) => {
                                           if (event.target !== event.currentTarget) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6332,11 +6332,16 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 }
 
 .idt-repo-finding-action-row {
+  position: relative;
   grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   column-gap: 0.9rem;
   row-gap: 0.45rem;
   overflow: visible;
+}
+
+.idt-repo-finding-action-row.is-menu-open {
+  z-index: 24;
 }
 
 .idt-repo-finding-action-row .idt-source-logo-mark.is-row,
@@ -6380,7 +6385,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 
 .idt-repo-finding-row-actions {
   position: relative;
-  z-index: 8;
+  z-index: 28;
   flex: 0 0 auto;
   align-self: center;
 }
@@ -6409,7 +6414,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   right: 0;
   top: calc(100% + 0.35rem);
   min-width: 12.5rem;
-  z-index: 10;
+  z-index: 32;
   border: 1px solid var(--app-border);
   border-radius: 8px;
   background: #080809;
@@ -26001,6 +26006,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-grou
   border-left-width: 4px;
   border-radius: 8px;
   background: #070708;
+  overflow: visible;
 }
 
 .idt-app-console-layout .idt-repo-finding-severity-group.is-critical,
@@ -27754,11 +27760,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout {
   position: absolute;
-  top: -0.45rem;
+  top: 0;
   left: calc(100% + 0.72rem);
   z-index: 50;
   display: grid;
-  gap: 0.58rem;
+  gap: 0.5rem;
   width: min(27rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
   max-height: min(78vh, 42rem);
   overflow: auto;
@@ -27768,25 +27774,26 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   border-radius: 8px;
   padding: 0.68rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 8rem),
-    #050607;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 7rem),
+    #030405;
   box-shadow:
     0 28px 90px rgba(0, 0, 0, 0.62),
     0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-  transform-origin: top left;
+  text-align: left;
+  transform-origin: left 1.08rem;
   animation: idtFlyoutRevealIn var(--idt-motion-slow) var(--idt-motion-ease) both;
 }
 
 .idt-domain-flyout::before {
   content: '';
   position: absolute;
-  top: 1.25rem;
+  top: 1.08rem;
   left: -0.45rem;
   width: 0.85rem;
   height: 0.85rem;
   border-left: 1px solid rgba(255, 255, 255, 0.13);
   border-bottom: 1px solid rgba(255, 255, 255, 0.13);
-  background: #050607;
+  background: #030405;
   transform: rotate(45deg);
 }
 
@@ -27820,15 +27827,16 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1.25rem;
+  grid-template-columns: minmax(0, 1fr) 1rem;
   gap: 0.65rem;
   align-items: center;
-  min-height: 2.28rem;
+  min-height: 2.34rem;
   border: 1px solid transparent;
   border-radius: 7px;
   padding: 0.44rem 0.54rem;
   color: #dce3eb;
   text-decoration: none;
+  text-align: left;
   transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
 
@@ -27852,6 +27860,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   gap: 0.08rem;
   min-width: 0;
   align-self: center;
+  justify-items: start;
+  text-align: left;
 }
 
 .idt-domain-flyout-link-copy strong {
@@ -27886,12 +27896,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1.25rem;
-  align-items: start;
+  grid-template-columns: minmax(0, 1fr) 1rem;
+  align-items: center;
   gap: 0.6rem;
+  min-height: 2.42rem;
   border-radius: 7px;
   padding: 0.45rem 0.5rem;
   color: #f3f5f7;
+  text-align: left;
   cursor: pointer;
   list-style: none;
 }
@@ -27904,6 +27916,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   display: grid;
   gap: 0.1rem;
   min-width: 0;
+  justify-items: start;
+  text-align: left;
 }
 
 .idt-domain-flyout-nested summary strong {
@@ -27913,7 +27927,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary svg {
   justify-self: end;
-  margin-top: 0.18rem;
   color: #8f98a4;
   transition: transform 0.14s ease;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5832,9 +5832,34 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
   flex-wrap: wrap;
 }
 
+.idt-repo-scan-health-actions-inline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  white-space: nowrap;
+}
+
 .idt-repo-scan-health a {
   white-space: nowrap;
   font-weight: 600;
+}
+
+.idt-repo-scan-health-remove {
+  border: 0;
+  background: transparent;
+  color: #ffd0d0;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+  cursor: pointer;
+}
+
+.idt-repo-scan-health-remove:hover,
+.idt-repo-scan-health-remove:focus-visible {
+  color: #ffffff;
+  outline: none;
 }
 
 .idt-repo-scan-health-panel {
@@ -27827,13 +27852,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1rem;
-  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr) 1.1rem;
+  gap: 0.7rem;
   align-items: center;
-  min-height: 2.34rem;
+  min-height: 3rem;
   border: 1px solid transparent;
   border-radius: 7px;
-  padding: 0.44rem 0.54rem;
+  padding: 0.5rem 0.6rem;
   color: #dce3eb;
   text-decoration: none;
   text-align: left;
@@ -27856,11 +27881,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-link-copy {
-  display: grid;
-  gap: 0.08rem;
+  display: flex;
+  min-height: 100%;
   min-width: 0;
   align-self: center;
-  justify-items: start;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.08rem;
   text-align: left;
 }
 
@@ -27868,7 +27896,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   color: inherit;
   font-size: 0.86rem;
   font-weight: 750;
-  line-height: 1.2;
+  line-height: 1.15;
   white-space: nowrap;
 }
 
@@ -27876,7 +27904,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   justify-self: end;
   align-self: center;
   width: 1rem;
+  height: 1rem;
   min-width: 1rem;
+  display: block;
 }
 
 .idt-domain-flyout-link-copy span,
@@ -27896,12 +27926,12 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 
 .idt-domain-flyout-nested summary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 1rem;
+  grid-template-columns: minmax(0, 1fr) 1.1rem;
   align-items: center;
-  gap: 0.6rem;
-  min-height: 2.42rem;
+  gap: 0.7rem;
+  min-height: 3rem;
   border-radius: 7px;
-  padding: 0.45rem 0.5rem;
+  padding: 0.5rem 0.6rem;
   color: #f3f5f7;
   text-align: left;
   cursor: pointer;
@@ -27913,20 +27943,27 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
 }
 
 .idt-domain-flyout-nested summary > span {
-  display: grid;
-  gap: 0.1rem;
+  display: flex;
   min-width: 0;
-  justify-items: start;
+  min-height: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.1rem;
   text-align: left;
 }
 
 .idt-domain-flyout-nested summary strong {
   font-size: 0.9rem;
-  line-height: 1.2;
+  line-height: 1.15;
 }
 
 .idt-domain-flyout-nested summary svg {
   justify-self: end;
+  align-self: center;
+  display: block;
+  width: 1rem;
+  height: 1rem;
   color: #8f98a4;
   transition: transform 0.14s ease;
 }


### PR DESCRIPTION
Done, closes: https://github.com/identrail/identrail/issues/1472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk deletion of repository findings with body-aware authorization and batch processing in the UI. Also adds a dismissible failed scan banner and preserves shadow authorization metrics.

- **New Features**
  - API: `POST /v1/repo-findings/bulk-delete` with request/response schemas; OpenAPI updated.
  - Authz: bulk route uses `repo_scans.run` on `repo_finding_bulk_delete`; per-item ABAC checks from request body; shadow evaluation metrics maintained.
  - Service: bulk delete with normalization, de-duplication, 500-item cap, and partial failure reporting.
  - Router: validates input, authorizes per target, returns bulk results.
  - Web client: `deleteRepoFindings(items)` and related types.
  - UI: “Clear all” uses bulk endpoint, chunks at 500, falls back to individual deletes on 404; shows partial completion counts.
  - UI: dismiss last failed scan alerts, persisted in local storage.

- **Bug Fixes**
  - Improved findings cleanup flow and reload/refresh behavior after bulk or partial deletes.
  - Fixed z-index/menu-open styling for finding rows and adjusted flyout panel visuals.
  - Ensured shadow authz metrics are recorded on body-aware routes.

<sup>Written for commit ff1fc7a92eb9fcbbe527c86980088d5f05ec4872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

