### PR TITLE
Polish AWS app experience

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,36 +81,81 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 ## Architecture and provider internals
 
 - Architecture overview: `architecture.md`
-- AWS collector details: `aws-collector.md`
+- AWS access key quarantine planner: `aws-access-key-quarantine-planner.md`
+- AWS account/region coverage planner: `aws-account-region-coverage-planner.md`
+- AWS account/region coverage: `aws-account-region-coverage.md`
 - AWS account/region fan-out worker: `aws-account-region-fanout-worker.md`
+- AWS advisory authorization decision API: `aws-advisory-authorization.md`
+- AWS agent identity detail: `aws-agent-identity-detail.md`
+- AWS agent runtime access: `aws-agent-runtime-access.md`
+- AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
 - AWS AI agent identities: `aws-ai-agent-identities.md`
 - AWS AI agent risk engine: `aws-ai-agent-risk-engine.md`
-- AWS remediation case model: `aws-remediation-case-model.md`
-- AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
-- AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
-- AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
-- AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
-- AWS access key disable and quarantine planner: `aws-access-key-quarantine-planner.md`
-- AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
-- AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
-- AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
-- AWS low-risk live remediation: `aws-low-risk-live-remediation.md`
-- AWS approved permission boundary executor: `aws-permission-boundary-executor.md`
-- AWS approved SCP guardrail executor: `aws-scp-guardrail-executor.md`
-- AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
-- AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
-- AWS advisory authorization decision API: `aws-advisory-authorization.md`
-- AWS limited enforcement framework: `aws-limited-enforcement.md`
-- AWS high-confidence limited enforcement pilot: `aws-limited-enforcement-pilot.md`
-- AWS Remediation Center unified experience: `aws-remediation-center.md`
-- AWS governance audit reporting: `aws-governance-audit-reporting.md`
+- AWS API hosting: `aws-api-hosting.md`
+- AWS Bedrock agents: `aws-bedrock-agents.md`
+- AWS blast radius engine: `aws-blast-radius-engine.md`
+- AWS CodeBuild service roles: `aws-codebuild-service-roles.md`
+- AWS CodePipeline deployment roles: `aws-codepipeline-deployment-roles.md`
+- AWS collector details: `aws-collector.md`
+- AWS credential references: `aws-credential-references.md`
+- AWS cross-account trust engine: `aws-cross-account-trust-engine.md`
+- AWS deployment foundation: `aws-deployment-foundation.md`
+- AWS DynamoDB and RDS reachability: `aws-dynamodb-rds-reachability.md`
+- AWS EC2 instance profiles: `aws-ec2-instance-profiles.md`
+- AWS ECR repository metadata: `aws-ecr-repository-metadata.md`
+- AWS ECS task roles: `aws-ecs-task-roles.md`
+- AWS EKS workload identities: `aws-eks-workload-identities.md`
+- AWS event-driven roles: `aws-event-driven-roles.md`
 - AWS executive outcome view: `aws-executive-outcome-view.md`
-- AWS platform observability: `aws-platform-observability.md`
 - AWS GA demo hardening: `aws-ga-demo-hardening.md`
-- AWS session policy recommendation path: `aws-session-policy-recommendation.md`
-- AWS AgentCore gateway policy advisory: `aws-agentcore-gateway-policy-advisory.md`
+- AWS governance audit reporting: `aws-governance-audit-reporting.md`
+- AWS graph explorer: `aws-graph-explorer.md`
+- AWS IaC remediation PR and verification plan generator: `aws-iac-remediation-planner.md`
+- AWS IAM PassRole relationships: `aws-iam-passrole-relationships.md`
+- AWS IAM policy least-privilege diff: `aws-iam-policy-least-privilege-diff.md`
+- AWS identity sprawl engine: `aws-identity-sprawl-engine.md`
+- AWS KMS decrypt reachability: `aws-kms-decrypt-reachability.md`
+- AWS Lambda execution roles: `aws-lambda-execution-roles.md`
+- AWS least-privilege engine: `aws-least-privilege-engine.md`
+- AWS high-confidence limited enforcement pilot: `aws-limited-enforcement-pilot.md`
+- AWS limited enforcement framework: `aws-limited-enforcement.md`
+- AWS low-risk live remediation: `aws-low-risk-live-remediation.md`
+- AWS machine identity detail: `aws-machine-identity-detail.md`
+- AWS managed compute roles: `aws-managed-compute-roles.md`
 - AWS normalizer and graph: `aws-normalizer-graph.md`
