### PR TITLE
Fix Vercel production deploy status handling

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     name: Deploy to Vercel Production
     if: github.repository == 'identrail/identrail' && (github.event_name != 'workflow_dispatch' || github.ref_name == 'dev')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       VERCEL_CLI_VERSION: 54.18.1
     steps:
@@ -312,7 +312,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deploy_output="$(vercel --cwd web deploy --prod --force --yes --token "$VERCEL_TOKEN")"
+          deploy_output="$(vercel --cwd web deploy --prod --force --yes)"
           printf '%s\n' "$deploy_output"
 
           deployment_url="$(printf '%s\n' "$deploy_output" | awk '/^https:\/\// { url=$0 } END { print url }')"
@@ -330,4 +330,4 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          vercel inspect "${{ steps.deploy.outputs.url }}" --wait --timeout 20m --token "$VERCEL_TOKEN"
+          vercel inspect "${{ steps.deploy.outputs.url }}" --wait --timeout 20m

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+      VERCEL_CLI_VERSION: 54.18.1
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -53,6 +53,7 @@ jobs:
             exit 0
           fi
 
+          # shellcheck disable=SC2140
           pr_json="$(gh api repos/"${{ github.repository_owner }}"/"${{ github.event.repository.name }}"/pulls/"${{ github.event.pull_request.number }}")"
           is_draft="$(jq -r '.draft // false' <<< "${pr_json}")"
           if [ "${is_draft}" = "true" ]; then
@@ -74,6 +75,7 @@ jobs:
           # "approved" on the same commit no longer permanently blocks the
           # deploy. This single query also avoids the multi-page jq breakage
           # that --paginate without --slurp causes when a PR has >100 reviews.