+- AWS OIDC deployment role: `aws-oidc-deployment.md`
+- AWS Organizations topology: `aws-organizations-topology.md`
+- AWS approved permission boundary executor: `aws-permission-boundary-executor.md`
+- AWS permission boundary and SCP planner: `aws-permission-boundary-scp-planner.md`
+- AWS platform baseline: `aws-platform-baseline.md`
+- AWS platform dependency index: `aws-platform-dependency-index.md`
+- AWS platform observability: `aws-platform-observability.md`
+- AWS platform validation harness: `aws-platform-validation-harness.md`
+- AWS post-remediation verification and rollback: `aws-post-remediation-verification.md`
+- AWS privilege escalation engine: `aws-privilege-escalation-engine.md`
+- AWS remediation approval workflow and RBAC gates: `aws-remediation-approval-rbac.md`
+- AWS remediation case model: `aws-remediation-case-model.md`
+- AWS Remediation Center unified experience: `aws-remediation-center.md`
+- AWS remediation dry-run executor: `aws-remediation-dry-run-executor.md`
 - AWS risk engine: `aws-risk-engine.md`
+- AWS runtime events: `aws-runtime-events.md`
+- AWS S3 bucket reachability: `aws-s3-bucket-reachability.md`
+- AWS S3 runtime access: `aws-s3-runtime-access.md`
+- AWS SageMaker workload roles: `aws-sagemaker-workload-roles.md`
+- AWS approved SCP guardrail executor: `aws-scp-guardrail-executor.md`
+- AWS secret and key rotation planner: `aws-secret-key-rotation-planner.md`
+- AWS secret permission equivalence engine: `aws-secret-permission-equivalence-engine.md`
+- AWS Secrets/KMS runtime access: `aws-secrets-kms-runtime-access.md`
+- AWS Secrets Manager metadata: `aws-secrets-manager-metadata.md`
+- AWS service collector contract: `aws-service-collector-contract.md`
+- AWS session policy recommendation path: `aws-session-policy-recommendation.md`
+- AWS SQS/SNS reachability: `aws-sqs-sns-reachability.md`
+- AWS SSM parameter metadata: `aws-ssm-parameter-metadata.md`
+- AWS StackSet onboarding: `aws-stackset-onboarding.md`
+- AWS Step Functions state machine roles: `aws-stepfunctions-state-machine-roles.md`
+- AWS approved trust-policy hardening executor: `aws-trust-policy-hardening-executor.md`
+- AWS trust policy hardening planner: `aws-trust-policy-hardening-planner.md`
+- AWS unused and dormant access engine: `aws-unused-dormant-access-engine.md`
 
 ## Historical Records
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3613,7 +3613,7 @@ describe('Domain-first app routes', () => {
       'href',
       '/app/tenant-a/workspace-a/aws/resources?environment=production'
     );
-    expect(screen.getByRole('link', { name: /Identities/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /^Identities/i })).toHaveAttribute(
       'href',
       '/app/tenant-a/workspace-a/aws/identities?environment=production'
     );
@@ -4843,7 +4843,7 @@ describe('Domain-first app routes', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 2, name: 'Agents' })).toBeInTheDocument();
-    expect(screen.getAllByText(/Connect AWS to populate current inventory anchors/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Connect AWS to load live inventory/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Bedrock agents/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/AgentCore runtime and gateway identity/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Secret metadata only, no value reads/i)).toBeInTheDocument();
@@ -7003,12 +7003,10 @@ describe('Domain-first app routes', () => {
             title: 'Governance audit: orders deployer',
             summary: 'Export-safe enforcement outcome report row.',
             input_hash: 'audit-hash-a',
-            evidence_summary: [
-              { source: 'source_link', label: 'pilot evidence', evidence_ref: '/docs/aws-limited-enforcement-pilot', exportable: true, redacted: true }
-            ],
+            evidence_summary: null,
             evidence_links: ['/docs/aws-limited-enforcement-pilot'],
             evidence_boundary: 'metadata_only_exportable_refs_no_secret_values_no_rendered_policy_bodies_no_customer_payloads',
-            audit_trail: [],
+            audit_trail: null,
             read_only_projection: true,
             exception: false,
             next_action: 'Export the audit row.',
@@ -7091,8 +7089,8 @@ describe('Domain-first app routes', () => {
           highest_score: 80,
           average_confidence_pct: 95
         },
-        caveats: [],
-        failure_reasons: [],
+        caveats: null,
+        failure_reasons: null,
         remediation_hints: [],
         evidence_links: [],
         coverage_gaps: [],

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3210,9 +3210,9 @@ const AWS_CONTROL_CARDS: AWSControlCard[] = [
     id: 'accounts',
     label: 'Accounts',
     routeID: 'accounts',
-    stage: 'coming',
+    stage: 'wired',
     metric: '',
-    detail: "Which AWS account and region you're connected to."
+    detail: 'Connected accounts, regions, and coverage anchors.'
   },
   {
     id: 'coverage',
@@ -3226,60 +3226,60 @@ const AWS_CONTROL_CARDS: AWSControlCard[] = [
     id: 'identities',
     label: 'Identities',
     routeID: 'identities',
-    stage: 'coming',
+    stage: 'wired',
     metric: '',
-    detail: 'IAM roles, workload identities, and what they can reach.'
+    detail: 'IAM roles and workload identities with reachability evidence.'
   },
   {
     id: 'agents',
     label: 'Agents',
     routeID: 'agents',
-    stage: 'coming',
+    stage: 'wired',
     metric: '',
-    detail: 'Bedrock and MCP agents Identrail can see.'
+    detail: 'Bedrock, AgentCore, custom, and MCP-backed agent identities.'
   },
   {
     id: 'resources',
     label: 'Resources',
     routeID: 'resources',
-    stage: 'coming',
+    stage: 'wired',
     metric: '',
-    detail: 'Secrets, KMS keys, and S3 buckets your AWS roles can reach.'
+    detail: 'Secrets, KMS keys, S3, queues, databases, parameters, ECR, and credential references.'
   },
   {
     id: 'runtime',
     label: 'Runtime',
     routeID: 'runtime',
-    stage: 'coming',
+    stage: 'wired',
     metric: '',
-    detail: 'What your AWS roles actually did, from runtime evidence.'
+    detail: 'CloudTrail, runtime, tool-call, and policy-use evidence.'
   },
   {
     id: 'findings',
     label: 'Findings',
     routeID: 'findings',
-    stage: 'not-available',
+    stage: 'wired',
     metric: '',
-    detail: 'Risks Identrail found in your AWS setup.'
+    detail: 'AWS risks produced from graph, runtime, and inventory evidence.'
   },
   {
     id: 'remediation',
     label: 'Remediation',
     routeID: 'remediation',
-    stage: 'not-available',
+    stage: 'wired',
     metric: '',
-    detail: 'AWS fixes Identrail prepares for you to approve.'
+    detail: 'Reviewable AWS fixes, dry-runs, approvals, and verification.'
   }
 ];
 
 function awsStageLabel(stage: AWSCapabilityStage): string {
   if (stage === 'wired') {
-    return 'Wired now';
+    return 'Ready';
   }
   if (stage === 'coming') {
-    return 'Coming';
+    return 'Needs evidence';
   }
-  return 'Not yet available';
+  return 'Unavailable';
 }
 
 function awsStageTone(stage: AWSCapabilityStage): 'success' | 'warning' | 'neutral' {
@@ -4261,7 +4261,7 @@ const AWS_INVENTORY_FILTER_DEFAULTS: Record<AWSInventoryRouteID, AWSInventoryFil
 
 const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
   accounts: [
-    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Planned accounts', value: 'planned' }] },
+    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Additional accounts', value: 'planned' }] },
     { id: 'region', label: 'Region', options: [{ label: 'All regions', value: 'all' }, { label: 'Current region', value: 'current' }, { label: 'Uncovered regions', value: 'uncovered' }] },
     {
       id: 'coverage',
@@ -4269,7 +4269,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       options: [
         { label: 'All coverage', value: 'all' },
         { label: 'Covered', value: 'covered' },
-        { label: 'Planned', value: 'planned' },
+        { label: 'Queued', value: 'planned' },
         { label: 'Missing', value: 'missing' },
         { label: 'Blocked', value: 'blocked' },
         { label: 'Unsupported', value: 'unsupported' },
@@ -4277,12 +4277,12 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'Degraded', value: 'degraded' },
         { label: 'Failed', value: 'failed' },
         { label: 'Permission denied', value: 'permission_denied' },
-        { label: 'Not yet available', value: 'not-yet-available' }
+        { label: 'Unavailable', value: 'not-yet-available' }
       ]
     }
   ],
   coverage: [
-    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Planned accounts', value: 'planned' }] },
+    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Additional accounts', value: 'planned' }] },
     { id: 'region', label: 'Region', options: [{ label: 'All regions', value: 'all' }, { label: 'Current region', value: 'current' }, { label: 'Uncovered regions', value: 'uncovered' }] },
     {
       id: 'coverage',
@@ -4290,7 +4290,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       options: [
         { label: 'All coverage', value: 'all' },
         { label: 'Covered', value: 'covered' },
-        { label: 'Planned', value: 'planned' },
+        { label: 'Queued', value: 'planned' },
         { label: 'Missing', value: 'missing' },
         { label: 'Blocked', value: 'blocked' },
         { label: 'Unsupported', value: 'unsupported' },
@@ -4298,7 +4298,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'Degraded', value: 'degraded' },
         { label: 'Failed', value: 'failed' },
         { label: 'Permission denied', value: 'permission_denied' },
-        { label: 'Not yet available', value: 'not-yet-available' }
+        { label: 'Unavailable', value: 'not-yet-available' }
       ]
     }
   ],
@@ -4332,11 +4332,11 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       label: 'Status',
       options: [
         { label: 'All status', value: 'all' },
-        { label: 'Wired now', value: 'wired-now' },
+        { label: 'Ready', value: 'wired-now' },
         { label: 'Degraded', value: 'degraded' },
         { label: 'Disabled', value: 'disabled' },
-        { label: 'Coming', value: 'coming' },
-        { label: 'Not yet available', value: 'not-yet-available' }
+        { label: 'Needs evidence', value: 'coming' },
+        { label: 'Unavailable', value: 'not-yet-available' }
       ]
     }
   ],