+          # shellcheck disable=SC2016
           review_state_json="$(gh api graphql \
             -F owner="${{ github.repository_owner }}" \
             -F name="${{ github.event.repository.name }}" \
@@ -156,8 +158,8 @@ jobs:
           set -euo pipefail
           token="$(printf '%s' "$RAW_TOKEN" | tr -d '\r\n' | sed -e 's/^"//' -e 's/"$//')"
           if [ -z "$token" ]; then
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "Missing VERCEL_TOKEN repository secret."
+            exit 1
           fi
           echo "::add-mask::$token"
           {
@@ -168,7 +170,6 @@ jobs:
       - name: Verify Vercel token
         id: verify-token
         if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.normalize-token.outputs.has_token == 'true'
-        continue-on-error: true
         env:
           VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
         run: |
@@ -178,8 +179,8 @@ jobs:
             echo "Token verified for Vercel user:"
             jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
           else
-            echo "token_verified=false" >> "$GITHUB_OUTPUT"
-            echo "Token verification failed; continuing with hook fallback."
+            echo "Vercel token verification failed."
+            exit 1
           fi
 
       - name: Prune stale queued deployments
@@ -295,34 +296,38 @@ jobs:
             "${connector_k8s_flag}" \
             "Enable the Kubernetes connector UI for Identrail Cloud production builds"
 
-      - name: Deploy to Vercel
-        id: deploy-action
-        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.normalize-token.outputs.has_token == 'true'
-        continue-on-error: true
-        uses: amondnet/vercel-action@de09aeac2ace6599ec9b11ef87558759a496bac4 # v42.3.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: false
-          vercel-token: ${{ steps.normalize-token.outputs.token }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          experimental-api: true
-          target: production
-          force: true
-          root-directory: web
-
-      - name: Fallback deploy via hook
-        id: deploy-hook
-        if: steps.deploy-gate.outputs.can_deploy == 'true' && (steps.normalize-token.outputs.has_token != 'true' || steps.deploy-action.outcome != 'success') && env.VERCEL_DEPLOY_HOOK_URL != ''
+      - name: Install Vercel CLI
+        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.verify-token.outputs.token_verified == 'true'
         run: |
           set -euo pipefail
-          curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL" > /tmp/vercel-hook-response.json
-          echo "Triggered Vercel deploy hook successfully."
+          npm install --global "vercel@${VERCEL_CLI_VERSION}"
+          vercel --version
 
-      - name: Fail if no deployment path succeeded
-        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.deploy-action.outcome != 'success' && steps.deploy-hook.outcome != 'success'
+      - name: Deploy to Vercel
+        id: deploy
+        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.verify-token.outputs.token_verified == 'true'
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
-          echo "Vercel deployment failed."
-          echo "Root cause is usually an invalid/stale VERCEL_TOKEN."
-          echo "Fix by rotating VERCEL_TOKEN, or set VERCEL_DEPLOY_HOOK_URL for hook-based fallback."
-          exit 1
+          set -euo pipefail
+          deploy_output="$(vercel --cwd web deploy --prod --force --yes --token "$VERCEL_TOKEN")"
+          printf '%s\n' "$deploy_output"
+
+          deployment_url="$(printf '%s\n' "$deploy_output" | awk '/^https:\/\// { url=$0 } END { print url }')"
+          if [ -z "$deployment_url" ]; then
+            echo "Vercel CLI did not return a deployment URL."
+            exit 1
+          fi
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Vercel deployment
+        if: steps.deploy-gate.outputs.can_deploy == 'true' && steps.deploy.outputs.url != ''
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          vercel inspect "${{ steps.deploy.outputs.url }}" --wait --timeout 20m --token "$VERCEL_TOKEN"

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -42,7 +42,7 @@ Identrail Cloud production web builds should set:
 VITE_FEATURE_ONBOARDING_WIZARD=true
 ```
 
-The token-based Vercel production deploy workflow upserts this value before the deploy action runs. It defaults to `true` for Identrail Cloud and reads the repository variable `VITE_FEATURE_ONBOARDING_WIZARD` when an operator needs to set the matching web rollback value to `false`. If the workflow falls back to a deploy hook, GitHub Actions cannot update Vercel project env values; keep `VITE_FEATURE_ONBOARDING_WIZARD=true` configured directly in Vercel before using hook-only deploys, or flip that Vercel value directly during rollback.
+The token-based Vercel production deploy workflow upserts this value before the Vercel CLI deploy runs. It defaults to `true` for Identrail Cloud and reads the repository variable `VITE_FEATURE_ONBOARDING_WIZARD` when an operator needs to set the matching web rollback value to `false`. The workflow waits for Vercel to report the deployment as ready, so GitHub Actions fails if Vercel fails during build initialization or deployment.
 
 ### Connector web flags
 


### PR DESCRIPTION
## Summary
- replace the internal experimental Vercel action path with a pinned official Vercel CLI deploy
- require a verified VERCEL_TOKEN instead of falling through to an unverifiable deploy hook
- wait for Vercel to report the deployment result so GitHub Actions fails when Vercel returns ERROR
- update the frontend topology docs to match the token-based deploy flow

## Root cause
The production workflow could report success even when Vercel failed. The experimental action returned a failed deployment with `sts_credentials_fetch_failed`, then the fallback deploy hook step succeeded because the hook request was accepted. GitHub therefore marked the workflow green without proving that Vercel reached READY.

## Validation
- `actionlint .github/workflows/vercel-production-deploy.yml`
- `git diff --check`
- `vercel --cwd web deploy --help`
- commit and push hooks: merge-conflict check, YAML check, EOF/whitespace, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches production deploys to the official Vercel CLI with strict token verification and blocking status checks. Fails fast on missing/invalid tokens, waits for readiness, and updates docs to match the CLI flow.

- **Bug Fixes**
  - Replaced the experimental action with pinned `vercel@54.18.1` installed via npm; added `vercel inspect --wait --timeout 20m`.
  - Require a verified `VERCEL_TOKEN`; fail immediately if missing or invalid; removed deploy hook fallback.
  - Surface the deployment URL and ensure the job fails on Vercel errors; increased job timeout to 30m.

- **Migration**
  - Ensure `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets are set and valid.
  - Stop using `VERCEL_DEPLOY_HOOK_URL` for production.
  - Docs updated to reflect token-based CLI deploys and wait-for-ready behavior.

<sup>Written for commit 261a8318caa03acf4b4ece50695a87aa56089185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