@@ -4418,7 +4418,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
     {
       id: 'status',
       label: 'Status',
-      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Candidate', value: 'candidate' }, { label: 'Degraded', value: 'degraded' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
+      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Candidate', value: 'candidate' }, { label: 'Degraded', value: 'degraded' }, { label: 'Needs evidence', value: 'coming' }, { label: 'Unavailable', value: 'not-yet-available' }]
     }
   ],
   resources: [
@@ -4654,6 +4654,24 @@ function awsInventoryPillTone(stage: AWSCapabilityStage): 'success' | 'warning' 
   return awsStageTone(stage);
 }
 
+function awsDisplayStatusLabel(label: string): string {
+  const normalizedLabel = normalizeValue(label).toLowerCase();
+  switch (normalizedLabel) {
+    case 'wired now':
+    case 'wired-now':
+      return 'Ready';
+    case 'coming':
+      return 'Needs evidence';
+    case 'not yet available':
+    case 'not-yet-available':
+      return 'Unavailable';
+    case 'planned':
+      return 'Queued';
+    default:
+      return label;
+  }
+}
+
 function AWSInventoryPill({
   stage,
   label
@@ -4661,7 +4679,7 @@ function AWSInventoryPill({
   stage: AWSCapabilityStage;
   label?: string;
 }) {
-  return <span className={`idt-aws-inventory-pill is-${awsInventoryPillTone(stage)}`}>{label ?? awsStageLabel(stage)}</span>;
+  return <span className={`idt-aws-inventory-pill is-${awsInventoryPillTone(stage)}`}>{label ? awsDisplayStatusLabel(label) : awsStageLabel(stage)}</span>;
 }
 
 function awsCoveragePlanFilterValue(state: string): string {
@@ -5267,8 +5285,8 @@ function AWSInventoryPrerequisites({
     return (
       <DomainEmptyState
         eyebrow="Connector prerequisite"
-        title="Connect AWS to populate current inventory anchors"
-        body="These pages stay honest until the read-only AWS role is validated. The planned tables remain visible, but current account, region, role, permission, and diagnostic data come from Connect AWS."
+        title="Connect AWS to load live inventory"
+        body="Inventory pages show the workspace shape now. Connect the read-only role to load account, region, role, permission, and diagnostic evidence."
         nextAction={{ label: 'Connect AWS', to: connectPath }}
       />
     );
@@ -5772,7 +5790,7 @@ function AWSMachineIdentitiesContent({
             scope: awsAccountRegionLabel(connection),
             status: connection.connected ? 'wired now' : 'pending validation',
             stage: connection.connected ? ('wired' as AWSCapabilityStage) : ('coming' as AWSCapabilityStage),
-            detail: connection.principal_arn ?? 'Role principal will appear after validation.',
+            detail: connection.principal_arn ?? 'Role principal appears after validation.',
             filters: {
               identityType: 'iam-role',
               service: 'iam',
@@ -7774,7 +7792,7 @@ function buildAWSAIAgentIdentityRows(
       scope: 'Account and region expansion',
       status: 'coming',
       stage: 'coming',
-      detail: 'Bedrock, AgentCore, custom, external-provider-backed, and gateway metadata will attach agents to runtime roles, tools, and credential references.',
+      detail: 'Bedrock, AgentCore, custom, external-provider-backed, and gateway metadata maps agents to runtime roles, tools, and credential references.',
       filters: { surface: 'bedrock-agents,agentcore-runtime,mcp-gateway,external-provider-keys', relationship: 'agent-to-role,agent-to-tool,agent-to-secret', status: 'coming', search: '' },
       searchText: inventorySearchText(['bedrock agentcore custom external provider gateway ai agent'])
     }
@@ -8090,8 +8108,8 @@ function AWSResourcesInventoryContent({
           total={1}
           detail={credentialReferencesState.loading ? 'Loading' : credentialReferencesInventory ? formatTokenLabel(credentialReferencesInventory.status) : 'Pending'}
         />
-        <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
-        <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Coming wave" />
+        <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Needs evidence" />
+        <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Needs evidence" />
       </section>
       {secretsManagerState.loading ? <DomainLoadingState label="Loading Secrets Manager metadata" /> : null}
       {secretsManagerState.error ? (
@@ -11699,7 +11717,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No runtime events yet',
-    unavailableBody: "Runtime activity will appear here once Identrail starts ingesting your AWS logs."
+    unavailableBody: 'Runtime activity appears after AWS runtime evidence is connected.'
   },
   observability: {
     routeID: 'observability',
@@ -11711,7 +11729,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No observability signals yet',
-    unavailableBody: 'Platform observability will appear once Identrail has collector, runtime, remediation, verification, and governance evidence.'
+    unavailableBody: 'Platform observability appears once collector, runtime, remediation, verification, and governance evidence is available.'
   },
   'ga-demo': {
     routeID: 'ga-demo',
@@ -11723,7 +11741,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No GA demo stages yet',
-    unavailableBody: 'GA demo hardening will appear once Identrail can compose validation, discovery, runtime, remediation, governance, outcome, and observability evidence.'
+    unavailableBody: 'GA demo hardening appears once validation, discovery, runtime, remediation, governance, outcome, and observability evidence is available.'
   },
   graph: {
     routeID: 'graph',
@@ -11735,7 +11753,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No graph yet',
-    unavailableBody: 'The graph will populate once Identrail has scanned your AWS roles and resources.'
+    unavailableBody: 'The graph populates after AWS roles and resources are scanned.'
   },
   findings: {
     routeID: 'findings',
@@ -11747,7 +11765,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No findings yet',
-    unavailableBody: "Findings will appear here after your first AWS scan."
+    unavailableBody: 'Findings appear after the first AWS scan.'
   },
   remediation: {
     routeID: 'remediation',
@@ -11759,7 +11777,7 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No fixes prepared',
-    unavailableBody: 'Fixes will appear here after a finding has been triaged.'
+    unavailableBody: 'Fixes appear after a finding is triaged.'
   },
   outcomes: {
     routeID: 'outcomes',
@@ -11771,19 +11789,19 @@ const AWS_RISK_OPERATION_PAGE_COPY: Record<AWSRiskOperationRouteID, AWSRiskOpera
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No outcomes yet',
-    unavailableBody: 'Outcome metrics will appear once Identrail has AWS coverage, risk, remediation, and governance evidence.'
+    unavailableBody: 'Outcome metrics appear after Identrail has AWS coverage, risk, remediation, and governance evidence.'
   },
   governance: {
     routeID: 'governance',
     title: 'Governance',
     eyebrow: '',
-    description: "Advice on AWS access. Identrail won't apply changes for you.",
+    description: 'Review AWS access decisions, approvals, enforcement posture, and audit evidence.',
     statusLabel: '',
     currentCapability: '',
     plannedCapability: '',
     nextAction: '',
     unavailableTitle: 'No advice yet',
-    unavailableBody: "Identrail will flag risky AWS access requests here once it has graph and runtime evidence."
+    unavailableBody: 'Identrail flags risky AWS access requests here after graph and runtime evidence is available.'
   }
 };
 
@@ -13883,7 +13901,15 @@ function AWSExecutorProjectionPanel<Row>({
   getRowKey: (row: Row) => string;
   columns: DomainDataTableColumn<Row>[];
 }) {
-  const rows = result?.entries ?? [];
+  const normalizedResult = result
+    ? {
+        ...result,
+        entries: Array.isArray(result.entries) ? result.entries : [],
+        caveats: Array.isArray(result.caveats) ? result.caveats : [],
+        failure_reasons: Array.isArray(result.failure_reasons) ? result.failure_reasons : []
+      }
+    : null;
+  const rows = normalizedResult?.entries ?? [];
   return (
     <section className="idt-aws-runtime-correlation" aria-label={ariaLabel}>
       <h3>{heading}</h3>
@@ -13902,16 +13928,16 @@ function AWSExecutorProjectionPanel<Row>({
           body={loadingBody}
         />
       ) : null}
-      {!error && !loading && result && rows.length === 0 ? (
+      {!error && !loading && normalizedResult && rows.length === 0 ? (
         <DomainEmptyState
-          eyebrow={emptyEyebrow(result)}
-          title={emptyTitle(result)}
-          body={emptyBody(result)}
+          eyebrow={emptyEyebrow(normalizedResult)}
+          title={emptyTitle(normalizedResult)}
+          body={emptyBody(normalizedResult)}
         />
       ) : null}
-      {!error && !loading && result && result.caveats.length > 0 ? (
+      {!error && !loading && normalizedResult && normalizedResult.caveats.length > 0 ? (
         <ul className="idt-aws-runtime-correlation-caveats">
-          {result.caveats.slice(0, 3).map((caveat) => (
+          {normalizedResult.caveats.slice(0, 3).map((caveat) => (
             <li key={caveat}>{caveat}</li>
           ))}
         </ul>
@@ -14553,7 +14579,7 @@ function AWSGovernanceAuditReportingContent({
         { key: 'decision_type', header: 'Decision type', render: (row) => formatTokenLabel(row.decision_type) },
         { key: 'state', header: 'State', render: (row) => formatTokenLabel(row.state) },
         { key: 'actor', header: 'Actor / approver', render: (row) => row.approver || row.actor || 'system' },
-        { key: 'evidence', header: 'Evidence', render: (row) => `${row.evidence_summary.length} refs · ${row.audit_trail.length} audit rows` },
+        { key: 'evidence', header: 'Evidence', render: (row) => `${row.evidence_summary?.length ?? 0} refs · ${row.audit_trail?.length ?? 0} audit rows` },
         {
           key: 'status',
           header: 'Status',
@@ -17056,7 +17082,7 @@ function AWSFindingsContent({
           <DomainEmptyState
             eyebrow="Empty"
             title="No AWS findings"
-            body="Finding generation is not connected yet."
+            body="No AWS finding matches this environment yet. Connect AWS or clear filters to load graph, runtime, and inventory evidence."
           />
         }
         columns={[

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24154,6 +24154,23 @@ html[data-theme='light'] .idt-app-shell-screen select {
   padding: 1rem;
 }
 
+.idt-aws-runtime-correlation {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.idt-aws-runtime-correlation > .idt-app-kicker,
+html[data-theme='light'] .idt-aws-runtime-correlation > .idt-app-kicker {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.55;
+  text-transform: none;
+}
+
 .idt-aws-runtime-timeline-panel {
   display: grid;
   gap: 0.7rem;


### PR DESCRIPTION
## Summary

- Polish the AWS app surfaces so shipped sections read as operator-ready instead of roadmap/placeholder UI.
- Clean AWS inventory and operations labels, empty states, and status pills across the AWS subsections.
- Fix the AWS Governance route crash by normalizing nullable projection arrays, with regression coverage.
- Add the missing AWS docs to the docs README index.

## Validation

- `npm test -- --run src/api/client.test.ts src/productShell.test.tsx src/App.test.tsx`
- `go test ./internal/api`
- `npm run build`
- Local app/API browser QA across 18 AWS routes with `fixture_state=success`: overview, connect, accounts, coverage, identities, identity detail, agents, agent detail, resources, runtime, observability, GA demo, graph, findings, remediation, remediation center, outcomes, governance.
- Browser QA confirmed no route crashes, no horizontal overflow, no suspicious placeholder wording, and no long AWS runtime-correlation paragraphs forced into all caps.

## Notes

- Local fake AWS role validation correctly reports permission diagnostics; route QA used the existing fixture query path rather than pretending the fake ARN is a live AWS role.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the AWS app to feel operator-ready with clearer labels, pills, and empty states, and marked core routes as Ready. Fixed null-related crashes in governance and runtime projections; expanded the AWS docs index.

- **UI Improvements**
  - Stage labels: Ready, Needs evidence, Unavailable; “Planned” → “Queued”; “Planned accounts” → “Additional accounts”.
  - Marked Accounts, Identities, Agents, Resources, Runtime, Findings, and Remediation as Ready; tightened copy across operations pages.
  - Unified pill/filter labels via a display helper; updated the “Connect AWS to load live inventory” empty state.
  - Added layout styles for the runtime correlation panel.

- **Bug Fixes**
  - Normalized nullable arrays in governance audit and executor projection panels and guarded counts (evidence, caveats, failure reasons) to prevent crashes; updated tests for null-safe paths and new copy.

<sup>Written for commit 60f3bbf92046975095e89e7a4f7369357b4c4827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

